### PR TITLE
feat: add intersection kernel

### DIFF
--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -56,7 +56,7 @@ namespace detray
         using point2 = __plugin::cartesian2::point2;
         using transform3 = transform_type;
 
-        using surface_intersection = intersection<scalar, point3, point2>;
+        using surface_intersection = intersection<point3, point2>;
 
         // Indexing
         using typed_dindex = darray<dindex, 2>;

--- a/core/include/core/intersection.hpp
+++ b/core/include/core/intersection.hpp
@@ -34,19 +34,18 @@ namespace detray
 
     /** This templated class holds the intersection information
      * 
-     * @tparam scalar_type is the type of the used scalar for intersecting
      * @tparam point3_type is the type of global intsersection vector
      * @tparam point2_type is the type of the local intersection vector
      * 
      **/
-    template <typename scalar_type, typename point3_type, typename point2_type>
+    template <typename point3_type, typename point2_type>
     struct intersection
     {
 
-        scalar_type path = std::numeric_limits<scalar_type>::infinity();
-        point3_type point3 = point3_type{std::numeric_limits<scalar_type>::infinity(),
-                                         std::numeric_limits<scalar_type>::infinity(),
-                                         std::numeric_limits<scalar_type>::infinity()};
+        scalar path = std::numeric_limits<scalar>::infinity();
+        point3_type point3 = point3_type{std::numeric_limits<scalar>::infinity(),
+                                         std::numeric_limits<scalar>::infinity(),
+                                         std::numeric_limits<scalar>::infinity()};
 
         std::optional<point2_type> point2 = std::nullopt;
         intersection_status status = e_missed;
@@ -56,7 +55,7 @@ namespace detray
         /** @param rhs is the right hand side intersection for comparison 
          **/
         bool operator<(
-            const intersection<scalar_type, point3_type, point2_type> &rhs) const
+            const intersection<point3_type, point2_type> &rhs) const
         {
             return (path < rhs.path);
         }
@@ -64,7 +63,7 @@ namespace detray
         /** @param rhs is the left hand side intersection for comparison 
          **/
         bool operator>(
-            const intersection<scalar_type, point3_type, point2_type> &rhs) const
+            const intersection<point3_type, point2_type> &rhs) const
         {
             return (path > rhs.path);
         }

--- a/core/include/masks/annulus2.hpp
+++ b/core/include/masks/annulus2.hpp
@@ -52,14 +52,14 @@ namespace detray
 
         using mask_values = darray<scalar, 7>;
 
+        using mask_links_type = links_type;
+
         mask_values _values = {0., std::numeric_limits<scalar>::infinity(),
                                -std::numeric_limits<scalar>::infinity(),
                                std::numeric_limits<scalar>::infinity(),
                                0., 0., 0.};
 
         links_type _links;
-
-        local_type _local;
 
         static constexpr unsigned int mask_context = kMaskContext;
 
@@ -183,8 +183,8 @@ namespace detray
         /** Return the values */
         const mask_values& values() const { return _values; }
 
-        /** Return the local frame type - const access*/
-        const local_type& local() const { return _local; }
+        /** Return the local frame type */
+        local_type local() const { return local_type{}; }
 
         /** Return the volume link - const reference */
         const links_type &links() const { return _links; }

--- a/core/include/masks/cylinder3.hpp
+++ b/core/include/masks/cylinder3.hpp
@@ -43,14 +43,14 @@ namespace detray
 
         using mask_values = darray<scalar, 3>;
 
+        using mask_links_type = links_type;
+
         mask_values _values =
             {std::numeric_limits<scalar>::infinity(),
              -std::numeric_limits<scalar>::infinity(),
              std::numeric_limits<scalar>::infinity()};
 
         links_type _links;
-
-        local_type _local;
 
         static constexpr unsigned int mask_context = kMaskContext;
 
@@ -139,8 +139,8 @@ namespace detray
         /** Return the values */
         const mask_values &values() const { return _values; }
 
-        /** Return the local frame type - const access*/
-        const local_type &local() const { return _local; }
+        /** Return the local frame type */
+        local_type local() const { return local_type{}; }
 
         /** Return the volume link - const reference */
         const links_type &links() const { return _links; }

--- a/core/include/masks/rectangle2.hpp
+++ b/core/include/masks/rectangle2.hpp
@@ -42,13 +42,13 @@ namespace detray
 
         using mask_values = darray<scalar, 2>;
 
