### PR TITLE
feat: adding nlohman library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option( DETRAY_EIGEN_PLUGIN "Build Eigen math plugin" ON )
 option( DETRAY_SMATRIX_PLUGIN "Build ROOT/SMatrix math plugin" OFF )
 option( DETRAY_VC_PLUGIN "Build Vc based math plugin" ON )
 option( DETRAY_IO_CSV "Build CSV IO module" ON )
+option( DETRAY_IO_JSON "Build Json IO module" ON )
 option( DETRAY_DISPLAY "Build matplot++ based display module" OFF )
 option( DETRAY_BUILD_CUDA "Build the CUDA sources included in detray"
    ${DETRAY_BUILD_CUDA_DEFAULT} )
@@ -102,6 +103,20 @@ if( DETRAY_SETUP_DFELIBS )
       find_package( dfelibs REQUIRED )
    else()
       add_subdirectory( extern/dfelibs )
+   endif()
+endif()
+
+# Set up nlohmann.
+option( DETRAY_SETUP_NLOHMANN
+   "Set up the nlohmann target(s) explicitly" TRUE )
+option( DETRAY_USE_SYSTEM_NLOHMANN
+   "Pick up an existing installation of nlohmann from the build environment"
+   FALSE )
+if( DETRAY_SETUP_NLOHMANN )
+   if( DETRAY_USE_SYSTEM_NLOHMANN )
+      find_package( nlohmann_json REQUIRED )
+   else()
+      add_subdirectory( extern/nlohmann )
    endif()
 endif()
 

--- a/extern/nlohmann/CMakeLists.txt
+++ b/extern/nlohmann/CMakeLists.txt
@@ -13,10 +13,18 @@ message( STATUS "Building nlohmann as part of the Detray project" )
 
 # Declare where to get Thrust from.
 set( DETRAY_NLOHMANN_SOURCE
-   "GIT_REPOSITORY;git@github.com:nlohmann/json.git;GIT_TAG;v3.10.0"
+   "URL;https://github.com/nlohmann/json/archive/refs/tags/v3.10.5.tar.gz;URL_MD5;5b946f7d892fa55eabec45e76a20286b"
    CACHE STRING "Source for nlohmann, when built as part of this project" )
 mark_as_advanced( DETRAY_NLOHMANN_SOURCE )
-FetchContent_Declare( nlohmann ${DETRAY_NLOHMANN_SOURCE} )
+FetchContent_Declare( nlohmann_json ${DETRAY_NLOHMANN_SOURCE} )
+
+# Set Test option sto false
+set( JSON_BuildTests FALSE CACHE BOOL
+   "Turn the tests in nlohmann_json on/off" )
+
+# Set Install option to True 
+set( JSON_Install TRUE CACHE BOOL
+   "Turn the installation of nlohmann_json on/off" )
 
 # Get it into the current directory.
-FetchContent_MakeAvailable( nlohmann )
+FetchContent_MakeAvailable( nlohmann_json )

--- a/extern/nlohmann/CMakeLists.txt
+++ b/extern/nlohmann/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.14 )
+include( FetchContent )
+
+# Tell the user what's happening.
+message( STATUS "Building nlohmann as part of the Detray project" )
+
+# Declare where to get Thrust from.
+set( DETRAY_NLOHMANN_SOURCE
+   "GIT_REPOSITORY;git@github.com:nlohmann/json.git;GIT_TAG;v3.10.0"
+   CACHE STRING "Source for nlohmann, when built as part of this project" )
+mark_as_advanced( DETRAY_NLOHMANN_SOURCE )
+FetchContent_Declare( nlohmann ${DETRAY_NLOHMANN_SOURCE} )
+
+# Get it into the current directory.
+FetchContent_MakeAvailable( nlohmann )

