### PR TITLE
rollback the transform store

### DIFF
--- a/core/include/detray/core/transform_store.hpp
+++ b/core/include/detray/core/transform_store.hpp
@@ -31,11 +31,11 @@ class static_transform_store {
 
     /** Constructor from static_transform_store_data
      **/
-    template <template <template <typename...> class>
-              class static_transform_store_data_t,
-              template <typename...> class data_vector_t>
-    DETRAY_DEVICE static_transform_store(
-        static_transform_store_data_t<data_vector_t> &store_data)
+    template <typename transform_store_t,
+              std::enable_if_t<!std::is_base_of<vecmem::memory_resource,
+                                                transform_store_t>::value,
+                               bool> = true>
+    DETRAY_DEVICE static_transform_store(transform_store_t &store_data)
         : _data(store_data._data) {}
 
     /** Empty context type struct */
@@ -213,14 +213,14 @@ class static_transform_store {
 };
 
 /** A static inplementation of transform store data for device*/
-template <template <typename...> class vector_type = dvector>
+template <typename transform_store_t>
 struct static_transform_store_data {
 
     /** Constructor from transform store
      *
      * @param store is the input transform store data from host
      **/
-    static_transform_store_data(static_transform_store<vector_type> &store)
+    static_transform_store_data(transform_store_t &store)
         : _data(vecmem::get_data(store.data())) {}
 
     vecmem::data::vector_view<transform3> _data;
@@ -229,8 +229,8 @@ struct static_transform_store_data {
 /** Get transform_store_data
  **/
 template <template <typename...> class vector_type>
-inline static_transform_store_data<vector_type> get_data(
-    static_transform_store<vector_type> &store) {
+inline static_transform_store_data<static_transform_store<vector_type> >
+get_data(static_transform_store<vector_type> &store) {
     return static_transform_store_data(store);
 }
 

--- a/core/include/detray/core/transform_store.hpp
+++ b/core/include/detray/core/transform_store.hpp
@@ -31,11 +31,11 @@ class static_transform_store {
 
     /** Constructor from static_transform_store_data
      **/
-    template <typename transform_store_t,
+    template <typename transform_store_data_t,
               std::enable_if_t<!std::is_base_of_v<vecmem::memory_resource,
                                                   transform_store_t>,
                                bool> = true>
-    DETRAY_DEVICE static_transform_store(transform_store_t &store_data)
+    DETRAY_DEVICE static_transform_store(transform_store_data_t &store_data)
         : _data(store_data._data) {}
 
     /** Empty context type struct */

--- a/core/include/detray/core/transform_store.hpp
+++ b/core/include/detray/core/transform_store.hpp
@@ -33,7 +33,7 @@ class static_transform_store {
      **/
     template <typename transform_store_data_t,
               std::enable_if_t<!std::is_base_of_v<vecmem::memory_resource,
-                                                  transform_store_t>,
+                                                  transform_store_data_t>,
                                bool> = true>
     DETRAY_DEVICE static_transform_store(transform_store_data_t &store_data)
         : _data(store_data._data) {}

--- a/core/include/detray/core/transform_store.hpp
+++ b/core/include/detray/core/transform_store.hpp
@@ -32,8 +32,8 @@ class static_transform_store {
     /** Constructor from static_transform_store_data
      **/
     template <typename transform_store_t,
-              std::enable_if_t<!std::is_base_of<vecmem::memory_resource,
-                                                transform_store_t>::value,
+              std::enable_if_t<!std::is_base_of_v<vecmem::memory_resource,
+                                                  transform_store_t>,
                                bool> = true>
     DETRAY_DEVICE static_transform_store(transform_store_t &store_data)
         : _data(store_data._data) {}

--- a/tests/unit_tests/cuda/transform_store_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/transform_store_cuda_kernel.cu
@@ -14,8 +14,9 @@ namespace detray {
 
 __global__ void transform_test_kernel(
     vecmem::data::vector_view<point3> input_data,
-    static_transform_store_data<> store_data,
+    static_transform_store_data<static_transform_store<>> store_data,
     vecmem::data::vector_view<point3> output_data) {
+
     static_transform_store<vecmem::device_vector>::context ctx0;
     static_transform_store<vecmem::device_vector> store(store_data);
 
@@ -27,9 +28,10 @@ __global__ void transform_test_kernel(
         range[threadIdx.x].point_to_global(input[threadIdx.x]);
 }
 
-void transform_test(vecmem::data::vector_view<point3>& input_data,
-                    static_transform_store_data<>& store_data,
-                    vecmem::data::vector_view<point3>& output_data) {
+void transform_test(
+    vecmem::data::vector_view<point3>& input_data,
+    static_transform_store_data<static_transform_store<>>& store_data,
+    vecmem::data::vector_view<point3>& output_data) {
 
     int block_dim = 1;
     int thread_dim(store_data._data.size());

--- a/tests/unit_tests/cuda/transform_store_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/transform_store_cuda_kernel.hpp
@@ -24,7 +24,8 @@ using namespace __plugin;
 
 namespace detray {
 
-void transform_test(vecmem::data::vector_view<point3>& input_data,
-                    static_transform_store_data<>& store_data,
-                    vecmem::data::vector_view<point3>& output_data);
+void transform_test(
+    vecmem::data::vector_view<point3>& input_data,
+    static_transform_store_data<static_transform_store<> >& store_data,
+    vecmem::data::vector_view<point3>& output_data);
 }


### PR DESCRIPTION
As been discuss with @krasznaa  in #150, I think it is OK for `foo_data` to take `foo` as template parameter. Let's make all classes (except mask_store with parameter pack) have unified format:)..