+        using mask_links_type = links_type;
+
         mask_values _values =
             {std::numeric_limits<scalar>::infinity(),
              std::numeric_limits<scalar>::infinity()};
 
         links_type _links;
-
-        local_type _local;
 
         static constexpr unsigned int mask_context = kMaskContext;
 
@@ -129,8 +129,8 @@ namespace detray
         /** Return an associated intersector type */
         intersector_type intersector() const { return intersector_type{}; };
 
-        /** Return the local frame type - const access*/
-        const local_type &local() const { return _local; }
+        /** Return the local frame type */
+        local_type local() const { return local_type{}; }
 
         /** Return the volume link - const reference */
         const links_type &links() const { return _links; }

--- a/core/include/masks/ring2.hpp
+++ b/core/include/masks/ring2.hpp
@@ -41,11 +41,11 @@ namespace detray
 
         using mask_values = darray<scalar, 2>;
 
+        using mask_links_type = links_type;
+
         mask_values _values = {0., std::numeric_limits<scalar>::infinity()};
 
         links_type _links;
-
-        local_type _local;
 
         static constexpr unsigned int mask_context = kMaskContext;
 
@@ -131,8 +131,8 @@ namespace detray
         /** Return the values */
         const mask_values &values() const { return _values; }
 
-        /** Return the local frame type - const access*/
-        const local_type &local() const { return _local; }
+        /** Return the local frame type */
+        local_type local() const { return local_type{}; }
 
         /** Return the volume link - const reference */
         const links_type &links() const { return _links; }

--- a/core/include/masks/single3.hpp
+++ b/core/include/masks/single3.hpp
@@ -41,12 +41,12 @@ namespace detray
 
         using mask_values = darray<scalar, 1>;
 
+        using mask_links_type = links_type;
+
         mask_values _values =
             {std::numeric_limits<scalar>::infinity()};
 
         links_type _links;
-
-        local_type _local;
 
         static constexpr unsigned int mask_context = kMaskContext;
 
@@ -124,8 +124,8 @@ namespace detray
         /** Return the values */
         const mask_values &values() const { return _values; }
 
-        /** Return the local frame type - const access*/
-        const local_type &local() const { return _local; }
+        /** Return the local frame type */
+        local_type local() const { return local_type{}; }
 
         /** Return the volume link - const reference */
         const links_type &links() const { return _links; }

--- a/core/include/masks/trapezoid2.hpp
+++ b/core/include/masks/trapezoid2.hpp
@@ -41,14 +41,14 @@ namespace detray
 
         using mask_values = darray<scalar, 3>;
 
+        using mask_links_type = links_type;
+
         mask_values _values =
             {std::numeric_limits<scalar>::infinity(),
              std::numeric_limits<scalar>::infinity(),
              std::numeric_limits<scalar>::infinity()};
 
         links_type _links;
-
-        local_type _local;
 
         static constexpr unsigned int mask_context = kMaskContext;
 
@@ -130,8 +130,8 @@ namespace detray
         /** Return the values */
         const mask_values &values() const { return _values; }
 
-        /** Return the local frame type - const access*/
-        const local_type &local() const { return _local; }
+        /** Return the local frame type */
+        local_type local() const { return local_type{}; }
 
         /** Return the volume link - const reference */
         const links_type &links() const { return _links; }

--- a/core/include/tools/concentric_cylinder_intersector.hpp
+++ b/core/include/tools/concentric_cylinder_intersector.hpp
@@ -26,6 +26,7 @@ namespace detray
         /** Intersection method for cylindrical surfaces
          * 
          * @tparam transform_type The transform type of the surface to be intersected
+         * @tparam track_type The type of the track caryying also the context object
          * @tparam local_type The local frame type to be intersected
          * @tparam mask_type The mask type applied to the local frame
          * 
@@ -40,10 +41,10 @@ namespace detray
          * 
          * @return the intersection with optional parameters
          **/
-        template <typename transform_type, typename local_type, typename mask_type>
-        intersection<scalar, typename transform_type::point3, typename local_type::point2>
+        template <typename transform_type, typename track_type, typename local_type, typename mask_type>
+        intersection<typename transform_type::point3, typename local_type::point2>
         intersect(const transform_type &trf,
-                  const track<transform_type> &track,
+                  const track_type &track,
                   const local_type &local,
                   const mask_type &mask,
                   const typename mask_type::mask_tolerance &tolerance = mask_type::within_epsilon) const
