### PR TITLE
fix: adapt display to new interface

### DIFF
--- a/apps/common/include/apps/common/display_bin_association.inl
+++ b/apps/common/include/apps/common/display_bin_association.inl
@@ -99,10 +99,11 @@ int main(int argc, char **argv)
             const auto &lvolume = d.indexed_volume(lvol);
             const auto &bounds = lvolume.bounds();
             bool is_cylinder = std::abs(bounds[1] - bounds[0]) < std::abs(bounds[3] - bounds[2]);
+            const auto &sf_range = lvolume. template range<>();
 
             dindex finder_entry = lvolume.surfaces_finder_entry();
-            const auto &surfaces = lvolume.surfaces();
-            const auto &surface_transforms = d.transforms(lvolume.surface_range(), s_context);
+            const auto &surfaces = d.surfaces();
+            const auto &surface_transforms = d.transforms(sf_range, s_context);
             const auto &surface_masks = d.masks();
 
             if (not is_cylinder)
@@ -126,8 +127,9 @@ int main(int argc, char **argv)
                 std::cout << std::endl;
 
                 // Loop over the surfaces within a volume
-                for (auto [is, s] : enumerate(surfaces.objects()))
+                for (dindex sfi = sf_range[0]; sfi < sf_range[1]; sfi++)
                 {
+                    const auto &s = surfaces[sfi];
                     dvector<point3> vertices = {};
                     const auto &mask_link = s.mask();
                     const auto &transform_link = s.transform();
@@ -145,7 +147,7 @@ int main(int argc, char **argv)
                     {
                         if (not vertices.empty())
                         {
-                            style draw_style = (std::find(bin_entry.begin(), bin_entry.end(), static_cast<dindex>(is)) != bin_entry.end())
+                            style draw_style = (std::find(bin_entry.begin(), bin_entry.end(), static_cast<dindex>(sfi - sf_range[0])) != bin_entry.end())
                                                    ? selected_surface_style
                                                    : surface_style;
 
@@ -208,8 +210,9 @@ int main(int argc, char **argv)
                 std::cout << std::endl;
 
                 // Loop over the surfaces within a volume
-                for (auto [is, s] : enumerate(surfaces.objects()))
+                for (dindex sfi = sf_range[0]; sfi < sf_range[1]; sfi++)
                 {
+                    const auto &s = surfaces[sfi];
                     dvector<point3> vertices = {};
                     const auto &mask_link = s.mask();
                     const auto &transform_link = s.transform();
@@ -230,7 +233,7 @@ int main(int argc, char **argv)
                         {
 
                             // Check the association (with potential splits)
-                            style draw_style = (std::find(bin_entry.begin(), bin_entry.end(), static_cast<dindex>(is)) != bin_entry.end())
+                            style draw_style = (std::find(bin_entry.begin(), bin_entry.end(), static_cast<dindex>(sfi - sf_range[0])) != bin_entry.end())
                                                    ? selected_surface_style
                                                    : surface_style;
 

--- a/apps/common/include/apps/common/display_bin_association.inl
+++ b/apps/common/include/apps/common/display_bin_association.inl
@@ -10,7 +10,6 @@
 #include "core/transform_store.hpp"
 #include "io/csv_io.hpp"
 #include "grids/associator.hpp"
-#include "utils/containers.hpp"
 #include "utils/enumerate.hpp"
 #include "utils/generators.hpp"
 #include "view/draw.hpp"

--- a/apps/common/include/apps/common/display_layers.inl
+++ b/apps/common/include/apps/common/display_layers.inl
@@ -9,7 +9,6 @@
 #include "core/detector.hpp"
 #include "core/transform_store.hpp"
 #include "io/csv_io.hpp"
-#include "utils/containers.hpp"
 #include "utils/enumerate.hpp"
 #include "utils/generators.hpp"
 #include "view/draw.hpp"

--- a/apps/common/include/apps/common/display_layers.inl
+++ b/apps/common/include/apps/common/display_layers.inl
@@ -81,19 +81,21 @@ int main(int argc, char **argv)
                 // Switch 'quiet' mode on during drawing
                 const auto &bounds = v.bounds();
                 bool is_cylinder = std::abs(bounds[1] - bounds[0]) < std::abs(bounds[3] - bounds[2]);
+                const auto &sf_range = v. template range<>();
 
-                const auto &surfaces = v.surfaces();
-                const auto &volume_transforms = d.transforms(v.surface_range(), s_context);
+                const auto &surfaces = d.surfaces<>();
+                const auto &volume_transforms = d.transforms(sf_range, s_context);
                 const auto &volume_masks = d.masks();
 
-                if (surfaces.objects().empty())
+                if (v.empty())
                 {
                     continue;
                 }
 
                 // Loop over the surfaces within a volume
-                for (const auto &s : surfaces.objects())
+                for (dindex sfi = sf_range[0]; sfi < sf_range[1]; sfi++)
                 {
+                    const auto &s = surfaces[sfi];
                     dvector<point3> vertices = {};
                     const auto &mask_link = s.mask();
                     const auto &transform_link = s.transform();

--- a/apps/common/include/apps/common/display_volumes_rz.inl
+++ b/apps/common/include/apps/common/display_volumes_rz.inl
@@ -9,7 +9,6 @@
 #include "core/detector.hpp"
 #include "core/transform_store.hpp"
 #include "io/csv_io.hpp"
-#include "utils/containers.hpp"
 
 #include <iostream>
 #include <climits>

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -419,6 +419,14 @@ namespace detray
         {
             unroll_container_filling<0, object_container, mask_container, add_surfaces>(surfaces, masks, volume, trfs, ctx);
         }
+        
+        /** @return all surfaces/portals in the detector */
+        template<bool get_surface = true>
+        const auto& surfaces() const
+        {
+            if constexpr (get_surface) { return _surfaces; }
+            else { return _portals; }
+        }
 
         /** Get @return all surface/portal masks in the detector */
         template<bool surface_masks = e_surface>
@@ -567,8 +575,6 @@ namespace detray
         {
             _surfaces_finders = std::move(surfaces_finders);
         }
-
-
 
         /** @return the surface finders - const access */
         const vector_type<surfaces_finder> &surfaces_finders() const { return _surfaces_finders; }

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -211,8 +211,7 @@ namespace detray
             /** @return if the volume is empty or not */
             bool empty() const
             {
-                return (is_empty_range(_surface_range) and
-                        is_empty_range(_portal_range));
+                return is_empty_range(_surface_range);
             }
 
             /** @return the number of surfaces in the volume */

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -73,6 +73,11 @@ namespace detray
             e_unknown = std::numeric_limits<unsigned int>::max(),
         };
 
+        enum use_primitive : bool {
+            e_surface = true,
+            e_portal = false,
+        };
+
 
         /// The detector type
         using detector_type = detector<array_type, tuple_type, vector_type, alignable_store, surface_source_link, bounds_source_link, surfaces_populator_type, surfaces_serializer_type>;
@@ -211,64 +216,61 @@ namespace detray
             }
 
             /** @return the number of surfaces in the volume */
-            dindex n_surfaces() { return in_range(_surface_range); }
+            template<bool use_surfaces = e_surface>
+            dindex n_objects()
+            {
+                if constexpr (use_surfaces) { return n_in_range(_surface_range); }
+                else { return n_in_range(_portal_range); }
+            }
 
             /** @return the number of surfaces in the volume */
-            const dindex n_surfaces() const { return in_range(_surface_range); }
+            template<bool use_surfaces = e_surface>
+            const dindex n_objects() const
+            {
+                if constexpr (use_surfaces) { return n_in_range(_surface_range); }
+                else { return n_in_range(_portal_range); }
+            }
 
             /** Set the index into the detector surface container
              *
              * @param range Surface index range
              */
-            void set_surface_range(dindex_range range)
+            template<bool surface_range = e_surface>
+            void set_range(dindex_range range)
             {
-                update_range(_surface_range, std::move(range));
+                if constexpr (surface_range) { update_range(_surface_range, std::move(range)); }
+                else { update_range(_portal_range, std::move(range)); }
             }
 
             /** @return range of surfaces- const access */
-            const auto &surface_range() const { return _surface_range; }
-
-            /** @return the number of portals of the volume */
-            dindex n_portals() { return in_range(_portal_range); }
-
-            /** @return the number of portals of the volume */
-            const dindex n_portals() const { return in_range(_portal_range); }
-
-            /** Set the index into the detector portal container
-             *
-             * @param range Portal index range
-             */
-            void set_portal_range(dindex_range range)
-            {
-                update_range(_portal_range, std::move(range));
+            template<bool surface_range = e_surface>
+            const auto &range() const {
+                
+                if constexpr (surface_range) { return _surface_range; }
+                else { return _portal_range;}
             }
 
             /** @return range of portals - const access */
-            const auto &portal_range() const { return _portal_range; }
-
-            /** Set the index into the detector transform store for surfaces
-             *
-             * @param range Surface transform index range
-             */
-            void set_surface_trf_range(dindex_range range)
-            {
-                update_range(_surface_trf_range, std::move(range));
-            }
+            //const auto &portal_range() const { return _portal_range; }
 
             /** @return range of surface transforms - const access */
-            const auto &surface_trf_range() const { return _surface_trf_range; }
+            template<bool surface_range = e_surface>
+            const auto &trf_range() const
+            {
+                if constexpr (surface_range) { return _surface_trf_range; }
+                else { return _portal_trf_range;}
+            }
 
             /** Set the index into the detector transform store for portals
              *
              * @param range Portal transform index range
              */
-            void set_portal_trf_range(dindex_range range)
+            template<bool surface_range = e_surface>
+            void set_trf_range(dindex_range range)
             {
-                update_range(_portal_trf_range, std::move(range));
+                if constexpr (surface_range) { update_range(_surface_trf_range, std::move(range)); }
+                else { update_range(_portal_trf_range, std::move(range)); }
             }
-
-            /** @return range of portal transforms - const access */
-            const auto &portal_trf_range() const { return _portal_trf_range; }
 
         private:
             /** Volume section: name */
@@ -300,14 +302,14 @@ namespace detray
              *
              * @return the number of indexed objects
              */
-            inline dindex in_range(const dindex_range &range) { return range[1] - range[0]; }
+            inline dindex n_in_range(const dindex_range &range) { return range[1] - range[0]; }
 
             /**
              * @param range Any index range
              *
              * @return the number of indexed objects
              */
-            inline const dindex in_range(const dindex_range &range) const { return range[1] - range[0]; }
+            inline const dindex n_in_range(const dindex_range &range) const { return range[1] - range[0]; }
 
             /** Test whether a range is empty
              *
@@ -315,7 +317,7 @@ namespace detray
              *
              * @return boolean whether the range is empty
              */
-            inline bool is_empty_range(const dindex_range &range) { return in_range(range) == 0; }
+            inline bool is_empty_range(const dindex_range &range) { return n_in_range(range) == 0; }
 
             /** Test whether a range is empty - const
              *
@@ -323,7 +325,7 @@ namespace detray
              *
              * @return boolean whether the range is empty
              */
-            inline const bool is_empty_range(const dindex_range &range) const { return in_range(range) == 0; }
+            inline const bool is_empty_range(const dindex_range &range) const { return n_in_range(range) == 0; }
 
 
             /** Set or update a range
@@ -405,49 +407,24 @@ namespace detray
          *
          * @note can throw an exception if input data is inconsistent
          */
-        void add_surfaces(
+        template <bool add_surfaces = e_surface,
+                  typename object_container,
+                  typename mask_container>
+        void add_objects(
             volume &volume,
-            surface_filling_container &surfaces,
-            surface_mask_container &masks,
+            object_container &surfaces,
+            mask_container &masks,
             transform_container &trfs,
             const typename alignable_store::context ctx = {}) noexcept(false)
         {
-            constexpr bool add_surfaces = true;
-            unroll_container_filling<0, surface_filling_container, surface_mask_container, add_surfaces>(surfaces, masks, volume, trfs, ctx);
-        }
-
-        /** @return all surfaces/portals in the detector */
-        template<bool get_surface = true>
-        const auto& surfaces() const
-        {
-            if constexpr (get_surface) { return _surfaces; }
-            else { return _portals; }
-        }
-
-        /** Add a new full set of alignable transforms for portals of a volume
-         *
-         * @param volume The volume we add the transforms to
-         * @param portals The portals of the volume
-         * @param trfs The portal transforms (same number as portals)
-         * @param ctx The context of the call
-         *
-         * @note can throw an exception if input data is inconsistent
-         */
-        void add_portals(volume &volume,
-                         portal_filling_container &portals,
-                         portal_mask_container &masks,
-                         transform_container &trfs,
-                         const typename alignable_store::context &ctx) noexcept(false)
-        {
-            constexpr bool add_surfaces = false;
-            unroll_container_filling<0, portal_filling_container, portal_mask_container, add_surfaces>(portals, masks, volume, trfs, ctx);
+            unroll_container_filling<0, object_container, mask_container, add_surfaces>(surfaces, masks, volume, trfs, ctx);
         }
 
         /** Get @return all surface/portal masks in the detector */
-        template<bool is_surface_masks = true>
+        template<bool surface_masks = e_surface>
         const auto& masks() const
         {
-            if constexpr (is_surface_masks) { return _surface_masks; }
+            if constexpr (surface_masks) { return _surface_masks; }
             else { return _portal_masks; }
         }
 
@@ -462,7 +439,7 @@ namespace detray
         template <size_t current_idx = 0,
                   typename object_container,
                   typename mask_container,
-                  bool add_surfaces>
+                  bool add_surfaces = e_surface>
         void unroll_container_filling(object_container &objects,
                                       mask_container &masks,
                                       volume &volume,
@@ -505,7 +482,7 @@ namespace detray
                 if constexpr (add_surfaces)
                 {
                     // Surface transforms for this volume
-                    volume.set_surface_trf_range(dindex_range{trsf_offset, transform_index(ctx)});
+                    volume.template set_trf_range<e_surface>(dindex_range{trsf_offset, transform_index(ctx)});
 
                     const auto sf_mask_offset = add_detector_masks(_surface_masks);
 
@@ -517,12 +494,12 @@ namespace detray
 
                     // Now put the surfaces into the detector
                     add_detector_objects(_surfaces);
-                    volume.set_surface_range({_surfaces.size() - typed_objects.size(), _surfaces.size()});
+                    volume.template set_range<e_surface>({_surfaces.size() - typed_objects.size(), _surfaces.size()});
                 }
                 else
                 {
                     // Portal transforms for this volume
-                    volume.set_portal_trf_range(dindex_range{trsf_offset, transform_index(ctx)});
+                    volume.template set_trf_range<e_portal>(dindex_range{trsf_offset, transform_index(ctx)});
 
                     // Fill the correct mask type
                     const auto pt_mask_offset = add_detector_masks(_portal_masks);
@@ -537,7 +514,7 @@ namespace detray
 
                     // Now put the portals into the detector
                     add_detector_objects(_portals);
-                    volume.set_portal_range({_portals.size() - typed_objects.size(), _portals.size()});
+                    volume.template set_range<e_portal>({_portals.size() - typed_objects.size(), _portals.size()});
                 }
             }
             // Next mask type
@@ -605,8 +582,8 @@ namespace detray
             for (const auto &[i, v] : enumerate(_volumes))
             {
                 ss << "[>>] Volume at index " << i << " - name: '" << v.name() << "'" << std::endl;
-                ss << "     contains    " << v.n_surfaces() << " detector surfaces" << std::endl;
-                ss << "                 " << v.n_portals() << " detector portals" << std::endl;
+                ss << "     contains    " << v.template n_objects<e_surface>() << " detector surfaces" << std::endl;
+                ss << "                 " << v.template n_objects<e_portal>() << " detector portals" << std::endl;
                 if (v._surfaces_finder_entry != dindex_invalid)
                 {
                     ss << "     finders idx " << v._surfaces_finder_entry << std::endl;

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -288,7 +288,7 @@ namespace detray
             add_cylinder_portal(lower_portals_info, 0);
 
             // Add portals to detector
-            d.add_portals(volume, portals, portal_masks, portal_transforms,  default_context);
+            d.template add_objects<detector_type::e_portal>(volume, portals, portal_masks, portal_transforms, default_context);
         }
     }
 }

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -46,7 +46,7 @@ namespace detray
 
         // Get surfaces, transforms and masks
         const auto &surfaces = detector.surfaces();
-        const auto &surface_transforms = detector.transforms(volume.surface_range(), context);
+        const auto &surface_transforms = detector.transforms(volume.template range<detector_type::e_surface>(), context);
         const auto &surface_masks = detector.masks();
 
         const auto &bounds = volume.bounds();
@@ -83,7 +83,7 @@ namespace detray
                                                                     phi_borders[1] + phi_add);
 
                     // Run through the surfaces and associate them by contour
-                    const auto& sf_range = volume.surface_range();
+                    const auto& sf_range = volume.template range<true>();
                     for (auto is = sf_range[0]; is < sf_range[1]; is++)
                     //for (auto [is, s] : enumerate(surfaces.objects()))
                     {
@@ -157,7 +157,7 @@ namespace detray
                     std::vector<point2> bin_contour = {p0_bin, p1_bin, p2_bin, p3_bin};
 
                     // Loop over the surfaces within a volume
-                    const auto& sf_range = volume.surface_range();
+                    const auto& sf_range = volume.template range<true>();
                     for (auto is = sf_range[0]; is < sf_range[1]; is++)
                     //for (auto [is, s] : enumerate(surfaces.objects()))
                     {

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -187,11 +187,11 @@ namespace detray
             if (navigation.volume_index == dindex_invalid or navigation.trust_level == e_no_trust)
             {
                 // First try to get the surface candidates
-                initialize_kernel(navigation, surface_kernel, track, volume.surface_range(), volume.surface_trf_range());
+                initialize_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>());
                 // If no surfaces are to processed, initialize the portals
                 if (surface_kernel.empty())
                 {
-                    initialize_kernel(navigation, portal_kernel, track, volume.portal_range(), volume.portal_trf_range());
+                    initialize_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
                     heartbeat = check_volume_switch(navigation);
                 }
                 // Before returning, run through the inspector
@@ -200,14 +200,14 @@ namespace detray
             }
 
             // Update the surface kernel
-            if (not is_exhausted(surface_kernel) and update_kernel(navigation, surface_kernel, track, volume.surface_range(), volume.surface_trf_range()))
+            if (not is_exhausted(surface_kernel) and update_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>()))
             {
                 navigation.inspector(navigation);
                 return heartbeat;
             }
 
             // Update the portal kernel
-            update_kernel(navigation, portal_kernel, track, volume.portal_range(), volume.portal_trf_range());
+            update_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
             heartbeat = check_volume_switch(navigation);
             navigation.inspector(navigation);
             return heartbeat;
@@ -249,27 +249,27 @@ namespace detray
                         // Clear the surface kernel
                         surface_kernel.clear();
                         navigation.trust_level = e_no_trust;
-                        update_kernel(navigation, portal_kernel, track, volume.portal_range(), volume.portal_trf_range());
+                        update_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
                         navigation.inspector(navigation);
                         return heartbeat;
                     }
-                    else if (update_kernel(navigation, surface_kernel, track, volume.surface_range(), volume.surface_trf_range()))
+                    else if (update_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>()))
                     {
                         navigation.inspector(navigation);
                         return heartbeat;
                     }
                 }
                 // Portals are present
-                update_kernel(navigation, portal_kernel, track, volume.portal_range(), volume.portal_trf_range());
+                update_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
             }
             else if (navigation.trust_level == e_no_trust)
             {
                 // First try to get the surface candidates
-                initialize_kernel(navigation, surface_kernel, track, volume.surface_range(), volume.surface_trf_range());
+                initialize_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>());
                 // If no surfaces are to processed, initialize the portals
                 if (surface_kernel.empty())
                 {
-                    initialize_kernel(navigation, portal_kernel, track, volume.portal_range(), volume.portal_trf_range(), navigation.status == e_on_portal);
+                    initialize_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>(), navigation.status == e_on_portal);
                     heartbeat = check_volume_switch(navigation);
                 }
             }

--- a/display/include/view/views.hpp
+++ b/display/include/view/views.hpp
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include "utils/containers.hpp"
-
 #include <cmath>
 
 namespace detray

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -295,7 +295,7 @@ namespace detray
         // Flush the former information / c_volume still points to the prior volume
         if (c_volume != nullptr)
         {
-          d.add_surfaces(*c_volume, c_surfaces, c_masks, c_transforms,  surface_default_context);
+          d.template add_objects<typed_detector::e_surface>(*c_volume, c_surfaces, c_masks, c_transforms,  surface_default_context);
 
           c_surfaces   = typename typed_detector::surface_filling_container();
           c_masks      = typename typed_detector::surface_mask_container();
@@ -418,6 +418,7 @@ namespace detray
         {
           // Trapezoid bounds
           constexpr auto trapezoid_context = typed_detector::surface_trapezoid::mask_context;
+
           // Add a new trapezoid mask
           auto &trapezoid_masks = std::get<trapezoid_context>(c_masks);
           dindex trapezoid_index = trapezoid_masks.size();

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -103,9 +103,9 @@ namespace __plugin
                     for (const auto &v : d.volumes())
                     {
                         // Loop over surfaces
-                        for (size_t si = v.surface_range()[0]; si < v.surface_range()[1]; si++)
+                        for (size_t si = v.template range<get_surface_masks>()[0]; si < v.template range<get_surface_masks>()[1]; si++)
                         {
-                            auto sfi_surface = intersect(track, surfaces[si], d.transforms(v.surface_trf_range(), default_context), masks);
+                            auto sfi_surface = intersect(track, surfaces[si], d.transforms(v.template trf_range<get_surface_masks>(), default_context), masks);
 
                             const auto &sfi = std::get<0>(sfi_surface);
                             

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -46,7 +46,7 @@ TEST(ALGEBRA_PLUGIN, detector)
 
     detector d("test_detector");
     auto &v = d.new_volume("test_volume", {0., 10., -5., 5., -M_PI, M_PI});
-    d.add_surfaces(v, surfaces, masks, trfs, ctx0);
+    d.template add_objects<detector::e_surface>(v, surfaces, masks, trfs, ctx0);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This PR continues #89 , where the detector display is adapted to the new detector and volume interface. It is based on recent  interface changes in #91, which has to be merged first