### PR TITLE
fix: incorrect template deduction in clang

### DIFF
--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -80,8 +80,8 @@ namespace detray
          * @tparam links_type the type of the links the candidate is holding
          * 
          **/
-        template <typename object_type, 
-                  typename candidate_type, 
+        template <typename object_type,
+                  typename candidate_type,
                   typename links_type,
                   template <typename> class vector_type = dvector>
         struct navigation_kernel
@@ -142,10 +142,10 @@ namespace detray
             /** Scalar representation of the navigation state,
              * @returns distance to next
              **/
-            scalar operator()() const {
+            scalar operator()() const
+            {
                 return distance_to_next;
             }
-
         };
 
         __plugin::cartesian2 cart2;
@@ -232,7 +232,7 @@ namespace detray
 
             // Retrieve the volume, either from valid index or through global search
             const auto &volume = (navigation.volume_index != dindex_invalid) ? detector.indexed_volume(navigation.volume_index)
-                                                                             : detector.indexed_volume(track.pos);          
+                                                                             : detector.indexed_volume(track.pos);
             navigation.volume_index = volume.index();
             // Retrieve the kernels
             auto &surface_kernel = navigation.surface_kernel;
@@ -268,7 +268,6 @@ namespace detray
                 // If no surfaces are to processed, initialize the portals
                 if (surface_kernel.empty())
                 {
-                    
 
                     initialize_kernel(navigation, portal_kernel, track, volume.portals(), navigation.status == e_on_portal);
                     heartbeat = check_volume_switch(navigation);
@@ -312,7 +311,9 @@ namespace detray
             const auto &transforms = constituents.transforms();
             const auto &masks = constituents.masks();
             // Loop over all indexed surfaces, intersect and fill
-            for (auto si : sequence({0, n_objects - 1}))
+            // @todo - will come from the local object finder
+            darray<dindex, 2> surface_range = {0, n_objects - 1};
+            for (auto si : sequence(surface_range))
             {
                 const auto &object = constituents.indexed_object(si);
                 auto [sfi, link] = intersect(track, object, transforms, masks);

--- a/core/include/utils/enumerate.hpp
+++ b/core/include/utils/enumerate.hpp
@@ -8,6 +8,7 @@
 
 #include "utils/indexing.hpp"
 
+#include <type_traits>
 #include <tuple>
 
 namespace detray
@@ -99,8 +100,9 @@ namespace detray
      * @note sequence({2,4}) will produce { 2, 3, 4 }
      * 
      **/
-    template<template <typename, unsigned int> class array_type = darray>
-    constexpr auto sequence(array_type<dindex, 2> iterable)
+    template <typename array_type, 
+              typename = std::enable_if_t<std::conditional_t<std::is_array_v<array_type>, std::extent<array_type>, std::tuple_size<array_type>>::value == 2U> >
+    constexpr auto sequence(array_type iterable)
     {
 
         struct iterator
@@ -121,11 +123,11 @@ namespace detray
         };
         struct iterable_wrapper
         {
-            array_type<dindex, 2> iterable;
-            auto begin() { return iterator{iterable[0], iterable[1]}; }
-            auto end() { return iterator{iterable[1] + 1, iterable[1] + 1}; }
+            array_type _iterable;
+            auto begin() { return iterator{_iterable[0], _iterable[1]}; }
+            auto end() { return iterator{_iterable[1] + 1, _iterable[1] + 1}; }
         };
-        return iterable_wrapper{std::forward<array_type<dindex, 2> >(iterable)};
+        return iterable_wrapper{std::forward<array_type>(iterable)};
     }
 
 } // namespace detray

--- a/tests/unit_tests/core/utils_enumerate.cpp
+++ b/tests/unit_tests/core/utils_enumerate.cpp
@@ -11,7 +11,6 @@
 
 #include <gtest/gtest.h>
 
-
 using namespace detray;
 
 // This tests the convenience range_enumeration function: single
@@ -20,45 +19,45 @@ TEST(utils, sequence_single)
 
     dindex check = 0;
     dindex single = 7;
-    for (auto i : sequence(single)){
+    for (auto i : sequence(single))
+    {
         check += i;
     }
     ASSERT_EQ(check, single);
-
 }
 
 // This tests the convenience range_enumeration function: range
 TEST(utils, sequence_range)
 {
 
-    darray<dindex, 2> range = {2,7};
+    darray<dindex, 2> range = {2, 7};
     std::vector<dindex> reference = {2, 3, 4, 5, 6, 7};
     std::vector<dindex> check = {};
-    for (auto i : sequence(range)){
+    for (auto i : sequence(range))
+    {
         check.push_back(i);
     }
     ASSERT_EQ(check, reference);
-
 }
 
 // This tests the convenience enumeration function
 TEST(utils, enumerate)
 {
 
-    struct uint_holder {
+    struct uint_holder
+    {
         unsigned int ui = 0;
     };
 
-    dvector<uint_holder> seq = { {0}, {1}, {2}, {3}, {4}, {5}};
+    dvector<uint_holder> seq = {{0}, {1}, {2}, {3}, {4}, {5}};
 
     using container_type_iter = decltype(std::begin(std::declval<dvector<uint_holder>>()));
 
-    for (auto [i, v] : enumerate(seq)){
+    for (auto [i, v] : enumerate(seq))
+    {
         ASSERT_EQ(i, v.ui);
     }
-
 }
-
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
This PR fixes a small problem with template deduction in the `enumerate(...)` function.