--- a/extern/nlohmann/README.md
+++ b/extern/nlohmann/README.md
@@ -1,0 +1,4 @@
+# Build Recipe for nlohmann
+
+This directory holds a simple build recipe for the
+[nlohmann](https://github.com/nlohmann/json) project.

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -14,3 +14,7 @@ detray_add_library( detray_io io )
 if( DETRAY_IO_CSV )
    add_subdirectory( csv )
 endif()
+
+if( DETRAY_IO_JSON )
+   add_subdirectory( json )
+endif()

--- a/io/json/CMakeLists.txt
+++ b/io/json/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Set the CMake minimum version.
+cmake_minimum_required( VERSION 3.13 )
+
+# Set up the library.
+detray_add_library( detray_io_json io_json
+  "include/detray/io/json_io.hpp" )
+target_link_libraries( detray_io_json INTERFACE nlohmann_json vecmem::core )
+
+# Make the "main I/O library" link against it.
+target_link_libraries( detray_io INTERFACE detray::io_json )

--- a/io/json/include/detray/io/json_io.hpp
+++ b/io/json/include/detray/io/json_io.hpp
@@ -1,0 +1,74 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// This header is used to disable GCC errors that could be occuring in
+// nlohmann/json.hpp
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#include <nlohmann/json.hpp>
+#pragma GCC diagnostic pop
+
+namespace ALGEBRA_TRANSFORM3_NAMESPACE {
+
+void to_json(nlohmann::json& j, const __plugin::transform3<detray::scalar>& t) {
+
+    // Get translation and write it
+    auto translation = t.translation();
+    detray::darray<detray::scalar, 3> tdata = {translation[0], translation[1],
+                                               translation[2]};
+    j["translation"] = tdata;
+    // Get rotation and write it
+    auto rotation = t.rotation();
+    detray::darray<detray::scalar, 9> rdata = {
+        algebra::getter::element(rotation, 0, 0),
+        algebra::getter::element(rotation, 0, 1),
+        algebra::getter::element(rotation, 0, 2),
+        algebra::getter::element(rotation, 1, 0),
+        algebra::getter::element(rotation, 1, 1),
+        algebra::getter::element(rotation, 1, 2),
+        algebra::getter::element(rotation, 2, 0),
+        algebra::getter::element(rotation, 2, 1),
+        algebra::getter::element(rotation, 2, 2)};
+    j["rotation"] = rdata;
+}
+
+void from_json(const nlohmann::json& j, __plugin::transform3<detray::scalar>& t) {
+
+    detray::darray<detray::scalar, 9> rdata = {1., 0., 0., 0., 1.,
+                                               0., 0., 0., 1.};
+    if (not j["rotation"].empty()) {
+        rdata = j["rotation"];
+    }
+    detray::darray<detray::scalar, 3> tdata = {0., 0., 0.};
+    if (not j["translation"].empty()) {
+        tdata = j["translation"];
+    }
+
+    detray::matrix<detray::scalar, 4, 4> ma;
+    algebra::getter::element(ma, 0, 0) = rdata[0];
+    algebra::getter::element(ma, 0, 1) = rdata[1];
+    algebra::getter::element(ma, 0, 2) = rdata[2];
+    algebra::getter::element(ma, 0, 3) = tdata[0];
+    algebra::getter::element(ma, 1, 0) = rdata[3];
+    algebra::getter::element(ma, 1, 1) = rdata[4];
+    algebra::getter::element(ma, 1, 2) = rdata[5];
+    algebra::getter::element(ma, 1, 3) = tdata[1];
+    algebra::getter::element(ma, 2, 0) = rdata[6];
+    algebra::getter::element(ma, 2, 1) = rdata[7];
+    algebra::getter::element(ma, 2, 2) = rdata[8];
+    algebra::getter::element(ma, 2, 3) = tdata[2];
+    algebra::getter::element(ma, 3, 0) = 0.;
+    algebra::getter::element(ma, 3, 1) = 0.;
+    algebra::getter::element(ma, 3, 2) = 0.;
+    algebra::getter::element(ma, 3, 3) = 1.;
+
+    t = __plugin::transform3<detray::scalar>(ma);
+}
+
+}  // namespace __plugin::math

--- a/io/json/include/detray/io/json_io.hpp
+++ b/io/json/include/detray/io/json_io.hpp
@@ -38,7 +38,8 @@ void to_json(nlohmann::json& j, const __plugin::transform3<detray::scalar>& t) {
     j["rotation"] = rdata;
 }
 
-void from_json(const nlohmann::json& j, __plugin::transform3<detray::scalar>& t) {
+void from_json(const nlohmann::json& j,
+               __plugin::transform3<detray::scalar>& t) {
 
     detray::darray<detray::scalar, 9> rdata = {1., 0., 0., 0., 1.,
                                                0., 0., 0., 1.};
@@ -71,4 +72,4 @@ void from_json(const nlohmann::json& j, __plugin::transform3<detray::scalar>& t)
     t = __plugin::transform3<detray::scalar>(ma);
 }
 
-}  // namespace __plugin::math
+}  // namespace ALGEBRA_TRANSFORM3_NAMESPACE

