### PR TITLE
feat: move transform storage to detector level

### DIFF
--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -420,9 +420,9 @@ namespace detray
          *
          * @return ranged iterator to the object transforms 
          */
-        const auto transforms(const dindex_range& range, const context &ctx = {}) const
+        const auto transforms(const dindex_range range, const context &ctx = {}) const
         {
-            return _transforms.range(range, ctx);
+            return _transforms.range(std::move(range), ctx);
         }
 
         /** @return the surface finders - const access */

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -217,11 +217,11 @@ namespace detray
 
             /** Set the index into the detector transform store for surfaces
              *
-             * @param idx Surface transform start index
+             * @param range Surface transform index range
              */
-            void set_surface_range(dindex_range &&range)
+            void set_surface_range(dindex_range range)
             {
-                _surface_range = std::move(range);
+                _surface_range = range;
             }
 
             /** Add the surfaces and their masks - move semantics
@@ -235,20 +235,20 @@ namespace detray
                 _surfaces._masks = std::move(volume_surface_masks);
             }
 
+            /** @return all surfaces - const access */
+            const auto &surfaces() const { return _surfaces; }
+
+            /** @return range of surface transforms - const access */
+            const auto &surface_range() const { return _surface_range; }
+
             /** Set the index into the detector transform store for portals
              *
-             * @param idx Portal transform start index
+             * @param range Portal transform index range
              */
             void set_portal_range(dindex_range range)
             {
                 _portal_range = range;
             }
-
-            /** @return all surfaces - const access */
-            const auto &surfaces() const { return _surfaces; }
-
-            /** @return all surfaces - const access */
-            const auto &surface_range() const { return _surface_range; }
 
             /** Add the portals, their transforms and their masks, move semantics
              *
@@ -265,7 +265,7 @@ namespace detray
             /** @return all portals - const access */
             const auto &portals() const { return _portals; }
 
-            /** @return all surfaces - const access */
+            /** @return range of portal transforms - const access */
             const auto &portal_range() const { return _portal_range; }
 
         private:
@@ -362,6 +362,7 @@ namespace detray
         /** Add a new full set of alignable transforms for surfaces - move semantics
          *
          * @param ctx The context of the call
+         * @param volume The volume we add the transforms to
          * @param trfs The transform container, move semantics
          *
          * @note can throw an exception if input data is inconsistent
@@ -378,6 +379,7 @@ namespace detray
         /** Add a new full set of alignable transforms for surfaces - move semantics
          *
          * @param ctx The context of the call
+         * @param volume The volume we add the transforms to
          * @param trfs The transform container, move semantics
          *
          * @note can throw an exception if input data is inconsistent
@@ -413,7 +415,7 @@ namespace detray
 
         /** Get all transform in an index range from the detector
          *
-         * @param range The range of surfaces in the transform store
+         * @param range The range of surfaces/portals in the transform store
          * @param ctx The context of the call
          *
          * @return ranged iterator to the object transforms 

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -179,16 +179,11 @@ namespace detray
                  *
                  * @param ctx The context of the call
                  *
-                 * @return all surface transforms 
+                 * @return ranged iterator to the object transforms 
                  */
-                // TODO: Do index based!
-                const transform_store transforms(const context &ctx) const
+                const auto transforms(const context &ctx) const
                 {
-                    auto start_it = _volume->_detector->_transforms.begin(ctx) + _transform_index;
-                    auto trfs = typename transform_store::storage(start_it, start_it+ _objects.size());
-                    auto store = transform_store();
-                    store.set_contextual_transforms(ctx, std::move(trfs));
-                    return store;
+                    return _volume->_detector->_transforms.range(_transform_index, _transform_index + _objects.size(), ctx);
                 }
             };
 
@@ -378,8 +373,7 @@ namespace detray
         const vector_type<volume> &volumes() const { return _volumes; }
 
         /** @return the volume by @param volume_index - const access */
-        const volume &indexed_volume(dindex volume_index) const {
-             return _volumes[volume_index]; }
+        const volume &indexed_volume(dindex volume_index) const { return _volumes[volume_index]; }
 
         /** @return the volume by @param position - const access */
         const volume &indexed_volume(const point3 &p) const
@@ -390,8 +384,7 @@ namespace detray
         }
 
         /** @return the volume by @param volume_index - non-const access */
-        volume &indexed_volume(dindex volume_index) {
-            return _volumes[volume_index]; }
+        volume &indexed_volume(dindex volume_index) { return _volumes[volume_index]; }
 
         /** Add the volume grid - move semantics 
          * 

--- a/core/include/core/transform_store.hpp
+++ b/core/include/core/transform_store.hpp
@@ -21,8 +21,8 @@ namespace detray
     public:
 
         /** Elementwise access. Needs []operator for storage type for now */
-        inline auto operator[](const unsigned int i) { return _data[i]; }
-        inline auto operator[](const unsigned int i) const { return _data[i]; }
+        inline decltype(auto) operator[](const dindex i) { return _data[i]; }
+        inline decltype(auto) operator[](const dindex i) const { return _data[i]; }
 
         /** Empty context type struct */
         struct context
