### PR TITLE
feat: change to proto detector

### DIFF
--- a/core/include/core/proto_detector.hpp
+++ b/core/include/core/proto_detector.hpp
@@ -22,6 +22,7 @@
 #include "utils/containers.hpp"
 #include "utils/enumerate.hpp"
 #include "tools/planar_intersector.hpp"
+#include "tools/cylinder_intersector.hpp"
 #include "tools/concentric_cylinder_intersector.hpp"
 
 #include <string>
@@ -86,7 +87,7 @@ namespace detray
          *  <transform_link, mask_link, volume_link, source_link >
          */
         using detector_surface = surface<dindex, surface_mask_index, dindex, surface_source_link>;
-        using surfaces = dvector<detector_surface>;
+        using detector_surfaces = dvector<detector_surface>;
 
         /** Nested volume struct that holds the local information of the
          * volume and its portals.
@@ -158,7 +159,7 @@ namespace detray
              * @param surfaces The (complete) volume surfaces
              * @param surface_masks The (complete) surface masks
              */
-            void add_surface_components(surfaces &&volume_surfaces, surface_masks &&volume_surface_masks)
+            void add_surface_components(detector_surfaces &&volume_surfaces, surface_masks &&volume_surface_masks)
             {
                 _surfaces = std::move(volume_surfaces);
                 _surface_masks = std::move(volume_surface_masks);
@@ -169,7 +170,7 @@ namespace detray
              * @param surfaces The (complete) volume surfaces
              * @param surface_masks The (complete) surface masks
              */
-            void add_surface_components(const surfaces &volume_surfaces, const surface_masks &volume_surface_masks)
+            void add_surface_components(const detector_surfaces &volume_surfaces, const surface_masks &volume_surface_masks)
             {
                 _surfaces = volume_surfaces;
                 _surface_masks = volume_surface_masks;
@@ -190,6 +191,15 @@ namespace detray
                 _portal_masks = std::move(volume_portal_masks);
             }
 
+            /** Const Access to the detector surfaces */
+            const detector_surfaces& surfaces() const { return _surfaces; }
+
+            /** Const Access to the surface transform store */
+            const alignable_store& surface_transforms() const { return _surface_transforms; }
+
+            /** Const Access to the surface masks */
+            const surface_masks& masks() const { return _surface_masks; }
+
         private:
             /// Volume section: name
             std::string _name = "unknown";
@@ -205,7 +215,7 @@ namespace detray
 
             /// Surface section
             surface_masks _surface_masks;
-            surfaces _surfaces;
+            detector_surfaces _surfaces;
             alignable_store _surface_transforms;
 
             /// Portal section

--- a/core/include/masks/cylinder3.hpp
+++ b/core/include/masks/cylinder3.hpp
@@ -39,7 +39,7 @@ namespace detray
     struct cylinder3
     {
 
-        using mask_tolerance = darray<scalar, 3>;
+        using mask_tolerance = darray<scalar, 2>;
 
         using mask_values = darray<scalar, 3>;
 

--- a/core/include/tools/concentric_cylinder_intersector.hpp
+++ b/core/include/tools/concentric_cylinder_intersector.hpp
@@ -49,7 +49,7 @@ namespace detray
                   const mask_type &mask,
                   const typename mask_type::mask_tolerance &tolerance = mask_type::within_epsilon) const
         {
-            return intersect(trf, track.pos, track.dir, local, mask, track.overstep_tolerance);
+            return intersect(trf, track.pos, track.dir, local, mask, tolerance, track.overstep_tolerance);
         }
 
         /** Intersection method for cylindrical surfaces

--- a/core/include/tools/cylinder_intersector.hpp
+++ b/core/include/tools/cylinder_intersector.hpp
@@ -45,7 +45,7 @@ namespace detray
         template <typename transform_type, typename track_type, typename local_type, typename mask_type>
         intersection<typename transform_type::transform3::point3, typename local_type::point2>
         intersect(const transform_type &trf,
-                  const track<transform_type> &track,
+                  const track_type &track,
                   const local_type &local,
                   const mask_type &mask,
                   const typename mask_type::mask_tolerance &tolerance = mask_type::within_epsilon) const

--- a/core/include/tools/intersection_kernel.hpp
+++ b/core/include/tools/intersection_kernel.hpp
@@ -199,13 +199,13 @@ namespace detray
         const auto &mask_range = std::get<1>(mask_link);
 
         // Create a return intersection and run the variadic unrolling
-        auto reference_group = std::get<0>(masks);
-        typename decltype(reference_group)::value_type::mask_links_type result_links;
+        const auto &reference_group = std::get<0>(masks);
+        typename std::decay_t<decltype(reference_group)>::value_type::mask_links_type result_links;
         intersection<point3, point2> result_intersection;
 
         // Unroll the intersection depending on the mask container size
         unroll_intersect(result_intersection, result_links, track, ctf, masks, mask_range, mask_context,
-                         std::make_integer_sequence<dindex, std::tuple_size_v<mask_container> >{});
+                         std::make_integer_sequence<dindex, std::tuple_size_v<mask_container>>{});
         // Return the (eventually update) intersection and links
         return std::make_tuple(result_intersection, result_links);
     }

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -139,7 +139,7 @@ namespace detray
 
     // Flushable containers
     typename proto_detector<alignable_store, surface_source_link, bounds_source_link>::volume *c_volume = nullptr;
-    typename proto_detector<alignable_store, surface_source_link, bounds_source_link>::surfaces c_surfaces;
+    typename proto_detector<alignable_store, surface_source_link, bounds_source_link>::detector_surfaces c_surfaces;
     typename proto_detector<alignable_store, surface_source_link, bounds_source_link>::surface_masks c_masks;
 
     std::map<volume_layer_index, darray<scalar, 6>> volume_bounds;
@@ -156,7 +156,8 @@ namespace detray
      * @param value the (eventually new) value for insertion
      * @param volume_index the index of the attached volume
      */
-    auto attach_volume = [](dmap<scalar, std::vector<dindex>> &attachments, scalar value, dindex volume_index) -> void {
+    auto attach_volume = [](dmap<scalar, std::vector<dindex>> &attachments, scalar value, dindex volume_index) -> void
+    {
       if (attachments.find(value) == attachments.end())
       {
         attachments[value] = {volume_index};
@@ -198,7 +199,7 @@ namespace detray
           // Get new clean containers
           surface_transform_storage = typename alignable_store::storage();
           c_surfaces =
-              typename proto_detector<alignable_store, surface_source_link, bounds_source_link>::surfaces();
+              typename proto_detector<alignable_store, surface_source_link, bounds_source_link>::detector_surfaces();
           c_masks =
               typename proto_detector<alignable_store, surface_source_link, bounds_source_link>::surface_masks();
         }
@@ -343,7 +344,8 @@ namespace detray
      * @return the key values
      */
     auto
-        sort_and_remove_duplicates = [](dmap<scalar, std::vector<dindex>> &att) -> dvector<scalar> {
+        sort_and_remove_duplicates = [](dmap<scalar, std::vector<dindex>> &att) -> dvector<scalar>
+    {
       dvector<scalar> keys;
       keys.reserve(att.size());
       for (auto [key, value] : att)
@@ -397,7 +399,7 @@ namespace detray
       }
     }
 
-    // Connect the cylindrical volumes 
+    // Connect the cylindrical volumes
     connect_cylindrical_volumes(d, v_grid);
 
     // Add the volume grid to the detector

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -11,6 +11,8 @@
 #include "masks/masks.hpp"
 #include "tools/intersection_kernel.hpp"
 #include "tools/planar_intersector.hpp"
+#include "tools/cylinder_intersector.hpp"
+#include "tools/concentric_cylinder_intersector.hpp"
 #include "utils/enumerate.hpp"
 
 #include <gtest/gtest.h>
@@ -33,9 +35,15 @@ TEST(tools, intersection_kernel_single)
     using surface_rectangle = rectangle2<planar_intersector, __plugin::cartesian2, mask_link, 0>;
     using surface_trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, mask_link, 1>;
     using surface_annulus = annulus2<planar_intersector, __plugin::cartesian2, mask_link, 2>;
+    using surface_cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, mask_link, 3>;
+    using surface_concentric_cylinder = cylinder3<false, concentric_cylinder_intersector, __plugin::cylindrical2, mask_link, 4>;
     /// - mask index: type, entry
     using surface_mask_index = darray<dindex, 2>;
-    using surface_masks = dtuple<dvector<surface_rectangle>, dvector<surface_trapezoid>, dvector<surface_annulus> >;
+    using surface_masks = dtuple<dvector<surface_rectangle>, 
+                                 dvector<surface_trapezoid>, 
+                                 dvector<surface_annulus>, 
+                                 dvector<surface_cylinder>,
+                                 dvector<surface_concentric_cylinder> >;
 
     /// The Surface definition:
     ///  <transform_link, mask_link, volume_link, source_link >


### PR DESCRIPTION
This PR changes the example to use the former `proto_detector`.

It will result into a slower `intersect_all` test as it evokes the unrolling for different surfaces.