### PR TITLE
feat: commit changes

### DIFF
--- a/core/include/grids/axis.hpp
+++ b/core/include/grids/axis.hpp
@@ -18,20 +18,18 @@ namespace detray
     {
         /** A regular closed axis.
          * 
-         * @tparam kDIM the number of bins
          * @tparam value_type the scalar value which is used
          * 
          * The axis is closed, i.e. each underflow bin is mapped to 0
-         * and henceforth each overflow bin is mapped to kDIM-1
+         * and henceforth each overflow bin is mapped to bins-1
          */
-        template <unsigned int kDIM, typename value_type = scalar>
+        template <typename value_type = scalar>
         struct closed
         {
 
-            value_type _min;
-            value_type _max;
-
-            static constexpr unsigned int axis_bins = kDIM;
+            unsigned int bins;
+            value_type min;
+            value_type max;
 
             static constexpr unsigned int axis_identifier = 0;
 
@@ -43,10 +41,10 @@ namespace detray
              **/
             guaranteed_index bin(value_type v) const
             {
-                optional_index ibin = static_cast<optional_index>((v - _min) / (_max - _min) * kDIM);
-                return (ibin >= 0 and ibin < kDIM) ? static_cast<guaranteed_index>(ibin)
+                optional_index ibin = static_cast<optional_index>((v - min) / (max - min) * bins);
+                return (ibin >= 0 and ibin < bins) ? static_cast<guaranteed_index>(ibin)
                                                    : ibin < 0 ? 0
-                                                              : static_cast<guaranteed_index>(kDIM - 1);
+                                                              : static_cast<guaranteed_index>(bins - 1);
             }
 
             /** Access function to a range with binned neighbourhood
@@ -58,9 +56,9 @@ namespace detray
              **/
             guaranteed_range range(value_type v, unsigned int nhood) const
             {
-                optional_index ibin = static_cast<optional_index>((v - _min) / (_max - _min) * kDIM);
+                optional_index ibin = static_cast<optional_index>((v - min) / (max - min) * bins);
                 guaranteed_index min_bin = (ibin - nhood) >= 0 ? static_cast<guaranteed_index>(ibin - nhood) : 0;
-                guaranteed_index max_bin = (ibin + nhood) < kDIM ? static_cast<guaranteed_index>(ibin + nhood) : static_cast<guaranteed_index>(kDIM - 1);
+                guaranteed_index max_bin = (ibin + nhood) < bins ? static_cast<guaranteed_index>(ibin + nhood) : static_cast<guaranteed_index>(bins - 1);
                 return {min_bin, max_bin};
             }
 
@@ -81,25 +79,22 @@ namespace detray
             }
 
             /** Copy the range zone */
-            darray<value_type, 2> range() const { return {_min, _max}; }
+            darray<value_type, 2> range() const { return {min, max}; }
         };
 
         /** A regular circular axis.
          * 
-         * @tparam kDIM the number of bins
          * @tparam value_type the scalar value which is used
          * 
          * The axis is circular, i.e. the underflow bins map into the circular sequence
-         * 
          */
