### PR TITLE
ref: move masks to detector level

### DIFF
--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -427,7 +427,7 @@ namespace detray
             unroll_container_filling<0, object_container, mask_container, is_surface_masks>(objects, masks);
         }
 
-        /** Get @return all surface masks of a volume from the detector */
+        /** Get @return all surface/portal masks in the detector */
         template<bool is_surface_masks = true>
         const auto& masks() const
         {
@@ -459,6 +459,13 @@ namespace detray
 
                         detector_masks.reserve(first_mask + object_masks.size());
                         detector_masks.insert(detector_masks.end(), object_masks.begin(), object_masks.end());
+
+                        for (auto &obj : objects)
+                        {
+                            if (std::get<0>(obj.mask()) == current_idx) {
+                                std::get<1>(obj.mask()) += first_mask;
+                            }
+                        }
                     }
                     else
                     {
@@ -468,18 +475,14 @@ namespace detray
 
                         detector_masks.reserve(first_mask + object_masks.size());
                         detector_masks.insert(detector_masks.end(), object_masks.begin(), object_masks.end());
-                    }
 
-                    // Update batch
-                    for (auto &obj : objects)
-                    {
-                        if constexpr (is_surface_masks)
+                        for (auto &obj : objects)
                         {
-                            obj.mask()[1] += first_mask;
-                        }
-                        else{
-                            auto& portal_mask_index = std::get<1>(obj.mask());
-                            portal_mask_index[1] += first_mask;
+                            if (std::get<0>(obj.mask()) == current_idx) {
+                                auto& portal_mask_index = std::get<1>(obj.mask());
+                                portal_mask_index[0] += first_mask;
+                                portal_mask_index[1] += first_mask;
+                            }
                         }
                     }
                 }

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -235,8 +235,8 @@ namespace detray
                     for (auto &info_ : portals_info)
                     {
                         typename detector_type::portal_disc _portal_disc = {std::get<0>(info_), {std::get<1>(info_), dindex_invalid}};
-                        mask_group.push_back(_portal_disc);
                         std::get<1>(mask_index)[1] = mask_group.size();
+                        mask_group.push_back(_portal_disc);
                     }
                     // Create the portal
                     typename detector_type::portal _portal{portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
@@ -266,8 +266,8 @@ namespace detray
                         const auto cylinder_range = std::get<0>(info_);
                         array_type<scalar, 3> cylinder_bounds = {volume_bounds[bound_index], cylinder_range[0], cylinder_range[1]};
                         typename detector_type::portal_cylinder _portal_cylinder = {cylinder_bounds, {std::get<1>(info_), dindex_invalid}};
-                        mask_group.push_back(_portal_cylinder);
                         std::get<1>(mask_index)[1] = mask_group.size();
+                        mask_group.push_back(_portal_cylinder);
                     }
                     // Create the portal
                     typename detector_type::portal _portal{portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
@@ -284,8 +284,8 @@ namespace detray
 
             // Create a transform store and add it
             // All componnents are added
-            constexpr bool is_surface_masks = false;
-            d.template add_masks<is_surface_masks>(portals, portal_masks);
+            constexpr bool add_surface_masks = false;
+            d.template add_masks<add_surface_masks>(portals, portal_masks);
             volume.add_portal_components(std::move(portals));
             d.add_portal_transforms(default_context, volume, std::move(portal_transforms));
         }

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -235,8 +235,8 @@ namespace detray
                     for (auto &info_ : portals_info)
                     {
                         typename detector_type::portal_disc _portal_disc = {std::get<0>(info_), {std::get<1>(info_), dindex_invalid}};
-                        std::get<1>(mask_index)[1] = mask_group.size();
                         mask_group.push_back(_portal_disc);
+                        std::get<1>(mask_index)[1] = mask_group.size();
                     }
                     // Create the portal
                     typename detector_type::portal _portal{portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
@@ -266,8 +266,8 @@ namespace detray
                         const auto cylinder_range = std::get<0>(info_);
                         array_type<scalar, 3> cylinder_bounds = {volume_bounds[bound_index], cylinder_range[0], cylinder_range[1]};
                         typename detector_type::portal_cylinder _portal_cylinder = {cylinder_bounds, {std::get<1>(info_), dindex_invalid}};
-                        std::get<1>(mask_index)[1] = mask_group.size();
                         mask_group.push_back(_portal_cylinder);
+                        std::get<1>(mask_index)[1] = mask_group.size();
                     }
                     // Create the portal
                     typename detector_type::portal _portal{portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
@@ -284,10 +284,10 @@ namespace detray
 
             // Create a transform store and add it
             // All componnents are added
-            volume.add_portal_components(std::move(portals));
-            d.add_portal_transforms(default_context, volume, std::move(portal_transforms));
             constexpr bool is_surface_masks = false;
             d.template add_masks<is_surface_masks>(portals, portal_masks);
+            volume.add_portal_components(std::move(portals));
+            d.add_portal_transforms(default_context, volume, std::move(portal_transforms));
         }
     }
 }

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -284,8 +284,10 @@ namespace detray
 
             // Create a transform store and add it
             // All componnents are added
