### PR TITLE
feat: toy geometry

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -6,7 +6,10 @@ on:
     branches:
       - main
       - 'release/**'
-      
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
 jobs:
   ubuntu:
     runs-on: ubuntu-latest

--- a/core/include/geometry/surface_base.hpp
+++ b/core/include/geometry/surface_base.hpp
@@ -69,8 +69,17 @@ class surface_base {
     bool operator==(
         const surface_base<transform_link, mask_link, source_link> &rhs) const {
         return (_trf == rhs.__trf and _mask == rhs._mask and
-                _vol == rhs._vol and _src == rhs._src);
+                _vol == rhs._vol and _src == rhs._src and _edg == rhs._edg);
     }
+
+    /** Explicitly set edge, since not all geometries keep the links here */
+    void set_edge(const edge_link &edg) { _edg = edg; }
+
+    /** Access to the edge information (next volume etc.)  */
+    const edge_link &edge() const { return _edg; }
+
+    /** Return the edge information (next volume etc.)  */
+    edge_link &edge() { return _edg; }
 
     /** Return the transform type */
     transform_link &transform() { return _trf; }
@@ -98,6 +107,7 @@ class surface_base {
     mask_link _mask;
     volume_link _vol;
     source_link _src;
+    edge_link _edg;
 };
 
 }  // namespace detray

--- a/tests/common/include/tests/common/benchmark_find_volume.inl
+++ b/tests/common/include/tests/common/benchmark_find_volume.inl
@@ -24,7 +24,7 @@ unsigned int gbench_repetitions = DETRAY_BENCHMARKS_REP;
 unsigned int gbench_repetitions = 0;
 #endif
 
-auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
+auto [d, name_map] = read_from_csv(tml_files);
 const unsigned int itest = 10000;
 
 namespace __plugin {

--- a/tests/common/include/tests/common/benchmark_find_volume.inl
+++ b/tests/common/include/tests/common/benchmark_find_volume.inl
@@ -14,6 +14,7 @@
 #include "core/detector.hpp"
 #include "core/transform_store.hpp"
 #include "io/csv_io.hpp"
+#include "tests/common/read_geometry.hpp"
 
 using namespace detray;
 
@@ -23,33 +24,7 @@ unsigned int gbench_repetitions = DETRAY_BENCHMARKS_REP;
 unsigned int gbench_repetitions = 0;
 #endif
 
-/** Read the detector from file */
-auto read_detector() {
-    auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set DETRAY_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d);
-
-    /*std::string name = "odd";
-    std::string surfaces = data_directory + "odd.csv";
-    std::string volumes = data_directory + "odd-layer-volumes.csv";
-    std::string grids = data_directory + "odd-surface-grids.csv";
-    std::string grid_entries = "";*/
-
-    std::string name = "tml";
-    std::string surfaces = data_directory + "tml.csv";
-    std::string volumes = data_directory + "tml-layer-volumes.csv";
-    std::string grids = data_directory + "tml-surface-grids.csv";
-    std::string grid_entries = "";
-    std::map<dindex, std::string> name_map{};
-
-    return detray::detector_from_csv<>(name, surfaces, volumes, grids,
-                                       grid_entries, name_map);
-};
-
-auto d = read_detector();
+auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
 const unsigned int itest = 10000;
 
 namespace __plugin {

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -38,7 +38,7 @@ unsigned int theta_steps = 100;
 unsigned int phi_steps = 100;
 bool stream_file = false;
 
-auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
+auto [d, name_map] = read_from_csv(tml_files);
 
 const auto &surfaces = d.surfaces();
 constexpr bool get_surface_masks = true;

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -15,6 +15,7 @@
 #include "core/detector.hpp"
 #include "core/transform_store.hpp"
 #include "io/csv_io.hpp"
+#include "tests/common/read_geometry.hpp"
 #include "tools/intersection_kernel.hpp"
 
 using namespace detray;
@@ -37,33 +38,7 @@ unsigned int theta_steps = 100;
 unsigned int phi_steps = 100;
 bool stream_file = false;
 
-/** Read the detector from file */
-auto read_detector() {
-    auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set DETRAY_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d);
-
-    /*std::string name = "odd";
-    std::string surfaces = data_directory + "odd.csv";
-    std::string volumes = data_directory + "odd-layer-volumes.csv";
-    std::string grids = data_directory + "odd-surface-grids.csv";
-    std::string grid_entries = "";*/
-
-    std::string name = "tml";
-    std::string surfaces = data_directory + "tml.csv";
-    std::string volumes = data_directory + "tml-layer-volumes.csv";
-    std::string grids = data_directory + "tml-surface-grids.csv";
-    std::string grid_entries = "";
-    std::map<dindex, std::string> name_map{};
-
-    return detray::detector_from_csv<>(name, surfaces, volumes, grids,
-                                       grid_entries, name_map);
-};
-
-auto d = read_detector();
+auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
 
 const auto &surfaces = d.surfaces();
 constexpr bool get_surface_masks = true;

--- a/tests/common/include/tests/common/io_read_detector.inl
+++ b/tests/common/include/tests/common/io_read_detector.inl
@@ -14,6 +14,7 @@
 #include "core/detector.hpp"
 #include "core/transform_store.hpp"
 #include "io/csv_io.hpp"
+#include "tests/common/read_geometry.hpp"
 
 /// @note __plugin has to be defined with a preprocessor command
 
@@ -21,28 +22,7 @@
 TEST(ALGEBRA_PLUGIN, read_detector) {
     using namespace detray;
 
-    auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set DETRAY_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d);
-
-    /*std::string name = "odd";
-    std::string surfaces = data_directory + "odd.csv";
-    std::string volumes = data_directory + "odd-layer-volumes.csv";
-    std::string grids = data_directory + "odd-surface-grids.csv";
-    std::string grid_entries = "";*/
-
-    std::string name = "tml";
-    std::string surfaces = data_directory + "tml.csv";
-    std::string volumes = data_directory + "tml-layer-volumes.csv";
-    std::string grids = data_directory + "tml-surface-grids.csv";
-    std::string grid_entries = "";
-    std::map<dindex, std::string> name_map{};
-
-    auto d = detector_from_csv<>(name, surfaces, volumes, grids, grid_entries,
-                                 name_map);
+    auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
 
     std::cout << d.to_string(name_map) << std::endl;
 }

--- a/tests/common/include/tests/common/io_read_detector.inl
+++ b/tests/common/include/tests/common/io_read_detector.inl
@@ -22,7 +22,7 @@
 TEST(ALGEBRA_PLUGIN, read_detector) {
     using namespace detray;
 
-    auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
+    auto [d, name_map] = read_from_csv(tml_files);
 
     std::cout << d.to_string(name_map) << std::endl;
 }

--- a/tests/common/include/tests/common/read_geometry.hpp
+++ b/tests/common/include/tests/common/read_geometry.hpp
@@ -10,7 +10,10 @@
 #include <string>
 
 #include "core/detector.hpp"
+#include "geometry/surface_base.hpp"
+#include "geometry/volume.hpp"
 #include "io/csv_io.hpp"
