### PR TITLE
idea: use custom detray get

### DIFF
--- a/core/include/core/mask_store.hpp
+++ b/core/include/core/mask_store.hpp
@@ -8,6 +8,7 @@
 
 #include <type_traits>
 
+#include "definitions/detray_get.hpp"
 #include "utils/enumerate.hpp"
 #include "utils/indexing.hpp"
 
@@ -20,7 +21,8 @@ template <template <typename...> class tuple_type = dtuple,
 class mask_store {
 
     public:
-    using mask_tuple = tuple_type<vector_type<mask_types>...>;
+    // using mask_tuple = tuple_type<vector_type<mask_types>...>;
+    using mask_tuple = dtuple<vector_type<mask_types>...>;
 
     /** Size : Contextual STL like API
      *
@@ -29,7 +31,7 @@ class mask_store {
      */
     template <unsigned int mask_id>
     const size_t size() const {
-        return std::get<mask_id>(_mask_tuple).size();
+        return detail::get<mask_id>(_mask_tuple).size();
     }
 
     /** Empty : Contextual STL like API
@@ -40,7 +42,7 @@ class mask_store {
      */
     template <unsigned int mask_id>
     bool empty() const {
-        return std::get<mask_id>(_mask_tuple).empty();
+        return detail::get<mask_id>(_mask_tuple).empty();
     }
 
     /** Retrieve a single mask - const
@@ -71,7 +73,7 @@ class mask_store {
      */
     template <unsigned int mask_id>
     constexpr auto &group() {
-        return std::get<mask_id>(_mask_tuple);
+        return detail::get<mask_id>(_mask_tuple);
     }
 
     /** Retrieve a vector of masks of a certain type (mask group) - const
@@ -81,7 +83,7 @@ class mask_store {
      */
     template <unsigned int mask_id>
     constexpr const auto &group() const {
-        return std::get<mask_id>(_mask_tuple);
+        return detail::get<mask_id>(_mask_tuple);
     }
 
     /** Access underlying container - const
@@ -108,7 +110,7 @@ class mask_store {
     template <unsigned int mask_id, typename... bounds_type>
     auto &add_mask(bounds_type &&... mask_bounds) noexcept(false) {
         // Get the mask group that will be updated
-        auto &mask_group = std::get<mask_id>(_mask_tuple);
+        auto &mask_group = detail::get<mask_id>(_mask_tuple);
         // Construct new mask in place
         return mask_group.emplace_back(
             std::forward<bounds_type>(mask_bounds)...);
@@ -126,7 +128,7 @@ class mask_store {
     template <unsigned int current_id = 0, typename mask_type>
     inline void add_masks(vector_type<mask_type> &masks) noexcept(false) {
         // Get the mask group that will be updated
-        auto &mask_group = std::get<current_id>(_mask_tuple);
+        auto &mask_group = detail::get<current_id>(_mask_tuple);
 
         if constexpr (std::is_same_v<decltype(masks), decltype(mask_group)>) {
             // Reserve memory and copy new masks
@@ -152,7 +154,7 @@ class mask_store {
     template <unsigned int current_id = 0, typename mask_type>
     inline void add_masks(vector_type<mask_type> &&masks) noexcept(false) {
         // Get the mask group that will be updated
-        auto &mask_group = std::get<current_id>(_mask_tuple);
+        auto &mask_group = detail::get<current_id>(_mask_tuple);
 
         if constexpr (std::is_same_v<decltype(masks), decltype(mask_group)>) {
             // Reserve memory and copy new masks
@@ -180,7 +182,7 @@ class mask_store {
     template <unsigned int current_id = 0>
     inline void append_masks(mask_store &&other) {
         // Add masks to current group
-        auto &mask_group = std::get<current_id>(other);
+        auto &mask_group = detail::get<current_id>(other);
         add_masks(mask_group);
 
         // Next mask type

--- a/core/include/core/mask_store.hpp
+++ b/core/include/core/mask_store.hpp
@@ -21,8 +21,7 @@ template <template <typename...> class tuple_type = dtuple,
 class mask_store {
 
     public:
-    // using mask_tuple = tuple_type<vector_type<mask_types>...>;
-    using mask_tuple = dtuple<vector_type<mask_types>...>;
+    using mask_tuple = tuple_type<vector_type<mask_types>...>;
 
     /** Size : Contextual STL like API
      *

--- a/core/include/definitions/detray_get.hpp
+++ b/core/include/definitions/detray_get.hpp
@@ -1,0 +1,119 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+#include <array>
+#include <tuple>
+#include <utility>
+
+#if defined(__CUDACC__)
+#include <thrust/tuple.h>
+#endif
+
+#include "definitions/cuda_qualifiers.hpp"
+
+namespace detray {
+
+namespace detail {
+
+/** This header defines how to get elements from detray container and range
+ * types in generic parts of the code.
+ */
+
+#if defined(__CUDACC__)
+template <unsigned int index, typename... value_types>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    const thrust::tuple<value_types...> &tuple) {
+    return thrust::get<index>(tuple);
+}
+
+template <unsigned int index, typename... value_types>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    thrust::tuple<value_types...> &tuple) {
+    return thrust::get<index>(tuple);
+}
+
+template <unsigned int index, typename... value_types>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    const thrust::pair<value_types...> &pair) {
+    return thrust::get<index>(pair);
+}
+
+template <unsigned int index, typename... value_types>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    thrust::pair<value_types...> &pair) {
+    return thrust::get<index>(pair);
+}
+#endif
+
+template <unsigned int index, typename... value_types>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    const std::tuple<value_types...> &tuple) {
+    return std::get<index>(tuple);
+}
+
+template <unsigned int index, typename... value_types>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    std::tuple<value_types...> &tuple) {
+    return std::get<index>(tuple);
+}
+
+/** In case the index is not known at compile time. */
+template <unsigned int current_index = 0, typename... value_types>
+DETRAY_HOST_DEVICE inline decltype(auto) get(
+    const std::tuple<value_types...> &tuple, unsigned int index) {
+    // Check index against constexpr
+    if (current_index == index) {
+        return std::get<current_index>(tuple);
+    }
+    // Next tuple index
+    if constexpr (current_index < std::tuple_size_v<tuple> - 1) {
+        return get<current_index + 1>(tuple, index);
+    }
+}
+
+template <unsigned int current_index = 0, typename... value_types>
+DETRAY_HOST_DEVICE inline decltype(auto) get(std::tuple<value_types...> &tuple,
+                                             unsigned int index) {
+    // Check index against constexpr
+    if (current_index == index) {
+        return std::get<current_index>(tuple);
+    }
+    // Next tuple index
+    if constexpr (current_index < std::tuple_size_v<tuple> - 1) {
+        return get<current_index + 1>(tuple, index);
+    }
+}
+
+template <unsigned int index, typename... value_types>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    const std::pair<value_types...> &pair) {
+    return std::get<index>(pair);
+}
+
+template <unsigned int index, typename... value_types>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    std::pair<value_types...> &pair) {
+    return std::get<index>(pair);
+}
+
+template <unsigned int index, typename value_type, unsigned int N>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    std::array<value_type, N> &array) {
+    return std::get<index>(array);
+}
+
+template <unsigned int index, typename value_type, unsigned int N>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    const std::array<value_type, N> &array) {
+    return std::get<index>(array);
+}
+
+/** Put new link types here */
+
+}  // namespace detail
+}  // namespace detray


### PR DESCRIPTION
Since we are using ```std::get``` quite extensively, and in contexts where we might not know whether we deal with an ```array```, a ```[thrust]std::tuple``` or a ```pair```, we need to call the correct ```get``` function. Using a custom get can also be useful in situations where we don't know the index of the element at compile time or for custom link types.