### PR TITLE
ref: move surfaces to det

### DIFF
--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -182,7 +182,7 @@ namespace detray
             dindex surfaces_finder_entry() const { return _surfaces_finder_entry; }
 
             /** @return if the volume is empty or not */
-            bool empty() const { return (_surfaces.objects().empty() and _portals.objects().empty()); }
+            bool empty() const { return ( _surface_range[1] - _surface_range[0] == 0 and _portal_range[1] - _portal_range[0] == 0); }
 
             /** Set the index into the detector surface container
              *

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -311,10 +311,10 @@ namespace detray
 
         /** Add a new full set of alignable transforms for surfaces of a volume
          *
-         * @param ctx The context of the call
          * @param volume The volume we add the transforms to
          * @param surfaces The surfaces in the volume
          * @param trfs The surface transforms (same number as surfaces)
+         * @param ctx The context of the call
          *
          * @note can throw an exception if input data is inconsistent
          */
@@ -329,6 +329,7 @@ namespace detray
             _transforms.append_contextual_transforms(ctx, std::move(trfs));
 
             volume.set_surface_range({_surfaces.size(), _surfaces.size() + surfaces.size()});
+
             _surfaces.reserve(_surfaces.size() + surfaces.size());
             _surfaces.insert(_surfaces.end(), surfaces.begin(), surfaces.end());
         }
@@ -343,10 +344,10 @@ namespace detray
 
         /** Add a new full set of alignable transforms for portals of a volume
          *
-         * @param ctx The context of the call
          * @param volume The volume we add the transforms to
          * @param portals The portals of the volume
          * @param trfs The portal transforms (same number as portals)
+         * @param ctx The context of the call
          *
          * @note can throw an exception if input data is inconsistent
          */
@@ -364,7 +365,7 @@ namespace detray
             _portals.insert(_portals.end(), portals.begin(), portals.end());
         }
 
-        /** Add new surface/portal masks of a volume to the detector
+        /** Add new surface/portal masks of a volume to the detector. This has to be called before surfaces are added, in order to update the mask links!
           *
           * @tparam is_surface_masks check whether we deal with surfaces or portals
           * @tparam object_container surfaces/portals for which the links are updated

--- a/core/include/core/transform_store.hpp
+++ b/core/include/core/transform_store.hpp
@@ -104,6 +104,17 @@ namespace detray
          * @param ctx The context of the call (ignored)
          * @param tcf The transform to be filled
          */
