### PR TITLE
Iterator Range Simplification, main branch (2021.11.26.)

### DIFF
--- a/core/include/detray/utils/enumerate.hpp
+++ b/core/include/detray/utils/enumerate.hpp
@@ -35,11 +35,9 @@ struct iterator_range {
      */
     template <typename range_type>
     DETRAY_HOST_DEVICE iterator_range(const container_type &iterable,
-                                      range_type &&range)
-        : _start(std::next(std::begin(iterable),
-                           std::get<0>(std::forward<range_type>(range)))),
-          _end(std::next(std::begin(iterable),
-                         std::get<1>(std::forward<range_type>(range)))) {}
+                                      const range_type &range)
+        : _start(std::begin(iterable) + std::get<0>(range)),
+          _end(std::begin(iterable) + std::get<1>(range)) {}
 
     /** @return start position of range on container. */
     DETRAY_HOST_DEVICE


### PR DESCRIPTION
Simplified the constructor of detray::iterator_range. This was necessary because CUDA (11.4) is not able to generate correct code with the previous implementation. Which only happens to show up in a full debug build (`cmake -DCMAKE_BUILD_TYPE=Debug ../detray`) during the `detray_test_array_transform_store_cuda` test.

When trying to run said test in the current main branch, I see the following:

```
[bash][Legolas]:build > ./test-bin/detray_test_array_transform_store_cuda 
Running main() from /data/ssd-1tb/projects/detray/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from transform_store_cuda
[ RUN      ] transform_store_cuda.transform_store
CUDAassert: an illegal memory access was encountered /data/ssd-1tb/projects/detray/detray/tests/unit_tests/cuda/transform_store_cuda_kernel.cu 45
[bash][Legolas]:build > cuda-gdb ./test-bin/detray_test_array_transform_store_cuda 
NVIDIA (R) CUDA Debugger
11.4 release
Portions Copyright (C) 2007-2021 NVIDIA Corporation
GNU gdb (GDB) 10.1
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./test-bin/detray_test_array_transform_store_cuda...
(cuda-gdb) run
Starting program: /data/ssd-1tb/projects/detray/build/test-bin/detray_test_array_transform_store_cuda 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Running main() from /data/ssd-1tb/projects/detray/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from transform_store_cuda
[ RUN      ] transform_store_cuda.transform_store
[Detaching after fork from child process 89665]
[New Thread 0x7fffefd79000 (LWP 89671)]
[New Thread 0x7fffef578000 (LWP 89672)]
[New Thread 0x7fffeebb3000 (LWP 89673)]

CUDA Exception: Warp Illegal Instruction
The exception was triggered at PC 0x0

Thread 1 "detray_test_arr" received signal CUDA_EXCEPTION_4, Warp Illegal Instruction.
[Switching focus to CUDA kernel 0, grid 1, block (0,0,0), thread (0,0,0), device 0, sm 0, warp 0, lane 0]
0x0000000000000010 in ?? ()
(cuda-gdb) bt
#0  0x0000000000000010 in ?? ()
#1  0x0000555555ba1100 in std::__advance<algebra::cmath::transform3<unsigned long, algebra::array::storage_type, double, std::array<std::array<double, 4ul>, 4ul>, algebra::cmath::element_getter<algebra::array::storage_type, double>, algebra::cmath::block_getter<algebra::array::storage_type, double>, std::array<double, 3ul>, std::array<double, 2ul> > const*, long> (__i=<error reading variable>, __n=0)
    at /usr/include/c++/9/bits/stl_iterator_base_funcs.h:180
#2  0x0000555555b9f2c0 in std::advance<algebra::cmath::transform3<unsigned long, algebra::array::storage_type, double, std::array<std::array<double, 4ul>, 4ul>, algebra::cmath::element_getter<algebra::array::storage_type, double>, algebra::cmath::block_getter<algebra::array::storage_type, double>, std::array<double, 3ul>, std::array<double, 2ul> > const*, long> (__i=<error reading variable>, __n=0)
    at /usr/include/c++/9/bits/stl_iterator_base_funcs.h:206
#3  0x0000555555b9bb50 in std::next<algebra::cmath::transform3<unsigned long, algebra::array::storage_type, double, std::array<std::array<double, 4ul>, 4ul>, algebra::cmath::element_getter<algebra::array::storage_type, double>, algebra::cmath::block_getter<algebra::array::storage_type, double>, std::array<double, 3ul>, std::array<double, 2ul> > const*> (__x=0x7fffc2000800, __n=0)
    at /usr/include/c++/9/bits/stl_iterator_base_funcs.h:218
#4  0x0000555555b982a0 in detray::iterator_range<vecmem::device_vector<algebra::cmath::transform3<unsigned long, algebra::array::storage_type, double, std::array<std::array<double, 4ul>, 4ul>, algebra::cmath::element_getter<algebra::array::storage_type, double>, algebra::cmath::block_getter<algebra::array::storage_type, double>, std::array<double, 3ul>, std::array<double, 2ul> > > >::iterator_range<std::array<unsigned long, 2ul> > (
    this=0x7ffff1fffcc0, iterable=..., range=...) at /data/ssd-1tb/projects/detray/detray/core/include/detray/utils/enumerate.hpp:39
#5  0x0000555555b50060 in detray::static_transform_store<vecmem::device_vector, unsigned long>::range (this=0x7ffff1fffd68, begin=0, end=5)
    at /data/ssd-1tb/projects/detray/detray/core/include/detray/core/transform_store.hpp:74
#6  0x0000555555ba3e10 in detray::transform_test_kernel<<<(1,1,1),(5,1,1)>>> (input_data=..., store_data=..., output_data=...)
    at /data/ssd-1tb/projects/detray/detray/tests/unit_tests/cuda/transform_store_cuda_kernel.cu:26
(cuda-gdb)
```

I played around with the code the bit, trying to understand what the issue may be. But in the end I decided that the best way forward would be to drastically simplify the constructor of the `detray::iterator_range` class. Since I have to say, I'm not sure why it would need to be as complicated as it is currently, to begin with. :confused:

In any case, with this update the test works fine in Debug mode as well.

```
[bash][Legolas]:build > cuda-memcheck ./test-bin/detray_test_array_transform_store_cuda 
========= CUDA-MEMCHECK
Running main() from /data/ssd-1tb/projects/detray/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from transform_store_cuda
[ RUN      ] transform_store_cuda.transform_store
[       OK ] transform_store_cuda.transform_store (105 ms)
[----------] 1 test from transform_store_cuda (105 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (105 ms total)
[  PASSED  ] 1 test.
========= ERROR SUMMARY: 0 errors
[bash][Legolas]:build >
```