### PR TITLE
feat: changing detector to templated date-types

### DIFF
--- a/apps/common/include/apps/common/display_volumes_rz.inl
+++ b/apps/common/include/apps/common/display_volumes_rz.inl
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
             std::string surfaces = argv[2];
             std::string grids = argv[3];
             std::string volumes = argv[4];
-            auto d = detector_from_csv<static_transform_store>(name, surfaces, grids, volumes);
+            auto d = detector_from_csv<static_transform_store<>>(name, surfaces, grids, volumes);
             std::cout << "[detray] Detector read successfully." << std::endl;
             std::cout << d.to_string() << std::endl;
             // std::cout << "         Volumes : " << d.volumes().size() << std::endl;

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -38,7 +38,7 @@ namespace detray
      * @tparam bounds_source_link the type of the link to an external bounds source
      * 
      */
-    template <typename alignable_store = static_transform_store,
+    template <typename alignable_store = static_transform_store<>,
               typename surface_source_link = dindex,
               typename bounds_source_link = dindex,
               template <typename, unsigned int> class array_type = darray,

--- a/core/include/core/transform_store.hpp
+++ b/core/include/core/transform_store.hpp
@@ -14,6 +14,7 @@ namespace detray
     using transform3 = __plugin::transform3;
 
     /** A static inplementation of an alignable transform store */
+    template < template <typename> class vector_type = dvector>
     class static_transform_store
     {
     public:
@@ -22,7 +23,7 @@ namespace detray
         {
         };
 
-        using storage = dvector<transform3>;
+        using storage = vector_type<transform3>;
 
         /** Reserve memory : Contextual STL like API
          *
@@ -94,7 +95,7 @@ namespace detray
 
     private:
         /** Common to surfaces & portals: transform store */
-        dvector<transform3> _data;
+        vector_type<transform3> _data;
     };
 
 } // namespace detray

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -103,7 +103,7 @@ namespace detray
   /// @param grid_file_name is the name of the surface grid file
   ///
   /// @return a drawable detector object
-  template <typename alignable_store = static_transform_store,
+  template <typename alignable_store = static_transform_store<>,
             typename surface_source_link = dindex,
             typename bounds_source_link = dindex>
   detector<alignable_store,

--- a/tests/common/include/tests/common/benchmark_find_volume.inl
+++ b/tests/common/include/tests/common/benchmark_find_volume.inl
@@ -30,7 +30,7 @@ auto read_detector()
     std::string surfaces = data_directory + "tml.csv";
     std::string grids = data_directory + "tml-surface-grids.csv";
     std::string volumes = data_directory + "tml-layer-volumes.csv";
-    return detray::detector_from_csv<static_transform_store>(name, surfaces, grids, volumes);
+    return detray::detector_from_csv<static_transform_store<>>(name, surfaces, grids, volumes);
 };
 
 auto d = read_detector();

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -43,7 +43,7 @@ auto read_detector()
     std::string surfaces = data_directory + "tml.csv";
     std::string grids = data_directory + "tml-surface-grids.csv";
     std::string volumes = data_directory + "tml-layer-volumes.csv";
-    return detray::detector_from_csv<static_transform_store>(name, surfaces, grids, volumes);
+    return detray::detector_from_csv<static_transform_store<>>(name, surfaces, grids, volumes);
 };
 
 auto d = read_detector();
@@ -68,7 +68,7 @@ namespace __plugin
         for (auto _ : state)
         {
 
-            track<static_transform_store::context> track;
+            track<static_transform_store<>::context> track;
             track.pos = point3{0., 0., 0.};
 
             // Loops of theta values

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -20,8 +20,8 @@ TEST(ALGEBRA_PLUGIN, detector)
 
     using detector = detector<>;
 
-    static_transform_store::storage static_storage;
-    static_transform_store::context ctx0;
+    static_transform_store<>::storage static_storage;
+    static_transform_store<>::context ctx0;
 
     detector::surface_mask_container masks;
 

--- a/tests/common/include/tests/common/core_transform_store.inl
+++ b/tests/common/include/tests/common/core_transform_store.inl
@@ -17,9 +17,9 @@ TEST(ALGEBRA_PLUGIN, static_transform_store)
     using namespace detray;
     using namespace __plugin;
 
-    static_transform_store static_store;   
-    static_transform_store::context ctx0;
-    static_transform_store::context ctx1;
+    static_transform_store<> static_store;   
+    static_transform_store<>::context ctx0;
+    static_transform_store<>::context ctx1;
 
     ASSERT_TRUE(static_store.empty(ctx0));
 

--- a/tests/common/include/tests/common/io_read_detector.inl
+++ b/tests/common/include/tests/common/io_read_detector.inl
@@ -30,7 +30,7 @@ TEST(ALGEBRA_PLUGIN, read_detector)
     std::string surface_grid_file = data_directory + std::string("tml-surface-grids.csv");
     std::string layer_volume_file = data_directory + std::string("tml-layer-volumes.csv");
 
-    auto d = detector_from_csv<static_transform_store>("tml", surface_file, surface_grid_file, layer_volume_file);
+    auto d = detector_from_csv<static_transform_store<>>("tml", surface_file, surface_grid_file, layer_volume_file);
 
     std::cout << d.to_string() << std::endl;
 }

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -49,7 +49,7 @@ TEST(tools, intersection_kernel_single)
     transform3 rectangle_transform(point3{0., 0., 10.});
     transform3 trapezoid_transform(point3{0., 0., 20.});
     transform3 annulus_transform(point3{0., -20., 30.});
