### PR TITLE
Refactor `mask_store_data`

### DIFF
--- a/tests/unit_tests/cuda/mask_store_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/mask_store_cuda_kernel.cu
@@ -13,8 +13,8 @@ namespace detray {
 /// test kernel function to fill the output vector with is_inside function
 /// return values
 __global__ void mask_test_kernel(
-    mask_store_data<thrust::tuple, rectangle, trapezoid, ring, cylinder, single,
-                    annulus>
+    mask_store_data<mask_store<thrust::tuple, dvector, rectangle, trapezoid,
+                               ring, cylinder, single, annulus>>
         store_data,
     vecmem::data::vector_view<point2> input_point2_data,
     vecmem::data::vector_view<point3> input_point3_data,
@@ -54,8 +54,8 @@ __global__ void mask_test_kernel(
 }
 
 void mask_test(
-    mask_store_data<thrust::tuple, rectangle, trapezoid, ring, cylinder, single,
-                    annulus>& store_data,
+    mask_store_data<mask_store<thrust::tuple, dvector, rectangle, trapezoid,
+                               ring, cylinder, single, annulus>>& store_data,
     vecmem::data::vector_view<point2>& input_point2_data,
     vecmem::data::vector_view<point3>& input_point3_data,
     vecmem::data::jagged_vector_view<intersection_status>& output_data) {

--- a/tests/unit_tests/cuda/mask_store_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/mask_store_cuda_kernel.hpp
@@ -42,8 +42,8 @@ using trapezoid = trapezoid2<>;
 
 /// test function for mask store
 void mask_test(
-    mask_store_data<thrust::tuple, rectangle, trapezoid, ring, cylinder, single,
-                    annulus>& store_data,
+    mask_store_data<mask_store<thrust::tuple, dvector, rectangle, trapezoid,
+                               ring, cylinder, single, annulus> >& store_data,
     vecmem::data::vector_view<point2>& input_point2_data,
     vecmem::data::vector_view<point3>& input_point3_data,
     vecmem::data::jagged_vector_view<intersection_status>& output_data);

--- a/tests/unit_tests/cuda/tuple_test_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/tuple_test_cuda_kernel.cu
@@ -12,7 +12,7 @@ namespace detray {
 
 template <template <typename...> class tuple_type>
 __global__ void tuple_copy_kernel(
-    vec_tuple_data<tuple_type, int, float, double> data,
+    vec_tuple_data<vec_tuple<tuple_type, dvector, int, float, double>> data,
     vecmem::data::vector_view<int> output1_data,
     vecmem::data::vector_view<float> output2_data,
     vecmem::data::vector_view<double> output3_data) {
@@ -42,7 +42,7 @@ __global__ void tuple_copy_kernel(
 }
 
 template void tuple_copy<thrust::tuple>(
-    vec_tuple_data<thrust::tuple, int, float, double>& data,
+    vec_tuple_data<vec_tuple<thrust::tuple, dvector, int, float, double>>& data,
     vecmem::data::vector_view<int>& output1_data,
     vecmem::data::vector_view<float>& output2_data,
     vecmem::data::vector_view<double>& output3_data);
@@ -56,10 +56,11 @@ template void tuple_copy<std::tuple>(
 */
 
 template <template <typename...> class tuple_type>
-void tuple_copy(vec_tuple_data<tuple_type, int, float, double>& data,
-                vecmem::data::vector_view<int>& output1_data,
-                vecmem::data::vector_view<float>& output2_data,
-                vecmem::data::vector_view<double>& output3_data) {
+void tuple_copy(
+    vec_tuple_data<vec_tuple<tuple_type, dvector, int, float, double>>& data,
+    vecmem::data::vector_view<int>& output1_data,
+    vecmem::data::vector_view<float>& output2_data,
+    vecmem::data::vector_view<double>& output3_data) {
 
     int thread_dim = 1;
     int block_dim = 1;

--- a/tests/unit_tests/cuda/tuple_test_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/tuple_test_cuda_kernel.hpp
@@ -35,6 +35,8 @@ template <template <typename...> class tuple_type = std::tuple,
           typename... Ts>
 struct vec_tuple {
 
+    using data_t = tuple_type<vecmem::data::vector_view<Ts>...>;
+
     // vtuple has different types based on the file location
     // 1) std::tuple in cpp/hpp; 2) thrust::tuple in cu
     vtuple::tuple<vector_type<Ts>...> _tuple;
@@ -53,56 +55,57 @@ struct vec_tuple {
      *
      * Used when creating vec_tuple with vecmem::device_vector
      */
-    template <template <template <typename...> class, typename...>
-              class vec_tuple_data>
-    DETRAY_DEVICE vec_tuple(vec_tuple_data<tuple_type, Ts...>& data)
-        : _tuple(data.device(std::make_index_sequence<sizeof...(Ts)>{})) {}
+    template <typename vec_tuple_data_t,
+              std::enable_if_t<
+                  !std::is_base_of_v<vecmem::memory_resource, vec_tuple_data_t>,
+                  bool> = true>
+    DETRAY_DEVICE vec_tuple(vec_tuple_data_t& data)
+        : _tuple(device(data, std::make_index_sequence<sizeof...(Ts)>{})) {}
+
+    template <std::size_t... ints>
+    DETRAY_HOST data_t data(std::index_sequence<ints...> /*seq*/) {
+        return detail::make_tuple<tuple_type>(vecmem::data::vector_view<Ts>(
+            vecmem::get_data(detail::get<ints>(_tuple)))...);
+    }
+
+    template <typename vec_tuple_data_t, std::size_t... ints>
+    DETRAY_DEVICE vtuple::tuple<vector_type<Ts>...> device(
+        vec_tuple_data_t& data, std::index_sequence<ints...> /*seq*/) {
+        return vtuple::make_tuple(
+            vector_type<Ts>(detail::get<ints>(data._tuple))...);
+    }
 };
 
 /** Tuple of vecmem::vector_view
- *
  */
-template <template <typename...> class tuple_type, typename... Ts>
+template <typename vec_tuple_t>
 struct vec_tuple_data {
-    tuple_type<vecmem::data::vector_view<Ts>...> _tuple;
+    typename vec_tuple_t::data_t _tuple;
 
     /** Constructor with vec_tuple - only for host
-     *
-     */
-    template <template <typename...> class vector_type, std::size_t... ints>
-    DETRAY_HOST vec_tuple_data(
-        vec_tuple<tuple_type, vector_type, Ts...>& vtuple,
-        std::index_sequence<ints...> /*seq*/)
-        : _tuple(detail::make_tuple<tuple_type>(vecmem::data::vector_view<Ts>(
-              vecmem::get_data(detail::get<ints>(vtuple._tuple)))...)) {}
-
-    /** Create tuple with vecmem::device_vector
-     *
-     * This function is called by vec_tuple constructor
      */
     template <std::size_t... ints>
-    DETRAY_DEVICE tuple_type<vecmem::device_vector<Ts>...> device(
-        std::index_sequence<ints...> /*seq*/) {
-        return detail::make_tuple<tuple_type>(
-            vecmem::device_vector<Ts>(detail::get<ints>(_tuple))...);
-    }
+    DETRAY_HOST vec_tuple_data(vec_tuple_t& vtuple,
+                               std::index_sequence<ints...> seq)
+        : _tuple(vtuple.data(seq)) {}
 };
 
 /** Get vec_tuple_data
  **/
 template <template <typename...> class tuple_type,
           template <typename...> class vector_type, typename... Ts>
-inline vec_tuple_data<tuple_type, Ts...> get_data(
+inline vec_tuple_data<vec_tuple<tuple_type, vector_type, Ts...> > get_data(
     vec_tuple<tuple_type, vector_type, Ts...>& vtuple) {
-    return vec_tuple_data<tuple_type, Ts...>(
+    return vec_tuple_data<vec_tuple<tuple_type, vector_type, Ts...> >(
         vtuple, std::make_index_sequence<sizeof...(Ts)>{});
 }
 
 // Test function to copy the contenst of vec_tuple_data into vecmem vector
 template <template <typename...> class tuple_type>
-void tuple_copy(vec_tuple_data<tuple_type, int, float, double>& data,
-                vecmem::data::vector_view<int>& output1_data,
-                vecmem::data::vector_view<float>& output2_data,
-                vecmem::data::vector_view<double>& output3_data);
+void tuple_copy(
+    vec_tuple_data<vec_tuple<tuple_type, dvector, int, float, double> >& data,
+    vecmem::data::vector_view<int>& output1_data,
+    vecmem::data::vector_view<float>& output2_data,
+    vecmem::data::vector_view<double>& output3_data);
 
 }  // namespace detray

--- a/tests/unit_tests/cuda/tuple_test_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/tuple_test_cuda_kernel.hpp
@@ -62,12 +62,18 @@ struct vec_tuple {
     DETRAY_DEVICE vec_tuple(vec_tuple_data_t& data)
         : _tuple(device(data, std::make_index_sequence<sizeof...(Ts)>{})) {}
 
+    /**
+     * Get vecmem::data::vector_view objects
+     */
     template <std::size_t... ints>
     DETRAY_HOST data_t data(std::index_sequence<ints...> /*seq*/) {
         return detail::make_tuple<tuple_type>(vecmem::data::vector_view<Ts>(
             vecmem::get_data(detail::get<ints>(_tuple)))...);
     }
 
+    /**
+     * Get vecmem::device_vector objects
+     */
     template <typename vec_tuple_data_t, std::size_t... ints>
     DETRAY_DEVICE vtuple::tuple<vector_type<Ts>...> device(
         vec_tuple_data_t& data, std::index_sequence<ints...> /*seq*/) {


### PR DESCRIPTION
Some changes were made to make `mask_store_data` directly take `mask_store` as an template parameter.
This should be useful when writing `detector_data` class.

Before:
```c++
template <template <typename...> class tuple_type, typename... mask_types>
struct mask_store_data {};
```

After:
```c++
template <typename mask_store_t>
struct mask_store_data {};
```