### PR TITLE
Fix a bug in tuple size accessor

### DIFF
--- a/core/include/detray/definitions/detail/accessor.hpp
+++ b/core/include/detray/definitions/detail/accessor.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/include/detray/definitions/detail/accessor.hpp
+++ b/core/include/detray/definitions/detail/accessor.hpp
@@ -49,12 +49,24 @@ constexpr auto get(mask_store_t&& mask_store) noexcept
  *  usage example:
  *  detail::tuple_size< tuple_type >::value
  */
-template <class T>
+template <class T, typename Enable = void>
 struct tuple_size;
 
+// std::tuple
 template <template <typename...> class tuple_type, class... value_types>
-struct tuple_size<tuple_type<value_types...>>
-    : std::integral_constant<std::size_t, sizeof...(value_types)> {};
+struct tuple_size<tuple_type<value_types...>,
+                  typename std::enable_if_t<
+                      std::is_same_v<tuple_type<value_types...>,
+                                     std::tuple<value_types...>> == true>>
+    : std::tuple_size<tuple_type<value_types...>> {};
+
+// thrust::tuple
+template <template <typename...> class tuple_type, class... value_types>
+struct tuple_size<tuple_type<value_types...>,
+                  typename std::enable_if_t<
+                      std::is_same_v<tuple_type<value_types...>,
+                                     thrust::tuple<value_types...>> == true>>
+    : thrust::tuple_size<tuple_type<value_types...>> {};
 
 /** make tuple accessor
  *  users have to specifiy tuple_type for detail::make_tuple

--- a/tests/unit_tests/core/CMakeLists.txt
+++ b/tests/unit_tests/core/CMakeLists.txt
@@ -21,3 +21,6 @@ add_detray_test(utils_quadratic_equation
 
 add_detray_test(thrust_tuple
                 thrust_tuple.cpp LINK_LIBRARIES detray::Thrust)
+
+add_detray_test(tuple_accessor
+                tuple_accessor.cpp LINK_LIBRARIES detray::core detray::Thrust)

--- a/tests/unit_tests/core/tuple_accessor.cpp
+++ b/tests/unit_tests/core/tuple_accessor.cpp
@@ -22,20 +22,20 @@ TEST(tuple_accessor, tuple_accessor) {
     // std::tuple test
     auto s_tuple = detail::make_tuple<std::tuple>(1.0, 2, "std::tuple");
 
-    const int s_tuple_size = detail::tuple_size<decltype(s_tuple)>::value;
+    const auto s_tuple_size = detail::tuple_size<decltype(s_tuple)>::value;
 
     EXPECT_EQ(s_tuple_size, 3);
-    EXPECT_EQ(detail::get<0>(s_tuple), 1.0);
+    EXPECT_FLOAT_EQ(detail::get<0>(s_tuple), 1.0);
     EXPECT_EQ(detail::get<1>(s_tuple), 2);
     EXPECT_EQ(detail::get<2>(s_tuple), "std::tuple");
 
     // thrust::tuple test
     auto t_tuple = detail::make_tuple<thrust::tuple>(1.0, 2, "thrust::tuple");
 
-    const int t_tuple_size = detail::tuple_size<decltype(t_tuple)>::value;
+    const auto t_tuple_size = detail::tuple_size<decltype(t_tuple)>::value;
 
     EXPECT_EQ(t_tuple_size, 3);
-    EXPECT_EQ(detail::get<0>(t_tuple), 1.0);
+    EXPECT_FLOAT_EQ(detail::get<0>(t_tuple), 1.0);
     EXPECT_EQ(detail::get<1>(t_tuple), 2);
     EXPECT_EQ(detail::get<2>(t_tuple), "thrust::tuple");
 }

--- a/tests/unit_tests/core/tuple_accessor.cpp
+++ b/tests/unit_tests/core/tuple_accessor.cpp
@@ -1,0 +1,47 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <iostream>
+
+#include "detray/definitions/detail/accessor.hpp"
+
+// Thrust include(s).
+#include <thrust/tuple.h>
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+namespace {
+
+struct TestStruct {
+
+    int m_int = 0;
+    float m_float = 0.;
+    double m_double = 0.;
+
+};  // struct TestStruct
+
+}  // namespace
+
+TEST(tuple_accessor, tuple_accessor) {
+
+    using namespace detray;
+
+    // detail::make_tuple
+
+    auto s_tuple = detail::make_tuple<std::tuple>(1, 2);
+
+    std::cout << detail::tuple_size<decltype(s_tuple)>::value << std::endl;
+
+    auto t_tuple = detail::make_tuple<thrust::tuple>(1, 2);
+
+    std::cout << detail::tuple_size<decltype(t_tuple)>::value << std::endl;
+
+    // detail::get
+
+    // detail::tuple_size
+}

--- a/tests/unit_tests/core/tuple_accessor.cpp
+++ b/tests/unit_tests/core/tuple_accessor.cpp
@@ -15,33 +15,27 @@
 // GoogleTest include(s).
 #include <gtest/gtest.h>
 
-namespace {
-
-struct TestStruct {
-
-    int m_int = 0;
-    float m_float = 0.;
-    double m_double = 0.;
-
-};  // struct TestStruct
-
-}  // namespace
-
 TEST(tuple_accessor, tuple_accessor) {
 
     using namespace detray;
 
-    // detail::make_tuple
+    // std::tuple test
+    auto s_tuple = detail::make_tuple<std::tuple>(1.0, 2, "std::tuple");
 
-    auto s_tuple = detail::make_tuple<std::tuple>(1, 2);
+    const int s_tuple_size = detail::tuple_size<decltype(s_tuple)>::value;
 
-    std::cout << detail::tuple_size<decltype(s_tuple)>::value << std::endl;
+    EXPECT_EQ(s_tuple_size, 3);
+    EXPECT_EQ(detail::get<0>(s_tuple), 1.0);
+    EXPECT_EQ(detail::get<1>(s_tuple), 2);
+    EXPECT_EQ(detail::get<2>(s_tuple), "std::tuple");
 
-    auto t_tuple = detail::make_tuple<thrust::tuple>(1, 2);
+    // thrust::tuple test
+    auto t_tuple = detail::make_tuple<thrust::tuple>(1.0, 2, "thrust::tuple");
 
-    std::cout << detail::tuple_size<decltype(t_tuple)>::value << std::endl;
+    const int t_tuple_size = detail::tuple_size<decltype(t_tuple)>::value;
 
-    // detail::get
-
-    // detail::tuple_size
+    EXPECT_EQ(t_tuple_size, 3);
+    EXPECT_EQ(detail::get<0>(t_tuple), 1.0);
+    EXPECT_EQ(detail::get<1>(t_tuple), 2);
+    EXPECT_EQ(detail::get<2>(t_tuple), "thrust::tuple");
 }


### PR DESCRIPTION
This PR fixes a bug in `detail::tuple_size<thrust::tuple<T...>>` whose value is fixed to 10. 
I also added a unit test for this.