### PR TITLE
Add an unit test for array of grid

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -42,6 +42,7 @@ detray_add_library( detray_core core
    "include/detray/tools/concentric_cylinder_intersector.hpp"
    "include/detray/tools/cylinder_intersector.hpp"
    "include/detray/tools/geometry_graph.hpp"
+   "include/detray/tools/grid_array_helper.hpp"
    "include/detray/tools/intersection_kernel.hpp"
    "include/detray/tools/line_stepper.hpp"
    "include/detray/tools/local_object_finder.hpp"

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -44,6 +44,13 @@ struct regular {
           boundaries({}) {}
 
     /** Constructor with vecmem memory resource **/
+    regular(vecmem::memory_resource &resource)
+        : n_bins(invalid_value<dindex>()),
+          min(0.),
+          max(static_cast<scalar>(n_bins)),
+          boundaries(&resource) {}
+
+    /** Constructor with vecmem memory resource **/
     DETRAY_HOST
     regular(dindex axis_bins, scalar axis_min, scalar axis_max,
             vecmem::memory_resource &resource)
@@ -229,6 +236,13 @@ struct circular {
           min(0.),
           max(static_cast<scalar>(n_bins)),
           boundaries({}) {}
+
+    /** Constructor with vecmem memory resource **/
+    circular(vecmem::memory_resource &resource)
+        : n_bins(invalid_value<dindex>()),
+          min(0.),
+          max(static_cast<scalar>(n_bins)),
+          boundaries(&resource) {}
 
     /** Constructor with vecmem memory resource **/
     DETRAY_HOST
@@ -440,8 +454,11 @@ struct irregular {
           boundaries({}) {}
 
     /** Constructor with vecmem memory resource **/
-    DETRAY_HOST irregular(vecmem::memory_resource &resource)
-        : boundaries(&resource) {}
+    irregular(vecmem::memory_resource &resource)
+        : n_bins(invalid_value<dindex>()),
+          min(0.),
+          max(static_cast<scalar>(n_bins)),
+          boundaries(&resource) {}
 
     /** Constructor with vecmem memory resource - rvalue **/
     DETRAY_HOST irregular(vector_type<scalar> &&bins,

--- a/core/include/detray/grids/grid2.hpp
+++ b/core/include/detray/grids/grid2.hpp
@@ -59,6 +59,16 @@ class grid2 {
     static constexpr array_type<dindex, 2> hermit1 = {0u, 0u};
     static constexpr neighborhood<dindex> hermit2 = {hermit1, hermit1};
 
+    grid2() = delete;
+
+    DETRAY_HOST
+    grid2(vecmem::memory_resource &mr,
+          const bare_value m_invalid = invalid_value<bare_value>())
+        : _axis_p0(mr),
+          _axis_p1(mr),
+          _data_serialized(&mr),
+          _populator(m_invalid) {}
+
     /** Constructor from axes - copy semantics
      *
      * @param axis_p0 is the axis in the first coordinate
@@ -96,9 +106,11 @@ class grid2 {
 
     /** Constructor from grid data
      **/
-    template <
-        typename grid_view_type,
-        std::enable_if_t<!std::is_same_v<grid2, grid_view_type>, bool> = true>
+    template <typename grid_view_type,
+              std::enable_if_t<!std::is_same_v<grid2, grid_view_type> &&
+                                   !std::is_base_of_v<vecmem::memory_resource,
+                                                      grid_view_type>,
+                               bool> = true>
     DETRAY_DEVICE grid2(
         grid_view_type &grid_data,
         const bare_value m_invalid = invalid_value<bare_value>())

--- a/core/include/detray/tools/grid_array_helper.hpp
+++ b/core/include/detray/tools/grid_array_helper.hpp
@@ -14,6 +14,9 @@
 
 namespace detray {
 
+/**
+ * detailed implementation of make_grid_data_array with index_sequence
+ */
 template <typename grid_type, std::size_t N, std::size_t... ints>
 auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
                           vecmem::memory_resource& resource,
@@ -23,6 +26,12 @@ auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
         get_data(arr[ints], resource)...};
 }
 
+/**
+ * Make the array of grid2_data from the array of grid2
+ * @param arr is the input array of grid2
+ * @param resource is the memory_resource
+ * @return is the output array of grid2_data
+ */
 template <typename grid_type, std::size_t N>
 auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
                           vecmem::memory_resource& resource) {
@@ -30,12 +39,21 @@ auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
     return make_grid_data_array(arr, resource, seq);
 }
 
+/**
+ * detailed implementation of make_grid_view_array with index_sequence
+ */
 template <typename grid_type, std::size_t N, std::size_t... ints>
 auto make_grid_view_array(vecmem::static_array<grid2_data<grid_type>, N>& arr,
                           std::index_sequence<ints...> seq) {
     return vecmem::static_array<grid2_view<grid_type>, N>{arr[ints]...};
 }
 
+/**
+ * Make the array of grid2_data from the array of grid2
+ * @param arr is the input array of grid2_data
+ * @param resource is the memory_resource
+ * @return is the output array of grid2_view
+ */
 template <typename grid_type, std::size_t N>
 auto make_grid_view_array(vecmem::static_array<grid2_data<grid_type>, N>& arr) {
     auto seq = std::make_index_sequence<N>{};

--- a/core/include/detray/tools/grid_array_helper.hpp
+++ b/core/include/detray/tools/grid_array_helper.hpp
@@ -20,8 +20,7 @@ namespace detray {
 template <typename grid_type, std::size_t N, std::size_t... ints>
 auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
                           vecmem::memory_resource& resource,
-                          std::index_sequence<ints...> seq) {
-
+                          std::index_sequence<ints...> /*seq*/) {
     return vecmem::static_array<grid2_data<grid_type>, N>{
         get_data(arr[ints], resource)...};
 }
@@ -35,8 +34,7 @@ auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
 template <typename grid_type, std::size_t N>
 auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
                           vecmem::memory_resource& resource) {
-    auto seq = std::make_index_sequence<N>{};
-    return make_grid_data_array(arr, resource, seq);
+    return make_grid_data_array(arr, resource, std::make_index_sequence<N>{});
 }
 
 /**
@@ -44,7 +42,7 @@ auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
  */
 template <typename grid_type, std::size_t N, std::size_t... ints>
 auto make_grid_view_array(vecmem::static_array<grid2_data<grid_type>, N>& arr,
-                          std::index_sequence<ints...> seq) {
+                          std::index_sequence<ints...> /*seq*/) {
     return vecmem::static_array<grid2_view<grid_type>, N>{arr[ints]...};
 }
 
@@ -56,8 +54,7 @@ auto make_grid_view_array(vecmem::static_array<grid2_data<grid_type>, N>& arr,
  */
 template <typename grid_type, std::size_t N>
 auto make_grid_view_array(vecmem::static_array<grid2_data<grid_type>, N>& arr) {
-    auto seq = std::make_index_sequence<N>{};
-    return make_grid_view_array(arr, seq);
+    return make_grid_view_array(arr, std::make_index_sequence<N>{});
 }
 
 }  // namespace detray

--- a/core/include/detray/tools/grid_array_helper.hpp
+++ b/core/include/detray/tools/grid_array_helper.hpp
@@ -1,0 +1,45 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <array>
+#include <detray/grids/grid2.hpp>
+#include <vecmem/containers/static_array.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+
+namespace detray {
+
+template <typename grid_type, std::size_t N, std::size_t... ints>
+auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
+                          vecmem::memory_resource& resource,
+                          std::index_sequence<ints...> seq) {
+
+    return vecmem::static_array<grid2_data<grid_type>, N>{
+        get_data(arr[ints], resource)...};
+}
+
+template <typename grid_type, std::size_t N>
+auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
+                          vecmem::memory_resource& resource) {
+    auto seq = std::make_index_sequence<N>{};
+    return make_grid_data_array(arr, resource, seq);
+}
+
+template <typename grid_type, std::size_t N, std::size_t... ints>
+auto make_grid_view_array(vecmem::static_array<grid2_data<grid_type>, N>& arr,
+                          std::index_sequence<ints...> seq) {
+    return vecmem::static_array<grid2_view<grid_type>, N>{arr[ints]...};
+}
+
+template <typename grid_type, std::size_t N>
+auto make_grid_view_array(vecmem::static_array<grid2_data<grid_type>, N>& arr) {
+    auto seq = std::make_index_sequence<N>{};
+    return make_grid_view_array(arr, seq);
+}
+
+}  // namespace detray

--- a/core/include/detray/tools/grid_array_helper.hpp
+++ b/core/include/detray/tools/grid_array_helper.hpp
@@ -17,11 +17,12 @@ namespace detray {
 /**
  * detailed implementation of make_grid_data_array with index_sequence
  */
-template <typename grid_type, std::size_t N, std::size_t... ints>
-auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
+template <template <typename, size_t> class array_type, typename grid_type,
+          std::size_t N, std::size_t... ints>
+auto make_grid_data_array(array_type<grid_type, N>& arr,
                           vecmem::memory_resource& resource,
                           std::index_sequence<ints...> /*seq*/) {
-    return vecmem::static_array<grid2_data<grid_type>, N>{
+    return array_type<grid2_data<grid_type>, N>{
         get_data(arr[ints], resource)...};
 }
 
@@ -31,8 +32,9 @@ auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
  * @param resource is the memory_resource
  * @return is the output array of grid2_data
  */
-template <typename grid_type, std::size_t N>
-auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
+template <template <typename, size_t> class array_type, typename grid_type,
+          std::size_t N>
+auto make_grid_data_array(array_type<grid_type, N>& arr,
                           vecmem::memory_resource& resource) {
     return make_grid_data_array(arr, resource, std::make_index_sequence<N>{});
 }
@@ -40,10 +42,11 @@ auto make_grid_data_array(vecmem::static_array<grid_type, N>& arr,
 /**
  * detailed implementation of make_grid_view_array with index_sequence
  */
-template <typename grid_type, std::size_t N, std::size_t... ints>
-auto make_grid_view_array(vecmem::static_array<grid2_data<grid_type>, N>& arr,
+template <template <typename, size_t> class array_type, typename grid_type,
+          std::size_t N, std::size_t... ints>
+auto make_grid_view_array(array_type<grid2_data<grid_type>, N>& arr,
                           std::index_sequence<ints...> /*seq*/) {
-    return vecmem::static_array<grid2_view<grid_type>, N>{arr[ints]...};
+    return array_type<grid2_view<grid_type>, N>{arr[ints]...};
 }
 
 /**
@@ -52,8 +55,9 @@ auto make_grid_view_array(vecmem::static_array<grid2_data<grid_type>, N>& arr,
  * @param resource is the memory_resource
  * @return is the output array of grid2_view
  */
-template <typename grid_type, std::size_t N>
-auto make_grid_view_array(vecmem::static_array<grid2_data<grid_type>, N>& arr) {
+template <template <typename, size_t> class array_type, typename grid_type,
+          std::size_t N>
+auto make_grid_view_array(array_type<grid2_data<grid_type>, N>& arr) {
     return make_grid_view_array(arr, std::make_index_sequence<N>{});
 }
 

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the Detray project" )
 
 # Declare where to get VecMem from.
 set( DETRAY_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.6.0.tar.gz;URL_MD5;d741067ff148d2df3c4e6d4587d65fdc"
+   "GIT_REPOSITORY;https://github.com/acts-project/vecmem;GIT_TAG;3950939125ee08924a5b37b411e2baa846ed8682"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( DETRAY_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${DETRAY_VECMEM_SOURCE} )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the Detray project" )
 
 # Declare where to get VecMem from.
 set( DETRAY_VECMEM_SOURCE
-   "GIT_REPOSITORY;https://github.com/acts-project/vecmem;GIT_TAG;3950939125ee08924a5b37b411e2baa846ed8682"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.8.0.tar.gz;URL_MD5;5394f2366e7a494852438cd1e7ef09a2"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( DETRAY_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${DETRAY_VECMEM_SOURCE} )

--- a/tests/unit_tests/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/cuda/grids_grid2_cuda.cpp
@@ -248,6 +248,8 @@ TEST(grids_cuda, grid2_array) {
     // declare the array of grids
     vecmem::static_array<host_grid2_attach, 2> grid2_array{
         {{mng_mr}, {mng_mr}}};
+    // std::array<host_grid2_attach, 2> grid2_array{
+    //   {{mng_mr}, {mng_mr}}};
 
     // first grid
     grid2_array[0] = host_grid2_attach(axis::circular<>{2, 0., 2., mng_mr},

--- a/tests/unit_tests/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/cuda/grids_grid2_cuda.cpp
@@ -248,8 +248,6 @@ TEST(grids_cuda, grid2_array) {
     // declare the array of grids
     vecmem::static_array<host_grid2_attach, 2> grid2_array{
         {{mng_mr}, {mng_mr}}};
-    // std::array<host_grid2_attach, 2> grid2_array{
-    //   {{mng_mr}, {mng_mr}}};
 
     // first grid
     grid2_array[0] = host_grid2_attach(axis::circular<>{2, 0., 2., mng_mr},

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
@@ -214,4 +214,29 @@ void grid_attach_fill_test(grid2_view<host_grid2_attach> grid_view) {
     DETRAY_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 }
 
+// cuda kernel for array_test
+__global__ void grid_array_test_kernel(
+    vecmem::static_array<grid2_view<host_grid2_attach>, 2> grid_array) {
+
+    vecmem::static_array<device_grid2_attach, 2> grid_device_array{
+        {{grid_array[0]}, {grid_array[1]}}};
+
+    auto data = grid_device_array[0].bin(1, 1);
+}
+
+// read test function for grid array
+void grid_array_test(
+    vecmem::static_array<grid2_view<host_grid2_attach>, 2> grid_array) {
+
+    int block_dim = 1;
+    int thread_dim = 1;
+
+    // run the kernel
+    grid_array_test_kernel<<<block_dim, thread_dim>>>(grid_array);
+
+    // cuda error check
+    DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());
+    DETRAY_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+}
+
 }  // namespace detray

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
@@ -246,18 +246,6 @@ __global__ void grid_array_test_kernel(
     }
 }
 
-// read test function for grid array with std::array
-template <>
-void grid_array_test(std::array<grid2_view<host_grid2_attach>, 2> grid_array,
-                     vecmem::data::vector_view<test::point3>& outputs_data) {
-    // run the kernel
-    grid_array_test_kernel<<<1, 1>>>(grid_array, outputs_data);
-
-    // cuda error check
-    DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());
-    DETRAY_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
-}
-
 // read test function for grid array with vecmem::static_array
 template <>
 void grid_array_test(

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
@@ -222,6 +222,10 @@ __global__ void grid_array_test_kernel(
         {{grid_array[0]}, {grid_array[1]}}};
 
     auto data = grid_device_array[0].bin(1, 1);
+
+    for (auto& pt : data) {
+        // printf("%f %f %f \n", pt[0], pt[1], pt[2]);
+    }
 }
 
 // read test function for grid array

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.hpp
@@ -79,6 +79,7 @@ void grid_attach_fill_test(grid2_view<host_grid2_attach> grid_view);
 
 // read test function for grid array
 void grid_array_test(
-    vecmem::static_array<grid2_view<host_grid2_attach>, 2> grid_array);
+    vecmem::static_array<grid2_view<host_grid2_attach>, 2> grid_array,
+    vecmem::data::vector_view<test::point3>& outputs_data);
 
 }  // namespace detray

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.hpp
@@ -78,8 +78,8 @@ void grid_attach_read_test(grid2_view<host_grid2_attach> grid_view);
 void grid_attach_fill_test(grid2_view<host_grid2_attach> grid_view);
 
 // read test function for grid array
-void grid_array_test(
-    vecmem::static_array<grid2_view<host_grid2_attach>, 2> grid_array,
-    vecmem::data::vector_view<test::point3>& outputs_data);
+template <template <typename, size_t> class array_type>
+void grid_array_test(array_type<grid2_view<host_grid2_attach>, 2> grid_array,
+                     vecmem::data::vector_view<test::point3>& outputs_data);
 
 }  // namespace detray

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.hpp
@@ -13,6 +13,7 @@
 #include "detray/grids/grid2.hpp"
 #include "detray/grids/populator.hpp"
 #include "detray/grids/serializer2.hpp"
+#include "detray/tools/grid_array_helper.hpp"
 #include "detray/utils/indexing.hpp"
 
 #pragma once
@@ -75,5 +76,9 @@ void grid_attach_read_test(grid2_view<host_grid2_attach> grid_view);
 
 // fill test function for grid buffer with attach populator
 void grid_attach_fill_test(grid2_view<host_grid2_attach> grid_view);
+
+// read test function for grid array
+void grid_array_test(
+    vecmem::static_array<grid2_view<host_grid2_attach>, 2> grid_array);
 
 }  // namespace detray


### PR DESCRIPTION
In detector class, there was `vector_type<grid>`, a.k.a surfaces_finder, which is commented out now.
Since `grid` already contains `vector_type` within it, we can not utilize the vecmem interface.

So I may propose using `array_type<grid, N>`, which I added a very simple unit test for it.

The problem is that the number of surfaces finders should get into the template argument. and this will lead us to define detector-specific struct which contains (hard-coded...) the number of surfaces finders, etc.

I strongly understand that it will mess up a few things indeed... but thinking of better alternatives is beyond my knowledge honestly :(

People who is going to review this can suggest alternatives or opinions on this.



 