### PR TITLE
feat: add propagate-all

### DIFF
--- a/core/include/core/track.hpp
+++ b/core/include/core/track.hpp
@@ -27,6 +27,7 @@ namespace detray
         context_type ctx;
 
         scalar overstep_tolerance = 0.;
+        scalar path_limit = std::numeric_limits<scalar>::max();
     };
 
 } // namespace detray

--- a/core/include/tools/line_stepper.hpp
+++ b/core/include/tools/line_stepper.hpp
@@ -30,7 +30,7 @@ namespace detray
             scalar _pl = std::numeric_limits<scalar>::max(); //!< Remaining path limit
 
             state() = delete;
-            state(track_type& t) : _track(t) {}
+            state(track_type& t) : _track(t), _pl(t.path_limit) {}
 
 
             /** @return the step and heartbeat given a step length s */


### PR DESCRIPTION
This adds a new benchmark frame for propagate all tests in order to compare them to the intersect all test.