@@ -71,7 +72,7 @@ namespace detray
          * @return the intersection with optional parameters
          **/
         template <typename transform_type, typename local_type, typename mask_type>
-        intersection<scalar, typename transform_type::point3, typename local_type::point2>
+        intersection<typename transform_type::point3, typename local_type::point2>
         intersect(const transform_type & /*trf*/,
                   const typename transform_type::point3 &ro,
                   const typename transform_type::vector3 &rd,
@@ -80,7 +81,7 @@ namespace detray
                   const typename mask_type::mask_tolerance &tolerance = mask_type::within_epsilon,
                   scalar overstep_tolerance = 0.) const
         {
-            using intersection = intersection<scalar, typename transform_type::point3, typename local_type::point2>;
+            using intersection = intersection<typename transform_type::point3, typename local_type::point2>;
 
             scalar r = mask[0];
 

--- a/core/include/tools/cylinder_intersector.hpp
+++ b/core/include/tools/cylinder_intersector.hpp
@@ -27,6 +27,7 @@ namespace detray
         /** Intersection method for cylindrical surfaces
          * 
          * @tparam transform_type The surface transform type to be intersected
+         * @tparam track_type The type of the track carrying the context object
          * @tparam local_type The local frame type to be intersected
          * @tparam mask_type The mask type applied to the local frame
          * 
@@ -41,8 +42,8 @@ namespace detray
          * 
          * @return the intersection with optional parameters
          **/
-        template <typename transform_type, typename local_type, typename mask_type>
-        intersection<scalar, typename transform_type::transform3::point3, typename local_type::point2>
+        template <typename transform_type, typename track_type, typename local_type, typename mask_type>
+        intersection<typename transform_type::transform3::point3, typename local_type::point2>
         intersect(const transform_type &trf,
                   const track<transform_type> &track,
                   const local_type &local,
@@ -72,7 +73,7 @@ namespace detray
          * @return the intersection with optional parameters
          **/
         template <typename transform_type, typename local_type, typename mask_type>
-        intersection<scalar, typename transform_type::point3, typename local_type::point2>
+        intersection<typename transform_type::point3, typename local_type::point2>
         intersect(const transform_type &trf,
                   const typename transform_type::point3 &ro,
                   const typename transform_type::vector3 &rd,
@@ -81,7 +82,7 @@ namespace detray
                   const typename mask_type::mask_tolerance &tolerance = mask_type::within_epsilon,
                   scalar overstep_tolerance = 0.) const
         {
-            using intersection = intersection<scalar, typename transform_type::point3, typename local_type::point2>;
+            using intersection = intersection<typename transform_type::point3, typename local_type::point2>;
 
             scalar r = mask[0];
 

--- a/core/include/tools/intersection_kernel.hpp
+++ b/core/include/tools/intersection_kernel.hpp
@@ -1,0 +1,213 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2021 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "core/track.hpp"
+#include "core/intersection.hpp"
+#include "utils/indexing.hpp"
+#include "utils/enumerate.hpp"
+
+#include <utility>
+#include <tuple>
+#include <iostream>
+
+namespace detray
+{
+
+    /// Transform definition
+    using transform3 = __plugin::transform3;
+    using point3 = transform3::point3;
+    using point2 = __plugin::cartesian2::point2;
+
+    /** Specialized method to update an intersection when the mask group is resolved
+     * 
+     * @tparam track_type is the type of the track information including context 
+     * @tparam mask_group is the type of the split out mask group from all masks
+     * @tparam mask_range is the type of the according mask range object
+     * 
+     * @param track is the track information 
+     * @param trf is the surface transform for the intersection
+     * @param masks is the associated (and split out) mask group
+     * @param range is the range list of masks to be processed
+     * 
+     * @note since all masks are on the same surface, only maximally one mask solution at a time
+     * is possbile. Once this solution is found, it is returned
+     * 
+     * @return the surface intersection 
+     **/
+    template <typename track_type,
+              typename mask_group,
+              typename mask_range>
+    auto intersect_by_group(const track_type &track,
+                            const transform3 &trf,
+                            const mask_group &masks,
+                            const mask_range &range)
+    {
+        for (auto i : sequence(range))
+        {
+            const auto &mask = masks[i];
+            auto local = mask.local();
+            auto sfi = mask.intersector().intersect(trf, track, local, mask);
+            if (sfi.status == e_inside)
+            {
+                auto valid_link = mask.links();
+                return std::make_tuple(sfi, valid_link);
+            }
+        }
+        typename mask_group::value_type::mask_links_type invalid_link;
+        intersection<point3, point2> invalid_intersection;
+        return std::make_tuple(invalid_intersection, invalid_link);
+    }
+
+    /** Variadic unrolled intersection - last entry 
+     * 
+     * @tparam intersection_type The type of intersection (to be updated)
+     * @tparam links_type The links type (to be updated)
+     * @tparam track_type is The type of the surface container
+     * @tparam mask_container is the type of the type of the mask container
+     * @tparam mask_range is the mask range type 
+     * @tparam last_mask_context is the last mask group context 
+     * 
+     * @param intersection [in, out] the intersection to be updated
+     * @param link [in, out] the links to be updated
+     * @param tack_type the track information containing the context
+     * @param ctf the contextual transform (context resolved)
+     * @param masks the masks container 
+     * @param range the range within the mask group to be checked
+     * @param mask_context the last mask group context 
+     *
+     * @return a bool for break condition (ignored here as last)
+     */
+    template <typename intersection_type,
+              typename links_type,
+              typename track_type,
+              typename mask_container,
+              typename mask_range,
+              dindex last_mask_context>
+    bool last_intersect(intersection_type &intersection,
+                        links_type &links,
+                        const track_type &track,
+                        const transform3 &ctf,
+                        const mask_container &masks,
+                        const mask_range &range,
+                        dindex mask_context)
+    {
+        if (mask_context == last_mask_context)
+        {
+            auto isg = intersect_by_group(track, ctf, std::get<last_mask_context>(masks), range);
+            intersection = std::get<0>(isg);
+            links = std::get<1>(isg);
+            return true;
+        }
+        return false;
+    }
+
+    /** Variadic unrolled intersection - any integer sequence
+     * 
+     * @tparam intersection_type The type of intersection (to be updated)
+     * @tparam links_type The links type (to be updated)
+     * @tparam track_type is The type of the surface container
+     * @tparam mask_container is the type of the type of the mask container
+     * @tparam mask_range is the mask range type 
+     * @tparam first_mask_context is the first mask group context 
+     * 
+     * @param intersection [in, out] the intersection to be updated
+     * @param link [in, out] the links to be updated
+     * @param tack_type the track information containing the context
+     * @param ctf the contextual transform (context resolved)
+     * @param masks the masks container 
+     * @param range the range within the mask group to be checked
+     * @param mask_context the last mask group context 
+     * @param available_contices the mask contices to be checked
+     *
+     * @return a bool for break condition 
+     */
+    template <typename intersection_type,
+              typename links_type,
+              typename track_type,
+              typename mask_container,
+              typename mask_range,
+              dindex first_mask_context,
+              dindex... remaining_mask_context>
+    bool unroll_intersect(intersection_type &intersection,
+                          links_type &links,
+                          const track_type &track,
+                          const transform3 &ctf,
+                          const mask_container &masks,
+                          const mask_range &range,
+                          dindex mask_context,
+                          std::integer_sequence<dindex, first_mask_context, remaining_mask_context...> available_contices)
+    {
+        // Pick the first one for interseciton
+        if (mask_context == first_mask_context)
+        {
+            auto isg = intersect_by_group(track, ctf, std::get<first_mask_context>(masks), range);
+            intersection = std::get<0>(isg);
+            links = std::get<1>(isg);
+            return true;
+        }
+        // The reduced integer sequence
+        std::integer_sequence<dindex, remaining_mask_context...> remaining;
+        // Unroll as long as you have at least 2 entries
+        if constexpr (remaining.size() > 1)
+        {
+            if (unroll_intersect(intersection, links, track, ctf, masks, range, mask_context, remaining))
+            {
+                return true;
+            }
+        }
+        // Last chance - intersect the last index if possible
+        return last_intersect<intersection_type,
+                              links_type,
+                              track_type,
+                              mask_container,
+                              mask_range,
+                              std::tuple_size_v<mask_container> - 1>(intersection, links, track, ctf, masks, range, mask_context);
+    }
+
+    /** Actual kernel method that updates the updates the intersections
+     * 
+     * @tparam surface_type is The type of the surface container
+     * @tparam transform_container is the type of the transform container
+     * @tparam mask_container is the type of the type of the mask container
+     *
+     * @param track the track information including the contexts
+     * @param surface the surface type to be intersected
+     * @param contextual_transform the transform container
+     * @param mask_container the tuple mask container to for the intersection
+     * 
+     * @return a boolean indicating if the update was successful
+    **/
+    template <typename surface_type,
+              typename transform_container,
+              typename mask_container>
+    const auto
+    intersect(const track<transform3, typename transform_container::context> &track,
+              const surface_type &surface,
+              const transform_container &contextual_transforms,
+              const mask_container &masks)
+    {
+        // Retrieve the (potentially) contextual transform
+        const auto &ctf = contextual_transforms.contextual_transform(track.ctx, surface.transform());
+        auto mask_link = surface.mask();
+        const auto &mask_context = std::get<0>(mask_link);
+        const auto &mask_range = std::get<1>(mask_link);
+
+        // Create a return intersection and run the variadic unrolling
+        auto reference_group = std::get<0>(masks);
+        typename decltype(reference_group)::value_type::mask_links_type result_links;
+        intersection<point3, point2> result_intersection;
+
+        // Unroll the intersection depending on the mask container size
+        unroll_intersect(result_intersection, result_links, track, ctf, masks, mask_range, mask_context,
+                         std::make_integer_sequence<dindex, std::tuple_size_v<mask_container> >{});
+        // Return the (eventually update) intersection and links
+        return std::make_tuple(result_intersection, result_links);
+    }
+
+}

--- a/core/include/tools/planar_intersector.hpp
+++ b/core/include/tools/planar_intersector.hpp
@@ -27,6 +27,7 @@ namespace detray
         /** Intersection method for planar surfaces
          * 
          * @tparam transform_type The transform type of the surface to be intersected
+         * @tparam track_type The type of the track (which carries the context object)
          * @tparam local_type The local frame type to be intersected
          * @tparam mask_type The mask type applied to the local frame
          * 
@@ -41,10 +42,10 @@ namespace detray
          * 
          * @return the intersection with optional parameters
          **/
-        template <typename transform_type, typename local_type, typename mask_type>
-        intersection<scalar, typename transform_type::point3, typename local_type::point2>
+        template <typename transform_type, typename track_type, typename local_type, typename mask_type>
+        intersection<typename transform_type::point3, typename local_type::point2>
         intersect(const transform_type &trf,
-                  const track<transform_type> &track,
+                  const track_type &track,
                   const local_type &local,
                   const mask_type &mask,
                   const typename mask_type::mask_tolerance &tolerance = mask_type::within_epsilon) const
@@ -71,7 +72,7 @@ namespace detray
          * @return the intersection with optional parameters
          **/
         template <typename transform_type, typename local_type = unbound, typename mask_type = unmasked>
-        intersection<scalar, typename transform_type::point3, typename local_type::point2>
+        intersection<typename transform_type::point3, typename local_type::point2>
         intersect(const transform_type &trf,
                   const typename transform_type::point3 &ro,
                   const typename transform_type::vector3 &rd,
@@ -81,7 +82,7 @@ namespace detray
                   scalar overstep_tolerance = 0.) const
         {
 
-            using intersection = intersection<scalar, typename transform_type::point3, typename local_type::point2>;
+            using intersection = intersection<typename transform_type::point3, typename local_type::point2>;
 
             // Retrieve the surface normal & translation (context resolved)
             const auto &sm = trf.matrix();

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -23,7 +23,7 @@ using surface = surface<transform3>;
 __plugin::cartesian2 cartesian2;
 using point2 = __plugin::cartesian2::point2;
 
-using planar_intersection = intersection<scalar, point3, point2>;
+using planar_intersection = intersection<point3, point2>;
 
 unsigned int theta_steps = 100;
 unsigned int phi_steps = 100;

--- a/tests/common/include/tests/common/test_core.inl
+++ b/tests/common/include/tests/common/test_core.inl
@@ -42,7 +42,7 @@ TEST(__plugin, surface)
 // This tests the construction of a intresection
 TEST(__plugin, intersection)
 {
-    using intersection = intersection<scalar, point3, point2>;
+    using intersection = intersection<point3, point2>;
 
     intersection i0 = {2., point3(0.3, 0.5, 0.7), point2(0.2, 0.4), intersection_status::e_hit};
 

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -1,0 +1,127 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2021 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#include "core/surface.hpp"
+#include "core/track.hpp"
+#include "core/transform_store.hpp"
+#include "masks/masks.hpp"
+#include "tools/intersection_kernel.hpp"
+#include "tools/planar_intersector.hpp"
+#include "utils/enumerate.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace detray;
+using namespace __plugin;
+
+// This tests the construction of a surface
+TEST(tools, intersection_kernel_single)
+{
+
+    using vector3 = transform3::vector3;
+    using point3 = transform3::point3;
+    using point2 = cartesian2::point2;
+
+    /// Surface components:
+    using mask_link = dindex;
+    using surface_link = dindex;
+    /// - masks, with mask identifiers 0,1,2
+    using surface_rectangle = rectangle2<planar_intersector, __plugin::cartesian2, mask_link, 0>;
+    using surface_trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, mask_link, 1>;
+    using surface_annulus = annulus2<planar_intersector, __plugin::cartesian2, mask_link, 2>;
+    /// - mask index: type, entry
+    using surface_mask_index = darray<dindex, 2>;
+    using surface_masks = dtuple<dvector<surface_rectangle>, dvector<surface_trapezoid>, dvector<surface_annulus> >;
+
+    /// The Surface definition:
+    ///  <transform_link, mask_link, volume_link, source_link >
+    using detector_surface = surface<dindex, surface_mask_index, dindex, surface_link>;
+    using detector_surfaces = dvector<detector_surface>;
+
+    using surface_intersection = intersection<point3, point2>;
+
+    // The transforms & their store
+    transform3 rectangle_transform(point3{0., 0., 10.});
+    transform3 trapezoid_transform(point3{0., 0., 20.});
+    transform3 annulus_transform(point3{0., -20., 30.});
+    static_transform_store::context static_context;
+    static_transform_store transform_store;
+    transform_store.push_back(static_context, rectangle_transform);
+    transform_store.push_back(static_context, trapezoid_transform);
+    transform_store.push_back(static_context, annulus_transform);
+    // The masks & their store
+    surface_rectangle first_rectangle = {10., 10.};
+    surface_trapezoid second_trapezoid = {10., 20., 30.};
+    surface_annulus thrid_annulus = {15., 55., 0.75, 1.95, 2., -2.};
+    surface_masks mask_store;
+    std::get<0>(mask_store).push_back(first_rectangle);
+    std::get<1>(mask_store).push_back(second_trapezoid);
+    std::get<2>(mask_store).push_back(thrid_annulus);
+    // The surfaces and their store
+    detector_surface rectangle_surface(0u, {0, 0}, 0, 0);
+    detector_surface trapezoid_surface(1u, {1, 0}, 0, 1);
+    detector_surface annulus_surface(2u, {2, 0}, 0, 2);
+    detector_surfaces surfaces = {rectangle_surface, trapezoid_surface, annulus_surface};
+
+    // Try the intersection - first one by one
+
+    track<transform3, decltype(transform_store)::context> track;
+    track.pos = point3{0., 0., 0.};
+    track.dir = vector::normalize(vector3{0.01, 0.01, 10.});
+
+    // Quick helper to check for within epsilon
+    auto within_epsilon = [](const point3 &a, const point3 &b, scalar epsilon) -> bool {
+        return (std::abs(a[0] - b[0]) < epsilon && std::abs(a[1] - b[1]) < epsilon && std::abs(a[2] - b[2]) < epsilon);
+    };
+
+    // Intersect the first surface
+    auto sfi_rectangle = intersect_by_group(
+        track, rectangle_transform, std::get<0>(mask_store), 0);
+
+    point3 expected_rectangle{0.01, 0.01, 10.};
+    ASSERT_TRUE(within_epsilon(std::get<0>(sfi_rectangle).point3, expected_rectangle, 1e-7));
+
+    auto sfi_trapezoid = intersect_by_group(
+        track, trapezoid_transform, std::get<1>(mask_store), 0);
+
+    point3 expected_trapezoid{0.02, 0.02, 20.};
+    ASSERT_TRUE(within_epsilon(std::get<0>(sfi_trapezoid).point3, expected_trapezoid, 1e-7));
+
+    auto sfi_annulus = intersect_by_group(
+        track, annulus_transform, std::get<2>(mask_store), 0);
+
+    point3 expected_annulus{0.03, 0.03, 30.};
+    ASSERT_TRUE(within_epsilon(std::get<0>(sfi_annulus).point3, expected_annulus, 1e-7));
+
+    std::vector<point3> expected_points = {expected_rectangle, expected_trapezoid, expected_annulus};
+    std::vector<point3> result_points = {};
+
+    // Try the intersection - with automated dispatching via the kernel
+    unsigned int it = 0;
+    for (const auto &surface : surfaces)
+    {
+        auto sfi_surface = intersect(track, surface, transform_store, mask_store);
+
+        const auto &sfi = std::get<0>(sfi_surface);
+        result_points.push_back(sfi.point3);
+
+        ASSERT_TRUE(within_epsilon(result_points[it], expected_points[it], 1e-7));
+        ++it;
+    }
+
+    return;
+}
+
+// Google Test can be run manually from the main() function
+// or, it can be linked to the gtest_main library for an already
+// set-up main() function primed to accept Google Test test cases.
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/unit_tests/eigen/CMakeLists.txt
+++ b/tests/unit_tests/eigen/CMakeLists.txt
@@ -1,13 +1,33 @@
 enable_testing()
 
-add_detray_test(eigen_masks_container
-                eigen_masks_container.cpp detray::eigen)
-
 add_detray_test(eigen_annulus2
                 eigen_annulus2.cpp detray::eigen)
 
 add_detray_test(eigen_cylinder3
                 eigen_cylinder3.cpp detray::eigen)
+
+add_detray_test(eigen_core
+                eigen_core.cpp
+                detray::eigen)
+
+add_detray_test(eigen_cylinder_intersection
+                eigen_cylinder_intersection.cpp
+                detray::eigen)
+
+add_detray_test(eigen_detector
+                eigen_detector.cpp
+                detray::eigen)
+
+add_detray_test(eigen_masks_container
+                eigen_masks_container.cpp detray::eigen)
+
+add_detray_test(eigen_intersection_kernel
+                eigen_intersection_kernel.cpp
+                detray::eigen)
+
+add_detray_test(eigen_read_detector
+                eigen_read_detector.cpp
+                detray::eigen)
 
 add_detray_test(eigen_rectangle2
                 eigen_rectangle2.cpp detray::eigen)
@@ -21,39 +41,24 @@ add_detray_test(eigen_single3
 add_detray_test(eigen_single_layer_components
                 eigen_single_layer_components.cpp detray::eigen)
 
+add_detray_test(eigen_transform_store
+                eigen_transform_store.cpp
+                detray::eigen)
+                
 add_detray_test(eigen_trapezoid2
                 eigen_trapezoid2.cpp detray::eigen)
 
 add_detray_test(eigen_unmasked
                 eigen_unmasked.cpp detray::eigen)
 
+ add_detray_test(eigen_planar_intersection
+                eigen_planar_intersection.cpp
+                detray::eigen)
+
 add_detray_test(eigen_plugin
                 eigen_plugin.cpp
                 detray::eigen)
 
-add_detray_test(eigen_core
-                eigen_core.cpp
-                detray::eigen)
-
-add_detray_test(eigen_detector
-                eigen_detector.cpp
-                detray::eigen)
-
-add_detray_test(eigen_transform_store
-                eigen_transform_store.cpp
-                detray::eigen)
-
-add_detray_test(eigen_cylinder_intersection
-                eigen_cylinder_intersection.cpp
-                detray::eigen)
-
-add_detray_test(eigen_planar_intersection
-                eigen_planar_intersection.cpp
-                detray::eigen)
-
-add_detray_test(eigen_read_detector
-                eigen_read_detector.cpp
-                detray::eigen)
 
 if (DETRAY_DISPLAY)
     set(UNIT_TEST_EXTRA_LIBRARIES detray::display)

--- a/tests/unit_tests/eigen/eigen_intersection_kernel.cpp
+++ b/tests/unit_tests/eigen/eigen_intersection_kernel.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2021 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/eigen_defs.hpp"
+#include "tests/common/tools_intersection_kernel.inl"


### PR DESCRIPTION
This PR adds the `intersection_kernel` with `variadic template` unrolling which should make it possible to use it for detector surfaces and portals at the same point.