### PR TITLE
feat: scan geometry linking by ray scan

### DIFF
--- a/core/include/core/intersection.hpp
+++ b/core/include/core/intersection.hpp
@@ -65,7 +65,9 @@ struct intersection {
 
     /** @param rhs is the left hand side intersection for comparison
      **/
-    bool operator==(const intersection &rhs) const { return (path == rhs.path); }
+    bool operator==(const intersection &rhs) const {
+        return (path == rhs.path);
+    }
 };
 
 }  // namespace detray

--- a/core/include/core/intersection.hpp
+++ b/core/include/core/intersection.hpp
@@ -62,6 +62,10 @@ struct intersection {
     /** @param rhs is the left hand side intersection for comparison
      **/
     bool operator>(const intersection &rhs) const { return (path > rhs.path); }
+
+    /** @param rhs is the left hand side intersection for comparison
+     **/
+    bool operator==(const intersection &rhs) const { return (path == rhs.path); }
 };
 
 }  // namespace detray

--- a/core/include/utils/ray_gun.hpp
+++ b/core/include/utils/ray_gun.hpp
@@ -1,0 +1,72 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "tools/intersection_kernel.hpp"
+
+namespace detray {
+
+/** Intersect all portals in a detector with a given ray.
+ *
+ * @tparam detector_type the type of the detector
+ *
+ * @param d the detector
+ * @param origin the origin of the ray in global coordinates
+ * @param direction the direction of the ray in global coordinater
+ *
+ * @return a sorted vector of volume indices with the corresponding
+ *         intersections of the portals that were encountered
+ */
+template <typename detector_type>
+inline auto shoot_ray(const detector_type &d, const std::pair<point3, point3> origin,
+               const std::pair<point3, point3> direction) {
+
+    using object_id = typename detector_type::objects;
+    using portal_links = typename detector_type::geometry::portal_links;
+    using detray_context = typename detector_type::transform_store::context;
+
+    detray_context default_context;
+
+    track<detray_context> ray;
+    ray.pos = origin.first;
+    ray.dir = direction.first;
+
+    std::vector<std::pair<dindex, intersection>> volume_record;
+
+    const auto &transforms = d.transforms(default_context);
+    const auto &portals = d.portals();
+    const auto &masks = d.masks();
+    // Loop over volumes
+    for (const auto &v : d.volumes()) {
+        // Record the portals the ray intersects
+        const auto &pt_range = v.template range<object_id::e_portal>();
+        portal_links links = {};
+        for (size_t pi = pt_range[0]; pi < pt_range[1]; pi++) {
+            auto pti = intersect(ray, portals[pi], transforms, masks, links);
+
+            // Walk along the direction of intersected masks
+            if (pti.status == intersection_status::e_inside &&
+                pti.direction == intersection_direction::e_along) {
+                volume_record.emplace_back(v.index(), pti);
+            }
+        }
+    }
+
+    // Sort by distance to origin of the ray and then volume index
+    auto sort_path = [&](std::pair<dindex, intersection> a,
+                         std::pair<dindex, intersection> b) -> bool {
+        return (a.second.path == b.second.path)
+                   ? (b.first < a.first)
+                   : (b.second.path < a.second.path);
+    };
+    std::sort(volume_record.begin(), volume_record.end(), sort_path);
+
+    return volume_record;
+};
+
+}  // namespace detray

