### PR TITLE
Warning Improvements, main branch (2022.02.04.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Run Benchmarks
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: cp $GITHUB_WORKSPACE/tests/scripts/* .; source ./run_benchmarks.sh
+      run: $GITHUB_WORKSPACE/tests/scripts/run_benchmarks.sh
 
     #- name: Upload Benchmark Results
     #  run: git push 'https://asalzburger:${{ secrets.PERSONAL_GITHUB_TOKEN }}@github.com/asalzburger/detray.git' gh-pages:gh-pages
@@ -82,7 +82,7 @@ jobs:
     - name: Run Benchmarks
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: cp $GITHUB_WORKSPACE/tests/scripts/* .; source ./run_benchmarks.sh
+      run: $GITHUB_WORKSPACE/tests/scripts/run_benchmarks.sh
 
   ubuntu_debug:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,12 @@
 cmake_minimum_required( VERSION 3.11 )
 project( detray VERSION 0.4 LANGUAGES CXX )
 
+# Set up the used C++ standard(s).
+set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (host) C++ standard to use" )
+set( CMAKE_CXX_EXTENSIONS FALSE CACHE BOOL "Disable (host) C++ extensions" )
+set( CMAKE_CUDA_STANDARD 17 CACHE STRING "The (CUDA) C++ standard to use" )
+set( CMAKE_CUDA_EXTENSIONS FALSE CACHE BOOL "Disable (CUDA) C++ extensions" )
+
 # CMake include(s).
 include( CMakeDependentOption )
 include( GNUInstallDirs )
@@ -27,7 +33,6 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY
 
 # Include the Detray CMake code.
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
-include( detray-compiler-options )
 include( detray-functions )
 
 # Check if CUDA is available.

--- a/cmake/detray-compiler-options-cpp.cmake
+++ b/cmake/detray-compiler-options-cpp.cmake
@@ -1,15 +1,11 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # Include the helper function(s).
 include( detray-functions )
-
-# Set the language standards to use.
-set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (Host) C++ standard to use" )
-set( CMAKE_CUDA_STANDARD 17 CACHE STRING "The (CUDA) C++ standard to use" )
 
 # Turn on the correct setting for the __cplusplus macro with MSVC.
 if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
@@ -26,6 +22,10 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    detray_add_flag( CMAKE_CXX_FLAGS "-Wshadow" )
    detray_add_flag( CMAKE_CXX_FLAGS "-Wunused-local-typedefs" )
 
+   # More rigorous tests for the Debug builds.
+   detray_add_flag( CMAKE_CXX_FLAGS_DEBUG "-Werror" )
+   detray_add_flag( CMAKE_CXX_FLAGS_DEBUG "-pedantic" )
+
 elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
 
    # Basic flags for all build modes.
@@ -33,12 +33,7 @@ elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
       "${CMAKE_CXX_FLAGS}" )
    detray_add_flag( CMAKE_CXX_FLAGS "/W4" )
 
+   # More rigorous tests for the Debug builds.
+   detray_add_flag( CMAKE_CXX_FLAGS_DEBUG "/WX" )
+
 endif()
-
-# Set the CUDA architecture to build code for.
-set( CMAKE_CUDA_ARCHITECTURES "52" CACHE STRING
-   "CUDA architectures to build device code for" )
-
-# Make CUDA generate debug symbols for the device code as well in a debug
-# build.
-detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G" )

--- a/cmake/detray-compiler-options-cuda.cmake
+++ b/cmake/detray-compiler-options-cuda.cmake
@@ -1,0 +1,39 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# FindCUDAToolkit needs at least CMake 3.17.
+cmake_minimum_required( VERSION 3.17 )
+
+# Include the helper function(s).
+include( detray-functions )
+
+# Figure out the properties of CUDA being used.
+find_package( CUDAToolkit REQUIRED )
+
+# Turn on the correct setting for the __cplusplus macro with MSVC.
+if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
+   detray_add_flag( CMAKE_CUDA_FLAGS "-Xcompiler /Zc:__cplusplus" )
+endif()
+
+# Set the CUDA architecture to build code for.
+set( CMAKE_CUDA_ARCHITECTURES "52" CACHE STRING
+   "CUDA architectures to build device code for" )
+
+# Allow to use functions in device code that are constexpr, even if they are
+# not marked with __device__.
+detray_add_flag( CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr" )
+
+# Turn off fast math for the device code.
+detray_add_flag( CMAKE_CUDA_FLAGS "-fmad=false" )
+
+# Make CUDA generate debug symbols for the device code as well in a debug
+# build.
+detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G" )
+
+# More rigorous tests for the Debug builds.
+if( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2" )
+   detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-Werror all-warnings" )
+endif()

--- a/cmake/detray-functions.cmake
+++ b/cmake/detray-functions.cmake
@@ -1,8 +1,11 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
+# CMake include(s).
+include( CMakeParseArguments )
 
 # Helper function for setting up the detray libraries.
 #
@@ -34,9 +37,31 @@ function( detray_add_library fullname basename )
 
 endfunction( detray_add_library )
 
+# Helper function for setting up the detray executables.
+#
+# The detray executables are *not* installed with the project, as they are only
+# used for testing / benchmarking the code. Clients of detray do not need them.
+#
+# Usage: detray_add_executable( foo bar.cpp
+#                               LINK_LIBRARIES detray::core )
+#
+function( detray_add_executable name )
+
+   # Parse the function's options.
+   cmake_parse_arguments( ARG "" "" "LINK_LIBRARIES" ${ARGN} )
+
+   # Create the executable.
+   set( exe_name "detray_${name}" )
+   add_executable( ${exe_name} ${ARG_UNPARSED_ARGUMENTS} )
+   if( ARG_LINK_LIBRARIES )
+      target_link_libraries( ${exe_name} PRIVATE ${ARG_LINK_LIBRARIES} )
+   endif()
+
+endfunction( detray_add_executable )
+
 # Helper function for setting up the detray tests.
 #
-# Usage: detray_add_test( source1.cpp source2.cpp
+# Usage: detray_add_test( core source1.cpp source2.cpp
 #                         LINK_LIBRARIES detray::core )
 #
 function( detray_add_test name )
@@ -54,6 +79,10 @@ function( detray_add_test name )
    # Run the executable as the test.
    add_test( NAME ${test_exe_name}
       COMMAND ${test_exe_name} )
+
+   # Set all properties for the test.
+   set_tests_properties( ${test_exe_name} PROPERTIES
+      ENVIRONMENT DETRAY_TEST_DATA_DIR=${PROJECT_SOURCE_DIR}/data/ )
 
 endfunction( detray_add_test )
 

--- a/core/include/detray/tools/propagator.hpp
+++ b/core/include/detray/tools/propagator.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -72,7 +72,7 @@ struct propagator {
             heartbeat &= _navigator.status(n_state, s_state());
         }
         return t_out;
-    };
+    }
 };
 
 }  // namespace detray

--- a/core/include/detray/utils/generators.hpp
+++ b/core/include/detray/utils/generators.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -324,6 +324,6 @@ std::vector<point2> r_phi_polygon(scalar rmin, scalar rmax, scalar phimin,
     r_phi_poly.push_back({rmax * cos_min_phi, rmax * sin_min_phi});
 
     return r_phi_poly;
-};
+}
 
 }  // namespace detray

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,7 +13,7 @@ message( STATUS "Building Algebra Plugins as part of the Detray project" )
 
 # Declare where to get Algebra Plugins from.
 set( DETRAY_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.4.0.tar.gz;URL_MD5;c9f8f1d29665b196f182060f871bb8f0"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.6.0.tar.gz;URL_MD5;a10303624248f05c43ab67c486a0d527"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced( DETRAY_ALGEBRA_PLUGINS_SOURCE )
 FetchContent_Declare( AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE} )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,7 +13,7 @@ message( STATUS "Building VecMem as part of the Detray project" )
 
 # Declare where to get VecMem from.
 set( DETRAY_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.9.0.tar.gz;URL_MD5;4db7e846af862cfd20099b9b0b8bdb96"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.10.0.tar.gz;URL_MD5;712888e704d2e4c915ac1f25f28da467"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( DETRAY_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${DETRAY_VECMEM_SOURCE} )

--- a/plugins/algebra/eigen/CMakeLists.txt
+++ b/plugins/algebra/eigen/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -20,3 +20,10 @@ target_link_libraries( detray_eigen
    INTERFACE algebra::eigen_eigen vecmem::core )
 target_compile_definitions( detray_eigen
    INTERFACE DETRAY_CUSTOM_SCALARTYPE=${DETRAY_CUSTOM_SCALARTYPE} )
+
+# For some wicked reason CUDA keeps complaining about the Eigen headers, even
+# though they are set up from a "system include path". So I had to explicitly
+# disable the warning triggered by those headers, for anything that uses them.
+# This is pretty bad, as we're now blind to these types of warnings/errors. :-(
+target_compile_options( detray_eigen INTERFACE
+   $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --diag_suppress=20012> )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,15 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-add_subdirectory(common)
-add_subdirectory(unit_tests)
+# Set the common C++ flags.
+include( detray-compiler-options-cpp )
 
-if(DETRAY_BENCHMARKS)
-    add_subdirectory(benchmarks)
+# Include all of the code-holding sub-directories.
+add_subdirectory( common )
+add_subdirectory( unit_tests )
+if( DETRAY_BENCHMARKS )
+   add_subdirectory( benchmarks )
 endif()

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -1,19 +1,18 @@
-message(STATUS "Testing: 'detray::benchmarks' enabled")
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-macro(add_detray_benchmark TESTNAME FILES PLUGIN_LIBRARY)
-    add_executable(${TESTNAME} ${FILES})
-    target_link_libraries(${TESTNAME} benchmark::benchmark detray::core detray::tests_common detray::io ${PLUGIN_LIBRARY})
-    install(TARGETS ${TESTNAME} RUNTIME DESTINATION bin)
-endmacro()
-
-add_subdirectory(core)
-add_subdirectory(array)
-if(DETRAY_EIGEN_PLUGIN)
-    add_subdirectory(eigen)
+# Include all of the benchmarks that can be built.
+add_subdirectory( core )
+add_subdirectory( array )
+if( DETRAY_EIGEN_PLUGIN )
+   add_subdirectory( eigen )
 endif()
-if(DETRAY_SMATRIX_PLUGIN)
-    add_subdirectory(smatrix)
+if( DETRAY_SMATRIX_PLUGIN )
+   add_subdirectory( smatrix )
 endif()
-if(DETRAY_VC_PLUGIN)
-    add_subdirectory(vc)
+if( DETRAY_VC_PLUGIN )
+   add_subdirectory( vc )
 endif()

--- a/tests/benchmarks/array/CMakeLists.txt
+++ b/tests/benchmarks/array/CMakeLists.txt
@@ -1,16 +1,17 @@
-add_detray_benchmark(array_find_volume
-                     array_find_volume.cpp
-                     detray::array)
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-add_detray_benchmark(array_intersect_all
-                     array_intersect_all.cpp
-                     detray::array)
+detray_add_executable( array_find_volume "array_find_volume.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::array )
 
-add_detray_benchmark(array_intersect_surfaces
-                     array_intersect_surfaces.cpp
-                     detray::array)
-                     
-add_detray_benchmark(array_masks
-                     array_masks.cpp
-                     detray::array)
+detray_add_executable( array_intersect_all "array_intersect_all.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::array )
 
+detray_add_executable( array_intersect_surfaces "array_intersect_surfaces.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::array )
+
+detray_add_executable( array_masks "array_masks.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::array )

--- a/tests/benchmarks/core/CMakeLists.txt
+++ b/tests/benchmarks/core/CMakeLists.txt
@@ -1,3 +1,9 @@
-add_detray_benchmark(benchmark_grids
-                     benchmark_grids.cpp
-                     "")
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+detray_add_executable( benchmark_grids "benchmark_grids.cpp"
+   LINK_LIBRARIES benchmark::benchmark vecmem::core detray_tests_common
+                  detray::core )

--- a/tests/benchmarks/eigen/CMakeLists.txt
+++ b/tests/benchmarks/eigen/CMakeLists.txt
@@ -1,16 +1,17 @@
-add_detray_benchmark(eigen_find_volume
-                     eigen_find_volume.cpp
-                     detray::eigen)
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-add_detray_benchmark(eigen_intersect_all
-                     eigen_intersect_all.cpp
-                     detray::eigen)
+detray_add_executable( eigen_find_volume "eigen_find_volume.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::eigen )
 
-add_detray_benchmark(eigen_intersect_surfaces
-                     eigen_intersect_surfaces.cpp
-                     detray::eigen)
-                     
-add_detray_benchmark(eigen_masks
-                     eigen_masks.cpp
-                     detray::eigen)
+detray_add_executable( eigen_intersect_all "eigen_intersect_all.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::eigen )
 
+detray_add_executable( eigen_intersect_surfaces "eigen_intersect_surfaces.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::eigen )
+
+detray_add_executable( eigen_masks "eigen_masks.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::eigen )

--- a/tests/benchmarks/smatrix/CMakeLists.txt
+++ b/tests/benchmarks/smatrix/CMakeLists.txt
@@ -1,15 +1,18 @@
-add_detray_benchmark(smatrix_find_volume
-                     smatrix_find_volume.cpp
-                     detray::smatrix)
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-add_detray_benchmark(smatrix_intersect_all
-                     smatrix_intersect_all.cpp
-                     detray::smatrix)
+detray_add_executable( smatrix_find_volume "smatrix_find_volume.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::smatrix )
 
-add_detray_benchmark(smatrix_intersect_surfaces
-                     smatrix_intersect_surfaces.cpp
-                     detray::smatrix)
+detray_add_executable( smatrix_intersect_all "smatrix_intersect_all.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::smatrix )
 
-add_detray_benchmark(smatrix_masks
-                     smatrix_masks.cpp
-                     detray::smatrix)
+detray_add_executable( smatrix_intersect_surfaces
+   "smatrix_intersect_surfaces.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::smatrix )
+
+detray_add_executable( smatrix_masks "smatrix_masks.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::smatrix )

--- a/tests/benchmarks/vc/CMakeLists.txt
+++ b/tests/benchmarks/vc/CMakeLists.txt
@@ -1,16 +1,18 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-add_detray_benchmark(vc_array_find_volume
-                     vc_array_find_volume.cpp
-                     detray::vc_array)
+detray_add_executable( vc_array_find_volume "vc_array_find_volume.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::vc_array )
 
-add_detray_benchmark(vc_array_intersect_all
-                     vc_array_intersect_all.cpp
-                     detray::vc_array)
+detray_add_executable( vc_array_intersect_all "vc_array_intersect_all.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::vc_array )
 
-add_detray_benchmark(vc_array_intersect_surfaces
-                     vc_array_intersect_surfaces.cpp
-                     detray::vc_array)
-                     
-add_detray_benchmark(vc_array_masks
-                     vc_array_masks.cpp
-                     detray::vc_array)
+detray_add_executable( vc_array_intersect_surfaces
+   "vc_array_intersect_surfaces.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::vc_array )
+
+detray_add_executable( vc_array_masks "vc_array_masks.cpp"
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::vc_array )

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -1,29 +1,24 @@
-add_library(detray_tests_common INTERFACE)
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-target_include_directories(detray_tests_common
-  INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
+# Set up a helper library, which would be used by most of the tests.
+add_library( detray_tests_common INTERFACE )
+target_include_directories( detray_tests_common
+   INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+target_link_libraries( detray_tests_common
+   INTERFACE vecmem::core detray::core detray::io )
 
-if(DETRAY_CUSTOM_SCALARTYPE)
-  target_compile_definitions(
-    detray_tests_common
-    INTERFACE -DDETRAY_CUSTOM_SCALARTYPE=${DETRAY_CUSTOM_SCALARTYPE})
+if( DETRAY_BENCHMARKS AND DETRAY_BENCHMARKS_REP )
+   message( STATUS "Repetitions for benchmarks: ${DETRAY_BENCHMARKS_REP}" )
+   target_compile_definitions( detray_tests_common
+      INTERFACE DETRAY_BENCHMARKS_REP=${DETRAY_BENCHMARKS_REP} )
 endif()
 
-if(DETRAY_BENCHMARKS AND DETRAY_BENCHMARKS_REP)
-  message(STATUS "Repetitions for benchmarks: " ${DETRAY_BENCHMARKS_REP})
-  target_compile_definitions(
-    detray_tests_common
-    INTERFACE -DDETRAY_BENCHMARKS_REP=${DETRAY_BENCHMARKS_REP})
+if( DETRAY_BENCHMARKS_MULTITHREAD )
+   message( STATUS "Using multithreaded benchmarks" )
+   target_compile_definitions( detray_tests_common
+      INTERFACE DETRAY_BENCHMARKS_MULTITHREAD )
 endif()
-
-if(DETRAY_BENCHMARKS_MULTITHREAD)
-  message(STATUS "Using multithreaded benchmarks")
-  target_compile_definitions(
-    detray_tests_common
-    INTERFACE -DDETRAY_BENCHMARKS_MULTITHREAD=ON)
-endif()
-
-add_library(detray::tests_common ALIAS detray_tests_common)

--- a/tests/common/include/tests/common/check_geometry_linking.inl
+++ b/tests/common/include/tests/common/check_geometry_linking.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -64,9 +64,3 @@ TEST(ALGEBRA_PLUGIN, check_geometry_linking) {
 }
 
 }  // namespace __plugin
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
-}

--- a/tests/common/include/tests/common/check_geometry_navigation.inl
+++ b/tests/common/include/tests/common/check_geometry_navigation.inl
@@ -259,9 +259,3 @@ TEST(ALGEBRA_PLUGIN, geometry_discovery) {
         }
     }
 }
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
-}

--- a/tests/common/include/tests/common/check_geometry_scan.inl
+++ b/tests/common/include/tests/common/check_geometry_scan.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -122,10 +122,4 @@ TEST(ALGEBRA_PLUGIN, geometry_scan) {
         hash_tree<decltype(adj_scan.at(3)), dindex>(adj_scan.at(3));
 
     EXPECT_EQ(geo_checker_vol3.root(), vol3_hash);*/
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -49,10 +49,4 @@ TEST(ALGEBRA_PLUGIN, detector) {
 
     auto &v = d.new_volume({0., 10., -5., 5., -M_PI, M_PI});
     d.add_objects(ctx0, v, surfaces, masks, trfs);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/core_mask_store.inl
+++ b/tests/common/include/tests/common/core_mask_store.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,7 +15,7 @@
 /// @note __plugin has to be defined with a preprocessor command
 
 // This tests the construction of a static transform store
-TEST(ALGEBRA_PLUGIN, static_transform_store) {
+TEST(ALGEBRA_PLUGIN, static_mask_store) {
 
     vecmem::host_memory_resource host_mr;
 
@@ -82,10 +82,4 @@ TEST(ALGEBRA_PLUGIN, static_transform_store) {
     ASSERT_TRUE(ring_masks.size() == 4);
     ASSERT_TRUE(single_masks.size() == 0);
     ASSERT_TRUE(trapezoid_masks.size() == 1);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/core_transform_store.inl
+++ b/tests/common/include/tests/common/core_transform_store.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -46,10 +46,4 @@ TEST(ALGEBRA_PLUGIN, static_transform_store) {
 
     static_store.emplace_back(ctx0);
     ASSERT_EQ(static_store.size(ctx0), 5u);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/display_masks.inl
+++ b/tests/common/include/tests/common/display_masks.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -59,10 +59,4 @@ TEST(display, trapezoid2) {
     display(false);
     draw_mask(trapezoid, transform, style{c}, gxy);
     save("trapezoid.png");
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/geometry_graph.inl
+++ b/tests/common/include/tests/common/geometry_graph.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -54,10 +54,4 @@ TEST(ALGEBRA_PLUGIN, geometry_linking) {
     // const auto &adj = g.adjacency_list();
     // ASSERT_TRUE(adj.at(0) == nbrs_map_v0);
     // ASSERT_TRUE(adj.at(1) == nbrs_map_v1);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/geometry_volume.inl
+++ b/tests/common/include/tests/common/geometry_volume.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -69,10 +69,4 @@ TEST(ALGEBRA_PLUGIN, volume) {
                 surface_range);
     ASSERT_TRUE(v2.template range<object_registry::id::e_portal>() ==
                 portal_range);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/io_read_detector.inl
+++ b/tests/common/include/tests/common/io_read_detector.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,10 +29,4 @@ TEST(ALGEBRA_PLUGIN, read_detector) {
         read_from_csv<detector_registry::tml_detector>(tml_files, host_mr);
 
     std::cout << d.to_string(name_map) << std::endl;
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/masks_annulus2.inl
+++ b/tests/common/include/tests/common/masks_annulus2.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -79,10 +79,4 @@ TEST(mask, annulus2) {
                 intersection_status::e_inside);
     ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out4), {0., 0.07}) ==
                 intersection_status::e_inside);
-}
-
-int main(int argc, char** argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/masks_cylinder3.inl
+++ b/tests/common/include/tests/common/masks_cylinder3.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -43,10 +43,4 @@ TEST(mask, cylinder3) {
     // Move outside point inside using a tolerance
     ASSERT_TRUE(c.is_inside<local_type>(p3_out, {0., 0.6}) ==
                 intersection_status::e_inside);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/masks_rectangle2.inl
+++ b/tests/common/include/tests/common/masks_rectangle2.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -40,10 +40,4 @@ TEST(mask, rectangle2) {
     // Move outside point inside using a tolerance
     ASSERT_TRUE(r2.is_inside<local_type>(p2_out, {1., 0.5}) ==
                 intersection_status::e_inside);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/masks_ring2.inl
+++ b/tests/common/include/tests/common/masks_ring2.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -47,10 +47,4 @@ TEST(mask, ring2) {
     // Move outside point inside using a tolerance
     ASSERT_TRUE(r2.is_inside<cartesian>(p2_c_out, 1.45) ==
                 intersection_status::e_inside);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/masks_single3.inl
+++ b/tests/common/include/tests/common/masks_single3.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -90,10 +90,4 @@ TEST(mask, single3_2) {
     // Move outside point inside using a tolerance - take t1 not t1
     ASSERT_TRUE(m1_2.is_inside<local_type>(p3_out, 6.1) ==
                 intersection_status::e_inside);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/masks_trapezoid2.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -42,10 +42,4 @@ TEST(mask, trapezoid2) {
     // Move outside point inside using a tolerance
     ASSERT_TRUE(t2.is_inside<local_type>(p2_out, {1., 0.5}) ==
                 intersection_status::e_inside);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/masks_unmasked.inl
+++ b/tests/common/include/tests/common/masks_unmasked.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,10 +21,4 @@ TEST(mask, unmasked) {
     ASSERT_TRUE(u.is_inside<local_type>(p2) == e_hit);
     ASSERT_TRUE(u.is_inside<local_type>(p2, true) == e_hit);
     ASSERT_TRUE(u.is_inside<local_type>(p2, false) == e_missed);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/surfaces_finder.inl
+++ b/tests/common/include/tests/common/surfaces_finder.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -60,10 +60,4 @@ TEST(ALGEBRA_PLUGIN, surfaces_finder) {
     EXPECT_EQ(finder[1].bin(1, 0)[0], 1u);
     EXPECT_EQ(finder[1].bin(0, 1)[0], 2u);
     EXPECT_EQ(finder[1].bin(1, 1)[0], 3u);
-}
-
-int main(int argc, char** argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/test_core.inl
+++ b/tests/common/include/tests/common/test_core.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -55,10 +55,4 @@ TEST(ALGEBRA_PLUGIN, intersection) {
     ASSERT_NEAR(intersections[0].path, 1.7, epsilon);
     ASSERT_NEAR(intersections[1].path, 2, epsilon);
     ASSERT_TRUE(std::isinf(intersections[2].path));
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -777,10 +777,4 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {4, 50},
                       {{18, inv_sf_finder}, {leaving_world, inv_sf_finder}});
-}
-
-int main(int argc, char** argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/tools/ray_gun.hpp
+++ b/tests/common/include/tests/common/tools/ray_gun.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -74,9 +74,9 @@ inline auto shoot_ray(const detector_t &detector, const point3 &origin,
     using detray_context = typename detector_t::context;
     // detray_context default_context;
 
-    track<detray_context> ray = {.pos = origin, .dir = direction};
+    track<detray_context> ray = {origin, direction};
 
     return shoot_ray(detector, ray);
-};
+}
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools/read_geometry.hpp
+++ b/tests/common/include/tests/common/tools/read_geometry.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -53,4 +53,4 @@ auto read_from_csv(detector_input_files& files,
 
     return std::make_pair<decltype(d), decltype(name_map)>(std::move(d),
                                                            std::move(name_map));
-};
+}

--- a/tests/common/include/tests/common/tools_cylinder_intersection.inl
+++ b/tests/common/include/tests/common/tools_cylinder_intersection.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -98,10 +98,4 @@ TEST(ALGEBRA_PLUGIN, concentric_cylinders) {
                 hit_cocylindrical.p2[1] != not_defined);
     ASSERT_NEAR(hit_cylinrical.p2[0], hit_cocylindrical.p2[0], isclose);
     ASSERT_NEAR(hit_cylinrical.p2[1], hit_cocylindrical.p2[1], isclose);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -98,10 +98,4 @@ TEST(tools, intersection_kernel_single) {
     }
 
     return;
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/tools_line_stepper.inl
+++ b/tests/common/include/tests/common/tools_line_stepper.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -44,10 +44,4 @@ TEST(ALGEBRA_PLUGIN, line_stepper) {
 
     heartbeat = lstepper.step(lstate, 10.);
     ASSERT_FALSE(heartbeat);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -249,10 +249,4 @@ TEST(ALGEBRA_PLUGIN, single_type_navigator) {
                       toy_navigator::navigation_trust_level::e_full_trust);
         }
     }
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/tools_planar_intersection.inl
+++ b/tests/common/include/tests/common/tools_planar_intersection.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -86,10 +86,4 @@ TEST(ALGEBRA_PLUGIN, translated_plane) {
     // Local intersection infoimation - unchanged
     ASSERT_NEAR(hit_bound_outside.p2[0], -1., epsilon);
     ASSERT_NEAR(hit_bound_outside.p2[1], -1., epsilon);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -55,10 +55,4 @@ TEST(ALGEBRA_PLUGIN, propagator) {
     void_track_inspector vi;
 
     /*auto end = */ p.propagate(traj, vi);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/scripts/run_benchmarks.sh
+++ b/tests/scripts/run_benchmarks.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
 echo "===> CI Benchmark running script for detray"
 
@@ -14,12 +20,12 @@ touch benchmark_${LASTCOMMIT}.csv
 
 for group in eigen array ; do
     echo "===> Running ${group}.benchmarks ..."
-    ./bin/${group}_masks --benchmark_out=${group}_masks.csv --benchmark_out_format=csv
-    ./bin/${group}_intersect_surfaces --benchmark_out=${group}_intersect_surfaces.csv --benchmark_out_format=csv
-    ./bin/${group}_intersect_all --benchmark_out=${group}_intersect_all.csv --benchmark_out_format=csv
+    ./bin/detray_${group}_masks --benchmark_out=${group}_masks.csv --benchmark_out_format=csv
+    ./bin/detray_${group}_intersect_surfaces --benchmark_out=${group}_intersect_surfaces.csv --benchmark_out_format=csv
+    ./bin/detray_${group}_intersect_all --benchmark_out=${group}_intersect_all.csv --benchmark_out_format=csv
 
     echo "===> Extracting benchmark results ..."
-    cat ${group}_masks.csv | tail -n5  > ${group}_masks_cropped.csv 
+    cat ${group}_masks.csv | tail -n5  > ${group}_masks_cropped.csv
     cat ${group}_intersect_surfaces.csv | tail -f -n3 > ${group}_intersect_surfaces_cropped.csv
     cat ${group}_intersect_all.csv | tail -f -n1 > ${group}_intersect_all_cropped.csv
     sed -i -e 's/"BM_/'$LASTCOMMIT',"'$group'","BM_/g' ${group}_masks_cropped.csv

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -1,60 +1,23 @@
-message(STATUS "Testing: 'detray::unit_tests' enabled")
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-mark_as_advanced(
-    BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
-    gmock_build_tests gtest_build_samples gtest_build_tests
-    gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
-)
-
-include(GoogleTest)
-
-function(add_detray_test name)
-  
-  # Parse the function's options.
-  cmake_parse_arguments( ARG "" "" "LINK_LIBRARIES" ${ARGN} )
-
-  # Create the test executable.
-  set( test_exe_name "detray_test_${name}" )
-  add_executable(${test_exe_name} ${ARG_UNPARSED_ARGUMENTS})
-  target_link_libraries( ${test_exe_name} PRIVATE gtest gmock gtest_main)
-  target_link_libraries( ${test_exe_name} PRIVATE detray::core detray::io detray::tests_common)  
-  if ( ARG_LINK_LIBRARIES )
-    target_link_libraries( ${test_exe_name} PRIVATE ${ARG_LINK_LIBRARIES})
-  endif()
-  foreach( _config "" "_DEBUG" "_RELEASE" "_MINSIZEREL" "_RELWITHDEBINFO" )
-    set_property( TARGET ${test_exe_name} PROPERTY
-      RUNTIME_OUTPUT_DIRECTORY${_config} "${CMAKE_BINARY_DIR}/test-bin" )
-  endforeach()
-
-  target_compile_options(${test_exe_name}
-    PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:
-    --expt-relaxed-constexpr -fmad=false>)
-  
-  # Run the executable as the test.
-  add_test( NAME ${test_exe_name} COMMAND $<TARGET_FILE:${test_exe_name}> )
-
-  set_tests_properties(${test_exe_name} PROPERTIES ENVIRONMENT DETRAY_TEST_DATA_DIR=${PROJECT_SOURCE_DIR}/data/)
-  
-endfunction(add_detray_test)  
-  
-set(all_unit_tests "core")
-list(APPEND all_unit_tests "annulus2;cylinder3;rectangle2;ring2;single3;unmasked;trapezoid2")
-list(APPEND all_unit_tests "propagator;line_stepper;navigator;cylinder_intersection;planar_intersection;intersection_kernel")
-list(APPEND all_unit_tests "detector;transform_store;mask_store")
-list(APPEND all_unit_tests "volume;toy_geometry;geometry_graph;surfaces_finder")
-list(APPEND all_unit_tests "geometry_linking;geometry_navigation;geometry_scan")
-
-add_subdirectory(core)
-add_subdirectory(array)
-if(DETRAY_EIGEN_PLUGIN)
-    add_subdirectory(eigen)
+# Set up all of the "host" tests.
+add_subdirectory( core )
+add_subdirectory( array )
+if( DETRAY_EIGEN_PLUGIN )
+   add_subdirectory( eigen )
 endif()
-if(DETRAY_SMATRIX_PLUGIN)
-    add_subdirectory(smatrix)
+if( DETRAY_SMATRIX_PLUGIN )
+   add_subdirectory( smatrix )
 endif()
-if(DETRAY_VC_PLUGIN)
-    add_subdirectory(vc)
+if( DETRAY_VC_PLUGIN )
+   add_subdirectory( vc )
 endif()
-if(DETRAY_BUILD_CUDA)
-  add_subdirectory(cuda)
+
+# Set up all of the "device" tests.
+if( DETRAY_BUILD_CUDA )
+   add_subdirectory( cuda )
 endif()

--- a/tests/unit_tests/array/CMakeLists.txt
+++ b/tests/unit_tests/array/CMakeLists.txt
@@ -1,22 +1,30 @@
-enable_testing()
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-foreach(etest ${all_unit_tests})
-    add_detray_test(array_${etest}
-                    array_${etest}.cpp
-                    LINK_LIBRARIES
-                    detray::array)
-endforeach(etest)
+# Set up all of the "standard" tests.
+detray_add_test( array
+   "array_annulus2.cpp" "array_core.cpp" "array_cylinder_intersection.cpp"
+   "array_cylinder3.cpp" "array_detector.cpp" "array_geometry_graph.cpp"
+   "array_geometry_linking.cpp" "array_geometry_navigation.cpp"
+   "array_geometry_scan.cpp" "array_intersection_kernel.cpp"
+   "array_line_stepper.cpp" "array_mask_store.cpp" "array_navigator.cpp"
+   "array_planar_intersection.cpp" "array_propagator.cpp" "array_rectangle2.cpp"
+   "array_ring2.cpp" "array_single3.cpp" "array_surfaces_finder.cpp"
+   "array_toy_geometry.cpp" "array_transform_store.cpp" "array_trapezoid2.cpp"
+   "array_unmasked.cpp" "array_volume.cpp"
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::array )
 
-if (DETRAY_IO_CSV)
-    add_detray_test(array_read_detector
-                    array_read_detector.cpp
-                    LINK_LIBRARIES
-                    detray::array)
+# Set up the "conditional" tests.
+if( DETRAY_IO_CSV )
+   detray_add_test( array_read_detector "array_read_detector.cpp"
+      LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::io
+                     detray::array )
 endif()
-
-if (DETRAY_DISPLAY)
-    add_detray_test(array_display_masks
-                    array_display_masks.cpp
-                    LINK_LIBRARIES
-                    detray::array detray::display)
+if( DETRAY_DISPLAY )
+   detray_add_test( array_display_masks "array_display_masks.cpp"
+      LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::display
+                     detray::array )
 endif()

--- a/tests/unit_tests/core/CMakeLists.txt
+++ b/tests/unit_tests/core/CMakeLists.txt
@@ -1,26 +1,13 @@
-add_detray_test(grids_axis
-                grids_axis.cpp LINK_LIBRARIES detray::core)
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-add_detray_test(grids_grid2
-                grids_grid2.cpp LINK_LIBRARIES detray::core)
-
-add_detray_test(grids_populator
-                grids_populator.cpp LINK_LIBRARIES detray::core)
-
-add_detray_test(grids_serializer
-                grids_serializer.cpp LINK_LIBRARIES detray::core)
-
-add_detray_test(utils_enumerate
-                utils_enumerate.cpp LINK_LIBRARIES detray::core)
-
-add_detray_test(utils_local_object_finder
-                utils_local_object_finder.cpp LINK_LIBRARIES detray::core)
-
-add_detray_test(utils_quadratic_equation
-                utils_quadratic_equation.cpp LINK_LIBRARIES detray::core)
-
-add_detray_test(thrust_tuple
-                thrust_tuple.cpp LINK_LIBRARIES detray::Thrust)
-
-add_detray_test(tuple_accessor
-                tuple_accessor.cpp LINK_LIBRARIES detray::core detray::Thrust)
+# Set up the core tests.
+detray_add_test( core
+   "grids_axis.cpp" "grids_grid2.cpp" "grids_populator.cpp"
+   "grids_serializer.cpp" "thrust_tuple.cpp" "tuple_accessor.cpp"
+   "utils_enumerate.cpp" "utils_local_object_finder.cpp"
+   "utils_quadratic_equation.cpp"
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::core )

--- a/tests/unit_tests/core/grids_axis.cpp
+++ b/tests/unit_tests/core/grids_axis.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -204,10 +204,4 @@ TEST(grids, irregular_closed_axis) {
 
     expected_zone = {1u, 2u};
     EXPECT_EQ(nonreg.zone(3., szone10), expected_zone);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/unit_tests/core/grids_grid2.cpp
+++ b/tests/unit_tests/core/grids_grid2.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -272,10 +272,4 @@ TEST(grids, grid2_irregular_replace) {
     test::point2<detray::scalar> p = {-0.5, 0.5};
     g2.populate(p, 4u);
     EXPECT_EQ(g2.bin(p), 4u);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/unit_tests/core/grids_populator.cpp
+++ b/tests/unit_tests/core/grids_populator.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -75,10 +75,4 @@ TEST(grids, attach_populator) {
     sort_attacher(stored, 11);
     test = {2u, 3u, 11u, 42u};
     EXPECT_EQ(stored, test);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/unit_tests/core/grids_serializer.cpp
+++ b/tests/unit_tests/core/grids_serializer.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -52,10 +52,4 @@ TEST(grids, serialize_deserialize) {
     expected_array = {5u, 2u};
     test_array = ser2.deserialize(r6, c12, 17u);
     EXPECT_EQ(test_array, expected_array);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/unit_tests/core/utils_enumerate.cpp
+++ b/tests/unit_tests/core/utils_enumerate.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -66,10 +66,4 @@ TEST(utils, range) {
         ASSERT_NE(v, 5);
         ASSERT_EQ(v, seq[i++]);
     }
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/unit_tests/core/utils_local_object_finder.cpp
+++ b/tests/unit_tests/core/utils_local_object_finder.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -56,10 +56,4 @@ TEST(utils, local_object_finder) {
 
     EXPECT_EQ(local_finders[0](p2), expected);
     EXPECT_EQ(local_finders[1](p2), expected);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/unit_tests/core/utils_quadratic_equation.cpp
+++ b/tests/unit_tests/core/utils_quadratic_equation.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,10 +23,4 @@ TEST(utils, quad_equation) {
     ASSERT_EQ(std::get<0>(solution), 2);
     ASSERT_NEAR(std::get<1>(solution)[0], -3., 1e-5);
     ASSERT_NEAR(std::get<1>(solution)[1], 0.5, 1e-5);
-}
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
 }

--- a/tests/unit_tests/cuda/CMakeLists.txt
+++ b/tests/unit_tests/cuda/CMakeLists.txt
@@ -1,89 +1,48 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # Enable CUDA as a language.
-enable_language(CUDA)
+enable_language( CUDA )
 
-# grid test
-add_detray_test(grids_grid2_cuda
-  "grids_grid2_cuda.cpp"
-  "grids_grid2_cuda_kernel.hpp"
-  "grids_grid2_cuda_kernel.cu"
-  LINK_LIBRARIES
-  vecmem::cuda)
+# Set the CUDA build flags.
+include( detray-compiler-options-cuda )
 
-# enumerate test
-add_detray_test(utils_enumerate_cuda
-  "utils_enumerate_cuda.cpp"
-  "utils_enumerate_cuda_kernel.hpp"
-  "utils_enumerate_cuda_kernel.cu"
-  LINK_LIBRARIES
-  vecmem::cuda)
+# "Core" tests.
+detray_add_test( core_cuda
+   "grids_grid2_cuda.cpp" "grids_grid2_cuda_kernel.hpp"
+   "grids_grid2_cuda_kernel.cu" "utils_enumerate_cuda.cpp"
+   "utils_enumerate_cuda_kernel.hpp" "utils_enumerate_cuda_kernel.cu"
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common vecmem::cuda )
 
 # make unit tests for multiple algebras
 # Currently vc and smatrix is not supported
 set( algebras "array" )
 if( DETRAY_EIGEN_PLUGIN )
-  list( APPEND algebras "eigen" )
+   list( APPEND algebras "eigen" )
 endif()
 
 foreach(algebra ${algebras})
 
-  # transform store test
-  add_detray_test(${algebra}_transform_store_cuda
-    "transform_store_cuda.cpp"
-    "transform_store_cuda_kernel.hpp"
-    "transform_store_cuda_kernel.cu"
-    LINK_LIBRARIES
-    vecmem::cuda detray::${algebra})
-  target_compile_definitions(detray_test_${algebra}_transform_store_cuda PRIVATE ${algebra}=${algebra})
-
-  # mask store test
-  add_detray_test(${algebra}_mask_store_cuda
-    "mask_store_cuda.cpp"
-    "mask_store_cuda_kernel.hpp"
-    "mask_store_cuda_kernel.cu"
-    LINK_LIBRARIES
-    vecmem::cuda detray::${algebra})
-  target_compile_definitions(detray_test_${algebra}_mask_store_cuda PRIVATE ${algebra}=${algebra})
-
-  # tuple test
-  add_detray_test(${algebra}_tuple_test_cuda
-    "tuple_test_cuda.cpp"
-    "tuple_test_cuda_kernel.hpp"
-    "tuple_test_cuda_kernel.cu"
-    LINK_LIBRARIES
-    vecmem::cuda detray::${algebra})
-  target_compile_definitions(detray_test_${algebra}_tuple_test_cuda PRIVATE ${algebra}=${algebra})
-
-  # surfaces finder test
-  add_detray_test(${algebra}_surfaces_finder_cuda
-    "surfaces_finder_cuda.cpp"
-    "surfaces_finder_cuda_kernel.hpp"
-    "surfaces_finder_cuda_kernel.cu"
-    LINK_LIBRARIES
-    vecmem::cuda detray::${algebra})
-  target_compile_definitions(detray_test_${algebra}_surfaces_finder_cuda PRIVATE ${algebra}=${algebra})
-
-  # detector test
-  add_detray_test(${algebra}_detector_cuda
-    "detector_cuda.cpp"
-    "detector_cuda_kernel.hpp"
-    "detector_cuda_kernel.cu"
-    LINK_LIBRARIES
-    vecmem::cuda detray::${algebra})
-  target_compile_definitions(detray_test_${algebra}_detector_cuda PRIVATE ${algebra}=${algebra})
-
-  # navigator test
-  add_detray_test(${algebra}_navigator_cuda
-    "navigator_cuda.cpp"
-    "navigator_cuda_kernel.hpp"
-    "navigator_cuda_kernel.cu"
-    LINK_LIBRARIES
-    vecmem::cuda detray::${algebra})
-  target_compile_definitions(detray_test_${algebra}_navigator_cuda PRIVATE ${algebra}=${algebra})
+   # Unit tests for the selected algebra.
+   detray_add_test( ${algebra}_cuda
+      "transform_store_cuda.cpp" "transform_store_cuda_kernel.hpp"
+      "transform_store_cuda_kernel.cu"
+      "mask_store_cuda.cpp" "mask_store_cuda_kernel.hpp"
+      "mask_store_cuda_kernel.cu"
+      "tuple_test_cuda.cpp" "tuple_test_cuda_kernel.hpp"
+      "tuple_test_cuda_kernel.cu"
+      "surfaces_finder_cuda.cpp" "surfaces_finder_cuda_kernel.hpp"
+      "surfaces_finder_cuda_kernel.cu"
+      "detector_cuda.cpp" "detector_cuda_kernel.hpp"
+      "detector_cuda_kernel.cu"
+      "navigator_cuda.cpp" "navigator_cuda_kernel.hpp"
+      "navigator_cuda_kernel.cu"
+      LINK_LIBRARIES GTest::gtest_main vecmem::cuda detray_tests_common
+                     detray::${algebra} )
+   target_compile_definitions( detray_test_${algebra}_cuda
+      PRIVATE ${algebra}=${algebra} )
 
 endforeach()

--- a/tests/unit_tests/eigen/CMakeLists.txt
+++ b/tests/unit_tests/eigen/CMakeLists.txt
@@ -1,20 +1,30 @@
-enable_testing()
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-foreach(etest ${all_unit_tests})
-    add_detray_test(eigen_${etest}
-                eigen_${etest}.cpp LINK_LIBRARIES detray::eigen)
-endforeach(etest)
+# Set up all of the "standard" tests.
+detray_add_test( eigen
+   "eigen_annulus2.cpp" "eigen_core.cpp" "eigen_cylinder_intersection.cpp"
+   "eigen_cylinder3.cpp" "eigen_detector.cpp" "eigen_geometry_graph.cpp"
+   "eigen_geometry_linking.cpp" "eigen_geometry_navigation.cpp"
+   "eigen_geometry_scan.cpp" "eigen_intersection_kernel.cpp"
+   "eigen_line_stepper.cpp" "eigen_mask_store.cpp" "eigen_navigator.cpp"
+   "eigen_planar_intersection.cpp" "eigen_propagator.cpp" "eigen_rectangle2.cpp"
+   "eigen_ring2.cpp" "eigen_single3.cpp" "eigen_surfaces_finder.cpp"
+   "eigen_toy_geometry.cpp" "eigen_transform_store.cpp" "eigen_trapezoid2.cpp"
+   "eigen_unmasked.cpp" "eigen_volume.cpp"
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::eigen )
 
-if (DETRAY_IO_CSV)
-    add_detray_test(eigen_read_detector
-      eigen_read_detector.cpp
-      LINK_LIBRARIES
-      detray::eigen)
+# Set up the "conditional" tests.
+if( DETRAY_IO_CSV )
+   detray_add_test( eigen_read_detector "eigen_read_detector.cpp"
+      LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::io
+                     detray::eigen )
 endif()
-
-if (DETRAY_DISPLAY)
-    add_detray_test(eigen_display_masks
-      eigen_display_masks.cpp
-      LINK_LIBRARIES
-      detray::eigen detray::display)
+if( DETRAY_DISPLAY )
+   detray_add_test( eigen_display_masks "eigen_display_masks.cpp"
+      LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::display
+                     detray::eigen )
 endif()

--- a/tests/unit_tests/smatrix/CMakeLists.txt
+++ b/tests/unit_tests/smatrix/CMakeLists.txt
@@ -1,23 +1,31 @@
-enable_testing()
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-foreach(etest ${all_unit_tests})
-    add_detray_test(smatrix_${etest}
-      smatrix_${etest}.cpp
-      LINK_LIBRARIES
-      detray::smatrix)
-endforeach(etest)
+# Set up all of the "standard" tests.
+detray_add_test( smatrix
+   "smatrix_annulus2.cpp" "smatrix_core.cpp" "smatrix_cylinder_intersection.cpp"
+   "smatrix_cylinder3.cpp" "smatrix_detector.cpp" "smatrix_geometry_graph.cpp"
+   "smatrix_geometry_linking.cpp" "smatrix_geometry_navigation.cpp"
+   "smatrix_geometry_scan.cpp" "smatrix_intersection_kernel.cpp"
+   "smatrix_line_stepper.cpp" "smatrix_mask_store.cpp" "smatrix_navigator.cpp"
+   "smatrix_planar_intersection.cpp" "smatrix_propagator.cpp"
+   "smatrix_rectangle2.cpp" "smatrix_ring2.cpp" "smatrix_single3.cpp"
+   "smatrix_surfaces_finder.cpp" "smatrix_toy_geometry.cpp"
+   "smatrix_transform_store.cpp" "smatrix_trapezoid2.cpp" "smatrix_unmasked.cpp"
+   "smatrix_volume.cpp"
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::smatrix )
 
-if (DETRAY_IO_CSV)
-    set(UNIT_TEST_EXTRA_LIBRARIES detray::io)
-    add_detray_test(smatrix_read_detector
-      smatrix_read_detector.cpp
-      LINK_LIBRARIES
-      detray::smatrix)
+# Set up the "conditional" tests.
+if( DETRAY_IO_CSV )
+   detray_add_test( smatrix_read_detector "smatrix_read_detector.cpp"
+      LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::io
+                     detray::smatrix )
 endif()
-
-if (DETRAY_DISPLAY)
-    add_detray_test(smatrix_display_masks
-      smatrix_display_masks.cpp
-      LINK_LIBRARIES
-      detray::smatrix detray::display)
+if( DETRAY_DISPLAY )
+   detray_add_test( smatrix_display_masks "smatrix_display_masks.cpp"
+      LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::display
+                     detray::smatrix )
 endif()

--- a/tests/unit_tests/vc/CMakeLists.txt
+++ b/tests/unit_tests/vc/CMakeLists.txt
@@ -1,22 +1,32 @@
-enable_testing()
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
 
-foreach(etest ${all_unit_tests})
-    add_detray_test(vc_array_${etest}
-      vc_array_${etest}.cpp
-      LINK_LIBRARIES
-      detray::vc_array)
-endforeach(etest)
+# Set up all of the "standard" tests.
+detray_add_test( vc_array
+   "vc_array_annulus2.cpp" "vc_array_core.cpp"
+   "vc_array_cylinder_intersection.cpp" "vc_array_cylinder3.cpp"
+   "vc_array_detector.cpp" "vc_array_geometry_graph.cpp"
+   "vc_array_geometry_linking.cpp" "vc_array_geometry_navigation.cpp"
+   "vc_array_geometry_scan.cpp" "vc_array_intersection_kernel.cpp"
+   "vc_array_line_stepper.cpp" "vc_array_mask_store.cpp"
+   "vc_array_navigator.cpp" "vc_array_planar_intersection.cpp"
+   "vc_array_propagator.cpp" "vc_array_rectangle2.cpp" "vc_array_ring2.cpp"
+   "vc_array_single3.cpp" "vc_array_surfaces_finder.cpp"
+   "vc_array_toy_geometry.cpp" "vc_array_transform_store.cpp"
+   "vc_array_trapezoid2.cpp" "vc_array_unmasked.cpp" "vc_array_volume.cpp"
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::vc_array )
 
-if (DETRAY_IO_CSV)
-    add_detray_test(vc_array_read_detector
-      vc_array_read_detector.cpp
-      LINK_LIBRARIES
-      detray::vc_array)
+# Set up the "conditional" tests.
+if( DETRAY_IO_CSV )
+   detray_add_test( vc_array_read_detector "vc_array_read_detector.cpp"
+      LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::io
+                     detray::vc_array )
 endif()
-
-if (DETRAY_DISPLAY)
-    add_detray_test(vc_array_display_masks
-      vc_array_display_masks.cpp
-      LINK_LIBRARIES
-      detray::vc_array detray::display)
+if( DETRAY_DISPLAY )
+   detray_add_test( vc_array_display_masks "vc_array_display_masks.cpp"
+      LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::display
+                     detray::vc_array )
 endif()


### PR DESCRIPTION
This is a follow-up from https://github.com/acts-project/algebra-plugins/pull/46, working towards making [traccc](https://github.com/acts-project/traccc) build warning-free.

I moved the compiler flags around just like in https://github.com/acts-project/algebra-plugins/pull/46, so that the strict flags would only affect the sources of this project. (And not those in the externals.)

While at it, I did go a bit overboard... I decided that I would update the tests and benchmarks at the same time. Similar to what I did for the tests in https://github.com/acts-project/algebra-plugins/pull/46. This meant touching quite a few files, but all of those were just technical updates. Most importantly removing all of the same `main()` functions from the tests, and instead linking the tests against `GTest::gtest_main`. This allowed me to group the test sources into "large executables". Which can be a bit more convenient to run by hand during debugging.

I only found a couple of warnings in the code like this. :confused: Which is clearly not all of them, since the [traccc](https://github.com/acts-project/traccc) build complains about the `grid2` class for sure. So this will not be the be all end all for fixing the warnings... :frowning: I still thought that it would be better to get these in, before I start testing the updated code together with traccc.