### PR TITLE
fix: skip benchmark step

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -38,10 +38,10 @@ jobs:
       shell: bash
       run: ctest -C Release
 
-    - name: Run Benchmarks
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: cp $GITHUB_WORKSPACE/tests/scripts/* .; source ./run_benchmarks.sh
+    #- name: Run Benchmarks
+    #  working-directory: ${{runner.workspace}}/build
+    #  shell: bash
+    #  run: cp $GITHUB_WORKSPACE/tests/scripts/* .; source ./run_benchmarks.sh
 
     #- name: Upload Benchmark Results
     #  run: git push 'https://asalzburger:${{ secrets.PERSONAL_GITHUB_TOKEN }}@github.com/asalzburger/detray.git' gh-pages:gh-pages
@@ -76,10 +76,10 @@ jobs:
       shell: bash
       run: ctest -C Release      
 
-    - name: Run Benchmarks
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: cp $GITHUB_WORKSPACE/tests/scripts/* .; source ./run_benchmarks.sh
+    #- name: Run Benchmarks
+    #  working-directory: ${{runner.workspace}}/build
+    #  shell: bash
+    #  run: cp $GITHUB_WORKSPACE/tests/scripts/* .; source ./run_benchmarks.sh
 
   ubuntu_debug:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Until the algebra-plugins commits are fixed, skip the benchmark step in the CI