### PR TITLE
feat: add default local-type to masks

### DIFF
--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -109,13 +109,13 @@ namespace detray
          **/
         using portal_links = darray<dindex, 4>;
 
-        using portal_rectangle_mask = rectangle2<planar_intersector, portal_links>;
+        using portal_rectangle_mask = rectangle2<planar_intersector, __plugin::cartesian2 ,portal_links>;
         using portal_rectangles = dvector<portal_rectangle_mask>;
-        using protal_trapezoid_mask = trapezoid2<planar_intersector, portal_links>;
+        using protal_trapezoid_mask = trapezoid2<planar_intersector, __plugin::cartesian2, portal_links>;
         using portal_trapezoids = dvector<protal_trapezoid_mask>;
-        using portal_cylinder_mask = cylinder3<false, concentric_cylinder_intersector, portal_links>;
+        using portal_cylinder_mask = cylinder3<false, concentric_cylinder_intersector, __plugin::cylindrical2,  portal_links>;
         using portal_cylinders = dvector<portal_cylinder_mask>;
-        using portal_disc_mask = ring2<planar_intersector, portal_links>;
+        using portal_disc_mask = ring2<planar_intersector, __plugin::cartesian2, portal_links>;
         using portal_discs = dvector<portal_disc_mask>;
         using portal_type_map = dmap<dindex, dindex>;
         using portal_surface = surface<dindex, typed_dindex_range, dindex>;

--- a/core/include/core/proto_detector.hpp
+++ b/core/include/core/proto_detector.hpp
@@ -44,8 +44,8 @@ namespace detray
         /// - links:  opposite volume, along volume, opposite object finder, along volume finder
         using portal_links = darray<dindex, 4>;
         /// - masks, with mask identifiers 0, 1
-        using portal_cylinder = cylinder3<false, concentric_cylinder_intersector, portal_links, 0>;
-        using portal_disc = ring2<planar_intersector, portal_links, 1>;
+        using portal_cylinder = cylinder3<false, concentric_cylinder_intersector, __plugin::cylindrical2, portal_links, 0>;
+        using portal_disc = ring2<planar_intersector, __plugin::cartesian2, portal_links, 1>;
         // - mask index: type, first/last
         using portal_mask_index = darray<dindex, 3>;
         using portal_masks = dtuple<dvector<portal_cylinder>, dvector<portal_disc> >;
@@ -59,9 +59,9 @@ namespace detray
 
         /// Surface components:
         /// - masks, with mask identifiers 0,1,2
-        using surface_rectangle = rectangle2<planar_intersector, bounds_source_link, 0>;
-        using surface_trapezoid = trapezoid2<planar_intersector, bounds_source_link, 1>;
-        using surface_annulus = annulus2<planar_intersector, bounds_source_link, 2>;
+        using surface_rectangle = rectangle2<planar_intersector, __plugin::cartesian2, bounds_source_link, 0>;
+        using surface_trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, bounds_source_link, 1>;
+        using surface_annulus = annulus2<planar_intersector, __plugin::cartesian2, bounds_source_link, 2>;
         /// - mask index: type, entry
         using surface_mask_index = darray<dindex, 2>;
         using surface_masks = dtuple<dvector<surface_rectangle>, dvector<surface_trapezoid>, dvector<surface_annulus> >;

--- a/core/include/masks/cylinder3.hpp
+++ b/core/include/masks/cylinder3.hpp
@@ -33,6 +33,7 @@ namespace detray
      **/
     template <bool kRadialCheck = true,
               typename intersector_type = detray::cylinder_intersector,
+              typename local_type = __plugin::cylindrical2,
               typename links_type = bool,
               unsigned int kMaskContext = e_cylinder3>
     struct cylinder3
@@ -49,6 +50,8 @@ namespace detray
 
         links_type _links;
 
+        local_type _local;
+
         static constexpr unsigned int mask_context = kMaskContext;
 
         static constexpr unsigned int mask_identifier = e_cylinder3;
@@ -60,7 +63,7 @@ namespace detray
          * 
          * @param rhs is the right hand side object
          **/