@@ -66,9 +66,8 @@ namespace detray
 
         /** Access to a predefined range of elements
          *
-         * @tparam start start index of rage
-         * @tparam end end index of rage
-         *
+         * @param start start index of rage
+         * @param end end index of rage
          * @param ctx The context of the call (ignored)
          *
          * @return range restricted iterator
@@ -80,9 +79,7 @@ namespace detray
 
         /** Access to a predefined range of elements
          *
-         * @tparam start start index of rage
-         * @tparam end end index of rage
-         *
+         * @param range index range in data store
          * @param ctx The context of the call (ignored)
          *
          * @return range restricted iterator

--- a/core/include/core/transform_store.hpp
+++ b/core/include/core/transform_store.hpp
@@ -25,6 +25,24 @@ namespace detray
 
         using storage = vector_type<transform3>;
 
+        /** Forward iterator : Contextual STL like API
+         *
+         * @param ctx The context of the call (ignored)
+         */
+        auto begin(const context & /*ctx*/) const ->decltype(auto)
+        {
+            return _data.begin();
+        }
+
+        /** Forward iterator : Contextual STL like API
+         *
+         * @param ctx The context of the call (ignored)
+         */
+        auto end(const context & /*ctx*/) const ->decltype(auto)
+        {
+            return _data.end();
+        }
+
         /** Reserve memory : Contextual STL like API
          *
          * @param ctx The context of the call (ignored)
@@ -58,7 +76,7 @@ namespace detray
         /** Size : Contextual STL like API
          * @param ctx The context of the call (ignored)
          */ 
-        size_t size(const context & /*ctx*/)
+        size_t size(const context & /*ctx*/) const
         {
             return _data.size();
         }
@@ -78,9 +96,22 @@ namespace detray
          *
          * @note in general can throw an exception
          */
-        void add_contextual_transforms(const context & /*ctx*/, storage &&trfs) noexcept(false)
+        void set_contextual_transforms(const context & /*ctx*/, storage &&trfs) noexcept(false)
         {
             _data = std::move(trfs);
+        }
+
+        /** Append a bunch of (contextual) transforms - move semantics
+         *
+         * @param ctx The context of the call (ignored)
+         * @param trfs The transform container, move semantics
+         *
+         * @note in general can throw an exception
+         */
+        void append_contextual_transforms(const context & /*ctx*/, storage &&trfs) noexcept(false)
+        {
+            _data.reserve(trfs.size());
+            _data.insert(_data.end(), std::make_move_iterator(trfs.begin()), std::make_move_iterator(trfs.end()));
         }
 
         /** Get the contextual transform

--- a/core/include/core/transform_store.hpp
+++ b/core/include/core/transform_store.hpp
@@ -76,7 +76,7 @@ namespace detray
         /** Size : Contextual STL like API
          * @param ctx The context of the call (ignored)
          */ 
-        size_t size(const context & /*ctx*/) const
+        const size_t size(const context & /*ctx*/) const
         {
             return _data.size();
         }

--- a/core/include/core/transform_store.hpp
+++ b/core/include/core/transform_store.hpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include "utils/enumerate.hpp"
 #include "utils/indexing.hpp"
 
 namespace detray
@@ -18,9 +19,29 @@ namespace detray
     class static_transform_store
     {
     public:
+
+        /** Elementwise access. Needs []oprator for storage type for now */
+        inline auto operator[](const unsigned int i) { return _data[i]; }
+        inline auto operator[](const unsigned int i) const { return _data[i]; }
+
         /** Empty context type struct */
         struct context
         {
+        };
+
+        /** Helper struct to pass range and context */
+        template<typename range_iterator>
+        struct contextual_range {
+            using context = static_transform_store::context;
+            /*context ctx;*/
+
+            const range_iterator r;
+
+            inline auto begin() { return r.begin(); }
+            inline auto end() { return r.end(); }
+
+            inline auto operator[](const unsigned int i) { return *(r.begin() + i); }
+            inline auto operator[](const unsigned int i) const { return *(r.begin() + i); }
         };
 
         using storage = vector_type<transform3>;
@@ -41,6 +62,20 @@ namespace detray
         auto end(const context & /*ctx*/) const ->decltype(auto)
         {
             return _data.end();
+        }
+
+        /** Access to a predefined range of elements
+         *
+         * @tparam start start index of rage
+         * @tparam end end index of rage
+         *
+         * @param ctx The context of the call (ignored)
+         *
+         * @return range restricted iterator
+         */
+        const inline auto range(const size_t begin, const size_t end, const context & ctx) const
+        {
+            return contextual_range<decltype(range_iter(_data, dindex_range{begin, end}))>{range_iter(_data, dindex_range{begin, end})};
         }
 
         /** Reserve memory : Contextual STL like API

--- a/core/include/core/transform_store.hpp
+++ b/core/include/core/transform_store.hpp
@@ -20,7 +20,7 @@ namespace detray
     {
     public:
 
-        /** Elementwise access. Needs []oprator for storage type for now */
+        /** Elementwise access. Needs []operator for storage type for now */
         inline auto operator[](const unsigned int i) { return _data[i]; }
         inline auto operator[](const unsigned int i) const { return _data[i]; }
 
@@ -40,8 +40,8 @@ namespace detray
             inline auto begin() { return r.begin(); }
             inline auto end() { return r.end(); }
 
-            inline auto operator[](const unsigned int i) { return *(r.begin() + i); }
-            inline auto operator[](const unsigned int i) const { return *(r.begin() + i); }
+            inline decltype(auto) operator[](const dindex i) { return *(r.begin() + i); }
+            inline decltype(auto) operator[](const dindex i) const { return *(r.begin() + i); }
         };
 
         using storage = vector_type<transform3>;
