### PR TITLE
feat: remove scalar template for masks

### DIFF
--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -101,13 +101,13 @@ namespace detray
          **/
         using portal_links = darray<dindex, 4>;
 
-        using portal_rectangle_mask = rectangle2<scalar, planar_intersector, portal_links>;
+        using portal_rectangle_mask = rectangle2<planar_intersector, portal_links>;
         using portal_rectangles = dvector<portal_rectangle_mask>;
-        using protal_trapezoid_mask = trapezoid2<scalar, planar_intersector, portal_links>;
+        using protal_trapezoid_mask = trapezoid2<planar_intersector, portal_links>;
         using portal_trapezoids = dvector<protal_trapezoid_mask>;
-        using portal_cylinder_mask = cylinder3<scalar, false, concentric_cylinder_intersector, portal_links>;
+        using portal_cylinder_mask = cylinder3<false, concentric_cylinder_intersector, portal_links>;
         using portal_cylinders = dvector<portal_cylinder_mask>;
-        using portal_disc_mask = ring2<scalar, planar_intersector, portal_links>;
+        using portal_disc_mask = ring2<planar_intersector, portal_links>;
         using portal_discs = dvector<portal_disc_mask>;
         using portal_type_map = dmap<dindex, dindex>;
         using portal_surface = surface<dindex, typed_dindex_range, dindex>;
@@ -228,10 +228,10 @@ namespace detray
          * Internal surfaces are all kind of navigation surfaces within a volume
          * 
          **/
-        using rectangle_mask = rectangle2<scalar>;
-        using trapezoid_mask = trapezoid2<scalar>;
-        using cylinder_mask = cylinder3<scalar, false, concentric_cylinder_intersector>;
-        using disc_mask = ring2<scalar, planar_intersector>;
+        using rectangle_mask = rectangle2<>;
+        using trapezoid_mask = trapezoid2<>;
+        using cylinder_mask = cylinder3<false, concentric_cylinder_intersector>;
+        using disc_mask = ring2<planar_intersector>;
         using rectangles = dvector<rectangle_mask>;
         using trapezoids = dvector<trapezoid_mask>;
         using cylinders = dvector<cylinder_mask>;

--- a/core/include/masks/annulus2.hpp
+++ b/core/include/masks/annulus2.hpp
@@ -134,9 +134,8 @@ namespace detray
          * 
          * @param rhs is the rectangle to be compared with
          * 
-         * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const darray<scalar, 2> &rhs)
+        bool operator==(const darray<scalar, 7> &rhs)
         {
             return (_values == rhs);
         }
@@ -145,7 +144,6 @@ namespace detray
          * 
          * @param rhs is the rectangle to be compared with
          * 
