### PR TITLE
Externals Update, main branch (2021.11.02.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,20 @@ if( DETRAY_SETUP_MATPLOTPP )
    endif()
 endif()
 
+# Set up Thrust.
+option( DETRAY_SETUP_THRUST
+   "Set up the Thrust target(s) explicitly" TRUE )
+option( DETRAY_USE_SYSTEM_THRUST
+   "Pick up an existing installation of Thrust from the build environment"
+   FALSE )
+if( DETRAY_SETUP_THRUST )
+   if( DETRAY_USE_SYSTEM_THRUST )
+      find_package( Thrust REQUIRED )
+   else()
+      add_subdirectory( extern/thrust )
+   endif()
+endif()
+
 # Set up GoogleTest.
 option( DETRAY_SETUP_GOOGLETEST
    "Set up the GoogleTest target(s) explicitly" TRUE )

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -13,8 +13,8 @@ message( STATUS "Building Algebra Plugins as part of the Detray project" )
 
 # Declare where to get Algebra Plugins from.
 FetchContent_Declare( AlgebraPlugins
-   URL "https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.1.0.tar.gz"
-   URL_MD5 "3a6f21d812f2cbaa2c21090b17427d40" )
+   URL "https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.2.0.tar.gz"
+   URL_MD5 "00a5387005ea6a826c1de31099bfa8bf" )
 
 # Options used in the build of Algebra Plugins.
 set( ALGEBRA_PLUGIN_BUILD_TESTING FALSE CACHE BOOL

--- a/extern/thrust/CMakeLists.txt
+++ b/extern/thrust/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.14 )
+include( FetchContent )
+
+# Tell the user what's happening.
+message( STATUS "Building Thrust as part of the Detray project" )
+
+# Declare where to get Thrust from.
+FetchContent_Declare( Thrust
+   URL "https://github.com/NVIDIA/thrust/archive/refs/tags/1.15.0.tar.gz"
+   URL_MD5 "01fac4fad227cfc1f455e6559dc2ab57" )
+
+# Options used in the build of Thrust.
+set( THRUST_ENABLE_HEADER_TESTING FALSE CACHE BOOL
+   "Turn off Thrust's internal header tests" )
+set( THRUST_ENABLE_TESTING FALSE CACHE BOOL
+   "Turn off the build of the Thrust tests" )
+set( THRUST_ENABLE_EXAMPLES FALSE CACHE BOOL
+   "Turn off the build of the Thrust examples" )
+set( THRUST_ENABLE_INSTALL_RULES TRUE CACHE BOOL
+   "Install Thrust together with this project" )
+set( THRUST_INSTALL_CUB_HEADERS FALSE CACHE BOOL
+   "Do not try to install the CUB headers" )
+
+# Get it into the current directory.
+FetchContent_MakeAvailable( Thrust )

--- a/extern/thrust/README.md
+++ b/extern/thrust/README.md
@@ -1,0 +1,4 @@
+# Build Recipe for Thrust
+
+This directory holds a build recipe for building
+[thrust](https://github.com/NVIDIA/thrust) for this project.


### PR DESCRIPTION
This PR updates to the (currently) latest version of [algebra-plugins](https://github.com/acts-project/algebra-plugins), for the benefit of #134 and #143.

It also introduces a recipe for "building" [Thrust](https://github.com/NVIDIA/thrust) as part of the project. In the same way in which all of the other externals are handled.

Note that I'm still a bit unsure what is meant to be **the** way of using Thrust with its own CMake configuration. :frowning: In this PR's setup the `Thrust::Thrust` target becomes available to use. So that might be all that we need. But according to

https://github.com/NVIDIA/thrust/blob/main/thrust/cmake/README.md

, one is not supposed to use that target directly. Rather, one should add code like the following for every target (library/executable/etc.) that wants to use Thrust:

```cmake
thrust_create_target(Thrust)
target_link_libraries(MyProgram Thrust)
```

As this would set up all the right flags for using TBB/OpenMP/etc. with the "host code" as well. I don't know though how this would work with exporting the configuration of `MyProgram`.

My point is, we should experiment with this a bit. For now, these updates just make `Thrust::Thrust` available. Which I believe results in the same behaviour that @beomki-yeo's "implicit" usage of the Thrust headers coming with CUDA was doing.