@@ -76,6 +76,20 @@ namespace detray
         const inline auto range(const size_t begin, const size_t end, const context & ctx) const
         {
             return contextual_range<decltype(range_iter(_data, dindex_range{begin, end}))>{range_iter(_data, dindex_range{begin, end})};
+        }
+
+        /** Access to a predefined range of elements
+         *
+         * @tparam start start index of rage
+         * @tparam end end index of rage
+         *
+         * @param ctx The context of the call (ignored)
+         *
+         * @return range restricted iterator
+         */
+        const inline auto range(const dindex_range& range, const context & ctx) const
+        {
+            return contextual_range<decltype(range_iter(_data, range))>{range_iter(_data, range)};
         }
 
         /** Reserve memory : Contextual STL like API
@@ -124,19 +138,19 @@ namespace detray
             return _data.empty();
         }
 
-        /** Add a new bunch of (contextual) transforms - move semantics
+        /** Add a new bunch of transforms for a new context - move semantics
          *
          * @param ctx The context of the call (ignored)
          * @param trfs The transform container, move semantics
          *
          * @note in general can throw an exception
          */
-        void set_contextual_transforms(const context & /*ctx*/, storage &&trfs) noexcept(false)
+        void add_contextual_transforms(const context & /*ctx*/, storage &&trfs) noexcept(false)
         {
             _data = std::move(trfs);
         }
 
-        /** Append a bunch of (contextual) transforms - move semantics
+        /** Append a bunch of transforms to existing context - move semantics
          *
          * @param ctx The context of the call (ignored)
          * @param trfs The transform container, move semantics

--- a/core/include/core/transform_store.hpp
+++ b/core/include/core/transform_store.hpp
@@ -110,7 +110,7 @@ namespace detray
          */
         void append_contextual_transforms(const context & /*ctx*/, storage &&trfs) noexcept(false)
         {
-            _data.reserve(trfs.size());
+            _data.reserve(_data.size() + trfs.size());
             _data.insert(_data.end(), std::make_move_iterator(trfs.begin()), std::make_move_iterator(trfs.end()));
         }
 

--- a/core/include/core/transform_store.hpp
+++ b/core/include/core/transform_store.hpp
@@ -84,9 +84,9 @@ namespace detray
          *
          * @return range restricted iterator
          */
-        const inline auto range(const dindex_range& range, const context & ctx) const
+        const inline auto range(const dindex_range&& range, const context & ctx) const
         {
-            return contextual_range<decltype(range_iter(_data, range))>{range_iter(_data, range)};
+            return contextual_range<decltype(range_iter(_data, std::move(range)))>{range_iter(_data, std::move(range))};
         }
 
         /** Reserve memory : Contextual STL like API

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -239,7 +239,7 @@ namespace detray
                         mask_group.push_back(_portal_disc);
                     }
                     // Create the portal
-                    typename detector_type::portal _portal{d.transform_index(default_context) + portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
+                    typename detector_type::portal _portal{portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
                     portals.push_back(std::move(_portal));
                     portal_transforms.push_back(std::move(_portal_transform));
                 }
@@ -270,7 +270,7 @@ namespace detray
                         mask_group.push_back(_portal_cylinder);
                     }
                     // Create the portal
-                    typename detector_type::portal _portal{d.transform_index(default_context) + portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
+                    typename detector_type::portal _portal{portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
                     portals.push_back(std::move(_portal));
                     portal_transforms.push_back(std::move(_portal_transform));
                 }

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -22,7 +22,7 @@ namespace detray
               template <typename> class vector_type = dvector>
     void connect_cylindrical_volumes(detector_type &d, const typename detector_type::volume_grid &volume_grid)
     {
-        typename detector_type::context default_context;
+        typename detector_type::context default_context = {};
 
         // The grid is populated, now create portal surfaces
         // Start from left bottom corner (0,0)
@@ -285,8 +285,7 @@ namespace detray
             // Create a transform store and add it
             // All componnents are added
             volume.add_portal_components(std::move(portals), std::move(portal_masks));
-            //volume.add_portal_transforms(default_context, std::move(portal_transforms));
-            d.add_transforms(default_context, std::move(portal_transforms));
+            d.add_portal_transforms(default_context, volume, std::move(portal_transforms));
         }
     }
 }

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -22,6 +22,8 @@ namespace detray
               template <typename> class vector_type = dvector>
     void connect_cylindrical_volumes(detector_type &d, const typename detector_type::volume_grid &volume_grid)
     {
+        typename detector_type::context default_context;
+
         // The grid is populated, now create portal surfaces
         // Start from left bottom corner (0,0)
         vector_type<array_type<dindex, 2>> seeds = {{0, 0}};
@@ -237,7 +239,7 @@ namespace detray
                         mask_group.push_back(_portal_disc);
                     }
                     // Create the portal
-                    typename detector_type::portal _portal{portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
+                    typename detector_type::portal _portal{d.transform_index(default_context) + portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
                     portals.push_back(std::move(_portal));
                     portal_transforms.push_back(std::move(_portal_transform));
                 }
@@ -268,7 +270,7 @@ namespace detray
                         mask_group.push_back(_portal_cylinder);
                     }
                     // Create the portal
-                    typename detector_type::portal _portal{portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
+                    typename detector_type::portal _portal{d.transform_index(default_context) + portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
                     portals.push_back(std::move(_portal));
                     portal_transforms.push_back(std::move(_portal_transform));
                 }
@@ -281,10 +283,10 @@ namespace detray
             add_cylinder_portal(lower_portals_info, 0);
 
             // Create a transform store and add it
-            typename detector_type::context default_context;
             // All componnents are added
             volume.add_portal_components(std::move(portals), std::move(portal_masks));
-            volume.add_portal_transforms(default_context, std::move(portal_transforms));
+            //volume.add_portal_transforms(default_context, std::move(portal_transforms));
+            d.add_transforms(default_context, std::move(portal_transforms));
         }
     }
 }

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -84,10 +84,9 @@ namespace detray
                     {
                         dvector<point3> vertices = {};
                         const auto &mask_link = s.mask();
-                        const auto &transform_link = s.transform();
 
                         // Unroll the mask container and generate vertices
-                        const auto &transform = surface_transforms.contextual_transform(context, transform_link);
+                        const auto &transform = surface_transforms[s.transform()];
 
                         const auto &mask_context = std::get<0>(mask_link);
                         const auto &mask_range = std::get<1>(mask_link);
@@ -156,10 +155,9 @@ namespace detray
                     {
                         dvector<point3> vertices = {};
                         const auto &mask_link = s.mask();
-                        const auto &transform_link = s.transform();
 
                         // Unroll the mask container and generate vertices
-                        const auto &transform = surface_transforms.contextual_transform(context, transform_link);
+                        const auto &transform = surface_transforms[s.transform()];
 
                         const auto &mask_context = std::get<0>(mask_link);
                         const auto &mask_range = std::get<1>(mask_link);

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -32,9 +32,11 @@ namespace detray
      *        taken absolute or relative
      */
     template <typename context_type,