--- a/core/include/utils/ray_gun.hpp
+++ b/core/include/utils/ray_gun.hpp
@@ -23,8 +23,9 @@ namespace detray {
  *         intersections of the portals that were encountered
  */
 template <typename detector_type>
-inline auto shoot_ray(const detector_type &d, const std::pair<point3, point3> origin,
-               const std::pair<point3, point3> direction) {
+inline auto shoot_ray(const detector_type &d,
+                      const std::pair<point3, point3> origin,
+                      const std::pair<point3, point3> direction) {
 
     using object_id = typename detector_type::objects;
     using portal_links = typename detector_type::geometry::portal_links;
@@ -60,9 +61,7 @@ inline auto shoot_ray(const detector_type &d, const std::pair<point3, point3> or
     // Sort by distance to origin of the ray and then volume index
     auto sort_path = [&](std::pair<dindex, intersection> a,
                          std::pair<dindex, intersection> b) -> bool {
-        return (a.second.path == b.second.path)
-                   ? (b.first < a.first)
-                   : (b.second.path < a.second.path);
+        return (a.second < b.second);
     };
     std::sort(volume_record.begin(), volume_record.end(), sort_path);
 

--- a/core/include/utils/ray_gun.hpp
+++ b/core/include/utils/ray_gun.hpp
@@ -55,7 +55,7 @@ inline auto shoot_ray(const detector_type &d, const point3 &origin,
         }
     }
 
-    // Sort by distance to origin of the ray and then volume index
+    // Sort intersections by distance to origin of the ray
     auto sort_path = [&](std::pair<dindex, intersection> a,
                          std::pair<dindex, intersection> b) -> bool {
         return (a.second < b.second);

--- a/core/include/utils/ray_gun.hpp
+++ b/core/include/utils/ray_gun.hpp
@@ -23,9 +23,8 @@ namespace detray {
  *         intersections of the portals that were encountered
  */
 template <typename detector_type>
-inline auto shoot_ray(const detector_type &d,
-                      const std::pair<point3, point3> origin,
-                      const std::pair<point3, point3> direction) {
+inline auto shoot_ray(const detector_type &d, const point3 &origin,
+                      const point3 &direction) {
 
     using object_id = typename detector_type::objects;
     using portal_links = typename detector_type::geometry::portal_links;
@@ -33,9 +32,7 @@ inline auto shoot_ray(const detector_type &d,
 
     detray_context default_context;
 
-    track<detray_context> ray;
-    ray.pos = origin.first;
-    ray.dir = direction.first;
+    track<detray_context> ray = {.pos = origin, .dir = direction};
 
     std::vector<std::pair<dindex, intersection>> volume_record;
 

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -46,7 +46,7 @@ auto read_detector() {
     }
     auto data_directory = std::string(env_d_d);
 
-    std::string name = "tml";
+    std::string name = "odd";
     std::string surfaces = data_directory + "odd.csv";
     std::string volumes = data_directory + "odd-layer-volumes.csv";
     std::string grids = data_directory + "odd-surface-grids.csv";

--- a/tests/common/include/tests/common/test_geometry_scan.inl
+++ b/tests/common/include/tests/common/test_geometry_scan.inl
@@ -32,17 +32,17 @@ auto read_detector() {
     }
     auto data_directory = std::string(env_d_d);
 
-    std::string name = "odd";
+    /*std::string name = "odd";
     std::string surfaces = data_directory + "odd.csv";
     std::string volumes = data_directory + "odd-layer-volumes.csv";
     std::string grids = data_directory + "odd-surface-grids.csv";
-    std::string grid_entries = "";
+    std::string grid_entries = "";*/
 
-    /*std::string name = "tml";
+    std::string name = "tml";
     std::string surfaces = data_directory + "tml.csv";
     std::string volumes = data_directory + "tml-layer-volumes.csv";
     std::string grids = data_directory + "tml-surface-grids.csv";
-    std::string grid_entries = "";*/
+    std::string grid_entries = "";
     // std::map<dindex, std::string> name_map{};
 
     /*return detray::detector_from_csv<>(name, surfaces, volumes, grids,

--- a/tests/common/include/tests/common/test_geometry_scan.inl
+++ b/tests/common/include/tests/common/test_geometry_scan.inl
@@ -1,0 +1,200 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/detector.hpp"
+#include "core/transform_store.hpp"
+#include "io/csv_io.hpp"
+#include "tools/intersection_kernel.hpp"
+
+using namespace detray;
+
+/** Read the detector from file */
+auto read_detector() {
+    auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
+    if (env_d_d == nullptr) {
+        throw std::ios_base::failure(
+            "Test data directory not found. Please set DETRAY_TEST_DATA_DIR.");
+    }
+    auto data_directory = std::string(env_d_d);
+
+    std::string name = "tml";
+    std::string surfaces = data_directory + "tml.csv";
+    std::string volumes = data_directory + "tml-layer-volumes.csv";
+    std::string grids = data_directory + "tml-surface-grids.csv";
+    std::string grid_entries = "";
+    //std::map<dindex, std::string> name_map{};
+
+    /*return detray::detector_from_csv<>(name, surfaces, volumes, grids,
+                                       grid_entries, name_map);*/
+    return detray::detector_from_csv<>(name, surfaces, volumes, grids,
+                                       grid_entries);
+};
+
+/** Return a random ray within some range */
+auto shoot_ray(std::pair<point3, point3> origin,
+               std::pair<point3, point3> direction) {
+    track<static_transform_store<>::context> ray;
+    ray.pos = origin.first;
+    ray.dir = direction.first;
+
+    return ray;
+};
+
+unsigned int theta_steps = 100;
+unsigned int phi_steps = 100;
+const unsigned int itest = 10000;
+
+auto d = read_detector();
+const auto &portals = d.portals();
+const auto &masks = d.masks();
+using links_type = typename decltype(d)::geometry::portal_links;
+
+namespace __plugin {
+// This test runs intersection with all surfaces of the TrackML detector
+TEST(ALGEBRA_PLUGIN, random_rays) {
+    /*std::ofstream hit_out;
+    if (stream_file)
+    {
+        hit_out.open("tml_hits.csv");
+    }*/
+    unsigned int hits = 0;
+    unsigned int missed = 0;
+
+    using detray_context = decltype(d)::transform_store::context;
+    detray_context default_context;
+
+    const auto ori = std::make_pair<point3, point3>({0., 0., 0.}, {0., 0., 0.});
+
+    // Loops of theta values
+    for (unsigned int itheta = 0; itheta < theta_steps; ++itheta) {
+        scalar theta = 0.1 + itheta * (M_PI - 0.1) / theta_steps;
+        scalar sin_theta = std::sin(theta);
+        scalar cos_theta = std::cos(theta);
+
+        // Loops of phi values
+        for (unsigned int iphi = 0; iphi < phi_steps; ++iphi) {
+            // The direction
+            scalar phi = -M_PI + iphi * (2 * M_PI) / phi_steps;
+            scalar sin_phi = std::sin(phi);
+            scalar cos_phi = std::cos(phi);
+            const auto dir = std::make_pair<point3, point3>(
+                {cos_phi * sin_theta, sin_phi * sin_theta, cos_theta},
+                {0., 0., 0.});
+
+            const auto ray = shoot_ray(ori, dir);
+            std::vector<std::pair<dindex, intersection>> volume_record;
+            // Loop over volumes
+            for (const auto &v : d.volumes()) {
+                // Loop over portals
+                const auto &pt_range = v.template range<decltype(d)::objects::e_portal>();
+                links_type links = {};
+                for (size_t pi = pt_range[0]; pi < pt_range[1]; pi++) {
+                    auto sfi = intersect(
+                        ray, portals[pi],
+                        d.transforms(default_context),
+                        masks, links);
+
+                    if (sfi.status == intersection_status::e_inside) {
+                        /* state.PauseTiming();
+                        if (stream_file)
+                        {
+                            hit_out << sfi.p3[0] << "," << sfi.p3[1] << "," <<
+                        sfi.p3[2] << "\n";
+                        }
+                        state.ResumeTiming();*/
+                        volume_record.emplace_back(v.index(), sfi);
+                    }
+                }
+            }
+            std::cout << "ray o (" << ori.first[0] << ", " << ori.first[1]
+                      << ", " << ori.first[2] << ") -> (" << dir.first[0]
+                      << ", " << dir.first[1] << ", " << dir.first[2]
+                      << "):" << std::endl;
+            for (const auto &v_id : volume_record) {
+                std::cout << v_id.first << " (" << v_id.second.path << ")"
+                          << std::endl;
+            }
+        }
+    }
+
+    /**if (stream_file)
+    {
+        hit_out.close();
+    }*/
+}
+
+// This test a reference run to deduce the random number
+/*static void BM_G(benchmark::State &state)
+{
+    auto volume_grid = d.volume_search_grid();
+
+    const auto &axis0 = volume_grid.axis_p0();
+    const auto &axis1 = volume_grid.axis_p1();
+
+    auto range0 = axis0.span();
+    auto range1 = axis1.span();
+
+    scalar step0 = (range0[1] - range0[0]) / itest;
+    scalar step1 = (range0[1] - range0[0]) / itest;
+
+    size_t successful = 0;
+    size_t unsuccessful = 0;
+
+    for (auto _ : state)
+    {
+        for (unsigned int i1 = 0; i1 < itest; ++i1)
+        {
+            for (unsigned int i0 = 0; i0 < itest; ++i0)
+            {
+                vector3 rz {i0 * step0, 0., i1 * step1};
+                auto &v = d.indexed_volume(rz);
+
+                benchmark::DoNotOptimize(successful);
+                benchmark::DoNotOptimize(unsuccessful);
+                if (v.index() == dindex_invalid)
+                {
+                    ++unsuccessful;
+                }
+                else
+                {
+                    ++successful;
+                }
+                benchmark::ClobberMemory();
+            }
+        }
+    }
+
+
+    #ifndef DETRAY_BENCHMARKS_MULTITHREAD
+    std::cout << "Successful   : " << successful << std::endl;
+    std::cout << "Unsuccessful : " << unsuccessful << std::endl;
+    #endif
+}*/
+
+/*BENCHMARK(BM_FIND_VOLUMES)
+#ifdef DETRAY_BENCHMARKS_MULTITHREAD
+->ThreadPerCpu()
+#endif
+->Unit(benchmark::kMillisecond)
+->Repetitions(gbench_repetitions)
+->DisplayAggregatesOnly(true);*/
+
+}  // namespace __plugin
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/common/include/tests/common/test_geometry_scan.inl
+++ b/tests/common/include/tests/common/test_geometry_scan.inl
@@ -53,7 +53,8 @@ auto read_detector() {
  *
  * @return true if the volumes form a connected chain.
  */
-inline bool trace_volumes(std::set<std::pair<dindex, dindex>> volume_records, dindex start_volume = 0) {
+inline bool trace_volumes(std::set<std::pair<dindex, dindex>> volume_records,
+                          dindex start_volume = 0) {
 
     // Where are we on the trace?
     dindex on_volume = start_volume;
@@ -65,9 +66,11 @@ inline bool trace_volumes(std::set<std::pair<dindex, dindex>> volume_records, di
 
         // find connection record for the current volume
         record = find_if(volume_records.begin(), volume_records.end(),
-        [&](const std::pair<dindex, dindex>& rec) -> bool {
-        return (rec.first == on_volume) or (rec.second == on_volume); });
-    
+                         [&](const std::pair<dindex, dindex> &rec) -> bool {
+                             return (rec.first == on_volume) or
+                                    (rec.second == on_volume);
+                         });
+
         // update to next volume
         on_volume = on_volume == record->first ? record->second : record->first;
 
@@ -91,7 +94,8 @@ inline bool trace_volumes(std::set<std::pair<dindex, dindex>> volume_records, di
  *         of a ray.
  */
 template <typename record_type = dvector<std::pair<dindex, intersection>>>
-inline auto check_connectivity(const record_type &volume_record, dindex start_volume = 0) {
+inline auto check_connectivity(const record_type &volume_record,
+                               dindex start_volume = 0) {
     std::set<std::pair<dindex, dindex>> valid_volumes = {};
 
     // Always read 2 elements from the sorted records vector

--- a/tests/common/include/tests/common/test_geometry_scan.inl
+++ b/tests/common/include/tests/common/test_geometry_scan.inl
@@ -7,8 +7,10 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <iostream>
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -43,39 +45,106 @@ auto read_detector() {
 };
 
 /** Return a random ray within some range */
-auto shoot_ray(std::pair<point3, point3> origin,
-               std::pair<point3, point3> direction) {
-    track<static_transform_store<>::context> ray;
+template<typename detector_type>
+auto shoot_ray(const detector_type &d, const std::pair<point3, point3> origin,
+               const std::pair<point3, point3> direction) {
+
+    using object_id = typename detector_type::objects;
+    using portal_links = typename detector_type::geometry::portal_links;
+    using detray_context = typename detector_type::transform_store::context;
+
+    detray_context default_context;
+
+    track<detray_context> ray;
     ray.pos = origin.first;
     ray.dir = direction.first;
 
-    return ray;
+    std::vector<std::pair<dindex, intersection>> volume_record;
+
+    const auto &transforms = d.transforms(default_context);
+    const auto &portals = d.portals();
+    const auto &masks = d.masks();
+    // Loop over volumes
+    for (const auto &v : d.volumes()) {
+        // Record the portals the ray intersects
+        const auto &pt_range = v.template range<object_id::e_portal>();
+        portal_links links = {};
+        for (size_t pi = pt_range[0]; pi < pt_range[1]; pi++) {
+            auto pti = intersect(ray, portals[pi], transforms, masks, links);
+
+            if (pti.status == intersection_status::e_inside /*&& pti.direction == intersection_direction::e_along*/) {
+                volume_record.emplace_back(v.index(), pti);
+            }
+        }
+    }
+
+    // Sort by distance to origin of the ray and then volume index
+    auto sort_path = [&](std::pair<dindex, intersection> a, std::pair<dindex, intersection> b) -> bool {
+        return (a.second.path == b.second.path) ? (a.first < b.first) : (a.second < b.second);
+    };
+    std::sort(volume_record.begin(), volume_record.end(), sort_path);
+
+    return volume_record;
 };
 
-unsigned int theta_steps = 100;
-unsigned int phi_steps = 100;
-const unsigned int itest = 10000;
+template<typename record_type = dvector<std::pair<dindex, intersection>>>
+auto check_record(const record_type &volume_record, dindex start_volume = 0) {
+    std::set<std::pair<dindex, dindex>> valid_volumes = {};
+
+    // Always read 2 elements from the sorted records vector
+    struct record_doublet {
+        // Two volume index, portal intersections
+        const typename record_type::value_type& lower, upper;
+
+        // Is this doublet connected via the portal intersection?
+        inline bool operator()() const {return lower.second == upper.second;}
+    };
+
+    // Don't look a start and end volume, as they are not connected at one side
+    for (size_t rec = 1; rec < volume_record.size() - 1; rec += 2) {
+        // Get 2 possibly connected entries
+        record_doublet doublet = {.lower = volume_record[rec], .upper = volume_record[rec + 1]};
+
+        /*std::cout << doublet.lower.first << " (" << doublet.lower.second.path << ")" << std::endl;
+        std::cout << doublet.upper.first << " (" << doublet.upper.second.path << ")" << std::endl;
+        std::cout << std::endl;*/
+
+        if (doublet()) {
+            // Insert into set of edges
+            valid_volumes.emplace(doublet.lower.first, doublet.upper.first);
+        }
+        // Something went wrong
+        else {
+            std::cout << "<<<<<<<<<<<<<<<" << std::endl;
+
+            std::cout << "Ray terminated at portal x-ing " << (rec + 1) / 2 << ": (" << doublet.lower.first << ", "
+            << doublet.lower.second.path << ") <-> (" << doublet.upper.first
+            << ", " << doublet.upper.second.path << ")" << std::endl;
+
+            std::cout << "Start volume : " << start_volume << ", leaves world at: (" << volume_record.front().first << ", " << volume_record.front().second.path << "), (" << volume_record.back().first << ", "
+            << volume_record.back().second.path << ")" << std::endl;
+
+            std::cout << ">>>>>>>>>>>>>>>" << std::endl;
+
+            return valid_volumes;
+        }
+    }
+
+    return valid_volumes;
+}
 
 auto d = read_detector();
-const auto &portals = d.portals();
-const auto &masks = d.masks();
-using links_type = typename decltype(d)::geometry::portal_links;
 
 namespace __plugin {
-// This test runs intersection with all surfaces of the TrackML detector
-TEST(ALGEBRA_PLUGIN, random_rays) {
-    /*std::ofstream hit_out;
-    if (stream_file)
-    {
-        hit_out.open("tml_hits.csv");
-    }*/
-    unsigned int hits = 0;
-    unsigned int missed = 0;
+// This test runs intersection with all portals of the TrackML detector
+TEST(ALGEBRA_PLUGIN, ray_scan) {
 
-    using detray_context = decltype(d)::transform_store::context;
-    detray_context default_context;
+    unsigned int theta_steps = 100;
+    unsigned int phi_steps = 100;
+    const unsigned int itest = 10000;
 
     const auto ori = std::make_pair<point3, point3>({0., 0., 0.}, {0., 0., 0.});
+    dindex start_index = d.volume_by_pos(ori.first).index();
 
     // Loops of theta values
     for (unsigned int itheta = 0; itheta < theta_steps; ++itheta) {
@@ -93,103 +162,17 @@ TEST(ALGEBRA_PLUGIN, random_rays) {
                 {cos_phi * sin_theta, sin_phi * sin_theta, cos_theta},
                 {0., 0., 0.});
 
-            const auto ray = shoot_ray(ori, dir);
-            std::vector<std::pair<dindex, intersection>> volume_record;
-            // Loop over volumes
-            for (const auto &v : d.volumes()) {
-                // Loop over portals
-                const auto &pt_range = v.template range<decltype(d)::objects::e_portal>();
-                links_type links = {};
-                for (size_t pi = pt_range[0]; pi < pt_range[1]; pi++) {
-                    auto sfi = intersect(
-                        ray, portals[pi],
-                        d.transforms(default_context),
-                        masks, links);
+            const auto volume_record = shoot_ray(d, ori, dir);
+            const auto volume_gaps = check_record(volume_record, start_index);
 
-                    if (sfi.status == intersection_status::e_inside) {
-                        /* state.PauseTiming();
-                        if (stream_file)
-                        {
-                            hit_out << sfi.p3[0] << "," << sfi.p3[1] << "," <<
-                        sfi.p3[2] << "\n";
-                        }
-                        state.ResumeTiming();*/
-                        volume_record.emplace_back(v.index(), sfi);
-                    }
-                }
-            }
-            std::cout << "ray o (" << ori.first[0] << ", " << ori.first[1]
-                      << ", " << ori.first[2] << ") -> (" << dir.first[0]
-                      << ", " << dir.first[1] << ", " << dir.first[2]
-                      << "):" << std::endl;
-            for (const auto &v_id : volume_record) {
-                std::cout << v_id.first << " (" << v_id.second.path << ")"
-                          << std::endl;
-            }
         }
     }
-
-    /**if (stream_file)
-    {
-        hit_out.close();
-    }*/
 }
 
-// This test a reference run to deduce the random number
-/*static void BM_G(benchmark::State &state)
-{
-    auto volume_grid = d.volume_search_grid();
 
-    const auto &axis0 = volume_grid.axis_p0();
-    const auto &axis1 = volume_grid.axis_p1();
-
-    auto range0 = axis0.span();
-    auto range1 = axis1.span();
-
-    scalar step0 = (range0[1] - range0[0]) / itest;
-    scalar step1 = (range0[1] - range0[0]) / itest;
-
-    size_t successful = 0;
-    size_t unsuccessful = 0;
-
-    for (auto _ : state)
-    {
-        for (unsigned int i1 = 0; i1 < itest; ++i1)
-        {
-            for (unsigned int i0 = 0; i0 < itest; ++i0)
-            {
-                vector3 rz {i0 * step0, 0., i1 * step1};
-                auto &v = d.indexed_volume(rz);
-
-                benchmark::DoNotOptimize(successful);
-                benchmark::DoNotOptimize(unsuccessful);
-                if (v.index() == dindex_invalid)
-                {
-                    ++unsuccessful;
-                }
-                else
-                {
-                    ++successful;
-                }
-                benchmark::ClobberMemory();
-            }
-        }
-    }
-
-
-    #ifndef DETRAY_BENCHMARKS_MULTITHREAD
-    std::cout << "Successful   : " << successful << std::endl;
-    std::cout << "Unsuccessful : " << unsuccessful << std::endl;
-    #endif
-}*/
-
-/*BENCHMARK(BM_FIND_VOLUMES)
-#ifdef DETRAY_BENCHMARKS_MULTITHREAD
-->ThreadPerCpu()
-#endif
-->Unit(benchmark::kMillisecond)
-->Repetitions(gbench_repetitions)
-->DisplayAggregatesOnly(true);*/
+// This test runs intersection with all portals of the TrackML detector
+TEST(ALGEBRA_PLUGIN, random_rays) {
+}
 
 }  // namespace __plugin
 

--- a/tests/common/include/tests/common/test_geometry_scan.inl
+++ b/tests/common/include/tests/common/test_geometry_scan.inl
@@ -43,12 +43,10 @@ auto read_detector() {
     std::string volumes = data_directory + "tml-layer-volumes.csv";
     std::string grids = data_directory + "tml-surface-grids.csv";
     std::string grid_entries = "";
-    // std::map<dindex, std::string> name_map{};
+    std::map<dindex, std::string> name_map{};
 
-    /*return detray::detector_from_csv<>(name, surfaces, volumes, grids,
-                                       grid_entries, name_map);*/
     return detray::detector_from_csv<>(name, surfaces, volumes, grids,
-                                       grid_entries);
+                                       grid_entries, name_map);
 };
 
 /** Check if a set of volume index pairs form a trace.

--- a/tests/common/include/tests/common/test_geometry_scan.inl
+++ b/tests/common/include/tests/common/test_geometry_scan.inl
@@ -168,8 +168,8 @@ TEST(ALGEBRA_PLUGIN, ray_scan) {
     unsigned int phi_steps = 100;
     const unsigned int itest = 10000;
 
-    const auto ori = std::make_pair<point3, point3>({0., 0., 0.}, {0., 0., 0.});
-    dindex start_index = d.volume_by_pos(ori.first).index();
+    const point3 ori{0., 0., 0.};
+    dindex start_index = d.volume_by_pos(ori).index();
 
     // Loops of theta values ]0,pi[
     for (unsigned int itheta = 0; itheta < theta_steps; ++itheta) {
@@ -183,9 +183,8 @@ TEST(ALGEBRA_PLUGIN, ray_scan) {
             scalar phi = -M_PI + iphi * (2 * M_PI) / phi_steps;
             scalar sin_phi = std::sin(phi);
             scalar cos_phi = std::cos(phi);
-            const auto dir = std::make_pair<point3, point3>(
-                {cos_phi * sin_theta, sin_phi * sin_theta, cos_theta},
-                {0., 0., 0.});
+            const point3 dir{cos_phi * sin_theta, sin_phi * sin_theta,
+                             cos_theta};
 
             const auto volume_record = shoot_ray(d, ori, dir);
             const auto volume_connections =

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -23,7 +23,7 @@ set(all_unit_tests "core")
 list(APPEND all_unit_tests "annulus2;cylinder3;rectangle2;ring2;single3;unmasked;trapezoid2")
 list(APPEND all_unit_tests "propagator;line_stepper;navigator;cylinder_intersection;planar_intersection;intersection_kernel")
 list(APPEND all_unit_tests "detector;transform_store;masks_container;mask_store")
-list(APPEND all_unit_tests "volume;index_geometry;unified_index_geometry")
+list(APPEND all_unit_tests "volume;index_geometry;unified_index_geometry;geometry_scan")
 
 add_subdirectory(core)
 if(DETRAY_ARRAY_PLUGIN)

--- a/tests/unit_tests/array/array_geometry_scan.cpp
+++ b/tests/unit_tests/array/array_geometry_scan.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2020 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/array_definitions.hpp"
+#include "tests/common/test_geometry_scan.inl"

--- a/tests/unit_tests/array/array_geometry_scan.cpp
+++ b/tests/unit_tests/array/array_geometry_scan.cpp
@@ -1,7 +1,7 @@
 /** Detray library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2020 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 

--- a/tests/unit_tests/eigen/eigen_geometry_scan.cpp
+++ b/tests/unit_tests/eigen/eigen_geometry_scan.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2020 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/eigen_definitions.hpp"
+#include "tests/common/test_geometry_scan.inl"

--- a/tests/unit_tests/eigen/eigen_geometry_scan.cpp
+++ b/tests/unit_tests/eigen/eigen_geometry_scan.cpp
@@ -1,7 +1,7 @@
 /** Detray library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2020 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 

--- a/tests/unit_tests/smatrix/smatrix_geometry_scan.cpp
+++ b/tests/unit_tests/smatrix/smatrix_geometry_scan.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2020 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/smatrix_definitions.hpp"
+#include "tests/common/test_geometry_scan.inl"

--- a/tests/unit_tests/smatrix/smatrix_geometry_scan.cpp
+++ b/tests/unit_tests/smatrix/smatrix_geometry_scan.cpp
@@ -1,7 +1,7 @@
 /** Detray library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2020 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 

--- a/tests/unit_tests/vc/vc_array_geometry_scan.cpp
+++ b/tests/unit_tests/vc/vc_array_geometry_scan.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2020 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/vc_array_definitions.hpp"
+#include "tests/common/test_geometry_scan.inl"

--- a/tests/unit_tests/vc/vc_array_geometry_scan.cpp
+++ b/tests/unit_tests/vc/vc_array_geometry_scan.cpp
@@ -1,7 +1,7 @@
 /** Detray library, part of the ACTS project (R&D line)
- * 
+ *
  * (c) 2020 CERN for the benefit of the ACTS project
- * 
+ *
  * Mozilla Public License Version 2.0
  */
 


### PR DESCRIPTION
Adds unittests that check the geometry linking consistency by shooting rays through the geometry and recording the volume portal trace. The ```ray_gun.hpp``` only records intersection paths in the direction of the ray (e_along) and checks The ray scan unittest check whether the intersection path and the volume inidces match, i.e. form a consisten chain. Only for ray origin 0 for now.