-            volume.add_portal_components(std::move(portals), std::move(portal_masks));
+            volume.add_portal_components(std::move(portals));
             d.add_portal_transforms(default_context, volume, std::move(portal_transforms));
+            constexpr bool is_surface_masks = false;
+            d.template add_masks<is_surface_masks>(portals, portal_masks);
         }
     }
 }

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -47,7 +47,7 @@ namespace detray
         // Get surfaces, transforms and masks
         const auto &surfaces = volume.surfaces();
         const auto &surface_transforms = detector.transforms(volume.surface_range(), context);
-        const auto &surface_masks = surfaces.masks();
+        const auto &surface_masks = detector.masks();
 
         const auto &bounds = volume.bounds();
         bool is_cylinder = std::abs(bounds[1] - bounds[0]) < std::abs(bounds[3] - bounds[2]);

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -269,10 +269,6 @@ namespace detray
                 // If no surfaces are to processed, initialize the portals
                 if (surface_kernel.empty())
                 {
-                    for (const auto& p : volume.portals().objects())
-                    {
-                        const auto& mask_link = p.mask();
-                    }
                     initialize_kernel(navigation, portal_kernel, track, volume.portals(), volume.portal_range(), navigation.status == e_on_portal);
                     heartbeat = check_volume_switch(navigation);
                 }

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -312,7 +312,7 @@ namespace detray
             }
             kernel.candidates.reserve(n_objects);
             const auto &transforms = detector.transforms(range, track.ctx);
-            const auto &masks = constituents.masks();
+            const auto &masks = detector.template masks<kSurfaceType>();
             // Loop over all indexed surfaces, intersect and fill
             // @todo - will come from the local object finder
             darray<dindex, 2> surface_range = {0, n_objects - 1};
@@ -368,7 +368,7 @@ namespace detray
             constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, surface_link>>);
 
             const auto &transforms = detector.transforms(range, track.ctx);
-            const auto &masks = constituents.masks();
+            const auto &masks = detector.template masks<kSurfaceType>();
 
             // Update current candidate, or step further
             // - do this only when you trust level is high

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -269,7 +269,10 @@ namespace detray
                 // If no surfaces are to processed, initialize the portals
                 if (surface_kernel.empty())
                 {
-
+                    for (const auto& p : volume.portals().objects())
+                    {
+                        const auto& mask_link = p.mask();
+                    }
                     initialize_kernel(navigation, portal_kernel, track, volume.portals(), volume.portal_range(), navigation.status == e_on_portal);
                     heartbeat = check_volume_switch(navigation);
                 }

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -295,9 +295,9 @@ namespace detray
         if (c_volume != nullptr and not surface_transform_storage.empty())
         {
           // Construction with move semantics
-          //c_volume->add_surface_transforms(surface_default_context, std::move(surface_transform_storage));
           d.add_surface_transforms(surface_default_context, *c_volume, std::move(surface_transform_storage));
-          c_volume->add_surface_components(std::move(c_surfaces), std::move(c_masks));
+          d.add_masks(c_surfaces, c_masks);
+          c_volume->add_surface_components(std::move(c_surfaces));
 
           // Get new clean containers
           surface_transform_storage = typename alignable_store::storage();

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -99,7 +99,8 @@ namespace __plugin
                     for (const auto &v : d.volumes())
                     {
                         const auto &surfaces = v.surfaces();
-                        const auto &masks = d.template masks<true>();
+                        constexpr bool get_surface_masks = true;
+                        const auto &masks = d.template masks<get_surface_masks>();
 
                         // Loop over surfaces
                         for (const auto &s : surfaces.objects())

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -103,7 +103,7 @@ namespace __plugin
                         // Loop over surfaces
                         for (const auto &s : surfaces.objects())
                         {
-                            auto sfi_surface = intersect(track, s, d.transforms(v.surface_range(), default_context), surfaces.masks());
+                            auto sfi_surface = intersect(track, s, d.transforms(v.surface_range(), default_context), d.masks());
 
                             const auto &sfi = std::get<0>(sfi_surface);
                             

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -99,11 +99,12 @@ namespace __plugin
                     for (const auto &v : d.volumes())
                     {
                         const auto &surfaces = v.surfaces();
+                        const auto &masks = d.template masks<true>();
 
                         // Loop over surfaces
                         for (const auto &s : surfaces.objects())
                         {
-                            auto sfi_surface = intersect(track, s, d.transforms(v.surface_range(), default_context), d.masks());
+                            auto sfi_surface = intersect(track, s, d.transforms(v.surface_range(), default_context), masks);
 
                             const auto &sfi = std::get<0>(sfi_surface);
                             


### PR DESCRIPTION
This PR continues the work of and builds upon #82 to also move the masks to detector level:

- The surface and portal links now point to masks in the big containers
- The masks are accessed through the detector as opposed to the constituents class. 
- A mask container of the appropriate type (surface/portal) is filled for each volume in the detector io and then unrolled again to fill the detectors containers.