### PR TITLE
Add surface finder to detector class

### DIFF
--- a/io/csv/include/detray/io/csv_io.hpp
+++ b/io/csv/include/detray/io/csv_io.hpp
@@ -20,7 +20,6 @@
 #include "detray/grids/serializer2.hpp"
 #include "detray/io/csv_io_types.hpp"
 #include "detray/tools/bin_association.hpp"
-#include "tests/common/tools/detector_registry.hpp"
 
 namespace detray {
 
@@ -43,7 +42,7 @@ namespace detray {
 /// z
 ///
 /// @return a detector object
-template <typename detector_registry = detector_registry::tml_detector,
+template <typename detector_registry,
           template <typename, unsigned int> class array_type = darray,
           template <typename...> class tuple_type = dtuple,
           template <typename...> class vector_type = dvector,

--- a/tests/common/include/tests/common/benchmark_find_volume.inl
+++ b/tests/common/include/tests/common/benchmark_find_volume.inl
@@ -15,6 +15,7 @@
 #include "detray/core/detector.hpp"
 #include "detray/core/transform_store.hpp"
 #include "detray/io/csv_io.hpp"
+#include "tests/common/tools/detector_registry.hpp"
 #include "tests/common/tools/read_geometry.hpp"
 
 using namespace detray;
@@ -26,7 +27,8 @@ unsigned int gbench_repetitions = 0;
 #endif
 
 vecmem::host_memory_resource host_mr;
-auto [d, name_map] = read_from_csv(tml_files, host_mr);
+auto [d, name_map] =
+    read_from_csv<detector_registry::tml_detector>(tml_files, host_mr);
 
 const unsigned int itest = 10000;
 

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -18,6 +18,7 @@
 #include "detray/io/csv_io.hpp"
 #include "detray/tools/intersection_kernel.hpp"
 #include "detray/utils/enumerate.hpp"
+#include "tests/common/tools/detector_registry.hpp"
 #include "tests/common/tools/read_geometry.hpp"
 
 using namespace detray;
@@ -33,7 +34,8 @@ unsigned int phi_steps = 100;
 bool stream_file = false;
 
 vecmem::host_memory_resource host_mr;
-auto [d, name_map] = read_from_csv(tml_files, host_mr);
+auto [d, name_map] =
+    read_from_csv<detector_registry::tml_detector>(tml_files, host_mr);
 
 using detector_t = decltype(d);
 constexpr auto k_surfaces = detector_t::object_id::e_surface;

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -11,6 +11,7 @@
 
 #include "detray/core/detector.hpp"
 #include "detray/core/transform_store.hpp"
+#include "tests/common/tools/detector_registry.hpp"
 
 /// @note __plugin has to be defined with a preprocessor command
 
@@ -21,7 +22,7 @@ TEST(ALGEBRA_PLUGIN, detector) {
     using namespace detray;
     using point3 = __plugin::point3<detray::scalar>;
 
-    using detector_t = detector<>;
+    using detector_t = detector<detector_registry::default_detector>;
 
     static_transform_store<>::context ctx0;
 
@@ -44,7 +45,7 @@ TEST(ALGEBRA_PLUGIN, detector) {
     trfs[detector_t::e_trapezoid2].emplace_back(ctx0, t2);
     masks.template add_mask<detector_t::e_trapezoid2>(1., 2., 3.);
 
-    detector d(host_mr);
+    detector_t d(host_mr);
 
     auto &v = d.new_volume({0., 10., -5., 5., -M_PI, M_PI});
     d.add_objects(ctx0, v, surfaces, masks, trfs);

--- a/tests/common/include/tests/common/io_read_detector.inl
+++ b/tests/common/include/tests/common/io_read_detector.inl
@@ -15,6 +15,7 @@
 #include "detray/core/detector.hpp"
 #include "detray/core/transform_store.hpp"
 #include "detray/io/csv_io.hpp"
+#include "tests/common/tools/detector_registry.hpp"
 #include "tests/common/tools/read_geometry.hpp"
 
 /// @note __plugin has to be defined with a preprocessor command
@@ -24,7 +25,8 @@ TEST(ALGEBRA_PLUGIN, read_detector) {
     vecmem::host_memory_resource host_mr;
     using namespace detray;
 
-    auto [d, name_map] = read_from_csv(tml_files, host_mr);
+    auto [d, name_map] =
+        read_from_csv<detector_registry::tml_detector>(tml_files, host_mr);
 
     std::cout << d.to_string(name_map) << std::endl;
 }

--- a/tests/common/include/tests/common/tools/create_toy_geometry.hpp
+++ b/tests/common/include/tests/common/tools/create_toy_geometry.hpp
@@ -6,6 +6,7 @@
  */
 
 #include "detray/core/detector.hpp"
+#include "tests/common/tools/detector_registry.hpp"
 
 namespace detray {
 
@@ -16,8 +17,8 @@ template <template <typename, unsigned int> class array_type = darray,
 auto create_toy_geometry(vecmem::memory_resource& resource) {
 
     // detector type
-    using detector_t =
-        detector<array_type, tuple_type, vector_type, jagged_vector_type>;
+    using detector_t = detector<detector_registry::toy_detector, array_type,
+                                tuple_type, vector_type, jagged_vector_type>;
 
     // sub-geometry components type
     using edge_links = typename detector_t::edge_type;

--- a/tests/common/include/tests/common/tools/detector_registry.hpp
+++ b/tests/common/include/tests/common/tools/detector_registry.hpp
@@ -1,0 +1,18 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+namespace detray {
+
+// detector_registy for the hard-coded values
+struct detector_registry {
+    enum class default_detector { n_grids = 1 };
+    enum class toy_detector { n_grids = 8 };
+    enum class tml_detector { n_grids = 192 };
+};
+
+}  // namespace detray

--- a/tests/common/include/tests/common/tools/read_geometry.hpp
+++ b/tests/common/include/tests/common/tools/read_geometry.hpp
@@ -31,6 +31,7 @@ detector_input_files tml_files = {"tml", "tml.csv", "tml-layer-volumes.csv",
                                   "tml-surface-grids.csv", ""};
 
 /** Read a detector from csv files */
+template <typename detector_registry>
 auto read_from_csv(detector_input_files& files,
                    vecmem::memory_resource& resource) {
     auto env_d_d = std::getenv("DETRAY_TEST_DATA_DIR");
@@ -46,9 +47,9 @@ auto read_from_csv(detector_input_files& files,
     std::string grid_entries = files.surface_grid_entries;
     std::map<detray::dindex, std::string> name_map{};
 
-    auto d =
-        detray::detector_from_csv<>(files.det_name, surfaces, volumes, grids,
-                                    grid_entries, name_map, resource);
+    auto d = detray::detector_from_csv<detector_registry>(
+        files.det_name, surfaces, volumes, grids, grid_entries, name_map,
+        resource);
 
     return std::make_pair<decltype(d), decltype(name_map)>(std::move(d),
                                                            std::move(name_map));

--- a/tests/unit_tests/cuda/detector_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/detector_cuda_kernel.cu
@@ -12,7 +12,7 @@ namespace detray {
 
 // cuda kernel to copy sub-detector objects
 __global__ void detector_test_kernel(
-    detector_data<detector_host_t> det_data,
+    detector_view<detector_host_t> det_data,
     vecmem::data::vector_view<volume_t> volumes_data,
     vecmem::data::vector_view<surface_t> surfaces_data,
     static_transform_store_data<transform_store_t> transforms_data,
@@ -70,7 +70,7 @@ __global__ void detector_test_kernel(
 
 /// implementation of the test function for detector
 void detector_test(
-    detector_data<detector_host_t>& det_data,
+    detector_view<detector_host_t> det_data,
     vecmem::data::vector_view<volume_t>& volumes_data,
     vecmem::data::vector_view<surface_t>& surfaces_data,
     static_transform_store_data<transform_store_t>& transforms_data,

--- a/tests/unit_tests/cuda/detector_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/detector_cuda_kernel.hpp
@@ -18,6 +18,7 @@
 #include <thrust/tuple.h>
 
 #include "detray/core/detector.hpp"
+#include "tests/common/tools/detector_registry.hpp"
 
 #pragma once
 
@@ -28,9 +29,11 @@ namespace detray {
 
 // some useful type declarations
 using detector_host_t =
-    detector<darray, thrust::tuple, vecmem::vector, vecmem::jagged_vector>;
-using detector_device_t = detector<darray, thrust::tuple, vecmem::device_vector,
-                                   vecmem::jagged_device_vector>;
+    detector<detector_registry::toy_detector, darray, thrust::tuple,
+             vecmem::vector, vecmem::jagged_vector>;
+using detector_device_t =
+    detector<detector_registry::toy_detector, darray, thrust::tuple,
+             vecmem::device_vector, vecmem::jagged_device_vector>;
 using volume_t = typename detector_host_t::volume_type;
 using surface_t = typename detector_host_t::surface_type;
 using transform_store_t = typename detector_host_t::transform_store;
@@ -40,7 +43,7 @@ using cylinder_t = typename detector_host_t::cylinder;
 
 /// declaration of a test function for detector
 void detector_test(
-    detector_data<detector_host_t>& det_data,
+    detector_view<detector_host_t> det_data,
     vecmem::data::vector_view<volume_t>& volumes_data,
     vecmem::data::vector_view<surface_t>& surfaces_data,
     static_transform_store_data<transform_store_t>& transforms_data,


### PR DESCRIPTION
This PR adds `surfaces_finder` into `detector`. (It is written on top of #172)

Instead passing the number of grids directly to the detector,  `detector_registry` struct which contains `enum` class for each detector is passed.

There are couple of things to be polished but early comments are welcomed