+#include "masks/masks.hpp"
 
 /// @note __plugin has to be defined with a preprocessor command
 namespace detray_tests {
@@ -49,7 +52,113 @@ auto read_from_csv(detector_input_files &files) {
 
     return std::make_pair<decltype(d), decltype(name_map)>(std::move(d),
                                                            std::move(name_map));
-    ;
 };
+
+// Build toy geometry
+auto toy_geometry() {
+    constexpr bool for_surface = true;
+    constexpr bool for_portal = false;
+
+    // Volume type
+    using volume_type = detray::volume<detray::darray>;
+    /// volume index: volume the surface belongs to
+    using volume_index = detray::dindex;
+    /// transform link: transform entry belonging to surface
+    using transform_link = detray::dindex;
+    /// mask index: type, range
+    using mask_index = detray::darray<detray::dindex, 2>;
+    /// volume links: next volume, next (local) object finder
+    using edge_links = detray::darray<detray::dindex, 2>;
+    /// source link
+    using source_link = detray::dindex;
+
+    // The surface transforms
+    using transform3 = __plugin::transform3;
+    // We have cylinder and rectangle surfaces
+    using cylinder = detray::cylinder3<false, detray::cylinder_intersector,
+                                       __plugin::cylindrical2, edge_links, 0>;
+    using rectangle = detray::rectangle2<detray::planar_intersector,
+                                         __plugin::cartesian2, edge_links, 1>;
+
+    // The surface type, both for volume portals and contained detector
+    // surfaces
+    using surface = detray::surface_base<transform_link, mask_index,
+                                         volume_index, source_link, edge_links>;
+
+    // The geometry data
+    using volume_container = detray::dvector<volume_type>;
+    using surface_container = detray::dvector<surface>;
+    using transf_container = detray::dvector<transform3>;
+    using cylinder_container = detray::dvector<cylinder>;
+    using rectangle_container = detray::dvector<rectangle>;
+
+    /** Volumes */
+    volume_container volumes = {};
+    /** Surfaces, including portals */
+    surface_container surfaces = {};
+    /** Surface transforms */
+    transf_container transforms = {};
+    /** Cylinder masks for volume boundaries (portals) */
+    cylinder_container cylinders = {};
+    /** Rectangle masks for detector surfaces */
+    rectangle_container rectangles = {};
+
+    mask_index m_id = {};
+    detray::darray<detray::scalar, 6> bounds = {};
+
+    // beampipe
+    detray::scalar detectorHalfZ = 500.;
+    detray::scalar beamPipeR = 27.;
+
+    cylinders.emplace_back(beamPipeR, detectorHalfZ, detectorHalfZ);
+    transforms.emplace_back();  // identity
+    m_id = {0, 0};
+    surfaces.emplace_back(0, m_id, 0, 0);  // only one cylinder portal
+    // build the volume
+    bounds = {0, beamPipeR, -detectorHalfZ, detectorHalfZ, -M_PI, M_PI};
+    volume_type &v = volumes.emplace_back(bounds);
+    v.set_index(volumes.size() - 1);
+    v.template set_range<for_portal>({0, 1});
+    v.template set_range<for_surface>({0, 0});
+    v.set_surfaces_finder(0);
+
+    /*std::shared_ptr<DetectorVolume> createCentralDetector(
+    ActsScalar detectorHalfZ = 500.) {
+  // Create the volume bounds
+  ActsScalar beamPipeR = 27.;
+  // Beam pipe volume
+  auto beamPipeBounds =
+      std::make_unique<CylinderVolumeBounds>(0., beamPipeR, detectorHalfZ);
+  auto beamPipe = DetectorVolume::makeShared(
+      Transform3::Identity(), std::move(beamPipeBounds), "BeamPipe");
+  // First layer
+  ActsScalar firstLayerOuterR = 38.;
+  auto firstLayer = createBarrelVolume(beamPipeR, firstLayerOuterR,
+                                       detectorHalfZ, "BarrelLayer0");
+  // First gap
+  ActsScalar secondLayerInnerR = 64.;
+  auto firstGapBounds = std::make_unique<CylinderVolumeBounds>(
+      firstLayerOuterR, secondLayerInnerR, detectorHalfZ);
+  auto firstGap = DetectorVolume::makeShared(
+      Transform3::Identity(), std::move(firstGapBounds), "BarrelGap0");
+  // Second layer
+  ActsScalar secondLayerOuterR = 80.;
+  auto secondLayer = createBarrelVolume(secondLayerInnerR, secondLayerOuterR,
+                                        detectorHalfZ, "BarrelLayer1", 8.4, 36.,
+                                        0.145, 72., 2., 5., {32, 14});
+
+  // The volumes in R
+  std::vector<std::shared_ptr<DetectorVolume>> barrelVolumes = {
+      beamPipe, firstLayer, firstGap, secondLayer};
+
+  // Return the container in R
+  return CylindricalContainerHelper::containerInR(std::move(barrelVolumes),
+                                                  "BarrelWithTwoLayers");*/
+    return std::make_tuple<volume_container, surface_container,
+                           transf_container, cylinder_container,
+                           rectangle_container>(
+        std::move(volumes), std::move(surfaces), std::move(transforms),
+        std::move(cylinders), std::move(rectangles));
+}
 
 }  // namespace detray_tests

--- a/tests/common/include/tests/common/read_geometry.hpp
+++ b/tests/common/include/tests/common/read_geometry.hpp
@@ -1,0 +1,55 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <iostream>
+#include <map>
+#include <string>
+
+#include "core/detector.hpp"
+#include "io/csv_io.hpp"
+
+/// @note __plugin has to be defined with a preprocessor command
+namespace detray_tests {
+
+/** Keeps the relevant csv file names */
+struct detector_input_files {
+    std::string det_name, surface, layer_volume, surface_grid,
+        surface_grid_entries;
+};
+
+/// open data detector
+detector_input_files odd_files = {"odd", "odd.csv", "odd-layer-volumes.csv",
+                                  "odd-surface-grids.csv", ""};
+
+/// track ml detector
+detector_input_files tml_files = {"tml", "tml.csv", "tml-layer-volumes.csv",
+                                  "tml-surface-grids.csv", ""};
+
+/** Read a detector from csv files */
+auto read_from_csv(detector_input_files &files) {
+    auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
+    if (env_d_d == nullptr) {
+        throw std::ios_base::failure(
+            "Test data directory not found. Please set DETRAY_TEST_DATA_DIR.");
+    }
+    auto data_directory = std::string(env_d_d);
+
+    std::string surfaces = data_directory + files.surface;
+    std::string volumes = data_directory + files.layer_volume;
+    std::string grids = data_directory + files.surface_grid;
+    std::string grid_entries = files.surface_grid_entries;
+    std::map<detray::dindex, std::string> name_map{};
+
+    auto d = detray::detector_from_csv<>(files.det_name, surfaces, volumes,
+                                         grids, grid_entries, name_map);
+
+    return std::make_pair<decltype(d), decltype(name_map)>(std::move(d),
+                                                           std::move(name_map));
+    ;
+};
+
+}  // namespace detray_tests

--- a/tests/common/include/tests/common/read_geometry.hpp
+++ b/tests/common/include/tests/common/read_geometry.hpp
@@ -5,7 +5,7 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <iostream>
+#include <cmath>
 #include <map>
 #include <string>
 
@@ -16,7 +16,9 @@
 #include "masks/masks.hpp"
 
 /// @note __plugin has to be defined with a preprocessor command