+              typename detector_type,
               typename volume_type,
               typename grid_type>
     static inline void bin_association(const context_type &context,
+                                       const detector_type &detector,
                                        const volume_type &volume,
                                        grid_type &grid,
                                        const std::array<scalar, 2> &bin_tolerance,
@@ -43,7 +45,7 @@ namespace detray
 
         // Get surfaces, transforms and masks
         const auto &surfaces = volume.surfaces();
-        const auto &surface_transforms = surfaces.transforms(context);
+        const auto &surface_transforms = detector.transforms(volume.surface_range(), context);
         const auto &surface_masks = surfaces.masks();
 
         const auto &bounds = volume.bounds();

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -43,7 +43,7 @@ namespace detray
 
         // Get surfaces, transforms and masks
         const auto &surfaces = volume.surfaces();
-        const auto surface_transforms = surfaces.transforms(context);
+        const auto &surface_transforms = surfaces.transforms(context);
         const auto &surface_masks = surfaces.masks();
 
         const auto &bounds = volume.bounds();

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -25,7 +25,8 @@ namespace detray
      *  - to a given grid.
      * 
      * @param context is the context to win which the association is done
-     * @param volume is the volume to which the volume belongs
+     * @param detector is the detector to which the grid belongs
+     * @param volume is the volume to which the surfaces belong
      * @param grid is the grid that will be filled 
      * @param tolerance is the bin_tolerance in the two local coordinates
      * @param absolute_tolerance is an indicator if the tolerance is to be

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -43,7 +43,7 @@ namespace detray
 
         // Get surfaces, transforms and masks
         const auto &surfaces = volume.surfaces();
-        const auto &surface_transforms = surfaces.transforms();
+        const auto surface_transforms = surfaces.transforms(context);
         const auto &surface_masks = surfaces.masks();
 
         const auto &bounds = volume.bounds();

--- a/core/include/tools/intersection_kernel.hpp
+++ b/core/include/tools/intersection_kernel.hpp
@@ -189,8 +189,7 @@ namespace detray
               const transform_container &contextual_transforms,
               const mask_container &masks)
     {
-        // Retrieve the (potentially) contextual transform
-        const auto &ctf = contextual_transforms.contextual_transform(track.ctx, surface.transform());
+        const auto &ctf = contextual_transforms[surface.transform()];
         auto mask_link = surface.mask();
         const auto &mask_context = std::get<0>(mask_link);
         const auto &mask_range = std::get<1>(mask_link);

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -13,6 +13,7 @@
 #include "utils/enumerate.hpp"
 #include "tools/intersection_kernel.hpp"
 #include <algorithm>
+#include <iostream>
 
 namespace detray
 {
@@ -309,6 +310,7 @@ namespace detray
             }
             kernel.candidates.reserve(n_objects);
             const auto &transforms = constituents.transforms(track.ctx);
+            std::cout << "I'm here!" << std::endl;
             const auto &masks = constituents.masks();
             // Loop over all indexed surfaces, intersect and fill
             // @todo - will come from the local object finder
@@ -317,6 +319,7 @@ namespace detray
             {
                 const auto &object = constituents.indexed_object(si);
                 auto [sfi, link] = intersect(track, object, transforms, masks);
+
                 sfi.index = si;
                 sfi.link = link[0];
                 // Ignore negative solutions - except overstep limit
@@ -352,7 +355,6 @@ namespace detray
                            const track<context> &track,
                            const constituents_t &constituents) const
         {
-
             // If the kernel is empty - intitalize it
             if (kernel.empty())
             {

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -287,6 +287,7 @@ namespace detray
          * @param kernel [in,out] the kernel to be checked/initialized 
          * @param track the track information 
          * @param constituens the constituents to be checked
+         * @param range the transform index range of the constituents
          * @param on_object ignores on surface solution
          * 
          */
@@ -345,6 +346,7 @@ namespace detray
          * @param kernel [in,out] the kernel to be checked/initialized 
          * @param track the track information 
          * @param constituens the constituents to be checked
+         * @param range the transform index range of the constituents
          * 
          * @return A boolean condition 
          */

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -318,7 +318,6 @@ namespace detray
             {
                 const auto &object = constituents.indexed_object(si);
                 auto [sfi, link] = intersect(track, object, transforms, masks);
-
                 sfi.index = si;
                 sfi.link = link[0];
                 // Ignore negative solutions - except overstep limit

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -187,11 +187,11 @@ namespace detray
             if (navigation.volume_index == dindex_invalid or navigation.trust_level == e_no_trust)
             {
                 // First try to get the surface candidates
-                initialize_kernel(navigation, surface_kernel, track, volume.surfaces());
+                initialize_kernel(navigation, surface_kernel, track, volume.surfaces(), volume.surface_range());
                 // If no surfaces are to processed, initialize the portals
                 if (surface_kernel.empty())
                 {
-                    initialize_kernel(navigation, portal_kernel, track, volume.portals());
+                    initialize_kernel(navigation, portal_kernel, track, volume.portals(), volume.portal_range());
                     heartbeat = check_volume_switch(navigation);
                 }
                 // Before returning, run through the inspector
@@ -200,14 +200,14 @@ namespace detray
             }
 
             // Update the surface kernel
-            if (not is_exhausted(surface_kernel) and update_kernel(navigation, surface_kernel, track, volume.surfaces()))
+            if (not is_exhausted(surface_kernel) and update_kernel(navigation, surface_kernel, track, volume.surfaces(), volume.surface_range()))
             {
                 navigation.inspector(navigation);
                 return heartbeat;
             }
 
             // Update the portal kernel
-            update_kernel(navigation, portal_kernel, track, volume.portals());
+            update_kernel(navigation, portal_kernel, track, volume.portals(), volume.portal_range());
             heartbeat = check_volume_switch(navigation);
             navigation.inspector(navigation);
             return heartbeat;
@@ -249,28 +249,28 @@ namespace detray
                         // Clear the surface kernel
                         surface_kernel.clear();
                         navigation.trust_level = e_no_trust;
-                        update_kernel(navigation, portal_kernel, track, volume.portals());
+                        update_kernel(navigation, portal_kernel, track, volume.portals(), volume.portal_range());
                         navigation.inspector(navigation);
                         return heartbeat;
                     }
-                    else if (update_kernel(navigation, surface_kernel, track, volume.surfaces()))
+                    else if (update_kernel(navigation, surface_kernel, track, volume.surfaces(), volume.surface_range()))
                     {
                         navigation.inspector(navigation);
                         return heartbeat;
                     }
                 }
                 // Portals are present
-                update_kernel(navigation, portal_kernel, track, volume.portals());
+                update_kernel(navigation, portal_kernel, track, volume.portals(), volume.portal_range());
             }
             else if (navigation.trust_level == e_no_trust)
             {
                 // First try to get the surface candidates
-                initialize_kernel(navigation, surface_kernel, track, volume.surfaces());
+                initialize_kernel(navigation, surface_kernel, track, volume.surfaces(), volume.surface_range());
                 // If no surfaces are to processed, initialize the portals
                 if (surface_kernel.empty())
                 {
 
-                    initialize_kernel(navigation, portal_kernel, track, volume.portals(), navigation.status == e_on_portal);
+                    initialize_kernel(navigation, portal_kernel, track, volume.portals(), volume.portal_range(), navigation.status == e_on_portal);
                     heartbeat = check_volume_switch(navigation);
                 }
             }
@@ -290,11 +290,12 @@ namespace detray
          * @param on_object ignores on surface solution
          * 
          */
-        template <typename kernel_t, typename constituents_t>
+        template <typename kernel_t, typename constituents_t, typename range_t>
         void initialize_kernel(state &navigation,
                                kernel_t &kernel,
                                const track<context> &track,
                                const constituents_t &constituents,
+                               const range_t &range,
                                bool on_object = false) const
         {
 
@@ -309,7 +310,7 @@ namespace detray
                 return;
             }
             kernel.candidates.reserve(n_objects);
-            const auto &transforms = constituents.transforms(track.ctx);
+            const auto &transforms = detector.transforms(range, track.ctx);
             const auto &masks = constituents.masks();
             // Loop over all indexed surfaces, intersect and fill
             // @todo - will come from the local object finder
@@ -347,23 +348,24 @@ namespace detray
          * 
          * @return A boolean condition 
          */
-        template <typename kernel_t, typename constituents_t>
+        template <typename kernel_t, typename constituents_t, typename range_t>
         bool update_kernel(state &navigation,
                            kernel_t &kernel,
                            const track<context> &track,
-                           const constituents_t &constituents) const
+                           const constituents_t &constituents,
+                           const range_t &range) const
         {
             // If the kernel is empty - intitalize it
             if (kernel.empty())
             {
-                initialize_kernel(navigation, kernel, track, constituents);
+                initialize_kernel(navigation, kernel, track, constituents, range);
                 return true;
             }
 
             // Get the type of the kernel via a const expression at compile time
             constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, surface_link>>);
 