-        cylinder3<kRadialCheck, intersector_type, links_type, kMaskContext> &
+        cylinder3<kRadialCheck, intersector_type, local_type, links_type, kMaskContext> &
         operator=(const darray<scalar, 3> &rhs)
         {
             _values = rhs;
@@ -69,7 +72,7 @@ namespace detray
 
         /** Mask operation 
          * 
-         * @tparam point3_type is the type of the point to be checked w.r.t. to
+         * @tparam inside_local_type::point3 is the deduced type of the point to be checked w.r.t. to
          * the mask bounds, it's assumed to be within the cylinder 3D frame
          * 
          * @param p the point to be checked
@@ -77,8 +80,8 @@ namespace detray
          * 
          * @return an intersection status e_inside / e_outside
          **/
-        template <typename local_type>
-        intersection_status is_inside(const typename local_type::point3 &p,
+        template <typename inside_local_type>
+        intersection_status is_inside(const typename inside_local_type::point3 &p,
                                       const mask_tolerance &t = within_epsilon) const
         {
             if (kRadialCheck)
@@ -134,7 +137,10 @@ namespace detray
         intersector_type intersector() const { return intersector_type{}; };
 
         /** Return the values */
-        const mask_values& values() const { return _values; }
+        const mask_values &values() const { return _values; }
+
+        /** Return the local frame type - const access*/
+        const local_type &local() const { return _local; }
 
         /** Return the volume link - const reference */
         const links_type &links() const { return _links; }

--- a/core/include/masks/rectangle2.hpp
+++ b/core/include/masks/rectangle2.hpp
@@ -20,6 +20,7 @@ namespace detray
     /** This is a simple 2-dimensional mask for a regular rectangle
      * 
      * @tparam intersector_type is a struct used for intersecting this cylinder
+     * @tparam local_type is the default local frame definition type
      * @tparam links_type is an object where the mask can link to 
      * @tparam kMaskContext is a unique mask identifier in a certain context
      * 
@@ -32,6 +33,7 @@ namespace detray
      *  
      **/
     template <typename intersector_type = planar_intersector,
+              typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_rectangle2>
     struct rectangle2
@@ -46,18 +48,20 @@ namespace detray
 
         links_type _links;
 
+        local_type _local;
+
         static constexpr unsigned int mask_context = kMaskContext;
 
         static constexpr unsigned int mask_indentifier = e_rectangle2;
 
         static constexpr mask_tolerance within_epsilon = {std::numeric_limits<scalar>::epsilon(),
-                                                           std::numeric_limits<scalar>::epsilon()};
+                                                          std::numeric_limits<scalar>::epsilon()};
 
         /** Assignment operator from an array, convenience function
          * 
          * @param rhs is the right hand side object
          **/
-        rectangle2<intersector_type, links_type, kMaskContext> &
+        rectangle2<intersector_type, local_type, links_type, kMaskContext> &
         operator=(const darray<scalar, 2> &rhs)
         {
             _values = rhs;
@@ -66,16 +70,16 @@ namespace detray
 
         /** Mask operation 
          * 
-         * @tparam point2_type is the type of the point to be checked w.r.t. to
-         * the mask bounds
+         * @tparam inside_local_type::point2 is the deduced type of the point to be checked 
+         * w.r.t. to the mask bounds
          * 
          * @param p the point to be checked
          * @param t is the tolerance tuple in (l0, l1)
          * 
          * @return an intersection status e_inside / e_outside
          **/
-        template <typename local_type>
-        intersection_status is_inside(const typename local_type::point2 &p,
+        template <typename inside_local_type>
+        intersection_status is_inside(const typename inside_local_type::point2 &p,
                                       const mask_tolerance &t = within_epsilon) const
         {
             return (std::abs(p[0]) <= _values[0] + t[0] and std::abs(p[1]) <= _values[1] + t[1]) ? e_inside : e_outside;
@@ -120,10 +124,13 @@ namespace detray
         }
 
         /** Return the values */
-        const mask_values& values() const { return _values; }
+        const mask_values &values() const { return _values; }
 
         /** Return an associated intersector type */
         intersector_type intersector() const { return intersector_type{}; };
+
+        /** Return the local frame type - const access*/
+        const local_type &local() const { return _local; }
 
         /** Return the volume link - const reference */
         const links_type &links() const { return _links; }

--- a/core/include/masks/single3.hpp
+++ b/core/include/masks/single3.hpp
@@ -20,6 +20,7 @@ namespace detray
      * 
      * @tparam kCheckIndex is the index of the position on which the mask is applied
      * @tparam intersector_type is a struct used for intersecting this cylinder
+     * @tparam local_type is the default local frame definition type
      * @tparam links_type is an object where the mask can link to 
      * @tparam kMaskContext is a unique mask identifier in a certain context
      * 
@@ -30,6 +31,7 @@ namespace detray
      **/
     template <unsigned int kCheckIndex,
               typename intersector_type = planar_intersector,
+              typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_single3>
     struct single3
@@ -44,6 +46,8 @@ namespace detray
 
         links_type _links;
 
+        local_type _local;
+
         static constexpr unsigned int mask_context = kMaskContext;
 
         static constexpr unsigned int mask_identifier = e_single3;
@@ -54,7 +58,7 @@ namespace detray
          * 
          * @param rhs is the right hand side object
          **/
-        single3<kCheckIndex, intersector_type, links_type, kMaskContext> &
+        single3<kCheckIndex, intersector_type, local_type, links_type, kMaskContext> &
         operator=(const darray<scalar, 1> &rhs)
         {
             _values = rhs;
@@ -63,16 +67,16 @@ namespace detray
 
         /** Mask operation 
          * 
-         * @tparam point3_type is the type of the point to be checked w.r.t. to
-         * the mask bounds
+         * @tparam inside_local_type::point3 is the deduced type of the point to be checked 
+         * w.r.t. to the mask bounds
          * 
          * @param p the point to be checked
          * @param t is the tolerance of the single parameter
          * 
          * @return an intersection status e_inside / e_outside
          **/
-        template <typename local_type>
-        intersection_status is_inside(const typename local_type::point3 &p,
+        template <typename inside_local_type>
+        intersection_status is_inside(const typename inside_local_type::point3 &p,
                                       const mask_tolerance &t = within_epsilon) const
         {
             return (std::abs(p[kCheckIndex]) <= _values[0] + t) ? e_inside : e_outside;
@@ -118,7 +122,10 @@ namespace detray
         intersector_type intersector() const { return intersector_type{}; };
 
         /** Return the values */
-        const mask_values& values() const { return _values; }
+        const mask_values &values() const { return _values; }
+
+        /** Return the local frame type - const access*/
+        const local_type &local() const { return _local; }
 
         /** Return the volume link - const reference */
         const links_type &links() const { return _links; }

--- a/core/include/masks/trapezoid2.hpp
+++ b/core/include/masks/trapezoid2.hpp
@@ -19,6 +19,7 @@ namespace detray
     /** This is a simple 2-dimensional mask for a regular trapezoid
      * 
      * @tparam intersector_type is a struct used for intersecting this cylinder
+     * @tparam local_type is the default local frame definition type
      * @tparam links_type is an object where the mask can link to 
      * @tparam kMaskContext is a unique mask identifier in a certain context
      *  
@@ -31,6 +32,7 @@ namespace detray
      *  
      **/
     template <typename intersector_type = planar_intersector,
+              typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_trapezoid2>
     struct trapezoid2
@@ -46,19 +48,20 @@ namespace detray
 
         links_type _links;
 
+        local_type _local;
+
         static constexpr unsigned int mask_context = kMaskContext;
 
         static constexpr unsigned int mask_identifier = e_trapezoid2;
 
-        static constexpr mask_tolerance within_epsilon 
-            = { std::numeric_limits<scalar>::epsilon(), 
-                std::numeric_limits<scalar>::epsilon() };
+        static constexpr mask_tolerance within_epsilon = {std::numeric_limits<scalar>::epsilon(),
+                                                          std::numeric_limits<scalar>::epsilon()};
 
         /** Assignment operator from an array, convenience function
          * 
          * @param rhs is the right hand side object
          **/
-        trapezoid2<intersector_type, links_type, kMaskContext> &
+        trapezoid2<intersector_type, local_type, links_type, kMaskContext> &
         operator=(const darray<scalar, 3> &rhs)
         {
             _values = rhs;
@@ -67,22 +70,20 @@ namespace detray
 
         /** Mask operation 
          * 
-         * @tparam point2_type is the type of the point to be checked w.r.t. to
-         * the mask bounds
+         * @tparam point2_type is the deduced type of the point to be checked 
+         * w.r.t. to the mask bounds
          * 
          * @param p the point to be checked
          * @param t us the tolerance tuple (l0,l1)
          * 
          * @return an intersection status e_inside / e_outside
          **/
-        template <typename local_type>
-        intersection_status is_inside(const typename local_type::point2 &p,
-                                      const mask_tolerance& t = within_epsilon) const
+        template <typename inside_local_type>
+        intersection_status is_inside(const typename inside_local_type::point2 &p,
+                                      const mask_tolerance &t = within_epsilon) const
         {
             scalar rel_y = (_values[2] + p[1]) / (2 * _values[2]);
-            return 
-                (std::abs(p[0]) <= _values[0] + rel_y * (_values[1] - _values[0]) + t[0] and std::abs(p[1]) <= _values[2] + t[1]) ? 
-                    e_inside : e_outside;
+            return (std::abs(p[0]) <= _values[0] + rel_y * (_values[1] - _values[0]) + t[0] and std::abs(p[1]) <= _values[2] + t[1]) ? e_inside : e_outside;
         }
 
         /** Equality operator from an array, convenience function
@@ -127,14 +128,16 @@ namespace detray
         intersector_type intersector() const { return intersector_type{}; };
 
         /** Return the values */
-        const mask_values& values() const  { return _values; }
+        const mask_values &values() const { return _values; }
+
+        /** Return the local frame type - const access*/
+        const local_type &local() const { return _local; }
 
         /** Return the volume link - const reference */
         const links_type &links() const { return _links; }
 
         /** Return the volume link - non-const access */
         links_type &links() { return _links; }
-
     };
 
 } // namespace detray


### PR DESCRIPTION
Masks do have their intrinsic local frame definition, hence this could be just handed by the make, will make the intersection kernel easier to program.