### PR TITLE
feat: implement mask store

### DIFF
--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -102,7 +102,7 @@ class detector {
     using surfaces_finder = surfaces_regular_circular_grid;
 
     // Temporary container struct, used to fill the detector data
-    using transform_container = array_type<transform_store, 6>;
+    using transform_container = array_type<transform_store, mask_id::e_mask_types>;
 
     /** Allowed costructor
      * @param name the detector

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -291,15 +291,12 @@ class detector {
         // Get the corresponding transforms
         const auto &object_transforms = trfs[current_type];
         // and the corresponding masks
-        auto &object_masks = std::get<current_type>(masks);
+        auto &object_masks = masks.template group<current_type>();
 
         // Fill object masks into the correct detector container
-        auto add_detector_masks = [&](auto &detector_container) -> dindex {
-            auto &detector_masks = std::get<current_type>(detector_container);
-            const dindex mask_offset = detector_masks.size();
-            detector_masks.reserve(mask_offset + object_masks.size());
-            detector_masks.insert(detector_masks.end(), object_masks.begin(),
-                                  object_masks.end());
+        auto add_detector_masks = [&](auto &detector_masks) -> dindex {
+            const dindex mask_offset = detector_masks.template size<current_type>();
+            detector_masks.template add_masks<current_type>(object_masks);
 
             return mask_offset;
         };
@@ -342,7 +339,7 @@ class detector {
         }
 
         // Next mask type
-        if constexpr (current_type < std::tuple_size_v<mask_container> - 1) {
+        if constexpr (current_type < std::tuple_size_v<typename mask_container::mask_tuple> - 1) {
             return unroll_container_filling<current_type + 1, object_container,
                                             mask_container, transform_container,
                                             object_type>(volume, objects, masks,

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -175,9 +175,7 @@ class detector {
     }
 
     /** Get @return all surface/portal masks in the geometry */
-    decltype(auto) masks() const {
-        return _masks;
-    }
+    decltype(auto) masks() const { return _masks; }
 
     /** Get the current number of transforms in the store
      *
@@ -244,8 +242,8 @@ class detector {
      * detector::add_objects(). */
     template <typename object_container>
     inline void add_surfaces(
-        volume &volume, object_container &surfaces,
-        mask_container &masks, transform_container &trfs,
+        volume &volume, object_container &surfaces, mask_container &masks,
+        transform_container &trfs,
         const typename alignable_store::context ctx = {}) noexcept(false) {
         add_objects<objects::e_surface>(volume, surfaces, masks, trfs, ctx);
     }
@@ -313,7 +311,9 @@ class detector {
         }
 
         // Next mask type
-        if constexpr (current_type < std::tuple_size_v<typename mask_container::mask_tuple> - 1) {
+        if constexpr (current_type <
+                      std::tuple_size_v<typename mask_container::mask_tuple> -
+                          1) {
             return unroll_container_filling<current_type + 1, object_container,
                                             mask_container, transform_container,
                                             object_type>(volume, objects, masks,

--- a/core/include/core/detector.hpp
+++ b/core/include/core/detector.hpp
@@ -102,7 +102,8 @@ class detector {
     using surfaces_finder = surfaces_regular_circular_grid;
 
     // Temporary container struct, used to fill the detector data
-    using transform_container = array_type<transform_store, mask_id::e_mask_types>;
+    using transform_container =
+        array_type<transform_store, mask_id::e_mask_types>;
 
     /** Allowed costructor
      * @param name the detector

--- a/core/include/core/index_geometry.hpp
+++ b/core/include/core/index_geometry.hpp
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "core/surface_base.hpp"
+#include "core/mask_store.hpp"
 #include "masks/masks.hpp"
 #include "utils/enumerate.hpp"
 #include "utils/indexing.hpp"
@@ -72,8 +73,10 @@ class index_geometry {
         ring2<planar_intersector, __plugin::cartesian2, portal_links, 1>;
     // - mask index: type, { first/last }
     using portal_mask_index = tuple_type<dindex, array_type<dindex, 2>>;
-    using portal_mask_container =
-        tuple_type<vector_type<portal_cylinder>, vector_type<portal_disc>>;
+    //using portal_mask_container =
+    //    tuple_type<vector_type<portal_cylinder>, vector_type<portal_disc>>;
+
+    using portal_mask_container = mask_store<tuple_type, vector_type, portal_cylinder, portal_disc>;
 
     /** The Portal definition:
      *  <transform_link, mask_index, volume_link, source_link >
@@ -105,10 +108,11 @@ class index_geometry {
                   surface_links, e_cylinder3>;
     /// - mask index: type, entry
     using surface_mask_index = array_type<dindex, 2>;
-    using surface_mask_container =
+    /*using surface_mask_container =
         tuple_type<vector_type<surface_rectangle>,
                    vector_type<surface_trapezoid>, vector_type<surface_annulus>,
-                   vector_type<surface_cylinder>>;
+                   vector_type<surface_cylinder>>;*/
+    using surface_mask_container = mask_store<tuple_type, vector_type, surface_rectangle, surface_trapezoid, surface_annulus, surface_cylinder>;
 
     using surface_link = surface_source_link;
     /** The Surface definition:

--- a/core/include/core/index_geometry.hpp
+++ b/core/include/core/index_geometry.hpp
@@ -52,13 +52,14 @@ class index_geometry {
 
     /** Encodes the position in a collection container for the respective
         mask type . */
-    enum mask_container_index : unsigned int {
-        e_mask_types = 5,
+    enum mask_id : unsigned int {
+        e_mask_types = 6,
         e_rectangle2 = 0,
         e_trapezoid2 = 1,
         e_annulus2 = 2,
         e_cylinder3 = 3,
-        e_ring2 = 4,
+        e_portal_cylinder3 = 4,
+        e_portal_ring2 = 5,
         e_single3 = std::numeric_limits<unsigned int>::max(),
         e_unknown = std::numeric_limits<unsigned int>::max(),
     };
@@ -68,15 +69,11 @@ class index_geometry {
     using portal_links = array_type<dindex, 2>;
     /// - masks, with mask identifiers 0, 1
     using portal_cylinder = cylinder3<false, cylinder_intersector,
-                                      __plugin::cylindrical2, portal_links, 0>;
+                                      __plugin::cylindrical2, portal_links, e_portal_cylinder3>;
     using portal_disc =
-        ring2<planar_intersector, __plugin::cartesian2, portal_links, 1>;
+        ring2<planar_intersector, __plugin::cartesian2, portal_links, e_portal_ring2>;
     // - mask index: type, { first/last }
     using portal_mask_index = tuple_type<dindex, array_type<dindex, 2>>;
-    //using portal_mask_container =
-    //    tuple_type<vector_type<portal_cylinder>, vector_type<portal_disc>>;
-
-    using portal_mask_container = mask_store<tuple_type, vector_type, portal_cylinder, portal_disc>;
 
     /** The Portal definition:
      *  <transform_link, mask_index, volume_link, source_link >
@@ -88,7 +85,7 @@ class index_geometry {
      *
      */
     using bounds_link = bounds_source_link;
-    using portal = surface_base<dindex, portal_mask_index, dindex, bounds_link>;
+    using portal = surface_base<dindex, portal_mask_index, dindex, bounds_link, portal_links>;
     using portal_container = vector_type<portal>;
 
     /// Surface components:
@@ -108,26 +105,23 @@ class index_geometry {
                   surface_links, e_cylinder3>;
     /// - mask index: type, entry
     using surface_mask_index = array_type<dindex, 2>;
-    /*using surface_mask_container =
-        tuple_type<vector_type<surface_rectangle>,
-                   vector_type<surface_trapezoid>, vector_type<surface_annulus>,
-                   vector_type<surface_cylinder>>;*/
-    using surface_mask_container = mask_store<tuple_type, vector_type, surface_rectangle, surface_trapezoid, surface_annulus, surface_cylinder>;
 
-    using surface_link = surface_source_link;
+    using mask_container = mask_store<tuple_type, vector_type, surface_rectangle, surface_trapezoid, surface_annulus, surface_cylinder, portal_cylinder, portal_disc>;
+
+    using source_link = surface_source_link;
     /** The Surface definition:
      *  <transform_link, mask_link, volume_link, source_link >
      */
     using surface =
-        surface_base<dindex, surface_mask_index, dindex, surface_link>;
+        surface_base<dindex, surface_mask_index, dindex, source_link, surface_links>;
     using surface_container = vector_type<surface>;
 
     /** Temporary container structures that are used to fill the geometry.
      * The respective objects are sorted by mask type, so that they can be
      * unrolled and filled in lockstep with the masks
      */
-    using surface_filling_container = array_type<vector_type<surface>, 5>;
-    using portal_filling_container = array_type<vector_type<portal>, 5>;
+    using surface_filling_container = array_type<vector_type<surface>, e_mask_types>;
+    using portal_filling_container = array_type<vector_type<portal>, e_mask_types>;
 
     /** Nested volume struct that holds the local information of the
      * volume and its portals.
@@ -258,6 +252,14 @@ class index_geometry {
         /** Volume section: name */
         std::string _name = "unknown";
 
+        /** Bounds section, default for r, z, phi */
+        array_type<scalar, 6> _bounds = {0.,
+                                         std::numeric_limits<scalar>::max(),
+                                         -std::numeric_limits<scalar>::max(),
+                                         std::numeric_limits<scalar>::max(),
+                                         -M_PI,
+                                         M_PI};
+
         /** Volume index */
         dindex _index = dindex_invalid;
 
@@ -271,14 +273,6 @@ class index_geometry {
 
         /** Index into the surface finder container */
         dindex _surfaces_finder_entry = dindex_invalid;
-
-        /** Bounds section, default for r, z, phi */
-        array_type<scalar, 6> _bounds = {0.,
-                                         std::numeric_limits<scalar>::max(),
-                                         -std::numeric_limits<scalar>::max(),
-                                         std::numeric_limits<scalar>::max(),
-                                         -M_PI,
-                                         M_PI};
 
         /**
          * @param range Any index range
@@ -391,16 +385,40 @@ class index_geometry {
         }
     }
 
+    inline void update_mask_link(surface &sf, const dindex mask_offset) {
+        std::get<1>(sf.mask()) += mask_offset;
+    }
+
+    inline void update_mask_link(portal &pt, const dindex mask_offset) {
+        auto &portal_mask_index = std::get<1>(pt.mask());
+        portal_mask_index[0] += mask_offset;
+        portal_mask_index[1] += mask_offset;
+    }
+    
+    inline void update_transform_link(surface &sf, const dindex trsf_offset) {
+        sf.transform() += trsf_offset;
+    }
+
+    inline void update_transform_link(portal &pt, const dindex trsf_offset) {
+        pt.transform() += trsf_offset;
+    }
+
     /** @return all surfaces/portals in the detector */
-    template <bool add_surface = true, typename object_container>
-    inline void add_objects(const object_container &objects) {
-        if constexpr (add_surface) {
-            _surfaces.reserve(_surfaces.size() + objects.size());
-            _surfaces.insert(_surfaces.end(), objects.begin(), objects.end());
-        } else {
-            _portals.reserve(_portals.size() + objects.size());
-            _portals.insert(_portals.end(), objects.begin(), objects.end());
-        }
+    inline void add_objects(volume &volume, const surface_container &surfaces) {
+        const auto offset = _surfaces.size();
+        _surfaces.reserve(_surfaces.size() + surfaces.size());
+        _surfaces.insert(_surfaces.end(), surfaces.begin(), surfaces.end());
+
+        volume.template set_range<e_surface>({offset, _surfaces.size()});
+    }
+
+    /** @return all surfaces/portals in the detector */
+    inline void add_objects(volume &volume, const portal_container &portals) {
+        const auto offset = _portals.size();
+        _portals.reserve(_portals.size() + portals.size());
+        _portals.insert(_portals.end(), portals.begin(), portals.end());
+
+        volume.template set_range<e_portal>({offset, _portals.size()});
     }
 
     /**

--- a/core/include/core/mask_store.hpp
+++ b/core/include/core/mask_store.hpp
@@ -103,7 +103,7 @@ class mask_store {
      * @note in general can throw an exception
      */
     template <unsigned int mask_id, typename... bounds_type>
-    void add_mask(bounds_type &&...mask_bounds) noexcept(false) {
+    void add_mask(bounds_type &&... mask_bounds) noexcept(false) {
         // Get the mask group that will be updated
         auto &mask_group = std::get<mask_id>(_mask_tuple);
         // Construct new mask in place

--- a/core/include/core/mask_store.hpp
+++ b/core/include/core/mask_store.hpp
@@ -22,48 +22,65 @@ class mask_store {
     using mask_tuple = tuple_type<vector_type<mask_types>...>;
 
     /** Size : Contextual STL like API
-     * @param ctx The context of the call (ignored)
+     *
+     * @tparam mask_id the index for the mask_type
+     * @return the size of the vector containing the masks of the required type
      */
-    constexpr auto n_types() const {
-        return std::tuple_size_v<mask_tuple>;
-    }
-
-    /** Size : Contextual STL like API
-     * @param ctx The context of the call (ignored)
-     */
-    template<unsigned int mask_index>
+    template<unsigned int mask_id>
     const size_t size() const {
-        return std::get<mask_index>(_mask_tuple).size();
+        return std::get<mask_id>(_mask_tuple).size();
     }
 
     /** Empty : Contextual STL like API
-     * @param ctx The context of the call (ignored)
+     *
+     * @tparam mask_id the index for the mask_type
+     * @return whether the vector containing the masks of the required type 
+     * is empty
      */
-    template<unsigned int mask_index>
+    template<unsigned int mask_id>
     bool empty() const {
-        return std::get<mask_index>(_mask_tuple).empty();
+        return std::get<mask_id>(_mask_tuple).empty();
+    }
+
+    /** Retrieve a single mask - const
+     *
+     * @tparam current_id the index for the mask_type
+     *
+     * @param mask_id the index for the mask_type
+     * @param mask_index the index for the mask
+     *
+     * @return the required mask
+     */
+    template <unsigned int current_id = 0>
+    const auto& mask(const dindex mask_id, const dindex mask_index) const
+    {
+        if (current_id == mask_id) {
+            return group<current_id>()[mask_index];
+        }
+        // Next mask type
+        if constexpr (current_id < std::tuple_size_v<mask_tuple> - 1) {
+            return mask<current_id + 1>(mask_id, mask_index);
+        }
     }
 
     /** Retrieve a vector of masks of a certain type (mask group)
      *
-     * @tparam mask_index index of requested mask type in masks container
-     *
+     * @tparam mask_id index of requested mask type in masks container
      * @return vector of masks of a given type.
      */
-    template<unsigned int mask_index>
+    template<unsigned int mask_id>
     auto& group() {
-        return std::get<mask_index>(_mask_tuple);
+        return std::get<mask_id>(_mask_tuple);
     }
 
     /** Retrieve a vector of masks of a certain type (mask group) - const
      *
-     * @tparam mask_index index of requested mask type in masks container
-     *
+     * @tparam mask_id index of requested mask type in masks container
      * @return vector of masks of a given type.
      */
-    template<unsigned int mask_index>
+    template<unsigned int mask_id>
     const auto& group() const {
-        return std::get<mask_index>(_mask_tuple);
+        return std::get<mask_id>(_mask_tuple);
     }
 
     /** Access underlying container - const
@@ -80,54 +97,36 @@ class mask_store {
 
     /** Add a new mask in place
      *
-     * @tparam mask_index index for this mask type in masks container
+     * @tparam mask_id index for this mask type in masks container
      * @tparam bounds_type type of the masks bounds
      *
      * @param mask_bounds list of mask bounds for construction
      *
      * @note in general can throw an exception
      */
-    template<unsigned int mask_index,
-             typename mask_type>
-    void add_mask(mask_type &&mask) noexcept(false) {
-        // Get the mask group that will be updated
-        auto &mask_group = std::get<mask_index>(_mask_tuple);
-        // Construct new mask in place
-        mask_group.push_back(std::forward<mask_type>(mask));
-    }
-
-    /** Add a new mask in place
-     *
-     * @tparam mask_index index for this mask type in masks container
-     * @tparam bounds_type type of the masks bounds
-     *
-     * @param mask_bounds list of mask bounds for construction
-     *
-     * @note in general can throw an exception
-     */
-    template<unsigned int mask_index,
+    template<unsigned int mask_id,
              typename... bounds_type>
     void add_mask(bounds_type &&...mask_bounds) noexcept(false) {
         // Get the mask group that will be updated
-        auto &mask_group = std::get<mask_index>(_mask_tuple);
+        auto &mask_group = std::get<mask_id>(_mask_tuple);
         // Construct new mask in place
         mask_group.emplace_back(std::forward<bounds_type>(mask_bounds)...);
     }
 
     /** Add a new bunch of masks
      *
-     * @tparam mask_index index for this mask type in masks container
+     * @tparam mask_id index for this mask type in masks container
      * @tparam mask_type mask type to be updated
      *
      * @param masks Vector of masks to be added
      *
      * @note in general can throw an exception
      */
-    template<unsigned int mask_index,
+    template<unsigned int mask_id,
              typename mask_type>
     void add_masks(const vector_type<mask_type> &masks) noexcept(false) {
         // Get the mask group that will be updated
-        auto &mask_group = std::get<mask_index>(_mask_tuple);
+        auto &mask_group = std::get<mask_id>(_mask_tuple);
         // Reserve memory and copy new masks
         mask_group.reserve(mask_group.size() + masks.size());
         mask_group.insert(mask_group.end(), masks.begin(), masks.end());
@@ -135,31 +134,21 @@ class mask_store {
 
     /** Add a new bunch of masks - move semantics
      *
-     * @tparam mask_index index for this mask type in masks container
+     * @tparam mask_id index for this mask type in masks container
      * @tparam mask_type mask type to be updated
      *
      * @param masks Vector of masks to be added
      *
      * @note in general can throw an exception
      */
-    template<unsigned int mask_index,
+    template<unsigned int mask_id,
              typename mask_type>
-    void add_masks(vector_type<mask_type> &masks) noexcept(false) {
+    void add_masks(vector_type<mask_type> &&masks) noexcept(false) {
         // Get the mask group that will be updated
-        auto &mask_group = std::get<mask_index>(_mask_tuple);
+        auto &mask_group = std::get<mask_id>(_mask_tuple);
         // Reserve memory and copy new masks
         mask_group.reserve(mask_group.size() + masks.size());
         mask_group.insert(mask_group.end(), std::make_move_iterator(masks.begin()), std::make_move_iterator(masks.end()));
-    }
-
-    /** Append a mask store to the current one
-     *
-     * @param other The other mask store, move semantics
-     *
-     * @note in general can throw an exception
-     */
-    void append_masks(mask_store<vector_type, tuple_type, mask_types...> &&mask_store) noexcept(false) {
-        return;
     }
 
     /** Append a mask store to the current one
@@ -171,7 +160,7 @@ class mask_store {
      * @note in general can throw an exception
      */
     template <unsigned int current_index = 0>
-    inline void append_masks(mask_store<vector_type, tuple_type, mask_types...> &other) {
+    inline void append_masks(mask_store<vector_type, tuple_type, mask_types...> &&other) {
         // Add masks to current group
         auto &mask_group = std::get<current_index>(other);
         add_masks<current_index>(mask_group);
@@ -184,7 +173,7 @@ class mask_store {
 
     private:
 
-    /** tuple of masks */
+    /** tuple of mask vectors (mask groups) */
     mask_tuple _mask_tuple;
 };
 

--- a/core/include/core/mask_store.hpp
+++ b/core/include/core/mask_store.hpp
@@ -14,11 +14,10 @@ namespace detray {
 /** A mask store that provides the correct mask containers to client classes. */
 template <template <typename...> class tuple_type = dtuple,
           template <typename> class vector_type = dvector,
-          typename ...mask_types>
+          typename... mask_types>
 class mask_store {
 
     public:
-
     using mask_tuple = tuple_type<vector_type<mask_types>...>;
 
     /** Size : Contextual STL like API
@@ -26,7 +25,7 @@ class mask_store {
      * @tparam mask_id the index for the mask_type
      * @return the size of the vector containing the masks of the required type
      */
-    template<unsigned int mask_id>
+    template <unsigned int mask_id>
     const size_t size() const {
         return std::get<mask_id>(_mask_tuple).size();
     }
@@ -34,10 +33,10 @@ class mask_store {
     /** Empty : Contextual STL like API
      *
      * @tparam mask_id the index for the mask_type
-     * @return whether the vector containing the masks of the required type 
+     * @return whether the vector containing the masks of the required type
      * is empty
      */
-    template<unsigned int mask_id>
+    template <unsigned int mask_id>
     bool empty() const {
         return std::get<mask_id>(_mask_tuple).empty();
     }
@@ -52,8 +51,7 @@ class mask_store {
      * @return the required mask
      */
     template <unsigned int current_id = 0>
-    const auto& mask(const dindex mask_id, const dindex mask_index) const
-    {
+    const auto &mask(const dindex mask_id, const dindex mask_index) const {
         if (current_id == mask_id) {
             return group<current_id>()[mask_index];
         }
@@ -68,8 +66,8 @@ class mask_store {
      * @tparam mask_id index of requested mask type in masks container
      * @return vector of masks of a given type.
      */
-    template<unsigned int mask_id>
-    auto& group() {
+    template <unsigned int mask_id>
+    auto &group() {
         return std::get<mask_id>(_mask_tuple);
     }
 
@@ -78,8 +76,8 @@ class mask_store {
      * @tparam mask_id index of requested mask type in masks container
      * @return vector of masks of a given type.
      */
-    template<unsigned int mask_id>
-    const auto& group() const {
+    template <unsigned int mask_id>
+    const auto &group() const {
         return std::get<mask_id>(_mask_tuple);
     }
 
@@ -87,13 +85,13 @@ class mask_store {
      *
      * @return internal masks tuple type
      */
-    const auto& masks() const { return _mask_tuple; }
+    const auto &masks() const { return _mask_tuple; }
 
     /** Access underlying container
      *
      * @return internal masks tuple type
      */
-    const auto& masks() { return _mask_tuple; }
+    const auto &masks() { return _mask_tuple; }
 
     /** Add a new mask in place
      *
@@ -104,8 +102,7 @@ class mask_store {
      *
      * @note in general can throw an exception
      */
-    template<unsigned int mask_id,
-             typename... bounds_type>
+    template <unsigned int mask_id, typename... bounds_type>
     void add_mask(bounds_type &&...mask_bounds) noexcept(false) {
         // Get the mask group that will be updated
         auto &mask_group = std::get<mask_id>(_mask_tuple);
@@ -122,8 +119,7 @@ class mask_store {
      *
      * @note in general can throw an exception
      */
-    template<unsigned int mask_id,
-             typename mask_type>
+    template <unsigned int mask_id, typename mask_type>
     void add_masks(const vector_type<mask_type> &masks) noexcept(false) {
         // Get the mask group that will be updated
         auto &mask_group = std::get<mask_id>(_mask_tuple);
@@ -141,14 +137,15 @@ class mask_store {
      *
      * @note in general can throw an exception
      */
-    template<unsigned int mask_id,
-             typename mask_type>
+    template <unsigned int mask_id, typename mask_type>
     void add_masks(vector_type<mask_type> &&masks) noexcept(false) {
         // Get the mask group that will be updated
         auto &mask_group = std::get<mask_id>(_mask_tuple);
         // Reserve memory and copy new masks
         mask_group.reserve(mask_group.size() + masks.size());
-        mask_group.insert(mask_group.end(), std::make_move_iterator(masks.begin()), std::make_move_iterator(masks.end()));
+        mask_group.insert(mask_group.end(),
+                          std::make_move_iterator(masks.begin()),
+                          std::make_move_iterator(masks.end()));
     }
 
     /** Append a mask store to the current one
@@ -160,7 +157,8 @@ class mask_store {
      * @note in general can throw an exception
      */
     template <unsigned int current_index = 0>
-    inline void append_masks(mask_store<vector_type, tuple_type, mask_types...> &&other) {
+    inline void append_masks(
+        mask_store<vector_type, tuple_type, mask_types...> &&other) {
         // Add masks to current group
         auto &mask_group = std::get<current_index>(other);
         add_masks<current_index>(mask_group);
@@ -172,7 +170,6 @@ class mask_store {
     }
 
     private:
-
     /** tuple of mask vectors (mask groups) */
     mask_tuple _mask_tuple;
 };

--- a/core/include/core/mask_store.hpp
+++ b/core/include/core/mask_store.hpp
@@ -103,7 +103,7 @@ class mask_store {
      * @note in general can throw an exception
      */
     template <unsigned int mask_id, typename... bounds_type>
-    void add_mask(bounds_type &&... mask_bounds) noexcept(false) {
+    void add_mask(bounds_type &&...mask_bounds) noexcept(false) {
         // Get the mask group that will be updated
         auto &mask_group = std::get<mask_id>(_mask_tuple);
         // Construct new mask in place

--- a/core/include/core/mask_store.hpp
+++ b/core/include/core/mask_store.hpp
@@ -157,8 +157,7 @@ class mask_store {
      * @note in general can throw an exception
      */
     template <unsigned int current_index = 0>
-    inline void append_masks(
-        mask_store<vector_type, tuple_type, mask_types...> &&other) {
+    inline void append_masks(mask_store &&other) {
         // Add masks to current group
         auto &mask_group = std::get<current_index>(other);
         add_masks<current_index>(mask_group);

--- a/core/include/core/mask_store.hpp
+++ b/core/include/core/mask_store.hpp
@@ -1,0 +1,191 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+#include "utils/enumerate.hpp"
+#include "utils/indexing.hpp"
+
+namespace detray {
+
+/** A mask store that provides the correct mask containers to client classes. */
+template <template <typename...> class tuple_type = dtuple,
+          template <typename> class vector_type = dvector,
+          typename ...mask_types>
+class mask_store {
+
+    public:
+
+    using mask_tuple = tuple_type<vector_type<mask_types>...>;
+
+    /** Size : Contextual STL like API
+     * @param ctx The context of the call (ignored)
+     */
+    constexpr auto n_types() const {
+        return std::tuple_size_v<mask_tuple>;
+    }
+
+    /** Size : Contextual STL like API
+     * @param ctx The context of the call (ignored)
+     */
+    template<unsigned int mask_index>
+    const size_t size() const {
+        return std::get<mask_index>(_mask_tuple).size();
+    }
+
+    /** Empty : Contextual STL like API
+     * @param ctx The context of the call (ignored)
+     */
+    template<unsigned int mask_index>
+    bool empty() const {
+        return std::get<mask_index>(_mask_tuple).empty();
+    }
+
+    /** Retrieve a vector of masks of a certain type (mask group)
+     *
+     * @tparam mask_index index of requested mask type in masks container
+     *
+     * @return vector of masks of a given type.
+     */
+    template<unsigned int mask_index>
+    auto& group() {
+        return std::get<mask_index>(_mask_tuple);
+    }
+
+    /** Retrieve a vector of masks of a certain type (mask group) - const
+     *
+     * @tparam mask_index index of requested mask type in masks container
+     *
+     * @return vector of masks of a given type.
+     */
+    template<unsigned int mask_index>
+    const auto& group() const {
+        return std::get<mask_index>(_mask_tuple);
+    }
+
+    /** Access underlying container - const
+     *
+     * @return internal masks tuple type
+     */
+    const auto& masks() const { return _mask_tuple; }
+
+    /** Access underlying container
+     *
+     * @return internal masks tuple type
+     */
+    const auto& masks() { return _mask_tuple; }
+
+    /** Add a new mask in place
+     *
+     * @tparam mask_index index for this mask type in masks container
+     * @tparam bounds_type type of the masks bounds
+     *
+     * @param mask_bounds list of mask bounds for construction
+     *
+     * @note in general can throw an exception
+     */
+    template<unsigned int mask_index,
+             typename mask_type>
+    void add_mask(mask_type &&mask) noexcept(false) {
+        // Get the mask group that will be updated
+        auto &mask_group = std::get<mask_index>(_mask_tuple);
+        // Construct new mask in place
+        mask_group.push_back(std::forward<mask_type>(mask));
+    }
+
+    /** Add a new mask in place
+     *
+     * @tparam mask_index index for this mask type in masks container
+     * @tparam bounds_type type of the masks bounds
+     *
+     * @param mask_bounds list of mask bounds for construction
+     *
+     * @note in general can throw an exception
+     */
+    template<unsigned int mask_index,
+             typename... bounds_type>
+    void add_mask(bounds_type &&...mask_bounds) noexcept(false) {
+        // Get the mask group that will be updated
+        auto &mask_group = std::get<mask_index>(_mask_tuple);
+        // Construct new mask in place
+        mask_group.emplace_back(std::forward<bounds_type>(mask_bounds)...);
+    }
+
+    /** Add a new bunch of masks
+     *
+     * @tparam mask_index index for this mask type in masks container
+     * @tparam mask_type mask type to be updated
+     *
+     * @param masks Vector of masks to be added
+     *
+     * @note in general can throw an exception
+     */
+    template<unsigned int mask_index,
+             typename mask_type>
+    void add_masks(const vector_type<mask_type> &masks) noexcept(false) {
+        // Get the mask group that will be updated
+        auto &mask_group = std::get<mask_index>(_mask_tuple);
+        // Reserve memory and copy new masks
+        mask_group.reserve(mask_group.size() + masks.size());
+        mask_group.insert(mask_group.end(), masks.begin(), masks.end());
+    }
+
+    /** Add a new bunch of masks - move semantics
+     *
+     * @tparam mask_index index for this mask type in masks container
+     * @tparam mask_type mask type to be updated
+     *
+     * @param masks Vector of masks to be added
+     *
+     * @note in general can throw an exception
+     */
+    template<unsigned int mask_index,
+             typename mask_type>
+    void add_masks(vector_type<mask_type> &masks) noexcept(false) {
+        // Get the mask group that will be updated
+        auto &mask_group = std::get<mask_index>(_mask_tuple);
+        // Reserve memory and copy new masks
+        mask_group.reserve(mask_group.size() + masks.size());
+        mask_group.insert(mask_group.end(), std::make_move_iterator(masks.begin()), std::make_move_iterator(masks.end()));
+    }
+
+    /** Append a mask store to the current one
+     *
+     * @param other The other mask store, move semantics
+     *
+     * @note in general can throw an exception
+     */
+    void append_masks(mask_store<vector_type, tuple_type, mask_types...> &&mask_store) noexcept(false) {
+        return;
+    }
+
+    /** Append a mask store to the current one
+     *
+     * @tparam current_index to start unrolling at
+     *
+     * @param other The other mask store, move semantics
+     *
+     * @note in general can throw an exception
+     */
+    template <unsigned int current_index = 0>
+    inline void append_masks(mask_store<vector_type, tuple_type, mask_types...> &other) {
+        // Add masks to current group
+        auto &mask_group = std::get<current_index>(other);
+        add_masks<current_index>(mask_group);
+
+        // Next mask type
+        if constexpr (current_index < std::tuple_size_v<mask_tuple> - 1) {
+            return append_masks<current_index + 1>(other);
+        }
+    }
+
+    private:
+
+    /** tuple of masks */
+    mask_tuple _mask_tuple;
+};
+
+}  // namespace detray

--- a/core/include/core/surface_base.hpp
+++ b/core/include/core/surface_base.hpp
@@ -20,11 +20,15 @@ namespace detray {
  * @tparam source_link the type of the source/source link representation
  */
 template <typename transform_link, typename mask_link = dindex,
-          typename volume_link = dindex, typename source_link = bool>
+          typename volume_link = dindex, typename source_link = bool, typename edge_link = dindex>
 class surface_base {
     public:
     // Broadcast the type of links
-    using links = volume_link;
+    using transform_links = transform_link;
+    using mask_links = mask_link;
+    using volume_links = volume_link;
+    using source_links = source_link;
+    using edge_links = edge_link;
 
     /** Constructor with full arguments - move semantics
      *

--- a/core/include/core/surface_base.hpp
+++ b/core/include/core/surface_base.hpp
@@ -20,7 +20,8 @@ namespace detray {
  * @tparam source_link the type of the source/source link representation
  */
 template <typename transform_link, typename mask_link = dindex,
-          typename volume_link = dindex, typename source_link = bool, typename edge_link = dindex>
+          typename volume_link = dindex, typename source_link = bool,
+          typename edge_link = dindex>
 class surface_base {
     public:
     // Broadcast the type of links

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -217,7 +217,7 @@ void connect_cylindrical_volumes(
         walk_up(bottom_right, right_portals_info, false, 1);
 
         typename detector_type::geometry::portal_filling_container portals = {};
-        typename detector_type::geometry::portal_mask_container portal_masks;
+        typename detector_type::mask_container portal_masks;
         typename detector_type::transform_container portal_transforms;
 
         // The bounds can be used for the mask and transform information
@@ -240,20 +240,24 @@ void connect_cylindrical_volumes(
                                                volume_bounds[bound_index]};
 
                 // Get the mask context group and fill it
-                constexpr auto disc_id = detector_type::geometry::portal_disc::mask_context;
+                constexpr auto disc_id = detector_type::mask_id::e_portal_ring2;
                 auto &disc_portal_transforms = std::get<disc_id>(portal_transforms);
                 auto &disc_portals = std::get<disc_id>(portals);
 
-                typename detector_type::geometry::portal_mask_index mask_index =
+                typename detector_type::portal::mask_links mask_index =
                     {disc_id, {portal_masks.template size<disc_id>(), portal_masks.template size<disc_id>()}};
                 // Create a stub mask for every unique index
                 for (auto &info_ : portals_info) {
+                    // Add new mask to container
                     std::get<1>(mask_index)[1] = portal_masks.template size<disc_id>();
+
                     portal_masks.template add_mask<disc_id>(std::get<0>(info_)[0], std::get<0>(info_)[1]);
+
+                    // Update mask link
                     portal_masks.template group<disc_id>().back().links() = {std::get<1>(info_), dindex_invalid};
                 }
                 // Create the portal
-                typename detector_type::geometry::portal _portal{
+                typename detector_type::portal _portal{
                     disc_portal_transforms.size(default_context), mask_index,
                     volume.index(), dindex_invalid};
                 // Save the data
@@ -275,21 +279,25 @@ void connect_cylindrical_volumes(
             // Fill in the upper side portals
             if (not portals_info.empty()) {
                 // Get the mask context group and fill it
-                constexpr auto cylinder_id = detector_type::geometry::portal_cylinder::mask_context;
+                constexpr auto cylinder_id = detector_type::mask_id::e_portal_cylinder3;
                 auto &cylinder_portal_transforms = std::get<cylinder_id>(
                     portal_transforms);
                 auto &cylinder_portals = std::get<cylinder_id>(portals);
 
-                typename detector_type::geometry::portal_mask_index mask_index =
+                typename detector_type::portal::mask_links mask_index =
                     {cylinder_id, {portal_masks.template size<cylinder_id>(), portal_masks.template size<cylinder_id>()}};
                 for (auto &info_ : portals_info) {
+                    // Add new mask to container
                     const auto cylinder_range = std::get<0>(info_);
                     std::get<1>(mask_index)[1] = portal_masks.template size<cylinder_id>();
+
                     portal_masks.template add_mask<cylinder_id>(volume_bounds[bound_index], cylinder_range[0], cylinder_range[1]);
+
+                    // Update masks links
                     portal_masks.template group<cylinder_id>().back().links() = {std::get<1>(info_), dindex_invalid};
                 }
                 // Create the portal
-                typename detector_type::geometry::portal _portal{
+                typename detector_type::portal _portal{
                     cylinder_portal_transforms.size(default_context),
                     mask_index, volume.index(), dindex_invalid};
                 cylinder_portals.push_back(std::move(_portal));

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -240,26 +240,17 @@ void connect_cylindrical_volumes(
                                                volume_bounds[bound_index]};
 
                 // Get the mask context group and fill it
-                auto &disc_portal_transforms = std::get<
-                    detector_type::geometry::portal_disc::mask_context>(
-                    portal_transforms);
-                auto &disc_portals = std::get<
-                    detector_type::geometry::portal_disc::mask_context>(
-                    portals);
-                auto &mask_group = std::get<
-                    detector_type::geometry::portal_disc::mask_context>(
-                    portal_masks);
+                constexpr auto disc_id = detector_type::geometry::portal_disc::mask_context;
+                auto &disc_portal_transforms = std::get<disc_id>(portal_transforms);
+                auto &disc_portals = std::get<disc_id>(portals);
 
                 typename detector_type::geometry::portal_mask_index mask_index =
-                    {detector_type::geometry::portal_disc::mask_context,
-                     {mask_group.size(), mask_group.size()}};
+                    {disc_id, {portal_masks.template size<disc_id>(), portal_masks.template size<disc_id>()}};
                 // Create a stub mask for every unique index
                 for (auto &info_ : portals_info) {
-                    typename detector_type::geometry::portal_disc _portal_disc =
-                        {std::get<0>(info_),
-                         {std::get<1>(info_), dindex_invalid}};
-                    std::get<1>(mask_index)[1] = mask_group.size();
-                    mask_group.push_back(_portal_disc);
+                    std::get<1>(mask_index)[1] = portal_masks.template size<disc_id>();
+                    portal_masks.template add_mask<disc_id>(std::get<0>(info_)[0], std::get<0>(info_)[1]);
+                    portal_masks.template group<disc_id>().back().links() = {std::get<1>(info_), dindex_invalid};
                 }
                 // Create the portal
                 typename detector_type::geometry::portal _portal{
@@ -284,30 +275,18 @@ void connect_cylindrical_volumes(
             // Fill in the upper side portals
             if (not portals_info.empty()) {
                 // Get the mask context group and fill it
-                auto &cylinder_portal_transforms = std::get<
-                    detector_type::geometry::portal_cylinder::mask_context>(
+                constexpr auto cylinder_id = detector_type::geometry::portal_cylinder::mask_context;
+                auto &cylinder_portal_transforms = std::get<cylinder_id>(
                     portal_transforms);
-                auto &cylinder_portals = std::get<
-                    detector_type::geometry::portal_cylinder::mask_context>(
-                    portals);
-                auto &mask_group = std::get<
-                    detector_type::geometry::portal_cylinder::mask_context>(
-                    portal_masks);
+                auto &cylinder_portals = std::get<cylinder_id>(portals);
 
                 typename detector_type::geometry::portal_mask_index mask_index =
-                    {detector_type::geometry::portal_cylinder::mask_context,
-                     {mask_group.size(), mask_group.size()}};
+                    {cylinder_id, {portal_masks.template size<cylinder_id>(), portal_masks.template size<cylinder_id>()}};
                 for (auto &info_ : portals_info) {
                     const auto cylinder_range = std::get<0>(info_);
-                    array_type<scalar, 3> cylinder_bounds = {
-                        volume_bounds[bound_index], cylinder_range[0],
-                        cylinder_range[1]};
-                    typename detector_type::geometry::portal_cylinder
-                        _portal_cylinder = {
-                            cylinder_bounds,
-                            {std::get<1>(info_), dindex_invalid}};
-                    std::get<1>(mask_index)[1] = mask_group.size();
-                    mask_group.push_back(_portal_cylinder);
+                    std::get<1>(mask_index)[1] = portal_masks.template size<cylinder_id>();
+                    portal_masks.template add_mask<cylinder_id>(volume_bounds[bound_index], cylinder_range[0], cylinder_range[1]);
+                    portal_masks.template group<cylinder_id>().back().links() = {std::get<1>(info_), dindex_invalid};
                 }
                 // Create the portal
                 typename detector_type::geometry::portal _portal{

--- a/core/include/core/volume_connector.hpp
+++ b/core/include/core/volume_connector.hpp
@@ -241,20 +241,26 @@ void connect_cylindrical_volumes(
 
                 // Get the mask context group and fill it
                 constexpr auto disc_id = detector_type::mask_id::e_portal_ring2;
-                auto &disc_portal_transforms = std::get<disc_id>(portal_transforms);
+                auto &disc_portal_transforms =
+                    std::get<disc_id>(portal_transforms);
                 auto &disc_portals = std::get<disc_id>(portals);
 
-                typename detector_type::portal::mask_links mask_index =
-                    {disc_id, {portal_masks.template size<disc_id>(), portal_masks.template size<disc_id>()}};
+                typename detector_type::portal::mask_links mask_index = {
+                    disc_id,
+                    {portal_masks.template size<disc_id>(),
+                     portal_masks.template size<disc_id>()}};
                 // Create a stub mask for every unique index
                 for (auto &info_ : portals_info) {
                     // Add new mask to container
-                    std::get<1>(mask_index)[1] = portal_masks.template size<disc_id>();
+                    std::get<1>(mask_index)[1] =
+                        portal_masks.template size<disc_id>();
 
-                    portal_masks.template add_mask<disc_id>(std::get<0>(info_)[0], std::get<0>(info_)[1]);
+                    portal_masks.template add_mask<disc_id>(
+                        std::get<0>(info_)[0], std::get<0>(info_)[1]);
 
                     // Update mask link
-                    portal_masks.template group<disc_id>().back().links() = {std::get<1>(info_), dindex_invalid};
+                    portal_masks.template group<disc_id>().back().links() = {
+                        std::get<1>(info_), dindex_invalid};
                 }
                 // Create the portal
                 typename detector_type::portal _portal{
@@ -279,22 +285,29 @@ void connect_cylindrical_volumes(
             // Fill in the upper side portals
             if (not portals_info.empty()) {
                 // Get the mask context group and fill it
-                constexpr auto cylinder_id = detector_type::mask_id::e_portal_cylinder3;
-                auto &cylinder_portal_transforms = std::get<cylinder_id>(
-                    portal_transforms);
+                constexpr auto cylinder_id =
+                    detector_type::mask_id::e_portal_cylinder3;
+                auto &cylinder_portal_transforms =
+                    std::get<cylinder_id>(portal_transforms);
                 auto &cylinder_portals = std::get<cylinder_id>(portals);
 
-                typename detector_type::portal::mask_links mask_index =
-                    {cylinder_id, {portal_masks.template size<cylinder_id>(), portal_masks.template size<cylinder_id>()}};
+                typename detector_type::portal::mask_links mask_index = {
+                    cylinder_id,
+                    {portal_masks.template size<cylinder_id>(),
+                     portal_masks.template size<cylinder_id>()}};
                 for (auto &info_ : portals_info) {
                     // Add new mask to container
                     const auto cylinder_range = std::get<0>(info_);
-                    std::get<1>(mask_index)[1] = portal_masks.template size<cylinder_id>();
+                    std::get<1>(mask_index)[1] =
+                        portal_masks.template size<cylinder_id>();
 
-                    portal_masks.template add_mask<cylinder_id>(volume_bounds[bound_index], cylinder_range[0], cylinder_range[1]);
+                    portal_masks.template add_mask<cylinder_id>(
+                        volume_bounds[bound_index], cylinder_range[0],
+                        cylinder_range[1]);
 
                     // Update masks links
-                    portal_masks.template group<cylinder_id>().back().links() = {std::get<1>(info_), dindex_invalid};
+                    portal_masks.template group<cylinder_id>().back().links() =
+                        {std::get<1>(info_), dindex_invalid};
                 }
                 // Create the portal
                 typename detector_type::portal _portal{

--- a/core/include/masks/annulus2.hpp
+++ b/core/include/masks/annulus2.hpp
@@ -71,6 +71,18 @@ struct annulus2 {
         std::numeric_limits<scalar>::epsilon(),
         std::numeric_limits<scalar>::epsilon()};
 
+    /** Construction from boundary values
+     *
+     * @param r_low lower r boundary
+     * @param r_high upper r boundary
+     * @param phi_low lower phi boundary
+     * @param phi_high upper phi boundary
+     * @param shift_x origin shift loc0
+     * @param shift_y origin shift loc1
+     * @param avg_phi average phi value
+     */
+    annulus2(scalar r_low, scalar r_high, scalar phi_low, scalar phi_high, scalar shift_x = 0., scalar shift_y = 0., scalar avg_phi = 0.) : _values{r_low, r_high, phi_low, phi_high, shift_x, shift_y, avg_phi} {}
+
     /** Assignment operator from an array, convenience function
      *
      * @param rhs is the right hand side object

--- a/core/include/masks/annulus2.hpp
+++ b/core/include/masks/annulus2.hpp
@@ -81,7 +81,10 @@ struct annulus2 {
      * @param shift_y origin shift loc1
      * @param avg_phi average phi value
      */
-    annulus2(scalar r_low, scalar r_high, scalar phi_low, scalar phi_high, scalar shift_x = 0., scalar shift_y = 0., scalar avg_phi = 0.) : _values{r_low, r_high, phi_low, phi_high, shift_x, shift_y, avg_phi} {}
+    annulus2(scalar r_low, scalar r_high, scalar phi_low, scalar phi_high,
+             scalar shift_x = 0., scalar shift_y = 0., scalar avg_phi = 0.)
+        : _values{r_low, r_high, phi_low, phi_high, shift_x, shift_y, avg_phi} {
+    }
 
     /** Assignment operator from an array, convenience function
      *

--- a/core/include/masks/cylinder3.hpp
+++ b/core/include/masks/cylinder3.hpp
@@ -66,7 +66,8 @@ struct cylinder3 {
      * @param half_length_1 half_length
      * @param half_length_2 half length
      */
-    cylinder3(scalar r, scalar half_length_1, scalar half_length_2 = 0.) : _values{r, half_length_1, half_length_2} {}
+    cylinder3(scalar r, scalar half_length_1, scalar half_length_2 = 0.)
+        : _values{r, half_length_1, half_length_2} {}
 
     /** Assignment operator from an array, convenience function
      *

--- a/core/include/masks/cylinder3.hpp
+++ b/core/include/masks/cylinder3.hpp
@@ -60,6 +60,14 @@ struct cylinder3 {
         std::numeric_limits<scalar>::epsilon(),
         std::numeric_limits<scalar>::epsilon()};
 
+    /** Construction from boundary values
+     *
+     * @param r radius
+     * @param half_length_1 half_length
+     * @param half_length_2 half length
+     */
+    cylinder3(scalar r, scalar half_length_1, scalar half_length_2 = 0.) : _values{r, half_length_1, half_length_2} {}
+
     /** Assignment operator from an array, convenience function
      *
      * @param rhs is the right hand side object

--- a/core/include/masks/rectangle2.hpp
+++ b/core/include/masks/rectangle2.hpp
@@ -56,6 +56,13 @@ struct rectangle2 {
         std::numeric_limits<scalar>::epsilon(),
         std::numeric_limits<scalar>::epsilon()};
 
+    /** Construction from boundary values
+     *
+     * @param half_length_0 half length in loc0
+     * @param half_length_1 half length in loc1
+     */
+    rectangle2(scalar half_length_0, scalar half_length_1) : _values{half_length_0, half_length_1} {}
+
     /** Assignment operator from an array, convenience function
      *
      * @param rhs is the right hand side object

--- a/core/include/masks/rectangle2.hpp
+++ b/core/include/masks/rectangle2.hpp
@@ -61,7 +61,8 @@ struct rectangle2 {
      * @param half_length_0 half length in loc0
      * @param half_length_1 half length in loc1
      */
-    rectangle2(scalar half_length_0, scalar half_length_1) : _values{half_length_0, half_length_1} {}
+    rectangle2(scalar half_length_0, scalar half_length_1)
+        : _values{half_length_0, half_length_1} {}
 
     /** Assignment operator from an array, convenience function
      *

--- a/core/include/masks/ring2.hpp
+++ b/core/include/masks/ring2.hpp
@@ -53,6 +53,13 @@ struct ring2 {
     static constexpr mask_tolerance within_epsilon =
         std::numeric_limits<scalar>::epsilon();
 
+    /** Construction from boundary values
+     *
+     * @param r_low lower radial bound
+     * @param r_high upper radial bound
+     */
+    ring2(scalar r_low, scalar r_high) : _values{r_low, r_high} {}
+
     /** Assignment operator from an array, convenience function
      *
      * @param rhs is the right hand side object

--- a/core/include/masks/trapezoid2.hpp
+++ b/core/include/masks/trapezoid2.hpp
@@ -63,7 +63,8 @@ struct trapezoid2 {
      * @param half_length_1 second half length in loc0
      * @param half_length_2 half length in loc1
      */
-    trapezoid2(scalar half_length_0, scalar half_length_1, scalar half_length_2) : _values{half_length_0, half_length_1, half_length_2} {}
+    trapezoid2(scalar half_length_0, scalar half_length_1, scalar half_length_2)
+        : _values{half_length_0, half_length_1, half_length_2} {}
 
     /** Assignment operator from an array, convenience function
      *

--- a/core/include/masks/trapezoid2.hpp
+++ b/core/include/masks/trapezoid2.hpp
@@ -57,6 +57,14 @@ struct trapezoid2 {
         std::numeric_limits<scalar>::epsilon(),
         std::numeric_limits<scalar>::epsilon()};
 
+    /** Construction from boundary values
+     *
+     * @param half_length_0 first half length in loc0
+     * @param half_length_1 second half length in loc0
+     * @param half_length_2 half length in loc1
+     */
+    trapezoid2(scalar half_length_0, scalar half_length_1, scalar half_length_2) : _values{half_length_0, half_length_1, half_length_2} {}
+
     /** Assignment operator from an array, convenience function
      *
      * @param rhs is the right hand side object

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -98,7 +98,7 @@ static inline void bin_association(const context_type &context,
                     auto vertices_per_masks = unroll_masks_for_vertices(
                         surface_masks, mask_range, mask_context,
                         std::make_integer_sequence<
-                            dindex, std::tuple_size_v<typename detector_type::surface_mask_container::mask_tuple>>{});
+                            dindex, std::tuple_size_v<typename detector_type::mask_container::mask_tuple>>{});
 
                     // Usually one mask per surface, but design allows - a
                     // single association  is sufficient though
@@ -176,7 +176,7 @@ static inline void bin_association(const context_type &context,
                     auto vertices_per_masks = unroll_masks_for_vertices(
                         surface_masks, mask_range, mask_context,
                         std::make_integer_sequence<
-                            dindex, std::tuple_size_v<typename detector_type::surface_mask_container::mask_tuple>>{});
+                            dindex, std::tuple_size_v<typename detector_type::mask_container::mask_tuple>>{});
 
                     for (auto &vertices : vertices_per_masks) {
 

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -98,7 +98,9 @@ static inline void bin_association(const context_type &context,
                     auto vertices_per_masks = unroll_masks_for_vertices(
                         surface_masks, mask_range, mask_context,
                         std::make_integer_sequence<
-                            dindex, std::tuple_size_v<typename detector_type::mask_container::mask_tuple>>{});
+                            dindex, std::tuple_size_v<
+                                        typename detector_type::mask_container::
+                                            mask_tuple>>{});
 
                     // Usually one mask per surface, but design allows - a
                     // single association  is sufficient though
@@ -176,7 +178,9 @@ static inline void bin_association(const context_type &context,
                     auto vertices_per_masks = unroll_masks_for_vertices(
                         surface_masks, mask_range, mask_context,
                         std::make_integer_sequence<
-                            dindex, std::tuple_size_v<typename detector_type::mask_container::mask_tuple>>{});
+                            dindex, std::tuple_size_v<
+                                        typename detector_type::mask_container::
+                                            mask_tuple>>{});
 
                     for (auto &vertices : vertices_per_masks) {
 

--- a/core/include/tools/bin_association.hpp
+++ b/core/include/tools/bin_association.hpp
@@ -49,8 +49,6 @@ static inline void bin_association(const context_type &context,
     bool is_cylinder =
         std::abs(bounds[1] - bounds[0]) < std::abs(bounds[3] - bounds[2]);
 
-    auto sfm_copy = surface_masks;
-
     const auto &axis_0 = grid.axis_p0();
     const auto &axis_1 = grid.axis_p1();
 
@@ -100,7 +98,7 @@ static inline void bin_association(const context_type &context,
                     auto vertices_per_masks = unroll_masks_for_vertices(
                         surface_masks, mask_range, mask_context,
                         std::make_integer_sequence<
-                            dindex, std::tuple_size_v<decltype(sfm_copy)>>{});
+                            dindex, std::tuple_size_v<typename detector_type::surface_mask_container::mask_tuple>>{});
 
                     // Usually one mask per surface, but design allows - a
                     // single association  is sufficient though
@@ -178,7 +176,7 @@ static inline void bin_association(const context_type &context,
                     auto vertices_per_masks = unroll_masks_for_vertices(
                         surface_masks, mask_range, mask_context,
                         std::make_integer_sequence<
-                            dindex, std::tuple_size_v<decltype(sfm_copy)>>{});
+                            dindex, std::tuple_size_v<typename detector_type::surface_mask_container::mask_tuple>>{});
 
                     for (auto &vertices : vertices_per_masks) {
 

--- a/core/include/tools/intersection_kernel.hpp
+++ b/core/include/tools/intersection_kernel.hpp
@@ -22,6 +22,7 @@ using transform3 = __plugin::transform3;
 
 /** Specialized method to update an intersection when the mask group is resolved
  *
+ * @tparam links_type is the type of the mask link
  * @tparam track_type is the type of the track information including context
  * @tparam mask_group is the type of the split out mask group from all masks
  * @tparam mask_range is the type of the according mask range object
@@ -36,19 +37,30 @@ using transform3 = __plugin::transform3;
  *
  * @return the surface intersection
  **/
-template <typename track_type, typename mask_group, typename mask_range>
-auto intersect_by_group(const track_type &track, const transform3 &trf,
+template <typename links_type = dindex, typename track_type, typename mask_group, typename mask_range>
+inline auto intersect_by_group(const track_type &track, const transform3 &trf,
                         const mask_group &masks, const mask_range &range) {
     for (auto i : sequence(range)) {
         const auto &mask = masks[i];
         auto local = mask.local();
         auto sfi = mask.intersector().intersect(trf, track, local, mask);
         if (sfi.status == e_inside) {
-            auto valid_link = mask.links();
+            links_type valid_link{};
+            // If different link types are present in the container, the code
+            // will not compile, since in the unrolling the code to compare 
+            // e.g. surface links with portal masks will be generated, even 
+            // though that branch can never be reached. So make sure, that 
+            // links are only set, when they have same type.
+            using mask_links = typename mask_group::value_type::mask_links_type;
+            if constexpr (std::is_same_v<links_type, mask_links>) {
+                valid_link = mask.links();
+            }
+
+            //links_type valid_link = mask.links();
             return std::make_tuple(sfi, valid_link);
         }
     }
-    typename mask_group::value_type::mask_links_type invalid_link;
+    links_type invalid_link;
     intersection invalid_intersection;
     return std::make_tuple(invalid_intersection, invalid_link);
 }
@@ -63,8 +75,8 @@ auto intersect_by_group(const track_type &track, const transform3 &trf,
  * @tparam last_mask_context is the last mask group context
  *
  * @param intersection [in, out] the intersection to be updated
- * @param link [in, out] the links to be updated
- * @param tack_type the track information containing the context
+ * @param links [in, out] the links to be updated
+ * @param tack the track information containing the context
  * @param ctf the contextual transform (context resolved)
  * @param masks the masks container
  * @param range the range within the mask group to be checked
@@ -75,12 +87,12 @@ auto intersect_by_group(const track_type &track, const transform3 &trf,
 template <typename intersection_type, typename links_type, typename track_type,
           typename mask_container, typename mask_range,
           dindex last_mask_context>
-bool last_intersect(intersection_type &intersection, links_type &links,
+inline bool last_intersect(intersection_type &intersection, links_type &links,
                     const track_type &track, const transform3 &ctf,
                     const mask_container &masks, const mask_range &range,
                     dindex mask_context) {
     if (mask_context == last_mask_context) {
-        auto isg = intersect_by_group(
+        auto isg = intersect_by_group<links_type>(
             track, ctf, masks.template group<last_mask_context>(), range);
         intersection = std::get<0>(isg);
         links = std::get<1>(isg);
@@ -99,8 +111,8 @@ bool last_intersect(intersection_type &intersection, links_type &links,
  * @tparam first_mask_context is the first mask group context
  *
  * @param intersection [in, out] the intersection to be updated
- * @param link [in, out] the links to be updated
- * @param tack_type the track information containing the context
+ * @param links [in, out] the links to be updated
+ * @param tack the track information containing the context
  * @param ctf the contextual transform (context resolved)
  * @param masks the masks container
  * @param range the range within the mask group to be checked
@@ -112,7 +124,7 @@ bool last_intersect(intersection_type &intersection, links_type &links,
 template <typename intersection_type, typename links_type, typename track_type,
           typename mask_container, typename mask_range,
           dindex first_mask_context, dindex... remaining_mask_context>
-bool unroll_intersect(
+inline bool unroll_intersect(
     intersection_type &intersection, links_type &links, const track_type &track,
     const transform3 &ctf, const mask_container &masks, const mask_range &range,
     dindex mask_context,
@@ -120,7 +132,7 @@ bool unroll_intersect(
         available_contices) {
     // Pick the first one for interseciton
     if (mask_context == first_mask_context) {
-        auto isg = intersect_by_group(
+        auto isg = intersect_by_group<links_type>(
             track, ctf, masks.template group<first_mask_context>(), range);
         intersection = std::get<0>(isg);
         links = std::get<1>(isg);
@@ -147,37 +159,39 @@ bool unroll_intersect(
  * @tparam surface_type is The type of the surface container
  * @tparam transform_container is the type of the transform container
  * @tparam mask_container is the type of the type of the mask container
+ * @tparam link_type is the type of the geometry links, that belong to the 
+ *         surface type
  *
  * @param track the track information including the contexts
  * @param surface the surface type to be intersected
  * @param contextual_transform the transform container
- * @param mask_container the tuple mask container to for the intersection
+ * @param masks the tuple mask container to for the intersection
+ * @param mask_links the geometry links discovered by the intersection
  *
  * @return an intersection and the link to the result
  **/
 template <typename surface_type, typename transform_container,
-          typename mask_container>
+          typename mask_container, typename link_type>
 const auto intersect(const track<typename transform_container::context> &track,
-                     const surface_type &surface,
+                     surface_type &surface,
                      const transform_container &contextual_transforms,
-                     const mask_container &masks) {
+                     const mask_container &masks,
+                     link_type &mask_links) {
     const auto &ctf = contextual_transforms[surface.transform()];
     auto mask_link = surface.mask();
     const auto &mask_context = std::get<0>(mask_link);
     const auto &mask_range = std::get<1>(mask_link);
 
     // Create a return intersection and run the variadic unrolling
-    const auto &reference_group = masks.template group<0>();
-    typename std::decay_t<decltype(
-        reference_group)>::value_type::mask_links_type result_links;
     intersection result_intersection;
 
     // Unroll the intersection depending on the mask container size
     unroll_intersect(
-        result_intersection, result_links, track, ctf, masks, mask_range,
+        result_intersection, mask_links, track, ctf, masks, mask_range,
         mask_context,
-        std::make_integer_sequence<dindex, std::tuple_size_v<typename mask_container::mask_tuple>>{});
+        std::make_integer_sequence<dindex,
+                                   std::tuple_size_v<typename mask_container::mask_tuple>>{});
     // Return the (eventually update) intersection and links
-    return std::make_tuple(result_intersection, result_links);
+    return result_intersection;
 }
 }  // namespace detray

--- a/core/include/tools/intersection_kernel.hpp
+++ b/core/include/tools/intersection_kernel.hpp
@@ -81,7 +81,7 @@ bool last_intersect(intersection_type &intersection, links_type &links,
                     dindex mask_context) {
     if (mask_context == last_mask_context) {
         auto isg = intersect_by_group(
-            track, ctf, std::get<last_mask_context>(masks), range);
+            track, ctf, masks.template group<last_mask_context>(), range);
         intersection = std::get<0>(isg);
         links = std::get<1>(isg);
         return true;
@@ -121,7 +121,7 @@ bool unroll_intersect(
     // Pick the first one for interseciton
     if (mask_context == first_mask_context) {
         auto isg = intersect_by_group(
-            track, ctf, std::get<first_mask_context>(masks), range);
+            track, ctf, masks.template group<first_mask_context>(), range);
         intersection = std::get<0>(isg);
         links = std::get<1>(isg);
         return true;
@@ -138,7 +138,7 @@ bool unroll_intersect(
     // Last chance - intersect the last index if possible
     return last_intersect<intersection_type, links_type, track_type,
                           mask_container, mask_range,
-                          std::tuple_size_v<mask_container> - 1>(
+                          std::tuple_size_v<typename mask_container::mask_tuple> - 1>(
         intersection, links, track, ctf, masks, range, mask_context);
 }
 
@@ -167,7 +167,7 @@ const auto intersect(const track<typename transform_container::context> &track,
     const auto &mask_range = std::get<1>(mask_link);
 
     // Create a return intersection and run the variadic unrolling
-    const auto &reference_group = std::get<0>(masks);
+    const auto &reference_group = masks.template group<0>();
     typename std::decay_t<decltype(
         reference_group)>::value_type::mask_links_type result_links;
     intersection result_intersection;
@@ -176,8 +176,7 @@ const auto intersect(const track<typename transform_container::context> &track,
     unroll_intersect(
         result_intersection, result_links, track, ctf, masks, mask_range,
         mask_context,
-        std::make_integer_sequence<dindex,
-                                   std::tuple_size_v<mask_container>>{});
+        std::make_integer_sequence<dindex, std::tuple_size_v<typename mask_container::mask_tuple>>{});
     // Return the (eventually update) intersection and links
     return std::make_tuple(result_intersection, result_links);
 }

--- a/core/include/tools/intersection_kernel.hpp
+++ b/core/include/tools/intersection_kernel.hpp
@@ -37,9 +37,11 @@ using transform3 = __plugin::transform3;
  *
  * @return the surface intersection
  **/
-template <typename links_type = dindex, typename track_type, typename mask_group, typename mask_range>
+template <typename links_type = dindex, typename track_type,
+          typename mask_group, typename mask_range>
 inline auto intersect_by_group(const track_type &track, const transform3 &trf,
-                        const mask_group &masks, const mask_range &range) {
+                               const mask_group &masks,
+                               const mask_range &range) {
     for (auto i : sequence(range)) {
         const auto &mask = masks[i];
         auto local = mask.local();
@@ -47,16 +49,16 @@ inline auto intersect_by_group(const track_type &track, const transform3 &trf,
         if (sfi.status == e_inside) {
             links_type valid_link{};
             // If different link types are present in the container, the code
-            // will not compile, since in the unrolling the code to compare 
-            // e.g. surface links with portal masks will be generated, even 
-            // though that branch can never be reached. So make sure, that 
+            // will not compile, since in the unrolling the code to compare
+            // e.g. surface links with portal masks will be generated, even
+            // though that branch can never be reached. So make sure, that
             // links are only set, when they have same type.
             using mask_links = typename mask_group::value_type::mask_links_type;
             if constexpr (std::is_same_v<links_type, mask_links>) {
                 valid_link = mask.links();
             }
 
-            //links_type valid_link = mask.links();
+            // links_type valid_link = mask.links();
             return std::make_tuple(sfi, valid_link);
         }
     }
@@ -88,9 +90,9 @@ template <typename intersection_type, typename links_type, typename track_type,
           typename mask_container, typename mask_range,
           dindex last_mask_context>
 inline bool last_intersect(intersection_type &intersection, links_type &links,
-                    const track_type &track, const transform3 &ctf,
-                    const mask_container &masks, const mask_range &range,
-                    dindex mask_context) {
+                           const track_type &track, const transform3 &ctf,
+                           const mask_container &masks, const mask_range &range,
+                           dindex mask_context) {
     if (mask_context == last_mask_context) {
         auto isg = intersect_by_group<links_type>(
             track, ctf, masks.template group<last_mask_context>(), range);
@@ -148,9 +150,9 @@ inline bool unroll_intersect(
         }
     }
     // Last chance - intersect the last index if possible
-    return last_intersect<intersection_type, links_type, track_type,
-                          mask_container, mask_range,
-                          std::tuple_size_v<typename mask_container::mask_tuple> - 1>(
+    return last_intersect<
+        intersection_type, links_type, track_type, mask_container, mask_range,
+        std::tuple_size_v<typename mask_container::mask_tuple> - 1>(
         intersection, links, track, ctf, masks, range, mask_context);
 }
 
@@ -159,7 +161,7 @@ inline bool unroll_intersect(
  * @tparam surface_type is The type of the surface container
  * @tparam transform_container is the type of the transform container
  * @tparam mask_container is the type of the type of the mask container
- * @tparam link_type is the type of the geometry links, that belong to the 
+ * @tparam link_type is the type of the geometry links, that belong to the
  *         surface type
  *
  * @param track the track information including the contexts
@@ -175,8 +177,7 @@ template <typename surface_type, typename transform_container,
 const auto intersect(const track<typename transform_container::context> &track,
                      surface_type &surface,
                      const transform_container &contextual_transforms,
-                     const mask_container &masks,
-                     link_type &mask_links) {
+                     const mask_container &masks, link_type &mask_links) {
     const auto &ctf = contextual_transforms[surface.transform()];
     auto mask_link = surface.mask();
     const auto &mask_context = std::get<0>(mask_link);
@@ -189,8 +190,8 @@ const auto intersect(const track<typename transform_container::context> &track,
     unroll_intersect(
         result_intersection, mask_links, track, ctf, masks, mask_range,
         mask_context,
-        std::make_integer_sequence<dindex,
-                                   std::tuple_size_v<typename mask_container::mask_tuple>>{});
+        std::make_integer_sequence<
+            dindex, std::tuple_size_v<typename mask_container::mask_tuple>>{});
     // Return the (eventually update) intersection and links
     return result_intersection;
 }

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -43,10 +43,10 @@ struct navigator {
 
     using objects = typename detector_type::objects;
     using surface = typename detector_type::surface;
-    using surface_link = typename surface::links;
+    using surface_link = typename surface::edge_links;
 
     using portal = typename detector_type::portal;
-    using portal_links = typename portal::links;
+    using portal_links = typename portal::edge_links;
 
     using context = typename detector_type::context;
 
@@ -85,7 +85,7 @@ struct navigator {
         const object_type *on = nullptr;
         vector_type<candidate_type> candidates = {};
         typename vector_type<candidate_type>::iterator next = candidates.end();
-        links_type links;
+        links_type object_links;
 
         /** Indicate that the kernel is empty */
         bool empty() const { return candidates.empty(); }
@@ -93,11 +93,14 @@ struct navigator {
         /** Forward the kernel size */
         size_t size() const { return candidates.size(); }
 
+        /** Return current links for one of the objects */
+        links_type& links() { return object_links; }
+
         /** Clear the kernel */
         void clear() {
             candidates.clear();
             next = candidates.end();
-            links = links_type{};
+            object_links = links_type{};
             on = nullptr;
         }
     };
@@ -321,15 +324,15 @@ struct navigator {
         kernel.candidates.reserve(n_objects);
         // const auto &transforms = detector.transforms(trf_range, track.ctx);
         const auto &transforms = detector.transforms(track.ctx);
-        const auto &surfaces = detector.template surfaces<kSurfaceType>();
-        const auto &masks = detector.template masks<kSurfaceType>();
+        const auto &surfaces = detector.template get_objects<kSurfaceType>();
+        const auto &masks = detector.masks();
         // Loop over all indexed surfaces, intersect and fill
         // @todo - will come from the local object finder
         for (size_t si = obj_range[0]; si < obj_range[1]; si++) {
             const auto &object = surfaces[si];
-            auto [sfi, link] = intersect(track, object, transforms, masks);
+            auto sfi = intersect(track, object, transforms, masks, kernel.links());
             sfi.index = si;
-            sfi.link = link[0];
+            sfi.link = kernel.links()[0];
             // Ignore negative solutions - except overstep limit
             if (sfi.path < track.overstep_tolerance) {
                 continue;
@@ -378,8 +381,8 @@ struct navigator {
 
         // const auto &transforms = detector.transforms(trf_range, track.ctx);
         const auto &transforms = detector.transforms(track.ctx);
-        const auto &surfaces = detector.template surfaces<kSurfaceType>();
-        const auto &masks = detector.template masks<kSurfaceType>();
+        const auto &surfaces = detector.template get_objects<kSurfaceType>();
+        const auto &masks = detector.masks();
 
         // Update current candidate, or step further
         // - do this only when you trust level is high
@@ -387,10 +390,10 @@ struct navigator {
             kernel.next != kernel.candidates.end()) {
             // Only update the last intersection
             dindex si = kernel.next->index;
-            const auto &s = surfaces[si];
-            auto [sfi, link] = intersect(track, s, transforms, masks);
+            const  auto &s = surfaces[si];
+            auto sfi = intersect(track, s, transforms, masks, kernel.links());
             sfi.index = si;
-            sfi.link = link[0];
+            sfi.link = kernel.links()[0];
             if (sfi.status == e_inside) {
                 // Update the intersection with a new one
                 (*kernel.next) = sfi;
@@ -424,11 +427,11 @@ struct navigator {
         else if (navigation.trust_level == e_fair_trust) {
             for (auto &c : kernel.candidates) {
                 dindex si = c.index;
-                const auto &s = surfaces[si];
-                auto [sfi, link] = intersect(track, s, transforms, masks);
+                auto &s = surfaces[si];
+                auto sfi= intersect(track, s, transforms, masks, kernel.links());
                 c = sfi;
                 c.index = si;
-                c.link = link[0];
+                c.link = kernel.links()[0];
             }
             sort_and_set(navigation, kernel);
             if (navigation.trust_level == e_high_trust) {

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -94,7 +94,7 @@ struct navigator {
         size_t size() const { return candidates.size(); }
 
         /** Return current links for one of the objects */
-        links_type& links() { return object_links; }
+        links_type &links() { return object_links; }
 
         /** Clear the kernel */
         void clear() {
@@ -330,7 +330,8 @@ struct navigator {
         // @todo - will come from the local object finder
         for (size_t si = obj_range[0]; si < obj_range[1]; si++) {
             const auto &object = surfaces[si];
-            auto sfi = intersect(track, object, transforms, masks, kernel.links());
+            auto sfi =
+                intersect(track, object, transforms, masks, kernel.links());
             sfi.index = si;
             sfi.link = kernel.links()[0];
             // Ignore negative solutions - except overstep limit
@@ -390,7 +391,7 @@ struct navigator {
             kernel.next != kernel.candidates.end()) {
             // Only update the last intersection
             dindex si = kernel.next->index;
-            const  auto &s = surfaces[si];
+            const auto &s = surfaces[si];
             auto sfi = intersect(track, s, transforms, masks, kernel.links());
             sfi.index = si;
             sfi.link = kernel.links()[0];
@@ -428,7 +429,8 @@ struct navigator {
             for (auto &c : kernel.candidates) {
                 dindex si = c.index;
                 auto &s = surfaces[si];
-                auto sfi= intersect(track, s, transforms, masks, kernel.links());
+                auto sfi =
+                    intersect(track, s, transforms, masks, kernel.links());
                 c = sfi;
                 c.index = si;
                 c.link = kernel.links()[0];

--- a/core/include/utils/generators.hpp
+++ b/core/include/utils/generators.hpp
@@ -252,8 +252,8 @@ auto vertices_for_last_mask_group(const mask_container &masks,
                                   dindex mask_context) {
     dvector<dvector<point3>> mask_vertices = {};
     if (mask_context == last_mask_context) {
-        mask_vertices =
-            vertices_for_mask_group(masks.template group<last_mask_context>(), range);
+        mask_vertices = vertices_for_mask_group(
+            masks.template group<last_mask_context>(), range);
     }
     return mask_vertices;
 }
@@ -279,7 +279,8 @@ auto unroll_masks_for_vertices(
         available_contices) {
     // Pick the first one for interseciton
     if (mask_context == first_mask_context) {
-        return vertices_for_mask_group(masks.template group<first_mask_context>(), range);
+        return vertices_for_mask_group(
+            masks.template group<first_mask_context>(), range);
     }
     // The reduced integer sequence
     std::integer_sequence<dindex, remaining_mask_context...> remaining;
@@ -292,8 +293,9 @@ auto unroll_masks_for_vertices(
         }
     }
     // Last chance - intersect the last index if possible
-    return vertices_for_last_mask_group<mask_container, mask_range,
-                                        std::tuple_size_v<typename mask_container::mask_tuple> - 1>(
+    return vertices_for_last_mask_group<
+        mask_container, mask_range,
+        std::tuple_size_v<typename mask_container::mask_tuple> - 1>(
         masks, range, mask_context);
 }
 

--- a/core/include/utils/generators.hpp
+++ b/core/include/utils/generators.hpp
@@ -253,7 +253,7 @@ auto vertices_for_last_mask_group(const mask_container &masks,
     dvector<dvector<point3>> mask_vertices = {};
     if (mask_context == last_mask_context) {
         mask_vertices =
-            vertices_for_mask_group(std::get<last_mask_context>(masks), range);
+            vertices_for_mask_group(masks.template group<last_mask_context>(), range);
     }
     return mask_vertices;
 }
@@ -279,8 +279,7 @@ auto unroll_masks_for_vertices(
         available_contices) {
     // Pick the first one for interseciton
     if (mask_context == first_mask_context) {
-        return vertices_for_mask_group(std::get<first_mask_context>(masks),
-                                       range);
+        return vertices_for_mask_group(masks.template group<first_mask_context>(), range);
     }
     // The reduced integer sequence
     std::integer_sequence<dindex, remaining_mask_context...> remaining;
@@ -294,7 +293,7 @@ auto unroll_masks_for_vertices(
     }
     // Last chance - intersect the last index if possible
     return vertices_for_last_mask_group<mask_container, mask_range,
-                                        std::tuple_size_v<mask_container> - 1>(
+                                        std::tuple_size_v<typename mask_container::mask_tuple> - 1>(
         masks, range, mask_context);
 }
 

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -82,7 +82,7 @@ detector_from_csv(const std::string &detector_name,
     // Flushable containers
     typename typed_detector::volume *c_volume = nullptr;
     typename typed_detector::geometry::surface_filling_container c_surfaces;
-    typename typed_detector::geometry::surface_mask_container c_masks;
+    typename typed_detector::mask_container c_masks;
     typename typed_detector::transform_container c_transforms;
 
     std::map<volume_layer_index, array_type<scalar, 6>> volume_bounds;
@@ -294,8 +294,7 @@ detector_from_csv(const std::string &detector_name,
 
                 c_surfaces = typename typed_detector::geometry::
                     surface_filling_container();
-                c_masks =
-                    typename typed_detector::geometry::surface_mask_container();
+                c_masks = typename typed_detector::mask_container();
                 c_transforms = typename typed_detector::transform_container();
             }
 
@@ -364,13 +363,13 @@ detector_from_csv(const std::string &detector_name,
             bounds.push_back(io_surface.bound_param6);
 
             // Acts naming convention for bounds
-            typename typed_detector::geometry::surface_mask_index mask_index = {
+            typename typed_detector::surface::mask_links mask_index = {
                 dindex_invalid, dindex_invalid};
 
             if (bounds_type == 1) {
                 // Cylinder Bounds
                 constexpr auto cylinder_id =
-                    typed_detector::geometry::surface_cylinder::mask_context;
+                    typed_detector::mask_id::e_cylinder3;
 
                 // Add a new cylinder mask
                 dindex cylinder_index = c_masks.template size<cylinder_id>();
@@ -392,8 +391,7 @@ detector_from_csv(const std::string &detector_name,
                 // Disc bounds
             } else if (bounds_type == 6) {
                 // Rectangle bounds
-                constexpr auto rectangle_id =
-                    typed_detector::geometry::surface_rectangle::mask_context;
+                constexpr auto rectangle_id = typed_detector::mask_id::e_rectangle2;
 
                 // Add a new rectangle mask
                 dindex rectangle_index = c_masks.template size<rectangle_id>();
@@ -419,7 +417,7 @@ detector_from_csv(const std::string &detector_name,
             } else if (bounds_type == 7) {
                 // Trapezoid bounds
                 constexpr auto trapezoid_id =
-                    typed_detector::geometry::surface_trapezoid::mask_context;
+                    typed_detector::mask_id::e_trapezoid2;
 
                 // Add a new trapezoid mask
                 dindex trapezoid_index = c_masks.template size<trapezoid_id>();
@@ -436,13 +434,12 @@ detector_from_csv(const std::string &detector_name,
 
                 // Save the corresponding surface
                 auto &trapezoid_surfaces = c_surfaces[trapezoid_id];
-                trapezoid_surfaces.push_back(
-                    {trapezoid_transforms.size(surface_default_context) - 1,
+                trapezoid_surfaces.push_back({trapezoid_transforms.size(surface_default_context) - 1,
                      mask_index, c_volume->index(), io_surface.geometry_id});
             } else if (bounds_type == 11) {
                 // Annulus bounds
                 constexpr auto annulus_id =
-                    typed_detector::geometry::surface_annulus::mask_context;
+                    typed_detector::mask_id::e_annulus2;
 
                 // Add a new annulus mask
                 dindex annulus_index = c_masks.template size<annulus_id>();

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -373,7 +373,10 @@ detector_from_csv(const std::string &detector_name,
 
                 // Add a new cylinder mask
                 dindex cylinder_index = c_masks.template size<cylinder_id>();
-                c_masks.template add_mask<cylinder_id>(io_surface.bound_param0, io_surface.cz - io_surface.bound_param1, io_surface.cz + io_surface.bound_param1);
+                c_masks.template add_mask<cylinder_id>(
+                    io_surface.bound_param0,
+                    io_surface.cz - io_surface.bound_param1,
+                    io_surface.cz + io_surface.bound_param1);
                 // The read is valid: set the index
                 mask_index = {cylinder_id, cylinder_index};
 
@@ -391,7 +394,8 @@ detector_from_csv(const std::string &detector_name,
                 // Disc bounds
             } else if (bounds_type == 6) {
                 // Rectangle bounds
-                constexpr auto rectangle_id = typed_detector::mask_id::e_rectangle2;
+                constexpr auto rectangle_id =
+                    typed_detector::mask_id::e_rectangle2;
 
                 // Add a new rectangle mask
                 dindex rectangle_index = c_masks.template size<rectangle_id>();
@@ -421,7 +425,9 @@ detector_from_csv(const std::string &detector_name,
 
                 // Add a new trapezoid mask
                 dindex trapezoid_index = c_masks.template size<trapezoid_id>();
-                c_masks.template add_mask<trapezoid_id>(io_surface.bound_param0, io_surface.bound_param1, io_surface.bound_param2);
+                c_masks.template add_mask<trapezoid_id>(
+                    io_surface.bound_param0, io_surface.bound_param1,
+                    io_surface.bound_param2);
 
                 // The read is valid: set the index
                 mask_index = {trapezoid_id, trapezoid_index};
@@ -434,26 +440,26 @@ detector_from_csv(const std::string &detector_name,
 
                 // Save the corresponding surface
                 auto &trapezoid_surfaces = c_surfaces[trapezoid_id];
-                trapezoid_surfaces.push_back({trapezoid_transforms.size(surface_default_context) - 1,
+                trapezoid_surfaces.push_back(
+                    {trapezoid_transforms.size(surface_default_context) - 1,
                      mask_index, c_volume->index(), io_surface.geometry_id});
             } else if (bounds_type == 11) {
                 // Annulus bounds
-                constexpr auto annulus_id =
-                    typed_detector::mask_id::e_annulus2;
+                constexpr auto annulus_id = typed_detector::mask_id::e_annulus2;
 
                 // Add a new annulus mask
                 dindex annulus_index = c_masks.template size<annulus_id>();
-                c_masks.template add_mask<annulus_id>(io_surface.bound_param0, io_surface.bound_param1,
-                     io_surface.bound_param2, io_surface.bound_param3,
-                     io_surface.bound_param4, io_surface.bound_param5,
-                     io_surface.bound_param6);
+                c_masks.template add_mask<annulus_id>(
+                    io_surface.bound_param0, io_surface.bound_param1,
+                    io_surface.bound_param2, io_surface.bound_param3,
+                    io_surface.bound_param4, io_surface.bound_param5,
+                    io_surface.bound_param6);
 
                 // The read is valid: set the index
                 mask_index = {annulus_id, annulus_index};
 
                 // Build the annulus transform
-                auto &annulus_transforms =
-                    std::get<annulus_id>(c_transforms);
+                auto &annulus_transforms = std::get<annulus_id>(c_transforms);
                 annulus_transforms.emplace_back(surface_default_context, t, z,
                                                 x);
 

--- a/io/csv/include/io/csv_io.hpp
+++ b/io/csv/include/io/csv_io.hpp
@@ -369,27 +369,22 @@ detector_from_csv(const std::string &detector_name,
 
             if (bounds_type == 1) {
                 // Cylinder Bounds
-                constexpr auto cylinder_context =
+                constexpr auto cylinder_id =
                     typed_detector::geometry::surface_cylinder::mask_context;
 
                 // Add a new cylinder mask
-                auto &cylinder_masks = std::get<cylinder_context>(c_masks);
-                dindex cylinder_index = cylinder_masks.size();
-                cylinder_masks.push_back(
-                    {io_surface.bound_param0,
-                     io_surface.cz - io_surface.bound_param1,
-                     io_surface.cz + io_surface.bound_param1});
+                dindex cylinder_index = c_masks.template size<cylinder_id>();
+                c_masks.template add_mask<cylinder_id>(io_surface.bound_param0, io_surface.cz - io_surface.bound_param1, io_surface.cz + io_surface.bound_param1);
                 // The read is valid: set the index
-                mask_index = {cylinder_context, cylinder_index};
+                mask_index = {cylinder_id, cylinder_index};
 
                 // Build the cylinder transform
-                auto &cylinder_transforms =
-                    std::get<cylinder_context>(c_transforms);
+                auto &cylinder_transforms = std::get<cylinder_id>(c_transforms);
                 cylinder_transforms.emplace_back(surface_default_context, t, z,
                                                  x);
 
                 // Save the corresponding surface
-                auto &cylinder_surfaces = c_surfaces[cylinder_context];
+                auto &cylinder_surfaces = c_surfaces[cylinder_id];
                 cylinder_surfaces.emplace_back(
                     cylinder_transforms.size(surface_default_context) - 1,
                     mask_index, c_volume->index(), io_surface.geometry_id);
@@ -397,80 +392,76 @@ detector_from_csv(const std::string &detector_name,
                 // Disc bounds
             } else if (bounds_type == 6) {
                 // Rectangle bounds
-                constexpr auto rectangle_context =
+                constexpr auto rectangle_id =
                     typed_detector::geometry::surface_rectangle::mask_context;
 
                 // Add a new rectangle mask
-                auto &rectangle_masks = std::get<rectangle_context>(c_masks);
-                dindex rectangle_index = rectangle_masks.size();
+                dindex rectangle_index = c_masks.template size<rectangle_id>();
                 scalar half_x =
                     0.5 * (io_surface.bound_param2 - io_surface.bound_param0);
                 scalar half_y =
                     0.5 * (io_surface.bound_param3 - io_surface.bound_param1);
-                rectangle_masks.push_back({half_x, half_y});
+                c_masks.template add_mask<rectangle_id>(half_x, half_y);
                 // The read is valid: set the index
-                mask_index = {rectangle_context, rectangle_index};
+                mask_index = {rectangle_id, rectangle_index};
 
                 // Build the rectangle transform
                 auto &rectangle_transforms =
-                    std::get<rectangle_context>(c_transforms);
+                    std::get<rectangle_id>(c_transforms);
                 rectangle_transforms.emplace_back(surface_default_context, t, z,
                                                   x);
 
                 // Save the corresponding surface
-                auto &rectangle_surfaces = c_surfaces[rectangle_context];
+                auto &rectangle_surfaces = c_surfaces[rectangle_id];
                 rectangle_surfaces.emplace_back(
                     rectangle_transforms.size(surface_default_context) - 1,
                     mask_index, c_volume->index(), io_surface.geometry_id);
             } else if (bounds_type == 7) {
                 // Trapezoid bounds
-                constexpr auto trapezoid_context =
+                constexpr auto trapezoid_id =
                     typed_detector::geometry::surface_trapezoid::mask_context;
 
                 // Add a new trapezoid mask
-                auto &trapezoid_masks = std::get<trapezoid_context>(c_masks);
-                dindex trapezoid_index = trapezoid_masks.size();
-                trapezoid_masks.push_back({io_surface.bound_param0,
-                                           io_surface.bound_param1,
-                                           io_surface.bound_param2});
+                dindex trapezoid_index = c_masks.template size<trapezoid_id>();
+                c_masks.template add_mask<trapezoid_id>(io_surface.bound_param0, io_surface.bound_param1, io_surface.bound_param2);
+
                 // The read is valid: set the index
-                mask_index = {trapezoid_context, trapezoid_index};
+                mask_index = {trapezoid_id, trapezoid_index};
 
                 // Build the trapezoid transform
                 auto &trapezoid_transforms =
-                    std::get<trapezoid_context>(c_transforms);
+                    std::get<trapezoid_id>(c_transforms);
                 trapezoid_transforms.emplace_back(surface_default_context, t, z,
                                                   x);
 
                 // Save the corresponding surface
-                auto &trapezoid_surfaces = c_surfaces[trapezoid_context];
+                auto &trapezoid_surfaces = c_surfaces[trapezoid_id];
                 trapezoid_surfaces.push_back(
                     {trapezoid_transforms.size(surface_default_context) - 1,
                      mask_index, c_volume->index(), io_surface.geometry_id});
             } else if (bounds_type == 11) {
                 // Annulus bounds
-                constexpr auto annulus_context =
+                constexpr auto annulus_id =
                     typed_detector::geometry::surface_annulus::mask_context;
 
                 // Add a new annulus mask
-                auto &annulus_masks = std::get<annulus_context>(c_masks);
-                dindex annulus_index = annulus_masks.size();
-                annulus_masks.push_back(
-                    {io_surface.bound_param0, io_surface.bound_param1,
+                dindex annulus_index = c_masks.template size<annulus_id>();
+                c_masks.template add_mask<annulus_id>(io_surface.bound_param0, io_surface.bound_param1,
                      io_surface.bound_param2, io_surface.bound_param3,
                      io_surface.bound_param4, io_surface.bound_param5,
-                     io_surface.bound_param6});
+                     io_surface.bound_param6);
+
                 // The read is valid: set the index
-                mask_index = {annulus_context, annulus_index};
+                mask_index = {annulus_id, annulus_index};
 
                 // Build the annulus transform
                 auto &annulus_transforms =
-                    std::get<annulus_context>(c_transforms);
+                    std::get<annulus_id>(c_transforms);
                 annulus_transforms.emplace_back(surface_default_context, t, z,
                                                 x);
 
                 // Save the corresponding surface
-                auto &annulus_surfaces = c_surfaces[annulus_context];
+                auto &annulus_surfaces = c_surfaces[annulus_id];
                 annulus_surfaces.emplace_back(
                     annulus_transforms.size(surface_default_context) - 1,
                     mask_index, c_volume->index(), io_surface.geometry_id);

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -102,9 +102,9 @@ static void BM_INTERSECT_ALL(benchmark::State &state) {
                     for (size_t si = v.template range<get_surface_masks>()[0];
                          si < v.template range<get_surface_masks>()[1]; si++) {
                         links_type links{};
-                        auto sfi =
-                            intersect(track, surfaces[si],
-                                      d.transforms(default_context), masks, links);
+                        auto sfi = intersect(track, surfaces[si],
+                                             d.transforms(default_context),
+                                             masks, links);
 
                         benchmark::DoNotOptimize(hits);
                         benchmark::DoNotOptimize(missed);

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -57,7 +57,8 @@ auto d = read_detector();
 
 const auto &surfaces = d.surfaces();
 constexpr bool get_surface_masks = true;
-const auto &masks = d.template masks<decltype(d)::objects::e_surface>();
+const auto &masks = d.masks();
+using links_type = typename decltype(d)::geometry::surface_links;
 
 namespace __plugin {
 // This test runs intersection with all surfaces of the TrackML detector
@@ -100,11 +101,10 @@ static void BM_INTERSECT_ALL(benchmark::State &state) {
                     // Loop over surfaces
                     for (size_t si = v.template range<get_surface_masks>()[0];
                          si < v.template range<get_surface_masks>()[1]; si++) {
-                        auto sfi_surface =
+                        links_type links{};
+                        auto sfi =
                             intersect(track, surfaces[si],
-                                      d.transforms(default_context), masks);
-
-                        const auto &sfi = std::get<0>(sfi_surface);
+                                      d.transforms(default_context), masks, links);
 
                         benchmark::DoNotOptimize(hits);
                         benchmark::DoNotOptimize(missed);

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -23,7 +23,7 @@ TEST(ALGEBRA_PLUGIN, detector) {
     static_transform_store<>::context ctx0;
 
     detector::transform_container trfs;
-    geometry::surface_mask_container masks;
+    detector::mask_container masks;
     geometry::surface_filling_container surfaces = {};
 
     /// Surface 0

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -34,12 +34,14 @@ TEST(ALGEBRA_PLUGIN, detector) {
     /// Surface 1
     point3 t1{1., 0., 0.};
     trfs[geometry::surface_annulus::mask_context].emplace_back(ctx0, t1);
-    masks.template add_mask<geometry::surface_annulus::mask_context>(1., 2., 3., 4., 5., 6., 7.);
+    masks.template add_mask<geometry::surface_annulus::mask_context>(
+        1., 2., 3., 4., 5., 6., 7.);
 
     /// Surface 2
     point3 t2{2., 0., 0.};
     trfs[geometry::surface_trapezoid::mask_context].emplace_back(ctx0, t2);
-    masks.template add_mask<geometry::surface_trapezoid::mask_context>(1., 2., 3.);
+    masks.template add_mask<geometry::surface_trapezoid::mask_context>(1., 2.,
+                                                                       3.);
 
     detector d("test_detector");
     auto &v = d.new_volume("test_volume", {0., 10., -5., 5., -M_PI, M_PI});

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -29,20 +29,17 @@ TEST(ALGEBRA_PLUGIN, detector) {
     /// Surface 0
     point3 t0{0., 0., 0.};
     trfs[geometry::surface_rectangle::mask_context].emplace_back(ctx0, t0);
-    geometry::surface_rectangle rect = {-3., 3.};
-    std::get<geometry::surface_rectangle::mask_context>(masks).push_back(rect);
+    masks.template add_mask<geometry::surface_rectangle::mask_context>(-3., 3.);
 
     /// Surface 1
     point3 t1{1., 0., 0.};
     trfs[geometry::surface_annulus::mask_context].emplace_back(ctx0, t1);
-    geometry::surface_annulus anns = {1., 2., 3., 4., 5., 6., 7.};
-    std::get<geometry::surface_annulus::mask_context>(masks).push_back(anns);
+    masks.template add_mask<geometry::surface_annulus::mask_context>(1., 2., 3., 4., 5., 6., 7.);
 
     /// Surface 2
     point3 t2{2., 0., 0.};
     trfs[geometry::surface_trapezoid::mask_context].emplace_back(ctx0, t2);
-    geometry::surface_trapezoid trap = {1., 2., 3.};
-    std::get<geometry::surface_trapezoid::mask_context>(masks).push_back(trap);
+    masks.template add_mask<geometry::surface_trapezoid::mask_context>(1., 2., 3.);
 
     detector d("test_detector");
     auto &v = d.new_volume("test_volume", {0., 10., -5., 5., -M_PI, M_PI});

--- a/tests/common/include/tests/common/core_mask_store.inl
+++ b/tests/common/include/tests/common/core_mask_store.inl
@@ -1,0 +1,86 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include "core/mask_store.hpp"
+#include "masks/masks.hpp"
+
+/// @note __plugin has to be defined with a preprocessor command
+
+// This tests the construction of a static transform store
+TEST(ALGEBRA_PLUGIN, static_transform_store) {
+    using namespace detray;
+    using namespace __plugin;
+
+    using annulus = annulus2<>;
+    using cylinder = cylinder3<>;
+    using rectangle = rectangle2<>;
+    using ring = ring2<>;
+    using single = single3<0>;
+    using trapezoid = trapezoid2<>;
+
+    // Types must be sorted according to their id (here: masks/mask_identifier)
+    mask_store<dtuple, dvector, rectangle, trapezoid, ring, cylinder, single,
+               annulus>
+        store;
+
+    ASSERT_TRUE(store.template empty<e_annulus2>());
+    ASSERT_TRUE(store.template empty<e_cylinder3>());
+    ASSERT_TRUE(store.template empty<e_rectangle2>());
+    ASSERT_TRUE(store.template empty<e_ring2>());
+    ASSERT_TRUE(store.template empty<e_single3>());
+    ASSERT_TRUE(store.template empty<e_trapezoid2>());
+
+    store.template add_mask<e_cylinder3>(1., 0.5, 2.0);
+
+    ASSERT_TRUE(store.template empty<e_annulus2>());
+    ASSERT_EQ(store.template size<e_cylinder3>(), 1);
+    ASSERT_TRUE(store.template empty<e_rectangle2>());
+    ASSERT_TRUE(store.template empty<e_ring2>());
+    ASSERT_TRUE(store.template empty<e_single3>());
+    ASSERT_TRUE(store.template empty<e_trapezoid2>());
+
+    store.template add_mask<e_cylinder3>(1., 1.5, 2.0);
+    store.template add_mask<e_trapezoid2>(0.5, 1.5, 4.0);
+    store.template add_mask<e_rectangle2>(1.0, 2.0);
+    store.template add_mask<e_rectangle2>(2.0, 1.0);
+    store.template add_mask<e_rectangle2>(10.0, 100.0);
+
+    ASSERT_TRUE(store.template empty<e_annulus2>());
+    ASSERT_EQ(store.template size<e_cylinder3>(), 2);
+    ASSERT_EQ(store.template size<e_rectangle2>(), 3);
+    ASSERT_TRUE(store.template empty<e_ring2>());
+    ASSERT_TRUE(store.template empty<e_single3>());
+    ASSERT_EQ(store.template size<e_trapezoid2>(), 1);
+
+    store.template add_mask<e_annulus2>(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
+    store.template add_mask<e_ring2>(10.0, 100.0);
+    store.template add_mask<e_ring2>(10.0, 100.0);
+    store.template add_mask<e_ring2>(10.0, 100.0);
+    store.template add_mask<e_ring2>(10.0, 100.0);
+
+    const auto &annulus_masks = store.template group<e_annulus2>();
+    const auto &cylinder_masks = store.template group<e_cylinder3>();
+    const auto &rectangle_masks = store.template group<e_rectangle2>();
+    const auto &ring_masks = store.template group<e_ring2>();
+    const auto &single_masks = store.template group<e_single3>();
+    const auto &trapezoid_masks = store.template group<e_trapezoid2>();
+
+    ASSERT_TRUE(annulus_masks.size() == 1);
+    ASSERT_TRUE(cylinder_masks.size() == 2);
+    ASSERT_TRUE(rectangle_masks.size() == 3);
+    ASSERT_TRUE(ring_masks.size() == 4);
+    ASSERT_TRUE(single_masks.size() == 0);
+    ASSERT_TRUE(trapezoid_masks.size() == 1);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include "core/mask_store.hpp"
 #include "core/surface_base.hpp"
 #include "core/track.hpp"
 #include "core/transform_store.hpp"
@@ -39,10 +40,7 @@ TEST(tools, intersection_kernel_single) {
                   __plugin::cylindrical2, mask_link, 4>;
     /// - mask index: type, entry
     using surface_mask_index = darray<dindex, 2>;
-    using surface_mask_container =
-        dtuple<dvector<surface_rectangle>, dvector<surface_trapezoid>,
-               dvector<surface_annulus>, dvector<surface_cylinder>,
-               dvector<surface_concentric_cylinder>>;
+    using surface_mask_container = mask_store<std::tuple, std::vector, surface_rectangle, surface_trapezoid, surface_annulus>;
 
     /// The Surface definition:
     ///  <transform_link, mask_link, volume_link, source_link >
@@ -60,13 +58,10 @@ TEST(tools, intersection_kernel_single) {
     transform_store.push_back(static_context, trapezoid_transform);
     transform_store.push_back(static_context, annulus_transform);
     // The masks & their store
-    surface_rectangle first_rectangle = {10., 10.};
-    surface_trapezoid second_trapezoid = {10., 20., 30.};
-    surface_annulus thrid_annulus = {15., 55., 0.75, 1.95, 2., -2.};
     surface_mask_container mask_store;
-    std::get<0>(mask_store).push_back(first_rectangle);
-    std::get<1>(mask_store).push_back(second_trapezoid);
-    std::get<2>(mask_store).push_back(thrid_annulus);
+    mask_store.template add_mask<0>(10., 10.);
+    mask_store.template add_mask<1>(10., 20., 30.);
+    mask_store.template add_mask<2>(15., 55., 0.75, 1.95, 2., -2.);
     // The surfaces and their store
     surface rectangle_surface(0u, {0, 0}, 0, 0);
     surface trapezoid_surface(1u, {1, 0}, 0, 1);
@@ -90,21 +85,21 @@ TEST(tools, intersection_kernel_single) {
 
     // Intersect the first surface
     auto sfi_rectangle = intersect_by_group(track, rectangle_transform,
-                                            std::get<0>(mask_store), 0);
+                                            mask_store.template group<0>(), 0);
 
     point3 expected_rectangle{0.01, 0.01, 10.};
     ASSERT_TRUE(within_epsilon(std::get<0>(sfi_rectangle).p3,
                                expected_rectangle, 1e-7));
 
     auto sfi_trapezoid = intersect_by_group(track, trapezoid_transform,
-                                            std::get<1>(mask_store), 0);
+                                            mask_store.template group<1>(), 0);
 
     point3 expected_trapezoid{0.02, 0.02, 20.};
     ASSERT_TRUE(within_epsilon(std::get<0>(sfi_trapezoid).p3,
                                expected_trapezoid, 1e-7));
 
     auto sfi_annulus = intersect_by_group(track, annulus_transform,
-                                          std::get<2>(mask_store), 0);
+                                          mask_store.template group<2>(), 0);
 
     point3 expected_annulus{0.03, 0.03, 30.};
     ASSERT_TRUE(

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -43,9 +43,9 @@ TEST(tools, intersection_kernel_single) {
     using surface_mask_container = mask_store<std::tuple, std::vector, surface_rectangle, surface_trapezoid, surface_annulus>;
 
     /// The Surface definition:
-    ///  <transform_link, mask_link, volume_link, source_link >
+    /// <transform_link, mask_link, volume_link, source_link, link_type_in_mask>
     using surface =
-        surface_base<dindex, surface_mask_index, dindex, surface_link>;
+        surface_base<dindex, surface_mask_index, dindex, surface_link, mask_link>;
     using surface_container = dvector<surface>;
 
     // The transforms & their store
@@ -84,21 +84,21 @@ TEST(tools, intersection_kernel_single) {
     };
 
     // Intersect the first surface
-    auto sfi_rectangle = intersect_by_group(track, rectangle_transform,
+    auto sfi_rectangle = intersect_by_group<mask_link>(track, rectangle_transform,
                                             mask_store.template group<0>(), 0);
 
     point3 expected_rectangle{0.01, 0.01, 10.};
     ASSERT_TRUE(within_epsilon(std::get<0>(sfi_rectangle).p3,
                                expected_rectangle, 1e-7));
 
-    auto sfi_trapezoid = intersect_by_group(track, trapezoid_transform,
+    auto sfi_trapezoid = intersect_by_group<mask_link>(track, trapezoid_transform,
                                             mask_store.template group<1>(), 0);
 
     point3 expected_trapezoid{0.02, 0.02, 20.};
     ASSERT_TRUE(within_epsilon(std::get<0>(sfi_trapezoid).p3,
                                expected_trapezoid, 1e-7));
 
-    auto sfi_annulus = intersect_by_group(track, annulus_transform,
+    auto sfi_annulus = intersect_by_group<mask_link>(track, annulus_transform,
                                           mask_store.template group<2>(), 0);
 
     point3 expected_annulus{0.03, 0.03, 30.};
@@ -112,10 +112,10 @@ TEST(tools, intersection_kernel_single) {
     // Try the intersection - with automated dispatching via the kernel
     unsigned int it = 0;
     for (const auto &surface : surfaces) {
-        auto sfi_surface =
-            intersect(track, surface, transform_store, mask_store);
+        mask_link link{};
+        auto sfi =
+            intersect(track, surface, transform_store, mask_store, link);
 
-        const auto &sfi = std::get<0>(sfi_surface);
         result_points.push_back(sfi.p3);
 
         ASSERT_TRUE(

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -40,12 +40,14 @@ TEST(tools, intersection_kernel_single) {
                   __plugin::cylindrical2, mask_link, 4>;
     /// - mask index: type, entry
     using surface_mask_index = darray<dindex, 2>;
-    using surface_mask_container = mask_store<std::tuple, std::vector, surface_rectangle, surface_trapezoid, surface_annulus>;
+    using surface_mask_container =
+        mask_store<std::tuple, std::vector, surface_rectangle,
+                   surface_trapezoid, surface_annulus>;
 
     /// The Surface definition:
     /// <transform_link, mask_link, volume_link, source_link, link_type_in_mask>
-    using surface =
-        surface_base<dindex, surface_mask_index, dindex, surface_link, mask_link>;
+    using surface = surface_base<dindex, surface_mask_index, dindex,
+                                 surface_link, mask_link>;
     using surface_container = dvector<surface>;
 
     // The transforms & their store
@@ -84,22 +86,22 @@ TEST(tools, intersection_kernel_single) {
     };
 
     // Intersect the first surface
-    auto sfi_rectangle = intersect_by_group<mask_link>(track, rectangle_transform,
-                                            mask_store.template group<0>(), 0);
+    auto sfi_rectangle = intersect_by_group<mask_link>(
+        track, rectangle_transform, mask_store.template group<0>(), 0);
 
     point3 expected_rectangle{0.01, 0.01, 10.};
     ASSERT_TRUE(within_epsilon(std::get<0>(sfi_rectangle).p3,
                                expected_rectangle, 1e-7));
 
-    auto sfi_trapezoid = intersect_by_group<mask_link>(track, trapezoid_transform,
-                                            mask_store.template group<1>(), 0);
+    auto sfi_trapezoid = intersect_by_group<mask_link>(
+        track, trapezoid_transform, mask_store.template group<1>(), 0);
 
     point3 expected_trapezoid{0.02, 0.02, 20.};
     ASSERT_TRUE(within_epsilon(std::get<0>(sfi_trapezoid).p3,
                                expected_trapezoid, 1e-7));
 
-    auto sfi_annulus = intersect_by_group<mask_link>(track, annulus_transform,
-                                          mask_store.template group<2>(), 0);
+    auto sfi_annulus = intersect_by_group<mask_link>(
+        track, annulus_transform, mask_store.template group<2>(), 0);
 
     point3 expected_annulus{0.03, 0.03, 30.};
     ASSERT_TRUE(
@@ -113,8 +115,7 @@ TEST(tools, intersection_kernel_single) {
     unsigned int it = 0;
     for (const auto &surface : surfaces) {
         mask_link link{};
-        auto sfi =
-            intersect(track, surface, transform_store, mask_store, link);
+        auto sfi = intersect(track, surface, transform_store, mask_store, link);
 
         result_points.push_back(sfi.p3);
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -22,7 +22,7 @@ endmacro()
 set(all_unit_tests "core")
 list(APPEND all_unit_tests "annulus2;cylinder3;rectangle2;ring2;single3;unmasked;trapezoid2")
 list(APPEND all_unit_tests "propagator;line_stepper;navigator;cylinder_intersection;planar_intersection;intersection_kernel")
-list(APPEND all_unit_tests "detector;transform_store;masks_container")
+list(APPEND all_unit_tests "detector;transform_store;masks_container;mask_store")
 
 add_subdirectory(core)
 if(DETRAY_ARRAY_PLUGIN)

--- a/tests/unit_tests/array/array_mask_store.cpp
+++ b/tests/unit_tests/array/array_mask_store.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/array_definitions.hpp"
+#include "tests/common/core_mask_store.inl"

--- a/tests/unit_tests/eigen/eigen_mask_store.cpp
+++ b/tests/unit_tests/eigen/eigen_mask_store.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/eigen_definitions.hpp"
+#include "tests/common/core_mask_store.inl"

--- a/tests/unit_tests/smatrix/smatrix_mask_store.cpp
+++ b/tests/unit_tests/smatrix/smatrix_mask_store.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/smatrix_definitions.hpp"
+#include "tests/common/core_mask_store.inl"

--- a/tests/unit_tests/vc/vc_array_mask_store.cpp
+++ b/tests/unit_tests/vc/vc_array_mask_store.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/vc_array_definitions.hpp"
+#include "tests/common/core_mask_store.inl"


### PR DESCRIPTION
Add a mask store for different mask types defined by the geometry, similar to the transform store. Thereby also defining a global interface for mask containers. Based on #108, which has to be merged first. Adds constructors to the masks, so that they can be constructed inplace when they are inserted into containers.
Some precautions were taken with intersection unrolling when different link types are present in the same container: Links must only be returned for their respective type