### PR TITLE
feat: run random direction navigation on toy geometry

### DIFF
--- a/core/include/detray/definitions/detail/accessor.hpp
+++ b/core/include/detray/definitions/detail/accessor.hpp
@@ -83,5 +83,21 @@ DETRAY_HOST_DEVICE constexpr tuple_type<unwrap_decay_t<Types>...> make_tuple(
     return tuple_type<unwrap_decay_t<Types>...>(std::forward<Types>(args)...);
 }
 
+template <typename mask_store_t,
+          std::enable_if_t<std::is_class_v<typename std::remove_reference_t<
+                               mask_store_t>::mask_tuple>,
+                           bool> = true>
+inline constexpr auto mask_store_size() noexcept {
+    return detail::tuple_size<typename mask_store_t::mask_tuple>::value;
+}
+
+template <class mask_store_t,
+          std::enable_if_t<std::is_default_constructible_v<
+                               std::remove_reference_t<mask_store_t>>,
+                           bool> = true>
+inline constexpr auto mask_store_size() noexcept {
+    return detail::tuple_size<mask_store_t>::value;
+}
+
 }  // namespace detail
 }  // namespace detray

--- a/core/include/detray/definitions/detail/accessor.hpp
+++ b/core/include/detray/definitions/detail/accessor.hpp
@@ -83,21 +83,5 @@ DETRAY_HOST_DEVICE constexpr tuple_type<unwrap_decay_t<Types>...> make_tuple(
     return tuple_type<unwrap_decay_t<Types>...>(std::forward<Types>(args)...);
 }
 
-template <typename mask_store_t,
-          std::enable_if_t<std::is_class_v<typename std::remove_reference_t<
-                               mask_store_t>::mask_tuple>,
-                           bool> = true>
-inline constexpr auto mask_store_size() noexcept {
-    return detail::tuple_size<typename mask_store_t::mask_tuple>::value;
-}
-
-template <class mask_store_t,
-          std::enable_if_t<std::is_default_constructible_v<
-                               std::remove_reference_t<mask_store_t>>,
-                           bool> = true>
-inline constexpr auto mask_store_size() noexcept {
-    return detail::tuple_size<mask_store_t>::value;
-}
-
 }  // namespace detail
 }  // namespace detray

--- a/core/include/detray/tools/single_type_navigator.hpp
+++ b/core/include/detray/tools/single_type_navigator.hpp
@@ -194,7 +194,7 @@ class single_type_navigator {
         inline bool abort() {
             _status = e_abort;
             _trust_level = e_no_trust;
-            run_inspector("aborted: ");
+            run_inspector("Aborted: ");
             return false;
         }
 
@@ -206,7 +206,7 @@ class single_type_navigator {
         inline bool exit() {
             _status = e_on_target;
             _trust_level = e_full_trust;
-            run_inspector("exited: ");
+            run_inspector("Exited: ");
             return false;
         }
 
@@ -465,11 +465,8 @@ class single_type_navigator {
                 navigation.set_object(kernel.next->index);
                 // The next object that we want to reach
                 ++navigation.next();
-                // Direct hit
+                // Set it briefly so that the inspector can catch this state
                 navigation.set_status(e_on_object);
-                // We might be wrong in this assumption, re-evaluate distance
-                // to next in the next pass
-                navigation.set_trust_level(e_high_trust);
                 // Call the inspector on this portal crossing, then go to next
                 navigation.run_inspector("Skipped direct hit: ");
             }
@@ -485,7 +482,7 @@ class single_type_navigator {
             navigation.set_trust_level(e_full_trust);
 
             // Call the inspector on new status
-            navigation.run_inspector("set next: ");
+            navigation.run_inspector("Set next: ");
         }
     }
 

--- a/tests/common/include/tests/common/check_geometry_navigation.inl
+++ b/tests/common/include/tests/common/check_geometry_navigation.inl
@@ -205,8 +205,8 @@ detray_stepper s;
 // This test runs intersection with all portals of the TrackML detector
 TEST(ALGEBRA_PLUGIN, geometry_discovery) {
 
-    unsigned int theta_steps = 10;
-    unsigned int phi_steps = 10;
+    unsigned int theta_steps = 100;
+    unsigned int phi_steps = 100;
 
     const point3 ori{0., 0., 0.};
     // dindex start_index = n.detector.volume_by_pos(ori).index();

--- a/tests/common/include/tests/common/tools_single_type_navigator.inl
+++ b/tests/common/include/tests/common/tools_single_type_navigator.inl
@@ -149,7 +149,7 @@ TEST(ALGEBRA_PLUGIN, single_type_navigator) {
     // be a surface
     ASSERT_EQ(state.next()->index, 128u);
     ASSERT_EQ(state.trust_level(),
-              toy_navigator::navigation_trust_level::e_high_trust);
+              toy_navigator::navigation_trust_level::e_full_trust);
 
     // Now step onto the surface in volume 1 (128)
     traj.pos = traj.pos + state() * traj.dir;
@@ -292,7 +292,7 @@ TEST(ALGEBRA_PLUGIN, single_type_navigator) {
     ASSERT_EQ(state.candidates().size(), 2u);
     ASSERT_EQ(state.next()->index, 234u);
     ASSERT_EQ(state.trust_level(),
-              toy_navigator::navigation_trust_level::e_high_trust);
+              toy_navigator::navigation_trust_level::e_full_trust);
 
     // Step onto the portal 234
     traj.pos = traj.pos + state() * traj.dir;
@@ -327,7 +327,7 @@ TEST(ALGEBRA_PLUGIN, single_type_navigator) {
     // be a surface
     ASSERT_EQ(state.next()->index, 482u);
     ASSERT_EQ(state.trust_level(),
-              toy_navigator::navigation_trust_level::e_high_trust);
+              toy_navigator::navigation_trust_level::e_full_trust);
 
     // Now step onto the surface (482)
     traj.pos = traj.pos + state() * traj.dir;
@@ -442,7 +442,7 @@ TEST(ALGEBRA_PLUGIN, single_type_navigator) {
     traj.pos = traj.pos + state() * traj.dir;
     heartbeat = n.status(state, traj);
     // Test that the navigator has a heartbeat
-    ASSERT_TRUE(heartbeat);
+    ASSERT_FALSE(heartbeat);
     // The status is: on portal
     ASSERT_EQ(state.status(), toy_navigator::navigation_status::e_on_target);
     // Switch to next volume leads out of the detector world -> exit


### PR DESCRIPTION
This PR introduces tests for random direction navigation that runs along straight lines. It works with the single_type_navigator/toy_geometry setup:
- the directions are 100x100 rays in theta and phi steps
- the navigation state can be printed automatically by an inspector
- the indices of the objects the navigator steps onto can be recorded with a dedicated inspector

Every navigation run is checked against the intersection trace produced by the ray gun.

A few minor fixed have been made to the ```single_type_navigator.hpp``` to make its navigation status more consistent