### PR TITLE
add comments to fix the header sequence

### DIFF
--- a/apps/src/eigen/eigen_display_bin_association.cpp
+++ b/apps/src/eigen/eigen_display_bin_association.cpp
@@ -5,5 +5,7 @@
  * Mozilla Public License Version 2.0
  */
 
-#include "apps/common/display_bin_association.inl"
+// algebra plugin header
 #include "plugins/algebra/eigen_definitions.hpp"
+// inline header
+#include "apps/common/display_bin_association.inl"

--- a/apps/src/eigen/eigen_display_layers.cpp
+++ b/apps/src/eigen/eigen_display_layers.cpp
@@ -5,5 +5,7 @@
  * Mozilla Public License Version 2.0
  */
 
-#include "apps/common/display_layers.inl"
+// algebra plugin header
 #include "plugins/algebra/eigen_definitions.hpp"
+// inline header
+#include "apps/common/display_layers.inl"

--- a/apps/src/eigen/eigen_display_volumes_rz.cpp
+++ b/apps/src/eigen/eigen_display_volumes_rz.cpp
@@ -5,5 +5,7 @@
  * Mozilla Public License Version 2.0
  */
 
-#include "apps/common/display_volumes_rz.inl"
+// algebra plugin header
 #include "plugins/algebra/eigen_definitions.hpp"
+// inline header
+#include "apps/common/display_volumes_rz.inl"


### PR DESCRIPTION
clang format keeps messing the header sequence in display directory.
I added some comments to prevent it