-namespace detray_tests {
+using namespace detray;
+
+namespace {
 
 /** Keeps the relevant csv file names */
 struct detector_input_files {
@@ -24,11 +26,11 @@ struct detector_input_files {
         surface_grid_entries;
 };
 
-/// open data detector
+/// open data detector file names
 detector_input_files odd_files = {"odd", "odd.csv", "odd-layer-volumes.csv",
                                   "odd-surface-grids.csv", ""};
 
-/// track ml detector
+/// track ml detector file names
 detector_input_files tml_files = {"tml", "tml.csv", "tml-layer-volumes.csv",
                                   "tml-surface-grids.csv", ""};
 
@@ -54,7 +56,136 @@ auto read_from_csv(detector_input_files &files) {
                                                            std::move(name_map));
 };
 
-// Build toy geometry
+/** Creates a number of pixel modules for the a cylindrical barrel region.
+  *
+  * @tparam surface_t The surface type that contains the container indices
+  * @tparam mask_t The geomterical boundaries of a surface (rectangles)
+  *
+  * @param m_half_x module half length in local x
+  * @param m_half_y module half length in local y
+  * @param m_tilt_phi phi tilt of the modules
+  * @param layer_r radius at which the modules are positioned in the volume
+  * @param radial_stagger module stagger in r
+  * @param l_overlap the z overlap of modules next in z
+  * @param binning phi, z bins of the surface grid
+  *
+  * @return a tuple that contains the surfaces (linking into the locally 
+  *         created container), the module transsforms and the surface masks.
+  */
+template<typename surface_t, typename mask_t>
+auto create_modules(
+    scalar m_half_x = 8.4, scalar m_half_y = 36., scalar m_tilt_phi = 0.145,
+    scalar layer_r = 32., scalar radial_stagger = 2.,
+    scalar l_overlap = 5., const std::pair<int, int> binning = {16, 14}) {
+
+    //using transform3 = __plugin::transform3;
+    //using point3 = __plugin::point3;
+    /// mask index: type, range
+    using mask_index = detray::darray<detray::dindex, 2>;
+
+    // Prepare the return container
+    using surface_container = detray::dvector<surface_t>;
+    using trfs_container = detray::dvector<transform3>;
+    using mask_container = detray::dvector<mask_t>;
+
+    surface_container surfaces;
+    trfs_container transforms;
+    mask_container masks;
+
+    // Create the module centers
+
+    // surface grid bins
+    int n_phi_bins = binning.first;
+    int n_z_bins = binning.second;
+    // module positions
+    detray::dvector<point3> m_centers;
+    m_centers.reserve(n_phi_bins * n_z_bins);
+
+    // prep work
+    scalar pi{static_cast<scalar>(M_PI)};
+    scalar phi_step = scalar{2} * pi / (n_phi_bins);
+    scalar min_phi = -pi + scalar{0.5} * phi_step;
+    scalar z_start = scalar{-0.5} * (n_z_bins - 1) * (scalar{2} * m_half_y - l_overlap);
+    scalar z_step = scalar{2} * std::abs(z_start) / (n_z_bins - 1);
+
+    // loop over the bins
+    for (size_t z_bin = 0; z_bin < size_t(n_z_bins); ++z_bin) {
+      // prepare z and r
+      scalar m_z = z_start + z_bin * z_step;
+      scalar m_r =
+          (z_bin % 2) != 0u ? layer_r - scalar{0.5} * radial_stagger : layer_r + scalar{0.5} * radial_stagger;
+      for (size_t phiBin = 0; phiBin < size_t(n_phi_bins); ++phiBin) {
+        // calculate the current phi value
+        scalar m_phi = min_phi + phiBin * phi_step;
+        m_centers.push_back(point3{m_r * std::cos(m_phi), m_r * std::sin(m_phi), m_z});
+      }
+    }
+
+    // Create geometry data
+
+    // First value is zero for rectangle type
+    mask_index m_id = {0, 0};
+
+    for (auto& m_center : m_centers) {
+
+        // Surfaces with the linking into the local containers
+        m_id = {0, masks.size()};
+        surfaces.emplace_back(transforms.size(), m_id, detray::dindex_invalid, detray::dindex_invalid);
+
+        // The rectangle bounds for this module
+        masks.emplace_back(m_half_x, m_half_y);
+
+        // Build the transform
+        // The local phi
+        scalar m_phi = algebra::getter::phi(m_center);
+        // Local z axis is the normal vector
+        point3 m_local_z{std::cos(m_phi + m_tilt_phi),
+                         std::sin(m_phi + m_tilt_phi), 0.};
+        // Local x axis the normal to local y,z
+        point3 m_local_x{-std::sin(m_phi + m_tilt_phi),
+                         std::cos(m_phi + m_tilt_phi), 0.};
+
+        // Create the module transform
+        transforms.emplace_back(m_center, m_local_z, m_local_x);
+    }
+
+    return std::make_tuple<surface_container, trfs_container, mask_container>(
+    std::move(surfaces), std::move(transforms), std::move(masks));
+}
+
+/** Add a single barrel layer volume to an existing collection.
+  *
+  * @param min_r minimal radius of volume
+  * @param max_r maximal radius of volume
+  * @param half_z half length in z of volume
+  *
+  * @return a detray cylinder volume
+  */
+template<typename volume_container_t>
+auto& add_cylinder_volume(volume_container_t &volumes,
+    scalar min_r = 25., scalar max_r = 40.,
+    scalar half_z = 500.) {
+
+    // The volume bounds
+    detray::darray<scalar, 6> bounds = {min_r, max_r, -half_z, half_z, -M_PI, M_PI};
+    
+    // Add the new volume to the collection
+    auto& v = volumes.emplace_back(bounds);
+    v.set_index(volumes.size() - 1);
+
+    return v;
+}
+
+/** Builds a simple detray geometry of the innermost tml layers. It contains:
+  *
+  * - a beampipe (r = 27mm, half_z = 500mm)
+  * - a layer (r_min = 27mm, r_max = 38mm) with n rectangular modules at 
+  *   r = 32mm
+  *
+  * @returns a tuple containing the geometry objects collections: [volumes,
+  *          surfaces, transforms, cylinder masks (portals), rectangle masks 
+  *          (modules)]
+  */
 auto toy_geometry() {
     constexpr bool for_surface = true;
     constexpr bool for_portal = false;
@@ -73,7 +204,7 @@ auto toy_geometry() {
     using source_link = detray::dindex;
 
     // The surface transforms
-    using transform3 = __plugin::transform3;
+    //using transform3 = __plugin::transform3;
     // We have cylinder and rectangle surfaces
     using cylinder = detray::cylinder3<false, detray::cylinder_intersector,
                                        __plugin::cylindrical2, edge_links, 0>;
@@ -102,25 +233,79 @@ auto toy_geometry() {
     cylinder_container cylinders = {};
     /** Rectangle masks for detector surfaces */
     rectangle_container rectangles = {};
-
+    // mask index for surfaces
     mask_index m_id = {};
-    detray::darray<detray::scalar, 6> bounds = {};
 
+    // parameters
+    scalar detector_half_z = 500.;
+    scalar beampipe_r = 27.;
+    scalar first_layer_outer_r = 38.;
+    scalar second_layer_inner_r = 64.;
+    scalar second_layer_outer_r = 80.;
+
+    /** Function that adds a cylinder portal with an identity transform to a 
+      * volume.
+      */
+    auto add_portal = [&](volume_type &vol, scalar r, scalar half_z) {
+        cylinders.emplace_back(r, -half_z, half_z);
+        transforms.emplace_back();  // identity
+        m_id = {cylinders.size(), 0};
+        surfaces.emplace_back(transforms.size(), m_id, vol.index(), 0);
+        vol.template set_range<for_portal>({surfaces.size() - 1, surfaces.size()});
+    };
+
+    /** Function that updates surface links when added to the global containers.
+      */
+    auto update_links = [&](volume_type &vol, surface_container& modules, dindex trfs_offset, dindex masks_offset) {
+        for (auto &sf : modules) {
+            sf.transform() += trfs_offset;
+            std::get<1>(sf.mask()) += masks_offset;
+            sf.volume() = vol.index();
+        }
+
+        vol.template set_range<for_surface>({surfaces.size(), surfaces.size() + modules.size()});
+    };
+
+    //
     // beampipe
-    detray::scalar detectorHalfZ = 500.;
-    detray::scalar beamPipeR = 27.;
+    //
 
-    cylinders.emplace_back(beamPipeR, detectorHalfZ, detectorHalfZ);
-    transforms.emplace_back();  // identity
-    m_id = {0, 0};
-    surfaces.emplace_back(0, m_id, 0, 0);  // only one cylinder portal
-    // build the volume
-    bounds = {0, beamPipeR, -detectorHalfZ, detectorHalfZ, -M_PI, M_PI};
-    volume_type &v = volumes.emplace_back(bounds);
-    v.set_index(volumes.size() - 1);
-    v.template set_range<for_portal>({0, 1});
-    v.template set_range<for_surface>({0, 0});
-    v.set_surfaces_finder(0);
+    // build the beampipe volume
+    volume_type &v = add_cylinder_volume(volumes, 0., beampipe_r, detector_half_z);
+
+    // portal surface to first layer
+    add_portal(v, beampipe_r, detector_half_z);
+
+    // module surfaces
+    v.template set_range<for_surface>({0, 0}); // no modules
+
+    //
+    // first layer
+    //
+
+    // build the first layer volume
+    v = add_cylinder_volume(volumes, beampipe_r, first_layer_outer_r, detector_half_z);
+
+    // inner and outer portal surface
+    add_portal(v, beampipe_r, detector_half_z);
+    add_portal(v, first_layer_outer_r, detector_half_z);
+
+    // Connect it to the beampipe volume
+    auto& beampipe_portal = surfaces.front();
+    beampipe_portal.set_edge({v.index(), 0});
+    auto& first_vol_portal = surfaces[1];
+    first_vol_portal.set_edge({volumes.front().index(), 0});
+
+    // create module surfaces
+    auto [l1_mods, l1_trfs, l1_masks] = create_modules<surface, rectangle>();
+
+    // update linking
+    update_links(v, l1_mods, transforms.size(), rectangles.size());
+    // Append to collections
+    surfaces.insert(surfaces.end(), l1_mods.begin(), l1_mods.end());
+    transforms.insert(transforms.end(), l1_trfs.begin(), l1_trfs.end());
+    rectangles.insert(rectangles.end(), l1_masks.begin(), l1_masks.end());
+
 
     /*std::shared_ptr<DetectorVolume> createCentralDetector(
     ActsScalar detectorHalfZ = 500.) {

--- a/tests/common/include/tests/common/read_geometry.hpp
+++ b/tests/common/include/tests/common/read_geometry.hpp
@@ -309,8 +309,9 @@ auto toy_geometry() {
     beampipe_portal.set_edge({layer_1.index(), dindex_invalid});
 
     dindex layer1_pt_index = layer_1.template range<for_portal>()[0];
+    ;
     auto& first_layer_inner_portal = surfaces[layer1_pt_index];
-    first_layer_inner_portal.set_edge({beampipe.index(), dindex_invalid});
+    first_layer_inner_portal.set_edge({layer_1.index() - 1, dindex_invalid});
 
     // create module surfaces
     auto [l1_mods, l1_trfs, l1_masks] = create_modules<surface, rectangle>(
@@ -342,7 +343,7 @@ auto toy_geometry() {
 
     dindex gap_pt_index = gap.template range<for_portal>()[0];
     auto& gap_inner_portal = surfaces[gap_pt_index];
-    gap_inner_portal.set_edge({layer_1.index(), dindex_invalid});
+    gap_inner_portal.set_edge({gap.index() - 1, dindex_invalid});
 
     //
     // second layer
@@ -363,7 +364,7 @@ auto toy_geometry() {
 
     dindex layer2_pt_index = layer_2.template range<for_portal>()[0];
     auto& second_layer_inner_portal = surfaces[layer2_pt_index];
-    second_layer_inner_portal.set_edge({gap.index(), dindex_invalid});
+    second_layer_inner_portal.set_edge({layer_2.index() - 1, dindex_invalid});
 
     auto& second_layer_outer_portal = surfaces[++layer2_pt_index];
     second_layer_outer_portal.set_edge({dindex_invalid, dindex_invalid});

--- a/tests/common/include/tests/common/read_geometry.hpp
+++ b/tests/common/include/tests/common/read_geometry.hpp
@@ -35,7 +35,7 @@ detector_input_files tml_files = {"tml", "tml.csv", "tml-layer-volumes.csv",
                                   "tml-surface-grids.csv", ""};
 
 /** Read a detector from csv files */
-auto read_from_csv(detector_input_files &files) {
+auto read_from_csv(detector_input_files& files) {
     auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
     if (env_d_d == nullptr) {
         throw std::ios_base::failure(
@@ -57,29 +57,29 @@ auto read_from_csv(detector_input_files &files) {
 };
 
 /** Creates a number of pixel modules for the a cylindrical barrel region.
-  *
-  * @tparam surface_t The surface type that contains the container indices
-  * @tparam mask_t The geomterical boundaries of a surface (rectangles)
-  *
-  * @param m_half_x module half length in local x
-  * @param m_half_y module half length in local y
-  * @param m_tilt_phi phi tilt of the modules
-  * @param layer_r radius at which the modules are positioned in the volume
-  * @param radial_stagger module stagger in r
-  * @param l_overlap the z overlap of modules next in z
-  * @param binning phi, z bins of the surface grid
-  *
-  * @return a tuple that contains the surfaces (linking into the locally 
-  *         created container), the module transsforms and the surface masks.
-  */
-template<typename surface_t, typename mask_t>
-auto create_modules(
-    scalar m_half_x = 8.4, scalar m_half_y = 36., scalar m_tilt_phi = 0.145,
-    scalar layer_r = 32., scalar radial_stagger = 2.,
-    scalar l_overlap = 5., const std::pair<int, int> binning = {16, 14}) {
+ *
+ * @tparam surface_t The surface type that contains the container indices
+ * @tparam mask_t The geomterical boundaries of a surface (rectangles)
+ *
+ * @param m_half_x module half length in local x
+ * @param m_half_y module half length in local y
+ * @param m_tilt_phi phi tilt of the modules
+ * @param layer_r radius at which the modules are positioned in the volume
+ * @param radial_stagger module stagger in r
+ * @param l_overlap the z overlap of modules next in z
+ * @param binning phi, z bins of the surface grid
+ *
+ * @return a tuple that contains the surfaces (linking into the locally
+ *         created container), the module transsforms and the surface masks.
+ */
+template <typename surface_t, typename mask_t>
+auto create_modules(scalar m_half_x = 8.4, scalar m_half_y = 36.,
+                    scalar m_tilt_phi = 0.145, scalar layer_r = 32.,
+                    scalar radial_stagger = 2., scalar l_overlap = 5.,
+                    const std::pair<int, int> binning = {16, 14}) {
 
-    //using transform3 = __plugin::transform3;
-    //using point3 = __plugin::point3;
+    // using transform3 = __plugin::transform3;
+    // using point3 = __plugin::point3;
     /// mask index: type, range
     using mask_index = detray::darray<detray::dindex, 2>;
 
@@ -105,20 +105,22 @@ auto create_modules(
     scalar pi{static_cast<scalar>(M_PI)};
     scalar phi_step = scalar{2} * pi / (n_phi_bins);
     scalar min_phi = -pi + scalar{0.5} * phi_step;
-    scalar z_start = scalar{-0.5} * (n_z_bins - 1) * (scalar{2} * m_half_y - l_overlap);
+    scalar z_start =
+        scalar{-0.5} * (n_z_bins - 1) * (scalar{2} * m_half_y - l_overlap);
     scalar z_step = scalar{2} * std::abs(z_start) / (n_z_bins - 1);
 
     // loop over the bins
     for (size_t z_bin = 0; z_bin < size_t(n_z_bins); ++z_bin) {
-      // prepare z and r
-      scalar m_z = z_start + z_bin * z_step;
-      scalar m_r =
-          (z_bin % 2) != 0u ? layer_r - scalar{0.5} * radial_stagger : layer_r + scalar{0.5} * radial_stagger;
-      for (size_t phiBin = 0; phiBin < size_t(n_phi_bins); ++phiBin) {
-        // calculate the current phi value
-        scalar m_phi = min_phi + phiBin * phi_step;
-        m_centers.push_back(point3{m_r * std::cos(m_phi), m_r * std::sin(m_phi), m_z});
-      }
+        // prepare z and r
+        scalar m_z = z_start + z_bin * z_step;
+        scalar m_r = (z_bin % 2) != 0u ? layer_r - scalar{0.5} * radial_stagger
+                                       : layer_r + scalar{0.5} * radial_stagger;
+        for (size_t phiBin = 0; phiBin < size_t(n_phi_bins); ++phiBin) {
+            // calculate the current phi value
+            scalar m_phi = min_phi + phiBin * phi_step;
+            m_centers.push_back(
+                point3{m_r * std::cos(m_phi), m_r * std::sin(m_phi), m_z});
+        }
     }
 
     // Create geometry data
@@ -130,7 +132,8 @@ auto create_modules(
 
         // Surfaces with the linking into the local containers
         m_id = {0, masks.size()};
-        surfaces.emplace_back(transforms.size(), m_id, detray::dindex_invalid, detray::dindex_invalid);
+        surfaces.emplace_back(transforms.size(), m_id, detray::dindex_invalid,
+                              detray::dindex_invalid);
 
         // The rectangle bounds for this module
         masks.emplace_back(m_half_x, m_half_y);
@@ -150,25 +153,25 @@ auto create_modules(
     }
 
     return std::make_tuple<surface_container, trfs_container, mask_container>(
-    std::move(surfaces), std::move(transforms), std::move(masks));
+        std::move(surfaces), std::move(transforms), std::move(masks));
 }
 
 /** Add a single barrel layer volume to an existing collection.
-  *
-  * @param min_r minimal radius of volume
-  * @param max_r maximal radius of volume
-  * @param half_z half length in z of volume
-  *
-  * @return a detray cylinder volume
-  */
-template<typename volume_container_t>
-auto& add_cylinder_volume(volume_container_t &volumes,
-    scalar min_r = 25., scalar max_r = 40.,
-    scalar half_z = 500.) {
+ *
+ * @param min_r minimal radius of volume
+ * @param max_r maximal radius of volume
+ * @param half_z half length in z of volume
+ *
+ * @return a detray cylinder volume
+ */
+template <typename volume_container_t>
+auto& add_cylinder_volume(volume_container_t& volumes, scalar min_r = 25.,
+                          scalar max_r = 40., scalar half_z = 500.) {
 
     // The volume bounds
-    detray::darray<scalar, 6> bounds = {min_r, max_r, -half_z, half_z, -M_PI, M_PI};
-    
+    detray::darray<scalar, 6> bounds = {min_r,  max_r, -half_z,
+                                        half_z, -M_PI, M_PI};
+
     // Add the new volume to the collection
     auto& v = volumes.emplace_back(bounds);
     v.set_index(volumes.size() - 1);
@@ -177,15 +180,15 @@ auto& add_cylinder_volume(volume_container_t &volumes,
 }
 
 /** Builds a simple detray geometry of the innermost tml layers. It contains:
-  *
-  * - a beampipe (r = 27mm, half_z = 500mm)
-  * - a layer (r_min = 27mm, r_max = 38mm) with n rectangular modules at 
-  *   r = 32mm
-  *
-  * @returns a tuple containing the geometry objects collections: [volumes,
-  *          surfaces, transforms, cylinder masks (portals), rectangle masks 
-  *          (modules)]
-  */
+ *
+ * - a beampipe (r = 27mm, half_z = 500mm)
+ * - a layer (r_min = 27mm, r_max = 38mm) with n rectangular modules at
+ *   r = 32mm
+ *
+ * @returns a tuple containing the geometry objects collections: [volumes,
+ *          surfaces, transforms, cylinder masks (portals), rectangle masks
+ *          (modules)]
+ */
 auto toy_geometry() {
     constexpr bool for_surface = true;
     constexpr bool for_portal = false;
@@ -204,7 +207,7 @@ auto toy_geometry() {
     using source_link = detray::dindex;
 
     // The surface transforms
-    //using transform3 = __plugin::transform3;
+    // using transform3 = __plugin::transform3;
     // We have cylinder and rectangle surfaces
     using cylinder = detray::cylinder3<false, detray::cylinder_intersector,
                                        __plugin::cylindrical2, edge_links, 0>;
@@ -243,27 +246,30 @@ auto toy_geometry() {
     scalar second_layer_inner_r = 64.;
     scalar second_layer_outer_r = 80.;
 
-    /** Function that adds a cylinder portal with an identity transform to a 
-      * volume.
-      */
-    auto add_portal = [&](volume_type &vol, scalar r, scalar half_z) {
+    /** Function that adds a cylinder portal with an identity transform to a
+     * volume.
+     */
+    auto add_portal = [&](volume_type& vol, scalar r, scalar half_z) {
         cylinders.emplace_back(r, -half_z, half_z);
         transforms.emplace_back();  // identity
         m_id = {cylinders.size(), 0};
         surfaces.emplace_back(transforms.size(), m_id, vol.index(), 0);
-        vol.template set_range<for_portal>({surfaces.size() - 1, surfaces.size()});
+        vol.template set_range<for_portal>(
+            {surfaces.size() - 1, surfaces.size()});
     };
 
     /** Function that updates surface links when added to the global containers.
-      */
-    auto update_links = [&](volume_type &vol, surface_container& modules, dindex trfs_offset, dindex masks_offset) {
-        for (auto &sf : modules) {
+     */
+    auto update_links = [&](volume_type& vol, surface_container& modules,
+                            dindex trfs_offset, dindex masks_offset) {
+        for (auto& sf : modules) {
             sf.transform() += trfs_offset;
             std::get<1>(sf.mask()) += masks_offset;
             sf.volume() = vol.index();
         }
 
-        vol.template set_range<for_surface>({surfaces.size(), surfaces.size() + modules.size()});
+        vol.template set_range<for_surface>(
+            {surfaces.size(), surfaces.size() + modules.size()});
     };
 
     //
@@ -271,20 +277,22 @@ auto toy_geometry() {
     //
 
     // build the beampipe volume
-    volume_type &v = add_cylinder_volume(volumes, 0., beampipe_r, detector_half_z);
+    volume_type& v =
+        add_cylinder_volume(volumes, 0., beampipe_r, detector_half_z);
 
     // portal surface to first layer
     add_portal(v, beampipe_r, detector_half_z);
 
     // module surfaces
-    v.template set_range<for_surface>({0, 0}); // no modules
+    v.template set_range<for_surface>({0, 0});  // no modules
 
     //
     // first layer
     //
 
     // build the first layer volume
-    v = add_cylinder_volume(volumes, beampipe_r, first_layer_outer_r, detector_half_z);
+    v = add_cylinder_volume(volumes, beampipe_r, first_layer_outer_r,
+                            detector_half_z);
 
     // inner and outer portal surface
     add_portal(v, beampipe_r, detector_half_z);
@@ -293,8 +301,8 @@ auto toy_geometry() {
     // Connect it to the beampipe volume
     auto& beampipe_portal = surfaces.front();
     beampipe_portal.set_edge({v.index(), 0});
-    auto& first_vol_portal = surfaces[1];
-    first_vol_portal.set_edge({volumes.front().index(), 0});
+    auto& first_layer_inner_portal = surfaces[1];
+    first_layer_inner_portal.set_edge({v.index() - 1, 0});
 
     // create module surfaces
     auto [l1_mods, l1_trfs, l1_masks] = create_modules<surface, rectangle>();
@@ -306,39 +314,46 @@ auto toy_geometry() {
     transforms.insert(transforms.end(), l1_trfs.begin(), l1_trfs.end());
     rectangles.insert(rectangles.end(), l1_masks.begin(), l1_masks.end());
 
+    //
+    // first gap
+    //
 
-    /*std::shared_ptr<DetectorVolume> createCentralDetector(
-    ActsScalar detectorHalfZ = 500.) {
-  // Create the volume bounds
-  ActsScalar beamPipeR = 27.;
-  // Beam pipe volume
-  auto beamPipeBounds =
-      std::make_unique<CylinderVolumeBounds>(0., beamPipeR, detectorHalfZ);
-  auto beamPipe = DetectorVolume::makeShared(
-      Transform3::Identity(), std::move(beamPipeBounds), "BeamPipe");
-  // First layer
-  ActsScalar firstLayerOuterR = 38.;
-  auto firstLayer = createBarrelVolume(beamPipeR, firstLayerOuterR,
-                                       detectorHalfZ, "BarrelLayer0");
-  // First gap
-  ActsScalar secondLayerInnerR = 64.;
-  auto firstGapBounds = std::make_unique<CylinderVolumeBounds>(
-      firstLayerOuterR, secondLayerInnerR, detectorHalfZ);
-  auto firstGap = DetectorVolume::makeShared(
-      Transform3::Identity(), std::move(firstGapBounds), "BarrelGap0");
-  // Second layer
-  ActsScalar secondLayerOuterR = 80.;
-  auto secondLayer = createBarrelVolume(secondLayerInnerR, secondLayerOuterR,
-                                        detectorHalfZ, "BarrelLayer1", 8.4, 36.,
-                                        0.145, 72., 2., 5., {32, 14});
+    // build gap volume
+    v = add_cylinder_volume(volumes, first_layer_outer_r, second_layer_outer_r,
+                            detector_half_z);
 
-  // The volumes in R
-  std::vector<std::shared_ptr<DetectorVolume>> barrelVolumes = {
-      beamPipe, firstLayer, firstGap, secondLayer};
+    // inner and outer portal surface
+    add_portal(v, first_layer_outer_r, detector_half_z);
+    add_portal(v, second_layer_outer_r, detector_half_z);
 
-  // Return the container in R
-  return CylindricalContainerHelper::containerInR(std::move(barrelVolumes),
-                                                  "BarrelWithTwoLayers");*/
+    // Connect it to the first layer
+    dindex current_portal = v.template range<for_portal>()[0];
+    auto& first_layer_outer_portal = surfaces[current_portal];
+    first_layer_outer_portal.set_edge({v.index(), 0});
+    auto& first_gap_inner_portal = surfaces[++current_portal];
+    first_gap_inner_portal.set_edge({v.index() - 1, 0});
+
+    /*
+      // First gap
+      ActsScalar secondLayerInnerR = 64.;
+      auto firstGapBounds = std::make_unique<CylinderVolumeBounds>(
+          firstLayerOuterR, secondLayerInnerR, detectorHalfZ);
+      auto firstGap = DetectorVolume::makeShared(
+          Transform3::Identity(), std::move(firstGapBounds), "BarrelGap0");
+
+      // Second layer
+      ActsScalar secondLayerOuterR = 80.;
+      auto secondLayer = createBarrelVolume(secondLayerInnerR,
+      secondLayerOuterR, detectorHalfZ, "BarrelLayer1", 8.4, 36.,
+                                            0.145, 72., 2., 5., {32, 14});
+
+      // The volumes in R
+      std::vector<std::shared_ptr<DetectorVolume>> barrelVolumes = {
+          beamPipe, firstLayer, firstGap, secondLayer};
+
+      // Return the container in R
+      return CylindricalContainerHelper::containerInR(std::move(barrelVolumes),
+                                                      "BarrelWithTwoLayers");*/
     return std::make_tuple<volume_container, surface_container,
                            transf_container, cylinder_container,
                            rectangle_container>(
@@ -346,4 +361,4 @@ auto toy_geometry() {
         std::move(cylinders), std::move(rectangles));
 }
 
-}  // namespace detray_tests
+}  // namespace

--- a/tests/common/include/tests/common/read_geometry.hpp
+++ b/tests/common/include/tests/common/read_geometry.hpp
@@ -19,8 +19,6 @@
 /// @note __plugin has to be defined with a preprocessor command
 using namespace detray;
 
-namespace /*detray_tests*/ {
-
 /** Keeps the relevant csv file names */
 struct detector_input_files {
     std::string det_name, surface, layer_volume, surface_grid,
@@ -126,13 +124,13 @@ inline auto create_modules(scalar m_half_x = 8.4, scalar m_half_y = 36.,
 
     // Create geometry data
 
-    // First value is zero for rectangle type
-    mask_index m_id = {0, 0};
+    // First value is two for rectangle type, then index into local container
+    mask_index m_id = {2, 0};
 
     for (auto& m_center : m_centers) {
 
         // Surfaces with the linking into the local containers
-        m_id = {1, masks.size()};
+        m_id = {2, masks.size()};
         surfaces.emplace_back(transforms.size(), m_id, detray::dindex_invalid,
                               detray::dindex_invalid);
 
@@ -143,11 +141,11 @@ inline auto create_modules(scalar m_half_x = 8.4, scalar m_half_y = 36.,
         // The local phi
         scalar m_phi = algebra::getter::phi(m_center);
         // Local z axis is the normal vector
-        point3 m_local_z{std::cos(m_phi + m_tilt_phi),
-                         std::sin(m_phi + m_tilt_phi), 0.};
+        vector3 m_local_z{std::cos(m_phi + m_tilt_phi),
+                          std::sin(m_phi + m_tilt_phi), 0.};
         // Local x axis the normal to local y,z
-        point3 m_local_x{-std::sin(m_phi + m_tilt_phi),
-                         std::cos(m_phi + m_tilt_phi), 0.};
+        vector3 m_local_x{-std::sin(m_phi + m_tilt_phi),
+                          std::cos(m_phi + m_tilt_phi), 0.};
 
         // Create the module transform
         transforms.emplace_back(m_center, m_local_z, m_local_x);
@@ -161,14 +159,14 @@ inline auto create_modules(scalar m_half_x = 8.4, scalar m_half_y = 36.,
  *
  * - a beampipe (r = 27mm, half_z = 500mm)
  * - a first layer (r_min = 27mm, r_max = 38mm, half_z = 500mm) with 224
- *   rectangular () modules at r = 32mm
+ *   rectangular (half_x = 8.4mm, half_y = 36mm) modules at r = 32mm
  * - an empty layer (r_min = 38mm, r_max = 64mm, half_z = 500mm)
  * - a second layer (r_min = 64mm, r_max = 80mm, half_z = 500mm) with 448
- *   rectangular () modules at r = mm.
+ *   rectangular (half_x = 8.4mm, half_y = 36mm) modules at r = 72mm.
  *
  * @returns a tuple containing the geometry objects collections: [volumes,
- *          surfaces, transforms, cylinder masks (portals), rectangle masks
- *          (modules)]
+ *          surfaces, transforms, disc masks (neg/pos portals), cylinder masks
+ *          (inner/outer portals), rectangle masks (modules)]
  */
 auto toy_geometry() {
     constexpr bool for_surface = true;
@@ -187,13 +185,15 @@ auto toy_geometry() {
     /// source link
     using source_link = detray::dindex;
 
-    // The surface transforms
-    // using transform3 = __plugin::transform3;
-    // We have cylinder and rectangle surfaces
+    // We have disc, cylinder and rectangle surfaces
+    using disc = detray::ring2<detray::planar_intersector, __plugin::cartesian2,
+                               edge_links, 0>;
+
     using cylinder = detray::cylinder3<false, detray::cylinder_intersector,
-                                       __plugin::cylindrical2, edge_links, 0>;
+                                       __plugin::cylindrical2, edge_links, 1>;
+
     using rectangle = detray::rectangle2<detray::planar_intersector,
-                                         __plugin::cartesian2, edge_links, 1>;
+                                         __plugin::cartesian2, edge_links, 2>;
 
     // The surface type, both for volume portals and contained detector
     // surfaces
@@ -204,6 +204,7 @@ auto toy_geometry() {
     using volume_container = detray::dvector<volume_type>;
     using surface_container = detray::dvector<surface>;
     using transf_container = detray::dvector<transform3>;
+    using disc_container = detray::dvector<disc>;
     using cylinder_container = detray::dvector<cylinder>;
     using rectangle_container = detray::dvector<rectangle>;
 
@@ -213,7 +214,9 @@ auto toy_geometry() {
     surface_container surfaces = {};
     /** Surface transforms */
     transf_container transforms = {};
-    /** Cylinder masks for volume boundaries (portals) */
+    /** Disc masks for neg/pos volume boundaries (portals) */
+    disc_container discs = {};
+    /** Cylinder masks for inner/outer volume boundaries (portals) */
     cylinder_container cylinders = {};
     /** Rectangle masks for detector surfaces */
     rectangle_container rectangles = {};
@@ -249,11 +252,34 @@ auto toy_geometry() {
         return vol;
     };
 
-    /** Function that adds a cylinder portal with an identity transform to a
-     * volume.
+    /** Function that adds a disc portal.
+     *
+     * @param vol volume the portal should be added to
+     * @param min_r lower radius of disc
+     * @param max_r upper radius of disc
+     * @param half_z z half length of the detector volume
      */
-    auto add_portal = [&](volume_type& vol, scalar r, scalar half_z) {
-        m_id = {0, cylinders.size()};
+    auto add_disc_portal = [&](volume_type& vol, scalar min_r, scalar max_r,
+                               scalar half_z) {
+        m_id = {0, discs.size()};
+        surfaces.emplace_back(transforms.size(), m_id, vol.index(), src_link);
+        discs.emplace_back(min_r, max_r);
+        // Position disc
+        vector3 translation{0., 0., half_z};
+        transforms.emplace_back(translation);
+
+        vol.template set_range<for_portal>(
+            {surfaces.size() - 1, surfaces.size()});
+    };
+
+    /** Function that adds a disc portal.
+     *
+     * @param vol volume the portal should be added to
+     * @param r raius of the cylinder
+     * @param half_z z half length of the cylinder
+     */
+    auto add_cylinder_portal = [&](volume_type& vol, scalar r, scalar half_z) {
+        m_id = {1, cylinders.size()};
         surfaces.emplace_back(transforms.size(), m_id, vol.index(), src_link);
         cylinders.emplace_back(r, -half_z, half_z);
         transforms.emplace_back();  // identity
@@ -262,8 +288,13 @@ auto toy_geometry() {
             {surfaces.size() - 1, surfaces.size()});
     };
 
-    /** Function that updates surface links when added to the global
-     *  containers.
+    /** Function that updates surface and volume links when added to the global
+     *  containers. The module surface edge point back into the volume.
+     *
+     * @param vol the volume the module surfaces belong to
+     * @param modules the module surface container
+     * @param trfs_offset offset into the global transform container
+     * @param masks_offset offset into the global mask container
      */
     auto update_links = [&](volume_type& vol, surface_container& modules,
                             dindex trfs_offset, dindex masks_offset) {
@@ -286,11 +317,20 @@ auto toy_geometry() {
     volume_type& beampipe =
         add_cylinder_volume(0., beampipe_r, detector_half_z);
 
-    // portal surface to first layer
-    add_portal(beampipe, beampipe_r, detector_half_z);
+    // negative and positive, outer portal surface
+    add_disc_portal(beampipe, 0., beampipe_r, -detector_half_z);
+    add_disc_portal(beampipe, 0., beampipe_r, detector_half_z);
+    add_cylinder_portal(beampipe, beampipe_r, detector_half_z);
 
-    // module surfaces
-    beampipe.template set_range<for_surface>({0, 0});  // no modules
+    // Set disc portal edges
+    dindex beampipe_portal_index = beampipe.template range<for_portal>()[0];
+    auto& beampipe_neg_portal = surfaces[beampipe_portal_index];
+    beampipe_neg_portal.set_edge({dindex_invalid, dindex_invalid});
+    auto& beampipe_pos_portal = surfaces[++beampipe_portal_index];
+    beampipe_pos_portal.set_edge({dindex_invalid, dindex_invalid});
+
+    // module surfaces (none)
+    beampipe.template set_range<for_surface>({dindex_invalid, dindex_invalid});
 
     //
     // first layer
@@ -300,27 +340,33 @@ auto toy_geometry() {
     volume_type& layer_1 =
         add_cylinder_volume(beampipe_r, first_layer_outer_r, detector_half_z);
 
-    // outer and inner portal surface
-    add_portal(layer_1, beampipe_r, detector_half_z);
-    add_portal(layer_1, first_layer_outer_r, detector_half_z);
+    // negative and positive, inner and outer portal surface
+    add_disc_portal(layer_1, beampipe_r, first_layer_outer_r, -detector_half_z);
+    add_disc_portal(layer_1, beampipe_r, first_layer_outer_r, detector_half_z);
+    add_cylinder_portal(layer_1, beampipe_r, detector_half_z);
+    add_cylinder_portal(layer_1, first_layer_outer_r, detector_half_z);
 
-    // Connect it to the beampipe volume
-    auto& beampipe_portal = surfaces.front();
-    beampipe_portal.set_edge({layer_1.index(), dindex_invalid});
-
+    // Connect portals (beampipe, gap)
+    auto& beampipe_outer_portal = surfaces[++beampipe_portal_index];
+    beampipe_outer_portal.set_edge({layer_1.index(), dindex_invalid});
+    // discs
     dindex layer1_pt_index = layer_1.template range<for_portal>()[0];
-    ;
-    auto& first_layer_inner_portal = surfaces[layer1_pt_index];
+    auto& first_layer_neg_portal = surfaces[layer1_pt_index];
+    first_layer_neg_portal.set_edge({dindex_invalid, dindex_invalid});
+    auto& first_layer_pos_portal = surfaces[++layer1_pt_index];
+    first_layer_pos_portal.set_edge({dindex_invalid, dindex_invalid});
+    // cylinder
+    auto& first_layer_inner_portal = surfaces[++layer1_pt_index];
     first_layer_inner_portal.set_edge({layer_1.index() - 1, dindex_invalid});
 
     // create module surfaces
-    auto [l1_mods, l1_trfs, l1_masks] = create_modules<surface, rectangle>(
+    auto [l1_modules, l1_trfs, l1_masks] = create_modules<surface, rectangle>(
         8.4, 36., 0.145, 32., 2., 5., {16, 14});
 
     // update linking in volumes and surfaces
-    update_links(layer_1, l1_mods, transforms.size(), rectangles.size());
+    update_links(layer_1, l1_modules, transforms.size(), rectangles.size());
     // Append to collections
-    surfaces.insert(surfaces.end(), l1_mods.begin(), l1_mods.end());
+    surfaces.insert(surfaces.end(), l1_modules.begin(), l1_modules.end());
     transforms.insert(transforms.end(), l1_trfs.begin(), l1_trfs.end());
     rectangles.insert(rectangles.end(), l1_masks.begin(), l1_masks.end());
 
@@ -332,18 +378,30 @@ auto toy_geometry() {
     volume_type& gap = add_cylinder_volume(
         first_layer_outer_r, second_layer_inner_r, detector_half_z);
 
-    // inner and outer portal surface
-    add_portal(gap, first_layer_outer_r, detector_half_z);
-    add_portal(gap, second_layer_inner_r, detector_half_z);
+    // negative and positive, inner and outer portal surface
+    add_disc_portal(gap, first_layer_outer_r, second_layer_inner_r,
+                    -detector_half_z);
+    add_disc_portal(gap, first_layer_outer_r, second_layer_inner_r,
+                    detector_half_z);
+    add_cylinder_portal(gap, first_layer_outer_r, detector_half_z);
+    add_cylinder_portal(gap, second_layer_inner_r, detector_half_z);
 
-    // Connect it to the first layer
+    // Connect portals (first layer, second layer)
     layer1_pt_index = layer_1.template range<for_portal>()[1] - 1;
     auto& first_layer_outer_portal = surfaces[layer1_pt_index];
     first_layer_outer_portal.set_edge({gap.index(), dindex_invalid});
-
+    // discs
     dindex gap_pt_index = gap.template range<for_portal>()[0];
-    auto& gap_inner_portal = surfaces[gap_pt_index];
+    auto& gap_neg_portal = surfaces[gap_pt_index];
+    gap_neg_portal.set_edge({dindex_invalid, dindex_invalid});
+    auto& gap_pos_portal = surfaces[++gap_pt_index];
+    gap_pos_portal.set_edge({dindex_invalid, dindex_invalid});
+    // cylinder
+    auto& gap_inner_portal = surfaces[++gap_pt_index];
     gap_inner_portal.set_edge({gap.index() - 1, dindex_invalid});
+
+    // module surfaces (none)
+    gap.template set_range<for_surface>({dindex_invalid, dindex_invalid});
 
     //
     // second layer
@@ -353,39 +411,45 @@ auto toy_geometry() {
     volume_type& layer_2 = add_cylinder_volume(
         second_layer_inner_r, second_layer_outer_r, detector_half_z);
 
-    // inner and outer portal surface
-    add_portal(layer_2, second_layer_inner_r, detector_half_z);
-    add_portal(layer_2, second_layer_outer_r, detector_half_z);
+    // negative and positive, inner and outer portal surface
+    add_disc_portal(layer_2, second_layer_inner_r, second_layer_outer_r,
+                    -detector_half_z);
+    add_disc_portal(layer_2, second_layer_inner_r, second_layer_outer_r,
+                    detector_half_z);
+    add_cylinder_portal(layer_2, second_layer_inner_r, detector_half_z);
+    add_cylinder_portal(layer_2, second_layer_outer_r, detector_half_z);
 
-    // Connect it to the gap
+    /// Connect portals (gap, world)
     gap_pt_index = gap.template range<for_portal>()[1] - 1;
     auto& gap_outer_portal = surfaces[gap_pt_index];
     gap_outer_portal.set_edge({layer_2.index(), dindex_invalid});
-
+    // discs
     dindex layer2_pt_index = layer_2.template range<for_portal>()[0];
-    auto& second_layer_inner_portal = surfaces[layer2_pt_index];
+    auto& second_layer_neg_portal = surfaces[layer2_pt_index];
+    second_layer_neg_portal.set_edge({dindex_invalid, dindex_invalid});
+    auto& second_layer_pos_portal = surfaces[++layer2_pt_index];
+    second_layer_pos_portal.set_edge({dindex_invalid, dindex_invalid});
+    // cylinder
+    auto& second_layer_inner_portal = surfaces[++layer2_pt_index];
     second_layer_inner_portal.set_edge({layer_2.index() - 1, dindex_invalid});
-
     auto& second_layer_outer_portal = surfaces[++layer2_pt_index];
     second_layer_outer_portal.set_edge({dindex_invalid, dindex_invalid});
 
     // create module surfaces
-    auto [l2_mods, l2_trfs, l2_masks] = create_modules<surface, rectangle>(
+    auto [l2_modules, l2_trfs, l2_masks] = create_modules<surface, rectangle>(
         8.4, 36., 0.145, 72., 2., 5., {32, 14});
 
     // update linking in volumes and surfaces
-    update_links(layer_2, l2_mods, transforms.size(), rectangles.size());
+    update_links(layer_2, l2_modules, transforms.size(), rectangles.size());
     // Append to collections
-    surfaces.insert(surfaces.end(), l2_mods.begin(), l2_mods.end());
+    surfaces.insert(surfaces.end(), l2_modules.begin(), l2_modules.end());
     transforms.insert(transforms.end(), l2_trfs.begin(), l2_trfs.end());
     rectangles.insert(rectangles.end(), l2_masks.begin(), l2_masks.end());
 
     // Return all geometry containers
     return std::make_tuple<volume_container, surface_container,
-                           transf_container, cylinder_container,
+                           transf_container, cylinder_container, disc_container,
                            rectangle_container>(
         std::move(volumes), std::move(surfaces), std::move(transforms),
-        std::move(cylinders), std::move(rectangles));
+        std::move(cylinders), std::move(discs), std::move(rectangles));
 }
-
-}  // namespace

--- a/tests/common/include/tests/common/test_geometry_navigation.inl
+++ b/tests/common/include/tests/common/test_geometry_navigation.inl
@@ -108,7 +108,7 @@ struct print_inspector {
     }
 };
 
-auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
+auto [d, name_map] = read_from_csv(tml_files);
 
 // Create the navigator
 using detray_context = decltype(d)::context;

--- a/tests/common/include/tests/common/test_geometry_navigation.inl
+++ b/tests/common/include/tests/common/test_geometry_navigation.inl
@@ -20,37 +20,12 @@
 #include "core/detector.hpp"
 #include "core/track.hpp"
 #include "io/csv_io.hpp"
+#include "tests/common/read_geometry.hpp"
 #include "tools/line_stepper.hpp"
 #include "tools/navigator.hpp"
 #include "utils/ray_gun.hpp"
 
 using namespace detray;
-
-/** Read the detector from file */
-auto read_detector() {
-    auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set DETRAY_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d);
-
-    /*std::string name = "odd";
-    std::string surfaces = data_directory + "odd.csv";
-    std::string volumes = data_directory + "odd-layer-volumes.csv";
-    std::string grids = data_directory + "odd-surface-grids.csv";
-    std::string grid_entries = "";*/
-
-    std::string name = "tml";
-    std::string surfaces = data_directory + "tml.csv";
-    std::string volumes = data_directory + "tml-layer-volumes.csv";
-    std::string grids = data_directory + "tml-surface-grids.csv";
-    std::string grid_entries = "";
-    std::map<dindex, std::string> name_map{};
-
-    return detray::detector_from_csv<>(name, surfaces, volumes, grids,
-                                       grid_entries, name_map);
-};
 
 /** A navigation inspector that relays information about the encountered
  *  portals the way we need them to compare with the ray
@@ -133,7 +108,7 @@ struct print_inspector {
     }
 };
 
-auto d = read_detector();
+auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
 
 // Create the navigator
 using detray_context = decltype(d)::context;

--- a/tests/common/include/tests/common/test_geometry_scan.inl
+++ b/tests/common/include/tests/common/test_geometry_scan.inl
@@ -19,35 +19,10 @@
 
 #include "core/detector.hpp"
 #include "io/csv_io.hpp"
+#include "tests/common/read_geometry.hpp"
 #include "utils/ray_gun.hpp"
 
 using namespace detray;
-
-/** Read the detector from file */
-auto read_detector() {
-    auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set DETRAY_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d);
-
-    /*std::string name = "odd";
-    std::string surfaces = data_directory + "odd.csv";
-    std::string volumes = data_directory + "odd-layer-volumes.csv";
-    std::string grids = data_directory + "odd-surface-grids.csv";
-    std::string grid_entries = "";*/
-
-    std::string name = "tml";
-    std::string surfaces = data_directory + "tml.csv";
-    std::string volumes = data_directory + "tml-layer-volumes.csv";
-    std::string grids = data_directory + "tml-surface-grids.csv";
-    std::string grid_entries = "";
-    std::map<dindex, std::string> name_map{};
-
-    return detray::detector_from_csv<>(name, surfaces, volumes, grids,
-                                       grid_entries, name_map);
-};
 
 /** Check if a set of volume index pairs form a trace.
  *
@@ -184,7 +159,7 @@ inline auto check_connectivity(const record_type &volume_record,
     return valid_volumes;
 }
 
-auto d = read_detector();
+auto [d, name_map] = read_from_csv(tml_files);
 
 namespace __plugin {
 

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <iostream>
+
 #include "tests/common/read_geometry.hpp"
 
 using namespace detray;
@@ -130,7 +132,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       {{2, dindex_invalid}, {dindex_invalid, dindex_invalid}});
 
     // Check links of modules
-    range = {231, 479};
+    range = {231, surfaces.size()};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {1, 224}, {{vol_itr->index(), dindex_invalid}});
 }

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -1,0 +1,32 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include "tests/common/read_geometry.hpp"
+
+using namespace detray;
+
+auto [volumes, surfaces, transforms, cylinders, rectangles] =
+    detray_tests::toy_geometry();
+
+// This test runs intersection with all portals of the TrackML detector
+TEST(ALGEBRA_PLUGIN, ray_scan) {
+
+    // Check number of geomtery objects
+    EXPECT_EQ(volumes.size(), 1);
+    EXPECT_EQ(surfaces.size(), 1);
+    EXPECT_EQ(transforms.size(), 1);
+    EXPECT_EQ(cylinders.size(), 1);
+    EXPECT_EQ(rectangles.size(), 0);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -17,10 +17,10 @@ auto [volumes, surfaces, transforms, cylinders, rectangles] = toy_geometry();
 TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check number of geomtery objects
-    EXPECT_EQ(volumes.size(), 2);
-    EXPECT_EQ(surfaces.size(), 227);
-    EXPECT_EQ(transforms.size(), 227);
-    EXPECT_EQ(cylinders.size(), 3);
+    EXPECT_EQ(volumes.size(), 3);
+    EXPECT_EQ(surfaces.size(), 229);
+    EXPECT_EQ(transforms.size(), 229);
+    EXPECT_EQ(cylinders.size(), 5);
     EXPECT_EQ(rectangles.size(), 224);
 }
 

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -11,18 +11,17 @@
 
 using namespace detray;
 
-auto [volumes, surfaces, transforms, cylinders, rectangles] =
-    detray_tests::toy_geometry();
+auto [volumes, surfaces, transforms, cylinders, rectangles] = toy_geometry();
 
-// This test runs intersection with all portals of the TrackML detector
-TEST(ALGEBRA_PLUGIN, ray_scan) {
+// This test check the building of the tml based toy geometry
+TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check number of geomtery objects
-    EXPECT_EQ(volumes.size(), 1);
-    EXPECT_EQ(surfaces.size(), 1);
-    EXPECT_EQ(transforms.size(), 1);
-    EXPECT_EQ(cylinders.size(), 1);
-    EXPECT_EQ(rectangles.size(), 0);
+    EXPECT_EQ(volumes.size(), 2);
+    EXPECT_EQ(surfaces.size(), 227);
+    EXPECT_EQ(transforms.size(), 227);
+    EXPECT_EQ(cylinders.size(), 3);
+    EXPECT_EQ(rectangles.size(), 224);
 }
 
 int main(int argc, char **argv) {

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -11,6 +11,9 @@
 
 using namespace detray;
 
+constexpr bool for_surface = true;
+constexpr bool for_portal = false;
+
 auto [volumes, surfaces, transforms, cylinders, rectangles] = toy_geometry();
 
 // This test check the building of the tml based toy geometry
@@ -22,9 +25,117 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(transforms.size(), 679);
     EXPECT_EQ(cylinders.size(), 7);
     EXPECT_EQ(rectangles.size(), 672);
+
+    auto test_portal_links =
+        [](dindex vol_index, decltype(surfaces.begin())&& sf_itr,
+           darray<dindex, 2>& range, dindex trf_index,
+           darray<dindex, 2>&& mask_index, dvector<darray<dindex, 2>>&& edges) {
+            for (dindex pti = range[0]; pti < range[1]; pti++) {
+                EXPECT_EQ(sf_itr->volume(), vol_index);
+                EXPECT_EQ(sf_itr->transform(), trf_index);
+                EXPECT_EQ(sf_itr->mask(), mask_index);
+                EXPECT_EQ(sf_itr->edge(), edges[pti - range[0]]);
+                sf_itr++;
+                trf_index++;
+                mask_index[1]++;
+            }
+        };
+
+    auto test_module_links =
+        [](dindex vol_index, decltype(surfaces.begin())&& sf_itr,
+           darray<dindex, 2>& range, dindex trf_index,
+           darray<dindex, 2>&& mask_index, dvector<darray<dindex, 2>>&& edges) {
+            for (dindex pti = range[0]; pti < range[1]; pti++) {
+                EXPECT_EQ(sf_itr->volume(), vol_index);
+                EXPECT_EQ(sf_itr->transform(), trf_index);
+                EXPECT_EQ(sf_itr->mask(), mask_index);
+                EXPECT_EQ(sf_itr->edge(), edges[0]);
+                sf_itr++;
+                trf_index++;
+                mask_index[1]++;
+            }
+        };
+
+    //
+    // beampipe
+    //
+
+    // Check volume
+    auto vol_itr = volumes.begin();
+    darray<scalar, 6> bounds = {0., 27., -500., 500, -M_PI, M_PI};
+    darray<dindex, 2> range = {0, 1};
+
+    EXPECT_EQ(vol_itr->index(), 0);
+    EXPECT_EQ(vol_itr->bounds(), bounds);
+    EXPECT_EQ(vol_itr->template range<for_portal>(), range);
+
+    // Check links of portals
+    test_portal_links(vol_itr->index(), surfaces.begin(), range, 0, {0, 0},
+                      {{1, dindex_invalid}});
+
+    //
+    // first layer
+    //
+
+    // Check volume
+    vol_itr++;
+    bounds = {27., 38., -500., 500, -M_PI, M_PI};
+    range = {1, 3};
+    EXPECT_EQ(vol_itr->index(), 1);
+    EXPECT_EQ(vol_itr->bounds(), bounds);
+    EXPECT_EQ(vol_itr->template range<for_portal>(), range);
+
+    // Check links of portals
+    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
+                      range[0], {0, 1},
+                      {{0, dindex_invalid}, {2, dindex_invalid}});
+
+    // Check links of modules
+    range = {3, 227};
+    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
+                      range[0], {1, 0}, {{vol_itr->index(), dindex_invalid}});
+
+    //
+    // gap
+    //
+
+    // Check volume
+    vol_itr++;
+    bounds = {38., 64., -500., 500, -M_PI, M_PI};
+    range = {227, 229};
+    EXPECT_EQ(vol_itr->index(), 2);
+    EXPECT_EQ(vol_itr->bounds(), bounds);
+    EXPECT_EQ(vol_itr->template range<for_portal>(), range);
+
+    // Check links of portals
+    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
+                      range[0], {0, 3},
+                      {{1, dindex_invalid}, {3, dindex_invalid}});
+
+    //
+    // second layer
+    //
+
+    // Check volume
+    vol_itr++;
+    bounds = {64., 80., -500., 500, -M_PI, M_PI};
+    range = {229, 231};
+    EXPECT_EQ(vol_itr->index(), 3);
+    EXPECT_EQ(vol_itr->bounds(), bounds);
+    EXPECT_EQ(vol_itr->template range<for_portal>(), range);
+
+    // Check links of portals
+    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
+                      range[0], {0, 5},
+                      {{2, dindex_invalid}, {dindex_invalid, dindex_invalid}});
+
+    // Check links of modules
+    range = {231, 479};
+    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
+                      range[0], {1, 224}, {{vol_itr->index(), dindex_invalid}});
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
 
     return RUN_ALL_TESTS();

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -17,11 +17,11 @@ auto [volumes, surfaces, transforms, cylinders, rectangles] = toy_geometry();
 TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check number of geomtery objects
-    EXPECT_EQ(volumes.size(), 3);
-    EXPECT_EQ(surfaces.size(), 229);
-    EXPECT_EQ(transforms.size(), 229);
-    EXPECT_EQ(cylinders.size(), 5);
-    EXPECT_EQ(rectangles.size(), 224);
+    EXPECT_EQ(volumes.size(), 4);
+    EXPECT_EQ(surfaces.size(), 679);
+    EXPECT_EQ(transforms.size(), 679);
+    EXPECT_EQ(cylinders.size(), 7);
+    EXPECT_EQ(rectangles.size(), 672);
 }
 
 int main(int argc, char **argv) {

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -23,7 +23,7 @@
 TEST(ALGEBRA_PLUGIN, navigator) {
     using namespace detray;
 
-    auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
+    auto [d, name_map] = read_from_csv(tml_files);
 
     // Create the navigator
     using detray_navigator = navigator<decltype(d)>;

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -14,6 +14,7 @@
 #include "core/track.hpp"
 #include "core/transform_store.hpp"
 #include "io/csv_io.hpp"
+#include "tests/common/read_geometry.hpp"
 #include "tools/navigator.hpp"
 
 /// @note __plugin has to be defined with a preprocessor command
@@ -22,28 +23,7 @@
 TEST(ALGEBRA_PLUGIN, navigator) {
     using namespace detray;
 
-    auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set DETRAY_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d);
-
-    /*std::string name = "odd";
-    std::string surfaces = data_directory + "odd.csv";
-    std::string volumes = data_directory + "odd-layer-volumes.csv";
-    std::string grids = data_directory + "odd-surface-grids.csv";
-    std::string grid_entries = "";*/
-
-    std::string name = "tml";
-    std::string surfaces = data_directory + "tml.csv";
-    std::string volumes = data_directory + "tml-layer-volumes.csv";
-    std::string grids = data_directory + "tml-surface-grids.csv";
-    std::string grid_entries = "";
-    std::map<dindex, std::string> name_map{};
-
-    auto d = detector_from_csv<>(name, surfaces, volumes, grids, grid_entries,
-                                 name_map);
+    auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
 
     // Create the navigator
     using detray_navigator = navigator<decltype(d)>;

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -25,7 +25,7 @@ TEST(ALGEBRA_PLUGIN, propagator) {
     using namespace detray;
     using namespace __plugin;
 
-    auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
+    auto [d, name_map] = read_from_csv(tml_files);
 
     // Create the navigator
     using detray_navigator = navigator<decltype(d)>;

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -13,6 +13,7 @@
 #include "core/track.hpp"
 #include "core/transform_store.hpp"
 #include "io/csv_io.hpp"
+#include "tests/common/read_geometry.hpp"
 #include "tools/line_stepper.hpp"
 #include "tools/navigator.hpp"
 #include "tools/propagator.hpp"
@@ -24,28 +25,7 @@ TEST(ALGEBRA_PLUGIN, propagator) {
     using namespace detray;
     using namespace __plugin;
 
-    auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
-    if (env_d_d == nullptr) {
-        throw std::ios_base::failure(
-            "Test data directory not found. Please set DETRAY_TEST_DATA_DIR.");
-    }
-    auto data_directory = std::string(env_d_d);
-
-    /*std::string name = "odd";
-    std::string surfaces = data_directory + "odd.csv";
-    std::string volumes = data_directory + "odd-layer-volumes.csv";
-    std::string grids = data_directory + "odd-surface-grids.csv";
-    std::string grid_entries = "";*/
-
-    std::string name = "tml";
-    std::string surfaces = data_directory + "tml.csv";
-    std::string volumes = data_directory + "tml-layer-volumes.csv";
-    std::string grids = data_directory + "tml-surface-grids.csv";
-    std::string grid_entries = "";
-    std::map<dindex, std::string> name_map{};
-
-    auto d = detector_from_csv<>(name, surfaces, volumes, grids, grid_entries,
-                                 name_map);
+    auto [d, name_map] = detray_tests::read_from_csv(detray_tests::tml_files);
 
     // Create the navigator
     using detray_navigator = navigator<decltype(d)>;

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -23,7 +23,7 @@ set(all_unit_tests "core")
 list(APPEND all_unit_tests "annulus2;cylinder3;rectangle2;ring2;single3;unmasked;trapezoid2")
 list(APPEND all_unit_tests "propagator;line_stepper;navigator;cylinder_intersection;planar_intersection;intersection_kernel")
 list(APPEND all_unit_tests "detector;transform_store;masks_container;mask_store")
-list(APPEND all_unit_tests "volume;index_geometry;unified_index_geometry;geometry_scan;geometry_navigation")
+list(APPEND all_unit_tests "volume;index_geometry;unified_index_geometry;geometry_scan;geometry_navigation;toy_geometry")
 
 add_subdirectory(core)
 if(DETRAY_ARRAY_PLUGIN)

--- a/tests/unit_tests/array/array_toy_geometry.cpp
+++ b/tests/unit_tests/array/array_toy_geometry.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2020 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/array_definitions.hpp"
+#include "tests/common/test_toy_geometry.inl"

--- a/tests/unit_tests/eigen/eigen_toy_geometry.cpp
+++ b/tests/unit_tests/eigen/eigen_toy_geometry.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2020 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/eigen_definitions.hpp"
+#include "tests/common/test_toy_geometry.inl"

--- a/tests/unit_tests/smatrix/smatrix_toy_geometry.cpp
+++ b/tests/unit_tests/smatrix/smatrix_toy_geometry.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2020 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/smatrix_definitions.hpp"
+#include "tests/common/test_toy_geometry.inl"

--- a/tests/unit_tests/vc/vc_array_toy_geometry.cpp
+++ b/tests/unit_tests/vc/vc_array_toy_geometry.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2020 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "plugins/algebra/vc_array_definitions.hpp"
+#include "tests/common/test_toy_geometry.inl"


### PR DESCRIPTION
Make a toy geometry available, that contains three volumes and a few surfaces.

Contains
- a beampipe (r = 27mm, half_z = 500mm)
- a first layer (r_min = 27mm, r_max = 38mm, half_z = 500mm) with 224  rectangular (half_x = 8.4mm, half_y = 36mm) modules at r = 32mm
- an empty layer (r_min = 38mm, r_max = 64mm, half_z = 500mm)
- a second layer (r_min = 64mm, r_max = 80mm, half_z = 500mm) with 448
    rectangular (half_x = 8.4mm, half_y = 36mm) modules at r = 72mm.

returns a tuple containing the geometry objects collections: [volumes,
           surfaces, transforms, disc masks (neg/pos portals), cylinder masks
           (inner/outer portals), rectangle masks (modules)]