### PR TITLE
Grid2 Const Correctness, main branch (2022.02.28.)

### DIFF
--- a/core/include/detray/core/surfaces_finder.hpp
+++ b/core/include/detray/core/surfaces_finder.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -83,7 +83,8 @@ struct surfaces_finder {
               std::enable_if_t<!std::is_base_of_v<vecmem::memory_resource,
                                                   surfaces_finder_data_t>,
                                bool> = true>
-    DETRAY_HOST_DEVICE surfaces_finder(surfaces_finder_data_t& finder_data)
+    DETRAY_HOST_DEVICE surfaces_finder(
+        const surfaces_finder_data_t& finder_data)
         : _surface_grids(initialize_device_grids(
               finder_data, std::make_index_sequence<N_GRIDS>{})) {}
 
@@ -96,10 +97,11 @@ struct surfaces_finder {
      */
     template <std::size_t... ints, typename surfaces_finder_data_t>
     DETRAY_HOST_DEVICE auto initialize_device_grids(
-        surfaces_finder_data_t& finder_data,
+        const surfaces_finder_data_t& finder_data,
         std::index_sequence<ints...> /*seq*/) {
-        return array_t<surfaces_regular_circular_grid, N_GRIDS>(
-            {{finder_data._surface_grids_view[ints]...}});
+        return array_t<surfaces_regular_circular_grid, N_GRIDS>{
+            surfaces_regular_circular_grid{
+                finder_data._surface_grids_view[ints]}...};
     }
 
     /** return the size of array of grids

--- a/core/include/detray/grids/populator.hpp
+++ b/core/include/detray/grids/populator.hpp
@@ -1,14 +1,18 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-#include <algorithm>
-#include <limits>
+// Project include(s).
+#include "detray/definitions/invalid_values.hpp"
+#include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/indexing.hpp"
+
+// VecMem include(s).
 #include <vecmem/containers/data/jagged_vector_buffer.hpp>
 #include <vecmem/containers/data/jagged_vector_view.hpp>
 #include <vecmem/containers/data/vector_buffer.hpp>
@@ -16,9 +20,9 @@
 #include <vecmem/containers/device_vector.hpp>
 #include <vecmem/containers/jagged_device_vector.hpp>
 
-#include "detray/definitions/invalid_values.hpp"
-#include "detray/definitions/qualifiers.hpp"
-#include "detray/utils/indexing.hpp"
+// System include(s).
+#include <algorithm>
+#include <limits>
 
 namespace detray {
 
@@ -45,7 +49,9 @@ struct replace_populator {
     using serialized_storage = vector_t<store_value>;
 
     using vector_view_type = vecmem::data::vector_view<store_value>;
+    using const_vector_view_type = vecmem::data::vector_view<const store_value>;
     using vector_data_type = vecmem::data::vector_view<store_value>;
+    using const_vector_data_type = vecmem::data::vector_view<const store_value>;
     using vector_buffer_type = vecmem::data::vector_buffer<store_value>;
     using buffer_size_type = typename vector_view_type::size_type;
 
@@ -88,14 +94,6 @@ struct replace_populator {
      */
     DETRAY_HOST_DEVICE
     store_value init() const { return m_invalid; }
-
-    /** Return a vector view
-     **/
-    DETRAY_HOST
-    static vector_data_type get_data(serialized_storage &data,
-                                     vecmem::memory_resource & /*resource*/) {
-        return vecmem::get_data(data);
-    }
 };
 
 /** A complete populator that adds values to the internal
@@ -125,7 +123,9 @@ struct complete_populator {
     using serialized_storage = vector_t<store_value>;
 
     using vector_view_type = vecmem::data::vector_view<store_value>;
+    using const_vector_view_type = vecmem::data::vector_view<const store_value>;
     using vector_data_type = vecmem::data::vector_view<store_value>;
+    using const_vector_data_type = vecmem::data::vector_view<const store_value>;
     using vector_buffer_type = vecmem::data::vector_buffer<store_value>;
     using buffer_size_type = typename vector_view_type::size_type;
 
@@ -192,14 +192,6 @@ struct complete_populator {
         }
         return init_bin;
     }
-
-    /** Return a vector view
-     **/
-    DETRAY_HOST
-    static vector_data_type get_data(serialized_storage &data,
-                                     vecmem::memory_resource & /*resource*/) {
-        return vecmem::get_data(data);
-    }
 };
 
 /** An attach populator that adds the new value to the
@@ -225,7 +217,11 @@ struct attach_populator {
     using serialized_storage = jagged_vector_t<bare_value>;
 
     using vector_view_type = vecmem::data::jagged_vector_view<bare_value>;
+    using const_vector_view_type =
+        vecmem::data::jagged_vector_view<const bare_value>;
     using vector_data_type = vecmem::data::jagged_vector_data<bare_value>;
+    using const_vector_data_type =
+        vecmem::data::jagged_vector_data<const bare_value>;
     using vector_buffer_type = vecmem::data::jagged_vector_buffer<bare_value>;
     using buffer_size_type = std::vector<typename vector_view_type::size_type>;
 
@@ -279,14 +275,6 @@ struct attach_populator {
      **/
     DETRAY_HOST_DEVICE
     store_value init() const { return {}; }