-        template <unsigned int kDIM, typename value_type = scalar>
+        template <typename value_type = scalar>
         struct circular
         {
 
-            value_type _min;
-            value_type _max;
-
-            static constexpr unsigned int axis_bins = kDIM;
+            unsigned int bins;
+            value_type min;
+            value_type max;
 
             static constexpr unsigned int axis_identifier = 1;
 
@@ -111,10 +106,10 @@ namespace detray
              **/
             guaranteed_index bin(value_type v) const
             {
-                optional_index ibin = static_cast<optional_index>((v - _min) / (_max - _min) * kDIM);
-                return (ibin >= 0 and ibin < kDIM) ? static_cast<guaranteed_index>(ibin)
-                                                   : ibin < 0 ? static_cast<guaranteed_index>(kDIM + ibin)
-                                                              : static_cast<guaranteed_index>(kDIM - ibin);
+                optional_index ibin = static_cast<optional_index>((v - min) / (max - min) * bins);
+                return (ibin >= 0 and ibin < bins) ? static_cast<guaranteed_index>(ibin)
+                                                   : ibin < 0 ? static_cast<guaranteed_index>(bins + ibin)
+                                                              : static_cast<guaranteed_index>(bins - ibin);
             }
 
             /** Access function to a range with binned neighbourhood
@@ -149,13 +144,13 @@ namespace detray
                     std::for_each(sequence.begin(), sequence.end(), [&](auto &n) { n += m++; });
                     return sequence;
                 }
-                guaranteed_index vl = static_cast<guaranteed_index>(kDIM - nh_range[0] + nh_range[1] + 1);
+                guaranteed_index vl = static_cast<guaranteed_index>(bins - nh_range[0] + nh_range[1] + 1);
                 guaranteed_index mi = 0;
                 guaranteed_index mo = 0;
                 guaranteed_sequence sequence(static_cast<guaranteed_sequence::size_type>(vl), nh_range[0]);
                 std::for_each(sequence.begin(), sequence.end(), [&](auto &n) {
                     n += mi++;
-                    if (n > kDIM - 1)
+                    if (n > bins - 1)
                     {
                         n = mo++;
                     } });
@@ -172,19 +167,19 @@ namespace detray
             guaranteed_index remap(guaranteed_index ibin, optional_index shood) const
             {
                 optional_index opt_bin = ibin + shood;
-                if (opt_bin >= 0 and opt_bin < kDIM - 1)
+                if (opt_bin >= 0 and opt_bin < bins - 1)
                 {
                     return static_cast<guaranteed_index>(opt_bin);
                 }
                 if (opt_bin < 0)
                 {
-                    return static_cast<guaranteed_index>(kDIM + opt_bin);
+                    return static_cast<guaranteed_index>(bins + opt_bin);
                 }
-                return static_cast<guaranteed_index>(opt_bin - kDIM);
+                return static_cast<guaranteed_index>(opt_bin - bins);
             }
 
             /** Copy the range zone */
-            darray<value_type, 2> range() const { return {_min, _max}; }
+            darray<value_type, 2> range() const { return {min, max}; }
 
         };
 

--- a/core/include/grids/serializer2.hpp
+++ b/core/include/grids/serializer2.hpp
@@ -28,12 +28,19 @@ namespace detray
          * @tparam faxis_type is the type of the first axis
          * @tparam saxis_type is the type of the second axis
          * 
+         * @param faxis the first axis
+         * @param saxis the second axis, unused here
+         * @param fbin first bin
+         * @param sbin second bin
+         * 
          * @return a guaranteed_index for the memory storage
          */
         template <typename faxis_type, typename saxis_type>
-        guaranteed_index serialize(guaranteed_index fbin, guaranteed_index sbin) const
+        guaranteed_index serialize(const faxis_type& faxis, const saxis_type& /*saxis*/,
+                                   guaranteed_index fbin, guaranteed_index sbin) const
         {
-            guaranteed_index offset = sbin * faxis_type::axis_bins;
+
+            guaranteed_index offset = sbin * faxis.bins;
             return offset + fbin;
         }
 
@@ -42,13 +49,17 @@ namespace detray
          * @tparam faxis_type is the type of the first axis
          * @tparam saxis_type is the type of the second axis
          * 
+         * @param faxis the first axis
+         * @param saxis the second axis, unused here
+         * @param serialbin the serial bin 
+         * 
          * @return a 2-dim array of guaranteed_index 
          */
         template <typename faxis_type, typename saxis_type>
-        darray<guaranteed_index, 2> deserialize(guaranteed_index serialbin) const
+        darray<guaranteed_index, 2> deserialize(const faxis_type& faxis, const saxis_type& /*saxis*/, guaranteed_index serialbin) const
         {
-            guaranteed_index sbin = static_cast<guaranteed_index>(serialbin/faxis_type::axis_bins);
-            guaranteed_index fbin = serialbin - sbin * faxis_type::axis_bins;
+            guaranteed_index sbin = static_cast<guaranteed_index>(serialbin/faxis.bins);
+            guaranteed_index fbin = serialbin - sbin * faxis.bins;
             return { fbin, sbin };
         }
     };