-            const auto &transforms = constituents.transforms(track.ctx);
+            const auto &transforms = detector.transforms(range, track.ctx);
             const auto &masks = constituents.masks();
 
             // Update current candidate, or step further
@@ -402,7 +404,7 @@ namespace detray
                 }
                 // If not successful: increase and switch to next
                 ++kernel.next;
-                if (update_kernel(navigation, kernel, track, constituents))
+                if (update_kernel(navigation, kernel, track, constituents, range))
                 {
                     return true;
                 }

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -12,8 +12,8 @@
 #include "utils/indexing.hpp"
 #include "utils/enumerate.hpp"
 #include "tools/intersection_kernel.hpp"
+
 #include <algorithm>
-#include <iostream>
 
 namespace detray
 {
@@ -310,7 +310,6 @@ namespace detray
             }
             kernel.candidates.reserve(n_objects);
             const auto &transforms = constituents.transforms(track.ctx);
-            std::cout << "I'm here!" << std::endl;
             const auto &masks = constituents.masks();
             // Loop over all indexed surfaces, intersect and fill
             // @todo - will come from the local object finder

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -308,7 +308,7 @@ namespace detray
                 return;
             }
             kernel.candidates.reserve(n_objects);
-            const auto &transforms = constituents.transforms();
+            const auto &transforms = constituents.transforms(track.ctx);
             const auto &masks = constituents.masks();
             // Loop over all indexed surfaces, intersect and fill
             // @todo - will come from the local object finder