+        template <class... Args>  
+        void emplace_back(const context & /*ctx*/, Args&&... args)
+        {
+            _data.emplace_back(std::forward<Args>(args)...);
+        }
+
+        /** Push back : Contextual STL like API, copy semantics
+         *
+         * @param ctx The context of the call (ignored)
+         * @param tcf The transform to be filled
+         */
         void push_back(const context & /*ctx*/, const transform3 &tf)
         {
             _data.push_back(tf);
@@ -133,6 +144,19 @@ namespace detray
         bool empty(const context & /*ctx*/)
         {
             return _data.empty();
+        }
+
+        /** Append a transform store to an existing one
+         *
+         * @param ctx The context of the call (ignored)
+         * @param other The transform store, move semantics
+         *
+         * @note in general can throw an exception
+         */
+        void append(const context & ctx, static_transform_store<vector_type> &&other) noexcept(false)
+        {
+            _data.reserve(_data.size() + other.size(ctx));
+            _data.insert(_data.end(), std::make_move_iterator(other.begin(ctx)), std::make_move_iterator(other.end(ctx)));
         }
 
         /** Add a new bunch of transforms for a new context - move semantics

--- a/core/include/core/transform_store.hpp
+++ b/core/include/core/transform_store.hpp
@@ -99,10 +99,10 @@ namespace detray
             _data.reserve(n_size);
         }
 
-        /** Push back : Contextual STL like API, copy semantics
+        /** Emplace back : Contextual STL like API
          *
          * @param ctx The context of the call (ignored)
-         * @param tcf The transform to be filled
+         * @param args Constructor arguments
          */
         template <class... Args>  
         void emplace_back(const context & /*ctx*/, Args&&... args)

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -207,10 +207,6 @@ namespace detray
             // Walk up from the bottom right corner
             walk_up(bottom_right, right_portals_info, false, 1);
 
-            /*typename detector_type::portal_container portals;
-            typename detector_type::portal_mask_container portal_masks;
-            typename detector_type::transform_store::storage portal_transforms;*/
-
             typename detector_type::portal_filling_container portals = {};
             typename detector_type::portal_mask_container portal_masks;
             typename detector_type::transform_container portal_transforms;

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -207,9 +207,13 @@ namespace detray
             // Walk up from the bottom right corner
             walk_up(bottom_right, right_portals_info, false, 1);
 
-            typename detector_type::portal_container portals;
+            /*typename detector_type::portal_container portals;
             typename detector_type::portal_mask_container portal_masks;
-            typename detector_type::transform_store::storage portal_transforms;
+            typename detector_type::transform_store::storage portal_transforms;*/
+
+            typename detector_type::portal_filling_container portals = {};
+            typename detector_type::portal_mask_container portal_masks;
+            typename detector_type::transform_container portal_transforms;
 
             // The bounds can be used for the mask and transform information
             const auto &volume_bounds = volume.bounds();
@@ -227,9 +231,12 @@ namespace detray
                 {
                     // The portal transfrom is given from the left
                     __plugin::vector3 _translation{0., 0., volume_bounds[bound_index]};
-                    __plugin::transform3 _portal_transform(_translation);
+
                     // Get the mask context group and fill it
-                    auto &mask_group = std::get<detector_type::portal_disc::mask_context>(portal_masks);
+                    auto &disc_portal_transforms = std::get<detector_type::portal_disc::mask_context>(portal_transforms);
+                    auto &disc_portals = std::get<detector_type::portal_disc::mask_context>(portals);
+                    auto &mask_group   = std::get<detector_type::portal_disc::mask_context>(portal_masks);
+                    
                     typename detector_type::portal_mask_index mask_index = {detector_type::portal_disc::mask_context, {mask_group.size(), mask_group.size()}};
                     // Create a stub mask for every unique index
                     for (auto &info_ : portals_info)
@@ -239,9 +246,10 @@ namespace detray
                         mask_group.push_back(_portal_disc);
                     }
                     // Create the portal
-                    typename detector_type::portal _portal{portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
-                    portals.push_back(std::move(_portal));
-                    portal_transforms.push_back(std::move(_portal_transform));
+                    typename detector_type::portal _portal{disc_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
+                    // Save the data
+                    disc_portals.push_back(std::move(_portal));
+                    disc_portal_transforms.emplace_back(default_context, _translation);
                 }
             };
 
@@ -255,10 +263,10 @@ namespace detray
                 // Fill in the upper side portals
                 if (not portals_info.empty())
                 {
-                    // This will be concentric targetted at nominal center
-                    __plugin::transform3 _portal_transform;
                     // Get the mask context group and fill it
-                    auto &mask_group = std::get<detector_type::portal_cylinder::mask_context>(portal_masks);
+                    auto &cylinder_portal_transforms = std::get<detector_type::portal_cylinder::mask_context>(portal_transforms);
+                    auto &cylinder_portals = std::get<detector_type::portal_cylinder::mask_context>(portals);
+                    auto &mask_group   = std::get<detector_type::portal_cylinder::mask_context>(portal_masks);
 
                     typename detector_type::portal_mask_index mask_index = {detector_type::portal_cylinder::mask_context, {mask_group.size(), mask_group.size()}};
                     for (auto &info_ : portals_info)
@@ -270,9 +278,10 @@ namespace detray
                         mask_group.push_back(_portal_cylinder);
                     }
                     // Create the portal
-                    typename detector_type::portal _portal{portal_transforms.size(), mask_index, volume.index(), dindex_invalid};
-                    portals.push_back(std::move(_portal));
-                    portal_transforms.push_back(std::move(_portal_transform));
+                    typename detector_type::portal _portal{cylinder_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
+                    cylinder_portals.push_back(std::move(_portal));
+                    // This will be concentric targetted at nominal center
+                    cylinder_portal_transforms.emplace_back(default_context);
                 }
             };
 
@@ -282,11 +291,8 @@ namespace detray
             add_disc_portals(right_portals_info, 3);
             add_cylinder_portal(lower_portals_info, 0);
 
-            // Create a transform store and add it
-            // All componnents are added
-            constexpr bool add_surface_masks = false;
-            d.template add_masks<add_surface_masks>(portals, portal_masks);
-            d.add_portals(volume, portals, portal_transforms, default_context);
+            // Add portals to detector
+            d.add_portals(volume, portals, portal_masks, portal_transforms,  default_context);
         }
     }
 }

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -284,10 +284,9 @@ namespace detray
 
             // Create a transform store and add it
             // All componnents are added
