### PR TITLE
fix: clang template template fix

### DIFF
--- a/core/include/core/mask_store.hpp
+++ b/core/include/core/mask_store.hpp
@@ -13,7 +13,7 @@ namespace detray {
 
 /** A mask store that provides the correct mask containers to client classes. */
 template <template <typename...> class tuple_type = dtuple,
-          template <typename> class vector_type = dvector,
+          template <typename...> class vector_type = dvector,
           typename... mask_types>
 class mask_store {
 


### PR DESCRIPTION
This should fix the error seen by @beomki-yeo in #117. It is rebased on top of that one.

The reason for the error is that clang complains that `std::vector` is not a `template <template>` because it has multiple template arguments. `template <template...>` does the trick.

I'm able to build fully on macOS with this branch.