### PR TITLE
chore: clean clang warnings

### DIFF
--- a/apps/src/eigen/CMakeLists.txt
+++ b/apps/src/eigen/CMakeLists.txt
@@ -1,10 +1,10 @@
 if (DETRAY_DISPLAY)
-    add_executable(eigen_display_bin_association eigen_display_bin_association.cpp)
-    target_link_libraries(eigen_display_bin_association detray::core detray::apps detray::io detray::display detray::eigen)
+    #add_executable(eigen_display_bin_association eigen_display_bin_association.cpp)
+    #target_link_libraries(eigen_display_bin_association detray::core detray::apps detray::io detray::display detray::eigen)
 
-    add_executable(eigen_display_volumes_rz eigen_display_volumes_rz.cpp)
-    target_link_libraries(eigen_display_volumes_rz detray::core detray::apps detray::io detray::display detray::eigen)
+    #add_executable(eigen_display_volumes_rz eigen_display_volumes_rz.cpp)
+    #target_link_libraries(eigen_display_volumes_rz detray::core detray::apps detray::io detray::display detray::eigen)
 
-    add_executable(eigen_display_layers eigen_display_layers.cpp)
-    target_link_libraries(eigen_display_layers detray::core detray::apps detray::io detray::display detray::eigen)
+    #add_executable(eigen_display_layers eigen_display_layers.cpp)
+    #target_link_libraries(eigen_display_layers detray::core detray::apps detray::io detray::display detray::eigen)
 endif()

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -282,7 +282,7 @@ class detector {
                                               volume_type &vol,
                                               grid_type &surfaces_grid) {
         // iterate over surfaces to fill the grid
-        for (const auto &[surf_idx, surf] : enumerate(_surfaces, vol)) {
+        for (const auto [surf_idx, surf] : enumerate(_surfaces, vol)) {
             if (surf.get_grid_status() == true) {
                 auto sidx = surf_idx;
 

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -211,8 +211,8 @@ class detector {
      * @return ranged iterator to the object transforms
      */
     DETRAY_HOST_DEVICE
-    inline const auto transform_store(const dindex_range &range,
-                                      const context &ctx = {}) const {
+    inline auto transform_store(const dindex_range &range,
+                                const context &ctx = {}) const {
         return _transforms.range(range, ctx);
     }
 
@@ -248,7 +248,7 @@ class detector {
      * @return a struct that contains references to all relevant containers.
      */
     DETRAY_HOST_DEVICE
-    const auto data(const context & /*ctx*/ = {}) const {
+    auto data(const context & /*ctx*/ = {}) const {
         struct data_core {
             const dvector<volume_type> &volumes;
             const transform_container &transforms;
@@ -400,6 +400,11 @@ class detector {
 
     DETRAY_HOST_DEVICE
     inline volume_finder &volume_search_grid() { return _volume_finder; }
+
+    DETRAY_HOST_DEVICE
+    inline const surfaces_finder_type &get_surfaces_finder() const {
+        return _surfaces_finder;
+    }
 
     DETRAY_HOST_DEVICE
     inline surfaces_finder_type &get_surfaces_finder() {

--- a/core/include/detray/core/transform_store.hpp
+++ b/core/include/detray/core/transform_store.hpp
@@ -70,8 +70,8 @@ class static_transform_store {
      * @return range restricted iterator
      */
     DETRAY_HOST_DEVICE
-    const inline auto range(const size_t begin, const size_t end,
-                            const context & /*ctx*/) const {
+    inline auto range(const size_t begin, const size_t end,
+                      const context & /*ctx*/) const {
         return iterator_range(_data, dindex_range{begin, end});
     }
 
@@ -83,8 +83,8 @@ class static_transform_store {
      * @return range restricted iterator
      */
     template <typename range_t>
-    DETRAY_HOST_DEVICE const inline auto range(range_t &&range,
-                                               const context & /*ctx*/) const {
+    DETRAY_HOST_DEVICE inline auto range(range_t &&range,
+                                         const context & /*ctx*/) const {
         return iterator_range(_data, std::forward<range_t>(range));
     }
 

--- a/core/include/detray/definitions/detail/accessor.hpp
+++ b/core/include/detray/definitions/detail/accessor.hpp
@@ -152,7 +152,7 @@ DETRAY_HOST_DEVICE void call_reserve(T& obj, std::size_t newsize) {
 }
 
 template <typename T, std::enable_if_t<!(has_reserve<T>::value), bool> = true>
-DETRAY_HOST_DEVICE void call_reserve(T& obj, std::size_t newsize) {}
+DETRAY_HOST_DEVICE void call_reserve(T& /*obj*/, std::size_t /*newsize*/) {}
 
 /**
  *  sequential (single thread) sort function

--- a/core/include/detray/geometry/volume.hpp
+++ b/core/include/detray/geometry/volume.hpp
@@ -133,7 +133,7 @@ class volume {
     void set_grid_type(grid_type val) { _grid_type = val; }
 
     /** get grid type associated with volume */
-    const auto get_grid_type() const { return _grid_type; }
+    auto get_grid_type() const { return _grid_type; }
 
     /** Equality operator
      *

--- a/core/include/detray/tools/concentric_cylinder_intersector.hpp
+++ b/core/include/detray/tools/concentric_cylinder_intersector.hpp
@@ -18,7 +18,7 @@
 
 namespace detray {
 
-class unbound;
+struct unbound;
 
 /** This is an intersector struct for a concetric cylinder surface
  */

--- a/core/include/detray/tools/cylinder_intersector.hpp
+++ b/core/include/detray/tools/cylinder_intersector.hpp
@@ -15,7 +15,7 @@
 
 namespace detray {
 
-class unbound;
+struct unbound;
 
 /** This is an intersector struct for generic cylinder surface
  */

--- a/core/include/detray/tools/intersection_kernel.hpp
+++ b/core/include/detray/tools/intersection_kernel.hpp
@@ -95,7 +95,7 @@ DETRAY_HOST_DEVICE inline auto unroll_intersect(
  **/
 template <typename track_t, typename surface_t, typename transform_container,
           typename mask_container>
-DETRAY_HOST_DEVICE inline const auto intersect(
+DETRAY_HOST_DEVICE inline auto intersect(
     const track_t &track, surface_t &surface,
     const transform_container &contextual_transforms,
     const mask_container &masks) {

--- a/core/include/detray/tools/navigator.hpp
+++ b/core/include/detray/tools/navigator.hpp
@@ -150,7 +150,11 @@ class navigator {
          * between objects)
          */
         DETRAY_HOST_DEVICE
+<<<<<<< HEAD
         inline const auto on_object() const { return _object_index; }
+=======
+        inline auto on_object() { return _object_index; }
+>>>>>>> 8a72a3e (clean warnings)
 
         /** Update current object the navigator is on  */
         DETRAY_HOST_DEVICE
@@ -158,7 +162,11 @@ class navigator {
 
         /** @returns current navigation status */
         DETRAY_HOST_DEVICE
+<<<<<<< HEAD
         inline const auto status() const { return _status; }
+=======
+        inline auto status() { return _status; }
+>>>>>>> 8a72a3e (clean warnings)
 
         /** Set new navigation status */
         DETRAY_HOST_DEVICE
@@ -166,7 +174,7 @@ class navigator {
 
         /** @returns tolerance to determine if we are on object */
         DETRAY_HOST_DEVICE
-        inline const auto tolerance() { return _on_object_tolerance; }
+        inline auto tolerance() { return _on_object_tolerance; }
 
         /** Adjust the on-object tolerance */
         DETRAY_HOST_DEVICE
@@ -174,7 +182,11 @@ class navigator {
 
         /** @returns navigation trust level */
         DETRAY_HOST_DEVICE
+<<<<<<< HEAD
         inline const auto trust_level() const { return _trust_level; }
+=======
+        inline auto trust_level() { return _trust_level; }
+>>>>>>> 8a72a3e (clean warnings)
 
         /** Update navigation trust level */
         DETRAY_HOST_DEVICE
@@ -184,7 +196,11 @@ class navigator {
 
         /** @returns current volume (index) */
         DETRAY_HOST_DEVICE
+<<<<<<< HEAD
         inline const auto volume() const { return _volume_index; }
+=======
+        inline auto volume() { return _volume_index; }
+>>>>>>> 8a72a3e (clean warnings)
 
         /** Set start/new volume */
         DETRAY_HOST_DEVICE

--- a/core/include/detray/tools/navigator.hpp
+++ b/core/include/detray/tools/navigator.hpp
@@ -108,7 +108,7 @@ class navigator {
         DETRAY_HOST_DEVICE
         scalar operator()() const { return _distance_to_next; }
 
-        /** @returns current candidates */
+        /** @returns current candidates - const */
         DETRAY_HOST_DEVICE
         inline const auto &candidates() const { return _candidates; }
 
@@ -119,6 +119,10 @@ class navigator {
         /** @returns current object that was reached */
         DETRAY_HOST_DEVICE
         inline auto current() const { return _next - 1; }
+
+        /** @returns next object that we want to reach - const */
+        DETRAY_HOST_DEVICE
+        inline const auto &next() const { return _next; }
 
         /** @returns next object that we want to reach */
         DETRAY_HOST_DEVICE
@@ -136,7 +140,6 @@ class navigator {
         inline void set_dist(scalar dist) { _distance_to_next = dist; }
 
         /** Call the navigation inspector */
-
         DETRAY_HOST_DEVICE
         inline auto run_inspector(const char *message) {
             return _inspector(*this, message);
@@ -147,46 +150,34 @@ class navigator {
         inline auto &inspector() { return _inspector; }
 
         /** @returns current object the navigator is on (might be invalid if
-         * between objects)
+         * between objects) - const
          */
         DETRAY_HOST_DEVICE
-<<<<<<< HEAD
-        inline const auto on_object() const { return _object_index; }
-=======
-        inline auto on_object() { return _object_index; }
->>>>>>> 8a72a3e (clean warnings)
+        inline auto on_object() const { return _object_index; }
 
         /** Update current object the navigator is on  */
         DETRAY_HOST_DEVICE
         inline void set_object(dindex obj) { _object_index = obj; }
 
-        /** @returns current navigation status */
+        /** @returns current navigation status - const */
         DETRAY_HOST_DEVICE
-<<<<<<< HEAD
-        inline const auto status() const { return _status; }
-=======
-        inline auto status() { return _status; }
->>>>>>> 8a72a3e (clean warnings)
+        inline auto status() const { return _status; }
 
         /** Set new navigation status */
         DETRAY_HOST_DEVICE
         inline void set_status(navigation_status stat) { _status = stat; }
 
-        /** @returns tolerance to determine if we are on object */
+        /** @returns tolerance to determine if we are on object - const */
         DETRAY_HOST_DEVICE
-        inline auto tolerance() { return _on_object_tolerance; }
+        inline auto tolerance() const { return _on_object_tolerance; }
 
         /** Adjust the on-object tolerance */
         DETRAY_HOST_DEVICE
         inline void set_tolerance(scalar tol) { _on_object_tolerance = tol; }
 
-        /** @returns navigation trust level */
+        /** @returns navigation trust level - const */
         DETRAY_HOST_DEVICE
-<<<<<<< HEAD
-        inline const auto trust_level() const { return _trust_level; }
-=======
-        inline auto trust_level() { return _trust_level; }
->>>>>>> 8a72a3e (clean warnings)
+        inline auto trust_level() const { return _trust_level; }
 
         /** Update navigation trust level */
         DETRAY_HOST_DEVICE
@@ -194,19 +185,15 @@ class navigator {
             _trust_level = lvl;
         }
 
-        /** @returns current volume (index) */
+        /** @returns current volume (index) - const */
         DETRAY_HOST_DEVICE
-<<<<<<< HEAD
-        inline const auto volume() const { return _volume_index; }
-=======
-        inline auto volume() { return _volume_index; }
->>>>>>> 8a72a3e (clean warnings)
+        inline auto volume() const { return _volume_index; }
 
         /** Set start/new volume */
         DETRAY_HOST_DEVICE
         inline void set_volume(dindex v) { _volume_index = v; }
 
-        /** Helper method to check if a kernel is exhausted */
+        /** Helper method to check if a kernel is exhausted - const */
         DETRAY_HOST_DEVICE
         bool is_exhausted() const { return (_next == _candidates.end()); }
 

--- a/core/include/detray/tools/volume_graph.hpp
+++ b/core/include/detray/tools/volume_graph.hpp
@@ -24,7 +24,7 @@ namespace detray {
  */
 template <typename node_t>
 struct void_node_inspector {
-    bool operator()(const node_t &n) { return true; }
+    bool operator()(const node_t & /*n*/) { return true; }
 };
 
 /** Placeholder struct for an action while walking through the graph.*/

--- a/core/include/detray/utils/enumerate.hpp
+++ b/core/include/detray/utils/enumerate.hpp
@@ -56,11 +56,11 @@ struct iterator_range {
 
     /** @return element at position i, relative to iterator range. */
     DETRAY_HOST_DEVICE
-    inline decltype(auto) operator[](const dindex i) { return *(_start + i); }
+    inline auto &operator[](const dindex i) { return *(_start + i); }
 
     /** @return element at position i, relative to iterator range - const */
     DETRAY_HOST_DEVICE
-    inline decltype(auto) operator[](const dindex i) const {
+    inline const auto &operator[](const dindex i) const {
         return *(_start + i);
     }
 

--- a/core/include/detray/utils/enumerate.hpp
+++ b/core/include/detray/utils/enumerate.hpp
@@ -66,7 +66,7 @@ struct iterator_range {
 
     /** @return the offset of the range start into the container. */
     DETRAY_HOST_DEVICE
-    inline const auto offset(const container_t &iterable) {
+    inline auto offset(const container_t &iterable) {
         return std::distance(_start, std::begin(iterable));
     }
 

--- a/tests/benchmarks/core/benchmark_grids.cpp
+++ b/tests/benchmarks/core/benchmark_grids.cpp
@@ -27,21 +27,9 @@ vecmem::host_memory_resource host_mr;
 
 darray<dindex, 2> zone22 = {2u, 2u};
 
-// This runs a reference test with random numbers only
-/*static void BM_RERERENCE_GRID(benchmark::State &state) {
-    for (auto _ : state) {
-        for (unsigned int itest = 0; itest < 1000000; ++itest) {
-            test::point2 p = {static_cast<scalar>((rand() % 50) * 0.5),
-                              static_cast<scalar>((rand() % 120) * 0.5)};
-        }
-    }
-}*/
-
-serializer2 serializer;
-
 // TrackML detector has 25 x 60 cells int he detector grid
-using grid2r = grid2<replace_populator, axis::regular, axis::regular,
-                     decltype(serializer)>;
+using grid2r =
+    grid2<replace_populator, axis::regular, axis::regular, serializer2>;
 grid2r::axis_p0_type xaxisr{25, 0., 25., host_mr};
 grid2r::axis_p1_type yaxisr{60, 0., 60., host_mr};
 
@@ -84,8 +72,8 @@ auto construct_irregular_grid() {
         yboundaries.push_back(i);
     }
 
-    using grid2ir = grid2<replace_populator, axis::irregular, axis::irregular,
-                          decltype(serializer)>;
+    using grid2ir =
+        grid2<replace_populator, axis::irregular, axis::irregular, serializer2>;
 
     grid2ir::axis_p0_type xaxisir{xboundaries, host_mr};
     grid2ir::axis_p1_type yaxisir{yboundaries, host_mr};

--- a/tests/common/include/tests/common/benchmark_intersect_surfaces.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_surfaces.inl
@@ -18,34 +18,28 @@
 
 using namespace detray;
 
-enum mask_ids : unsigned int {
-    e_rectangle2 = 0,
-    e_cylinder3 = 1,
-    e_conc_cylinder3 = 2,
-};
-
-using transform3 = __plugin::transform3<detray::scalar>;
-using point3 = __plugin::point3<detray::scalar>;
-using vector3 = __plugin::vector3<detray::scalar>;
-using mask_defs =
-    mask_registry<mask_ids, rectangle2<>,
-                  cylinder3<false, cylinder_intersector>,
-                  cylinder3<false, concentric_cylinder_intersector<>>>;
-using plane_surface = surface<mask_defs, transform3>;
-
 #ifdef DETRAY_BENCHMARKS_REP
 unsigned int gbench_repetitions = DETRAY_BENCHMARKS_REP;
 #else
 unsigned int gbench_repetitions = 0;
 #endif
 
+enum mask_ids : unsigned int {
+    e_rectangle2 = 0,
+    e_cylinder3 = 1,
+    e_conc_cylinder3 = 2,
+};
+
+using mask_defs =
+    mask_registry<mask_ids, rectangle2<>,
+                  cylinder3<false, cylinder_intersector>,
+                  cylinder3<false, concentric_cylinder_intersector<>>>;
+using plane_surface = surface<mask_defs, transform3>;
+
 unsigned int theta_steps = 1000;
 unsigned int phi_steps = 1000;
 
 dvector<scalar> dists = {1., 2., 3., 4., 5., 6., 7., 8., 9., 10.};
-
-auto planes =
-    planes_along_direction(dists, vector::normalize(vector3{1., 1., 1.}));
 
 // This test runs intersection with all surfaces of the TrackML detector
 static void BM_INTERSECT_PLANES(benchmark::State &state) {
@@ -53,6 +47,8 @@ static void BM_INTERSECT_PLANES(benchmark::State &state) {
     unsigned int sfhit = 0;
     unsigned int sfmiss = 0;
 
+    auto planes =
+        planes_along_direction(dists, vector::normalize(vector3{1., 1., 1.}));
     rectangle2<> rect{10., 20., 0u};
     point3 ori = {0., 0., 0.};
 
@@ -103,19 +99,19 @@ BENCHMARK(BM_INTERSECT_PLANES)
 // This test runs intersection with all surfaces of the TrackML detector
 static void BM_INTERSECT_CYLINDERS(benchmark::State &state) {
 
-    unsigned int sfhit = 0;
-    unsigned int sfmiss = 0;
-
     using cylinder_mask =
         typename mask_defs::template get_type<e_cylinder3>::type;
+
+    unsigned int sfhit = 0;
+    unsigned int sfmiss = 0;
     dvector<cylinder_mask> cylinders;
+
     for (auto r : dists) {
         cylinders.push_back(cylinder_mask{r, -10., 10., 0u});
     }
 
     typename mask_defs::link_type mask_link{e_cylinder3, 0};
-    plane_surface plain(std::move(transform3()), std::move(mask_link), 0, false,
-                        false);
+    plane_surface plain(transform3(), mask_link, 0, false, false);
 
     point3 ori = {0., 0., 0.};
 
@@ -179,8 +175,7 @@ static void BM_INTERSECT_CONCETRIC_CYLINDERS(benchmark::State &state) {
     }
 
     typename mask_defs::link_type mask_link{e_conc_cylinder3, 0};
-    plane_surface plain(std::move(transform3()), std::move(mask_link), 0, false,
-                        false);
+    plane_surface plain(transform3(), mask_link, 0, false, false);
 
     point3 ori = {0., 0., 0.};
 

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -17,13 +17,13 @@
 
 // This tests the construction of a detector class
 TEST(ALGEBRA_PLUGIN, detector) {
-    vecmem::host_memory_resource host_mr;
 
     using namespace detray;
-    using point3 = __plugin::point3<detray::scalar>;
 
     using detector_t = detector<detector_registry::default_detector>;
     using mask_ids = typename detector_t::masks::id;
+
+    vecmem::host_memory_resource host_mr;
 
     detector_t::context ctx0{};
     detector_t::transform_filling_container trfs;

--- a/tests/common/include/tests/common/core_transform_store.inl
+++ b/tests/common/include/tests/common/core_transform_store.inl
@@ -15,11 +15,10 @@
 TEST(ALGEBRA_PLUGIN, static_transform_store) {
     using namespace detray;
     using point3 = __plugin::point3<detray::scalar>;
-    using transform3 = __plugin::transform3<detray::scalar>;
 
     static_transform_store<> static_store;
-    static_transform_store<>::context ctx0;
-    static_transform_store<>::context ctx1;
+    static_transform_store<>::context ctx0{};
+    static_transform_store<>::context ctx1{};
 
     ASSERT_TRUE(static_store.empty(ctx0));
 

--- a/tests/common/include/tests/common/display_masks.inl
+++ b/tests/common/include/tests/common/display_masks.inl
@@ -18,16 +18,12 @@
 /// @note __plugin has to be defined with a preprocessor command
 using namespace detray;
 
-using transform3 = __plugin::transform3<detray::scalar>;
-using vector3 = __plugin::vector3<detray::scalar>;
-using point3 = __plugin::point3<detray::scalar>;
-
 TEST(display, annulus2) {
-    detray::global_xy_view gxy;
+    global_xy_view gxy;
 
     // First rectangle
     transform3 transform{};
-    annulus2<> annulus = {7.2, 12.0, 0.74195, 1.33970, 0., -2., 2.};
+    annulus2<> annulus = {7.2, 12.0, 0.74195, 1.33970, 0., -2., 2., 0u};
 
     color c = {0.2, 0.8, 0.6, 0.9};
     display(false);
@@ -36,11 +32,11 @@ TEST(display, annulus2) {
 }
 
 TEST(display, rectangle2) {
-    detray::global_xy_view gxy;
+    global_xy_view gxy;
 
     // First rectangle
     transform3 transform{};
-    rectangle2<> rectangle = {3., 4.};
+    rectangle2<> rectangle = {3., 4., 0u};
 
     color c = {0.5, 0.2, 0.6, 0.9};
     display(false);
@@ -49,11 +45,11 @@ TEST(display, rectangle2) {
 }
 
 TEST(display, trapezoid2) {
-    detray::global_xy_view gxy;
+    global_xy_view gxy;
 
     // First rectangle
     transform3 transform{};
-    trapezoid2<> trapezoid = {3., 4., 5.};
+    trapezoid2<> trapezoid = {3., 4., 5., 0u};
 
     color c = {0.5, 0.4, 0.4, 0.9};
     display(false);

--- a/tests/common/include/tests/common/masks_single3.inl
+++ b/tests/common/include/tests/common/masks_single3.inl
@@ -24,7 +24,7 @@ TEST(mask, single3_0) {
     point3 p3_out = {1.5, -9.8, 8.};
 
     scalar h0 = 1.;
-    single3<0> m1_0{-h0, h0, 0u};
+    single3<0> m1_0{{-h0, h0}, 0u};
 
     ASSERT_EQ(m1_0[0], -h0);
     ASSERT_EQ(m1_0[1], h0);
@@ -50,7 +50,7 @@ TEST(mask, single3_1) {
     point3 p3_out = {1.5, -9.8, 8.};
 
     scalar h1 = 9.3;
-    single3<1> m1_1 = {-h1, h1};
+    single3<1> m1_1 = {{-h1, h1}};
 
     ASSERT_EQ(m1_1[0], -h1);
     ASSERT_EQ(m1_1[1], h1);
@@ -76,7 +76,7 @@ TEST(mask, single3_2) {
     point3 p3_out = {1.5, -9.8, 8.};
 
     scalar h2 = 2.;
-    single3<2> m1_2 = {-h2, h2};
+    single3<2> m1_2 = {{-h2, h2}};
 
     ASSERT_EQ(m1_2[0], -h2);
     ASSERT_EQ(m1_2[1], h2);

--- a/tests/common/include/tests/common/masks_unmasked.inl
+++ b/tests/common/include/tests/common/masks_unmasked.inl
@@ -14,7 +14,6 @@ using namespace detray;
 // This tests the construction of a surface
 TEST(mask, unmasked) {
     using local_type = __plugin::cartesian2<detray::scalar>;
-    using point2 = __plugin::point2<detray::scalar>;
     point2 p2 = {0.5, -9.};
 
     unmasked u;

--- a/tests/common/include/tests/common/test_core.inl
+++ b/tests/common/include/tests/common/test_core.inl
@@ -19,16 +19,11 @@
 
 using namespace detray;
 
-using point2 = __plugin::point2<detray::scalar>;
+using transform3 = __plugin::transform3<detray::scalar>;
 
 enum mask_ids : unsigned int {
     e_unmasked = 0,
 };
-
-// Three-dimensional definitions
-using transform3 = __plugin::transform3<detray::scalar>;
-using vector3 = __plugin::vector3<detray::scalar>;
-using point3 = __plugin::point3<detray::scalar>;
 using mask_defs = mask_registry<mask_ids, unmasked<>>;
 using mask_link_t = typename mask_defs::link_type;
 

--- a/tests/common/include/tests/common/test_defs.hpp
+++ b/tests/common/include/tests/common/test_defs.hpp
@@ -63,7 +63,7 @@ DETRAY_HOST_DEVICE inline bool operator==(const test::point3<T> &lhs,
 
 // invalid value specialization for test::point3
 template <>
-DETRAY_HOST_DEVICE inline test::point3<scalar> detray::invalid_value() {
+DETRAY_HOST_DEVICE inline test::point3<scalar> invalid_value() {
     return test::point3<scalar>{0, 0, 0};
 }
 

--- a/tests/common/include/tests/common/tools/helix_gun.hpp
+++ b/tests/common/include/tests/common/tools/helix_gun.hpp
@@ -29,7 +29,7 @@ class helix_gun {
         _scaler = _R * std::sqrt(1 + std::pow(_vz_over_vt, 2));
 
         // get new z direction
-        _ez = vector::normalize(mag_field);
+        _ez = vector::normalize(_mag_field);
 
         // get new y direction
         scalar q = _vertex.qop() > 0 ? 1 : -1.;

--- a/tests/common/include/tests/common/tools/ray_scan_utils.hpp
+++ b/tests/common/include/tests/common/tools/ray_scan_utils.hpp
@@ -159,8 +159,7 @@ inline auto trace_intersections(const record_container &intersection_records,
 
     // Readable access to the data of a recorded intersection
     struct record {
-        using type = typename record_container::value_type;
-        const type &entry;
+        const typename record_container::value_type &entry;
 
         // getter
         inline auto &object_id() const { return entry.first; }

--- a/tests/common/include/tests/common/tools/test_surfaces.hpp
+++ b/tests/common/include/tests/common/tools/test_surfaces.hpp
@@ -28,7 +28,7 @@ vecmem::host_memory_resource host_mr;
 using namespace vector;
 
 enum plane_mask_ids : unsigned int {
-    e_rectangle2 = 0,
+    e_plane_rectangle2 = 0,
 };
 
 using transform3 = __plugin::transform3<detray::scalar>;
@@ -51,8 +51,8 @@ dvector<surface<plane_masks, transform3>> planes_along_direction(
     for (const auto &[idx, d] : enumerate(distances)) {
         vector3 t = d * direction;
         transform3 trf(t, z, x);
-        typename plane_masks::link_type mask_link{plane_masks::id::e_rectangle2,
-                                                  idx};
+        typename plane_masks::link_type mask_link{
+            plane_masks::id::e_plane_rectangle2, idx};
         return_surfaces.emplace_back(std::move(trf), std::move(mask_link), 0,
                                      false, false);
     }

--- a/tests/common/include/tests/common/tools_cylinder_intersection.inl
+++ b/tests/common/include/tests/common/tools_cylinder_intersection.inl
@@ -21,8 +21,6 @@ using namespace detray;
 
 // Three-dimensional definitions
 using transform3 = __plugin::transform3<detray::scalar>;
-using vector3 = __plugin::vector3<detray::scalar>;
-using point3 = __plugin::point3<detray::scalar>;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
 constexpr scalar not_defined = std::numeric_limits<scalar>::infinity();

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -60,7 +60,7 @@ TEST(tools, intersection_kernel_single) {
     transform3 rectangle_transform(point3{0., 0., 10.});
     transform3 trapezoid_transform(point3{0., 0., 20.});
     transform3 annulus_transform(point3{0., -20., 30.});
-    static_transform_store<>::context static_context;
+    static_transform_store<>::context static_context{};
     static_transform_store transform_store;
     transform_store.push_back(static_context, rectangle_transform);
     transform_store.push_back(static_context, trapezoid_transform);

--- a/tests/common/include/tests/common/tools_planar_intersection.inl
+++ b/tests/common/include/tests/common/tools_planar_intersection.inl
@@ -23,8 +23,6 @@ __plugin::cartesian2<detray::scalar> cartesian2;
 
 // Three-dimensional definitions
 using transform3 = __plugin::transform3<detray::scalar>;
-using vector3 = __plugin::vector3<detray::scalar>;
-using point3 = __plugin::point3<detray::scalar>;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
 constexpr scalar not_defined = std::numeric_limits<scalar>::infinity();

--- a/tests/common/include/tests/common/tools_track.inl
+++ b/tests/common/include/tests/common/tools_track.inl
@@ -14,11 +14,7 @@
 #include "detray/tools/track.hpp"
 
 using namespace detray;
-using point2 = __plugin::point2<detray::scalar>;
-using point3 = __plugin::point3<detray::scalar>;
 using vector2 = __plugin::vector2<detray::scalar>;
-using vector3 = __plugin::vector3<detray::scalar>;
-using transform3 = __plugin::transform3<detray::scalar>;
 
 enum mask_ids : unsigned int {
     e_rectangle2 = 0,
@@ -37,7 +33,7 @@ TEST(tools, bound_track_parameters) {
 
     // transform container
     static_transform_store trfs;
-    typename decltype(trfs)::context ctx;
+    typename decltype(trfs)::context ctx{};
 
     vector3 z1 = vector::normalize(vector3{1, 0., 0.});
     vector3 x1 = vector::normalize(vector3{0., 0., 1.});


### PR DESCRIPTION
This PR picks up the original branch from niermann999 and fixes the remaining clang-warnings, there's still a warning left from matplotlib itself.