### PR TITLE
fix: adapt display to new interface

### DIFF
--- a/apps/common/include/apps/common/display_bin_association.inl
+++ b/apps/common/include/apps/common/display_bin_association.inl
@@ -102,8 +102,8 @@ int main(int argc, char **argv)
 
             dindex finder_entry = lvolume.surfaces_finder_entry();
             const auto &surfaces = lvolume.surfaces();
-            const auto &surface_transforms = surfaces.transforms();
-            const auto &surface_masks = surfaces.masks();
+            const auto &surface_transforms = d.transforms(lvolume.surface_range(), s_context);
+            const auto &surface_masks = d.masks();
 
             if (not is_cylinder)
             {
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
                     const auto &transform_link = s.transform();
 
                     // Unroll the mask container and generate vertices
-                    const auto &transform = surface_transforms.contextual_transform(s_context, transform_link);
+                    const auto &transform = surface_transforms[transform_link];
 
                     const auto &mask_context = std::get<0>(mask_link);
                     const auto &mask_range = std::get<1>(mask_link);
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
                     const auto &transform_link = s.transform();
 
                     // Unroll the mask container and generate vertices
-                    const auto &transform = surface_transforms.contextual_transform(s_context, transform_link);
+                    const auto &transform = surface_transforms[transform_link];
 
                     const auto &mask_context = std::get<0>(mask_link);
                     const auto &mask_range = std::get<1>(mask_link);

--- a/apps/common/include/apps/common/display_layers.inl
+++ b/apps/common/include/apps/common/display_layers.inl
@@ -83,8 +83,8 @@ int main(int argc, char **argv)
                 bool is_cylinder = std::abs(bounds[1] - bounds[0]) < std::abs(bounds[3] - bounds[2]);
 
                 const auto &surfaces = v.surfaces();
-                const auto &volume_transforms = surfaces.transforms();
-                const auto &volume_masks = surfaces.masks();
+                const auto &volume_transforms = d.transforms(v.surface_range(), s_context);
+                const auto &volume_masks = d.masks();
 
                 if (surfaces.objects().empty())
                 {
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
                     const auto &transform_link = s.transform();
 
                     // Unroll the mask container and generate vertices
-                    const auto &transform = volume_transforms.contextual_transform(s_context, transform_link);
+                    const auto &transform = volume_transforms[transform_link];
 
                     const auto &mask_context = std::get<0>(mask_link);
                     const auto &mask_range = std::get<1>(mask_link);


### PR DESCRIPTION
Adapt the matplot++ display to new geometry interface in preparation of the navigation debugging. Will be updated, when PR #86 is merged.