@@ -363,7 +363,7 @@ namespace detray
             // Get the type of the kernel via a const expression at compile time
             constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, surface_link>>);
 
-            const auto &transforms = constituents.transforms();
+            const auto &transforms = constituents.transforms(track.ctx);
             const auto &masks = constituents.masks();
 
             // Update current candidate, or step further

--- a/core/include/tools/planar_intersector.hpp
+++ b/core/include/tools/planar_intersector.hpp
@@ -6,15 +6,15 @@
  */
 #pragma once
 
-#include <cmath>
-#include <climits>
-#include <optional>
-
 #include "core/intersection.hpp"
 #include "core/surface_base.hpp"
 #include "core/track.hpp"
 #include "masks/unmasked.hpp"
 #include "utils/unbound.hpp"
+
+#include <cmath>
+#include <climits>
+#include <optional>
 
 namespace detray
 {

--- a/core/include/utils/enumerate.hpp
+++ b/core/include/utils/enumerate.hpp
@@ -144,12 +144,12 @@ namespace detray
               typename = decltype(std::end(std::declval<container_type>())),
               typename array_type,
               typename = std::enable_if_t<std::conditional_t<std::is_array_v<array_type>, std::extent<array_type>, std::tuple_size<array_type>>::value == 2U>>
-    constexpr auto range_iter(const container_type &iterable, array_type &&range)
+    constexpr auto range_iter(const container_type &iterable, const array_type &range)
     {
         struct iterable_wrapper
         {
             const container_type &_iterable;
-            array_type _range;
+            const array_type &_range;
 
             inline auto begin() const {return _iterable.begin() + _range[0]; } 
 

--- a/core/include/utils/enumerate.hpp
+++ b/core/include/utils/enumerate.hpp
@@ -144,19 +144,22 @@ namespace detray
               typename = decltype(std::end(std::declval<container_type>())),
               typename array_type,
               typename = std::enable_if_t<std::conditional_t<std::is_array_v<array_type>, std::extent<array_type>, std::tuple_size<array_type>>::value == 2U>>
-    constexpr auto range_iter(const container_type &iterable, const array_type &range)
+    constexpr auto range_iter(const container_type &iterable, const array_type &&range)
     {
         struct iterable_wrapper
         {
-            const container_type &_iterable;
-            const array_type &_range;
+            iterable_wrapper() = delete;
+            iterable_wrapper(const container_type &i, const array_type &&r) : _iterable(i), _range(r) {}
 
-            inline auto begin() const {return _iterable.begin() + _range[0]; } 
+            const container_type &_iterable = {};
+            const array_type _range = {dindex_invalid, dindex_invalid};
 
-            inline auto end() const { return _iterable.begin() + _range[1]; }
+            inline decltype(auto) begin() const {return std::begin(_iterable) + _range[0]; }
+
+            inline decltype(auto) end() const { return std::begin(_iterable) + _range[1]; }
         };
 
-        return iterable_wrapper{iterable, range};
+        return iterable_wrapper(iterable, std::move(range));
     }
 
 } // namespace detray

--- a/core/include/utils/enumerate.hpp
+++ b/core/include/utils/enumerate.hpp
@@ -95,7 +95,7 @@ namespace detray
      * Usage:
      * for (auto i : sequence(r)) {}
      * 
-     * with r an range that can be accessed with r[0] and r[1]
+     * with r a range that can be accessed with r[0] and r[1]
      * 
      * @note sequence({2,4}) will produce { 2, 3, 4 }
      * 
@@ -128,6 +128,35 @@ namespace detray
             auto end() { return iterator{_iterable[1] + 1, _iterable[1] + 1}; }
         };
         return iterable_wrapper{std::forward<array_type>(iterable)};
+    }
+
+    /** Helper method to run over a range 
+     * 
+     * Usage:
+     * for (auto value : range(container, r)) {}
+     * 
+     * with r a range that can be accessed with r[0] and r[1]
+     *
+     * @note Convenience type: no range checks!
+     **/
+    template <typename container_type,
+              typename container_type_iter = decltype(std::begin(std::declval<container_type>())),
+              typename = decltype(std::end(std::declval<container_type>())),
+              typename array_type,
+              typename = std::enable_if_t<std::conditional_t<std::is_array_v<array_type>, std::extent<array_type>, std::tuple_size<array_type>>::value == 2U>>
+    constexpr auto range_iter(const container_type &iterable, array_type &&range)
+    {
+        struct iterable_wrapper
+        {
+            const container_type &_iterable;
+            array_type _range;
+
+            inline auto begin() const {return _iterable.begin() + _range[0]; } 
+
+            inline auto end() const { return _iterable.begin() + _range[1]; }
+        };
+
+        return iterable_wrapper{iterable, range};
     }
 
 } // namespace detray

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -357,8 +357,6 @@ namespace detray
         vector3 t{io_surface.cx, io_surface.cy, io_surface.cz};
         vector3 x{io_surface.rot_xu, io_surface.rot_yu, io_surface.rot_zu};
         vector3 z{io_surface.rot_xw, io_surface.rot_yw, io_surface.rot_zw};
