### PR TITLE
Add cuda qualifier to grid axis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
 
+# Set GPU-related options
+if(DETRAY_BUILD_CUDA)
+  enable_language(CUDA)
+endif()
+
 add_subdirectory(apps)
 add_subdirectory(core)
 add_subdirectory(extern)

--- a/core/include/definitions/qualifiers.hpp
+++ b/core/include/definitions/qualifiers.hpp
@@ -1,0 +1,33 @@
+/**
+ * DETRAY library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#if defined(__CUDACC__)
+#define DETRAY_DEVICE __device__
+#else
+#define DETRAY_DEVICE
+#endif
+
+#if defined(__CUDACC__)
+#define DETRAY_HOST __host__
+#else
+#define DETRAY_HOST
+#endif
+
+#if defined(__CUDACC__)
+#define DETRAY_HOST_DEVICE __host__ __device__
+#else
+#define DETRAY_HOST_DEVICE
+#endif
+
+#if defined(__CUDACC__)
+#define DETRAY_ALIGN(x) __align__(x)
+#else
+#define DETRAY_ALIGN(x) alignas(x)
+#endif

--- a/core/include/grids/axis.hpp
+++ b/core/include/grids/axis.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "utils/indexing.hpp"
+#include "definitions/qualifiers.hpp"
 
 #include <algorithm>
 
@@ -32,6 +33,7 @@ namespace detray
             static constexpr unsigned int axis_identifier = 0;
 
             /** Return the number of bins */
+	    DETRAY_HOST_DEVICE
             dindex bins() const { return n_bins; }
 
             /** Access function to a single bin from a value v
@@ -40,6 +42,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex type
              **/
