### PR TITLE
feat: typed indices

### DIFF
--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -338,12 +338,14 @@ class detector {
         // Get the corresponding transforms
         const auto &object_transforms = trfs[current_type];
         // and the corresponding masks
-        auto &object_masks = msks.template group<current_type>();
+        auto &object_masks =
+            msks.template group<mask_container::to_id(current_type)>();
 
         if (not object_transforms.empty(ctx) and not typed_surfaces.empty()) {
             // Current offsets into detectors containers
             const auto trsf_offset = _transforms.size(ctx);
-            const auto mask_offset = _masks.template size<current_type>();
+            const auto mask_offset =
+                _masks.template size<mask_container::to_id(current_type)>();
 
             // Fill the correct mask type
             _masks.add_masks(object_masks);

--- a/core/include/detray/core/mask_store.hpp
+++ b/core/include/detray/core/mask_store.hpp
@@ -133,7 +133,7 @@ class mask_store {
      * @note in general can throw an exception
      */
     template <std::size_t mask_id, typename... bounds_type>
-    DETRAY_HOST auto &add_mask(bounds_type &&...mask_bounds) noexcept(false) {
+    DETRAY_HOST auto &add_mask(bounds_type &&... mask_bounds) noexcept(false) {
         // Get the mask group that will be updated
         auto &mask_group = detail::get<mask_id>(_mask_tuple);
         // Construct new mask in place

--- a/core/include/detray/core/mask_store.hpp
+++ b/core/include/detray/core/mask_store.hpp
@@ -32,8 +32,7 @@ class mask_store {
      */
     using mask_tuple = vtuple::tuple<vector_t<mask_types>...>;
     using link_type = typed_index<unsigned int, dindex>;
-    // using link_type = std::array<dindex, 2>;
-    using range_type = tuple_t<std::size_t, darray<dindex, 2>>;
+    using range_type = typed_index<unsigned int, dindex_range>;
 
     /** data type for mask_store_data **/
     using mask_tuple_data = tuple_t<vecmem::data::vector_view<mask_types>...>;
@@ -134,7 +133,7 @@ class mask_store {
      * @note in general can throw an exception
      */
     template <std::size_t mask_id, typename... bounds_type>
-    DETRAY_HOST auto &add_mask(bounds_type &&... mask_bounds) noexcept(false) {
+    DETRAY_HOST auto &add_mask(bounds_type &&...mask_bounds) noexcept(false) {
         // Get the mask group that will be updated
         auto &mask_group = detail::get<mask_id>(_mask_tuple);
         // Construct new mask in place

--- a/core/include/detray/core/mask_store.hpp
+++ b/core/include/detray/core/mask_store.hpp
@@ -70,7 +70,7 @@ class mask_store {
         if (ref_idx == index) {
             // Produce a more helpful error than the usual tuple index error
             static_assert(
-                std::size_t{0} <= ref_idx and ref_idx < sizeof...(mask_types),
+                ref_idx < sizeof...(mask_types),
                 "Index out of range: Please make sure that indices and type "
                 "enums match the number of types in container.");
             return static_cast<id_type>(index);

--- a/core/include/detray/core/mask_store.hpp
+++ b/core/include/detray/core/mask_store.hpp
@@ -96,7 +96,7 @@ class mask_store {
      * @return the number of mask types in the store
      */
     DETRAY_HOST_DEVICE constexpr std::size_t size() const {
-        return detail::tuple_size<mask_tuple>::value;
+        return sizeof...(mask_types);
     }
 
     /** Empty : Contextual STL like API
@@ -184,7 +184,7 @@ class mask_store {
         }
 
         // Next mask type
-        if constexpr (current_id < detail::tuple_size<mask_tuple>::value - 1) {
+        if constexpr (current_id < sizeof...(mask_types) - 1) {
             return add_masks<current_id + 1>(masks);
         }
     }
@@ -213,7 +213,7 @@ class mask_store {
         }
 
         // Next mask type
-        if constexpr (current_id < detail::tuple_size<mask_tuple>::value - 1) {
+        if constexpr (current_id < sizeof...(mask_types) - 1) {
             return add_masks<current_id + 1>(masks);
         }
     }
@@ -234,7 +234,7 @@ class mask_store {
         add_masks(mask_group);
 
         // Next mask type
-        if constexpr (current_id < detail::tuple_size<mask_tuple>::value - 1) {
+        if constexpr (current_id < sizeof...(mask_types) - 1) {
             return append_masks<current_id + 1>(other);
         }
     }

--- a/core/include/detray/core/mask_store.hpp
+++ b/core/include/detray/core/mask_store.hpp
@@ -73,13 +73,13 @@ class mask_store {
                 std::size_t{0} <= ref_idx and ref_idx < sizeof...(mask_types),
                 "Index out of range: Please make sure that indices and type "
                 "enums match the number of types in container.");
-            return static_cast<ID>(index);
+            return static_cast<id_type>(index);
         }
         if constexpr (ref_idx < sizeof...(mask_types) - 1) {
             return to_id<ref_idx + 1>(index);
         }
         // This produces a compiler error when used in type unrolling code
-        return static_cast<ID>(sizeof...(mask_types));
+        return static_cast<id_type>(sizeof...(mask_types));
     }
 
     /** Size : Contextual STL like API
@@ -87,7 +87,7 @@ class mask_store {
      * @tparam mask_id the index for the mask_type
      * @return the size of the vector containing the masks of the required type
      */
-    template <ID mask_id>
+    template <std::size_t mask_id>
     DETRAY_HOST_DEVICE size_t size() const {
         return detail::get<mask_id>(_mask_tuple).size();
     }
@@ -105,7 +105,7 @@ class mask_store {
      * @return whether the vector containing the masks of the required type
      * is empty
      */
-    template <ID mask_id>
+    template <std::size_t mask_id>
     DETRAY_HOST_DEVICE bool empty() const {
         return detail::get<mask_id>(_mask_tuple).empty();
     }
@@ -115,7 +115,7 @@ class mask_store {
      * @tparam mask_id index of requested mask type in masks container
      * @return vector of masks of a given type.
      */
-    template <ID mask_id>
+    template <std::size_t mask_id>
     DETRAY_HOST_DEVICE constexpr auto &group() {
         return detail::get<mask_id>(_mask_tuple);
     }
@@ -125,7 +125,7 @@ class mask_store {
      * @tparam mask_id index of requested mask type in masks container
      * @return vector of masks of a given type.
      */
-    template <ID mask_id>
+    template <std::size_t mask_id>
     DETRAY_HOST_DEVICE constexpr const auto &group() const {
         return detail::get<mask_id>(_mask_tuple);
     }
@@ -153,7 +153,7 @@ class mask_store {
      *
      * @note in general can throw an exception
      */
-    template <ID mask_id, typename... bounds_type>
+    template <std::size_t mask_id, typename... bounds_type>
     DETRAY_HOST auto &add_mask(bounds_type &&... mask_bounds) noexcept(false) {
         // Get the mask group that will be updated
         auto &mask_group = detail::get<mask_id>(_mask_tuple);

--- a/core/include/detray/core/mask_store.hpp
+++ b/core/include/detray/core/mask_store.hpp
@@ -73,13 +73,13 @@ class mask_store {
                 ref_idx < sizeof...(mask_types),
                 "Index out of range: Please make sure that indices and type "
                 "enums match the number of types in container.");
-            return static_cast<id_type>(index);
+            return static_cast<ID>(index);
         }
         if constexpr (ref_idx < sizeof...(mask_types) - 1) {
             return to_id<ref_idx + 1>(index);
         }
         // This produces a compiler error when used in type unrolling code
-        return static_cast<id_type>(sizeof...(mask_types));
+        return static_cast<ID>(sizeof...(mask_types));
     }
 
     /** Size : Contextual STL like API
@@ -87,7 +87,7 @@ class mask_store {
      * @tparam mask_id the index for the mask_type
      * @return the size of the vector containing the masks of the required type
      */
-    template <std::size_t mask_id>
+    template <ID mask_id>
     DETRAY_HOST_DEVICE size_t size() const {
         return detail::get<mask_id>(_mask_tuple).size();
     }
@@ -105,7 +105,7 @@ class mask_store {
      * @return whether the vector containing the masks of the required type
      * is empty
      */
-    template <std::size_t mask_id>
+    template <ID mask_id>
     DETRAY_HOST_DEVICE bool empty() const {
         return detail::get<mask_id>(_mask_tuple).empty();
     }
@@ -115,7 +115,7 @@ class mask_store {
      * @tparam mask_id index of requested mask type in masks container
      * @return vector of masks of a given type.
      */
-    template <std::size_t mask_id>
+    template <ID mask_id>
     DETRAY_HOST_DEVICE constexpr auto &group() {
         return detail::get<mask_id>(_mask_tuple);
     }
@@ -125,7 +125,7 @@ class mask_store {
      * @tparam mask_id index of requested mask type in masks container
      * @return vector of masks of a given type.
      */
-    template <std::size_t mask_id>
+    template <ID mask_id>
     DETRAY_HOST_DEVICE constexpr const auto &group() const {
         return detail::get<mask_id>(_mask_tuple);
     }
@@ -153,7 +153,7 @@ class mask_store {
      *
      * @note in general can throw an exception
      */
-    template <std::size_t mask_id, typename... bounds_type>
+    template <ID mask_id, typename... bounds_type>
     DETRAY_HOST auto &add_mask(bounds_type &&... mask_bounds) noexcept(false) {
         // Get the mask group that will be updated
         auto &mask_group = detail::get<mask_id>(_mask_tuple);

--- a/core/include/detray/core/mask_store.hpp
+++ b/core/include/detray/core/mask_store.hpp
@@ -31,7 +31,8 @@ class mask_store {
      * cpp/hpp; 2) thrust::tuple in cu
      */
     using mask_tuple = vtuple::tuple<vector_t<mask_types>...>;
-    using link_type = std::array<dindex, 2>;
+    using link_type = typed_index<unsigned int, dindex>;
+    // using link_type = std::array<dindex, 2>;
     using range_type = tuple_t<std::size_t, darray<dindex, 2>>;
 
     /** data type for mask_store_data **/

--- a/core/include/detray/core/type_registry.hpp
+++ b/core/include/detray/core/type_registry.hpp
@@ -181,7 +181,7 @@ class mask_registry
     template <template <typename...> class tuple_t = dtuple,
               template <typename...> class vector_t = dvector>
     using container_type =
-        mask_store<tuple_t, vector_t, unsigned int, registered_types...>;
+        mask_store<tuple_t, vector_t, ID, registered_types...>;
     using link_type = typename container_type<>::link_type;
     using range_type = typename container_type<>::range_type;
 

--- a/core/include/detray/core/type_registry.hpp
+++ b/core/include/detray/core/type_registry.hpp
@@ -78,8 +78,8 @@ class registry_base<ID, true, registered_types...> {
      */
     template <ID type_id, template <typename...> class tuple_t = dtuple>
     struct get_type {
-        using type = std::remove_reference_t<decltype(
-            std::get<type_id>(tuple_t<registered_types...>{}))>;
+        using type = std::remove_reference_t<decltype(std::get<type_id>(
+            tuple_t<registered_types...>{}))>;
     };
 
     private:
@@ -156,7 +156,6 @@ class mask_registry
     template <template <typename...> class tuple_t = dtuple,
               template <typename...> class vector_t = dvector>
     using container_type = mask_store<tuple_t, vector_t, registered_types...>;
-    // using link_type = typed_index<id>;
     using link_type = typename container_type<>::link_type;
     using range_type = typename container_type<>::range_type;
 
@@ -190,10 +189,8 @@ class sf_finder_registry
         e_r_phi_grid = 2,  // endcap
     };
 
-    // using link_type = typed_index<id>;
-    // using range_type = typed_index<id, dindex_range>;
-    using link_type = std::array<dindex, 2>;
-    using range_type = dindex_range;
+    using link_type = typed_index<id>;
+    using range_type = typed_index<id, dindex_range>;
 
     template <typename T>
     using get_index = typename type_registry::template get_index<T>;

--- a/core/include/detray/core/type_registry.hpp
+++ b/core/include/detray/core/type_registry.hpp
@@ -62,9 +62,7 @@ class registry_base<ID, true, registered_types...> {
 
     /** Checks whether a given index can be mapped to a type.*/
     DETRAY_HOST_DEVICE static constexpr bool is_valid(
-        const std::size_t type_id) {
-        return std::size_t{0} <= type_id and type_id < n_types;
-    }
+        const std::size_t type_id) { return type_id < n_types; }
 
     /** Extract an index and check it.*/
     template <typename object_t>

--- a/core/include/detray/core/type_registry.hpp
+++ b/core/include/detray/core/type_registry.hpp
@@ -78,8 +78,8 @@ class registry_base<ID, true, registered_types...> {
      */
     template <ID type_id, template <typename...> class tuple_t = dtuple>
     struct get_type {
-        using type = std::remove_reference_t<decltype(
-            std::get<type_id>(tuple_t<registered_types...>{}))>;
+        using type = std::remove_reference_t<decltype(std::get<type_id>(
+            tuple_t<registered_types...>{}))>;
     };
 
     private:
@@ -155,7 +155,8 @@ class mask_registry
 
     template <template <typename...> class tuple_t = dtuple,
               template <typename...> class vector_t = dvector>
-    using container_type = mask_store<tuple_t, vector_t, registered_types...>;
+    using container_type =
+        mask_store<tuple_t, vector_t, ID, registered_types...>;
     using link_type = typename container_type<>::link_type;
     using range_type = typename container_type<>::range_type;
 

--- a/core/include/detray/core/type_registry.hpp
+++ b/core/include/detray/core/type_registry.hpp
@@ -102,8 +102,8 @@ class registry_base<ID, true, registered_types...> {
      */
     template <ID type_id, template <typename...> class tuple_t = dtuple>
     struct get_type {
-        using type = std::remove_reference_t<decltype(std::get<type_id>(
-            tuple_t<registered_types...>{}))>;
+        using type = std::remove_reference_t<decltype(
+            std::get<type_id>(tuple_t<registered_types...>{}))>;
     };
 
     private:
@@ -177,10 +177,11 @@ class mask_registry
     // Make the type IDs accessible
     using id = ID;
 
+    // Cuda cannot handle ID non-types here, so leave it for now
     template <template <typename...> class tuple_t = dtuple,
               template <typename...> class vector_t = dvector>
     using container_type =
-        mask_store<tuple_t, vector_t, ID, registered_types...>;
+        mask_store<tuple_t, vector_t, unsigned int, registered_types...>;
     using link_type = typename container_type<>::link_type;
     using range_type = typename container_type<>::range_type;
 

--- a/core/include/detray/core/type_registry.hpp
+++ b/core/include/detray/core/type_registry.hpp
@@ -78,8 +78,8 @@ class registry_base<ID, true, registered_types...> {
      */
     template <ID type_id, template <typename...> class tuple_t = dtuple>
     struct get_type {
-        using type = std::remove_reference_t<decltype(std::get<type_id>(
-            tuple_t<registered_types...>{}))>;
+        using type = std::remove_reference_t<decltype(
+            std::get<type_id>(tuple_t<registered_types...>{}))>;
     };
 
     private:

--- a/core/include/detray/core/type_registry.hpp
+++ b/core/include/detray/core/type_registry.hpp
@@ -62,7 +62,9 @@ class registry_base<ID, true, registered_types...> {
 
     /** Checks whether a given index can be mapped to a type.*/
     DETRAY_HOST_DEVICE static constexpr bool is_valid(
-        const std::size_t type_id) { return type_id < n_types; }
+        const std::size_t type_id) {
+        return type_id < n_types;
+    }
 
     /** Extract an index and check it.*/
     template <typename object_t>

--- a/core/include/detray/definitions/detail/accessor.hpp
+++ b/core/include/detray/definitions/detail/accessor.hpp
@@ -42,11 +42,6 @@ namespace detail {
 using std::get;
 using thrust::get;
 
-template <std::size_t id>
-dindex get(dindex idx) noexcept {
-    return idx;
-}
-
 template <std::size_t id, typename mask_store_t,
           std::enable_if_t<std::is_class_v<typename std::remove_reference_t<
                                mask_store_t>::mask_tuple>,

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -31,8 +31,8 @@ class surface {
     using mask_defs = mask_regsitry_t;
     using mask_link = typename mask_defs::link_type;
     // At least one mask type is present in any geometry
-    using edge_type = typename mask_defs::template get_type<
-        static_cast<typename mask_defs::id>(0)>::type::links_type;
+    using edge_type = typename mask_defs::template get_type<mask_defs::to_id(
+        0)>::type::links_type;
     using volume_link = volume_link_t;
     using source_link = source_link_t;
 

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -101,7 +101,7 @@ class surface {
      * @param offset update the position when move into new collection
      */
     DETRAY_HOST
-    void update_mask(dindex offset) { detail::get<1>(_mask) += offset; }
+    void update_mask(dindex offset) { _mask += offset; }
 
     /** Access to the mask  */
     DETRAY_HOST_DEVICE

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -111,6 +111,22 @@ class surface {
     DETRAY_HOST_DEVICE
     const mask_link &mask() const { return _mask; }
 
+    /** Access to the mask id */
+    DETRAY_HOST_DEVICE
+    auto mask_type() { return detail::get<0>(_mask); }
+
+    /** @return the mask link */
+    DETRAY_HOST_DEVICE
+    auto mask_type() const { return detail::get<0>(_mask); }
+
+    /** Access to the mask  */
+    DETRAY_HOST_DEVICE
+    const auto &mask_range() { return detail::get<1>(_mask); }
+
+    /** @return the mask link */
+    DETRAY_HOST_DEVICE
+    const auto &mask_range() const { return detail::get<1>(_mask); }
+
     /** Access to the volume */
     DETRAY_HOST_DEVICE
     volume_link volume() { return _vol; }
@@ -134,10 +150,10 @@ class surface {
     bool is_portal() const { return _is_portal; }
 
     private:
-    transform_link _trf;
+    transform_link_t _trf;
     mask_link _mask;
-    volume_link _vol;
-    source_link _src;
+    volume_link_t _vol;
+    source_link_t _src;
     bool _is_portal;
     bool _in_grid = false;
 };

--- a/core/include/detray/geometry/volume_connector.hpp
+++ b/core/include/detray/geometry/volume_connector.hpp
@@ -9,6 +9,8 @@
 
 #include <vecmem/memory/host_memory_resource.hpp>
 
+#include "detray/definitions/detail/accessor.hpp"
+
 namespace detray {
 /// Connector method for cylindrical volumes without phi separation
 ///
@@ -261,8 +263,8 @@ void connect_cylindrical_volumes(
                     portal_masks.template add_mask<disc_id>(
                         std::get<0>(info_)[0], std::get<0>(info_)[1], edge);
 
-                    std::get<1>(mask_index) =
-                        portal_masks.template size<disc_id>();
+                    mask_index = {disc_id,
+                                  portal_masks.template size<disc_id>()};
 
                     // Save the data
                     disc_portals.emplace_back(
@@ -305,8 +307,8 @@ void connect_cylindrical_volumes(
                         volume_bounds[bound_index], cylinder_range[0],
                         cylinder_range[1], edge);
 
-                    std::get<1>(mask_index) =
-                        portal_masks.template size<cylinder_id>();
+                    mask_index = {cylinder_id,
+                                  portal_masks.template size<cylinder_id>()};
 
                     // Create the portal
                     cylinder_portals.emplace_back(

--- a/core/include/detray/tools/bin_association.hpp
+++ b/core/include/detray/tools/bin_association.hpp
@@ -12,7 +12,6 @@
 #include <tuple>
 #include <vector>
 
-#include "detray/definitions/detail/accessor.hpp"
 #include "detray/grids/associator.hpp"
 #include "detray/utils/enumerate.hpp"
 #include "detray/utils/generators.hpp"

--- a/core/include/detray/tools/bin_association.hpp
+++ b/core/include/detray/tools/bin_association.hpp
@@ -81,13 +81,11 @@ static inline void bin_association(const context_t & /*context*/,
 
                 // Run through the surfaces and associate them by contour
                 for (auto [isf, sf] : enumerate(dc.surfaces, volume)) {
-                    const auto &mask_link = sf.mask();
-
                     // Unroll the mask container and generate vertices
                     const auto &transform = dc.transforms[sf.transform()];
 
-                    const auto &mask_context = detail::get<0>(mask_link);
-                    const auto &mask_range = detail::get<1>(mask_link);
+                    const auto &mask_context = sf.mask_type();
+                    const auto &mask_range = sf.mask_range();
 
                     auto vertices_per_masks = unroll_masks_for_vertices(
                         surface_masks, mask_range, mask_context,
@@ -156,13 +154,12 @@ static inline void bin_association(const context_t & /*context*/,
 
                 // Loop over the surfaces within a volume
                 for (auto [isf, sf] : enumerate(dc.surfaces, volume)) {
-                    const auto &mask_link = sf.mask();
 
                     // Unroll the mask container and generate vertices
                     const auto &transform = dc.transforms[sf.transform()];
 
-                    const auto &mask_context = detail::get<0>(mask_link);
-                    const auto &mask_range = detail::get<1>(mask_link);
+                    const auto &mask_context = sf.mask_type();
+                    const auto &mask_range = sf.mask_range();
 
                     auto vertices_per_masks = unroll_masks_for_vertices(
                         surface_masks, mask_range, mask_context,

--- a/core/include/detray/tools/bin_association.hpp
+++ b/core/include/detray/tools/bin_association.hpp
@@ -12,6 +12,7 @@
 #include <tuple>
 #include <vector>
 
+#include "detray/definitions/detail/accessor.hpp"
 #include "detray/grids/associator.hpp"
 #include "detray/utils/enumerate.hpp"
 #include "detray/utils/generators.hpp"
@@ -85,8 +86,8 @@ static inline void bin_association(const context_t & /*context*/,
                     // Unroll the mask container and generate vertices
                     const auto &transform = dc.transforms[sf.transform()];
 
-                    const auto &mask_context = std::get<0>(mask_link);
-                    const auto &mask_range = std::get<1>(mask_link);
+                    const auto &mask_context = detail::get<0>(mask_link);
+                    const auto &mask_range = detail::get<1>(mask_link);
 
                     auto vertices_per_masks = unroll_masks_for_vertices(
                         surface_masks, mask_range, mask_context,
@@ -160,8 +161,8 @@ static inline void bin_association(const context_t & /*context*/,
                     // Unroll the mask container and generate vertices
                     const auto &transform = dc.transforms[sf.transform()];
 
-                    const auto &mask_context = std::get<0>(mask_link);
-                    const auto &mask_range = std::get<1>(mask_link);
+                    const auto &mask_context = detail::get<0>(mask_link);
+                    const auto &mask_range = detail::get<1>(mask_link);
 
                     auto vertices_per_masks = unroll_masks_for_vertices(
                         surface_masks, mask_range, mask_context,

--- a/core/include/detray/tools/intersection_kernel.hpp
+++ b/core/include/detray/tools/intersection_kernel.hpp
@@ -99,10 +99,9 @@ DETRAY_HOST_DEVICE inline const auto intersect(
     const mask_container &masks) {
     // Gather all information to perform intersections
     const auto &ctf = contextual_transforms[surface.transform()];
-    const auto &volume_index = surface.volume();
-    const auto &mask_link = surface.mask();
-    const auto &mask_id = detail::get<0>(mask_link);
-    const auto &mask_range = detail::get<1>(mask_link);
+    const auto volume_index = surface.volume();
+    const auto mask_id = surface.mask_type();
+    const auto &mask_range = surface.mask_range();
 
     // Unroll the intersection depending on the mask container size
     using mask_defs = typename surface_t::mask_defs;

--- a/core/include/detray/tools/volume_graph.hpp
+++ b/core/include/detray/tools/volume_graph.hpp
@@ -126,6 +126,7 @@ class volume_graph {
     /** Builds a graph edge from the detector mask collection on the fly. */
     struct edge_collection {
         using mask_edge_t = typename detector_t::surface_type::edge_type;
+        using mask_link_t = typename detector_t::surface_type::mask_link;
 
         struct edge {
             edge(const dindex volume_id, const dindex link)
@@ -142,9 +143,9 @@ class volume_graph {
             using edge_iter =
                 decltype(std::begin(std::declval<vector_t<edge>>()));
 
-            iterator(const dindex volume_id, const mask_edge_t &mask_edge,
+            iterator(const dindex volume_id, const mask_link_t &mask_link,
                      const edge_collection &edges) {
-                build_edges_vector(volume_id, mask_edge, edges.get_container());
+                build_edges_vector(volume_id, mask_link, edges.get_container());
                 _itr = _edges.begin();
             }
 
@@ -175,13 +176,13 @@ class volume_graph {
 
             template <std::size_t current_id = 0>
             inline void build_edges_vector(const dindex volume_id,
-                                           const mask_edge_t &mask_edge,
+                                           const mask_link_t &mask_link,
                                            const mask_container_t &masks) {
 
-                if (detail::get<0>(mask_edge) == current_id) {
+                if (detail::get<0>(mask_link) == current_id) {
                     // Get the mask group that will be updated
                     const auto &mask_group = masks.template group<current_id>();
-                    const auto mask_range = detail::get<1>(mask_edge);
+                    const auto mask_range = detail::get<1>(mask_link);
                     for (const auto &mask : range(mask_group, mask_range)) {
                         _edges.emplace_back(volume_id, mask.volume_link());
                     }
@@ -191,7 +192,7 @@ class volume_graph {
                 using mask_defs = typename detector_t::surface_type::mask_defs;
                 if constexpr (current_id < mask_defs::n_types - 1) {
                     return build_edges_vector<current_id + 1>(volume_id,
-                                                              mask_edge, masks);
+                                                              mask_link, masks);
                 }
             }
 

--- a/core/include/detray/tools/volume_graph.hpp
+++ b/core/include/detray/tools/volume_graph.hpp
@@ -181,7 +181,9 @@ class volume_graph {
 
                 if (detail::get<0>(mask_link) == current_id) {
                     // Get the mask group that will be updated
-                    const auto &mask_group = masks.template group<current_id>();
+                    const auto &mask_group =
+                        masks.template group<mask_container_t::to_id(
+                            current_id)>();
                     const auto mask_range = detail::get<1>(mask_link);
                     for (const auto &mask : range(mask_group, mask_range)) {
                         _edges.emplace_back(volume_id, mask.volume_link());

--- a/core/include/detray/utils/indexing.hpp
+++ b/core/include/detray/utils/indexing.hpp
@@ -93,7 +93,10 @@ struct typed_index {
 
 namespace detail {
 
-using std::get;
+template <std::size_t ID>
+dindex get(dindex idx) noexcept {
+    return idx;
+}
 
 /** Custom get function for the typed_index struct. Get the type. */
 template <std::size_t ID, typename id_type, typename index_type,

--- a/core/include/detray/utils/indexing.hpp
+++ b/core/include/detray/utils/indexing.hpp
@@ -17,4 +17,100 @@ dindex constexpr dindex_invalid = std::numeric_limits<dindex>::max();
 using dindex_range = darray<dindex, 2>;
 using dindex_sequence = dvector<dindex>;
 
+/** Small type to tie an object type and an index into a container together.
+ *
+ * @tparam id_type Represents the indexed type
+ * @tparam intex_type The type of indexing needed for the indexed types
+ * container
+ */
+template <typename id_type = unsigned int, typename index_type = dindex>
+struct typed_index {
+    id_type _object_id;
+    index_type _index;
+
+    /** Equality operator */
+    DETRAY_HOST_DEVICE
+    bool operator==(const typed_index<id_type, index_type>& rhs) const {
+        return (_object_id == rhs._object_id && _index == rhs._index);
+    }
+
+    /** Arithmetic operators*/
+    DETRAY_HOST_DEVICE
+    typed_index<id_type, index_type> operator+(
+        const typed_index<id_type, index_type>& rhs) const {
+        return {_object_id, _index + rhs._index};
+    }
+
+    DETRAY_HOST_DEVICE
+    typed_index<id_type, index_type> operator+(const index_type& index) const {
+        return {_object_id, _index + index};
+    }
+
+    DETRAY_HOST_DEVICE
+    typed_index<id_type, index_type> operator-(
+        const typed_index<id_type, index_type>& rhs) const {
+        return {_object_id, _index - rhs._index};
+    }
+
+    DETRAY_HOST_DEVICE
+    typed_index<id_type, index_type> operator-(const index_type& index) const {
+        return {_object_id, _index - index};
+    }
+
+    DETRAY_HOST_DEVICE
+    typed_index<id_type, index_type>& operator+=(
+        const typed_index<id_type, index_type>& rhs) {
+        _index += rhs._index;
+        return *this;
+    }
+
+    DETRAY_HOST_DEVICE
+    typed_index<id_type, index_type>& operator+=(const index_type& index) {
+        _index += index;
+        return *this;
+    }
+
+    DETRAY_HOST_DEVICE
+    typed_index<id_type, index_type>& operator-=(
+        const typed_index<id_type, index_type>& rhs) {
+        _index -= rhs._index;
+        return *this;
+    }
+
+    DETRAY_HOST_DEVICE
+    typed_index<id_type, index_type>& operator-=(const index_type& index) {
+        _index -= index;
+        return *this;
+    }
+
+    /** Only make the prefix operator available */
+    DETRAY_HOST_DEVICE
+    typed_index<id_type, index_type>& operator++() {
+        ++_index;
+        return *this;
+    }
+};
+
+namespace detail {
+
+using std::get;
+
+/** Custom get function for the typed_index struct. Get the type. */
+template <std::size_t ID, typename id_type, typename index_type,
+          std::enable_if_t<ID == 0, bool> = true>
+DETRAY_HOST_DEVICE constexpr auto& get(
+    const typed_index<id_type, index_type>& index) noexcept {
+    return index._object_id;
+}
+
+/** Custom get function for the typed_index struct. Get the index. */
+template <std::size_t ID, typename id_type, typename index_type,
+          std::enable_if_t<ID == 1, bool> = true>
+DETRAY_HOST_DEVICE constexpr auto& get(
+    const typed_index<id_type, index_type>& index) noexcept {
+    return index._index;
+}
+
+}  // namespace detail
+
 }  // namespace detray

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -46,6 +46,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     using volume_t = typename detector_t::volume_type;
     using context_t = typename decltype(toy_det)::context;
     using mask_ids = typename detector_t::masks::id;
+    using mask_link_t = typename detector_t::surface_type::mask_link;
     context_t ctx{};
     auto& volumes = toy_det.volumes();
     auto& surfaces = toy_det.surfaces();
@@ -84,16 +85,16 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     auto test_portal_links = [&](dindex vol_index,
                                  decltype(surfaces.begin())&& sf_itr,
                                  darray<dindex, 2>& range, dindex trf_index,
-                                 darray<dindex, 2>&& mask_index,
+                                 mask_link_t&& mask_index,
                                  dvector<darray<dindex, 2>>&& edges) {
-        for (dindex pti = range[0]; pti < range[1]; pti++) {
+        for (dindex pti = range[0]; pti < range[1]; ++pti) {
             EXPECT_EQ(sf_itr->volume(), vol_index);
             EXPECT_EQ(sf_itr->transform(), trf_index);
             EXPECT_EQ(sf_itr->mask(), mask_index);
             EXPECT_EQ(get_edge(masks, sf_itr->mask()), edges[pti - range[0]]);
-            sf_itr++;
-            trf_index++;
-            mask_index[1]++;
+            ++sf_itr;
+            ++trf_index;
+            ++mask_index;
         }
     };
 
@@ -106,21 +107,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
      * @param mask_index type and index of module mask in respective mask cont
      * @param edges links to next volume and next surfaces finder
      */
-    auto test_module_links = [&](dindex vol_index,
-                                 decltype(surfaces.begin())&& sf_itr,
-                                 darray<dindex, 2>& range, dindex trf_index,
-                                 darray<dindex, 2>&& mask_index,
-                                 dvector<darray<dindex, 2>>&& edges) {
-        for (dindex pti = range[0]; pti < range[1]; pti++) {
-            EXPECT_EQ(sf_itr->volume(), vol_index);
-            EXPECT_EQ(sf_itr->transform(), trf_index);
-            EXPECT_EQ(sf_itr->mask(), mask_index);
-            EXPECT_EQ(get_edge(masks, sf_itr->mask()), edges[0]);
-            sf_itr++;
-            trf_index++;
-            mask_index[1]++;
-        }
-    };
+    auto test_module_links =
+        [&](dindex vol_index, decltype(surfaces.begin())&& sf_itr,
+            darray<dindex, 2>& range, dindex trf_index,
+            mask_link_t&& mask_index, dvector<darray<dindex, 2>>&& edges) {
+            for (dindex pti = range[0]; pti < range[1]; ++pti) {
+                EXPECT_EQ(sf_itr->volume(), vol_index);
+                EXPECT_EQ(sf_itr->transform(), trf_index);
+                EXPECT_EQ(sf_itr->mask(), mask_index);
+                EXPECT_EQ(get_edge(masks, sf_itr->mask()), edges[0]);
+                ++sf_itr;
+                ++trf_index;
+                ++mask_index;
+            }
+        };
 
     /** Test the surface grid.
      *
@@ -139,8 +139,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
             std::vector<dindex> indices;
 
             // Check if right volume is linked to surface in grid
-            for (unsigned int i = 0; i < sf_grid.axis_p0().bins(); i++) {
-                for (unsigned int j = 0; j < sf_grid.axis_p1().bins(); j++) {
+            for (unsigned int i = 0; i < sf_grid.axis_p0().bins(); ++i) {
+                for (unsigned int j = 0; j < sf_grid.axis_p1().bins(); ++j) {
                     auto sf_indices = sf_grid.bin(i, j);
                     for (auto sf_idx : sf_indices) {
                         EXPECT_EQ(sf_container[sf_idx].volume(),
@@ -153,7 +153,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
             // Check if surface indices are consistent with given range of
             // modules
             EXPECT_EQ(indices.size(), range[1] - range[0]);
-            for (dindex pti = range[0]; pti < range[1]; pti++) {
+            for (dindex pti = range[0]; pti < range[1]; ++pti) {
                 EXPECT_TRUE(std::find(indices.begin(), indices.end(), pti) !=
                             indices.end());
             }
@@ -213,7 +213,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., -825., -815., -M_PI, M_PI};
     range = {16, 128};
     EXPECT_EQ(vol_itr->index(), 1);
@@ -247,7 +247,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., -815., -705., -M_PI, M_PI};
     range = {128, 132};
     EXPECT_EQ(vol_itr->index(), 2);
@@ -273,7 +273,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., -705., -695., -M_PI, M_PI};
     range = {132, 244};
     EXPECT_EQ(vol_itr->index(), 3);
@@ -307,7 +307,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., -695., -605., -M_PI, M_PI};
     range = {244, 248};
     EXPECT_EQ(vol_itr->index(), 4);
@@ -333,7 +333,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., -605., -595., -M_PI, M_PI};
     range = {248, 360};
     EXPECT_EQ(vol_itr->index(), 5);
@@ -367,7 +367,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., -595., -500., -M_PI, M_PI};
     range = {360, 370};
     EXPECT_EQ(vol_itr->index(), 6);
@@ -404,7 +404,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 38., -500., 500, -M_PI, M_PI};
     range = {370, 598};
     EXPECT_EQ(vol_itr->index(), 7);
@@ -439,7 +439,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {38., 64., -500., 500, -M_PI, M_PI};
     range = {598, 602};
     EXPECT_EQ(vol_itr->index(), 8);
@@ -465,7 +465,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {64., 80., -500., 500, -M_PI, M_PI};
     range = {602, 1054};
     EXPECT_EQ(vol_itr->index(), 9);
@@ -500,7 +500,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {80., 108., -500., 500, -M_PI, M_PI};
     range = {1054, 1058};
     EXPECT_EQ(vol_itr->index(), 10);
@@ -526,7 +526,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {108., 124., -500., 500, -M_PI, M_PI};
     range = {1058, 1790};
     EXPECT_EQ(vol_itr->index(), 11);
@@ -561,7 +561,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {124., 164., -500., 500, -M_PI, M_PI};
     range = {1790, 1794};
     EXPECT_EQ(vol_itr->index(), 12);
@@ -587,7 +587,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {164., 180., -500., 500, -M_PI, M_PI};
     range = {1794, 2890};
     EXPECT_EQ(vol_itr->index(), 13);
@@ -626,7 +626,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., 500., 595., -M_PI, M_PI};
     range = {2890, 2900};
     EXPECT_EQ(vol_itr->index(), 14);
@@ -659,7 +659,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., 595., 605., -M_PI, M_PI};
     range = {2900, 3012};
     EXPECT_EQ(vol_itr->index(), 15);
@@ -693,7 +693,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., 605., 695., -M_PI, M_PI};
     range = {3012, 3016};
     EXPECT_EQ(vol_itr->index(), 16);
@@ -719,7 +719,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., 695., 705., -M_PI, M_PI};
     range = {3016, 3128};
     EXPECT_EQ(vol_itr->index(), 17);
@@ -753,7 +753,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., 705., 815., -M_PI, M_PI};
     range = {3128, 3132};
     EXPECT_EQ(vol_itr->index(), 18);
@@ -779,7 +779,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     //
 
     // Check volume
-    vol_itr++;
+    ++vol_itr;
     bounds = {27., 180., 815., 825., -M_PI, M_PI};
     range = {3132, 3244};
     EXPECT_EQ(vol_itr->index(), 19);

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -67,15 +67,14 @@ TEST(tools, intersection_kernel_single) {
     transform_store.push_back(static_context, annulus_transform);
     // The masks & their store
     mask_container_t mask_store(host_mr);
-    mask_store.template add_mask<0>(10., 10., 0);
-    mask_store.template add_mask<1>(10., 20., 30., 0);
-    mask_store.template add_mask<2>(15., 55., 0.75, 1.95, 2., -2., 0., 0);
+    mask_store.template add_mask<e_rectangle2>(10., 10., 0);
+    mask_store.template add_mask<e_trapezoid2>(10., 20., 30., 0);
+    mask_store.template add_mask<e_annulus2>(15., 55., 0.75, 1.95, 2., -2., 0.,
+                                             0);
     // The surfaces and their store
-    surface_t rectangle_surface(0u, {mask_defs::id::e_rectangle2, 0}, 0, 0,
-                                false);
-    surface_t trapezoid_surface(1u, {mask_defs::id::e_trapezoid2, 0}, 0, 1,
-                                false);
-    surface_t annulus_surface(2u, {mask_defs::id::e_annulus2, 0}, 0, 2, false);
+    surface_t rectangle_surface(0u, {e_rectangle2, 0}, 0, 0, false);
+    surface_t trapezoid_surface(1u, {e_trapezoid2, 0}, 0, 1, false);
+    surface_t annulus_surface(2u, {e_annulus2, 0}, 0, 2, false);
     surface_container_t surfaces = {rectangle_surface, trapezoid_surface,
                                     annulus_surface};
 

--- a/tests/common/include/tests/common/tools_track.inl
+++ b/tests/common/include/tests/common/tools_track.inl
@@ -30,8 +30,10 @@ TEST(tools, bound_track_parameters) {
 
     // surface container
     std::vector<surface<mask_defs>> surfaces;
-    surfaces.emplace_back(0, mask_defs::link_type{0, 0}, 0, 0, false);
-    surfaces.emplace_back(1, mask_defs::link_type{0, 0}, 0, 0, false);
+    surfaces.emplace_back(0, mask_defs::link_type{e_rectangle2, 0}, 0, 0,
+                          false);
+    surfaces.emplace_back(1, mask_defs::link_type{e_rectangle2, 0}, 0, 0,
+                          false);
 
     // transform container
     static_transform_store trfs;

--- a/tests/unit_tests/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/cuda/mask_store_cuda.cpp
@@ -21,8 +21,8 @@ TEST(mask_store_cuda, mask_store) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // Types must be sorted according to their id (here: masks/mask_identifier)
-    mask_store<thrust::tuple, vecmem::vector, rectangle, trapezoid, ring,
-               cylinder, single, annulus>
+    mask_store<thrust::tuple, vecmem::vector, mask_ids, rectangle, trapezoid,
+               ring, cylinder, single, annulus>
         store(mng_mr);
 
     ASSERT_TRUE(store.template empty<e_annulus2>());

--- a/tests/unit_tests/cuda/mask_store_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/mask_store_cuda_kernel.cu
@@ -13,8 +13,8 @@ namespace detray {
 /// test kernel function to fill the output vector with is_inside function
 /// return values
 __global__ void mask_test_kernel(
-    mask_store_data<mask_store<thrust::tuple, dvector, rectangle, trapezoid,
-                               ring, cylinder, single, annulus>>
+    mask_store_data<mask_store<thrust::tuple, dvector, mask_ids, rectangle,
+                               trapezoid, ring, cylinder, single, annulus>>
         store_data,
     vecmem::data::vector_view<point2> input_point2_data,
     vecmem::data::vector_view<point3> input_point3_data,
@@ -23,8 +23,8 @@ __global__ void mask_test_kernel(
     using cartesian2 = __plugin::cartesian2<detray::scalar>;
 
     /** get mask store **/
-    mask_store<thrust::tuple, vecmem::device_vector, rectangle, trapezoid, ring,
-               cylinder, single, annulus>
+    mask_store<thrust::tuple, vecmem::device_vector, mask_ids, rectangle,
+               trapezoid, ring, cylinder, single, annulus>
         store(store_data);
 
     /** get mask objects **/
@@ -56,8 +56,9 @@ __global__ void mask_test_kernel(
 }
 
 void mask_test(
-    mask_store_data<mask_store<thrust::tuple, dvector, rectangle, trapezoid,
-                               ring, cylinder, single, annulus>>& store_data,
+    mask_store_data<mask_store<thrust::tuple, dvector, mask_ids, rectangle,
+                               trapezoid, ring, cylinder, single, annulus>>&
+        store_data,
     vecmem::data::vector_view<point2>& input_point2_data,
     vecmem::data::vector_view<point3>& input_point3_data,
     vecmem::data::jagged_vector_view<intersection_status>& output_data) {

--- a/tests/unit_tests/cuda/mask_store_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/mask_store_cuda_kernel.hpp
@@ -52,8 +52,9 @@ enum mask_ids : unsigned int {
 
 /// test function for mask store
 void mask_test(
-    mask_store_data<mask_store<thrust::tuple, dvector, rectangle, trapezoid,
-                               ring, cylinder, single, annulus> >& store_data,
+    mask_store_data<mask_store<thrust::tuple, dvector, mask_ids, rectangle,
+                               trapezoid, ring, cylinder, single, annulus> >&
+        store_data,
     vecmem::data::vector_view<point2>& input_point2_data,
     vecmem::data::vector_view<point3>& input_point3_data,
     vecmem::data::jagged_vector_view<intersection_status>& output_data);


### PR DESCRIPTION
Introduce a dedicated class to deal with indexing that needs to resolve type. This way the ```mask_store``` does not need to use a ```pair``` or ```tuple``` for ranged links. Also, since the surface finder infrastructure will mimic that of the masks, it will enforce more prudence in building those links