-        dindex transform_index = surface_transform_storage.size();
-        surface_transform_storage.push_back(transform3{t, z, x});
 
         // Translate the mask & add it to the mask container
         unsigned int bounds_type = io_surface.bounds_type;
@@ -436,6 +434,8 @@ namespace detray
         // Fill the surface into the temporary container
         if (mask_index[0] != dindex_invalid)
         {
+          dindex transform_index = surface_transform_storage.size();
+          surface_transform_storage.push_back(transform3{t, z, x});
           c_surfaces.push_back({d.transform_index(surface_default_context) + transform_index, mask_index, c_volume->index(), io_surface.geometry_id});
         }
 

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -16,7 +16,6 @@
 #include "io/csv_io_types.hpp"
 #include "tools/bin_association.hpp"
 
-#include <iostream>
 #include <climits>
 #include <map>
 #include <vector>
@@ -436,7 +435,7 @@ namespace detray
         {
           dindex transform_index = surface_transform_storage.size();
           surface_transform_storage.push_back(transform3{t, z, x});
-          c_surfaces.push_back({d.transform_index(surface_default_context) + transform_index, mask_index, c_volume->index(), io_surface.geometry_id});
+          c_surfaces.push_back({transform_index, mask_index, c_volume->index(), io_surface.geometry_id});
         }
 
       } // end of exclusion for navigation layers

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -296,7 +296,8 @@ namespace detray
         if (c_volume != nullptr and not surface_transform_storage.empty())
         {
           // Construction with move semantics
-          c_volume->add_surface_transforms(surface_default_context, std::move(surface_transform_storage));
+          //c_volume->add_surface_transforms(surface_default_context, std::move(surface_transform_storage));
+          d.add_transforms(surface_default_context, std::move(surface_transform_storage));
           c_volume->add_surface_components(std::move(c_surfaces), std::move(c_masks));
 
           // Get new clean containers
@@ -435,7 +436,7 @@ namespace detray
         // Fill the surface into the temporary container
         if (mask_index[0] != dindex_invalid)
         {
-          c_surfaces.push_back({transform_index, mask_index, c_volume->index(), io_surface.geometry_id});
+          c_surfaces.push_back({d.transform_index(surface_default_context) + transform_index, mask_index, c_volume->index(), io_surface.geometry_id});
         }
 
       } // end of exclusion for navigation layers
