### PR TITLE
templating transform_store_data 

### DIFF
--- a/core/include/detray/core/transform_store.hpp
+++ b/core/include/detray/core/transform_store.hpp
@@ -31,12 +31,13 @@ class static_transform_store {
 
     /** Constructor from static_transform_store_data
      **/
-#if defined(__CUDACC__)  // required by macOS...
-    template <typename static_transform_store_data_t>
+    template <template <template <typename...> class>
+              class static_transform_store_data_t,
+              template <typename...> class data_vector_t>
     DETRAY_DEVICE static_transform_store(
-        static_transform_store_data_t &store_data)
+        static_transform_store_data_t<data_vector_t> &store_data)
         : _data(store_data._data) {}
-#endif
+
     /** Empty context type struct */
     struct context {};
 
@@ -212,13 +213,13 @@ class static_transform_store {
 };
 
 /** A static inplementation of transform store data for device*/
+template <template <typename> class vector_type = dvector>
 struct static_transform_store_data {
 
     /** Constructor from transform store
      *
      * @param store is the input transform store data from host
      **/
-    template <template <typename> class vector_type = dvector>
     static_transform_store_data(static_transform_store<vector_type> &store)
         : _data(vecmem::get_data(store.data())) {}
 
@@ -227,8 +228,8 @@ struct static_transform_store_data {
 
 /** Get transform_store_data
  **/
-template <template <typename> class vector_type = dvector>
-inline static_transform_store_data get_data(
+template <template <typename> class vector_type>
+inline static_transform_store_data<vector_type> get_data(
     static_transform_store<vector_type> &store) {
     return static_transform_store_data(store);
 }

--- a/core/include/detray/core/transform_store.hpp
+++ b/core/include/detray/core/transform_store.hpp
@@ -17,7 +17,7 @@ namespace detray {
 using transform3 = __plugin::transform3;
 
 /** A static inplementation of an alignable transform store */
-template <template <typename> class vector_type = dvector>
+template <template <typename...> class vector_type = dvector>
 class static_transform_store {
     public:
     using storage = vector_type<transform3>;
@@ -213,7 +213,7 @@ class static_transform_store {
 };
 
 /** A static inplementation of transform store data for device*/
-template <template <typename> class vector_type = dvector>
+template <template <typename...> class vector_type = dvector>
 struct static_transform_store_data {
 
     /** Constructor from transform store
@@ -228,7 +228,7 @@ struct static_transform_store_data {
 
 /** Get transform_store_data
  **/
-template <template <typename> class vector_type>
+template <template <typename...> class vector_type>
 inline static_transform_store_data<vector_type> get_data(
     static_transform_store<vector_type> &store) {
     return static_transform_store_data(store);

--- a/tests/unit_tests/cuda/transform_store_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/transform_store_cuda_kernel.cu
@@ -14,7 +14,7 @@ namespace detray {
 
 __global__ void transform_test_kernel(
     vecmem::data::vector_view<point3> input_data,
-    static_transform_store_data store_data,
+    static_transform_store_data<> store_data,
     vecmem::data::vector_view<point3> output_data) {
     static_transform_store<vecmem::device_vector>::context ctx0;
     static_transform_store<vecmem::device_vector> store(store_data);
@@ -28,7 +28,7 @@ __global__ void transform_test_kernel(
 }
 
 void transform_test(vecmem::data::vector_view<point3>& input_data,
-                    static_transform_store_data& store_data,
+                    static_transform_store_data<>& store_data,
                     vecmem::data::vector_view<point3>& output_data) {
 
     int block_dim = 1;

--- a/tests/unit_tests/cuda/transform_store_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/transform_store_cuda_kernel.hpp
@@ -25,6 +25,6 @@ using namespace __plugin;
 namespace detray {
 
 void transform_test(vecmem::data::vector_view<point3>& input_data,
-                    static_transform_store_data& store_data,
+                    static_transform_store_data<>& store_data,
                     vecmem::data::vector_view<point3>& output_data);
 }


### PR DESCRIPTION
This PR adds template parameter for `transform_store_data`

By doing this, `transform_store` constructor with `transform_store_data` doesn't require cuda macro anymore. (The current constructor requires cuda macro to avoid ambiguity from the constructor with `vecmem::memory_resource`)
