### PR TITLE
fix: use std::array as default array type in masks

### DIFF
--- a/core/include/masks/annulus2.hpp
+++ b/core/include/masks/annulus2.hpp
@@ -47,7 +47,7 @@ namespace detray
               typename local_type = __plugin::polar2,
               typename links_type = bool,
               unsigned int kMaskContext = e_annulus2,
-              template <typename, unsigned int> class array_type = darray>
+              template <typename, unsigned int> class array_type = std::array>
     struct annulus2
     {
         using mask_tolerance = array_type<scalar, 2>;

--- a/core/include/masks/annulus2.hpp
+++ b/core/include/masks/annulus2.hpp
@@ -47,7 +47,7 @@ namespace detray
               typename local_type = __plugin::polar2,
               typename links_type = bool,
               unsigned int kMaskContext = e_annulus2,
-              template <typename, unsigned int> class array_type = std::array>
+              template <typename, std::size_t> class array_type = std::array>
     struct annulus2
     {
         using mask_tolerance = array_type<scalar, 2>;

--- a/core/include/masks/cylinder3.hpp
+++ b/core/include/masks/cylinder3.hpp
@@ -37,7 +37,7 @@ namespace detray
               typename local_type = __plugin::cylindrical2,
               typename links_type = bool,
               unsigned int kMaskContext = e_cylinder3,
-              template <typename, unsigned int> class array_type = darray>
+              template <typename, unsigned int> class array_type = std::array>
     struct cylinder3
     {
 

--- a/core/include/masks/cylinder3.hpp
+++ b/core/include/masks/cylinder3.hpp
@@ -37,7 +37,7 @@ namespace detray
               typename local_type = __plugin::cylindrical2,
               typename links_type = bool,
               unsigned int kMaskContext = e_cylinder3,
-              template <typename, unsigned int> class array_type = std::array>
+              template <typename, std::size_t> class array_type = std::array>
     struct cylinder3
     {
 

--- a/core/include/masks/rectangle2.hpp
+++ b/core/include/masks/rectangle2.hpp
@@ -37,7 +37,7 @@ namespace detray
               typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_rectangle2,
-              template <typename, unsigned int> class array_type = std::array>
+              template <typename, std::size_t> class array_type = std::array>
     struct rectangle2
     {
         using mask_tolerance = array_type<scalar, 2>;

--- a/core/include/masks/rectangle2.hpp
+++ b/core/include/masks/rectangle2.hpp
@@ -37,7 +37,7 @@ namespace detray
               typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_rectangle2,
-              template <typename, unsigned int> class array_type = darray>
+              template <typename, unsigned int> class array_type = std::array>
     struct rectangle2
     {
         using mask_tolerance = array_type<scalar, 2>;

--- a/core/include/masks/ring2.hpp
+++ b/core/include/masks/ring2.hpp
@@ -36,7 +36,7 @@ namespace detray
               typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_ring2,
-              template <typename, unsigned int> class array_type = darray>
+              template <typename, unsigned int> class array_type = std::array>
     struct ring2
     {
         using mask_tolerance = scalar;

--- a/core/include/masks/ring2.hpp
+++ b/core/include/masks/ring2.hpp
@@ -36,7 +36,7 @@ namespace detray
               typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_ring2,
-              template <typename, unsigned int> class array_type = std::array>
+              template <typename, std::size_t> class array_type = std::array>
     struct ring2
     {
         using mask_tolerance = scalar;

--- a/core/include/masks/single3.hpp
+++ b/core/include/masks/single3.hpp
@@ -35,7 +35,7 @@ namespace detray
               typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_single3,
-              template <typename, unsigned int> class array_type = darray>
+              template <typename, unsigned int> class array_type = std::array>
     struct single3
     {
 

--- a/core/include/masks/single3.hpp
+++ b/core/include/masks/single3.hpp
@@ -35,7 +35,7 @@ namespace detray
               typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_single3,
-              template <typename, unsigned int> class array_type = std::array>
+              template <typename, std::size_t> class array_type = std::array>
     struct single3
     {
 

--- a/core/include/masks/trapezoid2.hpp
+++ b/core/include/masks/trapezoid2.hpp
@@ -36,7 +36,7 @@ namespace detray
               typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_trapezoid2,
-              template <typename, unsigned int> class array_type = darray>
+              template <typename, unsigned int> class array_type = std::array>
     struct trapezoid2
     {
         using mask_tolerance = array_type<scalar, 2>;

--- a/core/include/masks/trapezoid2.hpp
+++ b/core/include/masks/trapezoid2.hpp
@@ -36,7 +36,7 @@ namespace detray
               typename local_type = __plugin::cartesian2,
               typename links_type = bool,
               unsigned int kMaskContext = e_trapezoid2,
-              template <typename, unsigned int> class array_type = std::array>
+              template <typename, std::size_t> class array_type = std::array>
     struct trapezoid2
     {
         using mask_tolerance = array_type<scalar, 2>;


### PR DESCRIPTION
Use std::array in masks, since vecmem::static_array cannot be used as constexpr.