@@ -487,7 +488,7 @@ namespace detray
     // - run the bin association
     for (auto [iv, v] : enumerate(d.volumes()))
     {
-      // Get the volume bounds for fillind
+      // Get the volume bounds for filling
       const auto &v_bounds = v.bounds();
 
       dindex irl = v_grid.axis_p0().bin(v_bounds[0] + stepsilon);

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -297,7 +297,7 @@ namespace detray
         {
           // Construction with move semantics
           //c_volume->add_surface_transforms(surface_default_context, std::move(surface_transform_storage));
-          d.add_transforms(surface_default_context, std::move(surface_transform_storage));
+          d.add_surface_transforms(surface_default_context, *c_volume, std::move(surface_transform_storage));
           c_volume->add_surface_components(std::move(c_surfaces), std::move(c_masks));
 
           // Get new clean containers

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -515,7 +515,7 @@ namespace detray
       if (sfi != dindex_invalid and write_grid_entries)
       {
         auto &grid = is_cylinder ? detector_surfaces_finders[sfi + 2] : detector_surfaces_finders[sfi];
-        bin_association(surface_default_context, v, grid, {0.1, 0.1}, false);
+        bin_association(surface_default_context, d, v, grid, {0.1, 0.1}, false);
 
         csv_surface_grid_entry csv_ge;
         csv_ge.detray_volume_id = static_cast<int>(iv);

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -72,6 +72,7 @@ namespace __plugin
         point3 ori = {0., 0., 0.};
 
         using detray_context = decltype(d)::transform_store::context;
+        detray_context default_context;
 
         for (auto _ : state)
         {
@@ -102,7 +103,7 @@ namespace __plugin
                         // Loop over surfaces
                         for (const auto &s : surfaces.objects())
                         {
-                            auto sfi_surface = intersect(track, s, surfaces.transforms(), surfaces.masks());
+                            auto sfi_surface = intersect(track, s, surfaces.transforms(default_context), surfaces.masks());
 
                             const auto &sfi = std::get<0>(sfi_surface);
                             

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -103,7 +103,7 @@ namespace __plugin
                         // Loop over surfaces
                         for (const auto &s : surfaces.objects())
                         {
-                            auto sfi_surface = intersect(track, s, surfaces.transforms(default_context), surfaces.masks());
+                            auto sfi_surface = intersect(track, s, d.transforms(v.surface_range(), default_context), surfaces.masks());
 
                             const auto &sfi = std::get<0>(sfi_surface);
                             

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -48,7 +48,7 @@ TEST(ALGEBRA_PLUGIN, detector)
 
     detector d("test_detector");
     auto &v = d.new_volume("test_volume", {0., 10., -5., 5., -M_PI, M_PI});
-    v.add_surface_transforms(ctx0, std::move(static_storage));
+    d.add_transforms(ctx0, std::move(static_storage));
 }
 
 int main(int argc, char **argv)

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -48,7 +48,7 @@ TEST(ALGEBRA_PLUGIN, detector)
 
     detector d("test_detector");
     auto &v = d.new_volume("test_volume", {0., 10., -5., 5., -M_PI, M_PI});
-    d.add_transforms(ctx0, std::move(static_storage));
+    d.add_surface_transforms(ctx0, v, std::move(static_storage));
 }
 
 int main(int argc, char **argv)

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -131,6 +131,8 @@ TEST(ALGEBRA_PLUGIN, navigator)
     ASSERT_EQ(state.trust_level, detray_navigator::navigation_trust_level::e_high_trust);
 
     // New target call
+
+    std::cout << "This is the call:" << std::endl;
     heartbeat = n.target(state, traj);
     // Test that the navigator has a heartbeat
     ASSERT_TRUE(heartbeat);

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -131,8 +131,6 @@ TEST(ALGEBRA_PLUGIN, navigator)
     ASSERT_EQ(state.trust_level, detray_navigator::navigation_trust_level::e_high_trust);
 
     // New target call
-
-    std::cout << "This is the call:" << std::endl;
     heartbeat = n.target(state, traj);
     // Test that the navigator has a heartbeat
     ASSERT_TRUE(heartbeat);

--- a/tests/unit_tests/core/utils_enumerate.cpp
+++ b/tests/unit_tests/core/utils_enumerate.cpp
@@ -59,6 +59,21 @@ TEST(utils, enumerate)
     }
 }
 
+// This tests the restricted iterator
+TEST(utils, range)
+{
+    size_t begin = 1;
+    size_t end = 4;
+
+    dvector<int> seq = {0,1,2,3,4,5};
+
+    size_t i = 1;
+    for (const auto &v : range_iter(seq, std::array<size_t, 2>{begin, end}))
+    {
+        ASSERT_EQ(v, seq[i++]);
+    }
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/unit_tests/core/utils_enumerate.cpp
+++ b/tests/unit_tests/core/utils_enumerate.cpp
@@ -51,8 +51,6 @@ TEST(utils, enumerate)
 
     dvector<uint_holder> seq = {{0}, {1}, {2}, {3}, {4}, {5}};
 
-    using container_type_iter = decltype(std::begin(std::declval<dvector<uint_holder>>()));
-
     for (auto [i, v] : enumerate(seq))
     {
         ASSERT_EQ(i, v.ui);
@@ -65,11 +63,12 @@ TEST(utils, range)
     size_t begin = 1;
     size_t end = 4;
 
-    dvector<int> seq = {0,1,2,3,4,5};
+    dvector<int> seq = {0, 1, 2, 3, 4, 5};
 
     size_t i = 1;
     for (const auto &v : range_iter(seq, std::array<size_t, 2>{begin, end}))
     {
+        ASSERT_NE(v, 5);
         ASSERT_EQ(v, seq[i++]);
     }
 }


### PR DESCRIPTION
First step to single storage geometry:
- A single large transform store is owned by detector
- Iterator based access to detector data with the help of nested classes (volume, constituents): The volumes pass a transform index range to initialize the iterator. This avoids having to hold a detector instance pointer in the volume/constituents by which the data is accessed
- Removes what seems to be a bug in the csv reader, where transforms are now only stored, if they have a valid mask