-         * checks identity within epsilon and @return s a boolean*
          **/
         bool operator==(const annulus2<> &rhs)
         {

--- a/core/include/masks/annulus2.hpp
+++ b/core/include/masks/annulus2.hpp
@@ -122,7 +122,7 @@ namespace detray
                 scalar r_mod2 = shift_r * shift_r + p[0] * p[0] +
                                      2 * shift_r * p[0] * std::cos(phi_strp - shift_phi);
 
-                // apply tolerances
+                // Apply tolerances
                 scalar minR_tol = _values[0] - t[0];
                 scalar maxR_tol = _values[1] + t[0];
 

--- a/core/include/masks/cylinder3.hpp
+++ b/core/include/masks/cylinder3.hpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include "masks/mask_identifier.hpp"
 #include "core/intersection.hpp"
 #include "utils/containers.hpp"
 #include "tools/cylinder_intersector.hpp"
@@ -18,41 +19,42 @@ namespace detray
 {
     /** This is a simple mask for a full cylinder
      * 
-     * @tparam scalar_type the primitive scalar type
      * @tparam kRadialCheck is a boolean to steer wheter the radius compatibility needs to be checked
+     * @tparam intersector_type is a struct used for intersecting this cylinder
+     * @tparam links_type is an object where the mask can link to 
+     * @tparam kMaskIdentifier is a unique mask identifier in a program context
      * 
      * It is defined by r and the half length.
      **/
-    template <typename scalar_type,
-              bool kRadialCheck = true,
+    template <bool kRadialCheck = true,
               typename intersector_type = detray::cylinder_intersector,
               typename links_type = bool,
-              unsigned int kMaskIdentifier = 3>
+              unsigned int kMaskIdentifier = e_cylinder3>
     struct cylinder3
     {
 
-        using mask_tolerance = darray<scalar_type, 3>;
+        using mask_tolerance = darray<scalar, 3>;
 
-        using mask_values = darray<scalar_type, 3>;
+        using mask_values = darray<scalar, 3>;
 
         mask_values _values =
-            {std::numeric_limits<scalar_type>::infinity(),
-             -std::numeric_limits<scalar_type>::infinity(),
-             std::numeric_limits<scalar_type>::infinity()};
+            {std::numeric_limits<scalar>::infinity(),
+             -std::numeric_limits<scalar>::infinity(),
+             std::numeric_limits<scalar>::infinity()};
 
         links_type _links;
 
         static constexpr unsigned int mask_identifier = kMaskIdentifier;
 
-        static constexpr mask_tolerance within_epsilon = {std::numeric_limits<scalar_type>::epsilon(),
-                                                           std::numeric_limits<scalar_type>::epsilon()};
+        static constexpr mask_tolerance within_epsilon = {std::numeric_limits<scalar>::epsilon(),
+                                                          std::numeric_limits<scalar>::epsilon()};
 
         /** Assignment operator from an array, convenience function
          * 
          * @param rhs is the right hand side object
          **/
-        cylinder3<scalar_type, kRadialCheck, intersector_type, links_type, kMaskIdentifier> &
-        operator=(const darray<scalar_type, 3> &rhs)
+        cylinder3<kRadialCheck, intersector_type, links_type, kMaskIdentifier> &
+        operator=(const darray<scalar, 3> &rhs)
         {
             _values = rhs;
             return (*this);
@@ -74,8 +76,8 @@ namespace detray
         {
             if (kRadialCheck)
             {
-                scalar_type r = getter::perp(p);
-                if (std::abs(r - _values[0]) >= t[0] + 5 * std::numeric_limits<scalar_type>::epsilon())
+                scalar r = getter::perp(p);
+                if (std::abs(r - _values[0]) >= t[0] + 5 * std::numeric_limits<scalar>::epsilon())
                 {
                     return e_missed;
                 }
@@ -89,7 +91,7 @@ namespace detray
          * 
          * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const darray<scalar_type, 3> &rhs)
+        bool operator==(const darray<scalar, 3> &rhs)
         {
             return (_values == rhs);
         }
@@ -100,7 +102,7 @@ namespace detray
          * 
          * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const cylinder3<scalar_type> &rhs)
+        bool operator==(const cylinder3<> &rhs)
         {
             return operator==(rhs._values);
         }
@@ -108,7 +110,7 @@ namespace detray
         /** Access operator - non-const
          * @return the reference to the member variable
          */
-        scalar_type &operator[](unsigned int value_index)
+        scalar &operator[](unsigned int value_index)
         {
             return _values[value_index];
         }
@@ -116,7 +118,7 @@ namespace detray
         /** Access operator - non-const
          * @return a copy of the member variable
          */
-        scalar_type operator[](unsigned int value_index) const
+        scalar operator[](unsigned int value_index) const
         {
             return _values[value_index];
         }

--- a/core/include/masks/rectangle2.hpp
+++ b/core/include/masks/rectangle2.hpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include "masks/mask_identifier.hpp"
 #include "core/intersection.hpp"
 #include "utils/containers.hpp"
 #include "tools/planar_intersector.hpp"
@@ -18,36 +19,40 @@ namespace detray
 
     /** This is a simple 2-dimensional mask for a regular rectangle
      * 
+     * @tparam intersector_type is a struct used for intersecting this cylinder
+     * @tparam links_type is an object where the mask can link to 
+     * @tparam kMaskIdentifier is a unique mask identifier in a program context
+     * 
      * It is defined by half length in local0 coordinates _values[0] and _values[1], 
-     * and can be checked with a tolerance in t0 and t1.
+     * and can be checked with a tolerance in t[0] and t[1].
+     * 
      **/
-    template <typename scalar_type,
-              typename intersector_type = planar_intersector,
+    template <typename intersector_type = planar_intersector,
               typename links_type = bool,
-              unsigned int kMaskIdentifier = 0>
+              unsigned int kMaskIdentifier = e_rectangle2>
     struct rectangle2
     {
-        using mask_tolerance = darray<scalar_type, 2>;
+        using mask_tolerance = darray<scalar, 2>;
 
-        using mask_values = darray<scalar_type, 2>;
+        using mask_values = darray<scalar, 2>;
 
         mask_values _values =
-            {std::numeric_limits<scalar_type>::infinity(),
-             std::numeric_limits<scalar_type>::infinity()};
+            {std::numeric_limits<scalar>::infinity(),
+             std::numeric_limits<scalar>::infinity()};
 
         links_type _links;
 
         static constexpr unsigned int mask_identifier = kMaskIdentifier;
 
-        static constexpr mask_tolerance within_epsilon = {std::numeric_limits<scalar_type>::epsilon(),
-                                                           std::numeric_limits<scalar_type>::epsilon()};
+        static constexpr mask_tolerance within_epsilon = {std::numeric_limits<scalar>::epsilon(),
+                                                           std::numeric_limits<scalar>::epsilon()};
 
         /** Assignment operator from an array, convenience function
          * 
          * @param rhs is the right hand side object
          **/
-        rectangle2<scalar_type, intersector_type, links_type, kMaskIdentifier> &
-        operator=(const darray<scalar_type, 2> &rhs)
+        rectangle2<intersector_type, links_type, kMaskIdentifier> &
+        operator=(const darray<scalar, 2> &rhs)
         {
             _values = rhs;
             return (*this);
@@ -76,7 +81,7 @@ namespace detray
          * 
          * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const darray<scalar_type, 2> &rhs)
+        bool operator==(const darray<scalar, 2> &rhs)
         {
             return (_values == rhs);
         }
@@ -87,7 +92,7 @@ namespace detray
          * 
          * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const rectangle2<scalar_type> &rhs)
+        bool operator==(const rectangle2<> &rhs)
         {
             return operator==(rhs._values);
         }
@@ -95,7 +100,7 @@ namespace detray
         /** Access operator - non-const
          * @return the reference to the member variable
          */
-        scalar_type &operator[](unsigned int value_index)
+        scalar &operator[](unsigned int value_index)
         {
             return _values[value_index];
         }
@@ -103,7 +108,7 @@ namespace detray
         /** Access operator - non-const
          * @return a copy of the member variable
          */
-        scalar_type operator[](unsigned int value_index) const
+        scalar operator[](unsigned int value_index) const
         {
             return _values[value_index];
         }

--- a/core/include/masks/ring2.hpp
+++ b/core/include/masks/ring2.hpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include "masks/mask_identifier.hpp"
 #include "core/intersection.hpp"
 #include "utils/containers.hpp"
 #include "tools/planar_intersector.hpp"
@@ -17,34 +18,38 @@ namespace detray
 {
     /** This is a simple 2-dimensional mask for a closed ring
      * 
+     * @tparam intersector_type is a struct used for intersecting this cylinder
+     * @tparam links_type is an object where the mask can link to 
+     * @tparam kMaskIdentifier is a unique mask identifier in a program context
+     *  
      * It is defined by the two radii _values[0] and  _values[1], 
-     * and can be checked with a tolerance in t0 and t1.
+     * and can be checked with a tolerance in t[0] and t[1].
+     * 
      **/
-    template <typename scalar_type,
-              typename intersector_type = planar_intersector,
+    template <typename intersector_type = planar_intersector,
               typename links_type = bool,
-              unsigned int kMaskIdentifier = 2>
+              unsigned int kMaskIdentifier = e_ring2>
     struct ring2
     {
-        using mask_tolerance = scalar_type;
+        using mask_tolerance = scalar;
 
-        using mask_values = darray<scalar_type, 2>;
+        using mask_values = darray<scalar, 2>;
 
-        mask_values _values = {0., std::numeric_limits<scalar_type>::infinity()};
+        mask_values _values = {0., std::numeric_limits<scalar>::infinity()};
 
         links_type _links;
 
         static constexpr unsigned int mask_identifier = kMaskIdentifier;
 
         static constexpr mask_tolerance within_epsilon 
-            = std::numeric_limits<scalar_type>::epsilon();
+            = std::numeric_limits<scalar>::epsilon();
 
         /** Assignment operator from an array, convenience function
          * 
          * @param rhs is the right hand side object
          **/
-        ring2<scalar_type, intersector_type, links_type, kMaskIdentifier> &
-        operator=(const darray<scalar_type, 2> &rhs)
+        ring2<intersector_type, links_type, kMaskIdentifier> &
+        operator=(const darray<scalar, 2> &rhs)
         {
             _values = rhs;
             return (*this);
@@ -65,7 +70,7 @@ namespace detray
                                       const mask_tolerance &t = within_epsilon) const
         {
             if constexpr(std::is_same_v<local_type, __plugin::cartesian2>) {
-               scalar_type r = getter::perp(p);
+               scalar r = getter::perp(p);
                return (r + t >= _values[0] and r <= _values[1] + t) ? e_inside : e_outside;
             }
 
@@ -79,7 +84,7 @@ namespace detray
          * 
          * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const darray<scalar_type, 2> &rhs)
+        bool operator==(const darray<scalar, 2> &rhs)
         {
             return (_values == rhs);
         }
@@ -90,7 +95,7 @@ namespace detray
          * 
          * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const ring2<scalar_type> &rhs)
+        bool operator==(const ring2<> &rhs)
         {
             return operator==(rhs._values);
         }
@@ -98,7 +103,7 @@ namespace detray
         /** Access operator - non-const
          * @return the reference to the member variable
          */
-        scalar_type &operator[](unsigned int value_index)
+        scalar &operator[](unsigned int value_index)
         {
             return _values[value_index];
         }
@@ -106,7 +111,7 @@ namespace detray
         /** Access operator - non-const
          * @return a copy of the member variable
          */
-        scalar_type operator[](unsigned int value_index) const
+        scalar operator[](unsigned int value_index) const
         {
             return _values[value_index];
         }

--- a/core/include/masks/single3.hpp
+++ b/core/include/masks/single3.hpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include "masks/mask_identifier.hpp"
 #include "core/intersection.hpp"
 #include "utils/containers.hpp"
 #include "tools/planar_intersector.hpp"
@@ -17,36 +18,40 @@ namespace detray
 {
     /** This is a simple mask for single parameter bound mask
      * 
+     * @tparam kCheckIndex is the index of the position on which the mask is applied
+     * @tparam intersector_type is a struct used for intersecting this cylinder
+     * @tparam links_type is an object where the mask can link to 
+     * @tparam kMaskIdentifier is a unique mask identifier in a program context
+     * 
      **/
-    template <typename scalar_type, 
-              unsigned int kCheckIndex, 
-              typename intersector_type = planar_intersector, 
+    template <unsigned int kCheckIndex,
+              typename intersector_type = planar_intersector,
               typename links_type = bool,
-              unsigned int kMaskIdentifier=4>
+              unsigned int kMaskIdentifier = e_single3>
     struct single3
     {
 
-        using mask_tolerance = scalar_type;
+        using mask_tolerance = scalar;
 
-        using mask_values = darray<scalar_type, 1>;
+        using mask_values = darray<scalar, 1>;
 
-        mask_values _values=
-            {std::numeric_limits<scalar_type>::infinity()};
+        mask_values _values =
+            {std::numeric_limits<scalar>::infinity()};
 
         links_type _links;
 
         static constexpr unsigned int mask_identifier = kMaskIdentifier;
 
-        static constexpr mask_tolerance within_epsilon = std::numeric_limits<scalar_type>::epsilon();
+        static constexpr mask_tolerance within_epsilon = std::numeric_limits<scalar>::epsilon();
 
         /** Assignment operator from an array, convenience function
          * 
          * @param rhs is the right hand side object
          **/
-        single3<scalar_type, kCheckIndex, intersector_type, links_type, kMaskIdentifier>&
-        operator=(const darray<scalar_type, 1> &rhs)
+        single3<kCheckIndex, intersector_type, links_type, kMaskIdentifier> &
+        operator=(const darray<scalar, 1> &rhs)
         {
-            _values= rhs;
+            _values = rhs;
             return (*this);
         }
 
@@ -62,8 +67,8 @@ namespace detray
          **/
         template <typename local_type>
         intersection_status is_inside(const typename local_type::point3 &p,
-                                      const mask_tolerance& t = within_epsilon) const
-        {     
+                                      const mask_tolerance &t = within_epsilon) const
+        {
             return (std::abs(p[kCheckIndex]) <= _values[0] + t) ? e_inside : e_outside;
         }
 
@@ -73,9 +78,9 @@ namespace detray
          * 
          * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const darray<scalar_type, 2> &rhs)
+        bool operator==(const darray<scalar, 2> &rhs)
         {
-            return (_values== rhs);
+            return (_values == rhs);
         }
 
         /** Equality operator 
@@ -84,7 +89,7 @@ namespace detray
          * 
          * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const single3<scalar_type, kCheckIndex> &rhs)
+        bool operator==(const single3<kCheckIndex> &rhs)
         {
             return operator==(rhs._values);
         }
@@ -92,7 +97,7 @@ namespace detray
         /** Access operator - non-const
          * @return the reference to the member variable
          */
-        scalar_type &operator[](unsigned int value_index)
+        scalar &operator[](unsigned int value_index)
         {
             return _values[value_index];
         }
@@ -100,7 +105,7 @@ namespace detray
         /** Access operator - non-const
          * @return a copy of the member variable
          */
-        scalar_type operator[](unsigned int value_index) const
+        scalar operator[](unsigned int value_index) const
         {
             return _values[value_index];
         }
@@ -113,7 +118,6 @@ namespace detray
 
         /** Return the volume link - non-const access */
         links_type &links() { return _links; }
-
     };
 
 } // namespace detray

--- a/core/include/masks/single3.hpp
+++ b/core/include/masks/single3.hpp
@@ -76,9 +76,8 @@ namespace detray
          * 
          * @param rhs is the rectangle to be compared with
          * 
-         * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const darray<scalar, 2> &rhs)
+        bool operator==(const darray<scalar, 1> &rhs)
         {
             return (_values == rhs);
         }
@@ -87,7 +86,6 @@ namespace detray
          * 
          * @param rhs is the rectangle to be compared with
          * 
-         * checks identity within epsilon and @return s a boolean*
          **/
         bool operator==(const single3<kCheckIndex> &rhs)
         {

--- a/core/include/masks/trapezoid2.hpp
+++ b/core/include/masks/trapezoid2.hpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include "masks/mask_identifier.hpp"
 #include "core/intersection.hpp"
 #include "utils/containers.hpp"
 #include "tools/planar_intersector.hpp"
@@ -17,38 +18,41 @@ namespace detray
 {
     /** This is a simple 2-dimensional mask for a regular trapezoid
      * 
+     * @tparam intersector_type is a struct used for intersecting this cylinder
+     * @tparam links_type is an object where the mask can link to 
+     * @tparam kMaskIdentifier is a unique mask identifier in a program context
+     *  
      * It is defined by half lengths in local0 coordinate _values[0] and _values[1] at
      * -/+ half length in the local1 coordinate _values[2]
      **/
-    template <typename scalar_type,
-              typename intersector_type = planar_intersector,
+    template <typename intersector_type = planar_intersector,
               typename links_type = bool,
-              unsigned int kMaskIdentifier = 1>
+              unsigned int kMaskIdentifier = e_trapezoid2>
     struct trapezoid2
     {
-        using mask_tolerance = darray<scalar_type, 2>;
+        using mask_tolerance = darray<scalar, 2>;
 
-        using mask_values = darray<scalar_type, 3>;
+        using mask_values = darray<scalar, 3>;
 
         mask_values _values =
-            {std::numeric_limits<scalar_type>::infinity(),
-             std::numeric_limits<scalar_type>::infinity(),
-             std::numeric_limits<scalar_type>::infinity()};
+            {std::numeric_limits<scalar>::infinity(),
+             std::numeric_limits<scalar>::infinity(),
+             std::numeric_limits<scalar>::infinity()};
 
         links_type _links;
 
         static constexpr unsigned int mask_identifier = kMaskIdentifier;
 
         static constexpr mask_tolerance within_epsilon 
-            = { std::numeric_limits<scalar_type>::epsilon(), 
-                std::numeric_limits<scalar_type>::epsilon() };
+            = { std::numeric_limits<scalar>::epsilon(), 
+                std::numeric_limits<scalar>::epsilon() };
 
         /** Assignment operator from an array, convenience function
          * 
          * @param rhs is the right hand side object
          **/
-        trapezoid2<scalar_type, intersector_type, links_type, kMaskIdentifier> &
-        operator=(const darray<scalar_type, 3> &rhs)
+        trapezoid2<intersector_type, links_type, kMaskIdentifier> &
+        operator=(const darray<scalar, 3> &rhs)
         {
             _values = rhs;
             return (*this);
@@ -68,7 +72,7 @@ namespace detray
         intersection_status is_inside(const typename local_type::point2 &p,
                                       const mask_tolerance& t = within_epsilon) const
         {
-            scalar_type rel_y = (_values[2] + p[1]) / (2 * _values[2]);
+            scalar rel_y = (_values[2] + p[1]) / (2 * _values[2]);
             return 
                 (std::abs(p[0]) <= _values[0] + rel_y * (_values[1] - _values[0]) + t[0] and std::abs(p[1]) <= _values[2] + t[1]) ? 
                     e_inside : e_outside;
@@ -80,7 +84,7 @@ namespace detray
          * 
          * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const darray<scalar_type, 3> &rhs)
+        bool operator==(const darray<scalar, 3> &rhs)
         {
             return (_values == rhs);
         }
@@ -91,7 +95,7 @@ namespace detray
          * 
          * checks identity within epsilon and @return s a boolean*
          **/
-        bool operator==(const trapezoid2<scalar_type> &rhs)
+        bool operator==(const trapezoid2<> &rhs)
         {
             return operator==(rhs._values);
         }
@@ -99,7 +103,7 @@ namespace detray
         /** Access operator - non-const
          * @return the reference to the member variable
          */
-        scalar_type &operator[](unsigned int value_index)
+        scalar &operator[](unsigned int value_index)
         {
             return _values[value_index];
         }
@@ -107,7 +111,7 @@ namespace detray
         /** Access operator - non-const
          * @return a copy of the member variable
          */
-        scalar_type operator[](unsigned int value_index) const
+        scalar operator[](unsigned int value_index) const
         {
             return _values[value_index];
         }

--- a/core/include/masks/unmasked.hpp
+++ b/core/include/masks/unmasked.hpp
@@ -12,7 +12,6 @@
 
 namespace detray
 {
-    template <typename scalar_type = std::nullopt_t>
     struct unmasked
     {
 
@@ -46,7 +45,7 @@ namespace detray
          * @return a bool that is ture if inside
          **/
         template <typename local_type>
-        bool is_inside(const typename local_type::point2 & /*ignored*/, scalar_type /*ignored*/) const
+        bool is_inside(const typename local_type::point2 & /*ignored*/, scalar /*ignored*/) const
         {
             return true;
         }
@@ -61,7 +60,7 @@ namespace detray
          * @return a bool that is ture if inside
          **/
         template <typename local_type>
-        bool is_inside(const typename local_type::point2 & /*ignored*/, scalar_type /*ignored*/, scalar_type /*ignored*/) const
+        bool is_inside(const typename local_type::point2 & /*ignored*/, scalar /*ignored*/, scalar /*ignored*/) const
         {
             return true;
         }

--- a/core/include/tools/planar_intersector.hpp
+++ b/core/include/tools/planar_intersector.hpp
@@ -70,7 +70,7 @@ namespace detray
          * 
          * @return the intersection with optional parameters
          **/
-        template <typename transform_type, typename local_type = unbound, typename mask_type = unmasked<>>
+        template <typename transform_type, typename local_type = unbound, typename mask_type = unmasked>
         intersection<scalar, typename transform_type::point3, typename local_type::point2>
         intersect(const transform_type &trf,
                   const typename transform_type::point3 &ro,
@@ -96,9 +96,8 @@ namespace detray
                 is.path = vector::dot(sn, (st - ro)) / (denom);
                 is.point3 = ro + is.path * rd;
                 is.point2 = local(trf, is.point3);
-                is.status 
-                    = mask.template is_inside<local_type>(
-                            is.point2.value_or(typename local_type::point2()), tolerance);
+                is.status = mask.template is_inside<local_type>(
+                    is.point2.value_or(typename local_type::point2()), tolerance);
                 is.direction = denom > 0 ? e_along : e_opposite;
                 return is;
             }

--- a/tests/common/include/tests/common/benchmark_intersect_surfaces.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_surfaces.inl
@@ -42,7 +42,7 @@ namespace __plugin
         unsigned int sfhit = 0;
         unsigned int sfmiss = 0;
 
-        rectangle2<scalar> rect = {10., 20.};
+        rectangle2<> rect = {10., 20.};
         point3 ori = {0., 0., 0.};
 
         for (auto _ : state)
@@ -90,7 +90,7 @@ namespace __plugin
         unsigned int sfhit = 0;
         unsigned int sfmiss = 0;
 
-        using cylinder_mask = cylinder3<scalar,false,cylinder_intersector>;
+        using cylinder_mask = cylinder3<false,cylinder_intersector>;
         dvector<cylinder_mask> cylinders;
         for (auto r : dists)
         {
@@ -145,7 +145,7 @@ namespace __plugin
         unsigned int sfhit = 0;
         unsigned int sfmiss = 0;
 
-        using cylinder_mask = cylinder3<scalar,false,concentric_cylinder_intersector>;
+        using cylinder_mask = cylinder3<false,concentric_cylinder_intersector>;
         dvector<cylinder_mask> cylinders;
         for (auto r : dists)
         {

--- a/tests/common/include/tests/common/benchmark_masks.inl
+++ b/tests/common/include/tests/common/benchmark_masks.inl
@@ -37,7 +37,7 @@ namespace
         using local_type = __plugin::cartesian2;
         using point2 = local_type::point2;
 
-        rectangle2<scalar> r = {3, 4};
+        rectangle2<> r = {3, 4};
 
         scalar world = 10.;
         scalar area = 4 * r[0] * r[1];
@@ -82,7 +82,7 @@ namespace
         using local_type = __plugin::cartesian2;
         using point2 = local_type::point2;
 
-        trapezoid2<scalar> t = {2, 3, 4};
+        trapezoid2<> t = {2, 3, 4};
 
         scalar world = 10.;
         scalar area = 2 * (t[0] + t[1]) * t[2];
@@ -127,7 +127,7 @@ namespace
         using local_type = __plugin::cartesian2;
         using point2 = local_type::point2;
 
-        ring2<scalar> r = {0., 5.};
+        ring2<> r = {0., 5.};
 
         scalar world = 10.;
         scalar area = r[1] * r[1] * M_PI;
@@ -171,7 +171,7 @@ namespace
         using local_type = __plugin::cartesian2;
         using point2 = local_type::point2;
 
-        ring2<scalar> r = {2., 5.};
+        ring2<> r = {2., 5.};
 
         scalar world = 10.;
         scalar area = (r[1] * r[1] - r[0] * r[0]) * M_PI;
@@ -215,7 +215,7 @@ namespace
         using local_type = __plugin::transform3;
         using point3 = local_type::point3;
 
-        cylinder3<scalar> c = {3., 5.};
+        cylinder3<> c = {3., 5.};
 
         scalar world = 10.;
 
@@ -263,7 +263,7 @@ namespace
         using local_type = __plugin::cartesian2;
         using point2 = local_type::point2;
 
-        annulus2<scalar> ann = {2.5, 5., -0.64299, 4.13173, 1., 0.5};
+        annulus2<> ann = {2.5, 5., -0.64299, 4.13173, 1., 0.5};
 
         scalar world = 10.;
 

--- a/tests/common/include/tests/common/masks_annulus2.inl
+++ b/tests/common/include/tests/common/masks_annulus2.inl
@@ -40,7 +40,7 @@ TEST(mask, annulus2)
         return point2_pl{r, phi};
     };
 
-    annulus2<scalar> ann2 = {minR, maxR, minPhi, maxPhi, offset[0], offset[1]};
+    annulus2<> ann2 = {minR, maxR, minPhi, maxPhi, offset[0], offset[1]};
 
     ASSERT_EQ(ann2[0], static_cast<scalar>(7.2));
     ASSERT_EQ(ann2[1], static_cast<scalar>(12.0));

--- a/tests/common/include/tests/common/masks_containers.inl
+++ b/tests/common/include/tests/common/masks_containers.inl
@@ -19,8 +19,8 @@ using namespace __plugin;
 // This tests the construction of a surface
 TEST(mask, tuple)
 {
-    using rectangle_masks = dvector<rectangle2<scalar>>;
-    using cylinder_masks = dvector<cylinder3<scalar>>;
+    using rectangle_masks = dvector<rectangle2<>>;
+    using cylinder_masks = dvector<cylinder3<>>;
 
     rectangle_masks rectangles;
     cylinder_masks cylinders;

--- a/tests/common/include/tests/common/masks_cylinder3.inl
+++ b/tests/common/include/tests/common/masks_cylinder3.inl
@@ -26,7 +26,7 @@ TEST(mask, cylinder3)
     point3 p3_out = {static_cast<scalar>(r / std::sqrt(2.)), static_cast<scalar>(r / std::sqrt(2.)), 4.5};
     point3 p3_off = {1., 1., -9.};
 
-    cylinder3<scalar> c = {r, -hz, hz};
+    cylinder3<> c = {r, -hz, hz};
 
     ASSERT_EQ(c[0], r);
     ASSERT_EQ(c[1], -hz);

--- a/tests/common/include/tests/common/masks_rectangle2.inl
+++ b/tests/common/include/tests/common/masks_rectangle2.inl
@@ -26,7 +26,7 @@ TEST(mask, rectangle2)
     scalar hx = 1.;
     scalar hy = 9.3;
 
-    rectangle2<scalar> r2 = {hx, hy};
+    rectangle2<> r2 = {hx, hy};
 
     ASSERT_EQ(r2[0], hx);
     ASSERT_EQ(r2[1], hy);

--- a/tests/common/include/tests/common/masks_ring2.inl
+++ b/tests/common/include/tests/common/masks_ring2.inl
@@ -28,7 +28,7 @@ TEST(mask, ring2)
     point2_c p2_c_edge = {0., 3.5};
     point2_c p2_c_out = {3.5, 3.5};
 
-    ring2<scalar> r2 = {0., 3.5};
+    ring2<> r2 = {0., 3.5};
 
     ASSERT_EQ(r2[0], 0.);
     ASSERT_EQ(r2[1], 3.5);

--- a/tests/common/include/tests/common/masks_single3.inl
+++ b/tests/common/include/tests/common/masks_single3.inl
@@ -25,7 +25,7 @@ TEST(mask, single3_0)
     point3 p3_out = {1.5, -9.8, 8.};
 
     scalar h0 = 1.;
-    single3<scalar, 0> m1_0 = {h0};
+    single3<0> m1_0 = {h0};
 
     ASSERT_EQ(m1_0[0], h0);
 
@@ -47,7 +47,7 @@ TEST(mask, single3_1)
     point3 p3_out = {1.5, -9.8, 8.};
 
     scalar h1 = 9.3;
-    single3<scalar, 1> m1_1 = {h1};
+    single3<1> m1_1 = {h1};
 
     ASSERT_EQ(m1_1[0], h1);
 
@@ -69,7 +69,7 @@ TEST(mask, single3_2)
     point3 p3_out = {1.5, -9.8, 8.};
 
     scalar h2 = 2.;
-    single3<scalar, 2> m1_2 = {h2};
+    single3<2> m1_2 = {h2};
 
     ASSERT_EQ(m1_2[0], h2);
 

--- a/tests/common/include/tests/common/masks_trapezoid2.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2.inl
@@ -26,7 +26,7 @@ TEST(mask, trapezoid2)
     scalar hx_maxy = 3.;
     scalar hy = 2.;
 
-    trapezoid2<scalar> t2 = {hx_miny, hx_maxy, hy};
+    trapezoid2<> t2 = {hx_miny, hx_maxy, hy};
 
     ASSERT_EQ(t2[0], hx_miny);
     ASSERT_EQ(t2[1], hx_maxy);

--- a/tests/common/include/tests/common/masks_unmasked.inl
+++ b/tests/common/include/tests/common/masks_unmasked.inl
@@ -18,7 +18,7 @@ TEST(mask, unmasked)
     using local_type = __plugin::cartesian2;
     local_type::point2 p2 = {0.5, -9.};
 
-    unmasked<scalar> u;
+    unmasked u;
     ASSERT_TRUE(u.is_inside<local_type>(p2) == e_hit);
     ASSERT_TRUE(u.is_inside<local_type>(p2, true) == e_hit);
     ASSERT_TRUE(u.is_inside<local_type>(p2, false) == e_missed);

--- a/tests/common/include/tests/common/test_cylinder_intersection.inl
+++ b/tests/common/include/tests/common/test_cylinder_intersection.inl
@@ -33,7 +33,7 @@ TEST(__plugin, translated_cylinder)
 {
     // Create a translated cylinder and test untersection
     transform3 shifted(vector3{3., 2., 10.});
-    cylinder3<scalar> cylinder = {4., -10., 10.};
+    cylinder3<> cylinder = {4., -10., 10.};
     cylinder_intersector ci;
 
     // Unbound local frame test
@@ -66,7 +66,7 @@ TEST(__plugin, concentric_cylinders)
     scalar r = 4.;
     scalar hz = 10.;
     transform3 identity(vector3{0., 0., 0.});
-    cylinder3<scalar,false> cylinder = {r, -hz, hz};
+    cylinder3<false> cylinder = {r, -hz, hz};
     cylinder_intersector ci;
     concentric_cylinder_intersector cci;
 

--- a/tests/common/include/tests/common/test_planar_intersection.inl
+++ b/tests/common/include/tests/common/test_planar_intersection.inl
@@ -57,7 +57,7 @@ TEST(__plugin, translated_plane)
     ASSERT_NEAR(hit_bound.point2.value()[1], -1., epsilon);
 
     // The same test but bound to local frame & masked - inside
-    rectangle2<scalar> rect_for_inside = {3., 3.};
+    rectangle2<> rect_for_inside = {3., 3.};
     auto hit_bound_inside = pi.intersect(shifted, point3{2., 1., 0.}, vector3{0., 0., 1.}, cartesian2, rect_for_inside);
     ASSERT_TRUE(hit_bound_inside.status == intersection_status::e_inside);
     // Global intersection information - unchanged
@@ -69,7 +69,7 @@ TEST(__plugin, translated_plane)
     ASSERT_NEAR(hit_bound_inside.point2.value()[1], -1., epsilon);
 
     // The same test but bound to local frame & masked - outside
-    rectangle2<scalar> rect_for_outside = {0.5, 3.5};
+    rectangle2<> rect_for_outside = {0.5, 3.5};
     auto hit_bound_outside = pi.intersect(shifted, point3{2., 1., 0.}, vector3{0., 0., 1.}, cartesian2, rect_for_outside);
     ASSERT_TRUE(hit_bound_outside.status == intersection_status::e_outside);
     // Global intersection information - unchanged

--- a/tests/common/include/tests/common/test_single_layer_components.inl
+++ b/tests/common/include/tests/common/test_single_layer_components.inl
@@ -188,7 +188,7 @@ TEST(__plugin, barrel_object_finding)
     std::uniform_real_distribution<scalar> dist_theta(0.1, M_PI - 0.1);
 
     transform3 identity(vector3{0., 0., 0.});
-    cylinder3<scalar, false> cylinder = {vr_inner, -vz_half, vz_half};
+    cylinder3<false> cylinder = {vr_inner, -vz_half, vz_half};
 
     // Cylindrical and Cartesian local frames
     __plugin::cylindrical2 cylindrical2;
@@ -199,7 +199,7 @@ TEST(__plugin, barrel_object_finding)
     // Check if the finders make sense
     auto inner_finder = barrel_finders[0];
 
-    rectangle2<scalar> rect = {barrel_module[0], barrel_module[1]};
+    rectangle2<> rect = {barrel_module[0], barrel_module[1]};
 
     // Cross check
     unsigned int hit_modules_found = 0;
@@ -415,7 +415,7 @@ TEST(__plugin, endcap_object_finding)
     std::uniform_real_distribution<scalar> dist_theta(min_theta, max_theta);
 
     transform3 shift(vector3{0., 0., volume_min_z});
-    ring2<scalar> disc = {volume_inner_r, volume_outer_r};
+    ring2<> disc = {volume_inner_r, volume_outer_r};
 
     // Cylindrical and Cartesian local frames
     __plugin::cylindrical2 cylindrical2;
@@ -427,7 +427,7 @@ TEST(__plugin, endcap_object_finding)
     // Check if the finders make sense
     auto nec_finder = endcap_finders[2];
 
-    trapezoid2<scalar> trap = {endcap_module[0], endcap_module[1], endcap_module[2]};
+    trapezoid2<> trap = {endcap_module[0], endcap_module[1], endcap_module[2]};
 
     // Cross check
     unsigned int hit_modules_found = 0;

--- a/tests/io/include/tests/io/read_csv.hpp
+++ b/tests/io/include/tests/io/read_csv.hpp
@@ -24,8 +24,8 @@
 namespace detray
 {
 
-    using rectangles = dvector<rectangle2<scalar>>;
-    using trapezoids = dvector<trapezoid2<scalar>>;
+    using rectangles = dvector<rectangle2<>>;
+    using trapezoids = dvector<trapezoid2<>>;
 
     template <typename surface_type>
     struct csv_layer


### PR DESCRIPTION
This PR removes the unneccary `template <typename scalar_type, ..>` in favour of the `scalar` shorthand in masks.

Less template, more happy.