### PR TITLE
ref: Merge portal and surface types

### DIFF
--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -1,652 +1,621 @@
 /** Detray library, part of the ACTS project (R&D line)
- *
+ * 
  * (c) 2021 CERN for the benefit of the ACTS project
- *
+ * 
  * Mozilla Public License Version 2.0
  */
 #pragma once
-
-#include <sstream>
-#include <string>
 
 #include "core/intersection.hpp"
 #include "core/surface_base.hpp"
 #include "core/transform_store.hpp"
 #include "grids/axis.hpp"
 #include "grids/grid2.hpp"
-#include "grids/populator.hpp"
 #include "grids/serializer2.hpp"
+#include "grids/populator.hpp"
 #include "masks/masks.hpp"
-#include "tools/concentric_cylinder_intersector.hpp"
-#include "tools/cylinder_intersector.hpp"
-#include "tools/local_object_finder.hpp"
-#include "tools/planar_intersector.hpp"
-#include "utils/enumerate.hpp"
 #include "utils/indexing.hpp"
+#include "utils/enumerate.hpp"
+#include "tools/planar_intersector.hpp"
+#include "tools/cylinder_intersector.hpp"
+#include "tools/concentric_cylinder_intersector.hpp"
+#include "tools/local_object_finder.hpp"
 
