### PR TITLE
feat: add singe and range enumerator

### DIFF
--- a/core/include/utils/enumerate.hpp
+++ b/core/include/utils/enumerate.hpp
@@ -6,16 +6,21 @@
  */
 #pragma once
 
+#include "utils/indexing.hpp"
+#include "utils/containers.hpp"
+
 #include <tuple>
 
 namespace detray
 {
 
     /** Helper utility to allow indexed enumeration with structured binding
+     * 
      * Usage:
      * 
-     * auto [ i, value ] = enumerate(container);
+     * for (auto [ i, value ] = enumerate(container) ) { ... };
      * 
+     * with 'container' any stl-like container
      */
     template <typename container_type,
               typename container_type_iter = decltype(std::begin(std::declval<container_type>())),
@@ -26,7 +31,7 @@ namespace detray
         {
             size_t i;
             container_type_iter iter;
-            
+
             bool operator!=(const iterator &rhs) const { return iter != rhs.iter; }
 
             /** Increase index and iterator at once */
@@ -46,6 +51,81 @@ namespace detray
             auto end() { return iterator{0, std::end(iterable)}; }
         };
         return iterable_wrapper{std::forward<container_type>(iterable)};
+    }
+
+    /** Helper method to (fake a) run over a single entry
+     * 
+     * Usage:
+     * for (auto i : sequence(j)) {}
+     * 
+     * with j an unsinged dindex type
+     * 
+     * @note sequence(2) will produce {2}
+     * 
+     **/
+    constexpr auto sequence(dindex iterable)
+    {
+
+        struct iterator
+        {
+            size_t i;
+
+            bool operator!=(const iterator &rhs) const { return i != rhs.i; }
+
+            /** Increase index and iterator at once */
+            void operator++()
+            {
+                ++i;
+            }
+
+            /** Tie them together for returning */
+            auto operator*() const { return i; }
+        };
+        struct iterable_wrapper
+        {
+            dindex iterable;
+            auto begin() { return iterator{iterable}; }
+            auto end() { return iterator{iterable + 1}; }
+        };
+        return iterable_wrapper{std::forward<dindex>(iterable)};
+    }
+
+    /** Helper method to run over a range 
+     * 
+     * Usage:
+     * for (auto i : sequence(r)) {}
+     * 
+     * with r an range that can be accessed with r[0] and r[1]
+     * 
+     * @note sequence({2,4}) will produce { 2, 3, 4 }
+=     * 
+     **/
+    constexpr auto sequence(darray<dindex, 2> iterable)
+    {
+
+        struct iterator
+        {
+            size_t i;
+            size_t end;
+
+            bool operator!=(const iterator &rhs) const { return i != rhs.end; }
+
+            /** Increase index and iterator at once */
+            void operator++()
+            {
+                ++i;
+            }
+
+            /** Tie them together for returning */
+            auto operator*() const { return i; }
+        };
+        struct iterable_wrapper
+        {
+            darray<dindex, 2> iterable;
+            auto begin() { return iterator{iterable[0], iterable[1]}; }
+            auto end() { return iterator{iterable[1] + 1, iterable[1] + 1}; }
+        };
+        return iterable_wrapper{std::forward<darray<dindex, 2> >(iterable)};
     }
 
 } // namespace detray

--- a/tests/unit_tests/core/utils_enumerate.cpp
+++ b/tests/unit_tests/core/utils_enumerate.cpp
@@ -5,6 +5,7 @@
  * Mozilla Public License Version 2.0
  */
 
+#include "utils/indexing.hpp"
 #include "utils/containers.hpp"
 #include "utils/enumerate.hpp"
 #include "tests/common/test_defs.hpp"
@@ -14,8 +15,35 @@
 
 using namespace detray;
 
+// This tests the convenience range_enumeration function: single
+TEST(utils, sequence_single)
+{
+
+    dindex check = 0;
+    dindex single = 7;
+    for (auto i : sequence(single)){
+        check += i;
+    }
+    ASSERT_EQ(check, single);
+
+}
+
+// This tests the convenience range_enumeration function: range
+TEST(utils, sequence_range)
+{
+
+    darray<dindex, 2> range = {2,7};
+    std::vector<dindex> reference = {2, 3, 4, 5, 6, 7};
+    std::vector<dindex> check = {};
+    for (auto i : sequence(range)){
+        check.push_back(i);
+    }
+    ASSERT_EQ(check, reference);
+
+}
+
 // This tests the convenience enumeration function
-TEST(utils, enumerate_function)
+TEST(utils, enumerate)
 {
 
     struct uint_holder {


### PR DESCRIPTION
Convenience function for single and range enumerator, allows to write common intersection kernel for detector and portal surfaces.