### PR TITLE
Externals and CMake Updates, main branch (2021.11.05.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ if( CMAKE_CUDA_COMPILER )
 endif()
 
 # Flags controlling which parts of Detray to build.
-option( DETRAY_VECMEM_PLUGIN "Build vecmem::static_array math plugin" ON )
 option( DETRAY_EIGEN_PLUGIN "Build Eigen math plugin" ON )
 option( DETRAY_SMATRIX_PLUGIN "Build ROOT/SMatrix math plugin" OFF )
 option( DETRAY_VC_PLUGIN "Build Vc based math plugin" ON )
@@ -127,6 +126,12 @@ if( DETRAY_SETUP_THRUST )
    else()
       add_subdirectory( extern/thrust )
    endif()
+   # Set up an IMPORTED library on top of the Thrust library/libraries. One that
+   # the Detray code could depend on publicly.
+   set( DETRAY_THRUST_OPTIONS "" CACHE STRING
+      "Extra options for configuring how Thrust should be used" )
+   mark_as_advanced( DETRAY_THRUST_OPTIONS )
+   thrust_create_target( detray::Thrust ${DETRAY_THRUST_OPTIONS} )
 endif()
 
 # Set up GoogleTest.

--- a/README.md
+++ b/README.md
@@ -14,36 +14,52 @@ Testing and benchmarking is done with `googletest` and `google/benchmark`.
 
 ## Getting started
 
-Clone the repository and initialize the submodules (googletest, benchmark).
+The respository is meant to be possible to build "out of the box", with standard
+CMake build procedures.
 
 ```shell
-git clone git@github.com:acts-project/detray.git
-cd detray
-git submodule update --init
+git clone https://github.com/acts-project/detray.git
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -S detray -B detray-build
+cmake --build detray-build
 ```
 
-Running `CMake` (minimal version)
-```shell
-cmake -S . -B <build_directory>
-```
+The following cache variables are available to influence which parts of the
+project would be built:
 
-Build
-```shell
-cmake --build <build_directory>
-```
+- `DETRAY_EIGEN_PLUGIN` (`ON` by default), `DETRAY_SMATRIX_PLUGIN`
+  (`OFF` by default), `DETRAY_VC_PLUGIN` (`ON` by default): Boolean
+  flags turning the build of [Eigen](https://eigen.tuxfamily.org),
+  [SMatrix](https://root.cern/doc/master/group__SMatrixGroup.html) and
+  [Vc](https://github.com/VcDevel/Vc) using code on or off.
+  * Note that [Algebra Plugins](https://github.com/acts-project/algebra-plugins)
+    must have all of the appropriate options enabled for whichever option
+    is turned on from these.
+- `DETRAY_IO_CSV`: Boolean option turning on the build of `detray::io_csv`, the
+  library allowing the reading of geometries from CSV files (`ON` by default);
+- `DETRAY_DISPLAY`: Boolean option turning on the build of `detray::display`,
+  and additional helpers for displaying a geometry (`OFF` by default);
+- `DETRAY_BUILD_CUDA`: Boolean option turning on the build of all CUDA code
+  in the repository (`ON` by default, if CUDA is available);
+- `DETRAY_BUILD_TESTING`: Turn the build/setup of the unit tests on/off
+  (`ON` by default);
+  * `DETRAY_BENCHMARKS`: Boolean option turning on the build of the benchmark
+    executables (`ON` by default);
+  * `DETRAY_BENCHMARKS_MULTITHREAD`: Boolean option making the benchmarks
+    multithreaded (`OFF` by default);
+  * `DETRAY_BENCHMARKS_REP`: String option with an integer for the repetitions
+    that the benchmarks should run (`1` by default).
 
-### Plugins
+The following options configure how the build should set up the externals that
+it needs:
 
-The following algebra plugins are avaiable and can be switched on/off 
-
-| *Plugin* | *CMake Flag* | *Default value* | *Dependency requirement* |
-| ---------|--------------|-----------------|--------------------------|
-| array | DETRAY_ARRAY_PLUGIN | On | - |
-| eigen | DETRAY_EIGEN_PLUGIN | Off | Eigen, http://eigen.tuxfamily.org/ |
-| smatrix | DETRAY_SMATRIX_PLUGIN | Off | ROOT, http://github.com/root-project |
-
-
-
+- `DETRAY_SETUP_<XXX>`: Boolean to turn on/off the explicit "setup" of
+  the externals (`ALGEBRA_PLUGINS`, `VECMEM`, `DFELIBS`, `MATPLOTPP`, `THRUST`,
+  `GOOGLETEST` and `BENCHMARK`);
+- `DETRAY_USE_SYSTEM_<XXX>`: Boolean configuring how to set up a given external
+  * `ON`: The external is searched for "on the system" using
+    [find_package](https://cmake.org/cmake/help/latest/command/find_package.html);
+  * `OFF`: The package is set up for build as part of this project, using
+    [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html).
 
 ### Benchmark Monitoring
 

--- a/cmake/detray-config.cmake.in
+++ b/cmake/detray-config.cmake.in
@@ -9,7 +9,6 @@
 
 # Set up variables describing which components were enabled during the
 # Detray build.
-set( DETRAY_VECMEM_PLUGIN @DETRAY_VECMEM_PLUGIN@ )
 set( DETRAY_EIGEN_PLUGIN @DETRAY_EIGEN_PLUGIN@ )
 set( DETRAY_SMATRIX_PLUGIN @DETRAY_SMATRIX_PLUGIN@ )
 set( DETRAY_VC_PLUGIN @DETRAY_VC_PLUGIN@ )
@@ -20,9 +19,18 @@ set( DETRAY_BUILD_CUDA @DETRAY_BUILD_CUDA@ )
 # Find all packages that Detray needs to function.
 include( CMakeFindDependencyMacro )
 find_dependency( algebra-plugins )
-if( DETRAY_VECMEM_PLUGIN )
-   find_dependency( vecmem )
+find_dependency( Thrust )
+find_dependency( vecmem )
+if( DETRAY_IO_CSV )
+   find_dependency( dfelibs )
 endif()
+if( DETRAY_DISPLAY )
+   find_dependency( Matplot++ )
+endif()
+
+# Set up the detray::Thrust target.
+set( DETRAY_THRUST_OPTIONS @DETRAY_THRUST_OPTIONS@ )
+thrust_create_target( detray::Thrust ${DETRAY_THRUST_OPTIONS} )
 
 # Set up some simple variables for using the package.
 set( detray_VERSION "@PROJECT_VERSION@" )
@@ -32,7 +40,7 @@ set_and_check( detray_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@" )
 
 # Print a standard information message about the package being found.
 include( FindPackageHandleStandardArgs )
-find_package_handle_standard_args( algebra-plugins REQUIRED_VARS
+find_package_handle_standard_args( detray REQUIRED_VARS
    CMAKE_CURRENT_LIST_FILE
    VERSION_VAR detray_VERSION )
 

--- a/cmake/detray-functions.cmake
+++ b/cmake/detray-functions.cmake
@@ -30,7 +30,7 @@ function( detray_add_library fullname basename )
       ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
       RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" )
    install( DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
-      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" )
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" OPTIONAL )
 
 endfunction( detray_add_library )
 

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -12,31 +12,33 @@ include( FetchContent )
 message( STATUS "Building Algebra Plugins as part of the Detray project" )
 
 # Declare where to get Algebra Plugins from.
-FetchContent_Declare( AlgebraPlugins
-   URL "https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.2.0.tar.gz"
-   URL_MD5 "00a5387005ea6a826c1de31099bfa8bf" )
+set( DETRAY_ALGEBRA_PLUGINS_SOURCE
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.3.0.tar.gz;URL_MD5;7ffcfe299ebf654074b196e949afb010"
+   CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
+mark_as_advanced( DETRAY_ALGEBRA_PLUGINS_SOURCE )
+FetchContent_Declare( AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE} )
 
 # Options used in the build of Algebra Plugins.
-set( ALGEBRA_PLUGIN_BUILD_TESTING FALSE CACHE BOOL
+set( ALGEBRA_PLUGINS_BUILD_TESTING FALSE CACHE BOOL
    "Turn off the build of the Algebra Plugins unit tests" )
-set( ALGEBRA_PLUGIN_INCLUDE_EIGEN TRUE CACHE BOOL
+set( ALGEBRA_PLUGINS_INCLUDE_EIGEN TRUE CACHE BOOL
    "Turn on the build of algebra::eigen" )
-set( ALGEBRA_PLUGIN_INCLUDE_VC TRUE CACHE BOOL
+set( ALGEBRA_PLUGINS_INCLUDE_VC TRUE CACHE BOOL
    "Turn on the build of algebra::vc_array" )
-set( ALGEBRA_PLUGIN_INCLUDE_VECMEM TRUE CACHE BOOL
+set( ALGEBRA_PLUGINS_INCLUDE_VECMEM TRUE CACHE BOOL
    "Turn on the build of algebra::vecmem_array" )
 
-set( ALGEBRA_PLUGIN_SETUP_EIGEN3 TRUE CACHE BOOL
+set( ALGEBRA_PLUGINS_SETUP_EIGEN3 TRUE CACHE BOOL
    "Have Algebra Plugins set up Eigen3 for itself" )
-set( ALGEBRA_PLUGIN_USE_SYSTEM_EIGEN3 FALSE CACHE BOOL
+set( ALGEBRA_PLUGINS_USE_SYSTEM_EIGEN3 FALSE CACHE BOOL
    "Have Algebra Plugins pick up Eigen3 from the system" )
-set( ALGEBRA_PLUGIN_SETUP_VC TRUE CACHE BOOL
+set( ALGEBRA_PLUGINS_SETUP_VC TRUE CACHE BOOL
    "Have Algebra Plugins set up Vc for itself" )
-set( ALGEBRA_PLUGIN_USE_SYSTEM_VC FALSE CACHE BOOL
+set( ALGEBRA_PLUGINS_USE_SYSTEM_VC FALSE CACHE BOOL
    "Have Algebra Plugins build Vc itself" )
-set( ALGEBRA_PLUGIN_SETUP_VECMEM FALSE CACHE BOOL
+set( ALGEBRA_PLUGINS_SETUP_VECMEM FALSE CACHE BOOL
    "Do not set up VecMem in Algebra Plugins" )
-set( ALGEBRA_PLUGIN_SETUP_GOOGLETEST FALSE CACHE BOOL
+set( ALGEBRA_PLUGINS_SETUP_GOOGLETEST FALSE CACHE BOOL
    "Do not set up GoogleTest in Algebra Plugins" )
 
 # Get it into the current directory.

--- a/extern/benchmark/CMakeLists.txt
+++ b/extern/benchmark/CMakeLists.txt
@@ -12,9 +12,11 @@ include( FetchContent )
 message( STATUS "Building Google Benchmark as part of the Detray project" )
 
 # Declare where to get Google Benchmark from.
-FetchContent_Declare( Benchmark
-   URL "https://github.com/google/benchmark/archive/refs/tags/v1.6.0.tar.gz"
-   URL_MD5 "a7cb118b00430e22cb16774a28fce7ec" )
+set( DETRAY_BENCHMARK_SOURCE
+   "URL;https://github.com/google/benchmark/archive/refs/tags/v1.6.0.tar.gz;URL_MD5;a7cb118b00430e22cb16774a28fce7ec"
+   CACHE STRING "Source for Google Benchmark, when built as part of this project" )
+mark_as_advanced( DETRAY_BENCHMARK_SOURCE )
+FetchContent_Declare( Benchmark ${DETRAY_BENCHMARK_SOURCE} )
 
 # Options used in the build of Google Benchmark.
 set( BENCHMARK_ENABLE_TESTING OFF CACHE BOOL

--- a/extern/dfelibs/CMakeLists.txt
+++ b/extern/dfelibs/CMakeLists.txt
@@ -12,9 +12,11 @@ include( FetchContent )
 message( STATUS "Building dfelibs as part of the Detray project" )
 
 # Declare where to get dfelibs from.
-FetchContent_Declare( dfelibs
-   URL "https://github.com/acts-project/dfelibs/archive/refs/tags/v20211029.tar.gz"
-   URL_MD5 "87fb09c5a11b98250f5e266e9cd501ea" )
+set( DETRAY_DFELIBS_SOURCE
+   "URL;https://github.com/acts-project/dfelibs/archive/refs/tags/v20211029.tar.gz;URL_MD5;87fb09c5a11b98250f5e266e9cd501ea"
+   CACHE STRING "Source for dfelibs, when built as part of this project" )
+mark_as_advanced( DETRAY_DFELIBS_SOURCE )
+FetchContent_Declare( dfelibs ${DETRAY_DFELIBS_SOURCE} )
 
 # Options used in the build of dfelibs.
 set( dfelibs_BUILD_EXAMPLES FALSE CACHE BOOL

--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -12,9 +12,11 @@ include( FetchContent )
 message( STATUS "Building GoogleTest as part of the Detray project" )
 
 # Declare where to get GoogleTest from.
-FetchContent_Declare( GoogleTest
-   URL "https://github.com/google/googletest/archive/release-1.11.0.tar.gz"
-   URL_MD5 "e8a8df240b6938bb6384155d4c37d937" )
+set( DETRAY_GOOGLETEST_SOURCE
+   "URL;https://github.com/google/googletest/archive/release-1.11.0.tar.gz;URL_MD5;e8a8df240b6938bb6384155d4c37d937"
+   CACHE STRING "Source for GoogleTest, when built as part of this project" )
+mark_as_advanced( DETRAY_GOOGLETEST_SOURCE )
+FetchContent_Declare( GoogleTest ${DETRAY_GOOGLETEST_SOURCE} )
 
 # Options used in the build of GoogleTest.
 set( BUILD_GMOCK TRUE CACHE BOOL "Turn off the build of GMock" )

--- a/extern/matplotplusplus/CMakeLists.txt
+++ b/extern/matplotplusplus/CMakeLists.txt
@@ -12,9 +12,11 @@ include( FetchContent )
 message( STATUS "Building Matplot++ as part of the Detray project" )
 
 # Declare where to get Matplot++ from.
-FetchContent_Declare( Matplotpp
-   URL "https://github.com/alandefreitas/matplotplusplus/archive/refs/tags/v1.1.0.tar.gz"
-   URL_MD5 "261061a19eda6607215bf70fa9123744" )
+set( DETRAY_MATPLOTPP_SOURCE
+   "URL;https://github.com/alandefreitas/matplotplusplus/archive/refs/tags/v1.1.0.tar.gz;URL_MD5;261061a19eda6607215bf70fa9123744"
+   CACHE STRING "Source for Matplot++, when built as part of this project" )
+mark_as_advanced( DETRAY_MATPLOTPP_SOURCE )
+FetchContent_Declare( Matplotpp ${DETRAY_MATPLOTPP_SOURCE} )
 
 # Options used in the build of Matplot++.
 set( BUILD_INSTALLER TRUE CACHE BOOL

--- a/extern/thrust/CMakeLists.txt
+++ b/extern/thrust/CMakeLists.txt
@@ -12,21 +12,15 @@ include( FetchContent )
 message( STATUS "Building Thrust as part of the Detray project" )
 
 # Declare where to get Thrust from.
-FetchContent_Declare( Thrust
-   URL "https://github.com/NVIDIA/thrust/archive/refs/tags/1.15.0.tar.gz"
-   URL_MD5 "01fac4fad227cfc1f455e6559dc2ab57" )
+set( DETRAY_THRUST_SOURCE
+   "GIT_REPOSITORY;https://github.com/NVIDIA/thrust.git;GIT_TAG;1.15.0"
+   CACHE STRING "Source for Thrust, when built as part of this project" )
+mark_as_advanced( DETRAY_THRUST_SOURCE )
+FetchContent_Declare( Thrust ${DETRAY_THRUST_SOURCE} )
 
 # Options used in the build of Thrust.
-set( THRUST_ENABLE_HEADER_TESTING FALSE CACHE BOOL
-   "Turn off Thrust's internal header tests" )
-set( THRUST_ENABLE_TESTING FALSE CACHE BOOL
-   "Turn off the build of the Thrust tests" )
-set( THRUST_ENABLE_EXAMPLES FALSE CACHE BOOL
-   "Turn off the build of the Thrust examples" )
 set( THRUST_ENABLE_INSTALL_RULES TRUE CACHE BOOL
    "Install Thrust together with this project" )
-set( THRUST_INSTALL_CUB_HEADERS FALSE CACHE BOOL
-   "Do not try to install the CUB headers" )
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( Thrust )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -12,9 +12,11 @@ include( FetchContent )
 message( STATUS "Building VecMem as part of the Detray project" )
 
 # Declare where to get VecMem from.
-FetchContent_Declare( VecMem
-   URL "https://github.com/acts-project/vecmem/archive/refs/tags/v0.5.0.tar.gz"
-   URL_MD5 "436cb6f6fecd0bd72e67b1def6883902" )
+set( DETRAY_VECMEM_SOURCE
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.6.0.tar.gz;URL_MD5;d741067ff148d2df3c4e6d4587d65fdc"
+   CACHE STRING "Source for VecMem, when built as part of this project" )
+mark_as_advanced( DETRAY_VECMEM_SOURCE )
+FetchContent_Declare( VecMem ${DETRAY_VECMEM_SOURCE} )
 
 # Options used in the build of VecMem.
 set( VECMEM_BUILD_TESTING FALSE CACHE BOOL

--- a/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
@@ -29,10 +29,6 @@ using dmap = std::map<key_type, value_type>;
 template <class... types>
 using dtuple = std::tuple<types...>;
 
-using algebra::operator*;
-using algebra::operator+;
-using algebra::operator-;
-
 namespace getter = algebra::getter;
 namespace vector = algebra::vector;
 

--- a/plugins/algebra/eigen/CMakeLists.txt
+++ b/plugins/algebra/eigen/CMakeLists.txt
@@ -7,6 +7,12 @@
 # Let the user know what's happening.
 message(STATUS "Building 'detray::eigen' plugin")
 
+# A sanity check.
+if( NOT ALGEBRA_PLUGINS_INCLUDE_EIGEN )
+   message( WARNING "Eigen not available from Algebra Plugins. "
+      "The configuration will likely fail." )
+endif()
+
 # Set up the library.
 detray_add_library( detray_eigen eigen
    "include/detray/plugins/algebra/eigen_definitions.hpp" )

--- a/plugins/algebra/smatrix/CMakeLists.txt
+++ b/plugins/algebra/smatrix/CMakeLists.txt
@@ -7,6 +7,12 @@
 # Let the user know what's happening.
 message(STATUS "Building 'detray::smatrix' plugin")
 
+# A sanity check.
+if( NOT ALGEBRA_PLUGINS_INCLUDE_SMATRIX )
+   message( WARNING "SMatrix not available from Algebra Plugins. "
+      "The configuration will likely fail." )
+endif()
+
 # Set up the library.
 detray_add_library( detray_smatrix smatrix
    "include/detray/plugins/algebra/smatrix_definitions.hpp" )

--- a/plugins/algebra/vc/CMakeLists.txt
+++ b/plugins/algebra/vc/CMakeLists.txt
@@ -7,6 +7,12 @@
 # Let the user know what's happening.
 message(STATUS "Building 'detray::vc_array' plugin")
 
+# A sanity check.
+if( NOT ALGEBRA_PLUGINS_INCLUDE_VC )
+   message( WARNING "Vc not available from Algebra Plugins. "
+      "The configuration will likely fail." )
+endif()
+
 # Set up the library.
 detray_add_library( detray_vc_array vc_array
    "include/detray/plugins/algebra/vc_array_definitions.hpp" )

--- a/plugins/algebra/vc/include/detray/plugins/algebra/vc_array_definitions.hpp
+++ b/plugins/algebra/vc/include/detray/plugins/algebra/vc_array_definitions.hpp
@@ -29,10 +29,6 @@ using dmap = std::map<key_type, value_type>;
 template <class... types>
 using dtuple = std::tuple<types...>;
 
-using algebra::operator*;
-using algebra::operator+;
-using algebra::operator-;
-
 namespace getter = algebra::getter;
 namespace vector = algebra::vector;
 

--- a/tests/unit_tests/core/CMakeLists.txt
+++ b/tests/unit_tests/core/CMakeLists.txt
@@ -20,4 +20,4 @@ add_detray_test(utils_quadratic_equation
                 utils_quadratic_equation.cpp LINK_LIBRARIES detray::core)
 
 add_detray_test(thrust_tuple
-                thrust_tuple.cpp LINK_LIBRARIES Thrust::Thrust)
+                thrust_tuple.cpp LINK_LIBRARIES detray::Thrust)


### PR DESCRIPTION
This PR is a step-sibling of https://github.com/acts-project/algebra-plugins/pull/37.

Just as in https://github.com/acts-project/algebra-plugins/pull/37, I added "advanced" cache variables for setting up where the individual externals could be downloaded from.
  - At the same time updated the build to [Algebra Plugins v0.3.0](https://github.com/acts-project/algebra-plugins/releases/tag/v0.3.0) and [VecMem v0.6.0](https://github.com/acts-project/vecmem/releases/tag/v0.6.0);
  - With the new [Algebra Plugins](https://github.com/acts-project/algebra-plugins) version I could also simplify the array and vc plugin definitions a little bit.

As @beomki-yeo pointed out in https://github.com/acts-project/detray/pull/134#issuecomment-961672010, and as I pondered about it in #144, we can't simply use `Thrust::Thrust` after all. Since it is set up as an `INTERFACE` target, which is not installed by [Thrust](https://github.com/NVIDIA/thrust/releases)'s CMake configuration. After some digging around, I came up with the solution presented here. Where both the project's main `CMakeLists.txt` file, and its `detray-config.cmake` file would manually create the `detray::Thrust` target. With the helper function provided by the NVidia code. We would then link against this `detray::Thrust` target everywhere that we need Thrust.
  - Updated the example introduced in #147 to reflect this;

I now finally tried to make use of the installed version of the code with `find_package(detray)`, and had to quickly sort out a number of problems that I made in #145. @niermann999, you didn't catch one of the places where I left `algebra-plugins` in the code instead of changing it to `detray`. :stuck_out_tongue:

Finally, I updated the README of the project a little. But only the part about how the project can be built. The rest should be updated by those who know more about what the project actually does. :wink: