### PR TITLE
add surfaces to surface_grid

### DIFF
--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -324,6 +324,22 @@ class detector {
         fill_containers(ctx, std::forward<detector_components>(components)...);
     }
 
+    template <typename grid_type>
+    DETRAY_HOST inline void add_surfaces_grid(const context ctx,
+                                              volume_type &vol,
+                                              grid_type &surfaces_grid) {
+        auto &rg = std::get<object_id::e_surface>(vol.ranges());
+
+        auto surf_idx = rg[0];
+        for (const auto &surf : iterator_range(_surfaces, rg)) {
+            auto &trf = _transforms.contextual_transform(ctx, surf.transform());
+            auto tsl = trf.translation();
+
+            point2 loc{tsl[2], algebra::getter::phi(tsl)};
+            surfaces_grid.populate(loc, surf_idx++);
+        }
+    }
+
     /** Unrolls the data containers according to the mask type and fill the
      *  global containers. It registers the indexing in the geometry.
      *
@@ -344,6 +360,7 @@ class detector {
     DETRAY_HOST inline void fill_containers(
         const context ctx, volume_type &volume, surface_container &surfaces,
         mask_container &masks, transform_container &trfs) noexcept(false) {
+
         // Get the surfaces/portals for a mask type
         auto &typed_surfaces = surfaces[current_type];
         // Get the corresponding transforms

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -333,32 +333,25 @@ class detector {
 
         // iterate over surfaces to fill the grid
         auto surf_idx = rg[0];
+
         for (const auto &surf : iterator_range(_surfaces, rg)) {
             if (surf.get_grid_status() == true) {
                 auto &trf =
                     _transforms.contextual_transform(ctx, surf.transform());
                 auto tsl = trf.translation();
 
-                point2 loc;
                 if (vol.get_grid_type() ==
                     volume_type::grid_type::e_z_phi_grid) {
-                    loc = point2{tsl[2], algebra::getter::phi(tsl)};
+                    point2 loc{tsl[2], algebra::getter::phi(tsl)};
+                    surfaces_grid.populate(loc, surf_idx++);
                 } else if (vol.get_grid_type() ==
                            volume_type::grid_type::e_r_phi_grid) {
-                    loc = point2{algebra::getter::perp(tsl),
-                                 algebra::getter::phi(tsl)};
+                    point2 loc{algebra::getter::perp(tsl),
+                               algebra::getter::phi(tsl)};
+                    surfaces_grid.populate(loc, surf_idx++);
                 }
-                surfaces_grid.populate(loc, surf_idx++);
             }
         }
-
-        /*
-        for (int i = 0; i < surfaces_grid.axis_p0().bins(); i++){
-            for (int j = 0; i < surfaces_grid.axis_p1().bins(); j++){
-                printf("%d \n", surfaces_grid.bin(i,j).size());
-            }
-        }
-        */
 
         // add surfaces grid into surfaces finder
         _surfaces_finder[vol.index()] = surfaces_grid;

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -328,27 +328,27 @@ class detector {
     DETRAY_HOST inline void add_surfaces_grid(const context ctx,
                                               volume_type &vol,
                                               grid_type &surfaces_grid) {
-        // get the surface range associated with volume
-        auto &rg = std::get<object_id::e_surface>(vol.ranges());
-
         // iterate over surfaces to fill the grid
-        auto surf_idx = rg[0];
-
-        for (const auto &surf : iterator_range(_surfaces, rg)) {
+        for (const auto &[surf_idx, surf] : enumerate(_surfaces, vol)) {
             if (surf.get_grid_status() == true) {
+                auto sidx = surf_idx;
+
                 auto &trf =
                     _transforms.contextual_transform(ctx, surf.transform());
                 auto tsl = trf.translation();
 
                 if (vol.get_grid_type() ==
                     volume_type::grid_type::e_z_phi_grid) {
-                    point2 loc{tsl[2], algebra::getter::phi(tsl)};
-                    surfaces_grid.populate(loc, surf_idx++);
+
+                    point2 location{tsl[2], algebra::getter::phi(tsl)};
+                    surfaces_grid.populate(location, std::move(sidx));
+
                 } else if (vol.get_grid_type() ==
                            volume_type::grid_type::e_r_phi_grid) {
-                    point2 loc{algebra::getter::perp(tsl),
-                               algebra::getter::phi(tsl)};
-                    surfaces_grid.populate(loc, surf_idx++);
+
+                    point2 location{algebra::getter::perp(tsl),
+                                    algebra::getter::phi(tsl)};
+                    surfaces_grid.populate(location, std::move(sidx));
                 }
             }
         }

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -332,11 +332,14 @@ class detector {
 
         auto surf_idx = rg[0];
         for (const auto &surf : iterator_range(_surfaces, rg)) {
-            auto &trf = _transforms.contextual_transform(ctx, surf.transform());
-            auto tsl = trf.translation();
+            if (surf.get_grid_status() == true) {
+                auto &trf =
+                    _transforms.contextual_transform(ctx, surf.transform());
+                auto tsl = trf.translation();
 
-            point2 loc{tsl[2], algebra::getter::phi(tsl)};
-            surfaces_grid.populate(loc, surf_idx++);
+                point2 loc{tsl[2], algebra::getter::phi(tsl)};
+                surfaces_grid.populate(loc, surf_idx++);
+            }
         }
     }
 

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -354,13 +354,9 @@ class detector {
         }
 
         // add surfaces grid into surfaces finder
-        for (unsigned int i_s = 0; i_s < _surfaces_finder.size(); i_s++) {
-            if (_surfaces_finder[i_s].data().empty()) {
-                _surfaces_finder[i_s] = surfaces_grid;
-                vol.set_surfaces_finder(i_s);
-                break;
-            }
-        }
+        auto n_grids = _surfaces_finder.effective_size();
+        _surfaces_finder[n_grids] = surfaces_grid;
+        vol.set_surfaces_finder(n_grids);
     }
 
     /** Unrolls the data containers according to the mask type and fill the

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -352,6 +352,14 @@ class detector {
             }
         }
 
+        /*
+        for (int i = 0; i < surfaces_grid.axis_p0().bins(); i++){
+            for (int j = 0; i < surfaces_grid.axis_p1().bins(); j++){
+                printf("%d \n", surfaces_grid.bin(i,j).size());
+            }
+        }
+        */
+
         // add surfaces grid into surfaces finder
         _surfaces_finder[vol.index()] = surfaces_grid;
     }

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -135,10 +135,10 @@ class detector {
         array_type<transform_store, mask_id::e_mask_types>;
 
     // Neighborhood finder, using accelerator data structure
-    static constexpr size_t N_VOLUMES =
-        static_cast<size_t>(detector_registry::n_volumes);
+    static constexpr size_t N_GRIDS =
+        static_cast<size_t>(detector_registry::n_grids);
     using surfaces_finder_type =
-        surfaces_finder<N_VOLUMES, array_type, tuple_type, vector_type,
+        surfaces_finder<N_GRIDS, array_type, tuple_type, vector_type,
                         jagged_vector_type>;
 
     using surfaces_regular_circular_grid =
@@ -354,7 +354,13 @@ class detector {
         }
 
         // add surfaces grid into surfaces finder
-        _surfaces_finder[vol.index()] = surfaces_grid;
+        for (unsigned int i_s = 0; i_s < _surfaces_finder.size(); i_s++) {
+            if (_surfaces_finder[i_s].data().empty()) {
+                _surfaces_finder[i_s] = surfaces_grid;
+                vol.set_surfaces_finder(i_s);
+                break;
+            }
+        }
     }
 
     /** Unrolls the data containers according to the mask type and fill the

--- a/core/include/detray/core/surfaces_finder.hpp
+++ b/core/include/detray/core/surfaces_finder.hpp
@@ -43,6 +43,8 @@ struct surfaces_finder {
     template <typename... Args>
     using tuple_t = tuple_type<Args...>;
 
+    // TODO: We will need to consider regular_regular grid in case the rectangle
+    // layer is used in geometry
     using surfaces_regular_circular_grid =
         grid2<attach_populator, axis::regular, axis::circular, serializer2,
               vector_type, jagged_vector_type, array_type, tuple_type, dindex,

--- a/core/include/detray/core/surfaces_finder.hpp
+++ b/core/include/detray/core/surfaces_finder.hpp
@@ -129,6 +129,14 @@ struct surfaces_finder {
         return _surface_grids[value_index];
     }
 
+    /** Access operator - const access
+     * @return the surface grid element
+     */
+    DETRAY_HOST_DEVICE
+    const auto& operator[](unsigned int value_index) const {
+        return _surface_grids[value_index];
+    }
+
     /** Array of grids for the local surface navigation  **/
     array_type<surfaces_regular_circular_grid, N_GRIDS> _surface_grids;
 };

--- a/core/include/detray/core/surfaces_finder.hpp
+++ b/core/include/detray/core/surfaces_finder.hpp
@@ -108,6 +108,19 @@ struct surfaces_finder {
      */
     DETRAY_HOST_DEVICE constexpr size_t size() const { return N_GRIDS; }
 
+    /** return the number of grids that are not empty
+     * @return the effective number of grids
+     */
+    DETRAY_HOST_DEVICE size_t effective_size() {
+        size_t ret = 0;
+        for (unsigned int i_s = 0; i_s < N_GRIDS; i_s++) {
+            if (!_surface_grids[i_s].data().empty()) {
+                ret++;
+            }
+        }
+        return ret;
+    }
+
     /** Access operator - non-const
      * @return the surface grid element
      */

--- a/core/include/detray/geometry/surface_base.hpp
+++ b/core/include/detray/geometry/surface_base.hpp
@@ -113,6 +113,9 @@ class surface_base {
     DETRAY_HOST_DEVICE
     const source_link &source() const { return _src; }
 
+    /** set grid link **/
+    void is_in_grid() { _in_grid = true; }
+
     /** Is this instance a portal in the sense of the unified_index_geometry? */
     DETRAY_HOST_DEVICE
     bool is_portal() const { return not(std::get<0>(_edg) == _vol); }
@@ -123,6 +126,7 @@ class surface_base {
     volume_link _vol;
     source_link _src;
     edge_link _edg = {};
+    bool _in_grid = false;
 };
 
 }  // namespace detray

--- a/core/include/detray/geometry/surface_base.hpp
+++ b/core/include/detray/geometry/surface_base.hpp
@@ -113,8 +113,11 @@ class surface_base {
     DETRAY_HOST_DEVICE
     const source_link &source() const { return _src; }
 
-    /** set grid link **/
-    void is_in_grid() { _in_grid = true; }
+    /** get if the surface belongs to grid **/
+    auto get_grid_status() const { return _in_grid; }
+
+    /** set if the surface belongs to grid **/
+    void set_grid_status(bool status) { _in_grid = status; }
 
     /** Is this instance a portal in the sense of the unified_index_geometry? */
     DETRAY_HOST_DEVICE

--- a/core/include/detray/geometry/volume.hpp
+++ b/core/include/detray/geometry/volume.hpp
@@ -30,6 +30,12 @@ class volume {
     // used for sfinae
     using volume_def = volume<object_registry, range_type, array_type>;
 
+    enum grid_type : unsigned int {
+        e_no_grid = 0,
+        e_z_phi_grid = 2,  // barrel
+        e_r_phi_grid = 1,  // endcap
+    };
+
     /** Default constructor**/
     volume() = default;
 
@@ -125,6 +131,12 @@ class volume {
         return std::get<1>(rg) - std::get<0>(rg);
     }
 
+    /** set grid type associated with volume */
+    void set_grid_type(grid_type val) { _grid_type = val; }
+
+    /** get grid type associated with volume */
+    const auto get_grid_type() const { return _grid_type; }
+
     /** Equality operator
      *
      * @param rhs is the right hand side to be compared to
@@ -154,6 +166,9 @@ class volume {
 
     /** Index into the surface finder container */
     dindex _surfaces_finder_entry = dindex_invalid;
+
+    /** grid type associated with volume **/
+    grid_type _grid_type = e_no_grid;
 };
 
 }  // namespace detray

--- a/core/include/detray/geometry/volume.hpp
+++ b/core/include/detray/geometry/volume.hpp
@@ -32,8 +32,8 @@ class volume {
 
     enum grid_type : unsigned int {
         e_no_grid = 0,
-        e_z_phi_grid = 2,  // barrel
-        e_r_phi_grid = 1,  // endcap
+        e_z_phi_grid = 1,  // barrel
+        e_r_phi_grid = 2,  // endcap
     };
 
     /** Default constructor**/

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -16,12 +16,16 @@ using namespace detray;
 TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     vecmem::host_memory_resource host_mr;
-    auto toy_det = create_toy_geometry(host_mr, 4, 3);
+    std::size_t n_brl_layers = 4;
+    std::size_t n_edc_layers = 3;
+
+    auto toy_det = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
 
     using context_t = typename decltype(toy_det)::context;
     context_t ctx{};
     auto& volumes = toy_det.volumes();
     auto& surfaces = toy_det.surfaces();
+    auto& surfaces_finder = toy_det.get_surfaces_finder();
     auto& transforms = toy_det.transforms();
     auto& masks = toy_det.masks();
     auto& rectangles = masks.template group<0>();
@@ -39,6 +43,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     // Check number of geomtery objects
     EXPECT_EQ(volumes.size(), 20);
     EXPECT_EQ(surfaces.size(), 3244);
+    EXPECT_EQ(surfaces_finder.size(), decltype(toy_det)::N_GRIDS);
+    EXPECT_EQ(surfaces_finder.effective_size(),
+              n_brl_layers + 2 * n_edc_layers);
     EXPECT_EQ(transforms.size(ctx), 3244);
     EXPECT_EQ(rectangles.size(), 2492);
     EXPECT_EQ(trapezoids.size(), 648);

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -116,8 +116,10 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     auto test_surfaces_grid =
         [](const typename detector_t::surfaces_finder_type& sf_finder,
            const typename detector_t::surface_container& sf_container,
-           const volume_t& volume) {
+           const volume_t& volume, darray<dindex, 2>& range) {
             auto sf_grid = sf_finder[volume.surfaces_finder_entry()];
+
+            std::vector<dindex> indices;
 
             for (unsigned int i = 0; i < sf_grid.axis_p0().bins(); i++) {
                 for (unsigned int j = 0; j < sf_grid.axis_p1().bins(); j++) {
@@ -125,8 +127,15 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                     for (auto sf_idx : sf_indices) {
                         EXPECT_EQ(sf_container[sf_idx].volume(),
                                   volume.index());
+                        indices.push_back(sf_idx);
                     }
                 }
+            }
+
+            EXPECT_EQ(indices.size(), range[1] - range[0]);
+            for (dindex pti = range[0]; pti < range[1]; pti++) {
+                EXPECT_TRUE(std::find(indices.begin(), indices.end(), pti) !=
+                            indices.end());
             }
         };
 
@@ -195,6 +204,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {1, 0}, {{vol_itr->index(), inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+
     // Check links of portals
     // cylinder portals
     range = {124, 126};
@@ -206,9 +218,6 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 2},
                       {{leaving_world, inv_sf_finder}, {2, inv_sf_finder}});
-
-    // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 
     //
     // gap
@@ -254,6 +263,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {1, 108}, {{vol_itr->index(), inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+
     // Check links of portals
     // cylinder portals
     range = {240, 242};
@@ -265,9 +277,6 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 6},
                       {{2, inv_sf_finder}, {4, inv_sf_finder}});
-
-    // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 
     //
     // gap
@@ -313,6 +322,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {1, 216}, {{vol_itr->index(), inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+
     // Check links of portals
     // cylinder portals
     range = {356, 358};
@@ -324,9 +336,6 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 10},
                       {{4, inv_sf_finder}, {6, inv_sf_finder}});
-
-    // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 
     //
     // gap
@@ -383,6 +392,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {0, 0}, {{vol_itr->index(), inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+
     // Check links of portals
     // cylinder portals
     range = {594, 596};
@@ -395,9 +407,6 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 20},
                       {{6, inv_sf_finder}, {14, inv_sf_finder}});
-
-    // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 
     //
     // gap
@@ -443,6 +452,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {0, 224}, {{vol_itr->index(), inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+
     // Check links of portals
     // cylinder portals
     range = {1050, 1052};
@@ -455,9 +467,6 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 24},
                       {{6, inv_sf_finder}, {14, inv_sf_finder}});
-
-    // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 
     //
     // gap
@@ -503,6 +512,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {0, 672}, {{vol_itr->index(), inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+
     // Check links of portals
     // cylinder portals
     range = {1786, 1788};
@@ -515,9 +527,6 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 28},
                       {{6, inv_sf_finder}, {14, inv_sf_finder}});
-
-    // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 
     //
     // gap
@@ -563,6 +572,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {0, 1400}, {{vol_itr->index(), inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+
     // Check links of portals
     // cylinder portals
     range = {2886, 2888};
@@ -575,9 +587,6 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 32},
                       {{6, inv_sf_finder}, {14, inv_sf_finder}});
-
-    // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 
     //
     // positive endcap
@@ -634,6 +643,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {1, 324}, {{vol_itr->index(), inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+
     // Check links of portals
     // cylinder portals
     range = {3008, 3010};
@@ -645,9 +657,6 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 42},
                       {{14, inv_sf_finder}, {16, inv_sf_finder}});
-
-    // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 
     //
     // gap
@@ -693,6 +702,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {1, 432}, {{vol_itr->index(), inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+
     // Check links of portals
     // cylinder portals
     range = {3124, 3126};
@@ -704,9 +716,6 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 46},
                       {{16, inv_sf_finder}, {18, inv_sf_finder}});
-
-    // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 
     //
     // gap
@@ -752,6 +761,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {1, 540}, {{vol_itr->index(), inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+
     // Check links of portals
     // cylinder portals
     range = {3240, 3242};
@@ -763,9 +775,6 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 50},
                       {{18, inv_sf_finder}, {leaving_world, inv_sf_finder}});
-
-    // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 }
 
 int main(int argc, char** argv) {

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -21,6 +21,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     auto toy_det = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
 
+    using detector_t = decltype(toy_det);
+    using volume_t = typename detector_t::volume_type;
     using context_t = typename decltype(toy_det)::context;
     context_t ctx{};
     auto& volumes = toy_det.volumes();
@@ -102,6 +104,32 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
             }
         };
 
+    /** Test the surface grid.
+     *
+     * @param vol_index volume the modules belong to
+     * @param sf_itr iterator into the surface container, start of the modules
+     * @param range index range of the modules in the surface container
+     * @param trf_index index of the transform (trf container) for the module
+     * @param mask_index type and index of module mask in respective mask cont
+     * @param edges links to next volume and next surfaces finder
+     */
+    auto test_surfaces_grid =
+        [](const typename detector_t::surfaces_finder_type& sf_finder,
+           const typename detector_t::surface_container& sf_container,
+           const volume_t& volume) {
+            auto sf_grid = sf_finder[volume.surfaces_finder_entry()];
+
+            for (unsigned int i = 0; i < sf_grid.axis_p0().bins(); i++) {
+                for (unsigned int j = 0; j < sf_grid.axis_p1().bins(); j++) {
+                    auto sf_indices = sf_grid.bin(i, j);
+                    for (auto sf_idx : sf_indices) {
+                        EXPECT_EQ(sf_container[sf_idx].volume(),
+                                  volume.index());
+                    }
+                }
+            }
+        };
+
     //
     // beampipe
     //
@@ -113,6 +141,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 0);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
+    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
 
     // Check links of beampipe itself
     range = {0, 1};
@@ -158,6 +188,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 1);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
 
     // Check the trapezoid modules
     range = {16, 124};
@@ -176,6 +207,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {4, 2},
                       {{leaving_world, inv_sf_finder}, {2, inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
+
     //
     // gap
     //
@@ -187,6 +221,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 2);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
+    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
 
     // Check links of portals
     // cylinder portals
@@ -211,6 +247,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 3);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
 
     // Check the trapezoid modules
     range = {132, 240};
@@ -229,6 +266,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {4, 6},
                       {{2, inv_sf_finder}, {4, inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
+
     //
     // gap
     //
@@ -240,6 +280,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 4);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
+    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
 
     // Check links of portals
     // cylinder portals
@@ -264,6 +306,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 5);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
 
     // Check the trapezoid modules
     range = {248, 356};
@@ -282,6 +325,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {4, 10},
                       {{4, inv_sf_finder}, {6, inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
+
     //
     // gap
     //
@@ -293,6 +339,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 6);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
+    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
 
     // Check links of portals
     // cylinder portals
@@ -328,6 +376,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 7);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_z_phi_grid);
 
     // Check links of modules
     range = {370, 594};
@@ -347,6 +396,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {4, 20},
                       {{6, inv_sf_finder}, {14, inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
+
     //
     // gap
     //
@@ -358,6 +410,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 8);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
+    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
 
     // Check links of portals
     // cylinder portals
@@ -382,6 +436,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 9);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_z_phi_grid);
 
     // Check links of modules
     range = {602, 1050};
@@ -401,6 +456,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {4, 24},
                       {{6, inv_sf_finder}, {14, inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
+
     //
     // gap
     //
@@ -412,6 +470,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 10);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
+    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
 
     // Check links of portals
     // cylinder portals
@@ -436,6 +496,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 11);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_z_phi_grid);
 
     // Check links of modules
     range = {1058, 1786};
@@ -455,6 +516,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {4, 28},
                       {{6, inv_sf_finder}, {14, inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
+
     //
     // gap
     //
@@ -466,6 +530,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 12);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
+    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
 
     // Check links of portals
     // cylinder portals
@@ -490,6 +556,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 13);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_z_phi_grid);
 
     // Check links of modules
     range = {1794, 2886};
@@ -509,6 +576,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {4, 32},
                       {{6, inv_sf_finder}, {14, inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
+
     //
     // positive endcap
     //
@@ -524,6 +594,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 14);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
+    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
 
     // Check links of portals
     // cylinder portals
@@ -555,6 +627,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 15);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
 
     // Check the trapezoid modules
     range = {2900, 3008};
@@ -573,6 +646,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {4, 42},
                       {{14, inv_sf_finder}, {16, inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
+
     //
     // gap
     //
@@ -584,6 +660,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 16);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
+    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
 
     // Check links of portals
     // cylinder portals
@@ -598,7 +676,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       {{15, inv_sf_finder}, {17, inv_sf_finder}});
 
     //
-    // neg endcap (layer 2)
+    // pos endcap (layer 2)
     //
 
     // Check volume
@@ -608,6 +686,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 17);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
 
     // Check the trapezoid modules
     range = {3016, 3124};
@@ -626,6 +705,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {4, 46},
                       {{16, inv_sf_finder}, {18, inv_sf_finder}});
 
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
+
     //
     // gap
     //
@@ -637,6 +719,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 18);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
+    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
 
     // Check links of portals
     // cylinder portals
@@ -651,7 +735,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       {{17, inv_sf_finder}, {19, inv_sf_finder}});
 
     //
-    // neg endcap (layer 3)
+    // pos endcap (layer 3)
     //
 
     // Check volume
@@ -661,6 +745,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     EXPECT_EQ(vol_itr->index(), 19);
     EXPECT_EQ(vol_itr->bounds(), bounds);
     EXPECT_EQ(vol_itr->range(), range);
+    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
 
     // Check the trapezoid modules
     range = {3132, 3240};
@@ -678,6 +763,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 50},
                       {{18, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+
+    // Check link of surfaces in surface finder
+    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr);
 }
 
 int main(int argc, char** argv) {

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -106,32 +106,34 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     /** Test the surface grid.
      *
-     * @param vol_index volume the modules belong to
-     * @param sf_itr iterator into the surface container, start of the modules
+     * @param volume volume of detector being tested
+     * @param sf_finder surface finder of detector
+     * @param sf_container surface container of detector
      * @param range index range of the modules in the surface container
-     * @param trf_index index of the transform (trf container) for the module
-     * @param mask_index type and index of module mask in respective mask cont
-     * @param edges links to next volume and next surfaces finder
      */
     auto test_surfaces_grid =
-        [](const typename detector_t::surfaces_finder_type& sf_finder,
+        [](decltype(volumes.begin())& vol_itr,
+           const typename detector_t::surfaces_finder_type& sf_finder,
            const typename detector_t::surface_container& sf_container,
-           const volume_t& volume, darray<dindex, 2>& range) {
-            auto sf_grid = sf_finder[volume.surfaces_finder_entry()];
+           darray<dindex, 2>& range) {
+            auto sf_grid = sf_finder[vol_itr->surfaces_finder_entry()];
 
             std::vector<dindex> indices;
 
+            // Check if right volume is linked to surface in grid
             for (unsigned int i = 0; i < sf_grid.axis_p0().bins(); i++) {
                 for (unsigned int j = 0; j < sf_grid.axis_p1().bins(); j++) {
                     auto sf_indices = sf_grid.bin(i, j);
                     for (auto sf_idx : sf_indices) {
                         EXPECT_EQ(sf_container[sf_idx].volume(),
-                                  volume.index());
+                                  vol_itr->index());
                         indices.push_back(sf_idx);
                     }
                 }
             }
 
+            // Check if surface indices are consistent with given range of
+            // modules
             EXPECT_EQ(indices.size(), range[1] - range[0]);
             for (dindex pti = range[0]; pti < range[1]; pti++) {
                 EXPECT_TRUE(std::find(indices.begin(), indices.end(), pti) !=
@@ -205,7 +207,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {1, 0}, {{vol_itr->index(), inv_sf_finder}});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -264,7 +266,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {1, 108}, {{vol_itr->index(), inv_sf_finder}});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -323,7 +325,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {1, 216}, {{vol_itr->index(), inv_sf_finder}});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -393,7 +395,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {0, 0}, {{vol_itr->index(), inv_sf_finder}});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -453,7 +455,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {0, 224}, {{vol_itr->index(), inv_sf_finder}});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -513,7 +515,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {0, 672}, {{vol_itr->index(), inv_sf_finder}});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -573,7 +575,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {0, 1400}, {{vol_itr->index(), inv_sf_finder}});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -644,7 +646,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {1, 324}, {{vol_itr->index(), inv_sf_finder}});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -703,7 +705,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {1, 432}, {{vol_itr->index(), inv_sf_finder}});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -762,7 +764,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                       range[0], {1, 540}, {{vol_itr->index(), inv_sf_finder}});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(surfaces_finder, surfaces, *vol_itr, range);
+    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
 
     // Check links of portals
     // cylinder portals

--- a/tests/common/include/tests/common/tools/create_toy_geometry.hpp
+++ b/tests/common/include/tests/common/tools/create_toy_geometry.hpp
@@ -219,7 +219,7 @@ inline void create_barrel_modules(context_t &ctx, volume_type &vol,
 
     auto z_axis_info = cfg.get_z_axis_info();
     auto &z_start = std::get<0>(z_axis_info);
-    auto &z_end = std::get<1>(z_axis_info);
+    // auto &z_end = std::get<1>(z_axis_info);
     auto &z_step = std::get<2>(z_axis_info);
 
     // loop over the z bins

--- a/tests/common/include/tests/common/tools/create_toy_geometry.hpp
+++ b/tests/common/include/tests/common/tools/create_toy_geometry.hpp
@@ -98,7 +98,7 @@ auto create_toy_geometry(vecmem::memory_resource& resource) {
     /** Function that creates the modules
      */
     auto create_modules =
-        [&](const dindex volume_id, const dindex invalid_value,
+        [&](typename detector_t::volume_type& vol, const dindex invalid_value,
             typename transform_store::context& ctx, surface_container& surfaces,
             mask_container& masks, transform_container& transforms,
             typename detector_t::surfaces_regular_circular_grid& surfaces_grid,
@@ -106,6 +106,9 @@ auto create_toy_geometry(vecmem::memory_resource& resource) {
             const scalar m_tilt_phi = 0.145, const scalar layer_r = 32.,
             const scalar radial_stagger = 2., const scalar l_overlap = 5.,
             const std::pair<int, int> binning = {16, 14}) {
+            auto volume_id = vol.index();
+            vol.set_grid_type(detector_t::volume_type::grid_type::e_z_phi_grid);
+
             // surface grid bins
             int n_phi_bins = binning.first;
             int n_z_bins = binning.second;
@@ -132,7 +135,6 @@ auto create_toy_geometry(vecmem::memory_resource& resource) {
             typename detector_t::surfaces_regular_axis z_axis(
                 n_z_bins, z_start - z_step * 0.5, z_end - z_step * 0.5,
                 resource);
-
             surfaces_grid = typename detector_t::surfaces_regular_circular_grid(
                 z_axis, phi_axis, resource);
 
@@ -297,12 +299,14 @@ auto create_toy_geometry(vecmem::memory_resource& resource) {
                         {vol2.index(), inv_sf_finder});
 
     // create modules for the first layer
-    create_modules(vol1.index(), inv_sf_finder, ctx0, vol1_surfaces, vol1_masks,
+    create_modules(vol1, inv_sf_finder, ctx0, vol1_surfaces, vol1_masks,
                    vol1_transforms, vol1_surfaces_grid, 8.4, 36., 0.145, 32.,
                    2., 5., {16, 14});
 
     // Add all objects to detector
     det.add_objects(ctx0, vol1, vol1_surfaces, vol1_masks, vol1_transforms);
+
+    // Add surfaces grid
     det.add_surfaces_grid(ctx0, vol1, vol1_surfaces_grid);
 
     /**
@@ -366,12 +370,14 @@ auto create_toy_geometry(vecmem::memory_resource& resource) {
                         {leaving_world, inv_sf_finder});
 
     // create modules for the second layer
-    create_modules(vol3.index(), inv_sf_finder, ctx0, vol3_surfaces, vol3_masks,
+    create_modules(vol3, inv_sf_finder, ctx0, vol3_surfaces, vol3_masks,
                    vol3_transforms, vol3_surfaces_grid, 8.4, 36., 0.145, 72.,
                    2., 5., {32, 14});
 
     // Add all objects to detector
     det.add_objects(ctx0, vol3, vol3_surfaces, vol3_masks, vol3_transforms);
+
+    // Add surfaces grid
     det.add_surfaces_grid(ctx0, vol3, vol3_surfaces_grid);
 
     // return the detector

--- a/tests/common/include/tests/common/tools/create_toy_geometry.hpp
+++ b/tests/common/include/tests/common/tools/create_toy_geometry.hpp
@@ -170,7 +170,10 @@ void create_cyl_volume(detector_t &det, vecmem::memory_resource &resource,
                      inner_r, outer_r, upper_z, edges[3]);
 
     det.add_objects(ctx, cyl_volume, surfaces, masks, transforms);
-    det.add_surfaces_grid(ctx, cyl_volume, cyl_surfaces_grid);
+    if (cyl_volume.get_grid_type() !=
+        detector_t::volume_type::grid_type::e_no_grid) {
+        det.add_surfaces_grid(ctx, cyl_volume, cyl_surfaces_grid);
+    }
 }
 
 /** Helper function that creates a layer of rectangular barrel modules.
@@ -447,8 +450,8 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
     // TODO: WHat is the proper value of n_phi_bins?
     typename surfaces_grid_t::axis_p0_t r_axis(radii.size(), cfg.inner_r,
                                                cfg.outer_r, resource);
-    typename surfaces_grid_t::axis_p1_t phi_axis(cfg.disc_binning.back(), -M_PI,
-                                                 M_PI, resource);
+    typename surfaces_grid_t::axis_p1_t phi_axis(cfg.disc_binning.front(),
+                                                 -M_PI, M_PI, resource);
 
     surfaces_grid = surfaces_grid_t(r_axis, phi_axis, resource);
 }
@@ -698,6 +701,7 @@ void add_endcap_detector(
                               cfg.side * (vol_size_itr + cfg.side * i)->first,
                               cfg.side * (vol_size_itr + cfg.side * i)->second,
                               edges_vec[i], empty_factory);
+
         } else {
             m_factory.cfg.edc_position = *(pos_itr + cfg.side * i / 2);
             create_cyl_volume(det, resource, ctx, cfg.inner_r, cfg.outer_r,
@@ -870,7 +874,7 @@ auto create_toy_geometry(vecmem::memory_resource &resource,
     struct empty_vol_factory {
         void operator()(
             typename detector_t::context & /*ctx*/,
-            typename detector_t::volume_type /*volume*/,
+            typename detector_t::volume_type & /*volume*/,
             typename detector_t::surface_filling_container & /*surfaces*/,
             typename detector_t::surfaces_regular_circular_grid
                 & /*surfaces_grid*/,
@@ -885,7 +889,7 @@ auto create_toy_geometry(vecmem::memory_resource &resource,
 
         void operator()(
             typename detector_t::context &ctx,
-            typename detector_t::volume_type volume,
+            typename detector_t::volume_type &volume,
             typename detector_t::surface_filling_container &surfaces,
             typename detector_t::surfaces_regular_circular_grid &surfaces_grid,
             typename detector_t::mask_container &masks,
@@ -902,7 +906,7 @@ auto create_toy_geometry(vecmem::memory_resource &resource,
 
         void operator()(
             typename detector_t::context &ctx,
-            typename detector_t::volume_type volume,
+            typename detector_t::volume_type &volume,
             typename detector_t::surface_filling_container &surfaces,
             typename detector_t::surfaces_regular_circular_grid &surfaces_grid,
             typename detector_t::mask_container &masks,

--- a/tests/common/include/tests/common/tools/create_toy_geometry.hpp
+++ b/tests/common/include/tests/common/tools/create_toy_geometry.hpp
@@ -118,18 +118,20 @@ auto create_toy_geometry(vecmem::memory_resource& resource) {
             scalar pi{static_cast<scalar>(M_PI)};
             scalar phi_step = scalar{2} * pi / (n_phi_bins);
             scalar min_phi = -pi + scalar{0.5} * phi_step;
-            scalar max_phi = min_phi + (n_phi_bins - 1) * phi_step;
+            scalar max_phi = min_phi + n_phi_bins * phi_step;
 
             scalar z_start = scalar{-0.5} * (n_z_bins - 1) *
                              (scalar{2} * m_half_y - l_overlap);
             scalar z_step = scalar{2} * std::abs(z_start) / (n_z_bins - 1);
-            scalar z_end = z_start + (n_z_bins - 1) * z_step;
+            scalar z_end = z_start + n_z_bins * z_step;
 
             // add surface grid
             typename detector_t::surfaces_circular_axis phi_axis(
-                n_phi_bins, min_phi, max_phi, resource);
-            typename detector_t::surfaces_regular_axis z_axis(n_z_bins, z_start,
-                                                              z_end, resource);
+                n_phi_bins, min_phi - phi_step * 0.5, max_phi - phi_step * 0.5,
+                resource);
+            typename detector_t::surfaces_regular_axis z_axis(
+                n_z_bins, z_start - z_step * 0.5, z_end - z_step * 0.5,
+                resource);
 
             surfaces_grid = typename detector_t::surfaces_regular_circular_grid(
                 z_axis, phi_axis, resource);
@@ -183,7 +185,7 @@ auto create_toy_geometry(vecmem::memory_resource& resource) {
 
                 surf.set_edge({volume_id, invalid_value});
 
-                surf.is_in_grid();
+                surf.set_grid_status(true);
                 // add surface to surface container
                 surfaces[detector_t::e_rectangle2].push_back(surf);
             }

--- a/tests/common/include/tests/common/tools/create_toy_geometry.hpp
+++ b/tests/common/include/tests/common/tools/create_toy_geometry.hpp
@@ -874,7 +874,7 @@ auto create_toy_geometry(vecmem::memory_resource &resource,
             auto n_z_bins = m_binning.second;
             scalar z_start =
                 -0.5 * (n_z_bins - 1) * (2 * m_half_y - m_long_overlap);
-            scalar z_end = std::abs(z_start) * 2;
+            scalar z_end = std::abs(z_start);
             scalar z_step = (z_end - z_start) / (n_z_bins - 1);
 
             return {z_start, z_end, z_step};

--- a/tests/common/include/tests/common/tools/detector_registry.hpp
+++ b/tests/common/include/tests/common/tools/detector_registry.hpp
@@ -11,7 +11,7 @@ namespace detray {
 // detector_registy for the hard-coded values
 struct detector_registry {
     enum class default_detector { n_grids = 1 };
-    enum class toy_detector { n_grids = 20 };
+    enum class toy_detector { n_grids = 10 };
     enum class tml_detector { n_grids = 192 };
 };
 

--- a/tests/common/include/tests/common/tools/detector_registry.hpp
+++ b/tests/common/include/tests/common/tools/detector_registry.hpp
@@ -10,9 +10,9 @@ namespace detray {
 
 // detector_registy for the hard-coded values
 struct detector_registry {
-    enum class default_detector { n_volumes = 1 };
-    enum class toy_detector { n_volumes = 20 };
-    enum class tml_detector { n_volumes = 192 };
+    enum class default_detector { n_grids = 1 };
+    enum class toy_detector { n_grids = 20 };
+    enum class tml_detector { n_grids = 192 };
 };
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools/detector_registry.hpp
+++ b/tests/common/include/tests/common/tools/detector_registry.hpp
@@ -10,9 +10,9 @@ namespace detray {
 
 // detector_registy for the hard-coded values
 struct detector_registry {
-    enum class default_detector { n_grids = 1 };
-    enum class toy_detector { n_grids = 8 };
-    enum class tml_detector { n_grids = 192 };
+    enum class default_detector { n_volumes = 1 };
+    enum class toy_detector { n_volumes = 4 };
+    enum class tml_detector { n_volumes = 192 };
 };
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools/detector_registry.hpp
+++ b/tests/common/include/tests/common/tools/detector_registry.hpp
@@ -11,7 +11,7 @@ namespace detray {
 // detector_registy for the hard-coded values
 struct detector_registry {
     enum class default_detector { n_volumes = 1 };
-    enum class toy_detector { n_volumes = 4 };
+    enum class toy_detector { n_volumes = 20 };
     enum class tml_detector { n_volumes = 192 };
 };
 

--- a/tests/common/include/tests/common/tools/detector_registry.hpp
+++ b/tests/common/include/tests/common/tools/detector_registry.hpp
@@ -11,7 +11,7 @@ namespace detray {
 // detector_registy for the hard-coded values
 struct detector_registry {
     enum class default_detector { n_grids = 1 };
-    enum class toy_detector { n_grids = 10 };
+    enum class toy_detector { n_grids = 20 };
     enum class tml_detector { n_grids = 192 };
 };
 

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -100,7 +100,9 @@ TEST(ALGEBRA_PLUGIN, single_type_navigator) {
     /** Tolerance for tests */
     constexpr double tol = 0.01;
 
-    auto toy_det = create_toy_geometry(host_mr, 4, 3);
+    std::size_t n_brl_layers = 4;
+    std::size_t n_edc_layers = 3;
+    auto toy_det = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
     navigator n(toy_det);
     using toy_navigator = decltype(n);
     using nav_context = decltype(toy_det)::context;

--- a/tests/unit_tests/cuda/detector_cuda.cpp
+++ b/tests/unit_tests/cuda/detector_cuda.cpp
@@ -28,14 +28,15 @@ TEST(detector_cuda, detector) {
     auto ctx0 = typename detector_host_t::context();
 
     // host objects
-    auto volumes_host = toy_det.volumes();
-    auto surfaces_host = toy_det.surfaces();
-    auto transforms_host = toy_det.transforms();
-    auto masks_host = toy_det.masks();
+    auto& volumes_host = toy_det.volumes();
+    auto& surfaces_host = toy_det.surfaces();
+    auto& transforms_host = toy_det.transforms();
+    auto& masks_host = toy_det.masks();
     auto& discs_host = masks_host.group<detector_host_t::e_portal_ring2>();
     auto& cylinders_host =
         masks_host.group<detector_host_t::e_portal_cylinder3>();
     auto& rectangles_host = masks_host.group<detector_host_t::e_rectangle2>();
+    auto& sf_finder_host = toy_det.get_surfaces_finder();
 
     // copied outpus from device side
     vecmem::vector<volume_t> volumes_device(volumes_host.size(), &mng_mr);
@@ -47,6 +48,7 @@ TEST(detector_cuda, detector) {
                                                   &mng_mr);
     vecmem::vector<disc_t> discs_device(discs_host.size(), &mng_mr);
     vecmem::vector<cylinder_t> cylinders_device(cylinders_host.size(), &mng_mr);
+    typename detector_host_t::surfaces_finder_type sf_finder_device(mng_mr);
 
     // get data object for toy detector
     auto toy_det_data = get_data(toy_det);
@@ -58,10 +60,11 @@ TEST(detector_cuda, detector) {
     auto rectangles_data = vecmem::get_data(rectangles_device);
     auto discs_data = vecmem::get_data(discs_device);
     auto cylinders_data = vecmem::get_data(cylinders_device);
+    auto sf_finder_data = get_data(sf_finder_device, mng_mr);
 
     // run the test code to copy the objects
     detector_test(toy_det_data, volumes_data, surfaces_data, transforms_data,
-                  rectangles_data, discs_data, cylinders_data);
+                  rectangles_data, discs_data, cylinders_data, sf_finder_data);
 
     // check if the same volume objects are copied
     for (unsigned int i = 0; i < volumes_host.size(); i++) {

--- a/tests/unit_tests/cuda/detector_cuda.cpp
+++ b/tests/unit_tests/cuda/detector_cuda.cpp
@@ -36,7 +36,6 @@ TEST(detector_cuda, detector) {
     auto& cylinders_host =
         masks_host.group<detector_host_t::e_portal_cylinder3>();
     auto& rectangles_host = masks_host.group<detector_host_t::e_rectangle2>();
-    auto& sf_finder_host = toy_det.get_surfaces_finder();
 
     // copied outpus from device side
     vecmem::vector<volume_t> volumes_device(volumes_host.size(), &mng_mr);
@@ -48,7 +47,6 @@ TEST(detector_cuda, detector) {
                                                   &mng_mr);
     vecmem::vector<disc_t> discs_device(discs_host.size(), &mng_mr);
     vecmem::vector<cylinder_t> cylinders_device(cylinders_host.size(), &mng_mr);
-    typename detector_host_t::surfaces_finder_type sf_finder_device(mng_mr);
 
     // get data object for toy detector
     auto toy_det_data = get_data(toy_det);
@@ -60,11 +58,10 @@ TEST(detector_cuda, detector) {
     auto rectangles_data = vecmem::get_data(rectangles_device);
     auto discs_data = vecmem::get_data(discs_device);
     auto cylinders_data = vecmem::get_data(cylinders_device);
-    auto sf_finder_data = get_data(sf_finder_device, mng_mr);
 
     // run the test code to copy the objects
     detector_test(toy_det_data, volumes_data, surfaces_data, transforms_data,
-                  rectangles_data, discs_data, cylinders_data, sf_finder_data);
+                  rectangles_data, discs_data, cylinders_data);
 
     // check if the same volume objects are copied
     for (unsigned int i = 0; i < volumes_host.size(); i++) {
@@ -83,7 +80,7 @@ TEST(detector_cuda, detector) {
                   true);
     }
 
-    // chech if the same masks are copied
+    // check if the same masks are copied
     for (unsigned int i = 0; i < rectangles_host.size(); i++) {
         EXPECT_EQ(rectangles_host[i] == rectangles_device[i], true);
     }

--- a/tests/unit_tests/cuda/detector_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/detector_cuda_kernel.cu
@@ -18,9 +18,7 @@ __global__ void detector_test_kernel(
     static_transform_store_data<transform_store_t> transforms_data,
     vecmem::data::vector_view<rectangle_t> rectangles_data,
     vecmem::data::vector_view<disc_t> discs_data,
-    vecmem::data::vector_view<cylinder_t> cylinders_data,
-    surfaces_finder_view<typename detector_host_t::surfaces_finder_type>
-        surfaces_finder_data) {
+    vecmem::data::vector_view<cylinder_t> cylinders_data) {
 
     // convert toy detector_data into detector w/ device vectors
     detector_device_t det_device(det_data);
@@ -68,6 +66,20 @@ __global__ void detector_test_kernel(
     for (unsigned int i = 0; i < cylinders.size(); i++) {
         cylinders_device[i] = cylinders[i];
     }
+
+    // print output test for surface finder
+    auto& sf_finder_device = det_device.get_surfaces_finder();
+    for (unsigned int i_s = 0; i_s < sf_finder_device.size(); i_s++) {
+        auto& grid = sf_finder_device[i_s];
+        for (unsigned int i = 0; i < grid.axis_p0().bins(); i++) {
+            for (unsigned int j = 0; j < grid.axis_p1().bins(); j++) {
+                const auto& bin = grid.bin(i, j);
+                for (auto& id : bin) {
+                    // printf("%d \n", id);
+                }
+            }
+        }
+    }
 }
 
 /// implementation of the test function for detector
@@ -78,9 +90,7 @@ void detector_test(
     static_transform_store_data<transform_store_t>& transforms_data,
     vecmem::data::vector_view<rectangle_t>& rectangles_data,
     vecmem::data::vector_view<disc_t>& discs_data,
-    vecmem::data::vector_view<cylinder_t>& cylinders_data,
-    surfaces_finder_data<typename detector_host_t::surfaces_finder_type>&
-        surfaces_finder_data) {
+    vecmem::data::vector_view<cylinder_t>& cylinders_data) {
 
     constexpr int block_dim = 1;
     constexpr int thread_dim = 1;
@@ -88,7 +98,7 @@ void detector_test(
     // run the test kernel
     detector_test_kernel<<<block_dim, thread_dim>>>(
         det_data, volumes_data, surfaces_data, transforms_data, rectangles_data,
-        discs_data, cylinders_data, surfaces_finder_data);
+        discs_data, cylinders_data);
 
     // cuda error check
     DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());

--- a/tests/unit_tests/cuda/detector_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/detector_cuda_kernel.cu
@@ -18,7 +18,9 @@ __global__ void detector_test_kernel(
     static_transform_store_data<transform_store_t> transforms_data,
     vecmem::data::vector_view<rectangle_t> rectangles_data,
     vecmem::data::vector_view<disc_t> discs_data,
-    vecmem::data::vector_view<cylinder_t> cylinders_data) {
+    vecmem::data::vector_view<cylinder_t> cylinders_data,
+    surfaces_finder_view<typename detector_host_t::surfaces_finder_type>
+        surfaces_finder_data) {
 
     // convert toy detector_data into detector w/ device vectors
     detector_device_t det_device(det_data);
@@ -76,7 +78,9 @@ void detector_test(
     static_transform_store_data<transform_store_t>& transforms_data,
     vecmem::data::vector_view<rectangle_t>& rectangles_data,
     vecmem::data::vector_view<disc_t>& discs_data,
-    vecmem::data::vector_view<cylinder_t>& cylinders_data) {
+    vecmem::data::vector_view<cylinder_t>& cylinders_data,
+    surfaces_finder_data<typename detector_host_t::surfaces_finder_type>&
+        surfaces_finder_data) {
 
     constexpr int block_dim = 1;
     constexpr int thread_dim = 1;
@@ -84,7 +88,7 @@ void detector_test(
     // run the test kernel
     detector_test_kernel<<<block_dim, thread_dim>>>(
         det_data, volumes_data, surfaces_data, transforms_data, rectangles_data,
-        discs_data, cylinders_data);
+        discs_data, cylinders_data, surfaces_finder_data);
 
     // cuda error check
     DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());

--- a/tests/unit_tests/cuda/detector_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/detector_cuda_kernel.cu
@@ -69,7 +69,7 @@ __global__ void detector_test_kernel(
 
     // print output test for surface finder
     auto& sf_finder_device = det_device.get_surfaces_finder();
-    for (unsigned int i_s = 0; i_s < sf_finder_device.size(); i_s++) {
+    for (unsigned int i_s = 0; i_s < sf_finder_device.effective_size(); i_s++) {
         auto& grid = sf_finder_device[i_s];
         for (unsigned int i = 0; i < grid.axis_p0().bins(); i++) {
             for (unsigned int j = 0; j < grid.axis_p1().bins(); j++) {

--- a/tests/unit_tests/cuda/detector_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/detector_cuda_kernel.hpp
@@ -49,8 +49,6 @@ void detector_test(
     static_transform_store_data<transform_store_t>& transforms_data,
     vecmem::data::vector_view<rectangle_t>& rectangles_data,
     vecmem::data::vector_view<disc_t>& discs_data,
-    vecmem::data::vector_view<cylinder_t>& cylinders_data,
-    surfaces_finder_data<typename detector_host_t::surfaces_finder_type>&
-        surfaces_finder_data);
+    vecmem::data::vector_view<cylinder_t>& cylinders_data);
 
 }  // namespace detray

--- a/tests/unit_tests/cuda/detector_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/detector_cuda_kernel.hpp
@@ -49,6 +49,8 @@ void detector_test(
     static_transform_store_data<transform_store_t>& transforms_data,
     vecmem::data::vector_view<rectangle_t>& rectangles_data,
     vecmem::data::vector_view<disc_t>& discs_data,
-    vecmem::data::vector_view<cylinder_t>& cylinders_data);
+    vecmem::data::vector_view<cylinder_t>& cylinders_data,
+    surfaces_finder_data<typename detector_host_t::surfaces_finder_type>&
+        surfaces_finder_data);
 
 }  // namespace detray


### PR DESCRIPTION
This PR fills the surfaces_finder in toy geometry. 
I haven't figure out the best binning size of grids in surface finder, but this can be done while working on local navigation in the follow-up PRs.

Still needs to add more unit tests for this including cuda.