+	    DETRAY_HOST_DEVICE
             dindex bin(scalar v) const
             {
                 int ibin = static_cast<int>((v - min) / (max - min) * n_bins);
@@ -55,6 +58,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex_range
              **/
+	    DETRAY_HOST_DEVICE
             dindex_range range(scalar v, const array_type<dindex, 2> &nhood = {0u, 0u}) const
             {
 
@@ -73,6 +77,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex_range
              **/
+	    DETRAY_HOST_DEVICE
             dindex_range range(scalar v, const array_type<scalar, 2> &nhood) const
             {
                 int nbin = static_cast<int>((v - nhood[0] - min) / (max - min) * n_bins);
@@ -93,6 +98,7 @@ namespace detray
              * As the axis is closed it @returns a dindex_sequence
              **/
             template <typename neighbor_t>
+	    DETRAY_HOST_DEVICE
             dindex_sequence zone_t(scalar v, const array_type<neighbor_t, 2> &nhood) const
             {
                 dindex_range nh_range = range(v, nhood);
@@ -110,6 +116,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex_sequence
              **/
+	    DETRAY_HOST_DEVICE
             dindex_sequence zone(scalar v, const array_type<dindex, 2> &nhood) const
             {
                 return zone_t<dindex>(v, nhood);
@@ -122,12 +129,14 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex_sequence
              **/
+	    DETRAY_HOST_DEVICE
             dindex_sequence zone(scalar v, const array_type<scalar, 2> &nhood) const
             {
                 return zone_t<scalar>(v, nhood);
             }
 
             /** @return the bin boundaries for a given @param ibin */
+	    DETRAY_HOST_DEVICE
             array_type<scalar, 2> borders(dindex ibin) const
             {
                 scalar step = (max - min) / n_bins;
@@ -135,6 +144,7 @@ namespace detray
             }
 
             /** @return the values of the borders */
+	    DETRAY_HOST_DEVICE
             vector_type<scalar> all_borders() const
             {
                 vector_type<scalar> borders;
@@ -148,6 +158,7 @@ namespace detray
             }
 
             /** @return the axis span [min, max) */
+	    DETRAY_HOST_DEVICE
             array_type<scalar, 2> span() const { return {min, max}; }
         };
 
@@ -167,6 +178,7 @@ namespace detray
             static constexpr unsigned int axis_identifier = 1;
 
             /** Return the number of bins */
+	    DETRAY_HOST_DEVICE
             dindex bins() const { return n_bins; }
 
             /** Access function to a single bin from a value v
@@ -175,6 +187,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex type
              **/
+	    DETRAY_HOST_DEVICE
             dindex bin(scalar v) const
             {
                 dindex ibin = static_cast<dindex>((v - min) / (max - min) * n_bins);
@@ -190,6 +203,7 @@ namespace detray
              * 
              * As the axis is circular it @returns a dindex_range
              **/
+	    DETRAY_HOST_DEVICE
             dindex_range range(scalar v, const array_type<dindex, 2> nhood = {0u, 0u}) const
             {
                 dindex gbin = bin(v);
@@ -205,6 +219,7 @@ namespace detray
              * 
              * As the axis is circular it @returns a dindex_range
              **/
+	    DETRAY_HOST_DEVICE
             dindex_range range(scalar v, const array_type<scalar, 2> &nhood) const
             {
                 dindex nbin = bin(v - nhood[0]);
@@ -222,6 +237,7 @@ namespace detray
              * As the axis is closed it @returns a dindex_sequence
              **/
             template <typename neighbor_t>
+	    DETRAY_HOST_DEVICE	    
             dindex_sequence zone_t(scalar v, const array_type<neighbor_t, 2> &nhood) const
             {
                 dindex_range nh_range = range(v, nhood);
@@ -255,6 +271,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex_sequence
              **/
+	    DETRAY_HOST_DEVICE	    
             dindex_sequence zone(scalar v, const array_type<dindex, 2> &nhood) const
             {
                 return zone_t<dindex>(v, nhood);
@@ -267,6 +284,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex_sequence
              **/
+	    DETRAY_HOST_DEVICE	    
             dindex_sequence zone(scalar v, const array_type<scalar, 2> &nhood) const
             {
                 return zone_t<scalar>(v, nhood);
@@ -279,6 +297,7 @@ namespace detray
              * 
              * @return an index, remapped bin 
              **/
+	    DETRAY_HOST_DEVICE	    
             dindex remap(dindex ibin, int shood) const
             {
                 int opt_bin = static_cast<int>(ibin) + shood;
@@ -294,6 +313,7 @@ namespace detray
             }
 
             /** @return the bin boundaries for a given @param ibin */
+	    DETRAY_HOST_DEVICE	    
             array_type<scalar, 2> borders(dindex ibin) const
             {
                 scalar step = (max - min) / n_bins;
@@ -301,6 +321,7 @@ namespace detray
             }
 
             /** @return the values of the borders */
+	    DETRAY_HOST_DEVICE	    
             vector_type<scalar> all_borders() const
             {
                 vector_type<scalar> borders;
@@ -314,6 +335,7 @@ namespace detray
             }
 
             /** @return the range  */
+	    DETRAY_HOST_DEVICE	    
             array_type<scalar, 2> span() const { return {min, max}; }
         };
 
@@ -332,6 +354,7 @@ namespace detray
             static constexpr unsigned int axis_identifier = 2;
 
             /** Return the number of bins */
+	    DETRAY_HOST_DEVICE	    
             dindex bins() const { return static_cast<dindex>(boundaries.size() - 1); }
 
             /** Access function to a single bin from a value v
@@ -340,6 +363,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex type
              **/
+	    DETRAY_HOST_DEVICE	    
             dindex bin(scalar v) const
             {
                 dindex ibin = std::lower_bound(boundaries.begin(), boundaries.end(), v) - boundaries.begin();
@@ -354,6 +378,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex_range
              **/
+	    DETRAY_HOST_DEVICE	    
             dindex_range range(scalar v, const array_type<dindex, 2> &nhood = {0u, 0u}) const
             {
 
@@ -373,6 +398,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex_range
              **/
+	    DETRAY_HOST_DEVICE	    
             dindex_range range(scalar v, const array_type<scalar, 2> &nhood) const
             {
                 dindex nbin = bin(v - nhood[0]);
@@ -390,6 +416,7 @@ namespace detray
              * As the axis is closed it @returns a dindex_sequence
              **/
             template <typename neighbor_t>
+	    DETRAY_HOST_DEVICE
             dindex_sequence zone_t(scalar v, const array_type<neighbor_t, 2> nhood) const
             {
                 dindex_range nh_range = range(v, nhood);
@@ -407,6 +434,7 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex_sequence
              **/
+	    DETRAY_HOST_DEVICE	    
             dindex_sequence zone(scalar v, const array_type<dindex, 2> &nhood = {0, 0}) const
             {
                 return zone_t<dindex>(v, nhood);
@@ -419,12 +447,14 @@ namespace detray
              * 
              * As the axis is closed it @returns a dindex_sequence
              **/
+	    DETRAY_HOST_DEVICE	    
             dindex_sequence zone(scalar v, const array_type<scalar, 2> &nhood) const
             {
                 return zone_t<scalar>(v, nhood);
             }
 
             /** @return the bin boundaries for a given @param ibin */
+	    DETRAY_HOST_DEVICE	    
             array_type<scalar, 2> borders(dindex ibin) const
             {
                 return {boundaries[ibin], boundaries[ibin + 1]};
@@ -432,12 +462,14 @@ namespace detray
 
 
             /** @return the values of the borders of all bins */
+	    DETRAY_HOST_DEVICE	    
             vector_type<scalar> all_borders() const
             {
                 return boundaries;
             }
 
             /** @return the range  */
+	    DETRAY_HOST_DEVICE	    
             array_type<scalar, 2>
             span() const
             {

--- a/core/include/grids/grid2.hpp
+++ b/core/include/grids/grid2.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "definitions/qualifiers.hpp"
+
 namespace detray
 {
 
@@ -45,6 +47,7 @@ namespace detray
          * @param axis_p1 is the axis in the second coordinate
          * 
          **/
+	DETRAY_HOST_DEVICE
         grid2(const axis_p0_type &axis_p0, const axis_p1_type &axis_p1) : _axis_p0(axis_p0), _axis_p1(axis_p1)
         {
             _data_serialized = serialized_storage(_axis_p0.bins() * _axis_p1.bins(), _populator.init());
@@ -56,6 +59,7 @@ namespace detray
          * @param axis_p1 is the axis in the second coordinate
          * 
          **/
+	DETRAY_HOST_DEVICE	
         grid2(axis_p0_type &&axis_p0, axis_p1_type &&axis_p1) : _axis_p0(std::move(axis_p0)), _axis_p1(std::move(axis_p1))
         {
             _data_serialized = serialized_storage(_axis_p0.bins() * _axis_p1.bins(), _populator.init());
@@ -66,6 +70,7 @@ namespace detray
         * @param offset is the applied offset shift
         * 
         **/
+	DETRAY_HOST_DEVICE	
         void shift(const typename populator_type::bare_value &offset)
         {
             std::for_each(_data_serialized.begin(), _data_serialized.end(), [&](auto &ds)
@@ -80,6 +85,7 @@ namespace detray
          * @param fvalue is a single fill value to be filled
          * 
          **/
+	DETRAY_HOST_DEVICE	
         template <typename point2_type>
         void populate(const point2_type &p2, typename populator_type::bare_value &&fvalue)
         {
@@ -93,6 +99,7 @@ namespace detray
          * @param fvalue is a single fill value to be filled
          * 
          **/
+	DETRAY_HOST_DEVICE	
         void populate(dindex bin0, dindex bin1, typename populator_type::bare_value &&fvalue)
         {
             auto sbin = _serializer.template serialize<axis_p0_type, axis_p1_type>(_axis_p0, _axis_p1, bin0, bin1);
@@ -106,6 +113,7 @@ namespace detray
          * 
          * @return the const reference to the value in this bin 
          **/
+	DETRAY_HOST_DEVICE	
         const auto &bin(dindex bin0, dindex bin1) const
         {
             return _data_serialized[_serializer.template serialize<axis_p0_type, axis_p1_type>(_axis_p0, _axis_p1, bin0, bin1)];
@@ -117,6 +125,7 @@ namespace detray
          * 
          * @return the const reference to the value in this bin 
          **/
+	DETRAY_HOST_DEVICE	
         const auto &bin(const point2 &p2) const
         {
             return _data_serialized[_serializer.template serialize<axis_p0_type, axis_p1_type>(_axis_p0, _axis_p1, _axis_p0.bin(p2[0]), _axis_p1.bin(p2[1]))];
@@ -128,6 +137,7 @@ namespace detray
          * 
          * @return the const reference to the value in this bin 
          **/
+	DETRAY_HOST_DEVICE	
         auto &bin(const point2 &p2)
         {
             return _data_serialized[_serializer.template serialize<axis_p0_type, axis_p1_type>(_axis_p0, _axis_p1, _axis_p0.bin(p2[0]), _axis_p1.bin(p2[1]))];
@@ -144,6 +154,7 @@ namespace detray
          * @return the sequence of values
          **/
         template <typename neighbor_t>
+	DETRAY_HOST_DEVICE
         vector_type<typename populator_type::bare_value> zone_t(const point2 &p2, const neighborhood<neighbor_t> &nhood, bool sort) const
         {
             auto zone0 = _axis_p0.zone(p2[0], nhood[0]);
@@ -197,6 +208,7 @@ namespace detray
          * 
          * @return the sequence of values
          **/
+	DETRAY_HOST_DEVICE	
         vector_type<typename populator_type::bare_value> zone(const point2 &p2, const neighborhood<dindex> &nhood = hermit2, bool sort = false) const
         {
             return zone_t<dindex>(p2, nhood, sort);
@@ -212,24 +224,30 @@ namespace detray
          * 
          * @return the sequence of values
          **/
+	DETRAY_HOST_DEVICE	
         vector_type<typename populator_type::bare_value> zone(const point2 &p2, const neighborhood<scalar> &nhood, bool sort = false) const
         {
             return zone_t<scalar>(p2, nhood, sort);
         }
 
         /** Const access to axis p0  */
+	DETRAY_HOST_DEVICE	
         const axis_p0_type &axis_p0() const { return _axis_p0; }
 
         /** Const access to axis p1 */
+	DETRAY_HOST_DEVICE	
         const axis_p1_type &axis_p1() const { return _axis_p1; }
 
         /* Copy of axes in a tuple */
+	DETRAY_HOST_DEVICE	
         tuple_type<axis_p0_type, axis_p1_type> axes() const { return std::tie(_axis_p0, _axis_p1); }
 
         /** Const acess to the serializer */
+	DETRAY_HOST_DEVICE	
         const serializer_type &serializer() const { return _serializer; }
 
         /** Const acess to the polulator */
+	DETRAY_HOST_DEVICE	
         const populator_type &populator() const { return _populator; }
 
     private:

--- a/core/include/grids/populator.hpp
+++ b/core/include/grids/populator.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "utils/indexing.hpp"
+#include "definitions/qualifiers.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -37,6 +38,7 @@ namespace detray
          * @param stored the stored value for the population
          * @param bvalue the new value to be added
          **/
+	DETRAY_HOST_DEVICE	
         void operator()(store_value &stored, bare_value &&bvalue) const
         {
             stored = std::move(bvalue);
@@ -48,6 +50,7 @@ namespace detray
          * 
          * @return a sequence of bare values
          */
+	DETRAY_HOST_DEVICE	
         vector_type<bare_value> sequence(store_value &stored) const
         {
             if (stored != kInvalid)
@@ -63,6 +66,7 @@ namespace detray
          * @param offset is the shift offset
          * 
          **/
+	DETRAY_HOST_DEVICE	
         void shift(store_value &stored, const bare_value &offset) const
         {
             stored += offset;
@@ -70,6 +74,7 @@ namespace detray
 
         /** Return an initialized bin value
          */
+	DETRAY_HOST_DEVICE	
         store_value init() const
         {
             return kInvalid;
@@ -105,6 +110,7 @@ namespace detray
          * @param stored the stored value for the population
          * @param bvalue the new value to be added
          **/
+	DETRAY_HOST_DEVICE
         void operator()(store_value &stored, bare_value &&bvalue) const
         {
 
@@ -128,6 +134,7 @@ namespace detray
          * 
          * @return a sequence of bare values, @note it will ignore invalid entries
          */
+	DETRAY_HOST_DEVICE	
         vector_type<bare_value> sequence(store_value &stored) const
         {
             vector_type<bare_value> s;
@@ -148,6 +155,7 @@ namespace detray
          * @param offset is the shift offset
          * 
          **/
+	DETRAY_HOST_DEVICE	
         void shift(store_value &stored, const bare_value &offset) const
         {
             std::for_each(stored.begin(), stored.end(), [&](auto &d) { d += offset; });
@@ -155,6 +163,7 @@ namespace detray
 
         /** Return an initialized bin value
          **/
+	DETRAY_HOST_DEVICE	
         store_value init() const
         {
 
@@ -188,6 +197,7 @@ namespace detray
          * @param stored the stored value for the population
          * @param bvalue the new value to be added
          **/
+	DETRAY_HOST_DEVICE	
         void operator()(store_value &stored, bare_value &&bvalue) const
         {
             stored.push_back(bvalue);
@@ -203,6 +213,7 @@ namespace detray
          * 
          * @return a sequence of bare values
          */
+	DETRAY_HOST_DEVICE	
         vector_type<bare_value> sequence(store_value &stored) const
         {
             return stored;
@@ -214,6 +225,7 @@ namespace detray
          * @param offset is the shift offset
          * 
          **/
+	DETRAY_HOST_DEVICE
         void shift(store_value &stored, const bare_value &offset) const
         {
             std::for_each(stored.begin(), stored.end(), [&](auto &d) { d += offset; });
@@ -221,6 +233,7 @@ namespace detray
 
         /** Return an initialized bin value
          **/
+	DETRAY_HOST_DEVICE
         store_value init() const
         {
             return {};

--- a/core/include/grids/serializer2.hpp
+++ b/core/include/grids/serializer2.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "utils/indexing.hpp"
+#include "definitions/qualifiers.hpp"
 
 #include <algorithm>
 
@@ -35,6 +36,7 @@ namespace detray
          * @return a dindex for the memory storage
          */
         template <typename faxis_type, typename saxis_type>
+	DETRAY_HOST_DEVICE
         dindex serialize(const faxis_type& faxis, const saxis_type& /*saxis*/,
                                    dindex fbin, dindex sbin) const
         {
@@ -56,6 +58,7 @@ namespace detray
          */
         template <typename faxis_type, typename saxis_type,
                   template <typename, unsigned int> class array_type = darray>
+	DETRAY_HOST_DEVICE
         array_type<dindex, 2> deserialize(const faxis_type& faxis, const saxis_type& /*saxis*/, dindex serialbin) const
         {
             dindex sbin = static_cast<dindex>(serialbin/faxis.bins());

--- a/plugins/algebra/include/detray/array/include/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/include/detray/array/include/plugins/algebra/array_definitions.hpp
@@ -1,5 +1,5 @@
 
-#include "algebra/definitions/array.hpp"
+#include "algebra/definitions/std_array.hpp"
 
 #define ALGEBRA_PLUGIN array
 


### PR DESCRIPTION
This PR adds cuda qualifier to grid and axis so we can use them in cuda device code. 
I am planning to replace Acts grid axis with detray grid axis for spacepoint grouping.

@asalzburger @niermann999 