--- a/io/include/json/json_grids.hpp
+++ b/io/include/json/json_grids.hpp
@@ -30,7 +30,7 @@ namespace detray
         njson write_axis(const axis_type &a)
         {
             njson aj;
-            aj["bins"] = a.axis_bins;
+            aj["bins"] = a.bins;
             aj["identifier"] = a.axis_identifier;
             aj["range"] = a.range();
             return aj;

--- a/tests/common/include/tests/common/test_cylindrical_detector.inl
+++ b/tests/common/include/tests/common/test_cylindrical_detector.inl
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 
 unsigned int theta_steps = 10;
-unsigned int phi_steps = 10000;
+unsigned int phi_steps = 1000;
 bool stream_file = true;
 
 auto d = createDetector();

--- a/tests/io/json/write_grid.cpp
+++ b/tests/io/json/write_grid.cpp
@@ -24,8 +24,8 @@ int main(int argc, char **argv)
     serializer2 serializer;
 
     // A rectangular grid 
-    axis::closed<10> xaxis{-5., 5.};
-    axis::closed<10> yaxis{-5., 5.};
+    axis::closed<> xaxis{10, -5., 5.};
+    axis::closed<> yaxis{10, -5., 5.};
     using grid2r = grid2<decltype(replacer), decltype(xaxis), decltype(yaxis), decltype(serializer)>;
 
     grid2r gr(std::move(xaxis), std::move(yaxis));
@@ -35,8 +35,8 @@ int main(int argc, char **argv)
     output_file.close();
 
     // A polar sectoral grid
-    axis::closed<3> raxis{1., 5.};
-    axis::closed<10> phiaxis{-0.35, 0.35};
+    axis::closed<> raxis{3, 1., 5.};
+    axis::closed<> phiaxis{10, -0.35, 0.35};
 
     using grid2ps = grid2<decltype(replacer), decltype(raxis), decltype(phiaxis), decltype(serializer)>;
     grid2ps gps(std::move(raxis), std::move(phiaxis));

--- a/tests/unit_tests/core/grids_axis.cpp
+++ b/tests/unit_tests/core/grids_axis.cpp
@@ -18,9 +18,9 @@ using namespace detray;
 TEST(grids, regular_closed_axis)
 {
 
-    axis::closed<10> ten_bins{-3., 7.};
+    axis::closed<> ten_bins{10, -3., 7.};
     // N bins
-    EXPECT_EQ(ten_bins.axis_bins, 10u);
+    EXPECT_EQ(ten_bins.bins, 10u);
     // Axis bin access
     EXPECT_EQ(ten_bins.bin(-4.), 0u);
     EXPECT_EQ(ten_bins.bin(2.), 5u);
@@ -49,9 +49,9 @@ TEST(grids, regular_circular_axis)
     scalar half_module = 2 * M_PI_2 / 72;
     scalar phi_min = -M_PI + half_module;
     scalar phi_max = M_PI - half_module;
-    axis::circular<36> full_pi = {phi_min, phi_max};
+    axis::circular<> full_pi = {36, phi_min, phi_max};
     // N bins
-    EXPECT_EQ(full_pi.axis_bins, 36u);
+    EXPECT_EQ(full_pi.bins, 36u);
     // Axis bin access
     EXPECT_EQ(full_pi.bin(M_PI - epsilon), 0u);
     EXPECT_EQ(full_pi.bin(M_PI + epsilon), 0u);

--- a/tests/unit_tests/core/grids_grid2.cpp
+++ b/tests/unit_tests/core/grids_grid2.cpp
@@ -23,8 +23,8 @@ TEST(grids, grid2_replace_populator)
     replace_populator<guaranteed_index, std::numeric_limits<guaranteed_index>::max()> replacer;
     serializer2 serializer;
 
-    axis::closed<10> xaxis{-5., 5.};
-    axis::closed<10> yaxis{-5., 5.};
+    axis::closed<> xaxis{10, -5., 5.};
+    axis::closed<> yaxis{10, -5., 5.};
     using grid2r = grid2<decltype(replacer), decltype(xaxis), decltype(yaxis), decltype(serializer)>;
 
     grid2r g2(std::move(xaxis), std::move(yaxis));
@@ -73,8 +73,8 @@ TEST(grids, grid2_replace_populator)
     expect = {143u, 144u, 145u, 146u, 147u, 153u, 154u, 155u, 156u, 157u, 163u, 164u, 165u, 166u, 167u};
     EXPECT_EQ(test, expect);
 
-    axis::circular<4> circular{-2., 2.};
-    axis::closed<5> closed{0., 5.};
+    axis::circular<> circular{4, -2., 2.};
+    axis::closed<> closed{5, 0., 5.};
     using grid2cc = grid2<decltype(replacer), decltype(circular), decltype(closed), decltype(serializer)>;
 
     grid2cc g2cc(std::move(circular), std::move(closed));
@@ -101,8 +101,8 @@ TEST(grids, grid2_complete_populator)
     complete_populator<optional_index, -1, 3, false> completer;
     serializer2 serializer;
 
-    axis::closed<2> xaxis{-1., 1.};
-    axis::closed<2> yaxis{-1., 1.};
+    axis::closed<> xaxis{2, -1., 1.};
+    axis::closed<> yaxis{2, -1., 1.};
     using grid2r = grid2<decltype(completer), decltype(xaxis), decltype(yaxis), decltype(serializer)>;
 
     grid2r g2(std::move(xaxis), std::move(yaxis));
@@ -170,8 +170,8 @@ TEST(grids, grid2_attach_populator)
     attach_populator<guaranteed_index> attacher;
     serializer2 serializer;
 
-    axis::closed<2> xaxis{-1., 1.};
-    axis::closed<2> yaxis{-1., 1.};
+    axis::closed<> xaxis{2, -1., 1.};
+    axis::closed<> yaxis{2, -1., 1.};
     using grid2r = grid2<decltype(attacher), decltype(xaxis), decltype(yaxis), decltype(serializer)>;
 
     grid2r g2(std::move(xaxis), std::move(yaxis));
@@ -223,8 +223,8 @@ TEST(grids, grid2_shift)
     replace_populator<guaranteed_index, 0> replacer;
     serializer2 serializer;
 
-    axis::closed<10> xaxis{-5., 5.};
-    axis::closed<10> yaxis{-5., 5.};
+    axis::closed<> xaxis{10, -5., 5.};
+    axis::closed<> yaxis{10, -5., 5.};
 
     using grid2r = grid2<decltype(replacer), decltype(xaxis), decltype(yaxis), decltype(serializer)>;
 

--- a/tests/unit_tests/core/grids_serializer.cpp
+++ b/tests/unit_tests/core/grids_serializer.cpp
@@ -19,33 +19,33 @@ using namespace detray;
 TEST(grids, serialize_deserialize)
 {
 
-    axis::closed<6> r6{-3., 7.};
-    axis::circular<12> c12{-3., 3.};
+    axis::closed<> r6{6, -3., 7.};
+    axis::circular<> c12{12, -3., 3.};
 
     serializer2 ser2;
 
     // Serializing
-    guaranteed_index test = ser2.serialize<decltype(r6), decltype(c12)>(0u, 0u);
+    guaranteed_index test = ser2.serialize(r6, c12, 0u, 0u);
     EXPECT_EQ(test, 0u);
-    test = ser2.serialize<decltype(r6), decltype(c12)>(5u, 0u);
+    test = ser2.serialize(r6, c12, 5u, 0u);
     EXPECT_EQ(test, 5u);
-    test = ser2.serialize<decltype(r6), decltype(c12)>(0u, 1u);
+    test = ser2.serialize(r6, c12, 0u, 1u);
     EXPECT_EQ(test, 6u);
-    test = ser2.serialize<decltype(r6), decltype(c12)>(5u, 2u);
+    test = ser2.serialize(r6, c12, 5u, 2u);
     EXPECT_EQ(test, 17u);
 
     // Deserialize
     darray<guaranteed_index, 2> expected_array = {0u, 0u};
-    darray<guaranteed_index, 2> test_array = ser2.deserialize<decltype(r6), decltype(c12)>(0u);
+    darray<guaranteed_index, 2> test_array = ser2.deserialize(r6, c12, 0u);
     EXPECT_EQ(test_array, expected_array);
     expected_array = {5u, 0u};
-    test_array = ser2.deserialize<decltype(r6), decltype(c12)>(5u);
+    test_array = ser2.deserialize(r6, c12, 5u);
     EXPECT_EQ(test_array, expected_array);
     expected_array = {0u, 1u};
-    test_array = ser2.deserialize<decltype(r6), decltype(c12)>(6u);
+    test_array = ser2.deserialize(r6, c12, 6u);
     EXPECT_EQ(test_array, expected_array);
     expected_array = {5u, 2u};
-    test_array = ser2.deserialize<decltype(r6), decltype(c12)>(17u);
+    test_array = ser2.deserialize(r6, c12, 17u);
     EXPECT_EQ(test_array, expected_array);
 }
 

--- a/tests/unit_tests/core/utils_local_object_finder.cpp
+++ b/tests/unit_tests/core/utils_local_object_finder.cpp
@@ -32,8 +32,8 @@ TEST(utils, local_object_finder)
 
     test::point2 p2 = { -4.5, -4.5 };
 
-    axis::closed<10> xaxis{-5., 5.};
-    axis::closed<10> yaxis{-5., 5.};
+    axis::closed<> xaxis{10, -5., 5.};
+    axis::closed<> yaxis{10, -5., 5.};
     using grid2r = grid2<decltype(replacer), decltype(xaxis), decltype(yaxis), decltype(serializer)>;
 
     grid2r g2(std::move(xaxis), std::move(yaxis));


### PR DESCRIPTION
This PR changes the grid to have a dynamically sized storage:
 - this makes the axes not templated on the number of bins and allows for non-equidistant binning 