--- a/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
@@ -10,6 +10,7 @@
 
 #define __plugin algebra::array
 #define ALGEBRA_PLUGIN array
+#define ALGEBRA_TRANSFORM3_NAMESPACE algebra::cmath
 
 namespace detray {
 

--- a/plugins/algebra/eigen/include/detray/plugins/algebra/eigen_definitions.hpp
+++ b/plugins/algebra/eigen/include/detray/plugins/algebra/eigen_definitions.hpp
@@ -10,6 +10,7 @@
 
 #define __plugin algebra::eigen
 #define ALGEBRA_PLUGIN eigen
+#define ALGEBRA_TRANSFORM3_NAMESPACE algebra::eigen::math
 
 namespace detray {
 

--- a/tests/common/include/tests/common/display_masks.inl
+++ b/tests/common/include/tests/common/display_masks.inl
@@ -18,16 +18,12 @@
 /// @note __plugin has to be defined with a preprocessor command
 using namespace detray;
 
-using transform3 = __plugin::transform3<detray::scalar>;
-using vector3 = __plugin::vector3<detray::scalar>;
-using point3 = __plugin::point3<detray::scalar>;
-
 TEST(display, annulus2) {
-    detray::global_xy_view gxy;
+    global_xy_view gxy;
 
     // First rectangle
     transform3 transform{};
-    annulus2<> annulus = {7.2, 12.0, 0.74195, 1.33970, 0., -2., 2.};
+    annulus2<> annulus = {7.2, 12.0, 0.74195, 1.33970, 0., -2., 2., 0u};
 
     color c = {0.2, 0.8, 0.6, 0.9};
     display(false);
@@ -36,11 +32,11 @@ TEST(display, annulus2) {
 }
 
 TEST(display, rectangle2) {
-    detray::global_xy_view gxy;
+    global_xy_view gxy;
 
     // First rectangle
     transform3 transform{};
-    rectangle2<> rectangle = {3., 4.};
+    rectangle2<> rectangle = {3., 4., 1u};
 
     color c = {0.5, 0.2, 0.6, 0.9};
     display(false);
@@ -49,11 +45,11 @@ TEST(display, rectangle2) {
 }
 
 TEST(display, trapezoid2) {
-    detray::global_xy_view gxy;
+    global_xy_view gxy;
 
     // First rectangle
     transform3 transform{};
-    trapezoid2<> trapezoid = {3., 4., 5.};
+    trapezoid2<> trapezoid = {3., 4., 5., 2u};
 
     color c = {0.5, 0.4, 0.4, 0.9};
     display(false);

--- a/tests/common/include/tests/common/io_json_basics.inl
+++ b/tests/common/include/tests/common/io_json_basics.inl
@@ -48,7 +48,8 @@ TEST(IO_JSON, write_read_transform) {
 
     auto translation_in = t3_in.translation();
 
-    constexpr detray::scalar epsilon = std::numeric_limits<detray::scalar>::epsilon();
+    constexpr detray::scalar epsilon =
+        std::numeric_limits<detray::scalar>::epsilon();
 
     ASSERT_NEAR(translation_in[0], x, epsilon);
     ASSERT_NEAR(translation_in[1], y, epsilon);

--- a/tests/common/include/tests/common/io_json_basics.inl
+++ b/tests/common/include/tests/common/io_json_basics.inl
@@ -1,0 +1,56 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include "detray/io/json_io.hpp"
+
+/// @note __plugin has to be defined with a preprocessor command
+
+TEST(IO_JSON, write_read_transform) {
+
+    detray::scalar x = 10.;
+    detray::scalar y = 20.;
+    detray::scalar z = 30.;
+
+    // Let's make a matrix for
+    detray::matrix<detray::scalar, 4, 4> ma;
+    algebra::getter::element(ma, 0, 0) = 0.36;
+    algebra::getter::element(ma, 0, 1) = 0.48;
+    algebra::getter::element(ma, 0, 2) = -0.80;
+    algebra::getter::element(ma, 0, 3) = x;
+    algebra::getter::element(ma, 1, 0) = -0.80;
+    algebra::getter::element(ma, 1, 1) = 0.60;
+    algebra::getter::element(ma, 1, 2) = 0.;
+    algebra::getter::element(ma, 1, 3) = y;
+    algebra::getter::element(ma, 2, 0) = 0.48;
+    algebra::getter::element(ma, 2, 1) = 0.64;
+    algebra::getter::element(ma, 2, 2) = 0.60;
+    algebra::getter::element(ma, 2, 3) = z;
+    algebra::getter::element(ma, 3, 0) = 0.;
+    algebra::getter::element(ma, 3, 1) = 0.;
+    algebra::getter::element(ma, 3, 2) = 0.;
+    algebra::getter::element(ma, 3, 2) = 1.;
+
+    __plugin::transform3<detray::scalar> t3_out(ma);
+
+    // Create the json command for the
+    nlohmann::json tj = t3_out;
+
+    nlohmann::json j;
+    j["transform"] = tj;
+
+    auto t3_in = j["transform"].get<__plugin::transform3<detray::scalar>>();
+
+    auto translation_in = t3_in.translation();
+
+    constexpr detray::scalar epsilon = std::numeric_limits<detray::scalar>::epsilon();
+
+    ASSERT_NEAR(translation_in[0], x, epsilon);
+    ASSERT_NEAR(translation_in[1], y, epsilon);
+    ASSERT_NEAR(translation_in[2], z, epsilon);
+}

--- a/tests/unit_tests/array/CMakeLists.txt
+++ b/tests/unit_tests/array/CMakeLists.txt
@@ -23,6 +23,11 @@ if( DETRAY_IO_CSV )
       LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::io
                      detray::array )
 endif()
+if ( DETRAY_IO_JSON )
+   detray_add_test( array_json_io "array_io_json.cpp"
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::io
+                  detray::array )
+endif()
 if( DETRAY_DISPLAY )
    detray_add_test( array_display_masks "array_display_masks.cpp"
       LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::display

--- a/tests/unit_tests/array/array_io_json.cpp
+++ b/tests/unit_tests/array/array_io_json.cpp
@@ -1,0 +1,8 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/array_definitions.hpp"
+#include "tests/common/io_json_basics.inl"

--- a/tests/unit_tests/eigen/CMakeLists.txt
+++ b/tests/unit_tests/eigen/CMakeLists.txt
@@ -23,6 +23,11 @@ if( DETRAY_IO_CSV )
       LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::io
                      detray::eigen )
 endif()
+if ( DETRAY_IO_JSON )
+   detray_add_test( eigen_json_io "eigen_io_json.cpp"
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::io
+                  detray::eigen )
+endif()
 if( DETRAY_DISPLAY )
    detray_add_test( eigen_display_masks "eigen_display_masks.cpp"
       LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::display

--- a/tests/unit_tests/eigen/eigen_io_json.cpp
+++ b/tests/unit_tests/eigen/eigen_io_json.cpp
@@ -1,0 +1,8 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/eigen_definitions.hpp"
+#include "tests/common/io_json_basics.inl"


### PR DESCRIPTION
Preparation PR for json geometry reader, adding the nlohman library as optional dependency.

I had to introduce a `ALGEBRA_TRANSFORM3_NAMESPACE` macro that is set in the relevant algebra definitions, because `nlohmann::json` is very peculiar that the `to_json(...)` and `from_json(...)` methods are in the exact namespace of the `transform3` definition.