+            d.add_portals(volume, portals, portal_transforms, default_context);
             constexpr bool add_surface_masks = false;
             d.template add_masks<add_surface_masks>(portals, portal_masks);
-            volume.add_portal_components(std::move(portals));
-            d.add_portal_transforms(default_context, volume, std::move(portal_transforms));
         }
     }
 }

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -284,9 +284,9 @@ namespace detray
 
             // Create a transform store and add it
             // All componnents are added
-            d.add_portals(volume, portals, portal_transforms, default_context);
             constexpr bool add_surface_masks = false;
             d.template add_masks<add_surface_masks>(portals, portal_masks);
+            d.add_portals(volume, portals, portal_transforms, default_context);
         }
     }
 }

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -45,7 +45,7 @@ namespace detray
     {
 
         // Get surfaces, transforms and masks
-        const auto &surfaces = volume.surfaces();
+        const auto &surfaces = detector.surfaces();
         const auto &surface_transforms = detector.transforms(volume.surface_range(), context);
         const auto &surface_masks = detector.masks();
 
@@ -83,8 +83,11 @@ namespace detray
                                                                     phi_borders[1] + phi_add);
 
                     // Run through the surfaces and associate them by contour
-                    for (auto [is, s] : enumerate(surfaces.objects()))
+                    const auto& sf_range = volume.surface_range();
+                    for (auto is = sf_range[0]; is < sf_range[1]; is++)
+                    //for (auto [is, s] : enumerate(surfaces.objects()))
                     {
+                        const auto& s = surfaces[is];
                         dvector<point3> vertices = {};
                         const auto &mask_link = s.mask();
 
@@ -154,8 +157,11 @@ namespace detray
                     std::vector<point2> bin_contour = {p0_bin, p1_bin, p2_bin, p3_bin};
 
                     // Loop over the surfaces within a volume
-                    for (auto [is, s] : enumerate(surfaces.objects()))
+                    const auto& sf_range = volume.surface_range();
+                    for (auto is = sf_range[0]; is < sf_range[1]; is++)
+                    //for (auto [is, s] : enumerate(surfaces.objects()))
                     {
+                        const auto& s = surfaces[is];
                         dvector<point3> vertices = {};
                         const auto &mask_link = s.mask();
 

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -315,7 +315,6 @@ namespace detray
             const auto &masks = detector.template masks<kSurfaceType>();
             // Loop over all indexed surfaces, intersect and fill
             // @todo - will come from the local object finder
-            //darray<dindex, 2> surface_range = {0, n_objects - 1};
             for (auto si : sequence(obj_range))
             {
                 const auto &object = surfaces[si];

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -85,9 +85,6 @@ namespace detray
 
     // Flushable containers
     typename typed_detector::volume *c_volume = nullptr;
-    /*typename typed_detector::surface_container c_surfaces;
-    typename typed_detector::surface_mask_container c_masks;*/
-
     typename typed_detector::surface_filling_container c_surfaces;
     typename typed_detector::surface_mask_container c_masks;
     typename typed_detector::transform_container c_transforms;

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -295,8 +295,8 @@ namespace detray
         if (c_volume != nullptr and not surface_transform_storage.empty())
         {
           // Construction with move semantics
-          d.add_surfaces(*c_volume, c_surfaces, surface_transform_storage, surface_default_context);
           d.add_masks(c_surfaces, c_masks);
+          d.add_surfaces(*c_volume, c_surfaces, surface_transform_storage, surface_default_context);
 
           // Get new clean containers
           surface_transform_storage = typename alignable_store::storage();

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -85,8 +85,12 @@ namespace detray
 
     // Flushable containers
     typename typed_detector::volume *c_volume = nullptr;
-    typename typed_detector::surface_container c_surfaces;
+    /*typename typed_detector::surface_container c_surfaces;
+    typename typed_detector::surface_mask_container c_masks;*/
+
+    typename typed_detector::surface_filling_container c_surfaces;
     typename typed_detector::surface_mask_container c_masks;
+    typename typed_detector::transform_container c_transforms;
 
     std::map<volume_layer_index, array_type<scalar, 6>> volume_bounds;
 
@@ -292,16 +296,13 @@ namespace detray
       if (c_volume_itr == volumes.end())
       {
         // Flush the former information / c_volume still points to the prior volume
-        if (c_volume != nullptr and not surface_transform_storage.empty())
+        if (c_volume != nullptr)
         {
-          // Construction with move semantics
-          d.add_masks(c_surfaces, c_masks);
-          d.add_surfaces(*c_volume, c_surfaces, surface_transform_storage, surface_default_context);
+          d.add_surfaces(*c_volume, c_surfaces, c_masks, c_transforms,  surface_default_context);
 
-          // Get new clean containers
-          surface_transform_storage = typename alignable_store::storage();
-          c_surfaces = typename typed_detector::surface_container();
-          c_masks = typename typed_detector::surface_mask_container();
+          c_surfaces   = typename typed_detector::surface_filling_container();
+          c_masks      = typename typed_detector::surface_mask_container();
+          c_transforms = typename typed_detector::transform_container();
         }
 
         // Create a new volume & assign
@@ -372,15 +373,23 @@ namespace detray
 
         if (bounds_type == 1)
         {
-          // Cylinder bounds
+          // Cylinder Bounds
           constexpr auto cylinder_context = typed_detector::surface_cylinder::mask_context;
 
-          // Get the cylinder mask container
+          // Add a new cylinder mask
           auto &cylinder_masks = std::get<cylinder_context>(c_masks);
           dindex cylinder_index = cylinder_masks.size();
           cylinder_masks.push_back({io_surface.bound_param0, io_surface.cz - io_surface.bound_param1, io_surface.cz + io_surface.bound_param1});
           // The read is valid: set the index
           mask_index = {cylinder_context, cylinder_index};
+
+          // Build the cylinder transform
+          auto &cylinder_transforms = std::get<cylinder_context>(c_transforms);
+          cylinder_transforms.emplace_back(surface_default_context, t, z, x);
+
+          // Save the corresponding surface
+          auto &cylinder_surfaces = c_surfaces[cylinder_context];
+          cylinder_surfaces.emplace_back(cylinder_transforms.size(surface_default_context) - 1, mask_index, c_volume->index(), io_surface.geometry_id);
         }
         else if (bounds_type == 3)
         {
@@ -391,7 +400,7 @@ namespace detray
           // Rectangle bounds
           constexpr auto rectangle_context = typed_detector::surface_rectangle::mask_context;
 
-          // Get the rectangle mask container
+          // Add a new rectangle mask
           auto &rectangle_masks = std::get<rectangle_context>(c_masks);
           dindex rectangle_index = rectangle_masks.size();
           scalar half_x = 0.5 * (io_surface.bound_param2 - io_surface.bound_param0);
@@ -399,23 +408,40 @@ namespace detray
           rectangle_masks.push_back({half_x, half_y});
           // The read is valid: set the index
           mask_index = {rectangle_context, rectangle_index};
+
+          // Build the rectangle transform
+          auto &rectangle_transforms = std::get<rectangle_context>(c_transforms);
+          rectangle_transforms.emplace_back(surface_default_context, t, z, x);
+
+          // Save the corresponding surface
+          auto &rectangle_surfaces = c_surfaces[rectangle_context];
+          rectangle_surfaces.emplace_back(rectangle_transforms.size(surface_default_context) - 1, mask_index, c_volume->index(), io_surface.geometry_id);
         }
         else if (bounds_type == 7)
         {
           // Trapezoid bounds
           constexpr auto trapezoid_context = typed_detector::surface_trapezoid::mask_context;
-          // Get the trapezoid mask container
+          // Add a new trapezoid mask
           auto &trapezoid_masks = std::get<trapezoid_context>(c_masks);
           dindex trapezoid_index = trapezoid_masks.size();
           trapezoid_masks.push_back({io_surface.bound_param0, io_surface.bound_param1, io_surface.bound_param2});
           // The read is valid: set the index
           mask_index = {trapezoid_context, trapezoid_index};
+
+          // Build the trapezoid transform
+          auto &trapezoid_transforms = std::get<trapezoid_context>(c_transforms);
+          trapezoid_transforms.emplace_back(surface_default_context, t, z, x);
+
+          // Save the corresponding surface
+          auto &trapezoid_surfaces = c_surfaces[trapezoid_context];
+          trapezoid_surfaces.push_back({trapezoid_transforms.size(surface_default_context) - 1, mask_index, c_volume->index(), io_surface.geometry_id});
         }
         else if (bounds_type == 11)
         {
           // Annulus bounds
           constexpr auto annulus_context = typed_detector::surface_annulus::mask_context;
-          // Get the trapezoid mask container
+
+          // Add a new annulus mask
           auto &annulus_masks = std::get<annulus_context>(c_masks);
           dindex annulus_index = annulus_masks.size();
           annulus_masks.push_back({io_surface.bound_param0,
@@ -427,16 +453,15 @@ namespace detray
                                    io_surface.bound_param6});
           // The read is valid: set the index
           mask_index = {annulus_context, annulus_index};
-        }
 
-        // Fill the surface into the temporary container
-        if (mask_index[0] != dindex_invalid)
-        {
-          dindex transform_index = surface_transform_storage.size();
-          surface_transform_storage.push_back(transform3{t, z, x});
-          c_surfaces.push_back({transform_index, mask_index, c_volume->index(), io_surface.geometry_id});
-        }
+          // Build the annulus transform
+          auto &annulus_transforms = std::get<annulus_context>(c_transforms);
+          annulus_transforms.emplace_back(surface_default_context, t, z, x);
 
+          // Save the corresponding surface
+          auto &annulus_surfaces = c_surfaces[annulus_context];
+          annulus_surfaces.emplace_back(annulus_transforms.size(surface_default_context) - 1, mask_index, c_volume->index(), io_surface.geometry_id);
+        }
       } // end of exclusion for navigation layers
     }
 

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -295,9 +295,8 @@ namespace detray
         if (c_volume != nullptr and not surface_transform_storage.empty())
         {
           // Construction with move semantics
-          d.add_surface_transforms(surface_default_context, *c_volume, std::move(surface_transform_storage));
+          d.add_surfaces(*c_volume, c_surfaces, surface_transform_storage, surface_default_context);
           d.add_masks(c_surfaces, c_masks);
-          c_volume->add_surface_components(std::move(c_surfaces));
 
           // Get new clean containers
           surface_transform_storage = typename alignable_store::storage();

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -98,14 +98,14 @@ namespace __plugin
                     // Loop over volumes
                     for (const auto &v : d.volumes())
                     {
-                        const auto &surfaces = v.surfaces();
+                        const auto &surfaces = d.surfaces();
                         constexpr bool get_surface_masks = true;
                         const auto &masks = d.template masks<get_surface_masks>();
 
                         // Loop over surfaces
-                        for (const auto &s : surfaces.objects())
+                        for (auto si : sequence(v.surface_range()))
                         {
-                            auto sfi_surface = intersect(track, s, d.transforms(v.surface_range(), default_context), masks);
+                            auto sfi_surface = intersect(track, surfaces[si], d.transforms(v.surface_trf_range(), default_context), masks);
 
                             const auto &sfi = std::get<0>(sfi_surface);
                             

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -55,6 +55,10 @@ auto read_detector()
 
 auto d = read_detector();
 
+const auto &surfaces = d.surfaces();
+constexpr bool get_surface_masks = true;
+const auto &masks = d.template masks<get_surface_masks>();
+
 namespace __plugin
 {
     // This test runs intersection with all surfaces of the TrackML detector
@@ -98,12 +102,8 @@ namespace __plugin
                     // Loop over volumes
                     for (const auto &v : d.volumes())
                     {
-                        const auto &surfaces = d.surfaces();
-                        constexpr bool get_surface_masks = true;
-                        const auto &masks = d.template masks<get_surface_masks>();
-
                         // Loop over surfaces
-                        for (auto si : sequence(v.surface_range()))
+                        for (size_t si = v.surface_range()[0]; si < v.surface_range()[1]; si++)
                         {
                             auto sfi_surface = intersect(track, surfaces[si], d.transforms(v.surface_trf_range(), default_context), masks);
 

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -19,34 +19,34 @@ TEST(ALGEBRA_PLUGIN, detector)
     using namespace __plugin;
 
     using detector = detector<>;
-
-    static_transform_store<>::storage static_storage;
+    
     static_transform_store<>::context ctx0;
 
+    detector::transform_container trfs;
     detector::surface_mask_container masks;
-    detector::surface_container surfaces = {};
+    detector::surface_filling_container surfaces = {};
 
     /// Surface 0
     point3 t0{0., 0., 0.};
-    static_storage.emplace_back(t0);
+    trfs[detector::surface_rectangle::mask_context].emplace_back(ctx0, t0);
     detector::surface_rectangle rect = {-3., 3.};
     std::get<detector::surface_rectangle::mask_context>(masks).push_back(rect);
 
     /// Surface 1
     point3 t1{1., 0., 0.};
-    static_storage.emplace_back(t1);
+    trfs[detector::surface_annulus::mask_context].emplace_back(ctx0, t1);
     detector::surface_annulus anns = {1., 2., 3., 4., 5., 6., 7.};
     std::get<detector::surface_annulus::mask_context>(masks).push_back(anns);
 
     /// Surface 2
     point3 t2{2., 0., 0.};
-    static_storage.emplace_back(t2);
+    trfs[detector::surface_trapezoid::mask_context].emplace_back(ctx0, t2);
     detector::surface_trapezoid trap = {1., 2., 3.};
     std::get<detector::surface_trapezoid::mask_context>(masks).push_back(trap);
 
     detector d("test_detector");
     auto &v = d.new_volume("test_volume", {0., 10., -5., 5., -M_PI, M_PI});
-    d.add_surfaces(v, surfaces, static_storage, ctx0);
+    d.add_surfaces(v, surfaces, masks, trfs, ctx0);
 }
 
 int main(int argc, char **argv)

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -24,31 +24,29 @@ TEST(ALGEBRA_PLUGIN, detector)
     static_transform_store<>::context ctx0;
 
     detector::surface_mask_container masks;
+    detector::surface_container surfaces = {};
 
     /// Surface 0
     point3 t0{0., 0., 0.};
-    transform3 tf0{t0};
-    static_storage.push_back(std::move(tf0));
+    static_storage.emplace_back(t0);
     detector::surface_rectangle rect = {-3., 3.};
     std::get<detector::surface_rectangle::mask_context>(masks).push_back(rect);
 
     /// Surface 1
     point3 t1{1., 0., 0.};
-    transform3 tf1{t1};
-    static_storage.push_back(std::move(tf1));
+    static_storage.emplace_back(t1);
     detector::surface_annulus anns = {1., 2., 3., 4., 5., 6., 7.};
     std::get<detector::surface_annulus::mask_context>(masks).push_back(anns);
 
     /// Surface 2
     point3 t2{2., 0., 0.};
-    transform3 tf2{t2};
-    static_storage.push_back(std::move(tf2));
+    static_storage.emplace_back(t2);
     detector::surface_trapezoid trap = {1., 2., 3.};
     std::get<detector::surface_trapezoid::mask_context>(masks).push_back(trap);
 
     detector d("test_detector");
     auto &v = d.new_volume("test_volume", {0., 10., -5., 5., -M_PI, M_PI});
-    d.add_surface_transforms(ctx0, v, std::move(static_storage));
+    d.add_surfaces(v, surfaces, static_storage, ctx0);
 }
 
 int main(int argc, char **argv)

--- a/tests/common/include/tests/common/core_transform_store.inl
+++ b/tests/common/include/tests/common/core_transform_store.inl
@@ -40,6 +40,13 @@ TEST(ALGEBRA_PLUGIN, static_transform_store)
     static_store.push_back(ctx0, std::move(tf2));
     ASSERT_EQ(static_store.size(ctx0), 3u);
 
+    point3 t3{2.,0.,0.};
+    static_store.emplace_back(ctx0, std::move(t3));
+    ASSERT_EQ(static_store.size(ctx0), 4u);
+
+    static_store.emplace_back(ctx0);
+    ASSERT_EQ(static_store.size(ctx0), 5u);
+
 }
 
 

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -125,7 +125,7 @@ TEST(ALGEBRA_PLUGIN, navigator)
     ASSERT_TRUE(std::abs(state()) < state.on_surface_tolerance);
     ASSERT_EQ(state.status, detray_navigator::navigation_status::e_on_surface);
     // Get the surface
-    const auto &surface = d.indexed_volume(state.volume_index).surfaces().indexed_object(state.current_index);
+    const auto &surface = d.surfaces()[state.current_index];
     // Kernel is exhaused, and trust level is gone
     ASSERT_EQ(state.surface_kernel.next, state.surface_kernel.candidates.end());
     ASSERT_EQ(state.trust_level, detray_navigator::navigation_trust_level::e_high_trust);


### PR DESCRIPTION
This PR pools the surface and portal surface containers on detector level, leaving no dynamically allocated memory in the volumes, except for their string names.  As in the previous PRs, the volumes reference their surfaces by index range now and the actual data is provided by the detector interface. To avoid depency problems when updating links while adding components to the detector, all components are now added in one go, sorted by mask type.