-namespace detray {
+#include <string>
+#include <sstream>
 
-// Algebra, point2 is not strongly typed
-using point3 = __plugin::point3;
-using vector3 = __plugin::vector3;
-using point2 = __plugin::point2;
+namespace detray
+{
 
-/** Indexed detector definition.
- *
- * This class is a heavy templated detector definition class, that connects
- * surfaces, layers and volumes via an indexed system.
- *
- * @tparam array_type the type of the internal array, must have STL semantics
- * @tparam tuple_type the type of the internal tuple, must have STL semantics
- * @tparam vector_type the type of the internal array, must have STL semantics
- * @tparam alignable_store the type of the transform store
- * @tparam surface_source_link the type of the link to an external surface
- * source
- * @tparam bounds_source_link the type of the link to an external bounds source
- * @tparam surfaces_populator_type the type of populator used to fill the
- * surfaces grids
- * @tparam surfaces_serializer_type the type of the memory serializer for the
- * surfaces grids
- *
- */
-template <template <typename, unsigned int> class array_type = darray,
-          template <typename...> class tuple_type = dtuple,
-          template <typename> class vector_type = dvector,
-          typename alignable_store = static_transform_store<vector_type>,
-          typename surface_source_link = dindex,
-          typename bounds_source_link = dindex,
-          typename surfaces_populator_type =
-              attach_populator<false, dindex, vector_type>,
-          typename surfaces_serializer_type = serializer2>
-class detector {
+    // Algebra, point2 is not strongly typed
+    using point3 = __plugin::point3;
+    using vector3 = __plugin::vector3;
+    using point2 = __plugin::point2;
+
+    /** Indexed detector definition.
+     * 
+     * This class is a heavy templated detector definition class, that connects
+     * surfaces, layers and volumes via an indexed system.
+     *
+     * @tparam array_type the type of the internal array, must have STL semantics
+     * @tparam tuple_type the type of the internal tuple, must have STL semantics
+     * @tparam vector_type the type of the internal array, must have STL semantics
+     * @tparam alignable_store the type of the transform store
+     * @tparam surface_source_link the type of the link to an external surface source
+     * @tparam bounds_source_link the type of the link to an external bounds source
+     * @tparam surfaces_populator_type the type of populator used to fill the surfaces grids
+     * @tparam surfaces_serializer_type the type of the memory serializer for the surfaces grids
+     * 
+     */
+    template <template <typename, unsigned int> class array_type = darray,
+              template <typename...> class tuple_type = dtuple,
+              template <typename> class vector_type = dvector,
+              typename alignable_store = static_transform_store<vector_type>,
+              typename surface_source_link = dindex,
+              typename bounds_source_link = dindex,
+              typename surfaces_populator_type = attach_populator<false, dindex, vector_type>,
+              typename surfaces_serializer_type = serializer2>
+    class detector
+    {
 
     public:
-    /** Encodes the position in a collection container for the respective
-        mask type (not for portals for the moment). */
-    enum mask_container_index : unsigned int {
-        e_mask_types = 5,
-        e_rectangle2 = 0,
-        e_trapezoid2 = 1,
-        e_annulus2 = 2,
-        e_cylinder3 = 3,
-        e_ring2 = 4,
-        e_single3 = std::numeric_limits<unsigned int>::max(),
-        e_unknown = std::numeric_limits<unsigned int>::max(),
-    };
 
-    enum use_primitive : bool {
-        e_surface = true,
-        e_portal = false,
-    };
+        /** Encodes the position in a collection container for the respective
+            mask type (not for portals for the moment). */
+        enum mask_container_index : unsigned int {
+            e_mask_types = 5,
+            e_rectangle2 = 0,
+            e_trapezoid2 = 1,
+            e_annulus2 = 2,
+            e_cylinder3 = 3,
+            e_ring2 = 4,
+            e_single3 = std::numeric_limits<unsigned int>::max(),
+            e_unknown = std::numeric_limits<unsigned int>::max(),
+        };
 
-    /// The detector type
-    using detector_type = detector<array_type, tuple_type, vector_type, alignable_store, surface_source_link, bounds_source_link, surfaces_populator_type, surfaces_serializer_type>;
+        enum use_primitive : bool {
+            e_surface = true,
+            e_portal = false,
+        };
 
-    /// Forward the alignable container and context
-    using transform_store = alignable_store;
-    using context = typename alignable_store::context;
 
-    /// Volume grid definition
-    using volume_grid = grid2<replace_populator<dindex, std::numeric_limits<dindex>::max(), vector_type>,
+        /// The detector type
+        using detector_type = detector<array_type, tuple_type, vector_type, alignable_store, surface_source_link, bounds_source_link, surfaces_populator_type, surfaces_serializer_type>;
+
+        /// Forward the alignable container and context
+        using transform_store = alignable_store;
+        using context = typename alignable_store::context;
+
+        /// Volume grid definition
+        using volume_grid = grid2<replace_populator<dindex, std::numeric_limits<dindex>::max(), vector_type>,
                                   axis::irregular<array_type, vector_type>,
                                   axis::irregular<array_type, vector_type>,
                                   serializer2>;
 
-    /// Portals components:
-    /// - links:  next volume, next (local) object finder
-    using volume_links = array_type<dindex, 2>;
+        /// Portals components:
+        /// - links:  next volume, next (local) object finder
+        using volume_links = array_type<dindex, 2>;
 
-    /// - mask types
-    using rectangle = rectangle2<planar_intersector, __plugin::cartesian2, volume_links, 0>;
-    using trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, volume_links, 1>;
-    using annulus = annulus2<planar_intersector, __plugin::cartesian2, volume_links, 2>;
-    using cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, volume_links, 3>;
-    using disc = ring2<planar_intersector, __plugin::cartesian2, volume_links, 4>;
+        /// - mask types
+        using rectangle = rectangle2<planar_intersector, __plugin::cartesian2, volume_links, 0>;
+        using trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, volume_links, 1>;
+        using annulus = annulus2<planar_intersector, __plugin::cartesian2, volume_links, 2>;
+        using cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, volume_links, 3>;
+        using disc = ring2<planar_intersector, __plugin::cartesian2, volume_links, 4>;
+        
+        // - mask index: type, { first/last }
+        using portal_mask_index = array_type<dindex, 2>;
 
-    // - mask index: type, { first/last }
-    using portal_mask_index = tuple_type<dindex, array_type<dindex, 2>>;
+        /** The Portal definition:
+         *  <transform_link, mask_index, volume_link, source_link >
+         * 
+         * transform_link: index into the transform container
+         * mask_index: typed index into the mask container
+         * volume_link: index of the volume this portal belongs to
+         * source_link: some link to an eventual exernal representation
+         * 
+         */
+        using portal = surface_base<dindex, portal_mask_index, dindex, surface_source_link>;
+        using portal_container = vector_type<portal>;
 
-    /** The Portal definition:
-     *  <transform_link, mask_index, volume_link, source_link >
-     * 
-     * transform_link: index into the transform container
-     * mask_index: typed index into the mask container
-     * volume_link: index of the volume this portal belongs to
-     * source_link: some link to an eventual exernal representation
-     * 
-     */
-    using portal = surface_base<dindex, portal_mask_index, dindex, surface_source_link>;
-    using portal_container = vector_type<portal>;
+        /// Surface components:
+        /// - masks, with mask identifiers 0,1,2
 
-    /// Surface components:
-    /// - masks, with mask identifiers 0,1,2
+        /// - mask index: type, entry
+        using surface_mask_index = array_type<dindex, 2>;
+        using mask_container = tuple_type<vector_type<rectangle>,
+                                          vector_type<trapezoid>,
+                                          vector_type<annulus>,
+                                          vector_type<cylinder>,
+                                          vector_type<disc>>;
 
-    /// - mask index: type, entry
-    using surface_mask_index = array_type<dindex, 2>;
-    using mask_container = tuple_type<vector_type<rectangle>,
-                                      vector_type<trapezoid>,
-                                      vector_type<annulus>,
-                                      vector_type<cylinder>,
-                                      vector_type<disc>>;
-
-    using surface_link = surface_source_link;
-    /** The Surface definition:
-     *  <transform_link, mask_link, volume_link, source_link >
-     */
-    using surface = surface_base<dindex, surface_mask_index, dindex, surface_link>;
-    using surface_container = vector_type<surface>;
-
-    using surfaces_regular_axis = axis::regular<array_type>;
-    using surfaces_circular_axis = axis::circular<array_type>;
-    using surfaces_regular_circular_grid = grid2<surfaces_populator_type,
-                                                 surfaces_regular_axis,
-                                                 surfaces_circular_axis,
-                                                 surfaces_serializer_type,
-                                                 array_type,
-                                                 tuple_type,
-                                                 vector_type>;
-
-    using surfaces_finder = surfaces_regular_circular_grid;
-
-    /** Temporary container structures that are used to fill the detector. 
-     * The respective objects are sorted by mask type, so that they can be 
-     * unrolled and filled in lockstep with the masks
-     */
-    using surface_filling_container = array_type<vector_type<surface>, 5>;
-    using portal_filling_container = array_type<vector_type<portal>, 5>;
-    using transform_container = array_type<transform_store, 5>;
-
-    /** Nested volume struct that holds the local information of the
-     * volume and its portals.
-     */
-    class volume {
-        friend class detector<array_type, tuple_type, vector_type,
-                              alignable_store, surface_source_link,
-                              bounds_source_link, surfaces_populator_type,
-                              surfaces_serializer_type>;
-
-        public:
-        /** Deleted constructor */
-        volume() = delete;
-
-
+        using surface_link = surface_source_link;
         /** The Surface definition:
          *  <transform_link, mask_link, volume_link, source_link >
          */
-        volume(const std::string &name) : _name(name) {}
+        using surface = surface_base<dindex, surface_mask_index, dindex, surface_link>;
+        using surface_container = vector_type<surface>;
 
-        /** Contructor with name and bounds
-         * @param name of the volume
-         * @param bounds of the volume
-         * @param d detector the volume belongs to
+        using surfaces_regular_axis = axis::regular<array_type>;
+        using surfaces_circular_axis = axis::circular<array_type>;
+        using surfaces_regular_circular_grid = grid2<surfaces_populator_type,
+                                                     surfaces_regular_axis,
+                                                     surfaces_circular_axis,
+                                                     surfaces_serializer_type,
+                                                     array_type,
+                                                     tuple_type,
+                                                     vector_type>;
+
+        using surfaces_finder = surfaces_regular_circular_grid;
+
+        /** Temporary container structures that are used to fill the detector. 
+         * The respective objects are sorted by mask type, so that they can be 
+         * unrolled and filled in lockstep with the masks
          */
-        volume(const std::string &name, const array_type<scalar, 6> &bounds)
-            : _name(name), _bounds(bounds) {}
+        using surface_filling_container = array_type<vector_type<surface>, 5>;
+        using portal_filling_container = array_type<vector_type<portal>, 5>;
+        using transform_container = array_type<transform_store, 5>;
 
-        /** Copy ctor makes sure constituents keep valid volume pointer
-         *
-         * @param other Volume to be copied
+        /** Nested volume struct that holds the local information of the
+         * volume and its portals.
          */
-        volume(const volume &other) = default;
+        class volume
+        {
+            friend class detector<array_type,
+                                  tuple_type,
+                                  vector_type,
+                                  alignable_store,
+                                  surface_source_link,
+                                  bounds_source_link,
+                                  surfaces_populator_type,
+                                  surfaces_serializer_type>;
 
-        /** @return the bounds - const access */
-        const array_type<scalar, 6> &bounds() const { return _bounds; }
+        public:
 
-        /** @return the name */
-        const std::string &name() const { return _name; }
+            /** Deleted constructor */
+            volume() = delete;
 
-        /** @return the index */
-        dindex index() const { return _index; }
+            /** Allowed constructors
+             * @param name of the volume
+             * @param d detector the volume belongs to
+             * 
+             * @note will be contructed boundless
+             */
+            volume(const std::string &name) : _name(name){}
 
-        /** @return the entry into the local surface finders */
-        dindex surfaces_finder_entry() const { return _surfaces_finder_entry; }
+            /** Contructor with name and bounds 
+             * @param name of the volume
+             * @param bounds of the volume
+             * @param d detector the volume belongs to
+             */
+            volume(const std::string &name, const array_type<scalar, 6> &bounds) : _name(name), _bounds(bounds) {}
 
-        /** @return if the volume is empty or not */
-        bool empty() const { return is_empty_range(_surface_range); }
+            /** Copy ctor makes sure constituents keep valid volume pointer
+             *
+             * @param other Volume to be copied
+             */
+            volume(const volume &other) = default;
 
-        /** @return the number of surfaces in the volume */
-        template <bool use_surfaces = e_surface>
-        dindex n_objects() {
-            if constexpr (use_surfaces) {
-                return n_in_range(_surface_range);
-            } else {
-                return n_in_range(_portal_range);
+            /** @return the bounds - const access */
+            const array_type<scalar, 6> &bounds() const { return _bounds; }
+
+            /** @return the name */
+            const std::string &name() const { return _name; }
+
+            /** @return the index */
+            dindex index() const { return _index; }
+
+            /** @return the entry into the local surface finders */
+            dindex surfaces_finder_entry() const { return _surfaces_finder_entry; }
+
+            /** @return if the volume is empty or not */
+            bool empty() const
+            {
+                return (is_empty_range(_surface_range) and
+                        is_empty_range(_portal_range));
             }
-        }
 
-        /** @return the number of surfaces in the volume */
-        template <bool use_surfaces = e_surface>
-        const dindex n_objects() const {
-            if constexpr (use_surfaces) {
-                return n_in_range(_surface_range);
-            } else {
-                return n_in_range(_portal_range);
+            /** @return the number of surfaces in the volume */
+            template<bool use_surfaces = e_surface>
+            dindex n_objects()
+            {
+                if constexpr (use_surfaces) { return n_in_range(_surface_range); }
+                else { return n_in_range(_portal_range); }
             }
-        }
 
-        /** Set the index into the detector surface container
-         *
-         * @param range Surface index range
-         */
-        template <bool surface_range = e_surface>
-        void set_range(dindex_range range) {
-            if constexpr (surface_range) {
-                update_range(_surface_range, std::move(range));
-            } else {
-                update_range(_portal_range, std::move(range));
+            /** @return the number of surfaces in the volume */
+            template<bool use_surfaces = e_surface>
+            const dindex n_objects() const
+            {
+                if constexpr (use_surfaces) { return n_in_range(_surface_range); }
+                else { return n_in_range(_portal_range); }
             }
-        }
 
-        /** @return range of surfaces- const access */
-        template <bool surface_range = e_surface>
-        const auto &range() const {
-
-            if constexpr (surface_range) {
-                return _surface_range;
-            } else {
-                return _portal_range;
+            /** Set the index into the detector surface container
+             *
+             * @param range Surface index range
+             */
+            template<bool surface_range = e_surface>
+            void set_range(dindex_range range)
+            {
+                if constexpr (surface_range) { update_range(_surface_range, std::move(range)); }
+                else { update_range(_portal_range, std::move(range)); }
             }
-        }
 
-        /** @return range of portals - const access */
-        // const auto &portal_range() const { return _portal_range; }
-
-        /** @return range of surface transforms - const access */
-        template <bool surface_range = e_surface>
-        const auto &trf_range() const {
-            if constexpr (surface_range) {
-                return _surface_trf_range;
-            } else {
-                return _portal_trf_range;
+            /** @return range of surfaces- const access */
+            template<bool surface_range = e_surface>
+            const auto &range() const {
+                
+                if constexpr (surface_range) { return _surface_range; }
+                else { return _portal_range;}
             }
-        }
 
-        /** Set the index into the detector transform store for portals
-         *
-         * @param range Portal transform index range
-         */
-        template <bool surface_range = e_surface>
-        void set_trf_range(dindex_range range) {
-            if constexpr (surface_range) {
-                update_range(_surface_trf_range, std::move(range));
-            } else {
-                update_range(_portal_trf_range, std::move(range));
+            /** @return range of portals - const access */
+            //const auto &portal_range() const { return _portal_range; }
+
+            /** @return range of surface transforms - const access */
+            template<bool surface_range = e_surface>
+            const auto &trf_range() const
+            {
+                if constexpr (surface_range) { return _surface_trf_range; }
+                else { return _portal_trf_range;}
             }
-        }
+
+            /** Set the index into the detector transform store for portals
+             *
+             * @param range Portal transform index range
+             */
+            template<bool surface_range = e_surface>
+            void set_trf_range(dindex_range range)
+            {
+                if constexpr (surface_range) { update_range(_surface_trf_range, std::move(range)); }
+                else { update_range(_portal_trf_range, std::move(range)); }
+            }
 
         private:
-        /** Volume section: name */
-        std::string _name = "unknown";
+            /** Volume section: name */
+            std::string _name = "unknown";
 
-        /** Volume index */
-        dindex _index = dindex_invalid;
+            /** Volume index */
+            dindex _index = dindex_invalid;
 
-        /** Transform ranges in the detector transform store.*/
-        dindex_range _surface_trf_range = {dindex_invalid, dindex_invalid};
-        dindex_range _portal_trf_range = {dindex_invalid, dindex_invalid};
+            /** Transform ranges in the detector transform store.*/
+            dindex_range _surface_trf_range = {dindex_invalid, dindex_invalid};
+            dindex_range _portal_trf_range  = {dindex_invalid, dindex_invalid};
 
-        /** Index ranges in the detector surface/portal containers.*/
-        dindex_range _surface_range = {dindex_invalid, dindex_invalid};
-        dindex_range _portal_range = {dindex_invalid, dindex_invalid};
+            /** Index ranges in the detector surface/portal containers.*/
+            dindex_range _surface_range = {dindex_invalid, dindex_invalid};
+            dindex_range _portal_range  = {dindex_invalid, dindex_invalid};
 
-        /** Index into the surface finder container */
-        dindex _surfaces_finder_entry = dindex_invalid;
+            /** Index into the surface finder container */
+            dindex _surfaces_finder_entry = dindex_invalid;
 
-        /** Bounds section, default for r, z, phi */
-        array_type<scalar, 6> _bounds = {0.,
-                                         std::numeric_limits<scalar>::max(),
-                                         -std::numeric_limits<scalar>::max(),
-                                         std::numeric_limits<scalar>::max(),
-                                         -M_PI,
-                                         M_PI};
+            /** Bounds section, default for r, z, phi */
+            array_type<scalar, 6> _bounds = {0.,
+                                             std::numeric_limits<scalar>::max(),
+                                             -std::numeric_limits<scalar>::max(),
+                                             std::numeric_limits<scalar>::max(),
+                                             -M_PI, M_PI};
 
-        /**
-         * @param range Any index range
-         *
-         * @return the number of indexed objects
-         */
-        inline dindex n_in_range(const dindex_range &range) {
-            return range[1] - range[0];
-        }
+            /**
+             * @param range Any index range
+             *
+             * @return the number of indexed objects
+             */
+            inline dindex n_in_range(const dindex_range &range) { return range[1] - range[0]; }
 
-        /**
-         * @param range Any index range
-         *
-         * @return the number of indexed objects
-         */
-        inline const dindex n_in_range(const dindex_range &range) const {
-            return range[1] - range[0];
+            /**
+             * @param range Any index range
+             *
+             * @return the number of indexed objects
+             */
+            inline const dindex n_in_range(const dindex_range &range) const { return range[1] - range[0]; }
 
-        /** Test whether a range is empty
-         *
-         * @param range Any index range
-         *
-         * @return boolean whether the range is empty
-         */
-        inline bool is_empty_range(const dindex_range &range) {
-            return n_in_range(range) == 0;
-        }
+            /** Test whether a range is empty
+             *
+             * @param range Any index range
+             *
+             * @return boolean whether the range is empty
+             */
+            inline bool is_empty_range(const dindex_range &range) { return n_in_range(range) == 0; }
 
-        /** Test whether a range is empty - const
-         *
-         * @param range Any index range
-         *
-         * @return boolean whether the range is empty
-         */
-        inline const bool is_empty_range(const dindex_range &range) const {
-            return n_in_range(range) == 0;
-        }
+            /** Test whether a range is empty - const
+             *
+             * @param range Any index range
+             *
+             * @return boolean whether the range is empty
+             */
+            inline const bool is_empty_range(const dindex_range &range) const { return n_in_range(range) == 0; }
 
-        /** Set or update a range
-         *
-         * @param range One of the volume member ranges
-         * @param other new index range
-         *
-         * @return boolean whether the range is empty
-         */
-        inline void update_range(dindex_range &range, dindex_range &&other) {
-            // Range not set yet
-            if (range[0] == dindex_invalid) {
-                range = other;
-            } else {
-                range[1] += other[1] - other[0];
+
+            /** Set or update a range
+             *
+             * @param range One of the volume member ranges
+             * @param other new index range
+             *
+             * @return boolean whether the range is empty
+             */
+            inline void update_range(dindex_range &range, dindex_range &&other)
+            {
+                // Range not set yet
+                if (range[0] == dindex_invalid) {
+                    range = other;
+                }
+                else {
+                    range[1] += other[1] - other[0];
+                }
             }
+        };
+
+        /** Allowed costructor
+         * @param name the detector
+         */
+        detector(const std::string &name) : _name(name) {}
+
+        /** Copy constructor makes sure the volumes belong to new detector.
+         *
+         * @param other Detector to be copied
+         */
+        detector(const detector &other) = default;
+        detector() = delete;
+        ~detector() = default;
+
+        /** Add a new volume and retrieve a reference to it
+         *
+         * @param name of the volume
+         * @param bounds of the volume, they are expected to be already attaching
+         * @param surfaces_finder_entry of the volume, where to entry the surface finder 
+         *
+         * @return non-const reference of the new volume
+         */
+        volume &new_volume(const std::string &name, const array_type<scalar, 6> &bounds, dindex surfaces_finder_entry = dindex_invalid)
+        {
+            _volumes.emplace_back(name, bounds);
+            dindex cvolume_idx = _volumes.size() - 1;
+            volume &cvolume = _volumes[cvolume_idx];
+            cvolume._index = cvolume_idx;
+            cvolume._surfaces_finder_entry = surfaces_finder_entry;
+            return cvolume;
         }
-    };
 
-    /** Allowed costructor
-     * @param name the detector
-     */
-    detector(const std::string &name) : _name(name) {}
+        /** @return the name of the detector */
+        const std::string &name() const { return _name; }
 
-    /** Copy constructor makes sure the volumes belong to new detector.
-     *
-     * @param other Detector to be copied
-     */
-    detector(const detector &other) = default;
-    detector() = delete;
-    ~detector() = default;
+        /** @return the contained volumes of the detector - const access */
+        const vector_type<volume> &volumes() const { return _volumes; }
 
-    /** Add a new volume and retrieve a reference to it
-     *
-     * @param name of the volume
-     * @param bounds of the volume, they are expected to be already attaching
-     * @param surfaces_finder_entry of the volume, where to entry the surface
-     * finder
-     *
-     * @return non-const reference of the new volume
-     */
-    volume &new_volume(const std::string &name,
-                       const array_type<scalar, 6> &bounds,
-                       dindex surfaces_finder_entry = dindex_invalid) {
-        _volumes.emplace_back(name, bounds);
-        dindex cvolume_idx = _volumes.size() - 1;
-        volume &cvolume = _volumes[cvolume_idx];
-        cvolume._index = cvolume_idx;
-        cvolume._surfaces_finder_entry = surfaces_finder_entry;
-        return cvolume;
-    }
+        /** @return the volume by @param volume_index - const access */
+        const volume &indexed_volume(dindex volume_index) const { return _volumes[volume_index]; }
 
-    /** @return the name of the detector */
-    const std::string &name() const { return _name; }
-
-    /** @return the contained volumes of the detector - const access */
-    const vector_type<volume> &volumes() const { return _volumes; }
-
-    /** @return the volume by @param volume_index - const access */
-    const volume &indexed_volume(dindex volume_index) const {
-        return _volumes[volume_index];
-    }
-
-    /** @return the volume by @param position - const access */
-    const volume &indexed_volume(const point3 &p) const {
-        point2 p2 = {getter::perp(p), p[2]};
-        dindex volume_index = _volume_grid.bin(p2);
-        return _volumes[volume_index];
-    }
-
-    /** @return the volume by @param volume_index - non-const access */
-    volume &indexed_volume(dindex volume_index) {
-        return _volumes[volume_index];
-    }
-
-    /** Add a new full set of alignable transforms for surfaces of a volume
-     *
-     * @param volume The volume we add the transforms to
-     * @param surfaces The surfaces in the volume
-     * @param trfs The surface transforms (same number as surfaces)
-     * @param ctx The context of the call
-     *
-     * @note can throw an exception if input data is inconsistent
-     */
-    template <bool add_surfaces = e_surface, typename object_container,
-              typename mask_container>
-    void add_objects(
-        volume &volume, object_container &surfaces, mask_container &masks,
-        transform_container &trfs,
-        const typename alignable_store::context ctx = {}) noexcept(false) {
-        unroll_container_filling<0, object_container, mask_container,
-                                 add_surfaces>(surfaces, masks, volume, trfs,
-                                               ctx);
-    }
-
-    /** @return all surfaces/portals in the detector */
-    template <bool get_surface = true>
-    const auto &surfaces() const {
-        if constexpr (get_surface) {
-            return _surfaces;
-        } else {
-            return _portals;
+        /** @return the volume by @param position - const access */
+        const volume &indexed_volume(const point3 &p) const
+        {
+            point2 p2 = {getter::perp(p), p[2]};
+            dindex volume_index = _volume_grid.bin(p2);
+            return _volumes[volume_index];
         }
-    }
 
-    /** Get @return all surface/portal masks in the detector */
-    template <bool surface_masks = e_surface>
-    const auto &masks() const {
-        if constexpr (surface_masks) {
-            return _surface_masks;
-        } else {
-            return _portal_masks;
+        /** @return the volume by @param volume_index - non-const access */
+        volume &indexed_volume(dindex volume_index) { return _volumes[volume_index]; }
+
+        /** Add a new full set of alignable transforms for surfaces of a volume
+         *
+         * @param volume The volume we add the transforms to
+         * @param surfaces The surfaces in the volume
+         * @param trfs The surface transforms (same number as surfaces)
+         * @param ctx The context of the call
+         *
+         * @note can throw an exception if input data is inconsistent
+         */
+        template <bool add_surfaces = e_surface,
+                  typename object_container,
+                  typename mask_container>
+        void add_objects(
+            volume &volume,
+            object_container &surfaces,
+            mask_container &masks,
+            transform_container &trfs,
+            const typename alignable_store::context ctx = {}) noexcept(false)
+        {
+            unroll_container_filling<0, object_container, mask_container, add_surfaces>(surfaces, masks, volume, trfs, ctx);
         }
-    }
-
-    /** Get @return all surface/portal masks in the detector */
         
+        /** @return all surfaces/portals in the detector */
+        template<bool get_surface = true>
+        const auto& surfaces() const
+        {
+            if constexpr (get_surface) { return _surfaces; }
+            else { return _portals; }
+        }
+
+        /** Get @return all surface/portal masks in the detector */
         template<bool surface_masks = e_surface>
         const auto& masks() const
         {
             return _masks;
         }
 
-    /** Unrolls the data containers according to mask type and fills the
-     * detector.
-     *
-     * @tparam current_idx the current mask context to be processed
-     * @tparam object_container surfaces/portals for which the links are updated
-     * @tparam mask_container surface/portal masks, sorted by type
-     * @tparam add_surfaces check whether we deal with surfaces or portals
-     *
-     */
-    template <size_t current_idx = 0,
-              typename object_container,
-              typename mask_container,
-              bool add_surfaces = e_surface>
-    void unroll_container_filling(object_container &objects,
-                                  mask_container &masks,
-                                  volume &volume,
-                                  transform_container &trfs,
-                                  const typename alignable_store::context ctx = {})
-    {
-        // Get the surfaces/portals for a mask type
-        auto &typed_objects = objects[current_idx];
-        // Get the corresponding transforms
-        const auto &surface_transforms = trfs[current_idx];
-        // and the corresponding masks
-        auto &object_masks = std::get<current_idx>(masks);
-
-        // Fill object masks into the correct detector container
-        auto add_detector_masks = [&](auto &detector_container) -> dindex
+        /** Unrolls the data containers according to mask type and fills the detector.
+          *
+          * @tparam current_idx the current mask context to be processed
+          * @tparam object_container surfaces/portals for which the links are updated
+          * @tparam mask_container surface/portal masks, sorted by type
+          * @tparam add_surfaces check whether we deal with surfaces or portals
+          *
+          */
+        template <size_t current_idx = 0,
+                  typename object_container,
+                  typename mask_container,
+                  bool add_surfaces = e_surface>
+        void unroll_container_filling(object_container &objects,
+                                      mask_container &masks,
+                                      volume &volume,
+                                      transform_container &trfs,
+                                      const typename alignable_store::context ctx = {})
         {
-            auto &detector_masks = std::get<current_idx>(detector_container);
-            const dindex mask_offset = detector_masks.size();
-            detector_masks.reserve(mask_offset + object_masks.size());
-            detector_masks.insert(detector_masks.end(), object_masks.begin(), object_masks.end());
+            // Get the surfaces/portals for a mask type
+            auto &typed_objects = objects[current_idx];
+            // Get the corresponding transforms
+            const auto &surface_transforms = trfs[current_idx];
+            // and the corresponding masks
+            auto &object_masks = std::get<current_idx>(masks);
 
-            return mask_offset;
-        };
-
-        // Fill objects (surfaces or portals) into the detector container
-        auto add_detector_objects = [&](auto &detector_container)
-        {
-            detector_container.reserve(detector_container.size() + typed_objects.size());
-            detector_container.insert(detector_container.end(), typed_objects.begin(), typed_objects.end());
-        };
-
-
-        if (surface_transforms.size(ctx) != 0 and not typed_objects.empty())
-        {
-            // Current offsets into detectors containers
-            const auto trsf_offset = transform_index(ctx);
-            _transforms.append(ctx, std::move(std::get<current_idx>(trfs)));
-
-            // Fill surface or portal container?
-            if constexpr (add_surfaces)
+            // Fill object masks into the correct detector container
+            auto add_detector_masks = [&](auto &detector_container) -> dindex
             {
-                // Surface transforms for this volume
-                volume.template set_trf_range<e_surface>(dindex_range{trsf_offset, transform_index(ctx)});
+                auto &detector_masks = std::get<current_idx>(detector_container);
+                const dindex mask_offset = detector_masks.size();
+                detector_masks.reserve(mask_offset + object_masks.size());
+                detector_masks.insert(detector_masks.end(), object_masks.begin(), object_masks.end());
 
-                const auto sf_mask_offset = add_detector_masks(_masks);
+                return mask_offset;
+            };
 
-                // Update the surfaces mask link
-                for (auto &sf : typed_objects)
-                {
-                    std::get<1>(sf.mask()) += sf_mask_offset;
-                }
-
-                // Now put the surfaces into the detector
-                add_detector_objects(_surfaces);
-                volume.template set_range<e_surface>({_surfaces.size() - typed_objects.size(), _surfaces.size()});
-            }
-            else
+            // Fill objects (surfaces or portals) into the detector container
+            auto add_detector_objects = [&](auto &detector_container)
             {
-                // Portal transforms for this volume
-                volume.template set_trf_range<e_portal>(dindex_range{trsf_offset, transform_index(ctx)});
+                detector_container.reserve(detector_container.size() + typed_objects.size());
+                detector_container.insert(detector_container.end(), typed_objects.begin(), typed_objects.end());
+            };
 
-                // Fill the correct mask type
-                const auto pt_mask_offset = add_detector_masks(_masks);
 
-                // Update the portals mask links
-                for (auto &obj : typed_objects)
+            if (surface_transforms.size(ctx) != 0 and not typed_objects.empty())
+            {
+                // Current offsets into detectors containers
+                const auto trsf_offset = transform_index(ctx);
+                _transforms.append(ctx, std::move(std::get<current_idx>(trfs)));
+
+                // Fill surface or portal container?
+                if constexpr (add_surfaces)
                 {
-                    auto& portal_mask_index = std::get<1>(obj.mask());
-                    portal_mask_index[0] += pt_mask_offset;
-                    portal_mask_index[1] += pt_mask_offset;
+                    // Surface transforms for this volume
+                    volume.template set_trf_range<e_surface>(dindex_range{trsf_offset, transform_index(ctx)});
+
+                    const auto sf_mask_offset = add_detector_masks(_masks);
+
+                    // Update the surfaces mask link
+                    for (auto &sf : typed_objects)
+                    {
+                        std::get<1>(sf.mask()) += sf_mask_offset;
+                    }
+
+                    // Now put the surfaces into the detector
+                    add_detector_objects(_surfaces);
+                    volume.template set_range<e_surface>({_surfaces.size() - typed_objects.size(), _surfaces.size()});
                 }
+                else
+                {
+                    // Portal transforms for this volume
+                    volume.template set_trf_range<e_portal>(dindex_range{trsf_offset, transform_index(ctx)});
 
-                // Now put the portals into the detector
-                add_detector_objects(_portals);
-                volume.template set_range<e_portal>({_portals.size() - typed_objects.size(), _portals.size()});
+                    // Fill the correct mask type
+                    const auto pt_mask_offset = add_detector_masks(_masks);
+
+                    // Update the portals mask links
+                    for (auto &pt : typed_objects)
+                    {
+                        std::get<1>(pt.mask()) += pt_mask_offset;
+                    }
+
+                    // Now put the portals into the detector
+                    add_detector_objects(_portals);
+                    volume.template set_range<e_portal>({_portals.size() - typed_objects.size(), _portals.size()});
+                }
+            }
+            // Next mask type
+            if constexpr (current_idx < std::tuple_size_v<mask_container> - 1)
+            {
+                return unroll_container_filling<current_idx + 1, object_container, mask_container, add_surfaces>(objects, masks, volume, trfs, ctx);
             }
         }
-        // Next mask type
-        if constexpr (current_idx < std::tuple_size_v<mask_container> - 1)
+
+        /** Get the current transform index
+         *
+         * @param ctx The context of the call
+         *
+         * @return Index to add new transforms at 
+         */
+        const unsigned int transform_index(const context &ctx) const
         {
-            return unroll_container_filling<current_idx + 1, object_container, mask_container, add_surfaces>(objects, masks, volume, trfs, ctx);
+            return _transforms.size(ctx);
         }
-    }
 
-    /** Get the current transform index
-     *
-     * @param ctx The context of the call
-     *
-     * @return Index to add new transforms at
-     */
-    const unsigned int transform_index(const context &ctx) const {
-        return _transforms.size(ctx);
-    }
+        /** Get all transform in an index range from the detector
+         *
+         * @param range The range of surfaces/portals in the transform store
+         * @param ctx The context of the call
+         *
+         * @return ranged iterator to the object transforms 
+         */
+        const auto transforms(const dindex_range range, const context &ctx = {}) const
+        {
+            return _transforms.range(std::move(range), ctx);
+        }
 
-    /** Get all transform in an index range from the detector
-     *
-     * @param range The range of surfaces/portals in the transform store
-     * @param ctx The context of the call
-     *
-     * @return ranged iterator to the object transforms
-     */
-    const auto transforms(const dindex_range range,
-                          const context &ctx = {}) const {
-        return _transforms.range(std::move(range), ctx);
-    }
+        /** Add the volume grid - move semantics 
+         * 
+         * @param v_grid the volume grid to be added
+         */
+        void add_volume_grid(volume_grid &&v_grid)
+        {
+            _volume_grid = std::move(v_grid);
+        }
 
-    /** Add the volume grid - move semantics
-     *
-     * @param v_grid the volume grid to be added
-     */
-    void add_volume_grid(volume_grid &&v_grid) {
-        _volume_grid = std::move(v_grid);
-    }
+        /** @return the volume grid - const access */
+        const volume_grid &volume_search_grid() const { return _volume_grid; }
 
-    /** @return the volume grid - const access */
-    const volume_grid &volume_search_grid() const { return _volume_grid; }
+        /** Add local surface finders linked to from the portals - move semantics
+         * 
+         * This connects portals and surface grids
+         */
+        void add_surfaces_finders(vector_type<surfaces_finder> &&surfaces_finders)
+        {
+            _surfaces_finders = std::move(surfaces_finders);
+        }
 
-    /** Add local surface finders linked to from the portals - move semantics
-     *
-     * This connects portals and surface grids
-     */
-    void add_surfaces_finders(vector_type<surfaces_finder> &&surfaces_finders) {
-        _surfaces_finders = std::move(surfaces_finders);
-    }
+        /** @return the surface finders - const access */
+        const vector_type<surfaces_finder> &surfaces_finders() const { return _surfaces_finders; }
 
-    /** @return the surface finders - const access */
-    const vector_type<surfaces_finder> &surfaces_finders() const {
-        return _surfaces_finders;
-    }
-
-    /** Output to string */
-    const std::string to_string() const {
-        std::stringstream ss;
-        ss << "[>] Detector '" << _name << "' has " << _volumes.size()
-           << " volumes." << std::endl;
-        ss << "    contains  " << _surfaces_finders.size()
-           << " local surface finders." << std::endl;
-        for (const auto &[i, v] : enumerate(_volumes)) {
-            ss << "[>>] Volume at index " << i << " - name: '" << v.name()
-               << "'" << std::endl;
-            ss << "     contains    " << v.template n_objects<e_surface>()
-               << " detector surfaces" << std::endl;
-            ss << "                 " << v.template n_objects<e_portal>()
-               << " detector portals" << std::endl;
-            if (v._surfaces_finder_entry != dindex_invalid) {
-                ss << "     finders idx " << v._surfaces_finder_entry
-                   << std::endl;
+        /** Output to string */
+        const std::string to_string() const
+        {
+            std::stringstream ss;
+            ss << "[>] Detector '" << _name << "' has " << _volumes.size() << " volumes." << std::endl;
+            ss << "    contains  " << _surfaces_finders.size() << " local surface finders." << std::endl;
+            for (const auto &[i, v] : enumerate(_volumes))
+            {
+                ss << "[>>] Volume at index " << i << " - name: '" << v.name() << "'" << std::endl;
+                ss << "     contains    " << v.template n_objects<e_surface>() << " detector surfaces" << std::endl;
+                ss << "                 " << v.template n_objects<e_portal>() << " detector portals" << std::endl;
+                if (v._surfaces_finder_entry != dindex_invalid)
+                {
+                    ss << "     finders idx " << v._surfaces_finder_entry << std::endl;
+                }
+                ss << "     bounds r = (" << v._bounds[0] << ", " << v._bounds[1] << ")" << std::endl;
+                ss << "            z = (" << v._bounds[2] << ", " << v._bounds[3] << ")" << std::endl;
             }
-            ss << "     bounds r = (" << v._bounds[0] << ", " << v._bounds[1]
-               << ")" << std::endl;
-            ss << "            z = (" << v._bounds[2] << ", " << v._bounds[3]
-               << ")" << std::endl;
-        }
-        return ss.str();
-    };
+            return ss.str();
+        };
 
     private:
-    std::string _name = "unknown_detector";
+        std::string _name = "unknown_detector";
 
-    /** Contains the geometrical relations*/
-    vector_type<volume> _volumes = {};
+        /** Contains the geometrical relations*/
+        vector_type<volume> _volumes = {};
 
-    /** Keeps all of the transform data in contiguous memory*/
-    transform_store _transforms = {};
+        /** Keeps all of the transform data in contiguous memory*/
+        transform_store _transforms = {};
 
-    /** All surfaces and portals in the detector in contigous memory */
-    surface_container _surfaces = {};
-    portal_container _portals = {};
+        /** All surfaces and portals in the detector in contigous memory */
+        surface_container _surfaces = {};
+        portal_container _portals = {};
 
-    /** Surface and portal masks of the detector in contigous memory */
-    mask_container _masks = {};
+        /** Surface and portal masks of the detector in contigous memory */
+        mask_container _masks = {};
 
-    vector_type<surfaces_finder> _surfaces_finders;
+        vector_type<surfaces_finder> _surfaces_finders;
 
-    volume_grid _volume_grid = volume_grid(std::move(axis::irregular{{}}),
-                                           std::move(axis::irregular{{}}));
-};
+        volume_grid _volume_grid = volume_grid(std::move(axis::irregular{{}}), std::move(axis::irregular{{}}));
+    };
 
-}  // namespace detray
+}

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -95,9 +95,14 @@ class detector {
     /// Portals components:
     /// - links:  next volume, next (local) object finder
     using volume_links = array_type<dindex, 2>;
-    /// - masks, with mask identifiers 0, 1
-    using portal_cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, volume_links, 4>;
-    using portal_disc = ring2<planar_intersector, __plugin::cartesian2, volume_links, 5>;
+
+    /// - mask types
+    using rectangle = rectangle2<planar_intersector, __plugin::cartesian2, volume_links, 0>;
+    using trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, volume_links, 1>;
+    using annulus = annulus2<planar_intersector, __plugin::cartesian2, volume_links, 2>;
+    using cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, volume_links, 3>;
+    using disc = ring2<planar_intersector, __plugin::cartesian2, volume_links, 4>;
+
     // - mask index: type, { first/last }
     using portal_mask_index = tuple_type<dindex, array_type<dindex, 2>>;
 
@@ -115,43 +120,41 @@ class detector {
 
     /// Surface components:
     /// - masks, with mask identifiers 0,1,2
-    using surface_rectangle = rectangle2<planar_intersector, __plugin::cartesian2, volume_links, 0>;
-    using surface_trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, volume_links, 1>;
-    using surface_annulus = annulus2<planar_intersector, __plugin::cartesian2, volume_links, 2>;
-    using surface_cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, volume_links, 3>;
+
     /// - mask index: type, entry
     using surface_mask_index = array_type<dindex, 2>;
-    using mask_container = tuple_type<vector_type<surface_rectangle>,
-                                      vector_type<surface_trapezoid>,
-                                      vector_type<surface_annulus>,
-                                      vector_type<surface_cylinder>,
-                                      vector_type<portal_cylinder>,
-                                      vector_type<portal_disc>>;
+    using mask_container = tuple_type<vector_type<rectangle>,
+                                      vector_type<trapezoid>,
+                                      vector_type<annulus>,
+                                      vector_type<cylinder>,
+                                      vector_type<disc>>;
 
     using surface_link = surface_source_link;
     /** The Surface definition:
      *  <transform_link, mask_link, volume_link, source_link >
      */
-    using surface =
-        surface_base<dindex, surface_mask_index, dindex, surface_link>;
+    using surface = surface_base<dindex, surface_mask_index, dindex, surface_link>;
     using surface_container = vector_type<surface>;
 
     using surfaces_regular_axis = axis::regular<array_type>;
     using surfaces_circular_axis = axis::circular<array_type>;
-    using surfaces_regular_circular_grid =
-        grid2<surfaces_populator_type, surfaces_regular_axis,
-              surfaces_circular_axis, surfaces_serializer_type, array_type,
-              tuple_type, vector_type>;
+    using surfaces_regular_circular_grid = grid2<surfaces_populator_type,
+                                                 surfaces_regular_axis,
+                                                 surfaces_circular_axis,
+                                                 surfaces_serializer_type,
+                                                 array_type,
+                                                 tuple_type,
+                                                 vector_type>;
 
     using surfaces_finder = surfaces_regular_circular_grid;
 
-    /** Temporary container structures that are used to fill the detector.
-     * The respective objects are sorted by mask type, so that they can be
+    /** Temporary container structures that are used to fill the detector. 
+     * The respective objects are sorted by mask type, so that they can be 
      * unrolled and filled in lockstep with the masks
      */
-    using surface_filling_container = array_type<vector_type<surface>, 6>;
-    using portal_filling_container = array_type<vector_type<portal>, 6>;
-    using transform_container = array_type<transform_store, 6>;
+    using surface_filling_container = array_type<vector_type<surface>, 5>;
+    using portal_filling_container = array_type<vector_type<portal>, 5>;
+    using transform_container = array_type<transform_store, 5>;
 
     /** Nested volume struct that holds the local information of the
      * volume and its portals.

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -78,10 +78,6 @@ namespace detray
             e_portal = false,
         };
 
-
-        /// The detector type
-        using detector_type = detector<array_type, tuple_type, vector_type, alignable_store, surface_source_link, bounds_source_link, surfaces_populator_type, surfaces_serializer_type>;
-
         /// Forward the alignable container and context
         using transform_store = alignable_store;
         using context = typename alignable_store::context;
@@ -92,48 +88,43 @@ namespace detray
                                   axis::irregular<array_type, vector_type>,
                                   serializer2>;
 
-        /// Portals components:
-        /// - links:  next volume, next (local) object finder
-        using volume_links = array_type<dindex, 2>;
-
-        /// - mask types
-        using rectangle = rectangle2<planar_intersector, __plugin::cartesian2, volume_links, 0>;
-        using trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, volume_links, 1>;
-        using annulus = annulus2<planar_intersector, __plugin::cartesian2, volume_links, 2>;
-        using cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, volume_links, 3>;
-        using disc = ring2<planar_intersector, __plugin::cartesian2, volume_links, 4>;
-        
-        // - mask index: type, { first/last }
-        using portal_mask_index = array_type<dindex, 2>;
-
-        /** The Portal definition:
+        /** The Surface definition:
          *  <transform_link, mask_index, volume_link, source_link >
-         * 
+         *
+         * volume index: volume the surface belongs to
          * transform_link: index into the transform container
          * mask_index: typed index into the mask container
-         * volume_link: index of the volume this portal belongs to
+         * volume_link: index of the volume this surface links to (same for surfaces)
          * source_link: some link to an eventual exernal representation
-         * 
+         *
          */
-        using portal = surface_base<dindex, portal_mask_index, dindex, surface_source_link>;
-        using portal_container = vector_type<portal>;
 
-        /// Surface components:
-        /// - masks, with mask identifiers 0,1,2
+        /// volume index: volume the surface belongs to
+        using volume_index = dindex;
+        /// transform link: transform entry belonging to surface
+        using transform_link = dindex;
+        /// volume links: next volume, next (local) object finder
+        using volume_links = array_type<dindex, 2>;
+        /// mask index: type, entry
+        using mask_index = array_type<dindex, 2>;
+        /// source link
+        using source_link = surface_source_link;
 
-        /// - mask index: type, entry
-        using surface_mask_index = array_type<dindex, 2>;
+        /// mask types
+        using rectangle = rectangle2<planar_intersector, __plugin::cartesian2, volume_links, e_rectangle2>;
+        using trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, volume_links, e_trapezoid2>;
+        using annulus = annulus2<planar_intersector, __plugin::cartesian2, volume_links, e_annulus2>;
+        using cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, volume_links, e_cylinder3>;
+        using disc = ring2<planar_intersector, __plugin::cartesian2, volume_links, e_ring2>;
+
         using mask_container = tuple_type<vector_type<rectangle>,
                                           vector_type<trapezoid>,
                                           vector_type<annulus>,
                                           vector_type<cylinder>,
                                           vector_type<disc>>;
 
-        using surface_link = surface_source_link;
-        /** The Surface definition:
-         *  <transform_link, mask_link, volume_link, source_link >
-         */
-        using surface = surface_base<dindex, surface_mask_index, dindex, surface_link>;
+        /// The Surface definition
+        using surface = surface_base<transform_link, mask_index, volume_index, source_link>;
         using surface_container = vector_type<surface>;
 
         using surfaces_regular_axis = axis::regular<array_type>;
@@ -153,7 +144,7 @@ namespace detray
          * unrolled and filled in lockstep with the masks
          */
         using surface_filling_container = array_type<vector_type<surface>, 5>;
-        using portal_filling_container = array_type<vector_type<portal>, 5>;
+        using portal_filling_container = array_type<vector_type<surface>, 5>;
         using transform_container = array_type<transform_store, 5>;
 
         /** Nested volume struct that holds the local information of the
@@ -161,14 +152,15 @@ namespace detray
          */
         class volume
         {
-            friend class detector<array_type,
-                                  tuple_type,
-                                  vector_type,
-                                  alignable_store,
-                                  surface_source_link,
-                                  bounds_source_link,
-                                  surfaces_populator_type,
-                                  surfaces_serializer_type>;
+
+        friend class detector<array_type,
+                              tuple_type,
+                              vector_type,
+                              alignable_store,
+                              surface_source_link,
+                              bounds_source_link,
+                              surfaces_populator_type,
+                              surfaces_serializer_type>;
 
         public:
 
@@ -608,7 +600,7 @@ namespace detray
 
         /** All surfaces and portals in the detector in contigous memory */
         surface_container _surfaces = {};
-        portal_container _portals = {};
+        surface_container _portals = {};
 
         /** Surface and portal masks of the detector in contigous memory */
         mask_container _masks = {};

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -1,572 +1,593 @@
 /** Detray library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2021 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 #pragma once
+
+#include <sstream>
+#include <string>
 
 #include "core/intersection.hpp"
 #include "core/surface_base.hpp"
 #include "core/transform_store.hpp"
 #include "grids/axis.hpp"
 #include "grids/grid2.hpp"
-#include "grids/serializer2.hpp"
 #include "grids/populator.hpp"
+#include "grids/serializer2.hpp"
 #include "masks/masks.hpp"
-#include "utils/indexing.hpp"
-#include "utils/enumerate.hpp"
-#include "tools/planar_intersector.hpp"
-#include "tools/cylinder_intersector.hpp"
 #include "tools/concentric_cylinder_intersector.hpp"
+#include "tools/cylinder_intersector.hpp"
 #include "tools/local_object_finder.hpp"
+#include "tools/planar_intersector.hpp"
+#include "utils/enumerate.hpp"
+#include "utils/indexing.hpp"
 
-#include <string>
-#include <sstream>
+namespace detray {
 
-namespace detray
-{
+// Algebra, point2 is not strongly typed
+using point3 = __plugin::point3;
+using vector3 = __plugin::vector3;
+using point2 = __plugin::point2;
 
-    // Algebra, point2 is not strongly typed
-    using point3 = __plugin::point3;
-    using vector3 = __plugin::vector3;
-    using point2 = __plugin::point2;
-
-    /** Indexed detector definition.
-     * 
-     * This class is a heavy templated detector definition class, that connects
-     * surfaces, layers and volumes via an indexed system.
-     *
-     * @tparam array_type the type of the internal array, must have STL semantics
-     * @tparam tuple_type the type of the internal tuple, must have STL semantics
-     * @tparam vector_type the type of the internal array, must have STL semantics
-     * @tparam alignable_store the type of the transform store
-     * @tparam surface_source_link the type of the link to an external surface source
-     * @tparam bounds_source_link the type of the link to an external bounds source
-     * @tparam surfaces_populator_type the type of populator used to fill the surfaces grids
-     * @tparam surfaces_serializer_type the type of the memory serializer for the surfaces grids
-     * 
-     */
-    template <template <typename, unsigned int> class array_type = darray,
-              template <typename...> class tuple_type = dtuple,
-              template <typename> class vector_type = dvector,
-              typename alignable_store = static_transform_store<vector_type>,
-              typename surface_source_link = dindex,
-              typename bounds_source_link = dindex,
-              typename surfaces_populator_type = attach_populator<false, dindex, vector_type>,
-              typename surfaces_serializer_type = serializer2>
-    class detector
-    {
+/** Indexed detector definition.
+ *
+ * This class is a heavy templated detector definition class, that connects
+ * surfaces, layers and volumes via an indexed system.
+ *
+ * @tparam array_type the type of the internal array, must have STL semantics
+ * @tparam tuple_type the type of the internal tuple, must have STL semantics
+ * @tparam vector_type the type of the internal array, must have STL semantics
+ * @tparam alignable_store the type of the transform store
+ * @tparam surface_source_link the type of the link to an external surface
+ * source
+ * @tparam bounds_source_link the type of the link to an external bounds source
+ * @tparam surfaces_populator_type the type of populator used to fill the
+ * surfaces grids
+ * @tparam surfaces_serializer_type the type of the memory serializer for the
+ * surfaces grids
+ *
+ */
+template <template <typename, unsigned int> class array_type = darray,
+          template <typename...> class tuple_type = dtuple,
+          template <typename> class vector_type = dvector,
+          typename alignable_store = static_transform_store<vector_type>,
+          typename surface_source_link = dindex,
+          typename bounds_source_link = dindex,
+          typename surfaces_populator_type =
+              attach_populator<false, dindex, vector_type>,
+          typename surfaces_serializer_type = serializer2>
+class detector {
 
     public:
+    /** Encodes the position in a collection container for the respective
+        mask type (not for portals for the moment). */
+    enum mask_container_index : unsigned int {
+        e_mask_types = 5,
+        e_rectangle2 = 0,
+        e_trapezoid2 = 1,
+        e_annulus2 = 2,
+        e_cylinder3 = 3,
+        e_ring2 = 4,
+        e_single3 = std::numeric_limits<unsigned int>::max(),
+        e_unknown = std::numeric_limits<unsigned int>::max(),
+    };
 
-        /** Encodes the position in a collection container for the respective
-            mask type (not for portals for the moment). */
-        enum mask_container_index : unsigned int {
-            e_mask_types = 5,
-            e_rectangle2 = 0,
-            e_trapezoid2 = 1,
-            e_annulus2 = 2,
-            e_cylinder3 = 3,
-            e_ring2 = 4,
-            e_single3 = std::numeric_limits<unsigned int>::max(),
-            e_unknown = std::numeric_limits<unsigned int>::max(),
-        };
+    enum use_primitive : bool {
+        e_surface = true,
+        e_portal = false,
+    };
 
-        enum use_primitive : bool {
-            e_surface = true,
-            e_portal = false,
-        };
+    /// Forward the alignable container and context
+    using transform_store = alignable_store;
+    using context = typename alignable_store::context;
 
-        /// Forward the alignable container and context
-        using transform_store = alignable_store;
-        using context = typename alignable_store::context;
+    /// Volume grid definition
+    using volume_grid =
+        grid2<replace_populator<dindex, std::numeric_limits<dindex>::max(),
+                                vector_type>,
+              axis::irregular<array_type, vector_type>,
+              axis::irregular<array_type, vector_type>, serializer2>;
 
-        /// Volume grid definition
-        using volume_grid = grid2<replace_populator<dindex, std::numeric_limits<dindex>::max(), vector_type>,
-                                  axis::irregular<array_type, vector_type>,
-                                  axis::irregular<array_type, vector_type>,
-                                  serializer2>;
+    /** The Surface definition:
+     *  <transform_link, mask_index, volume_link, source_link >
+     *
+     * volume index: volume the surface belongs to
+     * transform_link: index into the transform container
+     * mask_index: typed index into the mask container
+     * volume_link: index of the volume this surface links to (same for
+     * surfaces) source_link: some link to an eventual exernal representation
+     *
+     */
 
-        /** The Surface definition:
-         *  <transform_link, mask_index, volume_link, source_link >
-         *
-         * volume index: volume the surface belongs to
-         * transform_link: index into the transform container
-         * mask_index: typed index into the mask container
-         * volume_link: index of the volume this surface links to (same for surfaces)
-         * source_link: some link to an eventual exernal representation
-         *
-         */
+    /// volume index: volume the surface belongs to
+    using volume_index = dindex;
+    /// transform link: transform entry belonging to surface
+    using transform_link = dindex;
+    /// volume links: next volume, next (local) object finder
+    using volume_links = array_type<dindex, 2>;
+    /// mask index: type, entry
+    using mask_index = array_type<dindex, 2>;
+    /// source link
+    using source_link = surface_source_link;
 
-        /// volume index: volume the surface belongs to
-        using volume_index = dindex;
-        /// transform link: transform entry belonging to surface
-        using transform_link = dindex;
-        /// volume links: next volume, next (local) object finder
-        using volume_links = array_type<dindex, 2>;
-        /// mask index: type, entry
-        using mask_index = array_type<dindex, 2>;
-        /// source link
-        using source_link = surface_source_link;
+    /// mask types
+    using rectangle = rectangle2<planar_intersector, __plugin::cartesian2,
+                                 volume_links, e_rectangle2>;
+    using trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2,
+                                 volume_links, e_trapezoid2>;
+    using annulus = annulus2<planar_intersector, __plugin::cartesian2,
+                             volume_links, e_annulus2>;
+    using cylinder =
+        cylinder3<false, cylinder_intersector, __plugin::cylindrical2,
+                  volume_links, e_cylinder3>;
+    using disc =
+        ring2<planar_intersector, __plugin::cartesian2, volume_links, e_ring2>;
 
-        /// mask types
-        using rectangle = rectangle2<planar_intersector, __plugin::cartesian2, volume_links, e_rectangle2>;
-        using trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, volume_links, e_trapezoid2>;
-        using annulus = annulus2<planar_intersector, __plugin::cartesian2, volume_links, e_annulus2>;
-        using cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, volume_links, e_cylinder3>;
-        using disc = ring2<planar_intersector, __plugin::cartesian2, volume_links, e_ring2>;
+    using mask_container =
+        tuple_type<vector_type<rectangle>, vector_type<trapezoid>,
+                   vector_type<annulus>, vector_type<cylinder>,
+                   vector_type<disc>>;
 
-        using mask_container = tuple_type<vector_type<rectangle>,
-                                          vector_type<trapezoid>,
-                                          vector_type<annulus>,
-                                          vector_type<cylinder>,
-                                          vector_type<disc>>;
+    /// The Surface definition
+    using surface =
+        surface_base<transform_link, mask_index, volume_index, source_link>;
+    using surface_container = vector_type<surface>;
 
-        /// The Surface definition
-        using surface = surface_base<transform_link, mask_index, volume_index, source_link>;
-        using surface_container = vector_type<surface>;
+    using surfaces_regular_axis = axis::regular<array_type>;
+    using surfaces_circular_axis = axis::circular<array_type>;
+    using surfaces_regular_circular_grid =
+        grid2<surfaces_populator_type, surfaces_regular_axis,
+              surfaces_circular_axis, surfaces_serializer_type, array_type,
+              tuple_type, vector_type>;
 
-        using surfaces_regular_axis = axis::regular<array_type>;
-        using surfaces_circular_axis = axis::circular<array_type>;
-        using surfaces_regular_circular_grid = grid2<surfaces_populator_type,
-                                                     surfaces_regular_axis,
-                                                     surfaces_circular_axis,
-                                                     surfaces_serializer_type,
-                                                     array_type,
-                                                     tuple_type,
-                                                     vector_type>;
+    using surfaces_finder = surfaces_regular_circular_grid;
 
-        using surfaces_finder = surfaces_regular_circular_grid;
+    /** Temporary container structures that are used to fill the detector.
+     * The respective objects are sorted by mask type, so that they can be
+     * unrolled and filled in lockstep with the masks
+     */
+    using surface_filling_container = array_type<vector_type<surface>, 5>;
+    using portal_filling_container = array_type<vector_type<surface>, 5>;
+    using transform_container = array_type<transform_store, 5>;
 
-        /** Temporary container structures that are used to fill the detector. 
-         * The respective objects are sorted by mask type, so that they can be 
-         * unrolled and filled in lockstep with the masks
-         */
-        using surface_filling_container = array_type<vector_type<surface>, 5>;
-        using portal_filling_container = array_type<vector_type<surface>, 5>;
-        using transform_container = array_type<transform_store, 5>;
+    /** Nested volume struct that holds the local information of the
+     * volume and its portals.
+     */
+    class volume {
 
-        /** Nested volume struct that holds the local information of the
-         * volume and its portals.
-         */
-        class volume
-        {
-
-        friend class detector<array_type,
-                              tuple_type,
-                              vector_type,
-                              alignable_store,
-                              surface_source_link,
-                              bounds_source_link,
-                              surfaces_populator_type,
+        friend class detector<array_type, tuple_type, vector_type,
+                              alignable_store, surface_source_link,
+                              bounds_source_link, surfaces_populator_type,
                               surfaces_serializer_type>;
 
         public:
+        /** Deleted constructor */
+        volume() = delete;
 
-            /** Deleted constructor */
-            volume() = delete;
-
-            /** Allowed constructors
-             * @param name of the volume
-             * @param d detector the volume belongs to
-             * 
-             * @note will be contructed boundless
-             */
-            volume(const std::string &name) : _name(name){}
-
-            /** Contructor with name and bounds 
-             * @param name of the volume
-             * @param bounds of the volume
-             * @param d detector the volume belongs to
-             */
-            volume(const std::string &name, const array_type<scalar, 6> &bounds) : _name(name), _bounds(bounds) {}
-
-            /** Copy ctor makes sure constituents keep valid volume pointer
-             *
-             * @param other Volume to be copied
-             */
-            volume(const volume &other) = default;
-
-            /** @return the bounds - const access */
-            const array_type<scalar, 6> &bounds() const { return _bounds; }
-
-            /** @return the name */
-            const std::string &name() const { return _name; }
-
-            /** @return the index */
-            dindex index() const { return _index; }
-
-            /** @return the entry into the local surface finders */
-            dindex surfaces_finder_entry() const { return _surfaces_finder_entry; }
-
-            /** @return if the volume is empty or not */
-            bool empty() const
-            {
-                return (is_empty_range(_surface_range) and
-                        is_empty_range(_portal_range));
-            }
-
-            /** @return the number of surfaces in the volume */
-            template<bool use_surfaces = e_surface>
-            dindex n_objects()
-            {
-                if constexpr (use_surfaces) { return n_in_range(_surface_range); }
-                else { return n_in_range(_portal_range); }
-            }
-
-            /** @return the number of surfaces in the volume */
-            template<bool use_surfaces = e_surface>
-            const dindex n_objects() const
-            {
-                if constexpr (use_surfaces) { return n_in_range(_surface_range); }
-                else { return n_in_range(_portal_range); }
-            }
-
-            /** Set the index into the detector surface container
-             *
-             * @param range Surface index range
-             */
-            template<bool surface_range = e_surface>
-            void set_range(dindex_range range)
-            {
-                if constexpr (surface_range) { update_range(_surface_range, std::move(range)); }
-                else { update_range(_portal_range, std::move(range)); }
-            }
-
-            /** @return range of surfaces- const access */
-            template<bool surface_range = e_surface>
-            const auto &range() const {
-                
-                if constexpr (surface_range) { return _surface_range; }
-                else { return _portal_range;}
-            }
-
-            /** @return range of portals - const access */
-            //const auto &portal_range() const { return _portal_range; }
-
-            /** @return range of surface transforms - const access */
-            template<bool surface_range = e_surface>
-            const auto &trf_range() const
-            {
-                if constexpr (surface_range) { return _surface_trf_range; }
-                else { return _portal_trf_range;}
-            }
-
-            /** Set the index into the detector transform store for portals
-             *
-             * @param range Portal transform index range
-             */
-            template<bool surface_range = e_surface>
-            void set_trf_range(dindex_range range)
-            {
-                if constexpr (surface_range) { update_range(_surface_trf_range, std::move(range)); }
-                else { update_range(_portal_trf_range, std::move(range)); }
-            }
-
-        private:
-            /** Volume section: name */
-            std::string _name = "unknown";
-
-            /** Volume index */
-            dindex _index = dindex_invalid;
-
-            /** Transform ranges in the detector transform store.*/
-            dindex_range _surface_trf_range = {dindex_invalid, dindex_invalid};
-            dindex_range _portal_trf_range  = {dindex_invalid, dindex_invalid};
-
-            /** Index ranges in the detector surface/portal containers.*/
-            dindex_range _surface_range = {dindex_invalid, dindex_invalid};
-            dindex_range _portal_range  = {dindex_invalid, dindex_invalid};
-
-            /** Index into the surface finder container */
-            dindex _surfaces_finder_entry = dindex_invalid;
-
-            /** Bounds section, default for r, z, phi */
-            array_type<scalar, 6> _bounds = {0.,
-                                             std::numeric_limits<scalar>::max(),
-                                             -std::numeric_limits<scalar>::max(),
-                                             std::numeric_limits<scalar>::max(),
-                                             -M_PI, M_PI};
-
-            /**
-             * @param range Any index range
-             *
-             * @return the number of indexed objects
-             */
-            inline dindex n_in_range(const dindex_range &range) { return range[1] - range[0]; }
-
-            /**
-             * @param range Any index range
-             *
-             * @return the number of indexed objects
-             */
-            inline const dindex n_in_range(const dindex_range &range) const { return range[1] - range[0]; }
-
-            /** Test whether a range is empty
-             *
-             * @param range Any index range
-             *
-             * @return boolean whether the range is empty
-             */
-            inline bool is_empty_range(const dindex_range &range) { return n_in_range(range) == 0; }
-
-            /** Test whether a range is empty - const
-             *
-             * @param range Any index range
-             *
-             * @return boolean whether the range is empty
-             */
-            inline const bool is_empty_range(const dindex_range &range) const { return n_in_range(range) == 0; }
-
-
-            /** Set or update a range
-             *
-             * @param range One of the volume member ranges
-             * @param other new index range
-             *
-             * @return boolean whether the range is empty
-             */
-            inline void update_range(dindex_range &range, dindex_range &&other)
-            {
-                // Range not set yet
-                if (range[0] == dindex_invalid) {
-                    range = other;
-                }
-                else {
-                    range[1] += other[1] - other[0];
-                }
-            }
-        };
-
-        /** Allowed costructor
-         * @param name the detector
-         */
-        detector(const std::string &name) : _name(name) {}
-
-        /** Copy constructor makes sure the volumes belong to new detector.
-         *
-         * @param other Detector to be copied
-         */
-        detector(const detector &other) = default;
-        detector() = delete;
-        ~detector() = default;
-
-        /** Add a new volume and retrieve a reference to it
-         *
+        /** Allowed constructors
          * @param name of the volume
-         * @param bounds of the volume, they are expected to be already attaching
-         * @param surfaces_finder_entry of the volume, where to entry the surface finder 
+         * @param d detector the volume belongs to
          *
-         * @return non-const reference of the new volume
+         * @note will be contructed boundless
          */
-        volume &new_volume(const std::string &name, const array_type<scalar, 6> &bounds, dindex surfaces_finder_entry = dindex_invalid)
-        {
-            _volumes.emplace_back(name, bounds);
-            dindex cvolume_idx = _volumes.size() - 1;
-            volume &cvolume = _volumes[cvolume_idx];
-            cvolume._index = cvolume_idx;
-            cvolume._surfaces_finder_entry = surfaces_finder_entry;
-            return cvolume;
-        }
+        volume(const std::string &name) : _name(name) {}
 
-        /** @return the name of the detector */
+        /** Contructor with name and bounds
+         * @param name of the volume
+         * @param bounds of the volume
+         * @param d detector the volume belongs to
+         */
+        volume(const std::string &name, const array_type<scalar, 6> &bounds)
+            : _name(name), _bounds(bounds) {}
+
+        /** Copy ctor makes sure constituents keep valid volume pointer
+         *
+         * @param other Volume to be copied
+         */
+        volume(const volume &other) = default;
+
+        /** @return the bounds - const access */
+        const array_type<scalar, 6> &bounds() const { return _bounds; }
+
+        /** @return the name */
         const std::string &name() const { return _name; }
 
-        /** @return the contained volumes of the detector - const access */
-        const vector_type<volume> &volumes() const { return _volumes; }
+        /** @return the index */
+        dindex index() const { return _index; }
 
-        /** @return the volume by @param volume_index - const access */
-        const volume &indexed_volume(dindex volume_index) const { return _volumes[volume_index]; }
+        /** @return the entry into the local surface finders */
+        dindex surfaces_finder_entry() const { return _surfaces_finder_entry; }
 
-        /** @return the volume by @param position - const access */
-        const volume &indexed_volume(const point3 &p) const
-        {
-            point2 p2 = {getter::perp(p), p[2]};
-            dindex volume_index = _volume_grid.bin(p2);
-            return _volumes[volume_index];
+        /** @return if the volume is empty or not */
+        bool empty() const {
+            return (is_empty_range(_surface_range) and
+                    is_empty_range(_portal_range));
         }
 
-        /** @return the volume by @param volume_index - non-const access */
-        volume &indexed_volume(dindex volume_index) { return _volumes[volume_index]; }
-
-        /** Add a new full set of alignable transforms for surfaces of a volume
-         *
-         * @param volume The volume we add the transforms to
-         * @param surfaces The surfaces in the volume
-         * @param trfs The surface transforms (same number as surfaces)
-         * @param ctx The context of the call
-         *
-         * @note can throw an exception if input data is inconsistent
-         */
-        template <bool add_surfaces = e_surface,
-                  typename object_container,
-                  typename mask_container>
-        void add_objects(
-            volume &volume,
-            object_container &surfaces,
-            mask_container &masks,
-            transform_container &trfs,
-            const typename alignable_store::context ctx = {}) noexcept(false)
-        {
-            unroll_container_filling<0, object_container, mask_container, add_surfaces>(surfaces, masks, volume, trfs, ctx);
-        }
-        
-        /** @return all surfaces/portals in the detector */
-        const auto& surfaces() const
-        {
-            return _surfaces;
-        }
-
-        /** Get @return all surface/portal masks in the detector */
-        const auto& masks() const
-        {
-            return _masks;
-        }
-
-        /** Unrolls the data containers according to mask type and fills the detector.
-         *
-         * @tparam current_idx the current mask context to be processed
-         * @tparam object_container surfaces/portals for which the links are updated
-         * @tparam mask_container surface/portal masks, sorted by type
-         * @tparam add_surfaces check whether we deal with surfaces or portals
-         *
-         */
-        template <size_t current_idx = 0,
-                  typename object_container,
-                  typename mask_container,
-                  bool add_surfaces = e_surface>
-        void unroll_container_filling(object_container &objects,
-                                      mask_container &masks,
-                                      volume &volume,
-                                      transform_container &trfs,
-                                      const typename alignable_store::context ctx = {})
-        {
-            // Get the surfaces/portals for a mask type
-            auto &typed_objects = objects[current_idx];
-            // Get the corresponding transforms
-            const auto &object_transforms = trfs[current_idx];
-            // and the corresponding masks
-            auto &object_masks = std::get<current_idx>(masks);
-
-            if (object_transforms.size(ctx) != 0 and not typed_objects.empty())
-            {
-                // Current offsets into detectors containers
-                const auto trsf_offset = transform_index(ctx);
-                _transforms.append(ctx, std::move(std::get<current_idx>(trfs)));
-                auto &detector_masks = std::get<current_idx>(_masks);
-                const dindex mask_offset = detector_masks.size();
-
-                // Fill masks
-                detector_masks.reserve(mask_offset + object_masks.size());
-                detector_masks.insert(detector_masks.end(), object_masks.begin(), object_masks.end());
-
-                // Update the surfaces mask link
-                for (auto &obj : typed_objects) {
-                    std::get<1>(obj.mask()) += mask_offset;
-                }
-
-                // Fill surfaces
-                _surfaces.reserve(_surfaces.size() + typed_objects.size());
-                _surfaces.insert(_surfaces.end(), typed_objects.begin(), typed_objects.end());
-
-                // Set links in volume
-                volume.template set_trf_range<add_surfaces>(dindex_range{trsf_offset, transform_index(ctx)});
-                volume.template set_range<add_surfaces>({_surfaces.size() - typed_objects.size(), _surfaces.size()});
-            }
-            // Next mask type
-            if constexpr (current_idx < std::tuple_size_v<mask_container> - 1)
-            {
-                return unroll_container_filling<current_idx + 1, object_container, mask_container, add_surfaces>(objects, masks, volume, trfs, ctx);
+        /** @return the number of surfaces in the volume */
+        template <bool use_surfaces = e_surface>
+        dindex n_objects() {
+            if constexpr (use_surfaces) {
+                return n_in_range(_surface_range);
+            } else {
+                return n_in_range(_portal_range);
             }
         }
 
-        /** Get the current transform index
-         *
-         * @param ctx The context of the call
-         *
-         * @return Index to add new transforms at 
-         */
-        const unsigned int transform_index(const context &ctx) const
-        {
-            return _transforms.size(ctx);
-        }
-
-        /** Get all transform in an index range from the detector
-         *
-         * @param range The range of surfaces/portals in the transform store
-         * @param ctx The context of the call
-         *
-         * @return ranged iterator to the object transforms 
-         */
-        const auto transforms(const dindex_range range, const context &ctx = {}) const
-        {
-            return _transforms.range(std::move(range), ctx);
-        }
-
-        /** Add the volume grid - move semantics 
-         * 
-         * @param v_grid the volume grid to be added
-         */
-        void add_volume_grid(volume_grid &&v_grid)
-        {
-            _volume_grid = std::move(v_grid);
-        }
-
-        /** @return the volume grid - const access */
-        const volume_grid &volume_search_grid() const { return _volume_grid; }
-
-        /** Add local surface finders linked to from the portals - move semantics
-         * 
-         * This connects portals and surface grids
-         */
-        void add_surfaces_finders(vector_type<surfaces_finder> &&surfaces_finders)
-        {
-            _surfaces_finders = std::move(surfaces_finders);
-        }
-
-        /** @return the surface finders - const access */
-        const vector_type<surfaces_finder> &surfaces_finders() const { return _surfaces_finders; }
-
-        /** Output to string */
-        const std::string to_string() const
-        {
-            std::stringstream ss;
-            ss << "[>] Detector '" << _name << "' has " << _volumes.size() << " volumes." << std::endl;
-            ss << "    contains  " << _surfaces_finders.size() << " local surface finders." << std::endl;
-            for (const auto &[i, v] : enumerate(_volumes))
-            {
-                ss << "[>>] Volume at index " << i << " - name: '" << v.name() << "'" << std::endl;
-                ss << "     contains    " << v.template n_objects<e_surface>() << " detector surfaces" << std::endl;
-                ss << "                 " << v.template n_objects<e_portal>() << " detector portals" << std::endl;
-                if (v._surfaces_finder_entry != dindex_invalid)
-                {
-                    ss << "     finders idx " << v._surfaces_finder_entry << std::endl;
-                }
-                ss << "     bounds r = (" << v._bounds[0] << ", " << v._bounds[1] << ")" << std::endl;
-                ss << "            z = (" << v._bounds[2] << ", " << v._bounds[3] << ")" << std::endl;
+        /** @return the number of surfaces in the volume */
+        template <bool use_surfaces = e_surface>
+        const dindex n_objects() const {
+            if constexpr (use_surfaces) {
+                return n_in_range(_surface_range);
+            } else {
+                return n_in_range(_portal_range);
             }
-            return ss.str();
-        };
+        }
 
-    private:
-        std::string _name = "unknown_detector";
+        /** Set the index into the detector surface container
+         *
+         * @param range Surface index range
+         */
+        template <bool surface_range = e_surface>
+        void set_range(dindex_range range) {
+            if constexpr (surface_range) {
+                update_range(_surface_range, std::move(range));
+            } else {
+                update_range(_portal_range, std::move(range));
+            }
+        }
 
-        /** Contains the geometrical relations*/
-        vector_type<volume> _volumes = {};
+        /** @return range of surfaces- const access */
+        template <bool surface_range = e_surface>
+        const auto &range() const {
 
-        /** Keeps all of the transform data in contiguous memory*/
-        transform_store _transforms = {};
+            if constexpr (surface_range) {
+                return _surface_range;
+            } else {
+                return _portal_range;
+            }
+        }
 
-        /** All surfaces and portals in the detector in contigous memory */
-        surface_container _surfaces = {};
+        /** @return range of portals - const access */
+        // const auto &portal_range() const { return _portal_range; }
 
-        /** Surface and portal masks of the detector in contigous memory */
-        mask_container _masks = {};
+        /** @return range of surface transforms - const access */
+        template <bool surface_range = e_surface>
+        const auto &trf_range() const {
+            if constexpr (surface_range) {
+                return _surface_trf_range;
+            } else {
+                return _portal_trf_range;
+            }
+        }
 
-        vector_type<surfaces_finder> _surfaces_finders;
+        /** Set the index into the detector transform store for portals
+         *
+         * @param range Portal transform index range
+         */
+        template <bool surface_range = e_surface>
+        void set_trf_range(dindex_range range) {
+            if constexpr (surface_range) {
+                update_range(_surface_trf_range, std::move(range));
+            } else {
+                update_range(_portal_trf_range, std::move(range));
+            }
+        }
 
-        volume_grid _volume_grid = volume_grid(std::move(axis::irregular{{}}), std::move(axis::irregular{{}}));
+        private:
+        /** Volume section: name */
+        std::string _name = "unknown";
+
+        /** Volume index */
+        dindex _index = dindex_invalid;
+
+        /** Transform ranges in the detector transform store.*/
+        dindex_range _surface_trf_range = {dindex_invalid, dindex_invalid};
+        dindex_range _portal_trf_range = {dindex_invalid, dindex_invalid};
+
+        /** Index ranges in the detector surface/portal containers.*/
+        dindex_range _surface_range = {dindex_invalid, dindex_invalid};
+        dindex_range _portal_range = {dindex_invalid, dindex_invalid};
+
+        /** Index into the surface finder container */
+        dindex _surfaces_finder_entry = dindex_invalid;
+
+        /** Bounds section, default for r, z, phi */
+        array_type<scalar, 6> _bounds = {0.,
+                                         std::numeric_limits<scalar>::max(),
+                                         -std::numeric_limits<scalar>::max(),
+                                         std::numeric_limits<scalar>::max(),
+                                         -M_PI,
+                                         M_PI};
+
+        /**
+         * @param range Any index range
+         *
+         * @return the number of indexed objects
+         */
+        inline dindex n_in_range(const dindex_range &range) {
+            return range[1] - range[0];
+        }
+
+        /**
+         * @param range Any index range
+         *
+         * @return the number of indexed objects
+         */
+        inline const dindex n_in_range(const dindex_range &range) const {
+            return range[1] - range[0];
+        }
+
+        /** Test whether a range is empty
+         *
+         * @param range Any index range
+         *
+         * @return boolean whether the range is empty
+         */
+        inline bool is_empty_range(const dindex_range &range) {
+            return n_in_range(range) == 0;
+        }
+
+        /** Test whether a range is empty - const
+         *
+         * @param range Any index range
+         *
+         * @return boolean whether the range is empty
+         */
+        inline const bool is_empty_range(const dindex_range &range) const {
+            return n_in_range(range) == 0;
+        }
+
+        /** Set or update a range
+         *
+         * @param range One of the volume member ranges
+         * @param other new index range
+         *
+         * @return boolean whether the range is empty
+         */
+        inline void update_range(dindex_range &range, dindex_range &&other) {
+            // Range not set yet
+            if (range[0] == dindex_invalid) {
+                range = other;
+            } else {
+                range[1] += other[1] - other[0];
+            }
+        }
     };
 
-}
+    /** Allowed costructor
+     * @param name the detector
+     */
+    detector(const std::string &name) : _name(name) {}
+
+    /** Copy constructor makes sure the volumes belong to new detector.
+     *
+     * @param other Detector to be copied
+     */
+    detector(const detector &other) = default;
+    detector() = delete;
+    ~detector() = default;
+
+    /** Add a new volume and retrieve a reference to it
+     *
+     * @param name of the volume
+     * @param bounds of the volume, they are expected to be already attaching
+     * @param surfaces_finder_entry of the volume, where to entry the surface
+     * finder
+     *
+     * @return non-const reference of the new volume
+     */
+    volume &new_volume(const std::string &name,
+                       const array_type<scalar, 6> &bounds,
+                       dindex surfaces_finder_entry = dindex_invalid) {
+        _volumes.emplace_back(name, bounds);
+        dindex cvolume_idx = _volumes.size() - 1;
+        volume &cvolume = _volumes[cvolume_idx];
+        cvolume._index = cvolume_idx;
+        cvolume._surfaces_finder_entry = surfaces_finder_entry;
+        return cvolume;
+    }
+
+    /** @return the name of the detector */
+    const std::string &name() const { return _name; }
+
+    /** @return the contained volumes of the detector - const access */
+    const vector_type<volume> &volumes() const { return _volumes; }
+
+    /** @return the volume by @param volume_index - const access */
+    const volume &indexed_volume(dindex volume_index) const {
+        return _volumes[volume_index];
+    }
+
+    /** @return the volume by @param position - const access */
+    const volume &indexed_volume(const point3 &p) const {
+        point2 p2 = {getter::perp(p), p[2]};
+        dindex volume_index = _volume_grid.bin(p2);
+        return _volumes[volume_index];
+    }
+
+    /** @return the volume by @param volume_index - non-const access */
+    volume &indexed_volume(dindex volume_index) {
+        return _volumes[volume_index];
+    }
+
+    /** Add a new full set of alignable transforms for surfaces of a volume
+     *
+     * @param volume The volume we add the transforms to
+     * @param surfaces The surfaces in the volume
+     * @param trfs The surface transforms (same number as surfaces)
+     * @param ctx The context of the call
+     *
+     * @note can throw an exception if input data is inconsistent
+     */
+    template <bool add_surfaces = e_surface, typename object_container,
+              typename mask_container>
+    void add_objects(
+        volume &volume, object_container &surfaces, mask_container &masks,
+        transform_container &trfs,
+        const typename alignable_store::context ctx = {}) noexcept(false) {
+        unroll_container_filling<0, object_container, mask_container,
+                                 add_surfaces>(surfaces, masks, volume, trfs,
+                                               ctx);
+    }
+
+    /** @return all surfaces/portals in the detector */
+    const auto &surfaces() const { return _surfaces; }
+
+    /** Get @return all surface/portal masks in the detector */
+    const auto &masks() const { return _masks; }
+
+    /** Unrolls the data containers according to mask type and fills the
+     * detector.
+     *
+     * @tparam current_idx the current mask context to be processed
+     * @tparam object_container surfaces/portals for which the links are updated
+     * @tparam mask_container surface/portal masks, sorted by type
+     * @tparam add_surfaces check whether we deal with surfaces or portals
+     *
+     */
+    template <size_t current_idx = 0, typename object_container,
+              typename mask_container, bool add_surfaces = e_surface>
+    void unroll_container_filling(
+        object_container &objects, mask_container &masks, volume &volume,
+        transform_container &trfs,
+        const typename alignable_store::context ctx = {}) {
+        // Get the surfaces/portals for a mask type
+        auto &typed_objects = objects[current_idx];
+        // Get the corresponding transforms
+        const auto &object_transforms = trfs[current_idx];
+        // and the corresponding masks
+        auto &object_masks = std::get<current_idx>(masks);
+
+        if (object_transforms.size(ctx) != 0 and not typed_objects.empty()) {
+            // Current offsets into detectors containers
+            const auto trsf_offset = transform_index(ctx);
+            _transforms.append(ctx, std::move(std::get<current_idx>(trfs)));
+            auto &detector_masks = std::get<current_idx>(_masks);
+            const dindex mask_offset = detector_masks.size();
+
+            // Fill masks
+            detector_masks.reserve(mask_offset + object_masks.size());
+            detector_masks.insert(detector_masks.end(), object_masks.begin(),
+                                  object_masks.end());
+
+            // Update the surfaces mask link
+            for (auto &obj : typed_objects) {
+                std::get<1>(obj.mask()) += mask_offset;
+            }
+
+            // Fill surfaces
+            _surfaces.reserve(_surfaces.size() + typed_objects.size());
+            _surfaces.insert(_surfaces.end(), typed_objects.begin(),
+                             typed_objects.end());
+
+            // Set links in volume
+            volume.template set_trf_range<add_surfaces>(
+                dindex_range{trsf_offset, transform_index(ctx)});
+            volume.template set_range<add_surfaces>(
+                {_surfaces.size() - typed_objects.size(), _surfaces.size()});
+        }
+        // Next mask type
+        if constexpr (current_idx < std::tuple_size_v<mask_container> - 1) {
+            return unroll_container_filling<current_idx + 1, object_container,
+                                            mask_container, add_surfaces>(
+                objects, masks, volume, trfs, ctx);
+        }
+    }
+
+    /** Get the current transform index
+     *
+     * @param ctx The context of the call
+     *
+     * @return Index to add new transforms at
+     */
+    const unsigned int transform_index(const context &ctx) const {
+        return _transforms.size(ctx);
+    }
+
+    /** Get all transform in an index range from the detector
+     *
+     * @param range The range of surfaces/portals in the transform store
+     * @param ctx The context of the call
+     *
+     * @return ranged iterator to the object transforms
+     */
+    const auto transforms(const dindex_range range,
+                          const context &ctx = {}) const {
+        return _transforms.range(std::move(range), ctx);
+    }
+
+    /** Add the volume grid - move semantics
+     *
+     * @param v_grid the volume grid to be added
+     */
+    void add_volume_grid(volume_grid &&v_grid) {
+        _volume_grid = std::move(v_grid);
+    }
+
+    /** @return the volume grid - const access */
+    const volume_grid &volume_search_grid() const { return _volume_grid; }
+
+    /** Add local surface finders linked to from the portals - move semantics
+     *
+     * This connects portals and surface grids
+     */
+    void add_surfaces_finders(vector_type<surfaces_finder> &&surfaces_finders) {
+        _surfaces_finders = std::move(surfaces_finders);
+    }
+
+    /** @return the surface finders - const access */
+    const vector_type<surfaces_finder> &surfaces_finders() const {
+        return _surfaces_finders;
+    }
+
+    /** Output to string */
+    const std::string to_string() const {
+        std::stringstream ss;
+        ss << "[>] Detector '" << _name << "' has " << _volumes.size()
+           << " volumes." << std::endl;
+        ss << "    contains  " << _surfaces_finders.size()
+           << " local surface finders." << std::endl;
+        for (const auto &[i, v] : enumerate(_volumes)) {
+            ss << "[>>] Volume at index " << i << " - name: '" << v.name()
+               << "'" << std::endl;
+            ss << "     contains    " << v.template n_objects<e_surface>()
+               << " detector surfaces" << std::endl;
+            ss << "                 " << v.template n_objects<e_portal>()
+               << " detector portals" << std::endl;
+            if (v._surfaces_finder_entry != dindex_invalid) {
+                ss << "     finders idx " << v._surfaces_finder_entry
+                   << std::endl;
+            }
+            ss << "     bounds r = (" << v._bounds[0] << ", " << v._bounds[1]
+               << ")" << std::endl;
+            ss << "            z = (" << v._bounds[2] << ", " << v._bounds[3]
+               << ")" << std::endl;
+        }
+        return ss.str();
+    };
+
+    private:
+    std::string _name = "unknown_detector";
+
+    /** Contains the geometrical relations*/
+    vector_type<volume> _volumes = {};
+
+    /** Keeps all of the transform data in contiguous memory*/
+    transform_store _transforms = {};
+
+    /** All surfaces and portals in the detector in contigous memory */
+    surface_container _surfaces = {};
+
+    /** Surface and portal masks of the detector in contigous memory */
+    mask_container _masks = {};
+
+    vector_type<surfaces_finder> _surfaces_finders;
+
+    volume_grid _volume_grid = volume_grid(std::move(axis::irregular{{}}),
+                                           std::move(axis::irregular{{}}));
+};
+
+}  // namespace detray

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -80,67 +80,52 @@ class detector {
     };
 
     /// The detector type
-    using detector_type =
-        detector<array_type, tuple_type, vector_type, alignable_store,
-                 surface_source_link, bounds_source_link,
-                 surfaces_populator_type, surfaces_serializer_type>;
+    using detector_type = detector<array_type, tuple_type, vector_type, alignable_store, surface_source_link, bounds_source_link, surfaces_populator_type, surfaces_serializer_type>;
 
     /// Forward the alignable container and context
     using transform_store = alignable_store;
     using context = typename alignable_store::context;
 
     /// Volume grid definition
-    using volume_grid =
-        grid2<replace_populator<dindex, std::numeric_limits<dindex>::max(),
-                                vector_type>,
-              axis::irregular<array_type, vector_type>,
-              axis::irregular<array_type, vector_type>, serializer2>;
+    using volume_grid = grid2<replace_populator<dindex, std::numeric_limits<dindex>::max(), vector_type>,
+                                  axis::irregular<array_type, vector_type>,
+                                  axis::irregular<array_type, vector_type>,
+                                  serializer2>;
 
     /// Portals components:
     /// - links:  next volume, next (local) object finder
-    using portal_links = array_type<dindex, 2>;
+    using volume_links = array_type<dindex, 2>;
     /// - masks, with mask identifiers 0, 1
-    using portal_cylinder = cylinder3<false, cylinder_intersector,
-                                      __plugin::cylindrical2, portal_links, 0>;
-    using portal_disc =
-        ring2<planar_intersector, __plugin::cartesian2, portal_links, 1>;
+    using portal_cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, volume_links, 0>;
+    using portal_disc = ring2<planar_intersector, __plugin::cartesian2, volume_links, 1>;
     // - mask index: type, { first/last }
     using portal_mask_index = tuple_type<dindex, array_type<dindex, 2>>;
-    using portal_mask_container =
-        tuple_type<vector_type<portal_cylinder>, vector_type<portal_disc>>;
+    using portal_mask_container = tuple_type<vector_type<portal_cylinder>, vector_type<portal_disc>>;
 
     /** The Portal definition:
      *  <transform_link, mask_index, volume_link, source_link >
-     *
+     * 
      * transform_link: index into the transform container
      * mask_index: typed index into the mask container
      * volume_link: index of the volume this portal belongs to
      * source_link: some link to an eventual exernal representation
-     *
+     * 
      */
-    using portal =
-        surface_base<dindex, portal_mask_index, dindex, surface_source_link>;
+    using portal = surface_base<dindex, portal_mask_index, dindex, surface_source_link>;
     using portal_container = vector_type<portal>;
 
     /// Surface components:
-    /// - surface links
-    using surface_links = array_type<dindex, 1>;
     /// - masks, with mask identifiers 0,1,2
-    using surface_rectangle =
-        rectangle2<planar_intersector, __plugin::cartesian2, surface_links, 0>;
-    using surface_trapezoid =
-        trapezoid2<planar_intersector, __plugin::cartesian2, surface_links, 1>;
-    using surface_annulus =
-        annulus2<planar_intersector, __plugin::cartesian2, surface_links, 2>;
-    using surface_cylinder =
-        cylinder3<false, cylinder_intersector, __plugin::cylindrical2,
-                  surface_links, 3>;
+    using surface_rectangle = rectangle2<planar_intersector, __plugin::cartesian2, volume_links, 0>;
+    using surface_trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2, volume_links, 1>;
+    using surface_annulus = annulus2<planar_intersector, __plugin::cartesian2, volume_links, 2>;
+    using surface_cylinder = cylinder3<false, cylinder_intersector, __plugin::cylindrical2, volume_links, 3>;
     /// - mask index: type, entry
     using surface_mask_index = array_type<dindex, 2>;
-    using surface_mask_container =
-        tuple_type<vector_type<surface_rectangle>,
-                   vector_type<surface_trapezoid>, vector_type<surface_annulus>,
-                   vector_type<surface_cylinder>>;
+    using surface_mask_container = tuple_type<vector_type<surface_rectangle>,
+                                                  vector_type<surface_trapezoid>,
+                                                  vector_type<surface_annulus>,
+                                                  vector_type<surface_cylinder>>;
 
     using surface_link = surface_source_link;
     /** The Surface definition:
@@ -180,11 +165,9 @@ class detector {
         /** Deleted constructor */
         volume() = delete;
 
-        /** Allowed constructors
-         * @param name of the volume
-         * @param d detector the volume belongs to
-         *
-         * @note will be contructed boundless
+
+        /** The Surface definition:
+         *  <transform_link, mask_link, volume_link, source_link >
          */
         volume(const std::string &name) : _name(name) {}
 

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -1,308 +1,296 @@
 /** Detray library, part of the ACTS project (R&D line)
- *
+ * 
  * (c) 2020 CERN for the benefit of the ACTS project
- *
+ * 
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-namespace detray {
-/// Connector method for cylindrical volumes without phi separation
-///
-/// @tparam detector_type is the type of the detector for the volume access
-///
-/// @param d [in,out] the detector to which the portal surfaces are added
-/// @param volume_grid [in] the indexed volume grid
-///
-template <typename detector_type,
-          template <typename, unsigned int> class array_type = darray,
-          template <typename...> class tuple_type = dtuple,
-          template <typename> class vector_type = dvector>
-void connect_cylindrical_volumes(
-    detector_type &d, const typename detector_type::volume_grid &volume_grid) {
-    typename detector_type::context default_context = {};
+namespace detray
+{
+    /// Connector method for cylindrical volumes without phi separation
+    ///
+    /// @tparam detector_type is the type of the detector for the volume access
+    ///
+    /// @param d [in,out] the detector to which the portal surfaces are added
+    /// @param volume_grid [in] the indexed volume grid
+    ///
+    template <typename detector_type,
+              template <typename, unsigned int> class array_type = darray,
+              template <typename...> class tuple_type = dtuple,
+              template <typename> class vector_type = dvector>
+    void connect_cylindrical_volumes(detector_type &d, const typename detector_type::volume_grid &volume_grid)
+    {
+        typename detector_type::context default_context = {};
 
-    // The grid is populated, now create portal surfaces
-    // Start from left bottom corner (0,0)
-    vector_type<array_type<dindex, 2>> seeds = {{0, 0}};
-    dmap<dindex, dindex> seed_map;
+        // The grid is populated, now create portal surfaces
+        // Start from left bottom corner (0,0)
+        vector_type<array_type<dindex, 2>> seeds = {{0, 0}};
+        dmap<dindex, dindex> seed_map;
 
-    // The axes are used quite a bit
-    const auto &axis_r = volume_grid.axis_p0();
-    const auto &axis_z = volume_grid.axis_p1();
+        // The axes are used quite a bit
+        const auto &axis_r = volume_grid.axis_p0();
+        const auto &axis_z = volume_grid.axis_p1();
 
-    /*** Helper function to add a new seed
-     * It checks for validity of the seed
-     *
-     * @param seed the (potential new seed)
-     * @param volume_index the volume index for this seed
-     *        to avoid duplicate entries
-     *
-     * @note seeds are only set in bottom left corners of blocks
-     **/
-    auto add_new_seed = [&](const array_type<dindex, 2> &seed,
-                            dindex volume_index) -> void {
-        if (volume_index == dindex_invalid) {
-            return;
-        }
-
-        if (seed_map.find(volume_index) != seed_map.end()) {
-            ++seed_map[volume_index];
-            return;
-        }
-        seed_map[volume_index] = 1;
-
-        if (seed[0] < axis_r.bins() and seed[1] < axis_z.bins()) {
-            seeds.push_back(seed);
-        }
-    };
-
-    // Growing loop over the seeds, process to the end
-    for (dindex iseed = 0; iseed < seeds.size(); ++iseed) {
-        // The running seed & the refence seed
-        auto seed = seeds[iseed];
-        const auto &ref = volume_grid.bin(seed[0], seed[1]);
-
-        // Build and add the portal surfaces
-        auto &volume = d.indexed_volume(ref);
-
-        // Collect portals per seed
-        vector_type<tuple_type<array_type<scalar, 2>, dindex>>
-            left_portals_info;
-        vector_type<tuple_type<array_type<scalar, 2>, dindex>>
-            upper_portals_info;
-        vector_type<tuple_type<array_type<scalar, 2>, dindex>>
-            right_portals_info;
-        vector_type<tuple_type<array_type<scalar, 2>, dindex>>
-            lower_portals_info;
-
-        /// Helper method for walking up along the bins
-        ///
-        /// @param start_bin is the start bin of the walk
-        /// @param portals_info is the container to collect for portals
-        /// @param peek is the peek direction in z
-        /// @param add_seed is a boolean whether new seeds should be added
-        ///
-        /// @return the end position of the the walk (inside position)
-        auto walk_up =
-            [&](array_type<dindex, 2> start_bin,
-                vector_type<tuple_type<array_type<scalar, 2>, dindex>>
-                    &portals_info,
-                int peek, bool add_seed = false) -> array_type<dindex, 2> {
-            auto running_bin = start_bin;
-            array_type<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
-            // Test entry
-            auto test = volume_grid.bin(running_bin[0], running_bin[1]);
-            // Low/high
-            auto low = axis_r.borders(running_bin[0]);
-            auto high = axis_r.borders(running_bin[0]);
-            //  1 - Left walk up
-            // First peek to the to the left for portal desitnations
-            dindex last_portal_dest =
-                (running_bin[1] > 0 and running_bin[1] < axis_r.bins())
-                    ? volume_grid.bin(running_bin[0], running_bin[1] + peek)
-                    : dindex_invalid;
-            while ((ref == test) and ++running_bin[0] < axis_r.bins()) {
-                high = axis_r.borders(running_bin[0]);
-                test = (seed[0] + 1 < axis_r.bins())
-                           ? volume_grid.bin(running_bin[0], running_bin[1])
-                           : dindex_invalid;
-                // Peek outside and see if the portal destination has changed
-                dindex portal_dest =
-                    (running_bin[1] > 0 and running_bin[1] < axis_r.bins())
-                        ? volume_grid.bin(running_bin[0], running_bin[1] + peek)
-                        : dindex_invalid;
-                if (portal_dest != last_portal_dest) {
-                    // Record the boundary
-                    portals_info.push_back(
-                        {{low[0], high[0]}, last_portal_dest});
-                    last_added = {running_bin[0] - 1, running_bin[1]};
-                    // low is the new high
-                    low = high;
-                    last_portal_dest = portal_dest;
-                }
-                high = axis_r.borders(running_bin[0]);
-            }
-
-            // First Potential new seed
-            if (add_seed) {
-                add_new_seed(running_bin, test);
-            }
-            // By this we undo the overstepping in the loop (either by grid
-            // boundary or ref/test fail)
-            high = axis_r.borders(--running_bin[0]);
-            if (last_added != running_bin) {
-                portals_info.push_back({{low[0], high[1]}, last_portal_dest});
-            }
-
-            // The new position after walking is returned
-            return running_bin;
-        };
-
-        /// Helper method for walking up along the bins
-        ///
-        /// @param start_bin is the start bin of the walk
-        /// @param portals_info is the container to collect for portals
-        /// @param peek is the peek direction in z
-        /// @param add_seed is a boolean whether new seeds should be added
-        /// @param walk_only is a boolean whether to actually add boundaries or
-        /// not
-        ///
-        /// @return the end position of the the walk (inside position)
-        auto walk_right =
-            [&](const array_type<dindex, 2> &start_bin,
-                vector_type<tuple_type<array_type<scalar, 2>, dindex>>
-                    &portals_info,
-                int peek, bool add_seed = false,
-                bool walk_only = false) -> array_type<dindex, 2> {
-            auto running_bin = start_bin;
-            array_type<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
-
-            // Test, low and high at seed position
-            auto test = volume_grid.bin(running_bin[0], running_bin[1]);
-            // Low/high
-            auto low = axis_z.borders(running_bin[1]);
-            auto high = axis_z.borders(running_bin[1]);
-
-            dindex last_portal_dest =
-                (running_bin[0] < axis_r.bins())
-                    ? volume_grid.bin(running_bin[0] + peek, running_bin[1])
-                    : dindex_invalid;
-
-            // Seed setting loop as well
-            while (ref == test and (++running_bin[1]) < axis_z.bins()) {
-                high = axis_z.borders(running_bin[1]);
-                test = volume_grid.bin(running_bin[0], running_bin[1]);
-                // Peek outside and see if the portal destination has changed
-                dindex portal_dest =
-                    (running_bin[0] < axis_r.bins())
-                        ? volume_grid.bin(running_bin[0] + peek, running_bin[1])
-                        : dindex_invalid;
-                if (portal_dest != last_portal_dest) {
-                    // Record the boundary
-                    if (not walk_only) {
-                        portals_info.push_back(
-                            {{low[0], high[0]}, last_portal_dest});
-                        last_added = {running_bin[0], running_bin[1] - 1};
-                    }
-                    // low is the new high
-                    low = high;
-                    last_portal_dest = portal_dest;
-                    // That's a new seed right here, except for last one
-                    if (running_bin[1] < axis_z.bins() and add_seed) {
-                        add_new_seed({running_bin[0] + peek, running_bin[1]},
-                                     portal_dest);
-                    }
-                }
-                high = axis_z.borders(running_bin[1]);
-            }
-            // By this we undo the overstepping (see above)
-            high = axis_z.borders(--running_bin[1]);
-            if (not walk_only and last_added != running_bin) {
-                portals_info.push_back({{low[0], high[1]}, last_portal_dest});
-            }
-            // The new bin position after walk
-            return running_bin;
-        };
-
-        // Walk up from the (initial) seed position
-        auto up_left = walk_up(seed, left_portals_info, true, -1);
-        // Walk to the right from the resulting upper position
-        walk_right(up_left, upper_portals_info, true, 1);
-        // Walk right from the (initial) seed position
-        auto bottom_right =
-            walk_right(seed, lower_portals_info, false, -1, seed[0] == 0);
-        // Walk up from the bottom right corner
-        walk_up(bottom_right, right_portals_info, false, 1);
-
-        // The bounds can be used for the mask and transform information
-        const auto &volume_bounds = volume.bounds();
-        typename detector_type::portal_filling_container portals = {};
-        typename detector_type::mask_container portal_masks;
-        typename detector_type::transform_container portal_transforms;
-
-        /** Helper lambda to build disc portals
-         *
-         * @param portals_info The volume_index
-         * @param bound_index The access for the boundary parameter
-         *
-         **/
-        auto add_disc_portals =
-            [&](vector_type<tuple_type<array_type<scalar, 2>, dindex>>
-                    &portals_info,
-                dindex bound_index) -> void {
-            // Fill in the left side portals
-            if (not portals_info.empty()) {
-                // The portal transfrom is given from the left
-                __plugin::vector3 _translation{0., 0.,
-                                               volume_bounds[bound_index]};
-
-                // Get the mask context group and fill it
-                auto &disc_portal_transforms = std::get<detector_type::disc::mask_context>(portal_transforms);
-                auto &disc_portals = std::get<detector_type::disc::mask_context>(portals);
-                auto &mask_group   = std::get<detector_type::disc::mask_context>(portal_masks);
-
-                typename detector_type::portal_mask_index mask_index = {detector_type::disc::mask_context, {mask_group.size(), mask_group.size()}};
-                // Create a stub mask for every unique index
-                for (auto &info_ : portals_info)
-                {
-                    typename detector_type::disc _portal_disc = {std::get<0>(info_), {std::get<1>(info_), dindex_invalid}};
-                    std::get<1>(mask_index)[1] = mask_group.size();
-                        mask_group.push_back(_portal_disc);
-                }
-                // Create the portal
-                typename detector_type::portal _portal{disc_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
-                // Save the data
-                disc_portals.push_back(std::move(_portal));
-            }
-            disc_portal_transforms.emplace_back(default_context,
-                                                    _translation);
-        }
-    };
-
-        /** Helper lambda for cylindrical portals
+        /*** Helper function to add a new seed
+         * It checks for validity of the seed
          * 
-         * @param portals_info 
-         * @param bound_index
+         * @param seed the (potential new seed)
+         * @param volume_index the volume index for this seed
+         *        to avoid duplicate entries
+         * 
+         * @note seeds are only set in bottom left corners of blocks
          **/
-        auto add_cylinder_portal = [&](vector_type<tuple_type<array_type<scalar, 2>, dindex>> &portals_info, dindex bound_index) -> void
+        auto add_new_seed = [&](const array_type<dindex, 2> &seed, dindex volume_index) -> void
         {
-            // Fill in the upper side portals
-            if (not portals_info.empty())
+            if (volume_index == dindex_invalid)
             {
-                // Get the mask context group and fill it
-                auto &cylinder_portal_transforms = std::get<detector_type::cylinder::mask_context>(portal_transforms);
-                auto &cylinder_portals = std::get<detector_type::cylinder::mask_context>(portals);
-                auto &mask_group   = std::get<detector_type::cylinder::mask_context>(portal_masks);
-
-                typename detector_type::portal_mask_index mask_index = {detector_type::cylinder::mask_context, {mask_group.size(), mask_group.size()}};
-                for (auto &info_ : portals_info)
-                {
-                    const auto cylinder_range = std::get<0>(info_);
-                    array_type<scalar, 3> cylinder_bounds = {volume_bounds[bound_index], cylinder_range[0], cylinder_range[1]};
-                    typename detector_type::cylinder _portal_cylinder = {cylinder_bounds, {std::get<1>(info_), dindex_invalid}};
-                    std::get<1>(mask_index)[1] = mask_group.size();
-                    mask_group.push_back(_portal_cylinder);
-                }
-                // Create the portal
-                typename detector_type::portal _portal{cylinder_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
-                cylinder_portals.push_back(std::move(_portal));
+                return;
             }
-            // This will be concentric targetted at nominal center
-            cylinder_portal_transforms.emplace_back(default_context);
+
+            if (seed_map.find(volume_index) != seed_map.end())
+            {
+                ++seed_map[volume_index];
+                return;
+            }
+            seed_map[volume_index] = 1;
+
+            if (seed[0] < axis_r.bins() and
+                seed[1] < axis_z.bins())
+            {
+                seeds.push_back(seed);
+            }
+        };
+
+        // Growing loop over the seeds, process to the end
+        for (dindex iseed = 0; iseed < seeds.size(); ++iseed)
+        {
+            // The running seed & the refence seed
+            auto seed = seeds[iseed];
+            const auto &ref = volume_grid.bin(seed[0], seed[1]);
+
+            // Build and add the portal surfaces
+            auto &volume = d.indexed_volume(ref);
+
+            // Collect portals per seed
+            vector_type<tuple_type<array_type<scalar, 2>, dindex>> left_portals_info;
+            vector_type<tuple_type<array_type<scalar, 2>, dindex>> upper_portals_info;
+            vector_type<tuple_type<array_type<scalar, 2>, dindex>> right_portals_info;
+            vector_type<tuple_type<array_type<scalar, 2>, dindex>> lower_portals_info;
+
+            /// Helper method for walking up along the bins
+            ///
+            /// @param start_bin is the start bin of the walk
+            /// @param portals_info is the container to collect for portals
+            /// @param peek is the peek direction in z
+            /// @param add_seed is a boolean whether new seeds should be added
+            ///
+            /// @return the end position of the the walk (inside position)
+            auto walk_up = [&](array_type<dindex, 2> start_bin,
+                               vector_type<tuple_type<array_type<scalar, 2>, dindex>> &portals_info,
+                               int peek,
+                               bool add_seed = false) -> array_type<dindex, 2>
+            {
+                auto running_bin = start_bin;
+                array_type<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
+                // Test entry
+                auto test = volume_grid.bin(running_bin[0], running_bin[1]);
+                // Low/high
+                auto low = axis_r.borders(running_bin[0]);
+                auto high = axis_r.borders(running_bin[0]);
+                //  1 - Left walk up
+                // First peek to the to the left for portal desitnations
+                dindex last_portal_dest = (running_bin[1] > 0 and running_bin[1] < axis_r.bins()) ? volume_grid.bin(running_bin[0], running_bin[1] + peek) : dindex_invalid;
+                while ((ref == test) and ++running_bin[0] < axis_r.bins())
+                {
+                    high = axis_r.borders(running_bin[0]);
+                    test = (seed[0] + 1 < axis_r.bins()) ? volume_grid.bin(running_bin[0], running_bin[1]) : dindex_invalid;
+                    // Peek outside and see if the portal destination has changed
+                    dindex portal_dest = (running_bin[1] > 0 and running_bin[1] < axis_r.bins()) ? volume_grid.bin(running_bin[0], running_bin[1] + peek) : dindex_invalid;
+                    if (portal_dest != last_portal_dest)
+                    {
+                        // Record the boundary
+                        portals_info.push_back({{low[0], high[0]}, last_portal_dest});
+                        last_added = {running_bin[0] - 1, running_bin[1]};
+                        // low is the new high
+                        low = high;
+                        last_portal_dest = portal_dest;
+                    }
+                    high = axis_r.borders(running_bin[0]);
+                }
+
+                // First Potential new seed
+                if (add_seed)
+                {
+                    add_new_seed(running_bin, test);
+                }
+                // By this we undo the overstepping in the loop (either by grid boundary or ref/test fail)
+                high = axis_r.borders(--running_bin[0]);
+                if (last_added != running_bin)
+                {
+                    portals_info.push_back({{low[0], high[1]}, last_portal_dest});
+                }
+
+                // The new position after walking is returned
+                return running_bin;
+            };
+
+            /// Helper method for walking up along the bins
+            ///
+            /// @param start_bin is the start bin of the walk
+            /// @param portals_info is the container to collect for portals
+            /// @param peek is the peek direction in z
+            /// @param add_seed is a boolean whether new seeds should be added
+            /// @param walk_only is a boolean whether to actually add boundaries or not
+            ///
+            /// @return the end position of the the walk (inside position)
+            auto walk_right = [&](const array_type<dindex, 2> &start_bin,
+                                  vector_type<tuple_type<array_type<scalar, 2>, dindex>> &portals_info,
+                                  int peek,
+                                  bool add_seed = false,
+                                  bool walk_only = false) -> array_type<dindex, 2>
+            {
+                auto running_bin = start_bin;
+                array_type<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
+
+                // Test, low and high at seed position
+                auto test = volume_grid.bin(running_bin[0], running_bin[1]);
+                // Low/high
+                auto low = axis_z.borders(running_bin[1]);
+                auto high = axis_z.borders(running_bin[1]);
+
+                dindex last_portal_dest = (running_bin[0] < axis_r.bins()) ? volume_grid.bin(running_bin[0] + peek, running_bin[1]) : dindex_invalid;
+
+                // Seed setting loop as well
+                while (ref == test and (++running_bin[1]) < axis_z.bins())
+                {
+                    high = axis_z.borders(running_bin[1]);
+                    test = volume_grid.bin(running_bin[0], running_bin[1]);
+                    // Peek outside and see if the portal destination has changed
+                    dindex portal_dest = (running_bin[0] < axis_r.bins()) ? volume_grid.bin(running_bin[0] + peek, running_bin[1]) : dindex_invalid;
+                    if (portal_dest != last_portal_dest)
+                    {
+                        // Record the boundary
+                        if (not walk_only)
+                        {
+                            portals_info.push_back({{low[0], high[0]}, last_portal_dest});
+                            last_added = {running_bin[0], running_bin[1] - 1};
+                        }
+                        // low is the new high
+                        low = high;
+                        last_portal_dest = portal_dest;
+                        // That's a new seed right here, except for last one
+                        if (running_bin[1] < axis_z.bins() and add_seed)
+                        {
+                            add_new_seed({running_bin[0] + peek, running_bin[1]}, portal_dest);
+                        }
+                    }
+                    high = axis_z.borders(running_bin[1]);
+                }
+                // By this we undo the overstepping (see above)
+                high = axis_z.borders(--running_bin[1]);
+                if (not walk_only and last_added != running_bin)
+                {
+                    portals_info.push_back({{low[0], high[1]}, last_portal_dest});
+                }
+                // The new bin position after walk
+                return running_bin;
+            };
+
+            // Walk up from the (initial) seed position
+            auto up_left = walk_up(seed, left_portals_info, true, -1);
+            // Walk to the right from the resulting upper position
+            walk_right(up_left, upper_portals_info, true, 1);
+            // Walk right from the (initial) seed position
+            auto bottom_right = walk_right(seed, lower_portals_info, false, -1, seed[0] == 0);
+            // Walk up from the bottom right corner
+            walk_up(bottom_right, right_portals_info, false, 1);
+
+            typename detector_type::portal_filling_container portals = {};
+            typename detector_type::mask_container portal_masks;
+            typename detector_type::transform_container portal_transforms;
+
+            // The bounds can be used for the mask and transform information
+            const auto &volume_bounds = volume.bounds();
+
+            /** Helper lambda to build disc portals
+             * 
+             * @param portals_info The volume_index 
+             * @param bound_index The access for the boundary parameter
+             * 
+             **/
+            auto add_disc_portals = [&](vector_type<tuple_type<array_type<scalar, 2>, dindex>> &portals_info, dindex bound_index) -> void
+            {
+                // Fill in the left side portals
+                if (not portals_info.empty())
+                {
+                    // The portal transfrom is given from the left
+                    __plugin::vector3 _translation{0., 0., volume_bounds[bound_index]};
+
+                    // Get the mask context group and fill it
+                    auto &disc_portal_transforms = std::get<detector_type::disc::mask_context>(portal_transforms);
+                    auto &disc_portals = std::get<detector_type::disc::mask_context>(portals);
+                    auto &mask_group   = std::get<detector_type::disc::mask_context>(portal_masks);
+                    
+                    typename detector_type::portal_mask_index mask_index = {detector_type::disc::mask_context, mask_group.size()};
+                    // Create a stub mask for every unique index
+                    for (auto &info_ : portals_info)
+                    {
+                        typename detector_type::disc _portal_disc = {std::get<0>(info_), {std::get<1>(info_), dindex_invalid}};
+                        std::get<1>(mask_index) = mask_group.size();
+                        mask_group.push_back(_portal_disc);
+
+                        // Create the portal
+                        typename detector_type::portal _portal{disc_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
+                        // Save the data
+                        disc_portals.push_back(std::move(_portal));
+                    }
+                    disc_portal_transforms.emplace_back(default_context, _translation);
+                }
+            };
+
+            /** Helper lambda for cylindrical portals
+             * 
+             * @param portals_info 
+             * @param bound_index
+             **/
+            auto add_cylinder_portal = [&](vector_type<tuple_type<array_type<scalar, 2>, dindex>> &portals_info, dindex bound_index) -> void
+            {
+                // Fill in the upper side portals
+                if (not portals_info.empty())
+                {
+                    // Get the mask context group and fill it
+                    auto &cylinder_portal_transforms = std::get<detector_type::cylinder::mask_context>(portal_transforms);
+                    auto &cylinder_portals = std::get<detector_type::cylinder::mask_context>(portals);
+                    auto &mask_group   = std::get<detector_type::cylinder::mask_context>(portal_masks);
+
+                    typename detector_type::portal_mask_index mask_index = {detector_type::cylinder::mask_context, mask_group.size()};
+                    for (auto &info_ : portals_info)
+                    {
+                        const auto cylinder_range = std::get<0>(info_);
+                        array_type<scalar, 3> cylinder_bounds = {volume_bounds[bound_index], cylinder_range[0], cylinder_range[1]};
+                        typename detector_type::cylinder _portal_cylinder = {cylinder_bounds, {std::get<1>(info_), dindex_invalid}};
+                        std::get<1>(mask_index) = mask_group.size();
+                        mask_group.push_back(_portal_cylinder);
+
+                        // Create the portal
+                        typename detector_type::portal _portal{cylinder_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
+                        cylinder_portals.push_back(std::move(_portal));
+                    }
+                    // This will be concentric targetted at nominal center
+                    cylinder_portal_transforms.emplace_back(default_context);
+                }
+            };
+
+            // Add portals to the volume
+            add_disc_portals(left_portals_info, 2);
+            add_cylinder_portal(upper_portals_info, 1);
+            add_disc_portals(right_portals_info, 3);
+            add_cylinder_portal(lower_portals_info, 0);
+
+            // Add portals to detector
+            d.template add_objects<detector_type::e_portal>(volume, portals, portal_masks, portal_transforms, default_context);
         }
-    };
-
-    // Add portals to the volume
-    add_disc_portals(left_portals_info, 2);
-    add_cylinder_portal(upper_portals_info, 1);
-    add_disc_portals(right_portals_info, 3);
-    add_cylinder_portal(lower_portals_info, 0);
-
-    // Add portals to detector
-    d.template add_objects<detector_type::e_portal>(
-            volume, portals, portal_masks, portal_transforms, default_context);
     }
 }
-}  // namespace detray

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -216,12 +216,11 @@ void connect_cylindrical_volumes(
         // Walk up from the bottom right corner
         walk_up(bottom_right, right_portals_info, false, 1);
 
-        typename detector_type::portal_filling_container portals = {};
-        typename detector_type::portal_mask_container portal_masks;
-        typename detector_type::transform_container portal_transforms;
-
         // The bounds can be used for the mask and transform information
         const auto &volume_bounds = volume.bounds();
+        typename detector_type::portal_filling_container portals = {};
+        typename detector_type::mask_container portal_masks;
+        typename detector_type::transform_container portal_transforms;
 
         /** Helper lambda to build disc portals
          *

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -233,7 +233,7 @@ namespace detray
                     auto &disc_portals = std::get<detector_type::disc::mask_context>(portals);
                     auto &mask_group   = std::get<detector_type::disc::mask_context>(portal_masks);
                     
-                    typename detector_type::portal_mask_index mask_index = {detector_type::disc::mask_context, mask_group.size()};
+                    typename detector_type::mask_index mask_index = {detector_type::disc::mask_context, mask_group.size()};
                     // Create a stub mask for every unique index
                     for (auto &info_ : portals_info)
                     {
@@ -242,7 +242,7 @@ namespace detray
                         mask_group.push_back(_portal_disc);
 
                         // Create the portal
-                        typename detector_type::portal _portal{disc_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
+                        typename detector_type::surface _portal{disc_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
                         // Save the data
                         disc_portals.push_back(std::move(_portal));
                     }
@@ -265,7 +265,7 @@ namespace detray
                     auto &cylinder_portals = std::get<detector_type::cylinder::mask_context>(portals);
                     auto &mask_group   = std::get<detector_type::cylinder::mask_context>(portal_masks);
 
-                    typename detector_type::portal_mask_index mask_index = {detector_type::cylinder::mask_context, mask_group.size()};
+                    typename detector_type::mask_index mask_index = {detector_type::cylinder::mask_context, mask_group.size()};
                     for (auto &info_ : portals_info)
                     {
                         const auto cylinder_range = std::get<0>(info_);
@@ -275,7 +275,7 @@ namespace detray
                         mask_group.push_back(_portal_cylinder);
 
                         // Create the portal
-                        typename detector_type::portal _portal{cylinder_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
+                        typename detector_type::surface _portal{cylinder_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
                         cylinder_portals.push_back(std::move(_portal));
                     }
                     // This will be concentric targetted at nominal center

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -1,296 +1,328 @@
 /** Detray library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2020 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-namespace detray
-{
-    /// Connector method for cylindrical volumes without phi separation
-    ///
-    /// @tparam detector_type is the type of the detector for the volume access
-    ///
-    /// @param d [in,out] the detector to which the portal surfaces are added
-    /// @param volume_grid [in] the indexed volume grid
-    ///
-    template <typename detector_type,
-              template <typename, unsigned int> class array_type = darray,
-              template <typename...> class tuple_type = dtuple,
-              template <typename> class vector_type = dvector>
-    void connect_cylindrical_volumes(detector_type &d, const typename detector_type::volume_grid &volume_grid)
-    {
-        typename detector_type::context default_context = {};
+namespace detray {
+/// Connector method for cylindrical volumes without phi separation
+///
+/// @tparam detector_type is the type of the detector for the volume access
+///
+/// @param d [in,out] the detector to which the portal surfaces are added
+/// @param volume_grid [in] the indexed volume grid
+///
+template <typename detector_type,
+          template <typename, unsigned int> class array_type = darray,
+          template <typename...> class tuple_type = dtuple,
+          template <typename> class vector_type = dvector>
+void connect_cylindrical_volumes(
+    detector_type &d, const typename detector_type::volume_grid &volume_grid) {
+    typename detector_type::context default_context = {};
 
-        // The grid is populated, now create portal surfaces
-        // Start from left bottom corner (0,0)
-        vector_type<array_type<dindex, 2>> seeds = {{0, 0}};
-        dmap<dindex, dindex> seed_map;
+    // The grid is populated, now create portal surfaces
+    // Start from left bottom corner (0,0)
+    vector_type<array_type<dindex, 2>> seeds = {{0, 0}};
+    dmap<dindex, dindex> seed_map;
 
-        // The axes are used quite a bit
-        const auto &axis_r = volume_grid.axis_p0();
-        const auto &axis_z = volume_grid.axis_p1();
+    // The axes are used quite a bit
+    const auto &axis_r = volume_grid.axis_p0();
+    const auto &axis_z = volume_grid.axis_p1();
 
-        /*** Helper function to add a new seed
-         * It checks for validity of the seed
-         * 
-         * @param seed the (potential new seed)
-         * @param volume_index the volume index for this seed
-         *        to avoid duplicate entries
-         * 
-         * @note seeds are only set in bottom left corners of blocks
+    /*** Helper function to add a new seed
+     * It checks for validity of the seed
+     *
+     * @param seed the (potential new seed)
+     * @param volume_index the volume index for this seed
+     *        to avoid duplicate entries
+     *
+     * @note seeds are only set in bottom left corners of blocks
+     **/
+    auto add_new_seed = [&](const array_type<dindex, 2> &seed,
+                            dindex volume_index) -> void {
+        if (volume_index == dindex_invalid) {
+            return;
+        }
+
+        if (seed_map.find(volume_index) != seed_map.end()) {
+            ++seed_map[volume_index];
+            return;
+        }
+        seed_map[volume_index] = 1;
+
+        if (seed[0] < axis_r.bins() and seed[1] < axis_z.bins()) {
+            seeds.push_back(seed);
+        }
+    };
+
+    // Growing loop over the seeds, process to the end
+    for (dindex iseed = 0; iseed < seeds.size(); ++iseed) {
+        // The running seed & the refence seed
+        auto seed = seeds[iseed];
+        const auto &ref = volume_grid.bin(seed[0], seed[1]);
+
+        // Build and add the portal surfaces
+        auto &volume = d.indexed_volume(ref);
+
+        // Collect portals per seed
+        vector_type<tuple_type<array_type<scalar, 2>, dindex>>
+            left_portals_info;
+        vector_type<tuple_type<array_type<scalar, 2>, dindex>>
+            upper_portals_info;
+        vector_type<tuple_type<array_type<scalar, 2>, dindex>>
+            right_portals_info;
+        vector_type<tuple_type<array_type<scalar, 2>, dindex>>
+            lower_portals_info;
+
+        /// Helper method for walking up along the bins
+        ///
+        /// @param start_bin is the start bin of the walk
+        /// @param portals_info is the container to collect for portals
+        /// @param peek is the peek direction in z
+        /// @param add_seed is a boolean whether new seeds should be added
+        ///
+        /// @return the end position of the the walk (inside position)
+        auto walk_up =
+            [&](array_type<dindex, 2> start_bin,
+                vector_type<tuple_type<array_type<scalar, 2>, dindex>>
+                    &portals_info,
+                int peek, bool add_seed = false) -> array_type<dindex, 2> {
+            auto running_bin = start_bin;
+            array_type<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
+            // Test entry
+            auto test = volume_grid.bin(running_bin[0], running_bin[1]);
+            // Low/high
+            auto low = axis_r.borders(running_bin[0]);
+            auto high = axis_r.borders(running_bin[0]);
+            //  1 - Left walk up
+            // First peek to the to the left for portal desitnations
+            dindex last_portal_dest =
+                (running_bin[1] > 0 and running_bin[1] < axis_r.bins())
+                    ? volume_grid.bin(running_bin[0], running_bin[1] + peek)
+                    : dindex_invalid;
+            while ((ref == test) and ++running_bin[0] < axis_r.bins()) {
+                high = axis_r.borders(running_bin[0]);
+                test = (seed[0] + 1 < axis_r.bins())
+                           ? volume_grid.bin(running_bin[0], running_bin[1])
+                           : dindex_invalid;
+                // Peek outside and see if the portal destination has changed
+                dindex portal_dest =
+                    (running_bin[1] > 0 and running_bin[1] < axis_r.bins())
+                        ? volume_grid.bin(running_bin[0], running_bin[1] + peek)
+                        : dindex_invalid;
+                if (portal_dest != last_portal_dest) {
+                    // Record the boundary
+                    portals_info.push_back(
+                        {{low[0], high[0]}, last_portal_dest});
+                    last_added = {running_bin[0] - 1, running_bin[1]};
+                    // low is the new high
+                    low = high;
+                    last_portal_dest = portal_dest;
+                }
+                high = axis_r.borders(running_bin[0]);
+            }
+
+            // First Potential new seed
+            if (add_seed) {
+                add_new_seed(running_bin, test);
+            }
+            // By this we undo the overstepping in the loop (either by grid
+            // boundary or ref/test fail)
+            high = axis_r.borders(--running_bin[0]);
+            if (last_added != running_bin) {
+                portals_info.push_back({{low[0], high[1]}, last_portal_dest});
+            }
+
+            // The new position after walking is returned
+            return running_bin;
+        };
+
+        /// Helper method for walking up along the bins
+        ///
+        /// @param start_bin is the start bin of the walk
+        /// @param portals_info is the container to collect for portals
+        /// @param peek is the peek direction in z
+        /// @param add_seed is a boolean whether new seeds should be added
+        /// @param walk_only is a boolean whether to actually add boundaries or
+        /// not
+        ///
+        /// @return the end position of the the walk (inside position)
+        auto walk_right =
+            [&](const array_type<dindex, 2> &start_bin,
+                vector_type<tuple_type<array_type<scalar, 2>, dindex>>
+                    &portals_info,
+                int peek, bool add_seed = false,
+                bool walk_only = false) -> array_type<dindex, 2> {
+            auto running_bin = start_bin;
+            array_type<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
+
+            // Test, low and high at seed position
+            auto test = volume_grid.bin(running_bin[0], running_bin[1]);
+            // Low/high
+            auto low = axis_z.borders(running_bin[1]);
+            auto high = axis_z.borders(running_bin[1]);
+
+            dindex last_portal_dest =
+                (running_bin[0] < axis_r.bins())
+                    ? volume_grid.bin(running_bin[0] + peek, running_bin[1])
+                    : dindex_invalid;
+
+            // Seed setting loop as well
+            while (ref == test and (++running_bin[1]) < axis_z.bins()) {
+                high = axis_z.borders(running_bin[1]);
+                test = volume_grid.bin(running_bin[0], running_bin[1]);
+                // Peek outside and see if the portal destination has changed
+                dindex portal_dest =
+                    (running_bin[0] < axis_r.bins())
+                        ? volume_grid.bin(running_bin[0] + peek, running_bin[1])
+                        : dindex_invalid;
+                if (portal_dest != last_portal_dest) {
+                    // Record the boundary
+                    if (not walk_only) {
+                        portals_info.push_back(
+                            {{low[0], high[0]}, last_portal_dest});
+                        last_added = {running_bin[0], running_bin[1] - 1};
+                    }
+                    // low is the new high
+                    low = high;
+                    last_portal_dest = portal_dest;
+                    // That's a new seed right here, except for last one
+                    if (running_bin[1] < axis_z.bins() and add_seed) {
+                        add_new_seed({running_bin[0] + peek, running_bin[1]},
+                                     portal_dest);
+                    }
+                }
+                high = axis_z.borders(running_bin[1]);
+            }
+            // By this we undo the overstepping (see above)
+            high = axis_z.borders(--running_bin[1]);
+            if (not walk_only and last_added != running_bin) {
+                portals_info.push_back({{low[0], high[1]}, last_portal_dest});
+            }
+            // The new bin position after walk
+            return running_bin;
+        };
+
+        // Walk up from the (initial) seed position
+        auto up_left = walk_up(seed, left_portals_info, true, -1);
+        // Walk to the right from the resulting upper position
+        walk_right(up_left, upper_portals_info, true, 1);
+        // Walk right from the (initial) seed position
+        auto bottom_right =
+            walk_right(seed, lower_portals_info, false, -1, seed[0] == 0);
+        // Walk up from the bottom right corner
+        walk_up(bottom_right, right_portals_info, false, 1);
+
+        typename detector_type::portal_filling_container portals = {};
+        typename detector_type::mask_container portal_masks;
+        typename detector_type::transform_container portal_transforms;
+
+        // The bounds can be used for the mask and transform information
+        const auto &volume_bounds = volume.bounds();
+
+        /** Helper lambda to build disc portals
+         *
+         * @param portals_info The volume_index
+         * @param bound_index The access for the boundary parameter
+         *
          **/
-        auto add_new_seed = [&](const array_type<dindex, 2> &seed, dindex volume_index) -> void
-        {
-            if (volume_index == dindex_invalid)
-            {
-                return;
-            }
+        auto add_disc_portals =
+            [&](vector_type<tuple_type<array_type<scalar, 2>, dindex>>
+                    &portals_info,
+                dindex bound_index) -> void {
+            // Fill in the left side portals
+            if (not portals_info.empty()) {
+                // The portal transfrom is given from the left
+                __plugin::vector3 _translation{0., 0.,
+                                               volume_bounds[bound_index]};
 
-            if (seed_map.find(volume_index) != seed_map.end())
-            {
-                ++seed_map[volume_index];
-                return;
-            }
-            seed_map[volume_index] = 1;
+                // Get the mask context group and fill it
+                auto &disc_portal_transforms =
+                    std::get<detector_type::disc::mask_context>(
+                        portal_transforms);
+                auto &disc_portals =
+                    std::get<detector_type::disc::mask_context>(portals);
+                auto &mask_group =
+                    std::get<detector_type::disc::mask_context>(portal_masks);
 
-            if (seed[0] < axis_r.bins() and
-                seed[1] < axis_z.bins())
-            {
-                seeds.push_back(seed);
+                typename detector_type::mask_index mask_index = {
+                    detector_type::disc::mask_context, mask_group.size()};
+                // Create a stub mask for every unique index
+                for (auto &info_ : portals_info) {
+                    typename detector_type::disc _portal_disc = {
+                        std::get<0>(info_),
+                        {std::get<1>(info_), dindex_invalid}};
+                    std::get<1>(mask_index) = mask_group.size();
+                    mask_group.push_back(_portal_disc);
+
+                    // Create the portal
+                    typename detector_type::surface _portal{
+                        disc_portal_transforms.size(default_context),
+                        mask_index, volume.index(), dindex_invalid};
+                    // Save the data
+                    disc_portals.push_back(std::move(_portal));
+                }
+                disc_portal_transforms.emplace_back(default_context,
+                                                    _translation);
             }
         };
 
-        // Growing loop over the seeds, process to the end
-        for (dindex iseed = 0; iseed < seeds.size(); ++iseed)
-        {
-            // The running seed & the refence seed
-            auto seed = seeds[iseed];
-            const auto &ref = volume_grid.bin(seed[0], seed[1]);
+        /** Helper lambda for cylindrical portals
+         *
+         * @param portals_info
+         * @param bound_index
+         **/
+        auto add_cylinder_portal =
+            [&](vector_type<tuple_type<array_type<scalar, 2>, dindex>>
+                    &portals_info,
+                dindex bound_index) -> void {
+            // Fill in the upper side portals
+            if (not portals_info.empty()) {
+                // Get the mask context group and fill it
+                auto &cylinder_portal_transforms =
+                    std::get<detector_type::cylinder::mask_context>(
+                        portal_transforms);
+                auto &cylinder_portals =
+                    std::get<detector_type::cylinder::mask_context>(portals);
+                auto &mask_group =
+                    std::get<detector_type::cylinder::mask_context>(
+                        portal_masks);
 
-            // Build and add the portal surfaces
-            auto &volume = d.indexed_volume(ref);
+                typename detector_type::mask_index mask_index = {
+                    detector_type::cylinder::mask_context, mask_group.size()};
+                for (auto &info_ : portals_info) {
+                    const auto cylinder_range = std::get<0>(info_);
+                    array_type<scalar, 3> cylinder_bounds = {
+                        volume_bounds[bound_index], cylinder_range[0],
+                        cylinder_range[1]};
+                    typename detector_type::cylinder _portal_cylinder = {
+                        cylinder_bounds, {std::get<1>(info_), dindex_invalid}};
+                    std::get<1>(mask_index) = mask_group.size();
+                    mask_group.push_back(_portal_cylinder);
 
-            // Collect portals per seed
-            vector_type<tuple_type<array_type<scalar, 2>, dindex>> left_portals_info;
-            vector_type<tuple_type<array_type<scalar, 2>, dindex>> upper_portals_info;
-            vector_type<tuple_type<array_type<scalar, 2>, dindex>> right_portals_info;
-            vector_type<tuple_type<array_type<scalar, 2>, dindex>> lower_portals_info;
-
-            /// Helper method for walking up along the bins
-            ///
-            /// @param start_bin is the start bin of the walk
-            /// @param portals_info is the container to collect for portals
-            /// @param peek is the peek direction in z
-            /// @param add_seed is a boolean whether new seeds should be added
-            ///
-            /// @return the end position of the the walk (inside position)
-            auto walk_up = [&](array_type<dindex, 2> start_bin,
-                               vector_type<tuple_type<array_type<scalar, 2>, dindex>> &portals_info,
-                               int peek,
-                               bool add_seed = false) -> array_type<dindex, 2>
-            {
-                auto running_bin = start_bin;
-                array_type<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
-                // Test entry
-                auto test = volume_grid.bin(running_bin[0], running_bin[1]);
-                // Low/high
-                auto low = axis_r.borders(running_bin[0]);
-                auto high = axis_r.borders(running_bin[0]);
-                //  1 - Left walk up
-                // First peek to the to the left for portal desitnations
-                dindex last_portal_dest = (running_bin[1] > 0 and running_bin[1] < axis_r.bins()) ? volume_grid.bin(running_bin[0], running_bin[1] + peek) : dindex_invalid;
-                while ((ref == test) and ++running_bin[0] < axis_r.bins())
-                {
-                    high = axis_r.borders(running_bin[0]);
-                    test = (seed[0] + 1 < axis_r.bins()) ? volume_grid.bin(running_bin[0], running_bin[1]) : dindex_invalid;
-                    // Peek outside and see if the portal destination has changed
-                    dindex portal_dest = (running_bin[1] > 0 and running_bin[1] < axis_r.bins()) ? volume_grid.bin(running_bin[0], running_bin[1] + peek) : dindex_invalid;
-                    if (portal_dest != last_portal_dest)
-                    {
-                        // Record the boundary
-                        portals_info.push_back({{low[0], high[0]}, last_portal_dest});
-                        last_added = {running_bin[0] - 1, running_bin[1]};
-                        // low is the new high
-                        low = high;
-                        last_portal_dest = portal_dest;
-                    }
-                    high = axis_r.borders(running_bin[0]);
+                    // Create the portal
+                    typename detector_type::surface _portal{
+                        cylinder_portal_transforms.size(default_context),
+                        mask_index, volume.index(), dindex_invalid};
+                    cylinder_portals.push_back(std::move(_portal));
                 }
+                // This will be concentric targetted at nominal center
+                cylinder_portal_transforms.emplace_back(default_context);
+            }
+        };
 
-                // First Potential new seed
-                if (add_seed)
-                {
-                    add_new_seed(running_bin, test);
-                }
-                // By this we undo the overstepping in the loop (either by grid boundary or ref/test fail)
-                high = axis_r.borders(--running_bin[0]);
-                if (last_added != running_bin)
-                {
-                    portals_info.push_back({{low[0], high[1]}, last_portal_dest});
-                }
+        // Add portals to the volume
+        add_disc_portals(left_portals_info, 2);
+        add_cylinder_portal(upper_portals_info, 1);
+        add_disc_portals(right_portals_info, 3);
+        add_cylinder_portal(lower_portals_info, 0);
 
-                // The new position after walking is returned
-                return running_bin;
-            };
-
-            /// Helper method for walking up along the bins
-            ///
-            /// @param start_bin is the start bin of the walk
-            /// @param portals_info is the container to collect for portals
-            /// @param peek is the peek direction in z
-            /// @param add_seed is a boolean whether new seeds should be added
-            /// @param walk_only is a boolean whether to actually add boundaries or not
-            ///
-            /// @return the end position of the the walk (inside position)
-            auto walk_right = [&](const array_type<dindex, 2> &start_bin,
-                                  vector_type<tuple_type<array_type<scalar, 2>, dindex>> &portals_info,
-                                  int peek,
-                                  bool add_seed = false,
-                                  bool walk_only = false) -> array_type<dindex, 2>
-            {
-                auto running_bin = start_bin;
-                array_type<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
-
-                // Test, low and high at seed position
-                auto test = volume_grid.bin(running_bin[0], running_bin[1]);
-                // Low/high
-                auto low = axis_z.borders(running_bin[1]);
-                auto high = axis_z.borders(running_bin[1]);
-
-                dindex last_portal_dest = (running_bin[0] < axis_r.bins()) ? volume_grid.bin(running_bin[0] + peek, running_bin[1]) : dindex_invalid;
-
-                // Seed setting loop as well
-                while (ref == test and (++running_bin[1]) < axis_z.bins())
-                {
-                    high = axis_z.borders(running_bin[1]);
-                    test = volume_grid.bin(running_bin[0], running_bin[1]);
-                    // Peek outside and see if the portal destination has changed
-                    dindex portal_dest = (running_bin[0] < axis_r.bins()) ? volume_grid.bin(running_bin[0] + peek, running_bin[1]) : dindex_invalid;
-                    if (portal_dest != last_portal_dest)
-                    {
-                        // Record the boundary
-                        if (not walk_only)
-                        {
-                            portals_info.push_back({{low[0], high[0]}, last_portal_dest});
-                            last_added = {running_bin[0], running_bin[1] - 1};
-                        }
-                        // low is the new high
-                        low = high;
-                        last_portal_dest = portal_dest;
-                        // That's a new seed right here, except for last one
-                        if (running_bin[1] < axis_z.bins() and add_seed)
-                        {
-                            add_new_seed({running_bin[0] + peek, running_bin[1]}, portal_dest);
-                        }
-                    }
-                    high = axis_z.borders(running_bin[1]);
-                }
-                // By this we undo the overstepping (see above)
-                high = axis_z.borders(--running_bin[1]);
-                if (not walk_only and last_added != running_bin)
-                {
-                    portals_info.push_back({{low[0], high[1]}, last_portal_dest});
-                }
-                // The new bin position after walk
-                return running_bin;
-            };
-
-            // Walk up from the (initial) seed position
-            auto up_left = walk_up(seed, left_portals_info, true, -1);
-            // Walk to the right from the resulting upper position
-            walk_right(up_left, upper_portals_info, true, 1);
-            // Walk right from the (initial) seed position
-            auto bottom_right = walk_right(seed, lower_portals_info, false, -1, seed[0] == 0);
-            // Walk up from the bottom right corner
-            walk_up(bottom_right, right_portals_info, false, 1);
-
-            typename detector_type::portal_filling_container portals = {};
-            typename detector_type::mask_container portal_masks;
-            typename detector_type::transform_container portal_transforms;
-
-            // The bounds can be used for the mask and transform information
-            const auto &volume_bounds = volume.bounds();
-
-            /** Helper lambda to build disc portals
-             * 
-             * @param portals_info The volume_index 
-             * @param bound_index The access for the boundary parameter
-             * 
-             **/
-            auto add_disc_portals = [&](vector_type<tuple_type<array_type<scalar, 2>, dindex>> &portals_info, dindex bound_index) -> void
-            {
-                // Fill in the left side portals
-                if (not portals_info.empty())
-                {
-                    // The portal transfrom is given from the left
-                    __plugin::vector3 _translation{0., 0., volume_bounds[bound_index]};
-
-                    // Get the mask context group and fill it
-                    auto &disc_portal_transforms = std::get<detector_type::disc::mask_context>(portal_transforms);
-                    auto &disc_portals = std::get<detector_type::disc::mask_context>(portals);
-                    auto &mask_group   = std::get<detector_type::disc::mask_context>(portal_masks);
-                    
-                    typename detector_type::mask_index mask_index = {detector_type::disc::mask_context, mask_group.size()};
-                    // Create a stub mask for every unique index
-                    for (auto &info_ : portals_info)
-                    {
-                        typename detector_type::disc _portal_disc = {std::get<0>(info_), {std::get<1>(info_), dindex_invalid}};
-                        std::get<1>(mask_index) = mask_group.size();
-                        mask_group.push_back(_portal_disc);
-
-                        // Create the portal
-                        typename detector_type::surface _portal{disc_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
-                        // Save the data
-                        disc_portals.push_back(std::move(_portal));
-                    }
-                    disc_portal_transforms.emplace_back(default_context, _translation);
-                }
-            };
-
-            /** Helper lambda for cylindrical portals
-             * 
-             * @param portals_info 
-             * @param bound_index
-             **/
-            auto add_cylinder_portal = [&](vector_type<tuple_type<array_type<scalar, 2>, dindex>> &portals_info, dindex bound_index) -> void
-            {
-                // Fill in the upper side portals
-                if (not portals_info.empty())
-                {
-                    // Get the mask context group and fill it
-                    auto &cylinder_portal_transforms = std::get<detector_type::cylinder::mask_context>(portal_transforms);
-                    auto &cylinder_portals = std::get<detector_type::cylinder::mask_context>(portals);
-                    auto &mask_group   = std::get<detector_type::cylinder::mask_context>(portal_masks);
-
-                    typename detector_type::mask_index mask_index = {detector_type::cylinder::mask_context, mask_group.size()};
-                    for (auto &info_ : portals_info)
-                    {
-                        const auto cylinder_range = std::get<0>(info_);
-                        array_type<scalar, 3> cylinder_bounds = {volume_bounds[bound_index], cylinder_range[0], cylinder_range[1]};
-                        typename detector_type::cylinder _portal_cylinder = {cylinder_bounds, {std::get<1>(info_), dindex_invalid}};
-                        std::get<1>(mask_index) = mask_group.size();
-                        mask_group.push_back(_portal_cylinder);
-
-                        // Create the portal
-                        typename detector_type::surface _portal{cylinder_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
-                        cylinder_portals.push_back(std::move(_portal));
-                    }
-                    // This will be concentric targetted at nominal center
-                    cylinder_portal_transforms.emplace_back(default_context);
-                }
-            };
-
-            // Add portals to the volume
-            add_disc_portals(left_portals_info, 2);
-            add_cylinder_portal(upper_portals_info, 1);
-            add_disc_portals(right_portals_info, 3);
-            add_cylinder_portal(lower_portals_info, 0);
-
-            // Add portals to detector
-            d.template add_objects<detector_type::e_portal>(volume, portals, portal_masks, portal_transforms, default_context);
-        }
+        // Add portals to detector
+        d.template add_objects<detector_type::e_portal>(
+            volume, portals, portal_masks, portal_transforms, default_context);
     }
 }
+}  // namespace detray

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -239,90 +239,69 @@ void connect_cylindrical_volumes(
                                                volume_bounds[bound_index]};
 
                 // Get the mask context group and fill it
-                auto &disc_portal_transforms =
-                    std::get<detector_type::portal_disc::mask_context>(
-                        portal_transforms);
-                auto &disc_portals =
-                    std::get<detector_type::portal_disc::mask_context>(portals);
-                auto &mask_group =
-                    std::get<detector_type::portal_disc::mask_context>(
-                        portal_masks);
+                auto &disc_portal_transforms = std::get<detector_type::disc::mask_context>(portal_transforms);
+                auto &disc_portals = std::get<detector_type::disc::mask_context>(portals);
+                auto &mask_group   = std::get<detector_type::disc::mask_context>(portal_masks);
 
-                typename detector_type::portal_mask_index mask_index = {
-                    detector_type::portal_disc::mask_context,
-                    {mask_group.size(), mask_group.size()}};
+                typename detector_type::portal_mask_index mask_index = {detector_type::disc::mask_context, {mask_group.size(), mask_group.size()}};
                 // Create a stub mask for every unique index
-                for (auto &info_ : portals_info) {
-                    typename detector_type::portal_disc _portal_disc = {
-                        std::get<0>(info_),
-                        {std::get<1>(info_), dindex_invalid}};
+                for (auto &info_ : portals_info)
+                {
+                    typename detector_type::disc _portal_disc = {std::get<0>(info_), {std::get<1>(info_), dindex_invalid}};
                     std::get<1>(mask_index)[1] = mask_group.size();
-                    mask_group.push_back(_portal_disc);
+                        mask_group.push_back(_portal_disc);
                 }
                 // Create the portal
-                typename detector_type::portal _portal{
-                    disc_portal_transforms.size(default_context), mask_index,
-                    volume.index(), dindex_invalid};
+                typename detector_type::portal _portal{disc_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
                 // Save the data
                 disc_portals.push_back(std::move(_portal));
-                disc_portal_transforms.emplace_back(default_context,
-                                                    _translation);
             }
-        };
+            disc_portal_transforms.emplace_back(default_context,
+                                                    _translation);
+        }
+    };
 
         /** Helper lambda for cylindrical portals
-         *
-         * @param portals_info
+         * 
+         * @param portals_info 
          * @param bound_index
          **/
-        auto add_cylinder_portal =
-            [&](vector_type<tuple_type<array_type<scalar, 2>, dindex>>
-                    &portals_info,
-                dindex bound_index) -> void {
+        auto add_cylinder_portal = [&](vector_type<tuple_type<array_type<scalar, 2>, dindex>> &portals_info, dindex bound_index) -> void
+        {
             // Fill in the upper side portals
-            if (not portals_info.empty()) {
+            if (not portals_info.empty())
+            {
                 // Get the mask context group and fill it
-                auto &cylinder_portal_transforms =
-                    std::get<detector_type::portal_cylinder::mask_context>(
-                        portal_transforms);
-                auto &cylinder_portals =
-                    std::get<detector_type::portal_cylinder::mask_context>(
-                        portals);
-                auto &mask_group =
-                    std::get<detector_type::portal_cylinder::mask_context>(
-                        portal_masks);
+                auto &cylinder_portal_transforms = std::get<detector_type::cylinder::mask_context>(portal_transforms);
+                auto &cylinder_portals = std::get<detector_type::cylinder::mask_context>(portals);
+                auto &mask_group   = std::get<detector_type::cylinder::mask_context>(portal_masks);
 
-                typename detector_type::portal_mask_index mask_index = {
-                    detector_type::portal_cylinder::mask_context,
-                    {mask_group.size(), mask_group.size()}};
-                for (auto &info_ : portals_info) {
+                typename detector_type::portal_mask_index mask_index = {detector_type::cylinder::mask_context, {mask_group.size(), mask_group.size()}};
+                for (auto &info_ : portals_info)
+                {
                     const auto cylinder_range = std::get<0>(info_);
-                    array_type<scalar, 3> cylinder_bounds = {
-                        volume_bounds[bound_index], cylinder_range[0],
-                        cylinder_range[1]};
-                    typename detector_type::portal_cylinder _portal_cylinder = {
-                        cylinder_bounds, {std::get<1>(info_), dindex_invalid}};
+                    array_type<scalar, 3> cylinder_bounds = {volume_bounds[bound_index], cylinder_range[0], cylinder_range[1]};
+                    typename detector_type::cylinder _portal_cylinder = {cylinder_bounds, {std::get<1>(info_), dindex_invalid}};
                     std::get<1>(mask_index)[1] = mask_group.size();
                     mask_group.push_back(_portal_cylinder);
                 }
                 // Create the portal
-                typename detector_type::portal _portal{
-                    cylinder_portal_transforms.size(default_context),
-                    mask_index, volume.index(), dindex_invalid};
+                typename detector_type::portal _portal{cylinder_portal_transforms.size(default_context), mask_index, volume.index(), dindex_invalid};
                 cylinder_portals.push_back(std::move(_portal));
-                // This will be concentric targetted at nominal center
-                cylinder_portal_transforms.emplace_back(default_context);
             }
-        };
+            // This will be concentric targetted at nominal center
+            cylinder_portal_transforms.emplace_back(default_context);
+        }
+    };
 
-        // Add portals to the volume
-        add_disc_portals(left_portals_info, 2);
-        add_cylinder_portal(upper_portals_info, 1);
-        add_disc_portals(right_portals_info, 3);
-        add_cylinder_portal(lower_portals_info, 0);
+    // Add portals to the volume
+    add_disc_portals(left_portals_info, 2);
+    add_cylinder_portal(upper_portals_info, 1);
+    add_disc_portals(right_portals_info, 3);
+    add_cylinder_portal(lower_portals_info, 0);
 
-        // Add portals to detector
-        d.template add_objects<detector_type::e_portal>(
+    // Add portals to detector
+    d.template add_objects<detector_type::e_portal>(
             volume, portals, portal_masks, portal_transforms, default_context);
     }
 }

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -47,7 +47,7 @@ namespace detray
         using surface = typename detector_type::surface;
         using volume_link = typename detector_type::volume_links;
 
-        using portal = typename detector_type::portal;
+        using portal = typename detector_type::surface;
 
         using context = typename detector_type::context;
 

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -1,89 +1,91 @@
 /** Detray library, part of the ACTS project (R&D line)
- *
+ * 
  * (c) 2021 CERN for the benefit of the ACTS project
- *
+ * 
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-#include <algorithm>
-
 #include "core/intersection.hpp"
 #include "core/track.hpp"
-#include "tools/intersection_kernel.hpp"
-#include "utils/enumerate.hpp"
 #include "utils/indexing.hpp"
+#include "utils/enumerate.hpp"
+#include "tools/intersection_kernel.hpp"
 
-namespace detray {
+#include <algorithm>
 
-/** A void inpector that does nothing.
- *
- * Inspectors can be plugged in to understand the
- * the current navigation state information.
- *
- */
-struct void_inspector {
-    template <typename state_type>
-    void operator()(const state_type & /*ignored*/) {}
-};
-
-/** The navigator struct. 
- * 
- * It follows the Acts::Navigator sturcture of sequence of
- * - status()
- * - target()
- * calls.
- * 
- * @tparam detector_tupe is the type of the detector
- * @tparam inspector_type is a validation inspector 
- */
-template <typename detector_type, typename inspector_type = void_inspector>
-struct navigator
+namespace detray
 {
 
-    using surface = typename detector_type::surface;
-    using volume_link = typename detector_type::volume_links;
-
-    using portal = typename detector_type::portal;
-
-    using context = typename detector_type::context;
-
-    /** Navigation status flag */
-    enum navigation_status : int
-    {
-        e_on_target = -3,
-        e_abort = -2,
-        e_unknown = -1,
-        e_towards_surface = 0,
-        e_on_surface = 1,
-        e_towards_portal = 2,
-        e_on_portal = 3,
-    };
-
-    /** Navigation trust level */
-    enum navigation_trust_level : int
-    {
-        e_no_trust = 0,   // re-evalute the candidates all over
-        e_fair_trust = 1, // re-evaluate the distance & order of the (preselected) candidates
-        e_high_trust = 3, // re-evaluate the distance to the next candidate
-        e_full_trust = 4  // trust fully: distance & next candidate
-    };
-
-    /** A nested navigation kernel struct which can be used for surfaces, portals,
-     *  volumes a like.
-     *  
-     * @tparam object_type the type of the relevant object
-     * @tparam candidate_type the type of the candidates in the list
-     * @tparam links_type the type of the links the candidate is holding
+    /** A void inpector that does nothing.
      * 
-     **/
-    template <typename object_type,
-              typename candidate_type,
-              typename links_type,
-              template <typename> class vector_type = dvector>
-    struct navigation_kernel
+     * Inspectors can be plugged in to understand the
+     * the current navigation state information.
+     * 
+     */
+    struct void_inspector
     {
+        template <typename state_type>
+        void operator()(const state_type & /*ignored*/) {}
+    };
+
+    /** The navigator struct. 
+     * 
+     * It follows the Acts::Navigator sturcture of sequence of
+     * - status()
+     * - target()
+     * calls.
+     * 
+     * @tparam detector_tupe is the type of the detector
+     * @tparam inspector_type is a validation inspector 
+     */
+    template <typename detector_type, typename inspector_type = void_inspector>
+    struct navigator
+    {
+
+        using surface = typename detector_type::surface;
+        using volume_link = typename detector_type::volume_links;
+
+        using portal = typename detector_type::portal;
+
+        using context = typename detector_type::context;
+
+        /** Navigation status flag */
+        enum navigation_status : int
+        {
+            e_on_target = -3,
+            e_abort = -2,
+            e_unknown = -1,
+            e_towards_surface = 0,
+            e_on_surface = 1,
+            e_towards_portal = 2,
+            e_on_portal = 3,
+        };
+
+        /** Navigation trust level */
+        enum navigation_trust_level : int
+        {
+            e_no_trust = 0,   // re-evalute the candidates all over
+            e_fair_trust = 1, // re-evaluate the distance & order of the (preselected) candidates
+            e_high_trust = 3, // re-evaluate the distance to the next candidate
+            e_full_trust = 4  // trust fully: distance & next candidate
+        };
+
+        /** A nested navigation kernel struct which can be used for surfaces, portals,
+         *  volumes a like.
+         *  
+         * @tparam object_type the type of the relevant object
+         * @tparam candidate_type the type of the candidates in the list
+         * @tparam links_type the type of the links the candidate is holding
+         * 
+         **/
+        template <typename object_type,
+                  typename candidate_type,
+                  typename links_type,
+                  template <typename> class vector_type = dvector>
+        struct navigation_kernel
+        {
             const object_type *on = nullptr;
             vector_type<candidate_type> candidates = {};
             typename vector_type<candidate_type>::iterator next = candidates.end();
@@ -105,190 +107,175 @@ struct navigator
             }
         };
 
-    /** A navigation state object used to cache the information of the
-     * current navigation stream.
-     * 
-     * It requires to have a scalar represenation to be used for a stepper
-     **/
-    struct state
-    {
-        /** Kernel for the surfaces */
-        navigation_kernel<surface, intersection, volume_link> surface_kernel;
-        /** Kernel for the portals */
-        navigation_kernel<portal, intersection, volume_link> portal_kernel;
-
-        /** Volume navigation: index */
-        dindex volume_index = dindex_invalid;
-
-        /**  Distance to next - will be casted into a scalar with call operator  */
-        scalar distance_to_next = std::numeric_limits<scalar>::infinity();
-        /** The on surface tolerance - permille */
-        scalar on_surface_tolerance = 1e-3;
-
-        /** The inspector type of this navigation engine */
-        inspector_type inspector;
-
-        /**  The navigation status */
-        navigation_status status = e_unknown;
-
-        /** If a surface / portal is reached */
-        dindex current_index = dindex_invalid;
-
-        /** The navigation trust level */
-        navigation_trust_level trust_level = e_no_trust;
-
-        /** Scalar representation of the navigation state,
-         * @returns distance to next
+        /** A navigation state object used to cache the information of the
+         * current navigation stream.
+         * 
+         * It requires to have a scalar represenation to be used for a stepper
          **/
-        scalar operator()() const
+        struct state
         {
-            return distance_to_next;
-        }
-    };
+            /** Kernel for the surfaces */
+            navigation_kernel<surface, intersection, volume_link> surface_kernel;
+            /** Kernel for the portals */
+            navigation_kernel<portal, intersection, volume_link> portal_kernel;
 
-        /** The inspector type of this navigation engine */
-        inspector_type inspector;
+            /** Volume navigation: index */
+            dindex volume_index = dindex_invalid;
 
-        /**  The navigation status */
-        navigation_status status = e_unknown;
+            /**  Distance to next - will be casted into a scalar with call operator  */
+            scalar distance_to_next = std::numeric_limits<scalar>::infinity();
+            /** The on surface tolerance - permille */
+            scalar on_surface_tolerance = 1e-3;
 
-        /** If a surface / portal is reached */
-        dindex current_index = dindex_invalid;
+            /** The inspector type of this navigation engine */
+            inspector_type inspector;
 
-        /** The navigation trust level */
-        navigation_trust_level trust_level = e_no_trust;
+            /**  The navigation status */
+            navigation_status status = e_unknown;
 
-        /** Scalar representation of the navigation state,
-         * @returns distance to next
-         **/
-        scalar operator()() const { return distance_to_next; }
-    };
+            /** If a surface / portal is reached */
+            dindex current_index = dindex_invalid;
 
-    __plugin::cartesian2 cart2;
-    __plugin::polar2 pol2;
-    __plugin::cylindrical2 cyl2;
+            /** The navigation trust level */
+            navigation_trust_level trust_level = e_no_trust;
 
-    /// The detector in which we are moving
-    detector_type detector;
-
-    /** Constructor with move constructor
-     *
-     * @param d the detector for this navigator
-     */
-    navigator(detector_type &&d) : detector(std::move(d)) {}
-
-    /** Navigation status() call which established the current navigation
-     *information.
-     *
-     * @param navigation [in, out] is the navigation cache object
-     * @param track [in] is the track infromation
-     *
-     * @return a heartbeat to indicate if the navigation is still alive
-     **/
-    bool status(state &navigation, const track<context> &track) const {
-
-        bool heartbeat = true;
-
-        // Retrieve the volume & set index
-        // Retrieve the volume, either from valid index or through global search
-        const auto &volume =
-            (navigation.volume_index != dindex_invalid)
-                ? detector.indexed_volume(navigation.volume_index)
-                : detector.indexed_volume(track.pos);
-        navigation.volume_index = volume.index();
-        // Retrieve the kernels
-        auto &surface_kernel = navigation.surface_kernel;
-        auto &portal_kernel = navigation.portal_kernel;
-
-        // The navigation is not yet initialized, or you lost trust in it
-        if (navigation.volume_index == dindex_invalid or
-            navigation.trust_level == e_no_trust) {
-            // First try to get the surface candidates
-            initialize_kernel(
-                navigation, surface_kernel, track,
-                volume.template range<detector_type::e_surface>(),
-                volume.template trf_range<detector_type::e_surface>());
-            // If no surfaces are to processed, initialize the portals
-            if (surface_kernel.empty()) {
-                initialize_kernel(
-                    navigation, portal_kernel, track,
-                    volume.template range<detector_type::e_portal>(),
-                    volume.template trf_range<detector_type::e_portal>());
-                heartbeat = check_volume_switch(navigation);
+            /** Scalar representation of the navigation state,
+             * @returns distance to next
+             **/
+            scalar operator()() const
+            {
+                return distance_to_next;
             }
-            // Before returning, run through the inspector
+        };
+
+        __plugin::cartesian2 cart2;
+        __plugin::polar2 pol2;
+        __plugin::cylindrical2 cyl2;
+
+        /// The detector in which we are moving
+        detector_type detector;
+
+        /** Constructor with move constructor
+         * 
+         * @param d the detector for this navigator
+         */
+        navigator(detector_type &&d) : detector(std::move(d)) {}
+
+        /** Navigation status() call which established the current navigation information.
+         * 
+         * @param navigation [in, out] is the navigation cache object
+         * @param track [in] is the track infromation
+         * 
+         * @return a heartbeat to indicate if the navigation is still alive
+         **/
+        bool status(state &navigation, const track<context> &track) const
+        {
+
+            bool heartbeat = true;
+
+            // Retrieve the volume & set index
+            // Retrieve the volume, either from valid index or through global search
+            const auto &volume = (navigation.volume_index != dindex_invalid) ? detector.indexed_volume(navigation.volume_index)
+                                                                             : detector.indexed_volume(track.pos);
+            navigation.volume_index = volume.index();
+            // Retrieve the kernels
+            auto &surface_kernel = navigation.surface_kernel;
+            auto &portal_kernel = navigation.portal_kernel;
+
+            // The navigation is not yet initialized, or you lost trust in it
+            if (navigation.volume_index == dindex_invalid or navigation.trust_level == e_no_trust)
+            {
+                // First try to get the surface candidates
+                initialize_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>());
+                // If no surfaces are to processed, initialize the portals
+                if (surface_kernel.empty())
+                {
+                    initialize_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
+                    heartbeat = check_volume_switch(navigation);
+                }
+                // Before returning, run through the inspector
+                navigation.inspector(navigation);
+                return heartbeat;
+            }
+
+            // Update the surface kernel
+            if (not is_exhausted(surface_kernel) and update_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>()))
+            {
+                navigation.inspector(navigation);
+                return heartbeat;
+            }
+
+            // Update the portal kernel
+            update_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
+            heartbeat = check_volume_switch(navigation);
             navigation.inspector(navigation);
             return heartbeat;
         }
 
-        // Update the surface kernel
-        if (not is_exhausted(surface_kernel) and
-            update_kernel(
-                navigation, surface_kernel, track,
-                volume.template range<detector_type::e_surface>(),
-                volume.template trf_range<detector_type::e_surface>())) {
+        /** Target function of the navigator, finds the next candidates 
+         *   and set the distance to next
+         * 
+         * @param navigation is the navigation cache
+         * @param track is the current track information
+         * 
+         * @return a heartbeat to indicate if the navigation is still alive
+         **/
+        bool target(state &navigation, const track<context> &track) const
+        {
+            bool heartbeat = true;
+
+            // Full trust level from target() call
+            if (navigation.trust_level == e_full_trust)
+            {
+                return heartbeat;
+            }
+
+            // Retrieve the volume, either from valid index or through global search
+            const auto &volume = (navigation.volume_index != dindex_invalid) ? detector.indexed_volume(navigation.volume_index)
+                                                                             : detector.indexed_volume(track.pos);
+            navigation.volume_index = volume.index();
+            // Retrieve the kernels
+            auto &surface_kernel = navigation.surface_kernel;
+            auto &portal_kernel = navigation.portal_kernel;
+            // High targetting level
+            if (navigation.trust_level == e_high_trust)
+            {
+                // Surfaces are/were present
+                if (not surface_kernel.empty())
+                {
+                    if (is_exhausted(surface_kernel))
+                    {
+                        // Clear the surface kernel
+                        surface_kernel.clear();
+                        navigation.trust_level = e_no_trust;
+                        update_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
+                        navigation.inspector(navigation);
+                        return heartbeat;
+                    }
+                    else if (update_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>()))
+                    {
+                        navigation.inspector(navigation);
+                        return heartbeat;
+                    }
+                }
+                // Portals are present
+                update_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
+            }
+            else if (navigation.trust_level == e_no_trust)
+            {
+                // First try to get the surface candidates
+                initialize_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>());
+                // If no surfaces are to processed, initialize the portals
+                if (surface_kernel.empty())
+                {
+                    initialize_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>(), navigation.status == e_on_portal);
+                    heartbeat = check_volume_switch(navigation);
+                }
+            }
             navigation.inspector(navigation);
             return heartbeat;
         }
 
-<<<<<<< HEAD
-        // Update the portal kernel
-        update_kernel(navigation, portal_kernel, track,
-                      volume.template range<detector_type::e_portal>(),
-                      volume.template trf_range<detector_type::e_portal>());
-        heartbeat = check_volume_switch(navigation);
-        navigation.inspector(navigation);
-        return heartbeat;
-    }
-
-    /** Target function of the navigator, finds the next candidates
-     *   and set the distance to next
-     *
-     * @param navigation is the navigation cache
-     * @param track is the current track information
-     *
-     * @return a heartbeat to indicate if the navigation is still alive
-     **/
-    bool target(state &navigation, const track<context> &track) const {
-        bool heartbeat = true;
-
-        // Full trust level from target() call
-        if (navigation.trust_level == e_full_trust) {
-            return heartbeat;
-        }
-
-        // Retrieve the volume, either from valid index or through global search
-        const auto &volume =
-            (navigation.volume_index != dindex_invalid)
-                ? detector.indexed_volume(navigation.volume_index)
-                : detector.indexed_volume(track.pos);
-        navigation.volume_index = volume.index();
-        // Retrieve the kernels
-        auto &surface_kernel = navigation.surface_kernel;
-        auto &portal_kernel = navigation.portal_kernel;
-        // High targetting level
-        if (navigation.trust_level == e_high_trust) {
-            // Surfaces are/were present
-            if (not surface_kernel.empty()) {
-                if (is_exhausted(surface_kernel)) {
-                    // Clear the surface kernel
-                    surface_kernel.clear();
-                    navigation.trust_level = e_no_trust;
-                    update_kernel(
-                        navigation, portal_kernel, track,
-                        volume.template range<detector_type::e_portal>(),
-                        volume.template trf_range<detector_type::e_portal>());
-                    navigation.inspector(navigation);
-                    return heartbeat;
-                } else if (update_kernel(
-                               navigation, surface_kernel, track,
-                               volume
-                                   .template range<detector_type::e_surface>(),
-                               volume.template trf_range<
-                                   detector_type::e_surface>())) {
-                    navigation.inspector(navigation);
-                    return heartbeat;
-=======
         /** Helper method to intersect all objects of a surface/portal store
          * 
          * @tparam kernel_t the type of the kernel: surfaces/portals
@@ -343,146 +330,38 @@ struct navigator
                 {
                     navigation.status = kSurfaceType ? e_towards_surface : e_towards_portal;
                     kernel.candidates.push_back(sfi);
->>>>>>> ff4fb14 (Use same links type in surface and portal masks: surface links reference back to current volume)
                 }
             }
-            // Portals are present
-            update_kernel(navigation, portal_kernel, track,
-                          volume.template range<detector_type::e_portal>(),
-                          volume.template trf_range<detector_type::e_portal>());
-        } else if (navigation.trust_level == e_no_trust) {
-            // First try to get the surface candidates
-            initialize_kernel(
-                navigation, surface_kernel, track,
-                volume.template range<detector_type::e_surface>(),
-                volume.template trf_range<detector_type::e_surface>());
-            // If no surfaces are to processed, initialize the portals
-            if (surface_kernel.empty()) {
-                initialize_kernel(
-                    navigation, portal_kernel, track,
-                    volume.template range<detector_type::e_portal>(),
-                    volume.template trf_range<detector_type::e_portal>(),
-                    navigation.status == e_on_portal);
-                heartbeat = check_volume_switch(navigation);
-            }
+            sort_and_set(navigation, kernel);
         }
-        navigation.inspector(navigation);
-        return heartbeat;
-    }
 
-    /** Helper method to intersect all objects of a surface/portal store
-     *
-     * @tparam kernel_t the type of the kernel: surfaces/portals
-     * @tparam range the type of range in the detector data containers
-     *
-     * @param navigation is the navigation cache object
-     * @param kernel [in,out] the kernel to be checked/initialized
-     * @param track the track information
-     * @param obj_range the surface/portal index range in the detector cont
-     * @param trf_range the transform index range in the detector cont
-     * @param on_object ignores on surface solution
-     *
-     */
-    template <typename kernel_t, typename range_t>
-    void initialize_kernel(state &navigation, kernel_t &kernel,
+        /** Helper method to the update the next candidate intersection 
+         * 
+         * @tparam kernel_t the type of the kernel: surfaces/portals
+         * @tparam range the type of range in the detector data containers
+         * 
+         * @param navigation [in, out] the navigation state
+         * @param kernel [in,out] the kernel to be checked/initialized 
+         * @param track the track information
+         * @param obj_range the surface/portal index range in the detector cont
+         * @param trf_range the transform index range in the detector cont
+         * 
+         * @return A boolean condition 
+         */
+        template <typename kernel_t, typename range_t>
+        bool update_kernel(state &navigation,
+                           kernel_t &kernel,
                            const track<context> &track,
-                           const range_t &obj_range, const range_t &trf_range,
-                           bool on_object = false) const {
-
-        // Get the type of the kernel via a const expression at compile time
-        constexpr bool kSurfaceType =
-            (std::is_same_v<kernel_t, navigation_kernel<surface, intersection,
-                                                        surface_link>>);
-
-        // Get the number of candidates & run them throuth the kernel
-        size_t n_objects = obj_range[1] - obj_range[0];
-        // Return if you have no objects
-        if (n_objects == 0) {
-            return;
-        }
-        kernel.candidates.reserve(n_objects);
-        const auto &transforms = detector.transforms(trf_range, track.ctx);
-        const auto &surfaces = detector.template surfaces<kSurfaceType>();
-        const auto &masks = detector.template masks<kSurfaceType>();
-        // Loop over all indexed surfaces, intersect and fill
-        // @todo - will come from the local object finder
-        for (auto si : sequence(obj_range)) {
-            const auto &object = surfaces[si];
-            auto [sfi, link] = intersect(track, object, transforms, masks);
-            sfi.index = si;
-            sfi.link = link[0];
-            // Ignore negative solutions - except overstep limit
-            if (sfi.path < track.overstep_tolerance) {
-                continue;
+                           const range_t &obj_range,
+                           const range_t &trf_range) const
+        {
+            // If the kernel is empty - intitalize it
+            if (kernel.empty())
+            {
+                initialize_kernel(navigation, kernel, track, obj_range, trf_range);
+                return true;
             }
-            // Accept if inside, but not if the same object is excluded
-            if (sfi.status == e_inside and
-                (not on_object or
-                 std::abs(sfi.path) > navigation.on_surface_tolerance)) {
-                navigation.status =
-                    kSurfaceType ? e_towards_surface : e_towards_portal;
-                kernel.candidates.push_back(sfi);
-            }
-        }
-        sort_and_set(navigation, kernel);
-    }
 
-    /** Helper method to the update the next candidate intersection
-     *
-     * @tparam kernel_t the type of the kernel: surfaces/portals
-     * @tparam range the type of range in the detector data containers
-     *
-     * @param navigation [in, out] the navigation state
-     * @param kernel [in,out] the kernel to be checked/initialized
-     * @param track the track information
-     * @param obj_range the surface/portal index range in the detector cont
-     * @param trf_range the transform index range in the detector cont
-     *
-     * @return A boolean condition
-     */
-    template <typename kernel_t, typename range_t>
-    bool update_kernel(state &navigation, kernel_t &kernel,
-                       const track<context> &track, const range_t &obj_range,
-                       const range_t &trf_range) const {
-        // If the kernel is empty - intitalize it
-        if (kernel.empty()) {
-            initialize_kernel(navigation, kernel, track, obj_range, trf_range);
-            return true;
-        }
-
-<<<<<<< HEAD
-        // Get the type of the kernel via a const expression at compile time
-        constexpr bool kSurfaceType =
-            (std::is_same_v<kernel_t, navigation_kernel<surface, intersection,
-                                                        surface_link>>);
-
-        const auto &transforms = detector.transforms(trf_range, track.ctx);
-        const auto &surfaces = detector.template surfaces<kSurfaceType>();
-        const auto &masks = detector.template masks<kSurfaceType>();
-
-        // Update current candidate, or step further
-        // - do this only when you trust level is high
-        if (navigation.trust_level >= e_high_trust and
-            kernel.next != kernel.candidates.end()) {
-            // Only update the last intersection
-            dindex si = kernel.next->index;
-            const auto &s = surfaces[si];
-            auto [sfi, link] = intersect(track, s, transforms, masks);
-            sfi.index = si;
-            sfi.link = link[0];
-            if (sfi.status == e_inside) {
-                // Update the intersection with a new one
-                (*kernel.next) = sfi;
-                navigation.distance_to_next = sfi.path;
-                if (std::abs(sfi.path) < navigation.on_surface_tolerance) {
-                    navigation.status =
-                        kSurfaceType ? e_on_surface : e_on_portal;
-                    navigation.current_index = si;
-                    if (navigation.status != e_on_portal) {
-                        ++kernel.next;
-                        // Trust level is high
-                        navigation.trust_level = e_high_trust;
-=======
             // Get the type of the kernel via a const expression at compile time
             constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, volume_link>>);
 
@@ -521,39 +400,40 @@ struct navigator
                         navigation.status = kSurfaceType ? e_towards_surface : e_towards_portal;
                         // Trust fully again
                         navigation.trust_level = e_full_trust;
->>>>>>> ff4fb14 (Use same links type in surface and portal masks: surface links reference back to current volume)
                     }
-                } else {
-                    navigation.status =
-                        kSurfaceType ? e_towards_surface : e_towards_portal;
-                    // Trust fully again
-                    navigation.trust_level = e_full_trust;
+                    return true;
                 }
-                return true;
+                // If not successful: increase and switch to next
+                ++kernel.next;
+                if (update_kernel(navigation, kernel, track, obj_range, trf_range))
+                {
+                    return true;
+                }
             }
-            // If not successful: increase and switch to next
-            ++kernel.next;
-            if (update_kernel(navigation, kernel, track, obj_range,
-                              trf_range)) {
-                return true;
+            // Loop over all candidates and intersect again all candidates
+            // - do this when your trust level is low
+            else if (navigation.trust_level == e_fair_trust)
+            {
+                for (auto &c : kernel.candidates)
+                {
+                    dindex si = c.index;
+                    const auto &s = surfaces[si];
+                    auto [sfi, link] = intersect(track, s, transforms, masks);
+                    c = sfi;
+                    c.index = si;
+                    c.link = link[0];
+                }
+                sort_and_set(navigation, kernel);
+                if (navigation.trust_level == e_high_trust)
+                {
+                    return true;
+                }
             }
+            // This kernel is exhausted
+            kernel.next = kernel.candidates.end();
+            navigation.trust_level = e_no_trust;
+            return false;
         }
-<<<<<<< HEAD
-        // Loop over all candidates and intersect again all candidates
-        // - do this when your trust level is low
-        else if (navigation.trust_level == e_fair_trust) {
-            for (auto &c : kernel.candidates) {
-                dindex si = c.index;
-                const auto &s = surfaces[si];
-                auto [sfi, link] = intersect(track, s, transforms, masks);
-                c = sfi;
-                c.index = si;
-                c.link = link[0];
-            }
-            sort_and_set(navigation, kernel);
-            if (navigation.trust_level == e_high_trust) {
-                return true;
-=======
 
         /** Helper method to sort within the kernel 
          *
@@ -580,76 +460,42 @@ struct navigator
                 }
                 navigation.current_index = dindex_invalid;
                 navigation.status = kSurfaceType ? e_towards_surface : e_towards_portal;
->>>>>>> ff4fb14 (Use same links type in surface and portal masks: surface links reference back to current volume)
             }
         }
-        // This kernel is exhausted
-        kernel.next = kernel.candidates.end();
-        navigation.trust_level = e_no_trust;
-        return false;
-    }
 
-    /** Helper method to sort within the kernel
-     *
-     * @param navigation is the state for setting the distance to next
-     * @param kernel is the kernel which should be updated
-     */
-    template <typename kernel_t>
-    void sort_and_set(state &navigation, kernel_t &kernel) const {
-        // Get the type of the kernel via a const expression at compile time
-        constexpr bool kSurfaceType =
-            (std::is_same_v<kernel_t, navigation_kernel<surface, intersection,
-                                                        surface_link>>);
-
-        // Sort and set distance to next & navigation status
-        if (not kernel.candidates.empty()) {
-            navigation.trust_level = e_full_trust;
-            std::sort(kernel.candidates.begin(), kernel.candidates.end());
-            kernel.next = kernel.candidates.begin();
-            navigation.distance_to_next = kernel.next->path;
-            if (navigation.distance_to_next < navigation.on_surface_tolerance) {
-                navigation.status = kSurfaceType ? e_on_surface : e_on_portal;
-                navigation.current_index = kernel.next->index;
+        /** Helper method to check and perform a volume switch
+         *
+         * @param navigation is the navigation state 
+         * 
+         * @return a flag if the volume navigation is still heartbeat
+         */
+        bool check_volume_switch(state &navigation) const
+        {
+            // On a portal: switch volume index and (re-)initialize
+            if (navigation.status == e_on_portal)
+            {
+                // Set volume index to the next volume provided by the portal, avoid setting to same
+                navigation.volume_index =
+                    (navigation.portal_kernel.next->link != navigation.volume_index) ? navigation.portal_kernel.next->link : dindex_invalid;
+                navigation.surface_kernel.clear();
+                navigation.portal_kernel.clear();
+                navigation.trust_level = e_no_trust;
             }
-            navigation.current_index = dindex_invalid;
-            navigation.status =
-                kSurfaceType ? e_towards_surface : e_towards_portal;
+            return (navigation.volume_index != dindex_invalid);
         }
-    }
 
-    /** Helper method to check and perform a volume switch
-     *
-     * @param navigation is the navigation state
-     *
-     * @return a flag if the volume navigation is still heartbeat
-     */
-    bool check_volume_switch(state &navigation) const {
-        // On a portal: switch volume index and (re-)initialize
-        if (navigation.status == e_on_portal) {
-            // Set volume index to the next volume provided by the portal, avoid
-            // setting to same
-            navigation.volume_index =
-                (navigation.portal_kernel.next->link != navigation.volume_index)
-                    ? navigation.portal_kernel.next->link
-                    : dindex_invalid;
-            navigation.surface_kernel.clear();
-            navigation.portal_kernel.clear();
-            navigation.trust_level = e_no_trust;
+        /** Helper method to check if a kernel is exhaused 
+         * 
+         * @tparam kernel_t the type of the kernel
+         * @param kernel the kernel to be checked
+         * 
+         * @return true if the kernel is exhaused 
+         */
+        template <typename kernel_t>
+        bool is_exhausted(const kernel_t &kernel) const
+        {
+            return (kernel.next == kernel.candidates.end());
         }
-        return (navigation.volume_index != dindex_invalid);
-    }
+    };
 
-    /** Helper method to check if a kernel is exhaused
-     *
-     * @tparam kernel_t the type of the kernel
-     * @param kernel the kernel to be checked
-     *
-     * @return true if the kernel is exhaused
-     */
-    template <typename kernel_t>
-    bool is_exhausted(const kernel_t &kernel) const {
-        return (kernel.next == kernel.candidates.end());
-    }
-};
-
-}  // namespace detray
+} // namespace detray

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -28,29 +28,30 @@ struct void_inspector {
     void operator()(const state_type & /*ignored*/) {}
 };
 
-/** The navigator struct.
- *
+/** The navigator struct. 
+ * 
  * It follows the Acts::Navigator sturcture of sequence of
  * - status()
  * - target()
  * calls.
- *
+ * 
  * @tparam detector_tupe is the type of the detector
- * @tparam inspector_type is a validation inspector
+ * @tparam inspector_type is a validation inspector 
  */
 template <typename detector_type, typename inspector_type = void_inspector>
-struct navigator {
+struct navigator
+{
 
     using surface = typename detector_type::surface;
-    using surface_link = typename detector_type::surface_link;
+    using volume_link = typename detector_type::volume_links;
 
     using portal = typename detector_type::portal;
-    using portal_links = typename detector_type::portal_links;
 
     using context = typename detector_type::context;
 
     /** Navigation status flag */
-    enum navigation_status : int {
+    enum navigation_status : int
+    {
         e_on_target = -3,
         e_abort = -2,
         e_unknown = -1,
@@ -61,65 +62,89 @@ struct navigator {
     };
 
     /** Navigation trust level */
-    enum navigation_trust_level : int {
-        e_no_trust = 0,    // re-evalute the candidates all over
-        e_fair_trust = 1,  // re-evaluate the distance & order of the
-                           // (preselected) candidates
-        e_high_trust = 3,  // re-evaluate the distance to the next candidate
-        e_full_trust = 4   // trust fully: distance & next candidate
+    enum navigation_trust_level : int
+    {
+        e_no_trust = 0,   // re-evalute the candidates all over
+        e_fair_trust = 1, // re-evaluate the distance & order of the (preselected) candidates
+        e_high_trust = 3, // re-evaluate the distance to the next candidate
+        e_full_trust = 4  // trust fully: distance & next candidate
     };
 
-    /** A nested navigation kernel struct which can be used for surfaces,
-     *portals, volumes a like.
-     *
+    /** A nested navigation kernel struct which can be used for surfaces, portals,
+     *  volumes a like.
+     *  
      * @tparam object_type the type of the relevant object
      * @tparam candidate_type the type of the candidates in the list
      * @tparam links_type the type of the links the candidate is holding
-     *
+     * 
      **/
-    template <typename object_type, typename candidate_type,
+    template <typename object_type,
+              typename candidate_type,
               typename links_type,
               template <typename> class vector_type = dvector>
-    struct navigation_kernel {
-        const object_type *on = nullptr;
-        vector_type<candidate_type> candidates = {};
-        typename vector_type<candidate_type>::iterator next = candidates.end();
-        links_type links;
+    struct navigation_kernel
+    {
+            const object_type *on = nullptr;
+            vector_type<candidate_type> candidates = {};
+            typename vector_type<candidate_type>::iterator next = candidates.end();
+            links_type links;
 
-        /** Indicate that the kernel is empty */
-        bool empty() const { return candidates.empty(); }
+            /** Indicate that the kernel is empty */
+            bool empty() const { return candidates.empty(); }
 
-        /** Forward the kernel size */
-        size_t size() const { return candidates.size(); }
+            /** Forward the kernel size */
+            size_t size() const { return candidates.size(); }
 
-        /** Clear the kernel */
-        void clear() {
-            candidates.clear();
-            next = candidates.end();
-            links = links_type{};
-            on = nullptr;
-        }
-    };
+            /** Clear the kernel */
+            void clear()
+            {
+                candidates.clear();
+                next = candidates.end();
+                links = links_type{};
+                on = nullptr;
+            }
+        };
 
     /** A navigation state object used to cache the information of the
      * current navigation stream.
-     *
+     * 
      * It requires to have a scalar represenation to be used for a stepper
      **/
-    struct state {
+    struct state
+    {
         /** Kernel for the surfaces */
-        navigation_kernel<surface, intersection, surface_link> surface_kernel;
+        navigation_kernel<surface, intersection, volume_link> surface_kernel;
         /** Kernel for the portals */
-        navigation_kernel<portal, intersection, portal_links> portal_kernel;
+        navigation_kernel<portal, intersection, volume_link> portal_kernel;
 
         /** Volume navigation: index */
         dindex volume_index = dindex_invalid;
 
-        /**  Distance to next - will be casted into a scalar with call operator
-         */
+        /**  Distance to next - will be casted into a scalar with call operator  */
         scalar distance_to_next = std::numeric_limits<scalar>::infinity();
         /** The on surface tolerance - permille */
         scalar on_surface_tolerance = 1e-3;
+
+        /** The inspector type of this navigation engine */
+        inspector_type inspector;
+
+        /**  The navigation status */
+        navigation_status status = e_unknown;
+
+        /** If a surface / portal is reached */
+        dindex current_index = dindex_invalid;
+
+        /** The navigation trust level */
+        navigation_trust_level trust_level = e_no_trust;
+
+        /** Scalar representation of the navigation state,
+         * @returns distance to next
+         **/
+        scalar operator()() const
+        {
+            return distance_to_next;
+        }
+    };
 
         /** The inspector type of this navigation engine */
         inspector_type inspector;
@@ -206,6 +231,7 @@ struct navigator {
             return heartbeat;
         }
 
+<<<<<<< HEAD
         // Update the portal kernel
         update_kernel(navigation, portal_kernel, track,
                       volume.template range<detector_type::e_portal>(),
@@ -262,6 +288,62 @@ struct navigator {
                                    detector_type::e_surface>())) {
                     navigation.inspector(navigation);
                     return heartbeat;
+=======
+        /** Helper method to intersect all objects of a surface/portal store
+         * 
+         * @tparam kernel_t the type of the kernel: surfaces/portals
+         * @tparam range the type of range in the detector data containers
+         * 
+         * @param navigation is the navigation cache object
+         * @param kernel [in,out] the kernel to be checked/initialized 
+         * @param track the track information
+         * @param obj_range the surface/portal index range in the detector cont
+         * @param trf_range the transform index range in the detector cont
+         * @param on_object ignores on surface solution
+         * 
+         */
+        template <typename kernel_t, typename range_t>
+        void initialize_kernel(state &navigation,
+                               kernel_t &kernel,
+                               const track<context> &track,
+                               const range_t &obj_range,
+                               const range_t &trf_range,
+                               bool on_object = false) const
+        {
+
+            // Get the type of the kernel via a const expression at compile time
+            constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, volume_link>>);
+
+            // Get the number of candidates & run them throuth the kernel
+            size_t n_objects = obj_range[1] - obj_range[0];
+            // Return if you have no objects
+            if (n_objects == 0)
+            {
+                return;
+            }
+            kernel.candidates.reserve(n_objects);
+            const auto &transforms = detector.transforms(trf_range, track.ctx);
+            const auto &surfaces = detector.template surfaces<kSurfaceType>();
+            const auto &masks = detector.template masks<kSurfaceType>();
+            // Loop over all indexed surfaces, intersect and fill
+            // @todo - will come from the local object finder
+            for (auto si : sequence(obj_range))
+            {
+                const auto &object = surfaces[si];
+                auto [sfi, link] = intersect(track, object, transforms, masks);
+                sfi.index = si;
+                sfi.link = link[0];
+                // Ignore negative solutions - except overstep limit
+                if (sfi.path < track.overstep_tolerance)
+                {
+                    continue;
+                }
+                // Accept if inside, but not if the same object is excluded
+                if (sfi.status == e_inside and (not on_object or std::abs(sfi.path) > navigation.on_surface_tolerance))
+                {
+                    navigation.status = kSurfaceType ? e_towards_surface : e_towards_portal;
+                    kernel.candidates.push_back(sfi);
+>>>>>>> ff4fb14 (Use same links type in surface and portal masks: surface links reference back to current volume)
                 }
             }
             // Portals are present
@@ -368,6 +450,7 @@ struct navigator {
             return true;
         }
 
+<<<<<<< HEAD
         // Get the type of the kernel via a const expression at compile time
         constexpr bool kSurfaceType =
             (std::is_same_v<kernel_t, navigation_kernel<surface, intersection,
@@ -399,6 +482,46 @@ struct navigator {
                         ++kernel.next;
                         // Trust level is high
                         navigation.trust_level = e_high_trust;
+=======
+            // Get the type of the kernel via a const expression at compile time
+            constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, volume_link>>);
+
+            const auto &transforms = detector.transforms(trf_range, track.ctx);
+            const auto &surfaces = detector.template surfaces<kSurfaceType>();
+            const auto &masks = detector.template masks<kSurfaceType>();
+
+            // Update current candidate, or step further
+            // - do this only when you trust level is high
+            if (navigation.trust_level >= e_high_trust and kernel.next != kernel.candidates.end())
+            {
+                // Only update the last intersection
+                dindex si = kernel.next->index;
+                const auto &s = surfaces[si];
+                auto [sfi, link] = intersect(track, s, transforms, masks);
+                sfi.index = si;
+                sfi.link = link[0];
+                if (sfi.status == e_inside)
+                {
+                    // Update the intersection with a new one
+                    (*kernel.next) = sfi;
+                    navigation.distance_to_next = sfi.path;
+                    if (std::abs(sfi.path) < navigation.on_surface_tolerance)
+                    {
+                        navigation.status = kSurfaceType ? e_on_surface : e_on_portal;
+                        navigation.current_index = si;
+                        if (navigation.status != e_on_portal)
+                        {
+                            ++kernel.next;
+                            // Trust level is high
+                            navigation.trust_level = e_high_trust;
+                        }
+                    }
+                    else
+                    {
+                        navigation.status = kSurfaceType ? e_towards_surface : e_towards_portal;
+                        // Trust fully again
+                        navigation.trust_level = e_full_trust;
+>>>>>>> ff4fb14 (Use same links type in surface and portal masks: surface links reference back to current volume)
                     }
                 } else {
                     navigation.status =
@@ -415,6 +538,7 @@ struct navigator {
                 return true;
             }
         }
+<<<<<<< HEAD
         // Loop over all candidates and intersect again all candidates
         // - do this when your trust level is low
         else if (navigation.trust_level == e_fair_trust) {
@@ -429,6 +553,34 @@ struct navigator {
             sort_and_set(navigation, kernel);
             if (navigation.trust_level == e_high_trust) {
                 return true;
+=======
+
+        /** Helper method to sort within the kernel 
+         *
+         * @param navigation is the state for setting the distance to next
+         * @param kernel is the kernel which should be updated
+         */
+        template <typename kernel_t>
+        void sort_and_set(state &navigation, kernel_t &kernel) const
+        {
+            // Get the type of the kernel via a const expression at compile time
+            constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, volume_link>>);
+
+            // Sort and set distance to next & navigation status
+            if (not kernel.candidates.empty())
+            {
+                navigation.trust_level = e_full_trust;
+                std::sort(kernel.candidates.begin(), kernel.candidates.end());
+                kernel.next = kernel.candidates.begin();
+                navigation.distance_to_next = kernel.next->path;
+                if (navigation.distance_to_next < navigation.on_surface_tolerance)
+                {
+                    navigation.status = kSurfaceType ? e_on_surface : e_on_portal;
+                    navigation.current_index = kernel.next->index;
+                }
+                navigation.current_index = dindex_invalid;
+                navigation.status = kSurfaceType ? e_towards_surface : e_towards_portal;
+>>>>>>> ff4fb14 (Use same links type in surface and portal masks: surface links reference back to current volume)
             }
         }
         // This kernel is exhausted

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -310,8 +310,8 @@ namespace detray
             }
             kernel.candidates.reserve(n_objects);
             const auto &transforms = detector.transforms(trf_range, track.ctx);
-            const auto &surfaces = detector.template surfaces<kSurfaceType>();
-            const auto &masks = detector.template masks<kSurfaceType>();
+            const auto &surfaces = detector.surfaces();
+            const auto &masks = detector.masks();
             // Loop over all indexed surfaces, intersect and fill
             // @todo - will come from the local object finder
             for (auto si : sequence(obj_range))
@@ -366,8 +366,8 @@ namespace detray
             constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, volume_link>>);
 
             const auto &transforms = detector.transforms(trf_range, track.ctx);
-            const auto &surfaces = detector.template surfaces<kSurfaceType>();
-            const auto &masks = detector.template masks<kSurfaceType>();
+            const auto &surfaces = detector.surfaces();
+            const auto &masks = detector.masks();
 
             // Update current candidate, or step further
             // - do this only when you trust level is high

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -1,501 +1,502 @@
 /** Detray library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2021 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-#include "core/intersection.hpp"
-#include "core/track.hpp"
-#include "utils/indexing.hpp"
-#include "utils/enumerate.hpp"
-#include "tools/intersection_kernel.hpp"
-
 #include <algorithm>
 
-namespace detray
-{
+#include "core/intersection.hpp"
+#include "core/track.hpp"
+#include "tools/intersection_kernel.hpp"
+#include "utils/enumerate.hpp"
+#include "utils/indexing.hpp"
 
-    /** A void inpector that does nothing.
-     * 
-     * Inspectors can be plugged in to understand the
-     * the current navigation state information.
-     * 
-     */
-    struct void_inspector
-    {
-        template <typename state_type>
-        void operator()(const state_type & /*ignored*/) {}
+namespace detray {
+
+/** A void inpector that does nothing.
+ *
+ * Inspectors can be plugged in to understand the
+ * the current navigation state information.
+ *
+ */
+struct void_inspector {
+    template <typename state_type>
+    void operator()(const state_type & /*ignored*/) {}
+};
+
+/** The navigator struct.
+ *
+ * It follows the Acts::Navigator sturcture of sequence of
+ * - status()
+ * - target()
+ * calls.
+ *
+ * @tparam detector_tupe is the type of the detector
+ * @tparam inspector_type is a validation inspector
+ */
+template <typename detector_type, typename inspector_type = void_inspector>
+struct navigator {
+
+    using surface = typename detector_type::surface;
+    using volume_link = typename detector_type::volume_links;
+
+    using portal = typename detector_type::surface;
+
+    using context = typename detector_type::context;
+
+    /** Navigation status flag */
+    enum navigation_status : int {
+        e_on_target = -3,
+        e_abort = -2,
+        e_unknown = -1,
+        e_towards_surface = 0,
+        e_on_surface = 1,
+        e_towards_portal = 2,
+        e_on_portal = 3,
     };
 
-    /** The navigator struct. 
-     * 
-     * It follows the Acts::Navigator sturcture of sequence of
-     * - status()
-     * - target()
-     * calls.
-     * 
-     * @tparam detector_tupe is the type of the detector
-     * @tparam inspector_type is a validation inspector 
+    /** Navigation trust level */
+    enum navigation_trust_level : int {
+        e_no_trust = 0,    // re-evalute the candidates all over
+        e_fair_trust = 1,  // re-evaluate the distance & order of the
+                           // (preselected) candidates
+        e_high_trust = 3,  // re-evaluate the distance to the next candidate
+        e_full_trust = 4   // trust fully: distance & next candidate
+    };
+
+    /** A nested navigation kernel struct which can be used for surfaces,
+     *portals, volumes a like.
+     *
+     * @tparam object_type the type of the relevant object
+     * @tparam candidate_type the type of the candidates in the list
+     * @tparam links_type the type of the links the candidate is holding
+     *
+     **/
+    template <typename object_type, typename candidate_type,
+              typename links_type,
+              template <typename> class vector_type = dvector>
+    struct navigation_kernel {
+        const object_type *on = nullptr;
+        vector_type<candidate_type> candidates = {};
+        typename vector_type<candidate_type>::iterator next = candidates.end();
+        links_type links;
+
+        /** Indicate that the kernel is empty */
+        bool empty() const { return candidates.empty(); }
+
+        /** Forward the kernel size */
+        size_t size() const { return candidates.size(); }
+
+        /** Clear the kernel */
+        void clear() {
+            candidates.clear();
+            next = candidates.end();
+            links = links_type{};
+            on = nullptr;
+        }
+    };
+
+    /** A navigation state object used to cache the information of the
+     * current navigation stream.
+     *
+     * It requires to have a scalar represenation to be used for a stepper
+     **/
+    struct state {
+        /** Kernel for the surfaces */
+        navigation_kernel<surface, intersection, volume_link> surface_kernel;
+        /** Kernel for the portals */
+        navigation_kernel<portal, intersection, volume_link> portal_kernel;
+
+        /** Volume navigation: index */
+        dindex volume_index = dindex_invalid;
+
+        /**  Distance to next - will be casted into a scalar with call operator
+         */
+        scalar distance_to_next = std::numeric_limits<scalar>::infinity();
+        /** The on surface tolerance - permille */
+        scalar on_surface_tolerance = 1e-3;
+
+        /** The inspector type of this navigation engine */
+        inspector_type inspector;
+
+        /**  The navigation status */
+        navigation_status status = e_unknown;
+
+        /** If a surface / portal is reached */
+        dindex current_index = dindex_invalid;
+
+        /** The navigation trust level */
+        navigation_trust_level trust_level = e_no_trust;
+
+        /** Scalar representation of the navigation state,
+         * @returns distance to next
+         **/
+        scalar operator()() const { return distance_to_next; }
+    };
+
+    __plugin::cartesian2 cart2;
+    __plugin::polar2 pol2;
+    __plugin::cylindrical2 cyl2;
+
+    /// The detector in which we are moving
+    detector_type detector;
+
+    /** Constructor with move constructor
+     *
+     * @param d the detector for this navigator
      */
-    template <typename detector_type, typename inspector_type = void_inspector>
-    struct navigator
-    {
+    navigator(detector_type &&d) : detector(std::move(d)) {}
 
-        using surface = typename detector_type::surface;
-        using volume_link = typename detector_type::volume_links;
+    /** Navigation status() call which established the current navigation
+     *information.
+     *
+     * @param navigation [in, out] is the navigation cache object
+     * @param track [in] is the track infromation
+     *
+     * @return a heartbeat to indicate if the navigation is still alive
+     **/
+    bool status(state &navigation, const track<context> &track) const {
 
-        using portal = typename detector_type::surface;
+        bool heartbeat = true;
 
-        using context = typename detector_type::context;
+        // Retrieve the volume & set index
+        // Retrieve the volume, either from valid index or through global search
+        const auto &volume =
+            (navigation.volume_index != dindex_invalid)
+                ? detector.indexed_volume(navigation.volume_index)
+                : detector.indexed_volume(track.pos);
+        navigation.volume_index = volume.index();
+        // Retrieve the kernels
+        auto &surface_kernel = navigation.surface_kernel;
+        auto &portal_kernel = navigation.portal_kernel;
 
-        /** Navigation status flag */
-        enum navigation_status : int
-        {
-            e_on_target = -3,
-            e_abort = -2,
-            e_unknown = -1,
-            e_towards_surface = 0,
-            e_on_surface = 1,
-            e_towards_portal = 2,
-            e_on_portal = 3,
-        };
-
-        /** Navigation trust level */
-        enum navigation_trust_level : int
-        {
-            e_no_trust = 0,   // re-evalute the candidates all over
-            e_fair_trust = 1, // re-evaluate the distance & order of the (preselected) candidates
-            e_high_trust = 3, // re-evaluate the distance to the next candidate
-            e_full_trust = 4  // trust fully: distance & next candidate
-        };
-
-        /** A nested navigation kernel struct which can be used for surfaces, portals,
-         *  volumes a like.
-         *  
-         * @tparam object_type the type of the relevant object
-         * @tparam candidate_type the type of the candidates in the list
-         * @tparam links_type the type of the links the candidate is holding
-         * 
-         **/
-        template <typename object_type,
-                  typename candidate_type,
-                  typename links_type,
-                  template <typename> class vector_type = dvector>
-        struct navigation_kernel
-        {
-            const object_type *on = nullptr;
-            vector_type<candidate_type> candidates = {};
-            typename vector_type<candidate_type>::iterator next = candidates.end();
-            links_type links;
-
-            /** Indicate that the kernel is empty */
-            bool empty() const { return candidates.empty(); }
-
-            /** Forward the kernel size */
-            size_t size() const { return candidates.size(); }
-
-            /** Clear the kernel */
-            void clear()
-            {
-                candidates.clear();
-                next = candidates.end();
-                links = links_type{};
-                on = nullptr;
+        // The navigation is not yet initialized, or you lost trust in it
+        if (navigation.volume_index == dindex_invalid or
+            navigation.trust_level == e_no_trust) {
+            // First try to get the surface candidates
+            initialize_kernel(
+                navigation, surface_kernel, track,
+                volume.template range<detector_type::e_surface>(),
+                volume.template trf_range<detector_type::e_surface>());
+            // If no surfaces are to processed, initialize the portals
+            if (surface_kernel.empty()) {
+                initialize_kernel(
+                    navigation, portal_kernel, track,
+                    volume.template range<detector_type::e_portal>(),
+                    volume.template trf_range<detector_type::e_portal>());
+                heartbeat = check_volume_switch(navigation);
             }
-        };
-
-        /** A navigation state object used to cache the information of the
-         * current navigation stream.
-         * 
-         * It requires to have a scalar represenation to be used for a stepper
-         **/
-        struct state
-        {
-            /** Kernel for the surfaces */
-            navigation_kernel<surface, intersection, volume_link> surface_kernel;
-            /** Kernel for the portals */
-            navigation_kernel<portal, intersection, volume_link> portal_kernel;
-
-            /** Volume navigation: index */
-            dindex volume_index = dindex_invalid;
-
-            /**  Distance to next - will be casted into a scalar with call operator  */
-            scalar distance_to_next = std::numeric_limits<scalar>::infinity();
-            /** The on surface tolerance - permille */
-            scalar on_surface_tolerance = 1e-3;
-
-            /** The inspector type of this navigation engine */
-            inspector_type inspector;
-
-            /**  The navigation status */
-            navigation_status status = e_unknown;
-
-            /** If a surface / portal is reached */
-            dindex current_index = dindex_invalid;
-
-            /** The navigation trust level */
-            navigation_trust_level trust_level = e_no_trust;
-
-            /** Scalar representation of the navigation state,
-             * @returns distance to next
-             **/
-            scalar operator()() const
-            {
-                return distance_to_next;
-            }
-        };
-
-        __plugin::cartesian2 cart2;
-        __plugin::polar2 pol2;
-        __plugin::cylindrical2 cyl2;
-
-        /// The detector in which we are moving
-        detector_type detector;
-
-        /** Constructor with move constructor
-         * 
-         * @param d the detector for this navigator
-         */
-        navigator(detector_type &&d) : detector(std::move(d)) {}
-
-        /** Navigation status() call which established the current navigation information.
-         * 
-         * @param navigation [in, out] is the navigation cache object
-         * @param track [in] is the track infromation
-         * 
-         * @return a heartbeat to indicate if the navigation is still alive
-         **/
-        bool status(state &navigation, const track<context> &track) const
-        {
-
-            bool heartbeat = true;
-
-            // Retrieve the volume & set index
-            // Retrieve the volume, either from valid index or through global search
-            const auto &volume = (navigation.volume_index != dindex_invalid) ? detector.indexed_volume(navigation.volume_index)
-                                                                             : detector.indexed_volume(track.pos);
-            navigation.volume_index = volume.index();
-            // Retrieve the kernels
-            auto &surface_kernel = navigation.surface_kernel;
-            auto &portal_kernel = navigation.portal_kernel;
-
-            // The navigation is not yet initialized, or you lost trust in it
-            if (navigation.volume_index == dindex_invalid or navigation.trust_level == e_no_trust)
-            {
-                // First try to get the surface candidates
-                initialize_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>());
-                // If no surfaces are to processed, initialize the portals
-                if (surface_kernel.empty())
-                {
-                    initialize_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
-                    heartbeat = check_volume_switch(navigation);
-                }
-                // Before returning, run through the inspector
-                navigation.inspector(navigation);
-                return heartbeat;
-            }
-
-            // Update the surface kernel
-            if (not is_exhausted(surface_kernel) and update_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>()))
-            {
-                navigation.inspector(navigation);
-                return heartbeat;
-            }
-
-            // Update the portal kernel
-            update_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
-            heartbeat = check_volume_switch(navigation);
+            // Before returning, run through the inspector
             navigation.inspector(navigation);
             return heartbeat;
         }
 
-        /** Target function of the navigator, finds the next candidates 
-         *   and set the distance to next
-         * 
-         * @param navigation is the navigation cache
-         * @param track is the current track information
-         * 
-         * @return a heartbeat to indicate if the navigation is still alive
-         **/
-        bool target(state &navigation, const track<context> &track) const
-        {
-            bool heartbeat = true;
-
-            // Full trust level from target() call
-            if (navigation.trust_level == e_full_trust)
-            {
-                return heartbeat;
-            }
-
-            // Retrieve the volume, either from valid index or through global search
-            const auto &volume = (navigation.volume_index != dindex_invalid) ? detector.indexed_volume(navigation.volume_index)
-                                                                             : detector.indexed_volume(track.pos);
-            navigation.volume_index = volume.index();
-            // Retrieve the kernels
-            auto &surface_kernel = navigation.surface_kernel;
-            auto &portal_kernel = navigation.portal_kernel;
-            // High targetting level
-            if (navigation.trust_level == e_high_trust)
-            {
-                // Surfaces are/were present
-                if (not surface_kernel.empty())
-                {
-                    if (is_exhausted(surface_kernel))
-                    {
-                        // Clear the surface kernel
-                        surface_kernel.clear();
-                        navigation.trust_level = e_no_trust;
-                        update_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
-                        navigation.inspector(navigation);
-                        return heartbeat;
-                    }
-                    else if (update_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>()))
-                    {
-                        navigation.inspector(navigation);
-                        return heartbeat;
-                    }
-                }
-                // Portals are present
-                update_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>());
-            }
-            else if (navigation.trust_level == e_no_trust)
-            {
-                // First try to get the surface candidates
-                initialize_kernel(navigation, surface_kernel, track, volume.template range<detector_type::e_surface>(), volume.template trf_range<detector_type::e_surface>());
-                // If no surfaces are to processed, initialize the portals
-                if (surface_kernel.empty())
-                {
-                    initialize_kernel(navigation, portal_kernel, track, volume.template range<detector_type::e_portal>(), volume.template trf_range<detector_type::e_portal>(), navigation.status == e_on_portal);
-                    heartbeat = check_volume_switch(navigation);
-                }
-            }
+        // Update the surface kernel
+        if (not is_exhausted(surface_kernel) and
+            update_kernel(
+                navigation, surface_kernel, track,
+                volume.template range<detector_type::e_surface>(),
+                volume.template trf_range<detector_type::e_surface>())) {
             navigation.inspector(navigation);
             return heartbeat;
         }
 
-        /** Helper method to intersect all objects of a surface/portal store
-         * 
-         * @tparam kernel_t the type of the kernel: surfaces/portals
-         * @tparam range the type of range in the detector data containers
-         * 
-         * @param navigation is the navigation cache object
-         * @param kernel [in,out] the kernel to be checked/initialized 
-         * @param track the track information
-         * @param obj_range the surface/portal index range in the detector cont
-         * @param trf_range the transform index range in the detector cont
-         * @param on_object ignores on surface solution
-         * 
-         */
-        template <typename kernel_t, typename range_t>
-        void initialize_kernel(state &navigation,
-                               kernel_t &kernel,
-                               const track<context> &track,
-                               const range_t &obj_range,
-                               const range_t &trf_range,
-                               bool on_object = false) const
-        {
+        // Update the portal kernel
+        update_kernel(navigation, portal_kernel, track,
+                      volume.template range<detector_type::e_portal>(),
+                      volume.template trf_range<detector_type::e_portal>());
+        heartbeat = check_volume_switch(navigation);
+        navigation.inspector(navigation);
+        return heartbeat;
+    }
 
-            // Get the type of the kernel via a const expression at compile time
-            constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, volume_link>>);
+    /** Target function of the navigator, finds the next candidates
+     *   and set the distance to next
+     *
+     * @param navigation is the navigation cache
+     * @param track is the current track information
+     *
+     * @return a heartbeat to indicate if the navigation is still alive
+     **/
+    bool target(state &navigation, const track<context> &track) const {
+        bool heartbeat = true;
 
-            // Get the number of candidates & run them throuth the kernel
-            size_t n_objects = obj_range[1] - obj_range[0];
-            // Return if you have no objects
-            if (n_objects == 0)
-            {
-                return;
-            }
-            kernel.candidates.reserve(n_objects);
-            const auto &transforms = detector.transforms(trf_range, track.ctx);
-            const auto &surfaces = detector.surfaces();
-            const auto &masks = detector.masks();
-            // Loop over all indexed surfaces, intersect and fill
-            // @todo - will come from the local object finder
-            for (auto si : sequence(obj_range))
-            {
-                const auto &object = surfaces[si];
-                auto [sfi, link] = intersect(track, object, transforms, masks);
-                sfi.index = si;
-                sfi.link = link[0];
-                // Ignore negative solutions - except overstep limit
-                if (sfi.path < track.overstep_tolerance)
-                {
-                    continue;
-                }
-                // Accept if inside, but not if the same object is excluded
-                if (sfi.status == e_inside and (not on_object or std::abs(sfi.path) > navigation.on_surface_tolerance))
-                {
-                    navigation.status = kSurfaceType ? e_towards_surface : e_towards_portal;
-                    kernel.candidates.push_back(sfi);
-                }
-            }
-            sort_and_set(navigation, kernel);
+        // Full trust level from target() call
+        if (navigation.trust_level == e_full_trust) {
+            return heartbeat;
         }
 
-        /** Helper method to the update the next candidate intersection 
-         * 
-         * @tparam kernel_t the type of the kernel: surfaces/portals
-         * @tparam range the type of range in the detector data containers
-         * 
-         * @param navigation [in, out] the navigation state
-         * @param kernel [in,out] the kernel to be checked/initialized 
-         * @param track the track information
-         * @param obj_range the surface/portal index range in the detector cont
-         * @param trf_range the transform index range in the detector cont
-         * 
-         * @return A boolean condition 
-         */
-        template <typename kernel_t, typename range_t>
-        bool update_kernel(state &navigation,
-                           kernel_t &kernel,
+        // Retrieve the volume, either from valid index or through global search
+        const auto &volume =
+            (navigation.volume_index != dindex_invalid)
+                ? detector.indexed_volume(navigation.volume_index)
+                : detector.indexed_volume(track.pos);
+        navigation.volume_index = volume.index();
+        // Retrieve the kernels
+        auto &surface_kernel = navigation.surface_kernel;
+        auto &portal_kernel = navigation.portal_kernel;
+        // High targetting level
+        if (navigation.trust_level == e_high_trust) {
+            // Surfaces are/were present
+            if (not surface_kernel.empty()) {
+                if (is_exhausted(surface_kernel)) {
+                    // Clear the surface kernel
+                    surface_kernel.clear();
+                    navigation.trust_level = e_no_trust;
+                    update_kernel(
+                        navigation, portal_kernel, track,
+                        volume.template range<detector_type::e_portal>(),
+                        volume.template trf_range<detector_type::e_portal>());
+                    navigation.inspector(navigation);
+                    return heartbeat;
+                } else if (update_kernel(
+                               navigation, surface_kernel, track,
+                               volume
+                                   .template range<detector_type::e_surface>(),
+                               volume.template trf_range<
+                                   detector_type::e_surface>())) {
+                    navigation.inspector(navigation);
+                    return heartbeat;
+                }
+            }
+            // Portals are present
+            update_kernel(navigation, portal_kernel, track,
+                          volume.template range<detector_type::e_portal>(),
+                          volume.template trf_range<detector_type::e_portal>());
+        } else if (navigation.trust_level == e_no_trust) {
+            // First try to get the surface candidates
+            initialize_kernel(
+                navigation, surface_kernel, track,
+                volume.template range<detector_type::e_surface>(),
+                volume.template trf_range<detector_type::e_surface>());
+            // If no surfaces are to processed, initialize the portals
+            if (surface_kernel.empty()) {
+                initialize_kernel(
+                    navigation, portal_kernel, track,
+                    volume.template range<detector_type::e_portal>(),
+                    volume.template trf_range<detector_type::e_portal>(),
+                    navigation.status == e_on_portal);
+                heartbeat = check_volume_switch(navigation);
+            }
+        }
+        navigation.inspector(navigation);
+        return heartbeat;
+    }
+
+    /** Helper method to intersect all objects of a surface/portal store
+     *
+     * @tparam kernel_t the type of the kernel: surfaces/portals
+     * @tparam range the type of range in the detector data containers
+     *
+     * @param navigation is the navigation cache object
+     * @param kernel [in,out] the kernel to be checked/initialized
+     * @param track the track information
+     * @param obj_range the surface/portal index range in the detector cont
+     * @param trf_range the transform index range in the detector cont
+     * @param on_object ignores on surface solution
+     *
+     */
+    template <typename kernel_t, typename range_t>
+    void initialize_kernel(state &navigation, kernel_t &kernel,
                            const track<context> &track,
-                           const range_t &obj_range,
-                           const range_t &trf_range) const
-        {
-            // If the kernel is empty - intitalize it
-            if (kernel.empty())
-            {
-                initialize_kernel(navigation, kernel, track, obj_range, trf_range);
+                           const range_t &obj_range, const range_t &trf_range,
+                           bool on_object = false) const {
+
+        // Get the type of the kernel via a const expression at compile time
+        constexpr bool kSurfaceType =
+            (std::is_same_v<kernel_t, navigation_kernel<surface, intersection,
+                                                        volume_link>>);
+
+        // Get the number of candidates & run them throuth the kernel
+        size_t n_objects = obj_range[1] - obj_range[0];
+        // Return if you have no objects
+        if (n_objects == 0) {
+            return;
+        }
+        kernel.candidates.reserve(n_objects);
+        const auto &transforms = detector.transforms(trf_range, track.ctx);
+        const auto &surfaces = detector.surfaces();
+        const auto &masks = detector.masks();
+        // Loop over all indexed surfaces, intersect and fill
+        // @todo - will come from the local object finder
+        for (auto si : sequence(obj_range)) {
+            const auto &object = surfaces[si];
+            auto [sfi, link] = intersect(track, object, transforms, masks);
+            sfi.index = si;
+            sfi.link = link[0];
+            // Ignore negative solutions - except overstep limit
+            if (sfi.path < track.overstep_tolerance) {
+                continue;
+            }
+            // Accept if inside, but not if the same object is excluded
+            if (sfi.status == e_inside and
+                (not on_object or
+                 std::abs(sfi.path) > navigation.on_surface_tolerance)) {
+                navigation.status =
+                    kSurfaceType ? e_towards_surface : e_towards_portal;
+                kernel.candidates.push_back(sfi);
+            }
+        }
+        sort_and_set(navigation, kernel);
+    }
+
+    /** Helper method to the update the next candidate intersection
+     *
+     * @tparam kernel_t the type of the kernel: surfaces/portals
+     * @tparam range the type of range in the detector data containers
+     *
+     * @param navigation [in, out] the navigation state
+     * @param kernel [in,out] the kernel to be checked/initialized
+     * @param track the track information
+     * @param obj_range the surface/portal index range in the detector cont
+     * @param trf_range the transform index range in the detector cont
+     *
+     * @return A boolean condition
+     */
+    template <typename kernel_t, typename range_t>
+    bool update_kernel(state &navigation, kernel_t &kernel,
+                       const track<context> &track, const range_t &obj_range,
+                       const range_t &trf_range) const {
+        // If the kernel is empty - intitalize it
+        if (kernel.empty()) {
+            initialize_kernel(navigation, kernel, track, obj_range, trf_range);
+            return true;
+        }
+
+        // Get the type of the kernel via a const expression at compile time
+        constexpr bool kSurfaceType =
+            (std::is_same_v<kernel_t, navigation_kernel<surface, intersection,
+                                                        volume_link>>);
+
+        const auto &transforms = detector.transforms(trf_range, track.ctx);
+        const auto &surfaces = detector.surfaces();
+        const auto &masks = detector.masks();
+
+        // Update current candidate, or step further
+        // - do this only when you trust level is high
+        if (navigation.trust_level >= e_high_trust and
+            kernel.next != kernel.candidates.end()) {
+            // Only update the last intersection
+            dindex si = kernel.next->index;
+            const auto &s = surfaces[si];
+            auto [sfi, link] = intersect(track, s, transforms, masks);
+            sfi.index = si;
+            sfi.link = link[0];
+            if (sfi.status == e_inside) {
+                // Update the intersection with a new one
+                (*kernel.next) = sfi;
+                navigation.distance_to_next = sfi.path;
+                if (std::abs(sfi.path) < navigation.on_surface_tolerance) {
+                    navigation.status =
+                        kSurfaceType ? e_on_surface : e_on_portal;
+                    navigation.current_index = si;
+                    if (navigation.status != e_on_portal) {
+                        ++kernel.next;
+                        // Trust level is high
+                        navigation.trust_level = e_high_trust;
+                    }
+                } else {
+                    navigation.status =
+                        kSurfaceType ? e_towards_surface : e_towards_portal;
+                    // Trust fully again
+                    navigation.trust_level = e_full_trust;
+                }
                 return true;
             }
-
-            // Get the type of the kernel via a const expression at compile time
-            constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, volume_link>>);
-
-            const auto &transforms = detector.transforms(trf_range, track.ctx);
-            const auto &surfaces = detector.surfaces();
-            const auto &masks = detector.masks();
-
-            // Update current candidate, or step further
-            // - do this only when you trust level is high
-            if (navigation.trust_level >= e_high_trust and kernel.next != kernel.candidates.end())
-            {
-                // Only update the last intersection
-                dindex si = kernel.next->index;
+            // If not successful: increase and switch to next
+            ++kernel.next;
+            if (update_kernel(navigation, kernel, track, obj_range,
+                              trf_range)) {
+                return true;
+            }
+        }
+        // Loop over all candidates and intersect again all candidates
+        // - do this when your trust level is low
+        else if (navigation.trust_level == e_fair_trust) {
+            for (auto &c : kernel.candidates) {
+                dindex si = c.index;
                 const auto &s = surfaces[si];
                 auto [sfi, link] = intersect(track, s, transforms, masks);
-                sfi.index = si;
-                sfi.link = link[0];
-                if (sfi.status == e_inside)
-                {
-                    // Update the intersection with a new one
-                    (*kernel.next) = sfi;
-                    navigation.distance_to_next = sfi.path;
-                    if (std::abs(sfi.path) < navigation.on_surface_tolerance)
-                    {
-                        navigation.status = kSurfaceType ? e_on_surface : e_on_portal;
-                        navigation.current_index = si;
-                        if (navigation.status != e_on_portal)
-                        {
-                            ++kernel.next;
-                            // Trust level is high
-                            navigation.trust_level = e_high_trust;
-                        }
-                    }
-                    else
-                    {
-                        navigation.status = kSurfaceType ? e_towards_surface : e_towards_portal;
-                        // Trust fully again
-                        navigation.trust_level = e_full_trust;
-                    }
-                    return true;
-                }
-                // If not successful: increase and switch to next
-                ++kernel.next;
-                if (update_kernel(navigation, kernel, track, obj_range, trf_range))
-                {
-                    return true;
-                }
+                c = sfi;
+                c.index = si;
+                c.link = link[0];
             }
-            // Loop over all candidates and intersect again all candidates
-            // - do this when your trust level is low
-            else if (navigation.trust_level == e_fair_trust)
-            {
-                for (auto &c : kernel.candidates)
-                {
-                    dindex si = c.index;
-                    const auto &s = surfaces[si];
-                    auto [sfi, link] = intersect(track, s, transforms, masks);
-                    c = sfi;
-                    c.index = si;
-                    c.link = link[0];
-                }
-                sort_and_set(navigation, kernel);
-                if (navigation.trust_level == e_high_trust)
-                {
-                    return true;
-                }
+            sort_and_set(navigation, kernel);
+            if (navigation.trust_level == e_high_trust) {
+                return true;
             }
-            // This kernel is exhausted
-            kernel.next = kernel.candidates.end();
+        }
+        // This kernel is exhausted
+        kernel.next = kernel.candidates.end();
+        navigation.trust_level = e_no_trust;
+        return false;
+    }
+
+    /** Helper method to sort within the kernel
+     *
+     * @param navigation is the state for setting the distance to next
+     * @param kernel is the kernel which should be updated
+     */
+    template <typename kernel_t>
+    void sort_and_set(state &navigation, kernel_t &kernel) const {
+        // Get the type of the kernel via a const expression at compile time
+        constexpr bool kSurfaceType =
+            (std::is_same_v<kernel_t, navigation_kernel<surface, intersection,
+                                                        volume_link>>);
+
+        // Sort and set distance to next & navigation status
+        if (not kernel.candidates.empty()) {
+            navigation.trust_level = e_full_trust;
+            std::sort(kernel.candidates.begin(), kernel.candidates.end());
+            kernel.next = kernel.candidates.begin();
+            navigation.distance_to_next = kernel.next->path;
+            if (navigation.distance_to_next < navigation.on_surface_tolerance) {
+                navigation.status = kSurfaceType ? e_on_surface : e_on_portal;
+                navigation.current_index = kernel.next->index;
+            }
+            navigation.current_index = dindex_invalid;
+            navigation.status =
+                kSurfaceType ? e_towards_surface : e_towards_portal;
+        }
+    }
+
+    /** Helper method to check and perform a volume switch
+     *
+     * @param navigation is the navigation state
+     *
+     * @return a flag if the volume navigation is still heartbeat
+     */
+    bool check_volume_switch(state &navigation) const {
+        // On a portal: switch volume index and (re-)initialize
+        if (navigation.status == e_on_portal) {
+            // Set volume index to the next volume provided by the portal, avoid
+            // setting to same
+            navigation.volume_index =
+                (navigation.portal_kernel.next->link != navigation.volume_index)
+                    ? navigation.portal_kernel.next->link
+                    : dindex_invalid;
+            navigation.surface_kernel.clear();
+            navigation.portal_kernel.clear();
             navigation.trust_level = e_no_trust;
-            return false;
         }
+        return (navigation.volume_index != dindex_invalid);
+    }
 
-        /** Helper method to sort within the kernel 
-         *
-         * @param navigation is the state for setting the distance to next
-         * @param kernel is the kernel which should be updated
-         */
-        template <typename kernel_t>
-        void sort_and_set(state &navigation, kernel_t &kernel) const
-        {
-            // Get the type of the kernel via a const expression at compile time
-            constexpr bool kSurfaceType = (std::is_same_v<kernel_t, navigation_kernel<surface, intersection, volume_link>>);
+    /** Helper method to check if a kernel is exhaused
+     *
+     * @tparam kernel_t the type of the kernel
+     * @param kernel the kernel to be checked
+     *
+     * @return true if the kernel is exhaused
+     */
+    template <typename kernel_t>
+    bool is_exhausted(const kernel_t &kernel) const {
+        return (kernel.next == kernel.candidates.end());
+    }
+};
 
-            // Sort and set distance to next & navigation status
-            if (not kernel.candidates.empty())
-            {
-                navigation.trust_level = e_full_trust;
-                std::sort(kernel.candidates.begin(), kernel.candidates.end());
-                kernel.next = kernel.candidates.begin();
-                navigation.distance_to_next = kernel.next->path;
-                if (navigation.distance_to_next < navigation.on_surface_tolerance)
-                {
-                    navigation.status = kSurfaceType ? e_on_surface : e_on_portal;
-                    navigation.current_index = kernel.next->index;
-                }
-                navigation.current_index = dindex_invalid;
-                navigation.status = kSurfaceType ? e_towards_surface : e_towards_portal;
-            }
-        }
-
-        /** Helper method to check and perform a volume switch
-         *
-         * @param navigation is the navigation state 
-         * 
-         * @return a flag if the volume navigation is still heartbeat
-         */
-        bool check_volume_switch(state &navigation) const
-        {
-            // On a portal: switch volume index and (re-)initialize
-            if (navigation.status == e_on_portal)
-            {
-                // Set volume index to the next volume provided by the portal, avoid setting to same
-                navigation.volume_index =
-                    (navigation.portal_kernel.next->link != navigation.volume_index) ? navigation.portal_kernel.next->link : dindex_invalid;
-                navigation.surface_kernel.clear();
-                navigation.portal_kernel.clear();
-                navigation.trust_level = e_no_trust;
-            }
-            return (navigation.volume_index != dindex_invalid);
-        }
-
-        /** Helper method to check if a kernel is exhaused 
-         * 
-         * @tparam kernel_t the type of the kernel
-         * @param kernel the kernel to be checked
-         * 
-         * @return true if the kernel is exhaused 
-         */
-        template <typename kernel_t>
-        bool is_exhausted(const kernel_t &kernel) const
-        {
-            return (kernel.next == kernel.candidates.end());
-        }
-    };
-
-} // namespace detray
+}  // namespace detray

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -366,7 +366,7 @@ namespace detray
         bounds.push_back(io_surface.bound_param6);
 
         // Acts naming convention for bounds
-        typename typed_detector::surface_mask_index mask_index = {dindex_invalid, dindex_invalid};
+        typename typed_detector::mask_index mask_index = {dindex_invalid, dindex_invalid};
         // A surface mask points back to the current volume
         typename typed_detector::volume_links volume_links = {c_volume->index(), c_volume->index()};
 

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -1,66 +1,64 @@
 /** Detray library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2021 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-#include "core/detector.hpp"
-#include "core/volume_connector.hpp"
-#include "grids/axis.hpp"
-#include "grids/grid2.hpp"
-#include "grids/serializer2.hpp"
-#include "grids/populator.hpp"
-#include "io/csv_io_types.hpp"
-#include "tools/bin_association.hpp"
-
 #include <climits>
 #include <map>
 #include <vector>
 
-namespace detray
-{
+#include "core/detector.hpp"
+#include "core/volume_connector.hpp"
+#include "grids/axis.hpp"
+#include "grids/grid2.hpp"
+#include "grids/populator.hpp"
+#include "grids/serializer2.hpp"
+#include "io/csv_io_types.hpp"
+#include "tools/bin_association.hpp"
 
-  /// Function to read the detector from the CSV file
-  ///
-  /// @tparam array_type is the type of the array used for the detector class
-  /// @tparam tuple_type is the type of the tuple used for the detector class
-  /// @tparam vector_type is the type of the tuple used for the detector class
-  ///
-  /// All other container types are STL containers, as they do not leave the function
-  ///
-  /// @param detector_name is the name of the detector
-  /// @param surface_file_name is the name of the detector surface file
-  /// @param grid_file_name is the name of the surface grid file
-  /// @param layer_volume_file_name is the name of the file containing layer/volume information
-  /// @param r_sync_tolerance is a tolerance to be for synching volumes in r
-  /// @param z_sync_tolerance is a toleranced to be used for synchinng volumes in z
-  ///
-  /// @return a detector object
-  template <template <typename, unsigned int> class array_type = darray,
-            template <typename...> class tuple_type = dtuple,
-            template <typename> class vector_type = dvector,
-            typename alignable_store = static_transform_store<vector_type>,
-            typename surface_source_link = dindex,
-            typename bounds_source_link = dindex>
-  detector<array_type,
-           tuple_type,
-           vector_type,
-           alignable_store,
-           surface_source_link,
-           bounds_source_link>
-  detector_from_csv(const std::string &detector_name,
-                    const std::string &surface_file_name,
-                    const std::string &layer_volume_file_name,
-                    const std::string &grid_file_name,
-                    const std::string &grid_entries_file_name,
-                    scalar r_sync_tolerance = 0.,
-                    scalar z_sync_tolerance = 0.)
-  {
+namespace detray {
 
-    using typed_detector = detector<array_type, tuple_type, vector_type, alignable_store, surface_source_link, bounds_source_link>;
+/// Function to read the detector from the CSV file
+///
+/// @tparam array_type is the type of the array used for the detector class
+/// @tparam tuple_type is the type of the tuple used for the detector class
+/// @tparam vector_type is the type of the tuple used for the detector class
+///
+/// All other container types are STL containers, as they do not leave the
+/// function
+///
+/// @param detector_name is the name of the detector
+/// @param surface_file_name is the name of the detector surface file
+/// @param grid_file_name is the name of the surface grid file
+/// @param layer_volume_file_name is the name of the file containing
+/// layer/volume information
+/// @param r_sync_tolerance is a tolerance to be for synching volumes in r
+/// @param z_sync_tolerance is a toleranced to be used for synchinng volumes in
+/// z
+///
+/// @return a detector object
+template <template <typename, unsigned int> class array_type = darray,
+          template <typename...> class tuple_type = dtuple,
+          template <typename> class vector_type = dvector,
+          typename alignable_store = static_transform_store<vector_type>,
+          typename surface_source_link = dindex,
+          typename bounds_source_link = dindex>
+detector<array_type, tuple_type, vector_type, alignable_store,
+         surface_source_link, bounds_source_link>
+detector_from_csv(const std::string &detector_name,
+                  const std::string &surface_file_name,
+                  const std::string &layer_volume_file_name,
+                  const std::string &grid_file_name,
+                  const std::string &grid_entries_file_name,
+                  scalar r_sync_tolerance = 0., scalar z_sync_tolerance = 0.) {
+
+    using typed_detector =
+        detector<array_type, tuple_type, vector_type, alignable_store,
+                 surface_source_link, bounds_source_link>;
 
     typed_detector d(detector_name);
 
@@ -98,21 +96,18 @@ namespace detray
     scalar z_max = -std::numeric_limits<scalar>::max();
 
     /** Helper method to attach volumes to bins
-     * 
+     *
      * @param attachments The attachnment map
      * @param value the (eventually new) value for insertion
      * @param volume_index the index of the attached volume
      */
-    auto attach_volume = [](std::map<scalar, std::vector<dindex>> &attachments, scalar value, dindex volume_index) -> void
-    {
-      if (attachments.find(value) == attachments.end())
-      {
-        attachments[value] = {volume_index};
-      }
-      else
-      {
-        attachments[value].push_back(volume_index);
-      }
+    auto attach_volume = [](std::map<scalar, std::vector<dindex>> &attachments,
+                            scalar value, dindex volume_index) -> void {
+        if (attachments.find(value) == attachments.end()) {
+            attachments[value] = {volume_index};
+        } else {
+            attachments[value].push_back(volume_index);
+        }
     };
 
     // (A) Pre-read the bounds values
@@ -121,52 +116,49 @@ namespace detray
     std::map<scalar, scalar> r_min_layer_volumes;
     std::map<scalar, scalar> r_max_layer_volumes;
 
-    while (lv_reader.read(io_layer_volume))
-    {
-      volume_layer_index c_index = {io_layer_volume.volume_id, io_layer_volume.layer_id};
-      array_type<scalar, 6> c_bounds = {
-          io_layer_volume.min_v0,
-          io_layer_volume.max_v0,
-          io_layer_volume.min_v1,
-          io_layer_volume.max_v1,
-          io_layer_volume.min_v2,
-          io_layer_volume.max_v2,
-      };
-      volume_bounds[c_index] = c_bounds;
+    while (lv_reader.read(io_layer_volume)) {
+        volume_layer_index c_index = {io_layer_volume.volume_id,
+                                      io_layer_volume.layer_id};
+        array_type<scalar, 6> c_bounds = {
+            io_layer_volume.min_v0, io_layer_volume.max_v0,
+            io_layer_volume.min_v1, io_layer_volume.max_v1,
+            io_layer_volume.min_v2, io_layer_volume.max_v2,
+        };
+        volume_bounds[c_index] = c_bounds;
 
-      // Register low, high volume
-      if (io_layer_volume.layer_id % 2 == 0)
-      {
-        z_min_layer_volumes[io_layer_volume.min_v1] = io_layer_volume.min_v1;
-        z_max_layer_volumes[-1. * io_layer_volume.max_v1] = io_layer_volume.max_v1;
-        r_min_layer_volumes[io_layer_volume.min_v0] = io_layer_volume.min_v0;
-        r_max_layer_volumes[-1. * io_layer_volume.max_v0] = io_layer_volume.max_v0;
-      }
+        // Register low, high volume
+        if (io_layer_volume.layer_id % 2 == 0) {
+            z_min_layer_volumes[io_layer_volume.min_v1] =
+                io_layer_volume.min_v1;
+            z_max_layer_volumes[-1. * io_layer_volume.max_v1] =
+                io_layer_volume.max_v1;
+            r_min_layer_volumes[io_layer_volume.min_v0] =
+                io_layer_volume.min_v0;
+            r_max_layer_volumes[-1. * io_layer_volume.max_v0] =
+                io_layer_volume.max_v0;
+        }
     }
-    /** Helper function to cluster boundaries 
-     * 
+    /** Helper function to cluster boundaries
+     *
      * @param boundaries is the unclustered boundaries map
      * @param tolerance is the tolerance parameter in which a cluster can lie
      * @param flip is a reverse flag for upper boundaries
-     * 
+     *
      */
-    auto cluster_boundaries = [&](std::map<scalar, scalar> &boundaries, scalar tolerance, int flip = 1) -> void
-    {
-      scalar last_ = std::numeric_limits<scalar>::max();
-      for (auto &[key, boundary] : boundaries)
-      {
-        // Do not adust the last one for max values
-        if (flip < 0 and key == boundaries.begin()->first)
-        {
-          continue;
-        }
+    auto cluster_boundaries = [&](std::map<scalar, scalar> &boundaries,
+                                  scalar tolerance, int flip = 1) -> void {
+        scalar last_ = std::numeric_limits<scalar>::max();
+        for (auto &[key, boundary] : boundaries) {
+            // Do not adust the last one for max values
+            if (flip < 0 and key == boundaries.begin()->first) {
+                continue;
+            }
 
-        if (std::abs(last_ - flip * key) < tolerance)
-        {
-          boundary = last_;
+            if (std::abs(last_ - flip * key) < tolerance) {
+                boundary = last_;
+            }
+            last_ = boundary;
         }
-        last_ = boundary;
-      }
     };
 
     // Cluster boundary synchronization
@@ -176,60 +168,54 @@ namespace detray
     cluster_boundaries(r_max_layer_volumes, 5., -1);
 
     /** Helper functions to find and replace in case
-     * 
+     *
      * @param value is the value in question
      * @param value_map is the map for the replacement value
-     * 
+     *
      **/
-    auto find_and_replace = [](scalar &value, const std::map<scalar, scalar> &value_map, int flip = 1) -> void
-    {
-      // synchronize lower bound
-      if (value_map.find(flip * value) != value_map.end())
-      {
-        value = value_map.find(flip * value)->second;
-      }
+    auto find_and_replace = [](scalar &value,
+                               const std::map<scalar, scalar> &value_map,
+                               int flip = 1) -> void {
+        // synchronize lower bound
+        if (value_map.find(flip * value) != value_map.end()) {
+            value = value_map.find(flip * value)->second;
+        }
     };
 
     /** Helper function to return syncrhonized boundary objects
-     * 
+     *
      * @param bounds the unsynchronized bounds object
-     * @param gap_volume an indicator if its a gap volume 
+     * @param gap_volume an indicator if its a gap volume
      **/
-    auto synchronize_bounds = [&](const array_type<scalar, 6> &bounds, bool gap_volume) -> array_type<scalar, 6>
-    {
-      scalar r_min = bounds[0];
-      scalar r_max = bounds[1];
-      scalar z_min = bounds[2];
-      scalar z_max = bounds[3];
-      scalar phi_min = bounds[4];
-      scalar phi_max = bounds[5];
+    auto synchronize_bounds = [&](const array_type<scalar, 6> &bounds,
+                                  bool gap_volume) -> array_type<scalar, 6> {
+        scalar r_min = bounds[0];
+        scalar r_max = bounds[1];
+        scalar z_min = bounds[2];
+        scalar z_max = bounds[3];
+        scalar phi_min = bounds[4];
+        scalar phi_max = bounds[5];
 
-      if (not gap_volume)
-      {
-        find_and_replace(r_min, r_min_layer_volumes);
-        find_and_replace(r_max, r_max_layer_volumes, -1);
-        find_and_replace(z_min, z_min_layer_volumes);
-        find_and_replace(z_max, z_max_layer_volumes, -1);
-      }
-      else
-      {
-        if (std::abs(z_max + z_min) < 0.1)
-        {
-          find_and_replace(r_min, r_max_layer_volumes, -1);
-          find_and_replace(r_max, r_min_layer_volumes);
-          find_and_replace(z_min, z_min_layer_volumes);
-          find_and_replace(z_max, z_max_layer_volumes, -1);
+        if (not gap_volume) {
+            find_and_replace(r_min, r_min_layer_volumes);
+            find_and_replace(r_max, r_max_layer_volumes, -1);
+            find_and_replace(z_min, z_min_layer_volumes);
+            find_and_replace(z_max, z_max_layer_volumes, -1);
+        } else {
+            if (std::abs(z_max + z_min) < 0.1) {
+                find_and_replace(r_min, r_max_layer_volumes, -1);
+                find_and_replace(r_max, r_min_layer_volumes);
+                find_and_replace(z_min, z_min_layer_volumes);
+                find_and_replace(z_max, z_max_layer_volumes, -1);
+            } else {
+                find_and_replace(r_min, r_min_layer_volumes);
+                find_and_replace(r_max, r_max_layer_volumes, -1);
+                find_and_replace(z_min, z_max_layer_volumes, -1);
+                find_and_replace(z_max, z_min_layer_volumes);
+            }
         }
-        else
-        {
-          find_and_replace(r_min, r_min_layer_volumes);
-          find_and_replace(r_max, r_max_layer_volumes, -1);
-          find_and_replace(z_min, z_max_layer_volumes, -1);
-          find_and_replace(z_max, z_min_layer_volumes);
-        }
-      }
 
-      return {r_min, r_max, z_min, z_max, phi_min, phi_max};
+        return {r_min, r_max, z_min, z_max, phi_min, phi_max};
     };
 
     // Create the surface finders & reserve
@@ -239,251 +225,280 @@ namespace detray
     using surfaces_z_axis = typename typed_detector::surfaces_regular_axis;
     using surfaces_phi_axis = typename typed_detector::surfaces_circular_axis;
 
-    using surfaces_r_phi_grid = typename typed_detector::surfaces_regular_circular_grid;
-    using surfaces_z_phi_grid = typename typed_detector::surfaces_regular_circular_grid;
+    using surfaces_r_phi_grid =
+        typename typed_detector::surfaces_regular_circular_grid;
+    using surfaces_z_phi_grid =
+        typename typed_detector::surfaces_regular_circular_grid;
     using surfaces_finder = typename typed_detector::surfaces_finder;
 
     vector_type<surfaces_finder> detector_surfaces_finders;
 
     // (B) Pre-read the grids & create local object finders
-    while (sg_reader.read(io_surface_grid))
-    {
-      volume_layer_index c_index = {io_surface_grid.volume_id, io_surface_grid.layer_id};
+    while (sg_reader.read(io_surface_grid)) {
+        volume_layer_index c_index = {io_surface_grid.volume_id,
+                                      io_surface_grid.layer_id};
 
-      surface_finder_entries[c_index] = detector_surfaces_finders.size();
+        surface_finder_entries[c_index] = detector_surfaces_finders.size();
 
-      bool is_disk = (io_surface_grid.type_loc0 == 3);
+        bool is_disk = (io_surface_grid.type_loc0 == 3);
 
-      // Prepare z axis parameters
-      scalar z_min = is_disk ? std::numeric_limits<scalar>::min() : io_surface_grid.min_loc1;
-      scalar z_max = is_disk ? std::numeric_limits<scalar>::max() : io_surface_grid.max_loc1;
-      dindex z_bins = is_disk ? 1u : static_cast<dindex>(io_surface_grid.nbins_loc1);
+        // Prepare z axis parameters
+        scalar z_min = is_disk ? std::numeric_limits<scalar>::min()
+                               : io_surface_grid.min_loc1;
+        scalar z_max = is_disk ? std::numeric_limits<scalar>::max()
+                               : io_surface_grid.max_loc1;
+        dindex z_bins =
+            is_disk ? 1u : static_cast<dindex>(io_surface_grid.nbins_loc1);
 
-      // Prepare r axis parameters
-      scalar r_min = is_disk ? io_surface_grid.min_loc0 : 0.;
-      scalar r_max = is_disk ? io_surface_grid.max_loc0 : std::numeric_limits<scalar>::max();
-      dindex r_bins = is_disk ? static_cast<dindex>(io_surface_grid.nbins_loc0) : 1u;
+        // Prepare r axis parameters
+        scalar r_min = is_disk ? io_surface_grid.min_loc0 : 0.;
+        scalar r_max = is_disk ? io_surface_grid.max_loc0
+                               : std::numeric_limits<scalar>::max();
+        dindex r_bins =
+            is_disk ? static_cast<dindex>(io_surface_grid.nbins_loc0) : 1u;
 
-      // Prepare phi axis parameters
-      scalar phi_min = is_disk ? io_surface_grid.min_loc1 : io_surface_grid.min_loc0;
-      scalar phi_max = is_disk ? io_surface_grid.max_loc1 : io_surface_grid.max_loc0;
-      dindex phi_bins = is_disk ? static_cast<dindex>(io_surface_grid.nbins_loc1) : static_cast<dindex>(io_surface_grid.nbins_loc0);
+        // Prepare phi axis parameters
+        scalar phi_min =
+            is_disk ? io_surface_grid.min_loc1 : io_surface_grid.min_loc0;
+        scalar phi_max =
+            is_disk ? io_surface_grid.max_loc1 : io_surface_grid.max_loc0;
+        dindex phi_bins = is_disk
+                              ? static_cast<dindex>(io_surface_grid.nbins_loc1)
+                              : static_cast<dindex>(io_surface_grid.nbins_loc0);
 
-      surfaces_z_axis z_axis{z_bins, z_min, z_max};
-      surfaces_r_axis r_axis{r_bins, r_min, r_max};
-      surfaces_phi_axis phi_axis{phi_bins, phi_min, phi_max};
+        surfaces_z_axis z_axis{z_bins, z_min, z_max};
+        surfaces_r_axis r_axis{r_bins, r_min, r_max};
+        surfaces_phi_axis phi_axis{phi_bins, phi_min, phi_max};
 
-      // negative / positive / inner / outer
-      surfaces_r_phi_grid rphi_grid_n(r_axis, phi_axis);
-      surfaces_r_phi_grid rphi_grid_p(r_axis, phi_axis);
-      surfaces_z_phi_grid zphi_grid_i{z_axis, phi_axis};
-      surfaces_z_phi_grid zphi_grid_o{z_axis, phi_axis};
+        // negative / positive / inner / outer
+        surfaces_r_phi_grid rphi_grid_n(r_axis, phi_axis);
+        surfaces_r_phi_grid rphi_grid_p(r_axis, phi_axis);
+        surfaces_z_phi_grid zphi_grid_i{z_axis, phi_axis};
+        surfaces_z_phi_grid zphi_grid_o{z_axis, phi_axis};
 
-      detector_surfaces_finders.push_back(rphi_grid_n);
-      detector_surfaces_finders.push_back(rphi_grid_p);
-      detector_surfaces_finders.push_back(zphi_grid_i);
-      detector_surfaces_finders.push_back(zphi_grid_o);
+        detector_surfaces_finders.push_back(rphi_grid_n);
+        detector_surfaces_finders.push_back(rphi_grid_p);
+        detector_surfaces_finders.push_back(zphi_grid_i);
+        detector_surfaces_finders.push_back(zphi_grid_o);
     }
 
     // (C) Read the surfaces and fill it
-    while (s_reader.read(io_surface))
-    {
-      volume_layer_index c_index = {io_surface.volume_id, io_surface.layer_id};
-      auto c_volume_itr = volumes.find(c_index);
-      if (c_volume_itr == volumes.end())
-      {
-        // Flush the former information / c_volume still points to the prior volume
-        if (c_volume != nullptr)
-        {
-          d.template add_objects<typed_detector::e_surface>(*c_volume, c_surfaces, c_masks, c_transforms,  surface_default_context);
+    while (s_reader.read(io_surface)) {
+        volume_layer_index c_index = {io_surface.volume_id,
+                                      io_surface.layer_id};
+        auto c_volume_itr = volumes.find(c_index);
+        if (c_volume_itr == volumes.end()) {
+            // Flush the former information / c_volume still points to the prior
+            // volume
+            if (c_volume != nullptr) {
+                d.template add_objects<typed_detector::e_surface>(
+                    *c_volume, c_surfaces, c_masks, c_transforms,
+                    surface_default_context);
 
-          c_surfaces   = typename typed_detector::surface_filling_container();
-          c_masks      = typename typed_detector::mask_container();
-          c_transforms = typename typed_detector::transform_container();
+                c_surfaces =
+                    typename typed_detector::surface_filling_container();
+                c_masks = typename typed_detector::mask_container();
+                c_transforms = typename typed_detector::transform_container();
+            }
+
+            // Create a new volume & assign
+            std::string volume_name = detector_name;
+            volume_name +=
+                std::string("_vol_") + std::to_string(io_surface.volume_id);
+            volume_name +=
+                std::string("_lay_") + std::to_string(io_surface.layer_id);
+            // Find and fill the bounds
+            auto new_bounds = volume_bounds.find(c_index);
+            if (new_bounds == volume_bounds.end()) {
+                // Bounds not found, do not build the volume
+                continue;
+            }
+
+            const auto &unsynchronized_volume_bounds = new_bounds->second;
+            // Check if you need to synchronize
+            bool is_gap = (io_surface.layer_id % 2 != 0);
+            auto volume_bounds =
+                synchronize_bounds(unsynchronized_volume_bounds, is_gap);
+
+            // Check if this volume has a surface finder entry associated
+            dindex surfaces_finder_entry = dindex_invalid;
+            auto surface_finder_itr = surface_finder_entries.find(c_index);
+            if (surface_finder_itr != surface_finder_entries.end()) {
+                surfaces_finder_entry = surface_finder_itr->second;
+            }
+
+            auto &new_volume =
+                d.new_volume(volume_name, volume_bounds, surfaces_finder_entry);
+
+            // RZ attachment storage
+            attach_volume(r_min_attachments, volume_bounds[0],
+                          new_volume.index());
+            attach_volume(z_min_attachments, volume_bounds[2],
+                          new_volume.index());
+
+            r_max = std::max(r_max, volume_bounds[1]);
+            z_max = std::max(z_max, volume_bounds[3]);
+
+            c_volume = &new_volume;
+            // Insert to volume map
+            volumes[c_index] = c_volume;
+        } else {
+            c_volume = c_volume_itr->second;
         }
 
-        // Create a new volume & assign
-        std::string volume_name = detector_name;
-        volume_name += std::string("_vol_") + std::to_string(io_surface.volume_id);
-        volume_name += std::string("_lay_") + std::to_string(io_surface.layer_id);
-        // Find and fill the bounds
-        auto new_bounds = volume_bounds.find(c_index);
-        if (new_bounds == volume_bounds.end())
-        {
-          // Bounds not found, do not build the volume
-          continue;
-        }
+        // Do not fill navigation layers
+        if (io_surface.layer_id % 2 == 0) {
 
-        const auto &unsynchronized_volume_bounds = new_bounds->second;
-        // Check if you need to synchronize
-        bool is_gap = (io_surface.layer_id % 2 != 0);
-        auto volume_bounds = synchronize_bounds(unsynchronized_volume_bounds, is_gap);
+            // Read the transform
+            vector3 t{io_surface.cx, io_surface.cy, io_surface.cz};
+            vector3 x{io_surface.rot_xu, io_surface.rot_yu, io_surface.rot_zu};
+            vector3 z{io_surface.rot_xw, io_surface.rot_yw, io_surface.rot_zw};
 
-        // Check if this volume has a surface finder entry associated
-        dindex surfaces_finder_entry = dindex_invalid;
-        auto surface_finder_itr = surface_finder_entries.find(c_index);
-        if (surface_finder_itr != surface_finder_entries.end())
-        {
-          surfaces_finder_entry = surface_finder_itr->second;
-        }
+            // Translate the mask & add it to the mask container
+            unsigned int bounds_type = io_surface.bounds_type;
+            std::vector<scalar> bounds;
+            bounds.push_back(io_surface.bound_param0);
+            bounds.push_back(io_surface.bound_param1);
+            bounds.push_back(io_surface.bound_param2);
+            bounds.push_back(io_surface.bound_param3);
+            bounds.push_back(io_surface.bound_param4);
+            bounds.push_back(io_surface.bound_param5);
+            bounds.push_back(io_surface.bound_param6);
 
-        auto &new_volume = d.new_volume(volume_name, volume_bounds, surfaces_finder_entry);
+            // Acts naming convention for bounds
+            typename typed_detector::mask_index mask_index = {dindex_invalid,
+                                                              dindex_invalid};
+            // A surface mask points back to the current volume
+            typename typed_detector::volume_links volume_links = {
+                c_volume->index(), c_volume->index()};
 
-        // RZ attachment storage
-        attach_volume(r_min_attachments, volume_bounds[0], new_volume.index());
-        attach_volume(z_min_attachments, volume_bounds[2], new_volume.index());
+            if (bounds_type == 1) {
+                // Cylinder Bounds
+                constexpr auto cylinder_context =
+                    typed_detector::cylinder::mask_context;
 
-        r_max = std::max(r_max, volume_bounds[1]);
-        z_max = std::max(z_max, volume_bounds[3]);
+                // Add a new cylinder mask
+                auto &cylinder_masks = std::get<cylinder_context>(c_masks);
+                dindex cylinder_index = cylinder_masks.size();
+                cylinder_masks.push_back(
+                    {io_surface.bound_param0,
+                     io_surface.cz - io_surface.bound_param1,
+                     io_surface.cz + io_surface.bound_param1, volume_links});
+                // The read is valid: set the index
+                mask_index = {cylinder_context, cylinder_index};
 
-        c_volume = &new_volume;
-        // Insert to volume map
-        volumes[c_index] = c_volume;
-      }
-      else
-      {
-        c_volume = c_volume_itr->second;
-      }
+                // Build the cylinder transform
+                auto &cylinder_transforms =
+                    std::get<cylinder_context>(c_transforms);
+                cylinder_transforms.emplace_back(surface_default_context, t, z,
+                                                 x);
 
-      // Do not fill navigation layers
-      if (io_surface.layer_id % 2 == 0)
-      {
+                // Save the corresponding surface
+                auto &cylinder_surfaces = c_surfaces[cylinder_context];
+                cylinder_surfaces.emplace_back(
+                    cylinder_transforms.size(surface_default_context) - 1,
+                    mask_index, c_volume->index(), io_surface.geometry_id);
+            } else if (bounds_type == 3) {
+                // Disc bounds
+            } else if (bounds_type == 6) {
+                // Rectangle bounds
+                constexpr auto rectangle_context =
+                    typed_detector::rectangle::mask_context;
 
-        // Read the transform
-        vector3 t{io_surface.cx, io_surface.cy, io_surface.cz};
-        vector3 x{io_surface.rot_xu, io_surface.rot_yu, io_surface.rot_zu};
-        vector3 z{io_surface.rot_xw, io_surface.rot_yw, io_surface.rot_zw};
+                // Add a new rectangle mask
+                auto &rectangle_masks = std::get<rectangle_context>(c_masks);
+                dindex rectangle_index = rectangle_masks.size();
+                scalar half_x =
+                    0.5 * (io_surface.bound_param2 - io_surface.bound_param0);
+                scalar half_y =
+                    0.5 * (io_surface.bound_param3 - io_surface.bound_param1);
+                rectangle_masks.push_back({half_x, half_y, volume_links});
+                // The read is valid: set the index
+                mask_index = {rectangle_context, rectangle_index};
 
-        // Translate the mask & add it to the mask container
-        unsigned int bounds_type = io_surface.bounds_type;
-        std::vector<scalar> bounds;
-        bounds.push_back(io_surface.bound_param0);
-        bounds.push_back(io_surface.bound_param1);
-        bounds.push_back(io_surface.bound_param2);
-        bounds.push_back(io_surface.bound_param3);
-        bounds.push_back(io_surface.bound_param4);
-        bounds.push_back(io_surface.bound_param5);
-        bounds.push_back(io_surface.bound_param6);
+                // Build the rectangle transform
+                auto &rectangle_transforms =
+                    std::get<rectangle_context>(c_transforms);
+                rectangle_transforms.emplace_back(surface_default_context, t, z,
+                                                  x);
 
-        // Acts naming convention for bounds
-        typename typed_detector::mask_index mask_index = {dindex_invalid, dindex_invalid};
-        // A surface mask points back to the current volume
-        typename typed_detector::volume_links volume_links = {c_volume->index(), c_volume->index()};
+                // Save the corresponding surface
+                auto &rectangle_surfaces = c_surfaces[rectangle_context];
+                rectangle_surfaces.emplace_back(
+                    rectangle_transforms.size(surface_default_context) - 1,
+                    mask_index, c_volume->index(), io_surface.geometry_id);
+            } else if (bounds_type == 7) {
+                // Trapezoid bounds
+                constexpr auto trapezoid_context =
+                    typed_detector::trapezoid::mask_context;
 
-        if (bounds_type == 1)
-        {
-          // Cylinder Bounds
-          constexpr auto cylinder_context = typed_detector::cylinder::mask_context;
+                // Add a new trapezoid mask
+                auto &trapezoid_masks = std::get<trapezoid_context>(c_masks);
+                dindex trapezoid_index = trapezoid_masks.size();
+                trapezoid_masks.push_back(
+                    {io_surface.bound_param0, io_surface.bound_param1,
+                     io_surface.bound_param2, volume_links});
+                // The read is valid: set the index
+                mask_index = {trapezoid_context, trapezoid_index};
 
-          // Add a new cylinder mask
-          auto &cylinder_masks = std::get<cylinder_context>(c_masks);
-          dindex cylinder_index = cylinder_masks.size();
-          cylinder_masks.push_back({io_surface.bound_param0, io_surface.cz - io_surface.bound_param1, io_surface.cz + io_surface.bound_param1, volume_links});
-          // The read is valid: set the index
-          mask_index = {cylinder_context, cylinder_index};
+                // Build the trapezoid transform
+                auto &trapezoid_transforms =
+                    std::get<trapezoid_context>(c_transforms);
+                trapezoid_transforms.emplace_back(surface_default_context, t, z,
+                                                  x);
 
-          // Build the cylinder transform
-          auto &cylinder_transforms = std::get<cylinder_context>(c_transforms);
-          cylinder_transforms.emplace_back(surface_default_context, t, z, x);
+                // Save the corresponding surface
+                auto &trapezoid_surfaces = c_surfaces[trapezoid_context];
+                trapezoid_surfaces.push_back(
+                    {trapezoid_transforms.size(surface_default_context) - 1,
+                     mask_index, c_volume->index(), io_surface.geometry_id});
+            } else if (bounds_type == 11) {
+                // Annulus bounds
+                constexpr auto annulus_context =
+                    typed_detector::annulus::mask_context;
 
-          // Save the corresponding surface
-          auto &cylinder_surfaces = c_surfaces[cylinder_context];
-          cylinder_surfaces.emplace_back(cylinder_transforms.size(surface_default_context) - 1, mask_index, c_volume->index(), io_surface.geometry_id);
-        }
-        else if (bounds_type == 3)
-        {
-          // Disc bounds
-        }
-        else if (bounds_type == 6)
-        {
-          // Rectangle bounds
-          constexpr auto rectangle_context = typed_detector::rectangle::mask_context;
+                // Add a new annulus mask
+                auto &annulus_masks = std::get<annulus_context>(c_masks);
+                dindex annulus_index = annulus_masks.size();
+                annulus_masks.push_back(
+                    {io_surface.bound_param0, io_surface.bound_param1,
+                     io_surface.bound_param2, io_surface.bound_param3,
+                     io_surface.bound_param4, io_surface.bound_param5,
+                     io_surface.bound_param6, volume_links});
+                // The read is valid: set the index
+                mask_index = {annulus_context, annulus_index};
 
-          // Add a new rectangle mask
-          auto &rectangle_masks = std::get<rectangle_context>(c_masks);
-          dindex rectangle_index = rectangle_masks.size();
-          scalar half_x = 0.5 * (io_surface.bound_param2 - io_surface.bound_param0);
-          scalar half_y = 0.5 * (io_surface.bound_param3 - io_surface.bound_param1);
-          rectangle_masks.push_back({half_x, half_y, volume_links});
-          // The read is valid: set the index
-          mask_index = {rectangle_context, rectangle_index};
+                // Build the annulus transform
+                auto &annulus_transforms =
+                    std::get<annulus_context>(c_transforms);
+                annulus_transforms.emplace_back(surface_default_context, t, z,
+                                                x);
 
-          // Build the rectangle transform
-          auto &rectangle_transforms = std::get<rectangle_context>(c_transforms);
-          rectangle_transforms.emplace_back(surface_default_context, t, z, x);
-
-          // Save the corresponding surface
-          auto &rectangle_surfaces = c_surfaces[rectangle_context];
-          rectangle_surfaces.emplace_back(rectangle_transforms.size(surface_default_context) - 1, mask_index, c_volume->index(), io_surface.geometry_id);
-        }
-        else if (bounds_type == 7)
-        {
-          // Trapezoid bounds
-          constexpr auto trapezoid_context = typed_detector::trapezoid::mask_context;
-
-          // Add a new trapezoid mask
-          auto &trapezoid_masks = std::get<trapezoid_context>(c_masks);
-          dindex trapezoid_index = trapezoid_masks.size();
-          trapezoid_masks.push_back({io_surface.bound_param0, io_surface.bound_param1, io_surface.bound_param2, volume_links});
-          // The read is valid: set the index
-          mask_index = {trapezoid_context, trapezoid_index};
-
-          // Build the trapezoid transform
-          auto &trapezoid_transforms = std::get<trapezoid_context>(c_transforms);
-          trapezoid_transforms.emplace_back(surface_default_context, t, z, x);
-
-          // Save the corresponding surface
-          auto &trapezoid_surfaces = c_surfaces[trapezoid_context];
-          trapezoid_surfaces.push_back({trapezoid_transforms.size(surface_default_context) - 1, mask_index, c_volume->index(), io_surface.geometry_id});
-        }
-        else if (bounds_type == 11)
-        {
-          // Annulus bounds
-          constexpr auto annulus_context = typed_detector::annulus::mask_context;
-
-          // Add a new annulus mask
-          auto &annulus_masks = std::get<annulus_context>(c_masks);
-          dindex annulus_index = annulus_masks.size();
-          annulus_masks.push_back({io_surface.bound_param0,
-                                   io_surface.bound_param1,
-                                   io_surface.bound_param2,
-                                   io_surface.bound_param3,
-                                   io_surface.bound_param4,
-                                   io_surface.bound_param5,
-                                   io_surface.bound_param6,
-                                   volume_links});
-          // The read is valid: set the index
-          mask_index = {annulus_context, annulus_index};
-
-          // Build the annulus transform
-          auto &annulus_transforms = std::get<annulus_context>(c_transforms);
-          annulus_transforms.emplace_back(surface_default_context, t, z, x);
-
-          // Save the corresponding surface
-          auto &annulus_surfaces = c_surfaces[annulus_context];
-          annulus_surfaces.emplace_back(annulus_transforms.size(surface_default_context) - 1, mask_index, c_volume->index(), io_surface.geometry_id);
-        }
-      } // end of exclusion for navigation layers
+                // Save the corresponding surface
+                auto &annulus_surfaces = c_surfaces[annulus_context];
+                annulus_surfaces.emplace_back(
+                    annulus_transforms.size(surface_default_context) - 1,
+                    mask_index, c_volume->index(), io_surface.geometry_id);
+            }
+        }  // end of exclusion for navigation layers
     }
 
     /** Helper method to sort and remove duplicates
-     * 
+     *
      * @param att attribute vector for sorting and duplicate removal
-     * 
+     *
      * @return the key values
      */
-    auto
-        sort_and_remove_duplicates = [](std::map<scalar, std::vector<dindex>> &att) -> dvector<scalar>
-    {
-      dvector<scalar> keys;
-      keys.reserve(att.size());
-      for (auto [key, value] : att)
-      {
-        keys.push_back(key);
-        std::sort(value.begin(), value.end());
-        value.erase(std::unique(value.begin(), value.end()), value.end());
-      }
-      return keys;
+    auto sort_and_remove_duplicates =
+        [](std::map<scalar, std::vector<dindex>> &att) -> dvector<scalar> {
+        dvector<scalar> keys;
+        keys.reserve(att.size());
+        for (auto [key, value] : att) {
+            keys.push_back(key);
+            std::sort(value.begin(), value.end());
+            value.erase(std::unique(value.begin(), value.end()), value.end());
+        }
+        return keys;
     };
 
     // Drawing the lines for the grid search
@@ -496,98 +511,100 @@ namespace detray
     axis::irregular raxis{{rs}};
     axis::irregular zaxis{{zs}};
 
-    typename typed_detector::volume_grid v_grid(std::move(raxis), std::move(zaxis));
+    typename typed_detector::volume_grid v_grid(std::move(raxis),
+                                                std::move(zaxis));
 
-    // A step into the volume (stepsilon), can be read in from the smallest difference
+    // A step into the volume (stepsilon), can be read in from the smallest
+    // difference
     scalar stepsilon = 1.;
 
     // Run the bin association and write out
     surface_grid_entries_writer sge_writer("grid-entries.csv");
-    bool write_grid_entries = (grid_entries_file_name.find("write") != std::string::npos);
-    bool read_grid_entries = not grid_entries_file_name.empty() and not write_grid_entries
-          and not (grid_entries_file_name.find("none") != std::string::npos);
+    bool write_grid_entries =
+        (grid_entries_file_name.find("write") != std::string::npos);
+    bool read_grid_entries =
+        not grid_entries_file_name.empty() and not write_grid_entries and
+        not(grid_entries_file_name.find("none") != std::string::npos);
 
     // Loop over the volumes
     // - fill the volume grid
     // - run the bin association
-    for (auto [iv, v] : enumerate(d.volumes()))
-    {
-      // Get the volume bounds for filling
-      const auto &v_bounds = v.bounds();
+    for (auto [iv, v] : enumerate(d.volumes())) {
+        // Get the volume bounds for filling
+        const auto &v_bounds = v.bounds();
 
-      dindex irl = v_grid.axis_p0().bin(v_bounds[0] + stepsilon);
-      dindex irh = v_grid.axis_p0().bin(v_bounds[1] - stepsilon);
-      dindex izl = v_grid.axis_p1().bin(v_bounds[2] + stepsilon);
-      dindex izh = v_grid.axis_p1().bin(v_bounds[3] - stepsilon);
-      dindex volume_index = v.index();
+        dindex irl = v_grid.axis_p0().bin(v_bounds[0] + stepsilon);
+        dindex irh = v_grid.axis_p0().bin(v_bounds[1] - stepsilon);
+        dindex izl = v_grid.axis_p1().bin(v_bounds[2] + stepsilon);
+        dindex izh = v_grid.axis_p1().bin(v_bounds[3] - stepsilon);
+        dindex volume_index = v.index();
 
-      auto r_low = v_grid.axis_p0().borders(irl)[0];
-      auto r_high = v_grid.axis_p0().borders(irh)[1];
-      auto z_low = v_grid.axis_p1().borders(izl)[0];
-      auto z_high = v_grid.axis_p1().borders(izh)[1];
+        auto r_low = v_grid.axis_p0().borders(irl)[0];
+        auto r_high = v_grid.axis_p0().borders(irh)[1];
+        auto z_low = v_grid.axis_p1().borders(izl)[0];
+        auto z_high = v_grid.axis_p1().borders(izh)[1];
 
-      bool is_cylinder = std::abs(v_bounds[1] - v_bounds[0]) < std::abs(v_bounds[3] - v_bounds[2]);
+        bool is_cylinder = std::abs(v_bounds[1] - v_bounds[0]) <
+                           std::abs(v_bounds[3] - v_bounds[2]);
 
-      for (dindex ir = irl; ir <= irh; ++ir)
-      {
-        for (dindex iz = izl; iz <= izh; ++iz)
-        {
-          v_grid.populate(ir, iz, std::move(volume_index));
-        }
-      }
-
-      dindex sfi = v.surfaces_finder_entry();
-      if (sfi != dindex_invalid and write_grid_entries)
-      {
-        auto &grid = is_cylinder ? detector_surfaces_finders[sfi + 2] : detector_surfaces_finders[sfi];
-        bin_association(surface_default_context, d, v, grid, {0.1, 0.1}, false);
-
-        csv_surface_grid_entry csv_ge;
-        csv_ge.detray_volume_id = static_cast<int>(iv);
-        size_t nbins0 = grid.axis_p0().bins();
-        size_t nbins1 = grid.axis_p1().bins();
-        for (size_t b0 = 0; b0 < nbins0; ++b0)
-        {
-          for (size_t b1 = 0; b1 < nbins1; ++b1)
-          {
-            csv_ge.detray_bin0 = b0;
-            csv_ge.detray_bin1 = b1;
-            for (auto e : grid.bin(b0, b1))
-            {
-              csv_ge.detray_entry = e;
-              sge_writer.append(csv_ge);
+        for (dindex ir = irl; ir <= irh; ++ir) {
+            for (dindex iz = izl; iz <= izh; ++iz) {
+                v_grid.populate(ir, iz, std::move(volume_index));
             }
-          }
         }
-      }
+
+        dindex sfi = v.surfaces_finder_entry();
+        if (sfi != dindex_invalid and write_grid_entries) {
+            auto &grid = is_cylinder ? detector_surfaces_finders[sfi + 2]
+                                     : detector_surfaces_finders[sfi];
+            bin_association(surface_default_context, d, v, grid, {0.1, 0.1},
+                            false);
+
+            csv_surface_grid_entry csv_ge;
+            csv_ge.detray_volume_id = static_cast<int>(iv);
+            size_t nbins0 = grid.axis_p0().bins();
+            size_t nbins1 = grid.axis_p1().bins();
+            for (size_t b0 = 0; b0 < nbins0; ++b0) {
+                for (size_t b1 = 0; b1 < nbins1; ++b1) {
+                    csv_ge.detray_bin0 = b0;
+                    csv_ge.detray_bin1 = b1;
+                    for (auto e : grid.bin(b0, b1)) {
+                        csv_ge.detray_entry = e;
+                        sge_writer.append(csv_ge);
+                    }
+                }
+            }
+        }
     }
 
     // Fast option, read the grid entries back in
-    if (read_grid_entries)
-    {
+    if (read_grid_entries) {
 
-      surface_grid_entries_reader sge_reader(grid_entries_file_name);
-      csv_surface_grid_entry surface_grid_entry;
-      while (sge_reader.read(surface_grid_entry))
-      {
-        // Get the volume bounds for fillind
-        const auto &v = d.indexed_volume(surface_grid_entry.detray_volume_id);
-        const auto &v_bounds = v.bounds();
-        dindex sfi = v.surfaces_finder_entry();
-        if (sfi != dindex_invalid)
-        {
-          bool is_cylinder = std::abs(v_bounds[1] - v_bounds[0]) < std::abs(v_bounds[3] - v_bounds[2]);
-          auto &grid = is_cylinder ? detector_surfaces_finders[sfi + 2] : detector_surfaces_finders[sfi];
-          // Fill the entry
-          grid.populate(static_cast<dindex>(surface_grid_entry.detray_bin0),
-                        static_cast<dindex>(surface_grid_entry.detray_bin1),
-                        static_cast<dindex>(surface_grid_entry.detray_entry));
+        surface_grid_entries_reader sge_reader(grid_entries_file_name);
+        csv_surface_grid_entry surface_grid_entry;
+        while (sge_reader.read(surface_grid_entry)) {
+            // Get the volume bounds for fillind
+            const auto &v =
+                d.indexed_volume(surface_grid_entry.detray_volume_id);
+            const auto &v_bounds = v.bounds();
+            dindex sfi = v.surfaces_finder_entry();
+            if (sfi != dindex_invalid) {
+                bool is_cylinder = std::abs(v_bounds[1] - v_bounds[0]) <
+                                   std::abs(v_bounds[3] - v_bounds[2]);
+                auto &grid = is_cylinder ? detector_surfaces_finders[sfi + 2]
+                                         : detector_surfaces_finders[sfi];
+                // Fill the entry
+                grid.populate(
+                    static_cast<dindex>(surface_grid_entry.detray_bin0),
+                    static_cast<dindex>(surface_grid_entry.detray_bin1),
+                    static_cast<dindex>(surface_grid_entry.detray_entry));
+            }
         }
-      }
     }
 
     // Connect the cylindrical volumes
-    connect_cylindrical_volumes<typed_detector, array_type, tuple_type, vector_type>(d, v_grid);
+    connect_cylindrical_volumes<typed_detector, array_type, tuple_type,
+                                vector_type>(d, v_grid);
 
     // Add the surface finders to the detector
     d.add_surfaces_finders(std::move(detector_surfaces_finders));
@@ -596,6 +613,6 @@ namespace detray
     d.add_volume_grid(std::move(v_grid));
 
     return d;
-  }
+}
 
-} // namespace detray
+}  // namespace detray

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -373,7 +373,7 @@ namespace detray
         if (bounds_type == 1)
         {
           // Cylinder Bounds
-          constexpr auto cylinder_context = typed_detector::surface_cylinder::mask_context;
+          constexpr auto cylinder_context = typed_detector::cylinder::mask_context;
 
           // Add a new cylinder mask
           auto &cylinder_masks = std::get<cylinder_context>(c_masks);
@@ -397,7 +397,7 @@ namespace detray
         else if (bounds_type == 6)
         {
           // Rectangle bounds
-          constexpr auto rectangle_context = typed_detector::surface_rectangle::mask_context;
+          constexpr auto rectangle_context = typed_detector::rectangle::mask_context;
 
           // Add a new rectangle mask
           auto &rectangle_masks = std::get<rectangle_context>(c_masks);
@@ -419,7 +419,7 @@ namespace detray
         else if (bounds_type == 7)
         {
           // Trapezoid bounds
-          constexpr auto trapezoid_context = typed_detector::surface_trapezoid::mask_context;
+          constexpr auto trapezoid_context = typed_detector::trapezoid::mask_context;
 
           // Add a new trapezoid mask
           auto &trapezoid_masks = std::get<trapezoid_context>(c_masks);
@@ -439,7 +439,7 @@ namespace detray
         else if (bounds_type == 11)
         {
           // Annulus bounds
-          constexpr auto annulus_context = typed_detector::surface_annulus::mask_context;
+          constexpr auto annulus_context = typed_detector::annulus::mask_context;
 
           // Add a new annulus mask
           auto &annulus_masks = std::get<annulus_context>(c_masks);

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -86,7 +86,7 @@ namespace detray
     // Flushable containers
     typename typed_detector::volume *c_volume = nullptr;
     typename typed_detector::surface_filling_container c_surfaces;
-    typename typed_detector::surface_mask_container c_masks;
+    typename typed_detector::mask_container c_masks;
     typename typed_detector::transform_container c_transforms;
 
     std::map<volume_layer_index, array_type<scalar, 6>> volume_bounds;
@@ -298,7 +298,7 @@ namespace detray
           d.template add_objects<typed_detector::e_surface>(*c_volume, c_surfaces, c_masks, c_transforms,  surface_default_context);
 
           c_surfaces   = typename typed_detector::surface_filling_container();
-          c_masks      = typename typed_detector::surface_mask_container();
+          c_masks      = typename typed_detector::mask_container();
           c_transforms = typename typed_detector::transform_container();
         }
 

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -367,6 +367,8 @@ namespace detray
 
         // Acts naming convention for bounds
         typename typed_detector::surface_mask_index mask_index = {dindex_invalid, dindex_invalid};
+        // A surface mask points back to the current volume
+        typename typed_detector::volume_links volume_links = {c_volume->index(), c_volume->index()};
 
         if (bounds_type == 1)
         {
@@ -376,7 +378,7 @@ namespace detray
           // Add a new cylinder mask
           auto &cylinder_masks = std::get<cylinder_context>(c_masks);
           dindex cylinder_index = cylinder_masks.size();
-          cylinder_masks.push_back({io_surface.bound_param0, io_surface.cz - io_surface.bound_param1, io_surface.cz + io_surface.bound_param1});
+          cylinder_masks.push_back({io_surface.bound_param0, io_surface.cz - io_surface.bound_param1, io_surface.cz + io_surface.bound_param1, volume_links});
           // The read is valid: set the index
           mask_index = {cylinder_context, cylinder_index};
 
@@ -402,7 +404,7 @@ namespace detray
           dindex rectangle_index = rectangle_masks.size();
           scalar half_x = 0.5 * (io_surface.bound_param2 - io_surface.bound_param0);
           scalar half_y = 0.5 * (io_surface.bound_param3 - io_surface.bound_param1);
-          rectangle_masks.push_back({half_x, half_y});
+          rectangle_masks.push_back({half_x, half_y, volume_links});
           // The read is valid: set the index
           mask_index = {rectangle_context, rectangle_index};
 
@@ -422,7 +424,7 @@ namespace detray
           // Add a new trapezoid mask
           auto &trapezoid_masks = std::get<trapezoid_context>(c_masks);
           dindex trapezoid_index = trapezoid_masks.size();
-          trapezoid_masks.push_back({io_surface.bound_param0, io_surface.bound_param1, io_surface.bound_param2});
+          trapezoid_masks.push_back({io_surface.bound_param0, io_surface.bound_param1, io_surface.bound_param2, volume_links});
           // The read is valid: set the index
           mask_index = {trapezoid_context, trapezoid_index};
 
@@ -448,7 +450,8 @@ namespace detray
                                    io_surface.bound_param3,
                                    io_surface.bound_param4,
                                    io_surface.bound_param5,
-                                   io_surface.bound_param6});
+                                   io_surface.bound_param6,
+                                   volume_links});
           // The read is valid: set the index
           mask_index = {annulus_context, annulus_index};
 

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -57,7 +57,7 @@ auto d = read_detector();
 
 const auto &surfaces = d.surfaces();
 constexpr bool get_surface_masks = true;
-const auto &masks = d.template masks<get_surface_masks>();
+const auto &masks = d.masks();
 
 namespace __plugin {
 // This test runs intersection with all surfaces of the TrackML detector

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -22,7 +22,7 @@ TEST(ALGEBRA_PLUGIN, detector) {
     static_transform_store<>::context ctx0;
 
     detector::transform_container trfs;
-    detector::surface_mask_container masks;
+    detector::mask_container masks;
     detector::surface_filling_container surfaces = {};
 
     /// Surface 0

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -27,21 +27,21 @@ TEST(ALGEBRA_PLUGIN, detector) {
 
     /// Surface 0
     point3 t0{0., 0., 0.};
-    trfs[detector::surface_rectangle::mask_context].emplace_back(ctx0, t0);
-    detector::surface_rectangle rect = {-3., 3.};
-    std::get<detector::surface_rectangle::mask_context>(masks).push_back(rect);
+    trfs[detector::rectangle::mask_context].emplace_back(ctx0, t0);
+    detector::rectangle rect = {-3., 3.};
+    std::get<detector::rectangle::mask_context>(masks).push_back(rect);
 
     /// Surface 1
     point3 t1{1., 0., 0.};
-    trfs[detector::surface_annulus::mask_context].emplace_back(ctx0, t1);
-    detector::surface_annulus anns = {1., 2., 3., 4., 5., 6., 7.};
-    std::get<detector::surface_annulus::mask_context>(masks).push_back(anns);
+    trfs[detector::annulus::mask_context].emplace_back(ctx0, t1);
+    detector::annulus anns = {1., 2., 3., 4., 5., 6., 7.};
+    std::get<detector::annulus::mask_context>(masks).push_back(anns);
 
     /// Surface 2
     point3 t2{2., 0., 0.};
-    trfs[detector::surface_trapezoid::mask_context].emplace_back(ctx0, t2);
-    detector::surface_trapezoid trap = {1., 2., 3.};
-    std::get<detector::surface_trapezoid::mask_context>(masks).push_back(trap);
+    trfs[detector::trapezoid::mask_context].emplace_back(ctx0, t2);
+    detector::trapezoid trap = {1., 2., 3.};
+    std::get<detector::trapezoid::mask_context>(masks).push_back(trap);
 
     detector d("test_detector");
     auto &v = d.new_volume("test_volume", {0., 10., -5., 5., -M_PI, M_PI});


### PR DESCRIPTION
This PR merges portal and surface types, so that containers can be merged, too, and the navigator can handle both the same. In order for this to work, both objects use the same mask links type, now called volume_links, which links to the next volume for portals and the current volume for surfaces. This should simplify the navigation validation for now