### PR TITLE
Algebra Plugins Update, main branch (2021.11.26.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DALGEBRA_PLUGIN_CUSTOM_SCALARTYPE=float
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DDETRAY_CUSTOM_SCALARTYPE=float
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/apps/common/include/apps/common/display_bin_association.inl
+++ b/apps/common/include/apps/common/display_bin_association.inl
@@ -28,7 +28,7 @@
 int main(int argc, char **argv) {
     vecmem::host_memory_resource host_mr;
 
-    using point2 = __plugin::point2;
+    using point2 = __plugin::point2<detray::scalar>;
     using namespace detray;
     using namespace matplot;
 

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -27,9 +27,9 @@
 namespace detray {
 
 // Algebra, point2 is not strongly typed
-using point3 = __plugin::point3;
-using vector3 = __plugin::vector3;
-using point2 = __plugin::point2;
+using point3 = __plugin::point3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
+using point2 = __plugin::point2<detray::scalar>;
 
 /** The detector definition.
  *
@@ -86,16 +86,20 @@ class detector {
     using edge_type = array_type<dindex, 2>;
 
     /// mask types
-    using rectangle = rectangle2<planar_intersector, __plugin::cartesian2,
-                                 edge_type, e_rectangle2>;
-    using trapezoid = trapezoid2<planar_intersector, __plugin::cartesian2,
-                                 edge_type, e_trapezoid2>;
-    using annulus = annulus2<planar_intersector, __plugin::cartesian2,
-                             edge_type, e_annulus2>;
+    using rectangle =
+        rectangle2<planar_intersector, __plugin::cartesian2<detray::scalar>,
+                   edge_type, e_rectangle2>;
+    using trapezoid =
+        trapezoid2<planar_intersector, __plugin::cartesian2<detray::scalar>,
+                   edge_type, e_trapezoid2>;
+    using annulus =
+        annulus2<planar_intersector, __plugin::cartesian2<detray::scalar>,
+                 edge_type, e_annulus2>;
     using cylinder = cylinder3<false, cylinder_intersector,
-                               __plugin::cylindrical2, edge_type, e_cylinder3>;
-    using disc =
-        ring2<planar_intersector, __plugin::cartesian2, edge_type, e_ring2>;
+                               __plugin::cylindrical2<detray::scalar>,
+                               edge_type, e_cylinder3>;
+    using disc = ring2<planar_intersector, __plugin::cartesian2<detray::scalar>,
+                       edge_type, e_ring2>;
 
     using mask_container = mask_store<tuple_type, vector_type, rectangle,
                                       trapezoid, annulus, cylinder, disc>;

--- a/core/include/detray/core/intersection.hpp
+++ b/core/include/detray/core/intersection.hpp
@@ -14,9 +14,9 @@
 
 namespace detray {
 
-using point3 = __plugin::point3;
-using vector3 = __plugin::vector3;
-using point2 = __plugin::point2;
+using point3 = __plugin::point3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
+using point2 = __plugin::point2<detray::scalar>;
 
 /** Intersection direction with respect to the
  * normal of the surface

--- a/core/include/detray/core/track.hpp
+++ b/core/include/detray/core/track.hpp
@@ -15,8 +15,8 @@ namespace detray {
 /** Track struct for navigation through the detector */
 template <typename context_type = bool>
 struct track {
-    using point3 = __plugin::point3;
-    using vector3 = __plugin::vector3;
+    using point3 = __plugin::point3<detray::scalar>;
+    using vector3 = __plugin::vector3<detray::scalar>;
 
     point3 pos = {0., 0., 0.};
     vector3 dir = {0., 0., 0.};

--- a/core/include/detray/core/transform_store.hpp
+++ b/core/include/detray/core/transform_store.hpp
@@ -14,7 +14,7 @@
 
 namespace detray {
 
-using transform3 = __plugin::transform3;
+using transform3 = __plugin::transform3<detray::scalar>;
 
 /** A static inplementation of an alignable transform store */
 template <template <typename...> class vector_type = dvector,

--- a/core/include/detray/geometry/volume_connector.hpp
+++ b/core/include/detray/geometry/volume_connector.hpp
@@ -240,8 +240,8 @@ void connect_cylindrical_volumes(
             // Fill in the left side portals
             if (not portals_info.empty()) {
                 // The portal transfrom is given from the left
-                __plugin::vector3 _translation{0., 0.,
-                                               volume_bounds[bound_index]};
+                __plugin::vector3<detray::scalar> _translation{
+                    0., 0., volume_bounds[bound_index]};
 
                 // Get the mask context group and fill it
                 constexpr auto disc_id = detector_t::mask_id::e_portal_ring2;

--- a/core/include/detray/grids/associator.hpp
+++ b/core/include/detray/grids/associator.hpp
@@ -12,7 +12,7 @@
 
 namespace detray {
 
-using point2 = __plugin::point2;
+using point2 = __plugin::point2<detray::scalar>;
 
 /** Struct that assigns the center of gravity to a rectangular bin */
 struct center_of_gravity_rectangle {

--- a/core/include/detray/grids/grid2.hpp
+++ b/core/include/detray/grids/grid2.hpp
@@ -51,7 +51,7 @@ class grid2 {
     using axis_p1_t = axis_p1_type<array_type, vector_type>;
     using bare_value = typename populator_t::bare_value;
     using serialized_storage = typename populator_t::serialized_storage;
-    using point2 = __plugin::point2;
+    using point2 = __plugin::point2<detray::scalar>;
 
     template <typename neighbor_t>
     using neighborhood = array_type<array_type<neighbor_t, 2>, 2>;

--- a/core/include/detray/masks/annulus2.hpp
+++ b/core/include/detray/masks/annulus2.hpp
@@ -44,7 +44,7 @@ namespace detray {
  *
  **/
 template <typename intersector_type = planar_intersector,
-          typename mask_local_type = __plugin::polar2,
+          typename mask_local_type = __plugin::polar2<detray::scalar>,
           typename mask_links_type = unsigned int,
           unsigned int kMaskContext = e_annulus2,
           template <typename, unsigned int> class array_type = darray>
@@ -117,7 +117,8 @@ struct annulus2 {
         // system
 
         // In cartesian coordinates go to modules system by shifting origin
-        if constexpr (std::is_same_v<inside_local_type, __plugin::cartesian2>) {
+        if constexpr (std::is_same_v<inside_local_type,
+                                     __plugin::cartesian2<detray::scalar> >) {
             // Calculate radial coordinate in module system:
             scalar x_mod = p[0] - _values[4];
             scalar y_mod = p[1] - _values[5];

--- a/core/include/detray/masks/cylinder3.hpp
+++ b/core/include/detray/masks/cylinder3.hpp
@@ -35,7 +35,7 @@ namespace detray {
  **/
 template <bool kRadialCheck = true,
           typename intersector_type = detray::cylinder_intersector,
-          typename mask_local_type = __plugin::cylindrical2,
+          typename mask_local_type = __plugin::cylindrical2<detray::scalar>,
           typename mask_links_type = unsigned int,
           unsigned int kMaskContext = e_cylinder3,
           template <typename, unsigned int> class array_type = darray>

--- a/core/include/detray/masks/rectangle2.hpp
+++ b/core/include/detray/masks/rectangle2.hpp
@@ -34,7 +34,7 @@ namespace detray {
  *
  **/
 template <typename intersector_type = planar_intersector,
-          typename mask_local_type = __plugin::cartesian2,
+          typename mask_local_type = __plugin::cartesian2<detray::scalar>,
           typename mask_links_type = unsigned int,
           unsigned int kMaskContext = e_rectangle2,
           template <typename, unsigned int> class array_type = darray>

--- a/core/include/detray/masks/ring2.hpp
+++ b/core/include/detray/masks/ring2.hpp
@@ -33,7 +33,7 @@ namespace detray {
  *
  **/
 template <typename intersector_type = planar_intersector,
-          typename mask_local_type = __plugin::cartesian2,
+          typename mask_local_type = __plugin::cartesian2<detray::scalar>,
           typename mask_links_type = unsigned int,
           unsigned int kMaskContext = e_ring2,
           template <typename, unsigned int> class array_type = darray>
@@ -88,7 +88,8 @@ struct ring2 {
     template <typename inside_local_type>
     DETRAY_HOST_DEVICE intersection_status
     is_inside(const point2 &p, const mask_tolerance t = within_epsilon) const {
-        if constexpr (std::is_same_v<inside_local_type, __plugin::cartesian2>) {
+        if constexpr (std::is_same_v<inside_local_type,
+                                     __plugin::cartesian2<detray::scalar> >) {
             scalar r = getter::perp(p);
             return (r + t >= _values[0] and r <= _values[1] + t) ? e_inside
                                                                  : e_outside;

--- a/core/include/detray/masks/single3.hpp
+++ b/core/include/detray/masks/single3.hpp
@@ -32,7 +32,7 @@ namespace detray {
  **/
 template <
     unsigned int kCheckIndex, typename intersector_type = planar_intersector,
-    typename mask_links_type = __plugin::cartesian2,
+    typename mask_links_type = __plugin::cartesian2<detray::scalar>,
     typename mask_local_type = bool, unsigned int kMaskContext = e_single3,
     template <typename, unsigned int> class array_type = darray>
 struct single3 {

--- a/core/include/detray/masks/trapezoid2.hpp
+++ b/core/include/detray/masks/trapezoid2.hpp
@@ -35,7 +35,7 @@ namespace detray {
  *
  **/
 template <typename intersector_type = planar_intersector,
-          typename mask_local_type = __plugin::cartesian2,
+          typename mask_local_type = __plugin::cartesian2<detray::scalar>,
           typename mask_links_type = unsigned int,
           unsigned int kMaskContext = e_trapezoid2,
           template <typename, unsigned int> class array_type = darray>

--- a/core/include/detray/tools/bin_association.hpp
+++ b/core/include/detray/tools/bin_association.hpp
@@ -17,8 +17,8 @@
 #include "detray/utils/generators.hpp"
 
 namespace detray {
-using point2 = __plugin::point2;
-using point3 = __plugin::point3;
+using point2 = __plugin::point2<detray::scalar>;
+using point3 = __plugin::point3<detray::scalar>;
 
 /** Run the bin association of surfaces (via their contour)
  *  - to a given grid.

--- a/core/include/detray/tools/concentric_cylinder_intersector.hpp
+++ b/core/include/detray/tools/concentric_cylinder_intersector.hpp
@@ -24,11 +24,11 @@ class unbound;
 template <template <typename, unsigned int> class array_type = darray>
 struct concentric_cylinder_intersector {
 
-    using transform3 = __plugin::transform3;
-    using point3 = __plugin::point3;
-    using vector3 = __plugin::vector3;
-    using point2 = __plugin::point2;
-    using cylindrical2 = __plugin::cylindrical2;
+    using transform3 = __plugin::transform3<detray::scalar>;
+    using point3 = __plugin::point3<detray::scalar>;
+    using vector3 = __plugin::vector3<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
+    using cylindrical2 = __plugin::cylindrical2<detray::scalar>;
 
     /** Intersection method for cylindrical surfaces
      *

--- a/core/include/detray/tools/cylinder_intersector.hpp
+++ b/core/include/detray/tools/cylinder_intersector.hpp
@@ -20,11 +20,11 @@ class unbound;
  */
 struct cylinder_intersector {
 
-    using transform3 = __plugin::transform3;
-    using point3 = __plugin::point3;
-    using vector3 = __plugin::vector3;
-    using point2 = __plugin::point2;
-    using cylindrical2 = __plugin::cylindrical2;
+    using transform3 = __plugin::transform3<detray::scalar>;
+    using point3 = __plugin::point3<detray::scalar>;
+    using vector3 = __plugin::vector3<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
+    using cylindrical2 = __plugin::cylindrical2<detray::scalar>;
 
     /** Intersection method for cylindrical surfaces
      *

--- a/core/include/detray/tools/intersection_kernel.hpp
+++ b/core/include/detray/tools/intersection_kernel.hpp
@@ -19,7 +19,7 @@
 namespace detray {
 
 /// Transform definition
-using transform3 = __plugin::transform3;
+using transform3 = __plugin::transform3<detray::scalar>;
 
 /** Variadic unrolled intersection - any integer sequence
  *

--- a/core/include/detray/tools/local_object_finder.hpp
+++ b/core/include/detray/tools/local_object_finder.hpp
@@ -18,7 +18,7 @@ struct local_zone_finder {
     grid_type _grid;
     bool _sort = true;
 
-    using point2 = __plugin::point2;
+    using point2 = __plugin::point2<detray::scalar>;
 
     /** Constructor from grid
      *
@@ -69,7 +69,7 @@ template <typename value_type, typename vector_type = dvector<value_type>,
           template <typename, unsigned int> class array_type = darray>
 struct local_single_finder {
 
-    using point2 = __plugin::point2;
+    using point2 = __plugin::point2<detray::scalar>;
 
     vector_type _value = {};
 

--- a/core/include/detray/tools/planar_intersector.hpp
+++ b/core/include/detray/tools/planar_intersector.hpp
@@ -17,10 +17,10 @@ namespace detray {
  */
 struct planar_intersector {
 
-    using transform3 = __plugin::transform3;
-    using point3 = __plugin::point3;
-    using vector3 = __plugin::vector3;
-    using point2 = __plugin::point2;
+    using transform3 = __plugin::transform3<detray::scalar>;
+    using point3 = __plugin::point3<detray::scalar>;
+    using vector3 = __plugin::vector3<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
 
     /** Intersection method for planar surfaces
      *

--- a/core/include/detray/utils/generators.hpp
+++ b/core/include/detray/utils/generators.hpp
@@ -11,8 +11,8 @@
 
 namespace detray {
 
-using transform3 = __plugin::transform3;
-using point2 = __plugin::point2;
+using transform3 = __plugin::transform3<detray::scalar>;
+using point2 = __plugin::point2<detray::scalar>;
 
 /** Generate phi values
  *

--- a/core/include/detray/utils/unbound.hpp
+++ b/core/include/detray/utils/unbound.hpp
@@ -12,9 +12,9 @@ namespace detray {
 
 /** A representation that is not bound to a local frame */
 struct unbound {
-    using transform3 = __plugin::transform3;
-    using point3 = __plugin::point3;
-    using point2 = __plugin::point2;
+    using transform3 = __plugin::transform3<detray::scalar>;
+    using point3 = __plugin::point3<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
 
     /** This method transform from a point from the global 3D cartesian frame to
      *  the local 2D cartesian frame, including the contextual transform into

--- a/display/include/detray/view/views.hpp
+++ b/display/include/detray/view/views.hpp
@@ -10,8 +10,8 @@
 #include <cmath>
 
 namespace detray {
-using point3 = __plugin::point3;
-using transform3 = __plugin::transform3;
+using point3 = __plugin::point3<detray::scalar>;
+using transform3 = __plugin::transform3<detray::scalar>;
 
 using contour = darray<dvector<scalar>, 2>;
 

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building Algebra Plugins as part of the Detray project" )
 
 # Declare where to get Algebra Plugins from.
 set( DETRAY_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.3.0.tar.gz;URL_MD5;7ffcfe299ebf654074b196e949afb010"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.4.0.tar.gz;URL_MD5;c9f8f1d29665b196f182060f871bb8f0"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced( DETRAY_ALGEBRA_PLUGINS_SOURCE )
 FetchContent_Declare( AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE} )

--- a/plugins/algebra/CMakeLists.txt
+++ b/plugins/algebra/CMakeLists.txt
@@ -4,6 +4,10 @@
 #
 # Mozilla Public License Version 2.0
 
+# Temporary setting for the detray::scalar type, until it can be removed.
+set( DETRAY_CUSTOM_SCALARTYPE "double" CACHE STRING
+   "Scalar type to use in the Detray code" )
+
 # Add all subdirectories.
 add_subdirectory( array )
 if( DETRAY_EIGEN_PLUGIN )

--- a/plugins/algebra/array/CMakeLists.txt
+++ b/plugins/algebra/array/CMakeLists.txt
@@ -12,3 +12,5 @@ detray_add_library( detray_array array
    "include/detray/plugins/algebra/array_definitions.hpp" )
 target_link_libraries( detray_array
    INTERFACE algebra::array_cmath vecmem::core )
+target_compile_definitions( detray_array
+   INTERFACE DETRAY_CUSTOM_SCALARTYPE=${DETRAY_CUSTOM_SCALARTYPE} )

--- a/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
@@ -12,7 +12,7 @@
 
 namespace detray {
 
-using scalar = algebra::scalar;
+using scalar = DETRAY_CUSTOM_SCALARTYPE;
 
 template <typename value_type, unsigned int kDIM>
 using darray = std::array<value_type, kDIM>;

--- a/plugins/algebra/eigen/CMakeLists.txt
+++ b/plugins/algebra/eigen/CMakeLists.txt
@@ -18,3 +18,5 @@ detray_add_library( detray_eigen eigen
    "include/detray/plugins/algebra/eigen_definitions.hpp" )
 target_link_libraries( detray_eigen
    INTERFACE algebra::eigen_eigen vecmem::core )
+target_compile_definitions( detray_eigen
+   INTERFACE DETRAY_CUSTOM_SCALARTYPE=${DETRAY_CUSTOM_SCALARTYPE} )

--- a/plugins/algebra/eigen/include/detray/plugins/algebra/eigen_definitions.hpp
+++ b/plugins/algebra/eigen/include/detray/plugins/algebra/eigen_definitions.hpp
@@ -12,7 +12,7 @@
 
 namespace detray {
 
-using scalar = algebra::scalar;
+using scalar = DETRAY_CUSTOM_SCALARTYPE;
 
 template <typename value_type, unsigned int kDIM>
 using darray = std::array<value_type, kDIM>;

--- a/plugins/algebra/smatrix/CMakeLists.txt
+++ b/plugins/algebra/smatrix/CMakeLists.txt
@@ -18,3 +18,5 @@ detray_add_library( detray_smatrix smatrix
    "include/detray/plugins/algebra/smatrix_definitions.hpp" )
 target_link_libraries( detray_smatrix
    INTERFACE algebra::smatrix_smatrix vecmem::core )
+target_compile_definitions( detray_smatrix
+   INTERFACE DETRAY_CUSTOM_SCALARTYPE=${DETRAY_CUSTOM_SCALARTYPE} )

--- a/plugins/algebra/smatrix/include/detray/plugins/algebra/smatrix_definitions.hpp
+++ b/plugins/algebra/smatrix/include/detray/plugins/algebra/smatrix_definitions.hpp
@@ -12,7 +12,7 @@
 
 namespace detray {
 
-using scalar = algebra::scalar;
+using scalar = DETRAY_CUSTOM_SCALARTYPE;
 
 template <typename value_type, unsigned int kDIM>
 using darray = std::array<value_type, kDIM>;

--- a/plugins/algebra/vc/CMakeLists.txt
+++ b/plugins/algebra/vc/CMakeLists.txt
@@ -18,3 +18,5 @@ detray_add_library( detray_vc_array vc_array
    "include/detray/plugins/algebra/vc_array_definitions.hpp" )
 target_link_libraries( detray_vc_array
    INTERFACE algebra::vc_vc vecmem::core )
+target_compile_definitions( detray_vc_array
+   INTERFACE DETRAY_CUSTOM_SCALARTYPE=${DETRAY_CUSTOM_SCALARTYPE} )

--- a/plugins/algebra/vc/include/detray/plugins/algebra/vc_array_definitions.hpp
+++ b/plugins/algebra/vc/include/detray/plugins/algebra/vc_array_definitions.hpp
@@ -12,7 +12,7 @@
 
 namespace detray {
 
-using scalar = algebra::scalar;
+using scalar = DETRAY_CUSTOM_SCALARTYPE;
 
 template <typename value_type, unsigned int kDIM>
 using darray = std::array<value_type, kDIM>;

--- a/tests/benchmarks/core/benchmark_grids.cpp
+++ b/tests/benchmarks/core/benchmark_grids.cpp
@@ -51,8 +51,9 @@ grid2r g2r(std::move(xaxisr), std::move(yaxisr), host_mr);
 static void BM_REGULAR_GRID_BIN(benchmark::State &state) {
     for (auto _ : state) {
         for (unsigned int itest = 0; itest < 1000000; ++itest) {
-            test::point2 p = {static_cast<scalar>((rand() % 50) * 0.5),
-                              static_cast<scalar>((rand() % 120) * 0.5)};
+            test::point2<detray::scalar> p = {
+                static_cast<scalar>((rand() % 50) * 0.5),
+                static_cast<scalar>((rand() % 120) * 0.5)};
             g2r.bin(p);
         }
     }
@@ -61,8 +62,9 @@ static void BM_REGULAR_GRID_BIN(benchmark::State &state) {
 static void BM_REGULAR_GRID_ZONE(benchmark::State &state) {
     for (auto _ : state) {
         for (unsigned int itest = 0; itest < 1000000; ++itest) {
-            test::point2 p = {static_cast<scalar>((rand() % 50) * 0.5),
-                              static_cast<scalar>((rand() % 120) * 0.5)};
+            test::point2<detray::scalar> p = {
+                static_cast<scalar>((rand() % 50) * 0.5),
+                static_cast<scalar>((rand() % 120) * 0.5)};
             g2r.zone(p, {zone22, zone22});
         }
     }
@@ -97,8 +99,9 @@ auto g2irr = construct_irregular_grid();
 static void BM_IRREGULAR_GRID_BIN(benchmark::State &state) {
     for (auto _ : state) {
         for (unsigned int itest = 0; itest < 1000000; ++itest) {
-            test::point2 p = {static_cast<scalar>((rand() % 50) * 0.5),
-                              static_cast<scalar>((rand() % 120) * 0.5)};
+            test::point2<detray::scalar> p = {
+                static_cast<scalar>((rand() % 50) * 0.5),
+                static_cast<scalar>((rand() % 120) * 0.5)};
             g2irr.bin(p);
         }
     }
@@ -107,8 +110,9 @@ static void BM_IRREGULAR_GRID_BIN(benchmark::State &state) {
 static void BM_IRREGULAR_GRID_ZONE(benchmark::State &state) {
     for (auto _ : state) {
         for (unsigned int itest = 0; itest < 1000000; ++itest) {
-            test::point2 p = {static_cast<scalar>((rand() % 50) * 0.5),
-                              static_cast<scalar>((rand() % 120) * 0.5)};
+            test::point2<detray::scalar> p = {
+                static_cast<scalar>((rand() % 50) * 0.5),
+                static_cast<scalar>((rand() % 120) * 0.5)};
             g2irr.zone(p, {zone22, zone22});
         }
     }

--- a/tests/common/include/tests/common/benchmark_find_volume.inl
+++ b/tests/common/include/tests/common/benchmark_find_volume.inl
@@ -30,7 +30,6 @@ auto [d, name_map] = read_from_csv(tml_files, host_mr);
 
 const unsigned int itest = 10000;
 
-namespace __plugin {
 // This test a reference run to deduce the random number
 static void BM_FIND_VOLUMES(benchmark::State &state) {
     auto volume_grid = d.volume_search_grid();
@@ -78,7 +77,5 @@ BENCHMARK(BM_FIND_VOLUMES)
     ->Unit(benchmark::kMillisecond)
     ->Repetitions(gbench_repetitions)
     ->DisplayAggregatesOnly(true);
-
-}  // namespace __plugin
 
 BENCHMARK_MAIN();

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -59,7 +59,7 @@ static void BM_INTERSECT_ALL(benchmark::State &state) {
 
     for (auto _ : state) {
         track<static_transform_store<>::context> track;
-        track.pos = point3{0., 0., 0.};
+        track.pos = point3<detray::scalar>{0., 0., 0.};
 
         // Loops of theta values
         for (unsigned int itheta = 0; itheta < theta_steps; ++itheta) {

--- a/tests/common/include/tests/common/benchmark_intersect_surfaces.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_surfaces.inl
@@ -17,9 +17,9 @@
 
 using namespace detray;
 
-using transform3 = __plugin::transform3;
-using point3 = point3;
-using vector3 = vector3;
+using transform3 = __plugin::transform3<detray::scalar>;
+using point3 = __plugin::point3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
 using plane_surface = surface_base<transform3>;
 
 #ifdef DETRAY_BENCHMARKS_REP
@@ -36,7 +36,6 @@ dvector<scalar> dists = {1., 2., 3., 4., 5., 6., 7., 8., 9., 10.};
 auto planes =
     planes_along_direction(dists, vector::normalize(vector3{1., 1., 1.}));
 
-namespace __plugin {
 // This test runs intersection with all surfaces of the TrackML detector
 static void BM_INTERSECT_PLANES(benchmark::State &state) {
 
@@ -209,7 +208,5 @@ BENCHMARK(BM_INTERSECT_CONCETRIC_CYLINDERS)
     ->Unit(benchmark::kMillisecond)
     ->Repetitions(gbench_repetitions)
     ->DisplayAggregatesOnly(true);
-
-}  // namespace __plugin
 
 BENCHMARK_MAIN();

--- a/tests/common/include/tests/common/benchmark_masks.inl
+++ b/tests/common/include/tests/common/benchmark_masks.inl
@@ -39,8 +39,8 @@ namespace {
 
 // This test runs a rectangle2 maks test operation
 static void BM_RECTANGLE2_MASK(benchmark::State &state) {
-    using local_type = __plugin::cartesian2;
-    using point2 = __plugin::point2;
+    using local_type = __plugin::cartesian2<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
 
     rectangle2<> r = {3, 4};
 
@@ -81,8 +81,8 @@ static void BM_RECTANGLE2_MASK(benchmark::State &state) {
 
 // This test runs intersection a trapezoid2 mask operation
 static void BM_TRAPEZOID2_MASK(benchmark::State &state) {
-    using local_type = __plugin::cartesian2;
-    using point2 = __plugin::point2;
+    using local_type = __plugin::cartesian2<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
 
     trapezoid2<> t = {2, 3, 4};
 
@@ -123,8 +123,8 @@ static void BM_TRAPEZOID2_MASK(benchmark::State &state) {
 
 // This test runs a ring2 mask operation
 static void BM_RING2_MASK(benchmark::State &state) {
-    using local_type = __plugin::cartesian2;
-    using point2 = __plugin::point2;
+    using local_type = __plugin::cartesian2<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
 
     ring2<> r = {0., 5.};
 
@@ -164,8 +164,8 @@ static void BM_RING2_MASK(benchmark::State &state) {
 
 // This test runs mask oeration on a disc2
 static void BM_DISC2_MASK(benchmark::State &state) {
-    using local_type = __plugin::cartesian2;
-    using point2 = __plugin::point2;
+    using local_type = __plugin::cartesian2<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
 
     ring2<> r = {2., 5.};
 
@@ -205,8 +205,8 @@ static void BM_DISC2_MASK(benchmark::State &state) {
 
 // This test runs masking operations on a cylinder3 mask
 static void BM_CYLINDER3_MASK(benchmark::State &state) {
-    using local_type = __plugin::transform3;
-    using point3 = __plugin::point3;
+    using local_type = __plugin::transform3<detray::scalar>;
+    using point3 = __plugin::point3<detray::scalar>;
 
     cylinder3<> c = {3., 5.};
 
@@ -250,8 +250,8 @@ static void BM_CYLINDER3_MASK(benchmark::State &state) {
 
 // This test runs a annulus mask operation
 static void BM_ANNULUS_MASK(benchmark::State &state) {
-    using local_type = __plugin::cartesian2;
-    using point2 = __plugin::point2;
+    using local_type = __plugin::cartesian2<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
 
     annulus2<> ann = {2.5, 5., -0.64299, 4.13173, 1., 0.5};
 

--- a/tests/common/include/tests/common/check_geometry_scan.inl
+++ b/tests/common/include/tests/common/check_geometry_scan.inl
@@ -18,7 +18,6 @@
 
 /// @note __plugin has to be defined with a preprocessor command
 using namespace detray;
-using namespace __plugin;
 
 constexpr std::size_t vol0_hash = 2;
 constexpr std::size_t vol1_hash = 2;  // TODO: Find hash function wihtout coll.!

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -19,7 +19,7 @@ TEST(ALGEBRA_PLUGIN, detector) {
     vecmem::host_memory_resource host_mr;
 
     using namespace detray;
-    using namespace __plugin;
+    using point3 = __plugin::point3<detray::scalar>;
 
     using detector_t = detector<>;
 

--- a/tests/common/include/tests/common/core_transform_store.inl
+++ b/tests/common/include/tests/common/core_transform_store.inl
@@ -14,7 +14,8 @@
 // This tests the construction of a static transform store
 TEST(ALGEBRA_PLUGIN, static_transform_store) {
     using namespace detray;
-    using namespace __plugin;
+    using point3 = __plugin::point3<detray::scalar>;
+    using transform3 = __plugin::transform3<detray::scalar>;
 
     static_transform_store<> static_store;
     static_transform_store<>::context ctx0;

--- a/tests/common/include/tests/common/display_masks.inl
+++ b/tests/common/include/tests/common/display_masks.inl
@@ -18,9 +18,9 @@
 /// @note __plugin has to be defined with a preprocessor command
 using namespace detray;
 
-using transform3 = __plugin::transform3;
-using vector3 = __plugin::vector3;
-using point3 = __plugin::point3;
+using transform3 = __plugin::transform3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
+using point3 = __plugin::point3<detray::scalar>;
 
 TEST(display, annulus2) {
     detray::global_xy_view gxy;

--- a/tests/common/include/tests/common/masks_annulus2.inl
+++ b/tests/common/include/tests/common/masks_annulus2.inl
@@ -14,9 +14,9 @@ using namespace __plugin;
 
 // This tests the basic function of a rectangle
 TEST(mask, annulus2) {
-    using polar = __plugin::polar2;
-    using cartesian = __plugin::cartesian2;
-    using point2 = __plugin::point2;
+    using polar = __plugin::polar2<detray::scalar>;
+    using cartesian = __plugin::cartesian2<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
 
     scalar minR = 7.2;
     scalar maxR = 12.0;

--- a/tests/common/include/tests/common/masks_cylinder3.inl
+++ b/tests/common/include/tests/common/masks_cylinder3.inl
@@ -14,8 +14,8 @@ using namespace __plugin;
 
 // This tests the basic function of a rectangle
 TEST(mask, cylinder3) {
-    using local_type = __plugin::transform3;
-    using point3 = __plugin::point3;
+    using local_type = __plugin::transform3<detray::scalar>;
+    using point3 = __plugin::point3<detray::scalar>;
 
     scalar r = 3.;
     scalar hz = 4.;

--- a/tests/common/include/tests/common/masks_rectangle2.inl
+++ b/tests/common/include/tests/common/masks_rectangle2.inl
@@ -16,8 +16,8 @@ using namespace __plugin;
 
 // This tests the basic function of a rectangle
 TEST(mask, rectangle2) {
-    using local_type = __plugin::cartesian2;
-    using point2 = point2;
+    using local_type = __plugin::cartesian2<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
 
     point2 p2_in = {0.5, -9.};
     point2 p2_edge = {1., 9.3};

--- a/tests/common/include/tests/common/masks_ring2.inl
+++ b/tests/common/include/tests/common/masks_ring2.inl
@@ -10,12 +10,11 @@
 #include "detray/masks/ring2.hpp"
 
 using namespace detray;
-using namespace __plugin;
 
 // This tests the basic function of a rectangle
 TEST(mask, ring2) {
-    using cartesian = __plugin::cartesian2;
-    using polar = __plugin::polar2;
+    using cartesian = __plugin::cartesian2<detray::scalar>;
+    using polar = __plugin::polar2<detray::scalar>;
 
     point2 p2_pl_in = {0.5, -2.};
     point2 p2_pl_edge = {0., 3.5};

--- a/tests/common/include/tests/common/masks_single3.inl
+++ b/tests/common/include/tests/common/masks_single3.inl
@@ -16,8 +16,8 @@ using namespace __plugin;
 
 // This tests the basic function of a rectangle
 TEST(mask, single3_0) {
-    using local_type = __plugin::transform3;
-    using point3 = __plugin::point3;
+    using local_type = __plugin::transform3<detray::scalar>;
+    using point3 = __plugin::point3<detray::scalar>;
 
     point3 p3_in = {0.5, -9., 0.};
     point3 p3_edge = {1., 9.3, 2.};
@@ -42,8 +42,8 @@ TEST(mask, single3_0) {
 
 // This tests the basic function of a rectangle
 TEST(mask, single3_1) {
-    using local_type = __plugin::transform3;
-    using point3 = __plugin::point3;
+    using local_type = __plugin::transform3<detray::scalar>;
+    using point3 = __plugin::point3<detray::scalar>;
 
     point3 p3_in = {0.5, -9., 0.};
     point3 p3_edge = {1., 9.3, 2.};
@@ -68,8 +68,8 @@ TEST(mask, single3_1) {
 
 // This tests the basic function of a rectangle
 TEST(mask, single3_2) {
-    using local_type = __plugin::transform3;
-    using point3 = __plugin::point3;
+    using local_type = __plugin::transform3<detray::scalar>;
+    using point3 = __plugin::point3<detray::scalar>;
 
     point3 p3_in = {0.5, -9., 0.};
     point3 p3_edge = {1., 9.3, 2.};

--- a/tests/common/include/tests/common/masks_trapezoid2.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2.inl
@@ -14,8 +14,8 @@ using namespace __plugin;
 
 // This tests the basic function of a trapezoid
 TEST(mask, trapezoid2) {
-    using local_type = __plugin::cartesian2;
-    using point2 = point2;
+    using local_type = __plugin::cartesian2<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
 
     point2 p2_in = {1., -0.5};
     point2 p2_edge = {2.5, 1.};

--- a/tests/common/include/tests/common/masks_unmasked.inl
+++ b/tests/common/include/tests/common/masks_unmasked.inl
@@ -10,11 +10,11 @@
 #include "detray/masks/unmasked.hpp"
 
 using namespace detray;
-using namespace __plugin;
 
 // This tests the construction of a surface
 TEST(mask, unmasked) {
-    using local_type = __plugin::cartesian2;
+    using local_type = __plugin::cartesian2<detray::scalar>;
+    using point2 = __plugin::point2<detray::scalar>;
     point2 p2 = {0.5, -9.};
 
     unmasked u;

--- a/tests/common/include/tests/common/test_core.inl
+++ b/tests/common/include/tests/common/test_core.inl
@@ -17,12 +17,12 @@
 
 using namespace detray;
 
-using point2 = __plugin::point2;
+using point2 = __plugin::point2<detray::scalar>;
 
 // Three-dimensional definitions
-using transform3 = __plugin::transform3;
-using vector3 = __plugin::vector3;
-using point3 = __plugin::point3;
+using transform3 = __plugin::transform3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
+using point3 = __plugin::point3<detray::scalar>;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
 

--- a/tests/common/include/tests/common/test_defs.hpp
+++ b/tests/common/include/tests/common/test_defs.hpp
@@ -25,8 +25,11 @@ namespace detray {
 using scalar = detray_scalar;
 
 namespace test {
-using point2 = darray<scalar, 2>;
-using point3 = darray<scalar, 3>;
+
+template <typename T>
+using point2 = darray<T, 2>;
+template <typename T>
+using point3 = darray<T, 3>;
 
 }  // namespace test
 
@@ -42,12 +45,15 @@ scalar perp(const point_type &p) {
 
 }  // namespace getter
 
-inline test::point2 operator-(const test::point2 &a, const test::point2 &b) {
+template <typename T>
+inline test::point2<T> operator-(const test::point2<T> &a,
+                                 const test::point2<T> &b) {
     return {a[0] - b[0], a[1] - b[1]};
 }
 
-DETRAY_HOST_DEVICE
-inline bool operator==(const test::point3 &lhs, const test::point3 &rhs) {
+template <typename T>
+DETRAY_HOST_DEVICE inline bool operator==(const test::point3<T> &lhs,
+                                          const test::point3<T> &rhs) {
     for (int i = 0; i < 3; i++) {
         if (lhs[i] != rhs[i])
             return false;
@@ -57,8 +63,8 @@ inline bool operator==(const test::point3 &lhs, const test::point3 &rhs) {
 
 // invalid value specialization for test::point3
 template <>
-DETRAY_HOST_DEVICE inline test::point3 detray::invalid_value() {
-    return test::point3{0, 0, 0};
+DETRAY_HOST_DEVICE inline test::point3<scalar> detray::invalid_value() {
+    return test::point3<scalar>{0, 0, 0};
 }
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools/test_surfaces.hpp
+++ b/tests/common/include/tests/common/tools/test_surfaces.hpp
@@ -24,9 +24,9 @@ vecmem::host_memory_resource host_mr;
 
 using namespace vector;
 
-using transform3 = __plugin::transform3;
-using point3 = point3;
-using vector3 = vector3;
+using transform3 = __plugin::transform3<detray::scalar>;
+using point3 = __plugin::point3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
 
 using binned_neighborhood = darray<darray<dindex, 2>, 2>;
 
@@ -49,8 +49,8 @@ dvector<surface_base<transform3>> planes_along_direction(
     return return_surfaces;
 }
 
-using cylinder_point2 = __plugin::point2;
-using disc_point2 = __plugin::point2;
+using cylinder_point2 = __plugin::point2<detray::scalar>;
+using disc_point2 = __plugin::point2<detray::scalar>;
 using endcap_surface_finder = std::function<dvector<dindex>(
     const disc_point2 &, const binned_neighborhood &)>;
 

--- a/tests/common/include/tests/common/tools_cylinder_intersection.inl
+++ b/tests/common/include/tests/common/tools_cylinder_intersection.inl
@@ -21,9 +21,9 @@
 using namespace detray;
 
 // Three-dimensional definitions
-using transform3 = __plugin::transform3;
-using vector3 = __plugin::vector3;
-using point3 = __plugin::point3;
+using transform3 = __plugin::transform3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
+using point3 = __plugin::point3<detray::scalar>;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
 constexpr scalar not_defined = std::numeric_limits<scalar>::infinity();
@@ -48,8 +48,8 @@ TEST(ALGEBRA_PLUGIN, translated_cylinder) {
                 hit_unbound.p2[1] == not_defined);
 
     // The same but bound
-    cylinder3<false, cylinder_intersector, __plugin::cylindrical2, unsigned int,
-              1>
+    cylinder3<false, cylinder_intersector,
+              __plugin::cylindrical2<detray::scalar>, unsigned int, 1>
         cylinder_bound = {4., -10., 10.};
     auto hit_bound = ci.intersect(shifted, point3{3., 2., 5.},
                                   vector3{1., 0., 0.}, cylinder_bound);

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -21,7 +21,6 @@
 #include "detray/utils/enumerate.hpp"
 
 using namespace detray;
-using namespace __plugin;
 
 // This tests the construction of a surface
 TEST(tools, intersection_kernel_single) {
@@ -33,11 +32,14 @@ TEST(tools, intersection_kernel_single) {
     using surface_link = dindex;
     /// - masks, with mask identifiers 0,1,2
     using surface_rectangle =
-        rectangle2<planar_intersector, __plugin::cartesian2, mask_link, 0>;
+        rectangle2<planar_intersector, __plugin::cartesian2<detray::scalar>,
+                   mask_link, 0>;
     using surface_trapezoid =
-        trapezoid2<planar_intersector, __plugin::cartesian2, mask_link, 1>;
+        trapezoid2<planar_intersector, __plugin::cartesian2<detray::scalar>,
+                   mask_link, 1>;
     using surface_annulus =
-        annulus2<planar_intersector, __plugin::cartesian2, mask_link, 2>;
+        annulus2<planar_intersector, __plugin::cartesian2<detray::scalar>,
+                 mask_link, 2>;
 
     /// - mask index: type, entry
     using surface_mask_index = darray<dindex, 2>;

--- a/tests/common/include/tests/common/tools_line_stepper.inl
+++ b/tests/common/include/tests/common/tools_line_stepper.inl
@@ -22,7 +22,7 @@ TEST(ALGEBRA_PLUGIN, line_stepper) {
 
     detray_track traj;
     traj.pos = {0., 0., 0.};
-    traj.dir = vector::normalize(vector3{1., 1., 0.});
+    traj.dir = vector::normalize(vector3<detray::scalar>{1., 1., 0.});
     traj.ctx = static_transform_store<>::context{};
     traj.momentum = 100.;
     traj.overstep_tolerance = -1e-5;

--- a/tests/common/include/tests/common/tools_planar_intersection.inl
+++ b/tests/common/include/tests/common/tools_planar_intersection.inl
@@ -19,12 +19,12 @@
 using namespace detray;
 
 // Two-dimensional bound frame to surface
-__plugin::cartesian2 cartesian2;
+__plugin::cartesian2<detray::scalar> cartesian2;
 
 // Three-dimensional definitions
-using transform3 = __plugin::transform3;
-using vector3 = __plugin::vector3;
-using point3 = __plugin::point3;
+using transform3 = __plugin::transform3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
+using point3 = __plugin::point3<detray::scalar>;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
 constexpr scalar not_defined = std::numeric_limits<scalar>::infinity();
@@ -49,7 +49,7 @@ TEST(ALGEBRA_PLUGIN, translated_plane) {
                 hit_unbound.p2[1] == not_defined);
 
     // The same test but bound to local frame
-    unmasked<__plugin::cartesian2> unmasked_bound{};
+    unmasked<__plugin::cartesian2<detray::scalar> > unmasked_bound{};
     auto hit_bound = pi.intersect(shifted, point3{2., 1., 0.},
                                   vector3{0., 0., 1.}, unmasked_bound);
     ASSERT_TRUE(hit_bound.status == intersection_status::e_hit);

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -39,7 +39,7 @@ TEST(ALGEBRA_PLUGIN, propagator) {
 
     detray_track traj;
     traj.pos = {0., 0., 0.};
-    traj.dir = vector::normalize(vector3{1., 1., 0.});
+    traj.dir = vector::normalize(__plugin::vector3<detray::scalar>{1., 1., 0.});
     traj.ctx = detray_context{};
     traj.momentum = 100.;
     traj.overstep_tolerance = -1e-4;

--- a/tests/unit_tests/core/grids_grid2.cpp
+++ b/tests/unit_tests/core/grids_grid2.cpp
@@ -36,7 +36,7 @@ TEST(grids, grid2_replace_populator) {
     grid2r g2(std::move(xaxis), std::move(yaxis), host_mr);
 
     // Test the initialization
-    test::point2 p = {-4.5, -4.5};
+    test::point2<detray::scalar> p = {-4.5, -4.5};
     for (unsigned int ib0 = 0; ib0 < 10; ++ib0) {
         for (unsigned int ib1 = 0; ib1 < 10; ++ib1) {
             p = {static_cast<scalar>(-4.5 + ib0),
@@ -118,7 +118,7 @@ TEST(grids, grid2_complete_populator) {
     grid2r g2(std::move(xaxis), std::move(yaxis), host_mr);
 
     // Test the initialization
-    test::point2 p = {-0.5, -0.5};
+    test::point2<detray::scalar> p = {-0.5, -0.5};
     grid2r::populator_t::store_value invalid = {dindex_invalid, dindex_invalid,
                                                 dindex_invalid};
     for (unsigned int ib0 = 0; ib0 < 2; ++ib0) {
@@ -191,7 +191,7 @@ TEST(grids, grid2_attach_populator) {
     grid2r g2(std::move(xaxis), std::move(yaxis), host_mr);
 
     // Test the initialization
-    test::point2 p = {-0.5, -0.5};
+    test::point2<detray::scalar> p = {-0.5, -0.5};
     grid2r::populator_t::store_value invalid = {};
     for (unsigned int ib0 = 0; ib0 < 2; ++ib0) {
         for (unsigned int ib1 = 0; ib1 < 2; ++ib1) {
@@ -246,7 +246,7 @@ TEST(grids, grid2_shift) {
     grid2r g2(std::move(xaxis), std::move(yaxis), host_mr, 0);
 
     // Test the initialization
-    test::point2 p = {-4.5, -4.5};
+    test::point2<detray::scalar> p = {-4.5, -4.5};
     EXPECT_EQ(g2.bin(p), 0u);
 
     g2.shift(8u);
@@ -268,7 +268,7 @@ TEST(grids, grid2_irregular_replace) {
 
     grid2ir g2(std::move(xaxis), std::move(yaxis), host_mr);
 
-    test::point2 p = {-0.5, 0.5};
+    test::point2<detray::scalar> p = {-0.5, 0.5};
     g2.populate(p, 4u);
     EXPECT_EQ(g2.bin(p), 4u);
 }

--- a/tests/unit_tests/core/utils_local_object_finder.cpp
+++ b/tests/unit_tests/core/utils_local_object_finder.cpp
@@ -30,7 +30,7 @@ TEST(utils, local_object_finder) {
 
     serializer2 serializer;
 
-    test::point2 p2 = {-4.5, -4.5};
+    test::point2<detray::scalar> p2 = {-4.5, -4.5};
 
     using grid2r = grid2<replace_populator, axis::regular, axis::regular,
                          decltype(serializer)>;
@@ -49,7 +49,8 @@ TEST(utils, local_object_finder) {
 
     local_single_finder<dindex> local_single(8u);
 
-    using local_finder = std::function<dvector<dindex>(const test::point2 &)>;
+    using local_finder =
+        std::function<dvector<dindex>(const test::point2<detray::scalar> &)>;
 
     std::vector<local_finder> local_finders = {local_zone, local_single};
 

--- a/tests/unit_tests/cuda/CMakeLists.txt
+++ b/tests/unit_tests/cuda/CMakeLists.txt
@@ -16,7 +16,10 @@ add_detray_test(grids_grid2_cuda
 
 # make unit tests for multiple algebras
 # Currently vc and smatrix is not supported
-list(APPEND algebras "array;eigen")
+set( algebras "array" )
+if( DETRAY_EIGEN_PLUGIN )
+  list( APPEND algebras "eigen" )
+endif()
 
 foreach(algebra ${algebras})
 
@@ -46,7 +49,7 @@ foreach(algebra ${algebras})
     LINK_LIBRARIES
     vecmem::cuda detray::${algebra})
   target_compile_definitions(detray_test_${algebra}_tuple_test_cuda PRIVATE ${algebra}=${algebra})
-  
+
   # detector test
   add_detray_test(${algebra}_detector_cuda
     "detector_cuda.cpp"

--- a/tests/unit_tests/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/cuda/grids_grid2_cuda.cpp
@@ -29,7 +29,7 @@ TEST(grids_cuda, grid2_replace_populator) {
 
     // declare host grid
     host_grid2_replace g2(std::move(xaxis), std::move(yaxis), mng_mr,
-                          test::point3{0, 0, 0});
+                          test::point3<detray::scalar>{0, 0, 0});
 
     // pre-check
     for (unsigned int i_x = 0; i_x < xaxis.bins(); i_x++) {
@@ -53,8 +53,9 @@ TEST(grids_cuda, grid2_replace_populator) {
             auto bin_id = i_x + i_y * xaxis.bins();
             const auto& data = g2.bin(i_x, i_y);
 
-            test::point3 tp({xaxis.min + bin_id * x_interval,
-                             yaxis.min + bin_id * y_interval, 0.5});
+            test::point3<detray::scalar> tp({xaxis.min + bin_id * x_interval,
+                                             yaxis.min + bin_id * y_interval,
+                                             0.5});
 
             EXPECT_EQ(data, tp);
         }
@@ -73,7 +74,7 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
 
     // declare host grid
     host_grid2_replace_ci g2(std::move(caxis), std::move(iaxis), mng_mr,
-                             test::point3{0, 0, 0});
+                             test::point3<detray::scalar>{0, 0, 0});
 
     // pre-check
     for (unsigned int i_x = 0; i_x < caxis.bins(); i_x++) {
@@ -99,8 +100,9 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
 
             const auto& data = g2.bin(i_x, i_y);
 
-            test::point3 tp({caxis.min + bin_id * x_interval,
-                             iaxis.min + bin_id * y_interval, 0.5});
+            test::point3<detray::scalar> tp({caxis.min + bin_id * x_interval,
+                                             iaxis.min + bin_id * y_interval,
+                                             0.5});
 
             EXPECT_EQ(data, tp);
         }
@@ -117,7 +119,7 @@ TEST(grids_cuda, grid2_complete_populator) {
 
     // declare grid
     host_grid2_complete g2(std::move(xaxis), std::move(yaxis), mng_mr,
-                           test::point3{0, 0, 0});
+                           test::point3<detray::scalar>{0, 0, 0});
 
     // pre-check
     for (unsigned int i_x = 0; i_x < xaxis.bins(); i_x++) {
@@ -152,8 +154,9 @@ TEST(grids_cuda, grid2_complete_populator) {
                 auto bin_id = i_x + i_y * xaxis.bins();
                 auto gid = i_p + bin_id * data.size();
 
-                test::point3 tp({xaxis.min + gid * x_interval,
-                                 yaxis.min + gid * y_interval, 0.5});
+                test::point3<detray::scalar> tp({xaxis.min + gid * x_interval,
+                                                 yaxis.min + gid * y_interval,
+                                                 0.5});
                 EXPECT_EQ(pt, tp);
             }
         }
@@ -171,7 +174,8 @@ TEST(grids_cuda, grid2_attach_populator) {
     auto x_interval = (xaxis.max - xaxis.min) / xaxis.n_bins;
     auto y_interval = (yaxis.max - yaxis.min) / yaxis.n_bins;
 
-    host_grid2_attach g2(xaxis, yaxis, mng_mr, test::point3{0, 0, 0});
+    host_grid2_attach g2(xaxis, yaxis, mng_mr,
+                         test::point3<detray::scalar>{0, 0, 0});
 
     for (unsigned int i_y = 0; i_y < yaxis.bins(); i_y++) {
         for (unsigned int i_x = 0; i_x < xaxis.bins(); i_x++) {
@@ -181,8 +185,9 @@ TEST(grids_cuda, grid2_attach_populator) {
                 auto bin_id = i_x + i_y * xaxis.bins();
                 auto gid = i_p + bin_id * 100;
 
-                test::point3 tp({xaxis.min + gid * x_interval,
-                                 yaxis.min + gid * y_interval, 0.5});
+                test::point3<detray::scalar> tp({xaxis.min + gid * x_interval,
+                                                 yaxis.min + gid * y_interval,
+                                                 0.5});
                 g2.populate(i_x, i_y, std::move(tp));
             }
         }
@@ -229,7 +234,8 @@ TEST(grids_cuda, grid2_buffer_attach_populator) {
     // fill each bin with 100 points
     grid_attach_fill_test(g2_buffer);
 
-    host_grid2_attach g2(xaxis, yaxis, mng_mr, test::point3{0, 0, 0});
+    host_grid2_attach g2(xaxis, yaxis, mng_mr,
+                         test::point3<detray::scalar>{0, 0, 0});
     copy(g2_buffer._buffer, g2.data());
 
     // Check if each bin has 100 points
@@ -250,14 +256,14 @@ TEST(grids_cuda, grid2_array) {
         {{mng_mr}, {mng_mr}}};
 
     // first grid
-    grid2_array[0] = host_grid2_attach(axis::circular<>{2, 0., 2., mng_mr},
-                                       axis::regular<>{2, 2., 4., mng_mr},
-                                       mng_mr, test::point3{0, 0, 0});
+    grid2_array[0] = host_grid2_attach(
+        axis::circular<>{2, 0., 2., mng_mr}, axis::regular<>{2, 2., 4., mng_mr},
+        mng_mr, test::point3<detray::scalar>{0, 0, 0});
 
     // second grid
-    grid2_array[1] = host_grid2_attach(axis::circular<>{3, 0., 3., mng_mr},
-                                       axis::regular<>{3, 2., 5., mng_mr},
-                                       mng_mr, test::point3{0, 0, 0});
+    grid2_array[1] = host_grid2_attach(
+        axis::circular<>{3, 0., 3., mng_mr}, axis::regular<>{3, 2., 5., mng_mr},
+        mng_mr, test::point3<detray::scalar>{0, 0, 0});
 
     // fill out the grid
     for (unsigned int i_g = 0; i_g < grid2_array.size(); i_g++) {
@@ -267,7 +273,7 @@ TEST(grids_cuda, grid2_array) {
 
         for (unsigned int i_y = 0; i_y < yaxis.bins(); i_y++) {
             for (unsigned int i_x = 0; i_x < xaxis.bins(); i_x++) {
-                test::point3 tp({i_x, i_y, 0.});
+                test::point3<detray::scalar> tp({i_x, i_y, 0.});
                 g2.populate(i_x, i_y, std::move(tp));
             }
         }
@@ -279,24 +285,24 @@ TEST(grids_cuda, grid2_array) {
     auto grid2_view_array = make_grid_view_array(grid2_data_array);
 
     // output vector to readout grid elements
-    vecmem::vector<test::point3> outputs(13, &mng_mr);
+    vecmem::vector<test::point3<detray::scalar> > outputs(13, &mng_mr);
     auto outputs_data = vecmem::get_data(outputs);
 
     // run the test kernel
     grid_array_test(grid2_view_array, outputs_data);
 
     // checkout the results
-    EXPECT_EQ(outputs[0], test::point3({0, 0, 0}));
-    EXPECT_EQ(outputs[1], test::point3({1, 0, 0}));
-    EXPECT_EQ(outputs[2], test::point3({0, 1, 0}));
-    EXPECT_EQ(outputs[3], test::point3({1, 1, 0}));
-    EXPECT_EQ(outputs[4], test::point3({0, 0, 0}));
-    EXPECT_EQ(outputs[5], test::point3({1, 0, 0}));
-    EXPECT_EQ(outputs[6], test::point3({2, 0, 0}));
-    EXPECT_EQ(outputs[7], test::point3({0, 1, 0}));
-    EXPECT_EQ(outputs[8], test::point3({1, 1, 0}));
-    EXPECT_EQ(outputs[9], test::point3({2, 1, 0}));
-    EXPECT_EQ(outputs[10], test::point3({0, 2, 0}));
-    EXPECT_EQ(outputs[11], test::point3({1, 2, 0}));
-    EXPECT_EQ(outputs[12], test::point3({2, 2, 0}));
+    EXPECT_EQ(outputs[0], test::point3<detray::scalar>({0, 0, 0}));
+    EXPECT_EQ(outputs[1], test::point3<detray::scalar>({1, 0, 0}));
+    EXPECT_EQ(outputs[2], test::point3<detray::scalar>({0, 1, 0}));
+    EXPECT_EQ(outputs[3], test::point3<detray::scalar>({1, 1, 0}));
+    EXPECT_EQ(outputs[4], test::point3<detray::scalar>({0, 0, 0}));
+    EXPECT_EQ(outputs[5], test::point3<detray::scalar>({1, 0, 0}));
+    EXPECT_EQ(outputs[6], test::point3<detray::scalar>({2, 0, 0}));
+    EXPECT_EQ(outputs[7], test::point3<detray::scalar>({0, 1, 0}));
+    EXPECT_EQ(outputs[8], test::point3<detray::scalar>({1, 1, 0}));
+    EXPECT_EQ(outputs[9], test::point3<detray::scalar>({2, 1, 0}));
+    EXPECT_EQ(outputs[10], test::point3<detray::scalar>({0, 2, 0}));
+    EXPECT_EQ(outputs[11], test::point3<detray::scalar>({1, 2, 0}));
+    EXPECT_EQ(outputs[12], test::point3<detray::scalar>({2, 2, 0}));
 }

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
@@ -29,8 +29,8 @@ __global__ void grid_replace_test_kernel(
     auto y_interval = (axis1.max - axis1.min) / axis1.n_bins;
 
     auto gid = threadIdx.x + threadIdx.y * blockDim.x;
-    auto pt = test::point3{axis0.min + gid * x_interval,
-                           axis1.min + gid * y_interval, 0.5};
+    auto pt = test::point3<detray::scalar>{axis0.min + gid * x_interval,
+                                           axis1.min + gid * y_interval, 0.5};
 
     // replace the bin elements
     g2_device.populate(threadIdx.x, threadIdx.y, std::move(pt));
@@ -67,8 +67,8 @@ __global__ void grid_replace_ci_test_kernel(
         axis1.boundaries[threadIdx.y + 1] - axis1.boundaries[threadIdx.y];
 
     auto gid = threadIdx.x + threadIdx.y * blockDim.x;
-    auto pt = test::point3{axis0.min + gid * x_interval,
-                           axis1.min + gid * y_interval, 0.5};
+    auto pt = test::point3<detray::scalar>{axis0.min + gid * x_interval,
+                                           axis1.min + gid * y_interval, 0.5};
 
     // replace the bin elements
     g2_device.populate(threadIdx.x, threadIdx.y, std::move(pt));
@@ -100,7 +100,8 @@ __global__ void grid_complete_kernel(
     grid2_view<host_grid2_complete> grid_view) {
 
     // Let's try building the grid object
-    device_grid2_complete g2_device(grid_view, test::point3{0, 0, 0});
+    device_grid2_complete g2_device(grid_view,
+                                    test::point3<detray::scalar>{0, 0, 0});
 
     const auto& axis0 = g2_device.axis_p0();
     const auto& axis1 = g2_device.axis_p1();
@@ -112,8 +113,8 @@ __global__ void grid_complete_kernel(
 
     for (int i_p = 0; i_p < n_points; i_p++) {
         auto gid = i_p + bin_id * n_points;
-        auto pt = test::point3{axis0.min + gid * x_interval,
-                               axis1.min + gid * y_interval, 0.5};
+        auto pt = test::point3<detray::scalar>{
+            axis0.min + gid * x_interval, axis1.min + gid * y_interval, 0.5};
         // printf("%f %f %f \n", pt[0], pt[1], pt[2]);
         g2_device.populate(threadIdx.x, threadIdx.y, std::move(pt));
     }
@@ -145,7 +146,8 @@ __global__ void grid_attach_read_test_kernel(
     grid2_view<host_grid2_attach> grid_view) {
 
     // Let's try building the grid object
-    device_grid2_attach g2_device(grid_view, test::point3{0, 0, 0});
+    device_grid2_attach g2_device(grid_view,
+                                  test::point3<detray::scalar>{0, 0, 0});
 
     auto data = g2_device.bin(threadIdx.x, threadIdx.y);
 
@@ -183,8 +185,8 @@ __global__ void grid_attach_fill_test_kernel(
     device_grid2_attach g2_device(grid_view);
 
     // Fill with 100 points
-    auto pt =
-        test::point3{1. * threadIdx.x, 1. * threadIdx.x, 1. * threadIdx.x};
+    auto pt = test::point3<detray::scalar>{1. * threadIdx.x, 1. * threadIdx.x,
+                                           1. * threadIdx.x};
     g2_device.populate(blockIdx.x, blockIdx.y, std::move(pt));
 
     __syncthreads();
@@ -218,12 +220,13 @@ void grid_attach_fill_test(grid2_view<host_grid2_attach> grid_view) {
 template <template <typename, size_t> class array_type>
 __global__ void grid_array_test_kernel(
     array_type<grid2_view<host_grid2_attach>, 2> grid_array,
-    vecmem::data::vector_view<test::point3> outputs_data) {
+    vecmem::data::vector_view<test::point3<detray::scalar>> outputs_data) {
 
     // get the device objects from input arguments
     array_type<device_grid2_attach, 2> grid2_device_array{
         {{grid_array[0]}, {grid_array[1]}}};
-    vecmem::device_vector<test::point3> outputs_device(outputs_data);
+    vecmem::device_vector<test::point3<detray::scalar>> outputs_device(
+        outputs_data);
 
     // fill the output vector with grid elements
     int counts = 0;
@@ -250,7 +253,7 @@ __global__ void grid_array_test_kernel(
 template <>
 void grid_array_test(
     vecmem::static_array<grid2_view<host_grid2_attach>, 2> grid_array,
-    vecmem::data::vector_view<test::point3>& outputs_data) {
+    vecmem::data::vector_view<test::point3<detray::scalar>>& outputs_data) {
     // run the kernel
     grid_array_test_kernel<<<1, 1>>>(grid_array, outputs_data);
 

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.hpp
@@ -25,42 +25,42 @@ static constexpr int n_points = 3;
 using host_grid2_replace =
     grid2<replace_populator, axis::regular, axis::regular, serializer2,
           vecmem::vector, vecmem::jagged_vector, darray, std::tuple,
-          test::point3>;
+          test::point3<detray::scalar> >;
 
 using device_grid2_replace =
     grid2<replace_populator, axis::regular, axis::regular, serializer2,
           vecmem::device_vector, vecmem::jagged_device_vector, darray,
-          std::tuple, test::point3>;
+          std::tuple, test::point3<detray::scalar> >;
 
 using host_grid2_replace_ci =
     grid2<replace_populator, axis::circular, axis::irregular, serializer2,
           vecmem::vector, vecmem::jagged_vector, darray, std::tuple,
-          test::point3>;
+          test::point3<detray::scalar> >;
 
 using device_grid2_replace_ci =
     grid2<replace_populator, axis::circular, axis::irregular, serializer2,
           vecmem::device_vector, vecmem::jagged_device_vector, darray,
-          std::tuple, test::point3>;
+          std::tuple, test::point3<detray::scalar> >;
 
 using host_grid2_complete =
     grid2<complete_populator, axis::regular, axis::regular, serializer2,
           vecmem::vector, vecmem::jagged_vector, darray, std::tuple,
-          test::point3, false, n_points>;
+          test::point3<detray::scalar>, false, n_points>;
 
 using device_grid2_complete =
     grid2<complete_populator, axis::regular, axis::regular, serializer2,
           vecmem::device_vector, vecmem::jagged_device_vector, darray,
-          std::tuple, test::point3, false, n_points>;
+          std::tuple, test::point3<detray::scalar>, false, n_points>;
 
 using host_grid2_attach =
     grid2<attach_populator, axis::circular, axis::regular, serializer2,
           vecmem::vector, vecmem::jagged_vector, darray, std::tuple,
-          test::point3, false>;
+          test::point3<detray::scalar>, false>;
 
 using device_grid2_attach =
     grid2<attach_populator, axis::circular, axis::regular, serializer2,
           vecmem::device_vector, vecmem::jagged_device_vector, darray,
-          std::tuple, test::point3, false>;
+          std::tuple, test::point3<detray::scalar>, false>;
 
 // test function for replace populator
 void grid_replace_test(grid2_view<host_grid2_replace> grid_view);
@@ -79,7 +79,8 @@ void grid_attach_fill_test(grid2_view<host_grid2_attach> grid_view);
 
 // read test function for grid array
 template <template <typename, size_t> class array_type>
-void grid_array_test(array_type<grid2_view<host_grid2_attach>, 2> grid_array,
-                     vecmem::data::vector_view<test::point3>& outputs_data);
+void grid_array_test(
+    array_type<grid2_view<host_grid2_attach>, 2> grid_array,
+    vecmem::data::vector_view<test::point3<detray::scalar> >& outputs_data);
 
 }  // namespace detray

--- a/tests/unit_tests/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/cuda/mask_store_cuda.cpp
@@ -16,6 +16,8 @@
 
 TEST(mask_store_cuda, mask_store) {
 
+    using cartesian2 = __plugin::cartesian2<detray::scalar>;
+
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;
 

--- a/tests/unit_tests/cuda/mask_store_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/mask_store_cuda_kernel.cu
@@ -20,6 +20,8 @@ __global__ void mask_test_kernel(
     vecmem::data::vector_view<point3> input_point3_data,
     vecmem::data::jagged_vector_view<intersection_status> output_data) {
 
+    using cartesian2 = __plugin::cartesian2<detray::scalar>;
+
     /** get mask store **/
     mask_store<thrust::tuple, vecmem::device_vector, rectangle, trapezoid, ring,
                cylinder, single, annulus>

--- a/tests/unit_tests/cuda/mask_store_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/mask_store_cuda_kernel.hpp
@@ -27,7 +27,6 @@
 #pragma once
 
 using namespace detray;
-using namespace __plugin;
 
 const int n_points = 1000;
 

--- a/tests/unit_tests/cuda/transform_store_cuda.cpp
+++ b/tests/unit_tests/cuda/transform_store_cuda.cpp
@@ -14,6 +14,10 @@
 #include "transform_store_cuda_kernel.hpp"
 
 TEST(transform_store_cuda, transform_store) {
+
+    using point3 = __plugin::point3<detray::scalar>;
+    using transform3 = __plugin::transform3<detray::scalar>;
+
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;
 

--- a/tests/unit_tests/cuda/transform_store_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/transform_store_cuda_kernel.cu
@@ -13,15 +13,15 @@
 namespace detray {
 
 __global__ void transform_test_kernel(
-    vecmem::data::vector_view<point3> input_data,
+    vecmem::data::vector_view<point3<detray::scalar>> input_data,
     static_transform_store_data<static_transform_store<>> store_data,
-    vecmem::data::vector_view<point3> output_data) {
+    vecmem::data::vector_view<point3<detray::scalar>> output_data) {
 
     static_transform_store<vecmem::device_vector>::context ctx0;
     static_transform_store<vecmem::device_vector> store(store_data);
 
-    vecmem::device_vector<point3> input(input_data);
-    vecmem::device_vector<point3> output(output_data);
+    vecmem::device_vector<point3<detray::scalar>> input(input_data);
+    vecmem::device_vector<point3<detray::scalar>> output(output_data);
 
     auto range = store.range(0, store.size(ctx0), ctx0);
     output[threadIdx.x] =
@@ -29,9 +29,9 @@ __global__ void transform_test_kernel(
 }
 
 void transform_test(
-    vecmem::data::vector_view<point3>& input_data,
+    vecmem::data::vector_view<point3<detray::scalar>>& input_data,
     static_transform_store_data<static_transform_store<>>& store_data,
-    vecmem::data::vector_view<point3>& output_data) {
+    vecmem::data::vector_view<point3<detray::scalar>>& output_data) {
 
     int block_dim = 1;
     int thread_dim(store_data._data.size());

--- a/tests/unit_tests/cuda/transform_store_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/transform_store_cuda_kernel.hpp
@@ -25,7 +25,7 @@ using namespace __plugin;
 namespace detray {
 
 void transform_test(
-    vecmem::data::vector_view<point3>& input_data,
+    vecmem::data::vector_view<point3<detray::scalar> >& input_data,
     static_transform_store_data<static_transform_store<> >& store_data,
-    vecmem::data::vector_view<point3>& output_data);
+    vecmem::data::vector_view<point3<detray::scalar> >& output_data);
 }


### PR DESCRIPTION
Adapted the code to the removal of `algebra::scalar`, as implemented in https://github.com/acts-project/algebra-plugins/pull/44.

The [algebra-plugins](https://github.com/acts-project/algebra-plugins) code no longer makes a decision during compilation about the scalar type that it would let its clients use. The clients need to make that decision themselves.

The Detray code is still making this decision during the CMake configuration, with the revival of the `DETRAY_CUSTOM_SCALARTYPE` cache variable. But later on of course I'll want to get rid of `detray::scalar` as well, making all types in this repository work with any scalar type "at the same time". (Allowing users to create separate instances of Detray types side-by-side, which may use different scalar types. Which they'll receive through template parameters.)

For now this is just a draft. I needed to test https://github.com/acts-project/algebra-plugins/pull/44 with these changes. Once/if that PR is accepted, this PR will be updated to build a new release of [algebra-plugins](https://github.com/acts-project/algebra-plugins) by default.