-    static_transform_store::context static_context;
+    static_transform_store<>::context static_context;
     static_transform_store transform_store;
     transform_store.push_back(static_context, rectangle_transform);
     transform_store.push_back(static_context, trapezoid_transform);

--- a/tests/common/include/tests/common/tools_line_stepper.inl
+++ b/tests/common/include/tests/common/tools_line_stepper.inl
@@ -19,12 +19,12 @@ TEST(ALGEBRA_PLUGIN, line_stepper)
     using namespace detray;
     using namespace __plugin;
 
-    using detray_track = track<static_transform_store::context>;
+    using detray_track = track<static_transform_store<>::context>;
 
     detray_track traj;
     traj.pos = {0., 0., 0.};
     traj.dir = vector::normalize(vector3{1., 1., 0.});
-    traj.ctx = static_transform_store::context{};
+    traj.ctx = static_transform_store<>::context{};
     traj.momentum = 100.;
     traj.overstep_tolerance = -1e-5;
 

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -31,17 +31,17 @@ TEST(ALGEBRA_PLUGIN, navigator)
     std::string surface_grid_file = data_directory + std::string("tml-surface-grids.csv");
     std::string layer_volume_file = data_directory + std::string("tml-layer-volumes.csv");
 
-    auto d = detector_from_csv<static_transform_store>("tml", surface_file, surface_grid_file, layer_volume_file);
+    auto d = detector_from_csv<static_transform_store<>>("tml", surface_file, surface_grid_file, layer_volume_file);
 
     // Create the navigator
     using detray_navigator = navigator<decltype(d)>;
 
     detray_navigator n(std::move(d));
 
-    track<static_transform_store::context> traj;
+    track<static_transform_store<>::context> traj;
     traj.pos = {0., 0., 0.};
     traj.dir = vector::normalize(vector3{1., 1., 0.});
-    traj.ctx = static_transform_store::context{};
+    traj.ctx = static_transform_store<>::context{};
     traj.momentum = 100.;
     traj.overstep_tolerance = -1e-4;
 

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -33,16 +33,16 @@ TEST(ALGEBRA_PLUGIN, propagator)
     std::string surface_grid_file = data_directory + std::string("tml-surface-grids.csv");
     std::string layer_volume_file = data_directory + std::string("tml-layer-volumes.csv");
 
-    auto d = detector_from_csv<static_transform_store>("tml", surface_file, surface_grid_file, layer_volume_file);
+    auto d = detector_from_csv<static_transform_store<>>("tml", surface_file, surface_grid_file, layer_volume_file);
 
     // Create the navigator
     using detray_navigator = navigator<decltype(d)>;    
-    using detray_track = track<static_transform_store::context>;
+    using detray_track = track<static_transform_store<>::context>;
 
     detray_track traj;
     traj.pos = {0., 0., 0.};
     traj.dir = vector::normalize(vector3{1., 1., 0.});
-    traj.ctx = static_transform_store::context{};
+    traj.ctx = static_transform_store<>::context{};
     traj.momentum = 100.;
     traj.overstep_tolerance = -1e-4;
 


### PR DESCRIPTION
This PR changes the detector to template types to prepare later usage with `vecmem`.

@krasznaa @stephenswat @niermann999 - Is that along the lines you discussed?

There are a few more classes that might need this update then:
- `axis`
- `grid`

Also, I am using a tuple for typing the bounds, not sure what your plans are with tuples (if any), we might have to write a custom class for this I suppose.