### PR TITLE
feat: speedup trapezoid masks boundary check

### DIFF
--- a/core/include/masks/trapezoid2.hpp
+++ b/core/include/masks/trapezoid2.hpp
@@ -90,7 +90,6 @@ struct trapezoid2 {
     template <typename inside_local_type>
     intersection_status is_inside(
         const point2 &p, const mask_tolerance &t = within_epsilon) const {
-        // scalar rel_y = (_values[2] + p[1]) * (1. / (2 * _values[2]));
         scalar rel_y = (_values[2] + p[1]) * _values[3];
         return (std::abs(p[0]) <=
                     _values[0] + rel_y * (_values[1] - _values[0]) + t[0] and

--- a/core/include/masks/trapezoid2.hpp
+++ b/core/include/masks/trapezoid2.hpp
@@ -66,7 +66,8 @@ struct trapezoid2 {
      * @param half_length_2 half length in loc1
      */
     trapezoid2(scalar half_length_0, scalar half_length_1, scalar half_length_2)
-        : _values{half_length_0, half_length_1, half_length_2, static_cast<scalar>(1. / (2. * half_length_2))} {}
+        : _values{half_length_0, half_length_1, half_length_2,
+                  static_cast<scalar>(1. / (2. * half_length_2))} {}
 
     /** Assignment operator from an array, convenience function
      *

--- a/core/include/masks/trapezoid2.hpp
+++ b/core/include/masks/trapezoid2.hpp
@@ -24,8 +24,9 @@ namespace detray {
  * @tparam kMaskContext is a unique mask identifier in a certain context
  *
  * It is defined by half lengths in local0 coordinate _values[0] and _values[1]
- *at
- * -/+ half length in the local1 coordinate _values[2]
+ * at -/+ half length in the local1 coordinate _values[2]. _values[3] contains
+ * the precomputed value of 1 / (2 * _values[2]), which avoids
+ * excessive floating point divisions.
  *
  * @note  While the mask_context can change depending on the typed container
  * structure the mask_identifier is a const expression that determines the
@@ -39,11 +40,12 @@ template <typename intersector_type = planar_intersector,
 struct trapezoid2 {
     using mask_tolerance = array_type<scalar, 2>;
 
-    using mask_values = array_type<scalar, 3>;
+    using mask_values = array_type<scalar, 4>;
 
     using mask_links_type = links_type;
 
     mask_values _values = {std::numeric_limits<scalar>::infinity(),
+                           std::numeric_limits<scalar>::infinity(),
                            std::numeric_limits<scalar>::infinity(),
                            std::numeric_limits<scalar>::infinity()};
 
@@ -64,7 +66,7 @@ struct trapezoid2 {
      * @param half_length_2 half length in loc1
      */
     trapezoid2(scalar half_length_0, scalar half_length_1, scalar half_length_2)
-        : _values{half_length_0, half_length_1, half_length_2} {}
+        : _values{half_length_0, half_length_1, half_length_2, static_cast<scalar>(1. / (2. * half_length_2))} {}
 
     /** Assignment operator from an array, convenience function
      *
@@ -88,7 +90,8 @@ struct trapezoid2 {
     template <typename inside_local_type>
     intersection_status is_inside(
         const point2 &p, const mask_tolerance &t = within_epsilon) const {
-        scalar rel_y = (_values[2] + p[1]) / (2 * _values[2]);
+        // scalar rel_y = (_values[2] + p[1]) * (1. / (2 * _values[2]));
+        scalar rel_y = (_values[2] + p[1]) * _values[3];
         return (std::abs(p[0]) <=
                     _values[0] + rel_y * (_values[1] - _values[0]) + t[0] and
                 std::abs(p[1]) <= _values[2] + t[1])

--- a/tests/common/include/tests/common/masks_trapezoid2.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2.inl
@@ -26,7 +26,7 @@ TEST(mask, trapezoid2) {
     scalar hy = 2.;
     scalar divisor = 1. / (2. * hy);
 
-    trapezoid2<> t2 = {hx_miny, hx_maxy, hy, divisor};
+    trapezoid2<> t2 = {hx_miny, hx_maxy, hy};
 
     ASSERT_EQ(t2[0], hx_miny);
     ASSERT_EQ(t2[1], hx_maxy);

--- a/tests/common/include/tests/common/masks_trapezoid2.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2.inl
@@ -24,12 +24,14 @@ TEST(mask, trapezoid2) {
     scalar hx_miny = 1.;
     scalar hx_maxy = 3.;
     scalar hy = 2.;
+    scalar divisor = 1. / (2. * hy);
 
-    trapezoid2<> t2 = {hx_miny, hx_maxy, hy};
+    trapezoid2<> t2 = {hx_miny, hx_maxy, hy, divisor};
 
     ASSERT_EQ(t2[0], hx_miny);
     ASSERT_EQ(t2[1], hx_maxy);
     ASSERT_EQ(t2[2], hy);
+    ASSERT_EQ(t2[3], divisor);
 
     ASSERT_TRUE(t2.is_inside<local_type>(p2_in) ==
                 intersection_status::e_inside);


### PR DESCRIPTION
Small change that caches the expensive floating point division in the is_inside function of the trapezoid mask. Seems to make vtune happier than my CPU  actually