-
-    /** Return a vector data
-     **/
-    DETRAY_HOST
-    static vector_data_type get_data(serialized_storage &data,
-                                     vecmem::memory_resource &resource) {
-        return vecmem::get_data(data, &resource);
-    }
 };
 
 }  // namespace detray

--- a/tests/unit_tests/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/cuda/grids_grid2_cuda.cpp
@@ -1,18 +1,23 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
+// Detray include(s).
+#include "grids_grid2_cuda_kernel.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/cuda/managed_memory_resource.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+
+// GTest include(s).
 #include <gtest/gtest.h>
 
+// System include(s).
 #include <climits>
 #include <iostream>
-#include <vecmem/memory/cuda/managed_memory_resource.hpp>
-
-#include "grids_grid2_cuda_kernel.hpp"
-#include "vecmem/utils/cuda/copy.hpp"
 
 using namespace detray;
 
@@ -194,7 +199,8 @@ TEST(grids_cuda, grid2_attach_populator) {
     }
 
     // get grid_data
-    auto g2_data = get_data(g2, mng_mr);
+    const host_grid2_attach& const_g2 = g2;
+    auto g2_data = get_data(const_g2, mng_mr);
 
     // Read the grid
     grid_attach_read_test(g2_data);

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,8 +39,8 @@ __global__ void grid_replace_test_kernel(
 // grid_replace_test implementation
 void grid_replace_test(grid2_view<host_grid2_replace> grid_view) {
 
-    const auto& axis0 = grid_view._axis_p0;
-    const auto& axis1 = grid_view._axis_p1;
+    const auto& axis0 = grid_view._axis_p0_view;
+    const auto& axis1 = grid_view._axis_p1_view;
 
     int block_dim = 1;
     dim3 thread_dim(axis0.n_bins, axis1.n_bins);
@@ -77,8 +77,8 @@ __global__ void grid_replace_ci_test_kernel(
 // test function for replace populator with circular and irregular axis
 void grid_replace_ci_test(grid2_view<host_grid2_replace_ci> grid_view) {
 
-    const auto& axis0 = grid_view._axis_p0;
-    const auto& axis1 = grid_view._axis_p1;
+    const auto& axis0 = grid_view._axis_p0_view;
+    const auto& axis1 = grid_view._axis_p1_view;
 
     int block_dim = 1;
     dim3 thread_dim(axis0.n_bins, axis1.n_bins);
@@ -123,8 +123,8 @@ __global__ void grid_complete_kernel(
 // grid_complete_test implementation
 void grid_complete_test(grid2_view<host_grid2_complete> grid_view) {
 
-    const auto& axis0 = grid_view._axis_p0;
-    const auto& axis1 = grid_view._axis_p1;
+    const auto& axis0 = grid_view._axis_p0_view;
+    const auto& axis1 = grid_view._axis_p1_view;
 
     int block_dim = 1;
     dim3 thread_dim(axis0.n_bins, axis1.n_bins);
@@ -143,11 +143,11 @@ void grid_complete_test(grid2_view<host_grid2_complete> grid_view) {
 
 // cuda kernel for attach_read_test
 __global__ void grid_attach_read_test_kernel(
-    grid2_view<host_grid2_attach> grid_view) {
+    const_grid2_view<host_grid2_attach> grid_view) {
 
     // Let's try building the grid object
-    device_grid2_attach g2_device(grid_view,
-                                  test::point3<detray::scalar>{0, 0, 0});
+    const_device_grid2_attach g2_device(grid_view,
+                                        test::point3<detray::scalar>{0, 0, 0});
 
     auto data = g2_device.bin(threadIdx.x, threadIdx.y);
 
@@ -157,10 +157,10 @@ __global__ void grid_attach_read_test_kernel(
 }
 
 // attach_read_test implementation
-void grid_attach_read_test(grid2_view<host_grid2_attach> grid_view) {
+void grid_attach_read_test(const_grid2_view<host_grid2_attach> grid_view) {
 
-    const auto& axis0 = grid_view._axis_p0;
-    const auto& axis1 = grid_view._axis_p1;
+    const auto& axis0 = grid_view._axis_p0_view;
+    const auto& axis1 = grid_view._axis_p1_view;
 
     int block_dim = 1;
     dim3 thread_dim(axis0.n_bins, axis1.n_bins);
@@ -203,8 +203,8 @@ __global__ void grid_attach_fill_test_kernel(
 // attach_fill_test implementation
 void grid_attach_fill_test(grid2_view<host_grid2_attach> grid_view) {
 
-    const auto& axis0 = grid_view._axis_p0;
-    const auto& axis1 = grid_view._axis_p1;
+    const auto& axis0 = grid_view._axis_p0_view;
+    const auto& axis1 = grid_view._axis_p1_view;
 
     dim3 block_dim(axis0.n_bins, axis1.n_bins);
     int thread_dim = 100;

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.hpp
@@ -62,6 +62,11 @@ using device_grid2_attach =
           vecmem::device_vector, vecmem::jagged_device_vector, darray,
           std::tuple, test::point3<detray::scalar>, false>;
 
+using const_device_grid2_attach =
+    grid2<attach_populator, axis::circular, axis::regular, serializer2,
+          vecmem::device_vector, vecmem::jagged_device_vector, darray,
+          std::tuple, const test::point3<detray::scalar>, false>;
+
 // test function for replace populator
 void grid_replace_test(grid2_view<host_grid2_replace> grid_view);
 
@@ -72,7 +77,7 @@ void grid_replace_ci_test(grid2_view<host_grid2_replace_ci> grid_view);
 void grid_complete_test(grid2_view<host_grid2_complete> grid_view);
 
 // read test function for grid with attach populator
-void grid_attach_read_test(grid2_view<host_grid2_attach> grid_view);
+void grid_attach_read_test(const_grid2_view<host_grid2_attach> grid_view);
 
 // fill test function for grid buffer with attach populator
 void grid_attach_fill_test(grid2_view<host_grid2_attach> grid_view);

--- a/tests/unit_tests/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/cuda/mask_store_cuda.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,8 +21,8 @@ TEST(mask_store_cuda, mask_store) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // Types must be sorted according to their id (here: masks/mask_identifier)
-    mask_store<thrust::tuple, vecmem::vector, mask_ids, rectangle, trapezoid,
-               ring, cylinder, single, annulus>
+    mask_store<thrust::tuple, dvector, mask_ids, rectangle, trapezoid, ring,
+               cylinder, single, annulus>
         store(mng_mr);
 
     ASSERT_TRUE(store.template empty<e_annulus2>());

--- a/tests/unit_tests/cuda/surfaces_finder_cuda.cpp
+++ b/tests/unit_tests/cuda/surfaces_finder_cuda.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -20,7 +20,7 @@ TEST(surfaces_finder_cuda, surfaces_finder) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     /** Make surface finder object **/
-    surfaces_finder<n_grids, std::array, thrust::tuple, vecmem::vector,
+    surfaces_finder<n_grids, darray, thrust::tuple, vecmem::vector,
                     vecmem::jagged_vector>
         finder(mng_mr);
 

--- a/tests/unit_tests/cuda/tuple_test_cuda.cpp
+++ b/tests/unit_tests/cuda/tuple_test_cuda.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,8 +19,7 @@ TEST(tuple_test_cuda, tuple_test) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // mask_store-like tuple container
-    vec_tuple<thrust::tuple, vecmem::vector, int, float, double> input_host(
-        mng_mr);
+    vec_tuple<thrust::tuple, dvector, int, float, double> input_host(mng_mr);
     detail::get<0>(input_host._tuple) = vecmem::vector<int>({1, 2, 3});
     detail::get<1>(input_host._tuple) = vecmem::vector<float>({1.1, 5, 6});
     detail::get<2>(input_host._tuple) = vecmem::vector<double>({2.1, 2.2, 0.});


### PR DESCRIPTION
Made it possible to access constant `detray::grid2` data on a device.

I had to introduce a bunch of "const data types" to make this happen, and tweak the various `get_data(...)` functions.
  - I'm fairly happy with what I did in `axis.hpp` and `populator.hpp`. Those things should not change much while improving the const correctness of all the other types.
  - I'm however not all too happy with `grid2.hpp` yet. As discussed in our meeting today, I ended up creating all of the following types:
    * `grid2_view`
    * `const_grid2_view`
    * `grid2_data`
    * `const_grid2_data`
    * `grid2_buffer`
  - In the future we should think about merging the "const" and "non-const" types, implementing their behaviour through some clever templating.

I modified the `grid2_attach_populator` test to exercise this constant data access, to exercise the new code. It's good that I did, because the code was still quite broken when I already thought that I was done...

There is one really big problem with this code... In vecmem we made sure that a `vecmem::vector_view<T>` object could be seamlessly translated into a `vecmem::vector_view<const T>` object. (Since giving a non-const object to a function that expects a const object is fine.) But that is all missing for these new types at the moment. Making it a whole lot more awkward to pass the correct data type to the kernel in `grid2_attach_populator`. :frowning:

I also encountered some other things along the way:
  - As we discussed, there are a bunch of warnings during the build. I even ended up seeing most of them (I think...) with GCC 9. So it's not purely an issue with Clang.
  - When using Clang I ended up having to change a couple of template types here and there to make the compiler accept the code. I believe these are actually bugs in Clang itself (where it wouldn't recognise that `darray` is `std::array` in the depth of a complicated template), but side-stepping those compilation issues for now seemed easy enough.

We'll have a bunch more work with this, but hopefully this will already give a reasonable view of more or less what I have in mind.

P.S. The updates also ended up having a weird effect on `detray::surfaces_finder`. A conversion that could be executed implicitly before, can no longer be. That was a really painful thing to find the root of...