### PR TITLE
exp: trust based navigation

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug -DDETRAY_BENCHMARKS=Off
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug 
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -130,7 +130,6 @@ jobs:
         cmake -B build -S . \
           -DCMAKE_BUILD_TYPE=Debug \
           -DDETRAY_EIGEN_PLUGIN=On \
-          -DDETRAY_BENCHMARKS=Off \
           -DCMAKE_CUDA_COMPILER=$(which nvcc) \
           -DDETRAY_BUILD_CUDA=On
 
@@ -158,7 +157,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DDETRAY_BENCHMARKS=Off
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -157,7 +157,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DDETRAY_BENCHMARKS=Off
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -188,13 +188,13 @@ class detector {
 
     /** @return a surface by index - const access */
     DETRAY_HOST_DEVICE
-    inline const auto &get_surface(dindex sfidx) const {
+    inline const auto &surface_by_index(dindex sfidx) const {
         return _surfaces[sfidx];
     }
 
     /** @return a surface by index - non-const access */
     DETRAY_HOST_DEVICE
-    inline auto &get_surface(dindex sfidx) { return _surfaces[sfidx]; }
+    inline auto &surface_by_index(dindex sfidx) { return _surfaces[sfidx]; }
 
     /** @return all surface/portal masks in the geometry - const access */
     DETRAY_HOST_DEVICE
@@ -282,7 +282,7 @@ class detector {
     template <typename... detector_components>
     DETRAY_HOST inline void add_objects(
         const context ctx,
-        detector_components &&... components) noexcept(false) {
+        detector_components &&...components) noexcept(false) {
         // Fill according to type, starting at type '0' (see 'masks')
         fill_containers(ctx, std::forward<detector_components>(components)...);
     }

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -282,7 +282,7 @@ class detector {
     template <typename... detector_components>
     DETRAY_HOST inline void add_objects(
         const context ctx,
-        detector_components &&...components) noexcept(false) {
+        detector_components &&... components) noexcept(false) {
         // Fill according to type, starting at type '0' (see 'masks')
         fill_containers(ctx, std::forward<detector_components>(components)...);
     }

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -178,13 +178,23 @@ class detector {
         return _volumes[volume_index];
     }
 
-    /** @return all objects of a given type - const access */
+    /** @return all surfaces - const access */
     DETRAY_HOST_DEVICE
-    inline auto &surfaces() const { return _surfaces; }
+    inline const auto &surfaces() const { return _surfaces; }
 
-    /** @return all objects of a given type - non-const access */
+    /** @return all surfaces - non-const access */
     DETRAY_HOST_DEVICE
     inline auto &surfaces() { return _surfaces; }
+
+    /** @return a surface by index - const access */
+    DETRAY_HOST_DEVICE
+    inline const auto &get_surface(dindex sfidx) const {
+        return _surfaces[sfidx];
+    }
+
+    /** @return a surface by index - non-const access */
+    DETRAY_HOST_DEVICE
+    inline auto &get_surface(dindex sfidx) { return _surfaces[sfidx]; }
 
     /** @return all surface/portal masks in the geometry - const access */
     DETRAY_HOST_DEVICE

--- a/core/include/detray/definitions/detail/accessor.hpp
+++ b/core/include/detray/definitions/detail/accessor.hpp
@@ -8,6 +8,7 @@
 
 #if defined(__CUDACC__)
 #include <thrust/execution_policy.h>
+#include <thrust/find.h>
 #include <thrust/sort.h>
 #endif
 
@@ -175,6 +176,18 @@ DETRAY_HOST_DEVICE void sequential_sort(RandomIt first, RandomIt last,
     thrust::sort(thrust::seq, first, last, comp);
 #elif !defined(__CUDACC__)
     std::sort(first, last, comp);
+#endif
+}
+
+/**
+ *  find_if implementation for device
+ */
+template <class RandomIt, class Predicate>
+DETRAY_HOST_DEVICE auto find_if(RandomIt first, RandomIt last, Predicate comp) {
+#if defined(__CUDACC__)
+    return thrust::find_if(thrust::seq, first, last, comp);
+#elif !defined(__CUDACC__)
+    return std::find_if(first, last, comp);
 #endif
 }
 

--- a/core/include/detray/definitions/units.hpp
+++ b/core/include/detray/definitions/units.hpp
@@ -11,6 +11,9 @@ namespace detray {
 
 namespace unit_constants {
 
+// Length, native unit um
+constexpr double um = 0.001;
+
 // Length, native unit mm
 constexpr double mm = 1.0;
 

--- a/core/include/detray/definitions/units.hpp
+++ b/core/include/detray/definitions/units.hpp
@@ -14,6 +14,12 @@ namespace unit_constants {
 // Length, native unit mm
 constexpr double mm = 1.0;
 
+// Length, convert to cm
+constexpr double cm = 10.0;
+
+// Length, convert to m
+constexpr double m = 1000.0;
+
 // Energy/mass/momentum, native unit GeV
 constexpr double GeV = 1.0;
 

--- a/core/include/detray/tools/base_stepper.hpp
+++ b/core/include/detray/tools/base_stepper.hpp
@@ -18,7 +18,7 @@
 namespace detray {
 
 /** abstract stepper implementation */
-template <typename track_t, template <typename...> class tuple_t = dtuple>
+template <typename track_t>
 class base_stepper {
 
     public:

--- a/core/include/detray/tools/base_stepper.hpp
+++ b/core/include/detray/tools/base_stepper.hpp
@@ -9,7 +9,6 @@
 
 // detray definitions
 #include "detray/definitions/qualifiers.hpp"
-#include "detray/definitions/units.hpp"
 
 // detray tools
 #include "detray/tools/track.hpp"

--- a/core/include/detray/tools/base_stepper.hpp
+++ b/core/include/detray/tools/base_stepper.hpp
@@ -79,7 +79,7 @@ class base_stepper {
 
         /// @returns this states remaining path length.
         DETRAY_HOST_DEVICE
-        inline scalar path_limit() const { return _path_limit; }
+        inline scalar dist_to_path_limit() const { return _path_limit; }
 
         /// Set the path limit to a scalar @param pl
         DETRAY_HOST_DEVICE
@@ -88,8 +88,7 @@ class base_stepper {
         /// Update and check the path limit against a new @param step size.
         DETRAY_HOST_DEVICE
         inline bool check_path_limit() {
-            _path_limit = (_step_size > _path_limit) ? _step_size - _path_limit
-                                                     : _path_limit - _step_size;
+            _path_limit = _path_limit - _step_size;
             if (_path_limit <= 0.) {
                 return false;
             }

--- a/core/include/detray/tools/base_stepper.hpp
+++ b/core/include/detray/tools/base_stepper.hpp
@@ -88,7 +88,7 @@ class base_stepper {
         /// Update and check the path limit against a new @param step size.
         DETRAY_HOST_DEVICE
         inline bool check_path_limit() {
-            _path_limit = _path_limit - _step_size;
+            _path_limit -= _step_size;
             if (_path_limit <= 0.) {
                 return false;
             }

--- a/core/include/detray/tools/base_stepper.hpp
+++ b/core/include/detray/tools/base_stepper.hpp
@@ -10,6 +10,7 @@
 // detray definitions
 #include "detray/definitions/detail/accessor.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
 
 // detray tools
 #include "detray/tools/track.hpp"
@@ -34,30 +35,33 @@ class base_stepper {
 
         state() = delete;
 
+        /// Sets track parameters.
         DETRAY_HOST_DEVICE
         state(track_t &t) : _track(t) {}
 
-        // free track parameter
+        /// free track parameter
         track_t &_track;
 
-        // jacobian
+        /// jacobian
         bound_matrix _jacobian;
 
-        // jacobian transport matrix
+        /// jacobian transport matrix
         free_matrix _jac_transport;
 
-        // jacobian transformation
+        /// jacobian transformation
         bound_to_free_matrix _jac_to_global;
 
-        // covariance matrix on surface
+        /// covariance matrix on surface
         bound_matrix _cov;
 
-        // The propagation derivative
+        /// The propagation derivative
         free_vector _derivative;
 
+        /// @returns track parameters - const access
         DETRAY_HOST_DEVICE
         track_t &operator()() { return _track; }
 
+        /// @returns track parameters.
         DETRAY_HOST_DEVICE
         const track_t &operator()() const { return _track; }
 
@@ -68,8 +72,16 @@ class base_stepper {
 
         navigation_direction _nav_dir = e_forward;
 
+        /// step size cutoff value
+        scalar _max_pathlength = 0.5 * unit_constants::m;
+
+        /// Set next step size
         DETRAY_HOST_DEVICE
-        void release_step_size(const scalar /*step*/) {}
+        void set_step_size(const scalar /*step*/) {}
+
+        /// Set next step size and release constrained stepping
+        DETRAY_HOST_DEVICE
+        void release_step_size() {}
     };
 };
 

--- a/core/include/detray/tools/base_stepper.hpp
+++ b/core/include/detray/tools/base_stepper.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 // detray definitions
-#include "detray/definitions/detail/accessor.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 
@@ -72,12 +71,38 @@ class base_stepper {
 
         navigation_direction _nav_dir = e_forward;
 
-        /// step size cutoff value
-        scalar _max_pathlength = 0.5 * unit_constants::m;
+        /// Remaining path length
+        scalar _path_limit = std::numeric_limits<scalar>::max();
+
+        /// Current step size
+        scalar _step_size = std::numeric_limits<scalar>::infinity();
+
+        /// @returns this states remaining path length.
+        DETRAY_HOST_DEVICE
+        inline scalar path_limit() const { return _path_limit; }
+
+        /// Set the path limit to a scalar @param pl
+        DETRAY_HOST_DEVICE
+        inline void set_path_limit(const scalar pl) { _path_limit = pl; }
+
+        /// Update and check the path limit against a new @param step size.
+        DETRAY_HOST_DEVICE
+        inline bool check_path_limit() {
+            _path_limit = (_step_size > _path_limit) ? _step_size - _path_limit
+                                                     : _path_limit - _step_size;
+            if (_path_limit <= 0.) {
+                return false;
+            }
+            return true;
+        }
+
+        /// @returns the current step size of this state.
+        DETRAY_HOST_DEVICE
+        inline scalar step_size() const { return _step_size; }
 
         /// Set next step size
         DETRAY_HOST_DEVICE
-        void set_step_size(const scalar /*step*/) {}
+        inline void set_step_size(const scalar step) { _step_size = step; }
 
         /// Set next step size and release constrained stepping
         DETRAY_HOST_DEVICE

--- a/core/include/detray/tools/intersection_kernel.hpp
+++ b/core/include/detray/tools/intersection_kernel.hpp
@@ -7,15 +7,15 @@
 
 #pragma once
 
-#include <tuple>
-#include <utility>
-
 #include "detray/core/intersection.hpp"
 #include "detray/definitions/detail/accessor.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/tools/track.hpp"
 #include "detray/utils/enumerate.hpp"
 #include "detray/utils/indexing.hpp"
+
+#include <tuple>
+#include <utility>
 
 namespace detray {
 
@@ -58,7 +58,7 @@ DETRAY_HOST_DEVICE inline auto unroll_intersect(
         for (const auto &mask : range(mask_group, mask_range)) {
             auto sfi =
                 std::move(mask.intersector().intersect(ctf, track, mask));
-
+ 
             if (sfi.status == e_inside) {
                 sfi.index = volume_index;
                 return sfi;

--- a/core/include/detray/tools/intersection_kernel.hpp
+++ b/core/include/detray/tools/intersection_kernel.hpp
@@ -7,15 +7,15 @@
 
 #pragma once
 
+#include <tuple>
+#include <utility>
+
 #include "detray/core/intersection.hpp"
 #include "detray/definitions/detail/accessor.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/tools/track.hpp"
 #include "detray/utils/enumerate.hpp"
 #include "detray/utils/indexing.hpp"
-
-#include <tuple>
-#include <utility>
 
 namespace detray {
 
@@ -58,7 +58,7 @@ DETRAY_HOST_DEVICE inline auto unroll_intersect(
         for (const auto &mask : range(mask_group, mask_range)) {
             auto sfi =
                 std::move(mask.intersector().intersect(ctf, track, mask));
- 
+
             if (sfi.status == e_inside) {
                 sfi.index = volume_index;
                 return sfi;

--- a/core/include/detray/tools/line_stepper.hpp
+++ b/core/include/detray/tools/line_stepper.hpp
@@ -18,11 +18,11 @@
 namespace detray {
 
 /** Line stepper implementation */
-template <typename track_t, template <typename...> class tuple_t = dtuple>
-class line_stepper final : public base_stepper<track_t, tuple_t> {
+template <typename track_t>
+class line_stepper final : public base_stepper<track_t> {
 
     public:
-    using base_type = base_stepper<track_t, tuple_t>;
+    using base_type = base_stepper<track_t>;
 
     struct state : public base_type::state {
         state(track_t &t) : base_type::state(t) {}

--- a/core/include/detray/tools/line_stepper.hpp
+++ b/core/include/detray/tools/line_stepper.hpp
@@ -67,8 +67,7 @@ class line_stepper final : public base_stepper<track_t> {
         if (not stepping.check_path_limit()) {
             printf("Stepper: Above maximal path length!\n");
             // State is broken
-            navigation.set_no_trust();
-            return false;
+            return navigation.abort();
         }
 
         // Update track state

--- a/core/include/detray/tools/line_stepper.hpp
+++ b/core/include/detray/tools/line_stepper.hpp
@@ -60,13 +60,13 @@ class line_stepper final : public base_stepper<track_t> {
         // Step hit a constraint - the track state was probably severly altered
         else {
             stepping.set_step_size(max_step_size);
-            // Not a severe change to thrack state
+            // Re-evaluate all candidates
             navigation.set_fair_trust();
         }
 
         // Update and check path limit
         if (not stepping.check_path_limit()) {
-            printf("Above maximal path length!\n");
+            printf("Stepper: Above maximal path length!\n");
             // State is broken
             navigation.set_no_trust();
             return false;

--- a/core/include/detray/tools/line_stepper.hpp
+++ b/core/include/detray/tools/line_stepper.hpp
@@ -11,8 +11,6 @@
 #include "detray/tools/base_stepper.hpp"
 
 // detray definitions
-#include <climits>
-
 #include "detray/definitions/qualifiers.hpp"
 
 namespace detray {
@@ -57,7 +55,8 @@ class line_stepper final : public base_stepper<track_t> {
             stepping.set_step_size(step_size);
             navigation.set_high_trust();
         }
-        // Step hit a constraint - the track state was probably severly altered
+        // Step size hit a constraint - the track state was probably changed a
+        // lot
         else {
             stepping.set_step_size(max_step_size);
             // Re-evaluate all candidates

--- a/core/include/detray/tools/line_stepper.hpp
+++ b/core/include/detray/tools/line_stepper.hpp
@@ -11,6 +11,8 @@
 #include "detray/tools/base_stepper.hpp"
 
 // detray definitions
+#include <climits>
+
 #include "detray/definitions/qualifiers.hpp"
 
 namespace detray {
@@ -26,17 +28,16 @@ class line_stepper final : public base_stepper<track_t, tuple_t> {
         state(track_t &t) : base_type::state(t) {}
 
         // Remaining path limit
-        scalar _pl = std::numeric_limits<scalar>::max();
+        scalar _path_limit = std::numeric_limits<scalar>::max();
 
-        /** @return the step and heartbeat given a step length s */
-        tuple_t<scalar, bool> step(scalar s) {
-            _pl = (s > _pl) ? s - _pl : _pl - s;
-            const bool heartbeat = (_pl > 0.);
-            return std::tie(std::min(s, _pl), heartbeat);
-        }
+        scalar _step_size = std::numeric_limits<scalar>::infinity();
 
         /** Set the path limit to a scalar @param l */
-        void set_limit(scalar pl) { _pl = pl; }
+        void set_limit(scalar pl) { _path_limit = pl; }
+
+        /// Set next step size
+        DETRAY_HOST_DEVICE
+        void set_step_size(const scalar /*step*/) {}
     };
 
     /** Take a step, regulared by a constrained step
@@ -46,11 +47,21 @@ class line_stepper final : public base_stepper<track_t, tuple_t> {
      *
      * @return returning the heartbeat, indicating if the stepping is alive
      */
-    DETRAY_HOST_DEVICE
-    bool step(state &s, scalar es) {
-        const auto [sl, heartbeat] = s.step(es);
-        s._track.set_pos(s._track.pos() + s._track.dir() * sl);
-        return heartbeat;
+    template <typename navigation_state_t>
+    DETRAY_HOST_DEVICE bool step(
+        state &s, navigation_state_t &navigation,
+        scalar max_step_size = std::numeric_limits<scalar>::max()) {
+        scalar step_size = navigation();
+        s._path_limit = (step_size > s._path_limit) ? step_size - s._path_limit
+                                                    : s._path_limit - step_size;
+        if (s._path_limit <= 0.) {
+            return false;
+        }
+        s._step_size =
+            std::min(step_size, std::min(s._path_limit, max_step_size));
+        s._track.set_pos(s._track.pos() + s._track.dir() * s._step_size);
+        navigation.set_high_trust();
+        return true;
     }
 };
 

--- a/core/include/detray/tools/navigator.hpp
+++ b/core/include/detray/tools/navigator.hpp
@@ -266,7 +266,7 @@ class navigator {
         scalar _distance_to_next = std::numeric_limits<scalar>::infinity();
 
         /** The inspector type of this navigation engine */
-        inspector_type _inspector = {};
+        inspector_type _inspector;
 
         /** Index of a object (surface/portal) if is reached, otherwise invalid
          */
@@ -310,7 +310,7 @@ class navigator {
         update_kernel(navigation, stepping);
 
         // Did we hit a portal? (kernel needs to be re-initialized)
-        heartbeat = check_volume_switch(navigation, stepping);
+        heartbeat = check_volume_switch(navigation);
 
         // If after the update call no trust could be restored, local
         // navigation might be exhausted or we switched volumes: re-initialize
@@ -540,9 +540,7 @@ class navigator {
      *
      * @param navigation is the navigation state
      */
-    template <typename stepper_state_t>
-    DETRAY_HOST_DEVICE bool check_volume_switch(
-        state &navigation, stepper_state_t &stepping) const {
+    DETRAY_HOST_DEVICE bool check_volume_switch(state &navigation) const {
         // Check if we need to switch volume index and (re-)initialize
         if (navigation.status() == navigation::e_on_target and
             navigation.volume() != navigation.current()->link) {

--- a/core/include/detray/tools/navigator.hpp
+++ b/core/include/detray/tools/navigator.hpp
@@ -356,8 +356,6 @@ class navigator {
             update_kernel(navigation, stepping);
         }
 
-        // navigation.run_inspector("Update complete: ");
-
         // Should never be the case after complete update call
         if (navigation.trust_level() != navigation::e_full_trust) {
             heartbeat &= navigation.abort();
@@ -407,8 +405,7 @@ class navigator {
         }
         // What is the closest object we can reach?
         set_next(track, navigation, stepping);
-
-        navigation.run_inspector("Init complete: ");
+        // navigation.run_inspector("Init complete: ");
     }
 
     /** Helper method to update the next candidate intersection based on
@@ -460,6 +457,9 @@ class navigator {
                         ++navigation.next();
                         if (not navigation.is_exhausted() or
                             navigation() < track.overstep_tolerance()) {
+                            // After update, trust in candidate is restored
+                            navigation.run_inspector(
+                                "Update next (high trust):");
                             // Ready the next candidate in line
                             continue;
                         } else {
@@ -485,8 +485,9 @@ class navigator {
                 ++navigation.next();
             }
             // Kernel is exhausted at this point
-            // Call the inspector before returning
-            navigation.run_inspector("Update (high trust) no candidate found:");
+            // Call the inspector before returning (only for debugging)
+            // navigation.run_inspector("Update (high trust) no candidate
+            // found:");
         }
         // Re-evaluate all currently available candidates
         // - do this when your navigation state is stale, but not invalid
@@ -507,9 +508,8 @@ class navigator {
                 navigation.set_no_trust();
             }
             // Call the inspector before returning
-            navigation.run_inspector("Update (fair trust): ");
+            // navigation.run_inspector("Update (fair trust): ");
         }
-
         // Finally, if no candidate was found, trust could no be restored
         if (navigation.is_exhausted()) {
             navigation.set_no_trust();
@@ -563,7 +563,7 @@ class navigator {
         // Release stepping constraints
         stepping.release_step_size();
         // Call the inspector on new status
-        navigation.run_inspector("Set next: ");
+        // navigation.run_inspector("Set next: ");
     }
 
     /** Helper method to check and perform a volume switch

--- a/core/include/detray/tools/navigator.hpp
+++ b/core/include/detray/tools/navigator.hpp
@@ -568,6 +568,22 @@ class navigator {
     DETRAY_HOST_DEVICE
     const detector_t &get_detector() const { return *_detector; }
 
+    /** @return the vecmem jagged vector buffer for surface candidates */
+    // TODO: det.get_n_max_objects_per_volume() is way too many for
+    // candidates size allocation. With the local navigation, the size can be
+    // restricted to much smaller value
+    DETRAY_HOST
+    vecmem::data::jagged_vector_buffer<intersection> create_candidates_buffer(
+        const unsigned int n_tracks,
+        vecmem::memory_resource &device_resource) const {
+
+        return vecmem::data::jagged_vector_buffer<intersection>(
+            std::vector<std::size_t>(n_tracks, 0),
+            std::vector<std::size_t>(n_tracks,
+                                     _detector->get_n_max_objects_per_volume()),
+            device_resource, _detector->resource());
+    }
+
     private:
     /** the containers for all data */
     const detector_t *_detector;

--- a/core/include/detray/tools/navigator.hpp
+++ b/core/include/detray/tools/navigator.hpp
@@ -102,6 +102,7 @@ class navigator {
 
         /** Constructor with memory resource
          **/
+        DETRAY_HOST
         state(vecmem::memory_resource &resource) : _candidates(&resource) {}
 
         /** Constructor from candidates vector_view
@@ -628,7 +629,7 @@ class navigator {
         const track_t &track, intersection &candidate) const {
         const dindex obj_idx = candidate.index;
         candidate =
-            intersect(track, _detector->get_surface(obj_idx),
+            intersect(track, _detector->surface_by_index(obj_idx),
                       _detector->transform_store(), _detector->mask_store());
 
         candidate.index = obj_idx;

--- a/core/include/detray/tools/navigator.hpp
+++ b/core/include/detray/tools/navigator.hpp
@@ -363,13 +363,10 @@ class navigator {
                                           stepper_state_t &stepping) const {
         bool heartbeat = true;
 
-        if (navigation.candidates().capacity() != 0)
-            // navigation.run_inspector("Before update: ");
-
-            // If there is no_trust (e.g. at the beginning of the navigation in
-            // a volume), the kernel will be initialized. Otherwise the
-            // candidates are re-evaluated based on current trust level
-            update_kernel(navigation, stepping);
+        // If there is no_trust (e.g. at the beginning of the navigation in
+        // a volume), the kernel will be initialized. Otherwise the
+        // candidates are re-evaluated based on current trust level
+        update_kernel(navigation, stepping);
 
         // Did we hit a portal? Then switch volume
         heartbeat &= check_volume_switch(navigation);
@@ -424,6 +421,7 @@ class navigator {
         }
         // What is the closest object we can reach?
         set_next(track, navigation, stepping);
+        // Call the inspector before returning (only for debugging)
         // navigation.run_inspector("Init complete: ");
     }
 
@@ -525,7 +523,7 @@ class navigator {
                 // Re-initialize the volume in the next update call
                 navigation.set_no_trust();
             }
-            // Call the inspector before returning
+            // Call the inspector before returning (only for debugging)
             // navigation.run_inspector("Update (fair trust): ");
         }
         // Finally, if no candidate was found, trust could no be restored
@@ -589,7 +587,7 @@ class navigator {
         }
         // Release stepping constraints
         stepping.release_step_size();
-        // Call the inspector on new status
+        // Call the inspector before returning (only for debugging)
         // navigation.run_inspector("Set next: ");
     }
 

--- a/core/include/detray/tools/navigator.hpp
+++ b/core/include/detray/tools/navigator.hpp
@@ -342,7 +342,6 @@ class navigator {
     /** Helper method to intersect all objects of a surface/portal store
      *
      * @tparam track_t type of the track (including context)
-     * @tparam range_t the type of range in the detector data containers
      *
      * @param navigation [in, out] navigation state that contains the kernel
      * @param track the track information
@@ -384,6 +383,15 @@ class navigator {
         navigation.run_inspector("Init complete: ");
     }
 
+    /** Helper method that updates a single candidate
+     *
+     * @tparam track_t type of the track (including context)
+     *
+     * @param navigation [in, out] navigation state that contains the kernel
+     * @param track the track information
+     * @param volume the current tracking volume
+     *
+     */
     template <typename track_t>
     DETRAY_HOST_DEVICE inline void update_candidate(
         const track_t &track, intersection &candidate) const {
@@ -402,9 +410,6 @@ class navigator {
      *
      * @param navigation [in, out] navigation state that contains the kernel
      * @param stepping the track information in the stepper state
-     * @param volume the current tracking volume
-     *
-     * @return A boolean condition whether kernel is exhausted or not
      */
     template <typename stepper_state_t>
     DETRAY_HOST_DEVICE inline void update_kernel(
@@ -476,7 +481,8 @@ class navigator {
             for (auto &candidate : navigation.candidates()) {
                 update_candidate(track, candidate);
                 // Disregard this candidate
-                if (candidate.status != e_inside) {
+                if ((candidate.status != e_inside) or
+                    (candidate.path < track.overstep_tolerance())) {
                     candidate.path = std::numeric_limits<scalar>::max();
                 }
             }
@@ -558,6 +564,7 @@ class navigator {
         return true;
     }
 
+    /// @returns pointer to detector
     DETRAY_HOST_DEVICE
     const detector_t &get_detector() const { return *_detector; }
 

--- a/core/include/detray/tools/propagator.hpp
+++ b/core/include/detray/tools/propagator.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <climits>
+
 #include "detray/definitions/qualifiers.hpp"
 
 namespace detray {
@@ -18,7 +20,7 @@ struct void_inspector {
 
     /** void operator **/
     template <typename... args>
-    DETRAY_HOST_DEVICE void operator()(const args &... /*ignored*/) {
+    DETRAY_HOST_DEVICE void operator()(const args &.../*ignored*/) {
         return;
     }
 };
@@ -77,8 +79,9 @@ struct propagator {
      */
     template <typename state_t,
               typename inspector_t = propagation::void_inspector>
-    DETRAY_HOST_DEVICE bool propagate(state_t &p_state,
-                                      inspector_t &inspector) {
+    DETRAY_HOST_DEVICE bool propagate(
+        state_t &p_state, inspector_t &inspector,
+        scalar max_step_size = std::numeric_limits<scalar>::max()) {
 
         auto &n_state = p_state._navigation;
         auto &s_state = p_state._stepping;
@@ -90,7 +93,7 @@ struct propagator {
         while (heartbeat) {
 
             // Take the step
-            heartbeat &= _stepper.step(s_state, n_state);
+            heartbeat &= _stepper.step(s_state, n_state, max_step_size);
 
             inspector(n_state, s_state);
 

--- a/core/include/detray/tools/propagator.hpp
+++ b/core/include/detray/tools/propagator.hpp
@@ -18,7 +18,7 @@ struct void_inspector {
 
     /** void operator **/
     template <typename... args>
-    DETRAY_HOST_DEVICE void operator()(const args &.../*ignored*/) {
+    DETRAY_HOST_DEVICE void operator()(const args &... /*ignored*/) {
         return;
     }
 };

--- a/core/include/detray/tools/propagator.hpp
+++ b/core/include/detray/tools/propagator.hpp
@@ -20,7 +20,7 @@ struct void_inspector {
 
     /** void operator **/
     template <typename... args>
-    DETRAY_HOST_DEVICE void operator()(const args &.../*ignored*/) {
+    DETRAY_HOST_DEVICE void operator()(const args &... /*ignored*/) {
         return;
     }
 };

--- a/core/include/detray/tools/propagator.hpp
+++ b/core/include/detray/tools/propagator.hpp
@@ -16,7 +16,7 @@ struct void_propagator_inspector {
 
     /** void operator **/
     template <typename... args>
-    DETRAY_HOST_DEVICE void operator()(const args &... /*ignored*/) {
+    DETRAY_HOST_DEVICE void operator()(const args &.../*ignored*/) {
         return;
     }
 };
@@ -76,14 +76,11 @@ struct propagator {
         // For now, always start at zero
         n_state.set_volume(0u);
 
-        // bool heartbeat = _navigator.status(n_state, s_state);
         bool heartbeat = true;
-
+        // initialize the navigation
+        heartbeat &= _navigator.init(n_state, s_state);
         // Run while there is a heartbeat
         while (heartbeat) {
-
-            // (Re-)target
-            heartbeat &= _navigator.target(n_state, s_state);
 
             // Take the step
             heartbeat &= _stepper.step(s_state, n_state());

--- a/core/include/detray/tools/rk_stepper.hpp
+++ b/core/include/detray/tools/rk_stepper.hpp
@@ -43,9 +43,6 @@ class rk_stepper final : public base_stepper<track_t> {
         /// maximum trial number of RK stepping
         size_t _max_rk_step_trials = 10000;
 
-        // accumulated path length
-        scalar _path_accumulated = 0;
-
         /// stepping data required for RKN4
         struct stepping_data {
             vector3 b_first, b_middle, b_last;
@@ -164,10 +161,11 @@ class rk_stepper final : public base_stepper<track_t> {
         if (stepping.step_size() < max_step_size) {
             navigation.set_high_trust();
         }
-        // Step hit a constraint - the track state was probably severly altered
+        // Step size hit a constraint - the track state was probably changed a
+        // lot
         else {
             stepping.set_step_size(max_step_size);
-            // Not a severe change to thrack state
+            // Re-evaluate all candidates
             navigation.set_fair_trust();
         }
 
@@ -179,7 +177,6 @@ class rk_stepper final : public base_stepper<track_t> {
             return false;
         }
 
-        stepping._path_accumulated += stepping._step_size;
         // Update track state
         stepping.advance_track();
 

--- a/core/include/detray/tools/rk_stepper.hpp
+++ b/core/include/detray/tools/rk_stepper.hpp
@@ -11,8 +11,6 @@
 #include "detray/tools/base_stepper.hpp"
 
 // detray definitions
-#include <iostream>
-
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 
@@ -180,8 +178,7 @@ class rk_stepper final : public base_stepper<track_t> {
 
         // Update and check path limit
         if (not stepping.check_path_limit()) {
-            std::cout << "Stepper: Above maximal path length!\n"
-                      << stepping.dist_to_path_limit() << std::endl;
+            printf("Stepper: Above maximal path length!\n");
             // State is broken
             return navigation.abort();
         }

--- a/core/include/detray/tools/rk_stepper.hpp
+++ b/core/include/detray/tools/rk_stepper.hpp
@@ -38,19 +38,22 @@ class rk_stepper final : public base_stepper<track_t, tuple_t> {
         // TODO: Define default step size somewhere
         scalar _step_size = 1. * unit_constants::mm;
 
-        // error tolerance
+        /// error tolerance
         scalar _tolerance = 1e-4;
 
-        // step size cutoff value
+        /// step size cutoff value
         scalar _step_size_cutoff = 1e-4;
 
-        // maximum trial number of RK stepping
+        /// step size cutoff value
+        scalar _max_step_size = 5. * unit_constants::mm;
+
+        /// maximum trial number of RK stepping
         size_t _max_rk_step_trials = 10000;
 
-        // accumulated path length
+        /// accumulated path length
         scalar _path_accumulated = 0;
 
-        // stepping data required for RKN4
+        /// stepping data required for RKN4
         struct stepping_data {
             vector3 b_first, b_middle, b_last;
             vector3 k1, k2, k3, k4;
@@ -59,8 +62,8 @@ class rk_stepper final : public base_stepper<track_t, tuple_t> {
 
         stepping_data _step_data;
 
-        DETRAY_HOST_DEVICE
-        void release_step_size(const scalar step) { _step_size = step; }
+        // DETRAY_HOST_DEVICE
+        // void set_step_size(const scalar step) { _step_size = step; }
     };
 
     /** Take a step, regulared by a constrained step
@@ -71,16 +74,16 @@ class rk_stepper final : public base_stepper<track_t, tuple_t> {
      * @return returning the heartbeat, indicating if the stepping is alive
      */
     DETRAY_HOST_DEVICE
-    bool step(state& stepping,
-              const scalar path_limit = std::numeric_limits<scalar>::max()) {
+    bool step(state& stepping, scalar step_size_estimate) {
         auto& sd = stepping._step_data;
+        stepping.set_step_size(step_size_estimate);
 
         scalar error_estimate = 0;
 
         // First Runge-Kutta point
         sd.b_first =
             _magnetic_field.get_field(stepping().pos(), context_type{});
-        sd.k1 = evaluatek(stepping, sd.b_first, 0);
+        sd.k1 = evaluate_k(stepping, sd.b_first, 0);
 
         const auto try_rk4 = [&](const scalar& h) -> bool {
             // State the square and half of the step size
@@ -92,15 +95,15 @@ class rk_stepper final : public base_stepper<track_t, tuple_t> {
             // Second Runge-Kutta point
             const vector3 pos1 = pos + half_h * dir + h2 * 0.125 * sd.k1;
             sd.b_middle = _magnetic_field.get_field(pos1, context_type{});
-            sd.k2 = evaluatek(stepping, sd.b_middle, 1, half_h, sd.k1);
+            sd.k2 = evaluate_k(stepping, sd.b_middle, 1, half_h, sd.k1);
 
             // Third Runge-Kutta point
-            sd.k3 = evaluatek(stepping, sd.b_middle, 2, half_h, sd.k2);
+            sd.k3 = evaluate_k(stepping, sd.b_middle, 2, half_h, sd.k2);
 
             // Last Runge-Kutta point
             const vector3 pos2 = pos + h * dir + h2 * 0.5 * sd.k3;
             sd.b_last = _magnetic_field.get_field(pos2, context_type{});
-            sd.k4 = evaluatek(stepping, sd.b_last, 3, h, sd.k3);
+            sd.k4 = evaluate_k(stepping, sd.b_last, 3, h, sd.k3);
 
             // Compute and check the local integration error estimate
             // @Todo
@@ -143,9 +146,10 @@ class rk_stepper final : public base_stepper<track_t, tuple_t> {
             n_step_trials++;
         }
 
-        stepping._step_size = std::min(stepping._step_size, path_limit);
+        stepping._step_size =
+            std::min(stepping._step_size, stepping._max_step_size);
 
-        auto h = stepping._step_size;
+        const auto h = stepping._step_size;
         auto pos = stepping().pos();
         auto dir = stepping().dir();
 
@@ -160,6 +164,14 @@ class rk_stepper final : public base_stepper<track_t, tuple_t> {
 
         stepping._path_accumulated += h;
 
+        // If the parameter is off track too much or given step_size is not
+        // appropriate
+        if (stepping._path_accumulated > stepping._max_pathlength) {
+            // Too many trials, have to abort
+            printf("too many rk4 trials. will break. \n");
+            return false;
+        }
+
         // state.stepping.derivative.template head<3>() = dir;
         // state.stepping.derivative.template segment<3>(4) = sd.k4;
 
@@ -167,9 +179,9 @@ class rk_stepper final : public base_stepper<track_t, tuple_t> {
     }
 
     DETRAY_HOST_DEVICE
-    inline vector3 evaluatek(const state& stepping, const vector3& b_field,
-                             const int i, const scalar h = 0.,
-                             const vector3& k_prev = vector3{0, 0, 0}) {
+    inline vector3 evaluate_k(const state& stepping, const vector3& b_field,
+                              const int i, const scalar h = 0.,
+                              const vector3& k_prev = vector3{0, 0, 0}) {
         vector3 k_new;
         auto qop = stepping().qop();
         auto dir = stepping().dir();

--- a/core/include/detray/tools/rk_stepper.hpp
+++ b/core/include/detray/tools/rk_stepper.hpp
@@ -11,6 +11,8 @@
 #include "detray/tools/base_stepper.hpp"
 
 // detray definitions
+#include <iostream>
+
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 
@@ -43,6 +45,9 @@ class rk_stepper final : public base_stepper<track_t> {
         /// maximum trial number of RK stepping
         size_t _max_rk_step_trials = 10000;
 
+        /// Accumulated path length
+        scalar _path_length = 0.;
+
         /// stepping data required for RKN4
         struct stepping_data {
             vector3 b_first, b_middle, b_last;
@@ -68,6 +73,8 @@ class rk_stepper final : public base_stepper<track_t> {
             dir = dir + h / 6. * (sd.k1 + 2. * (sd.k2 + sd.k3) + sd.k4);
             dir = vector::normalize(dir);
             track.set_dir(dir);
+
+            this->_path_length += h;
         }
     };
 
@@ -173,7 +180,8 @@ class rk_stepper final : public base_stepper<track_t> {
 
         // Update and check path limit
         if (not stepping.check_path_limit()) {
-            printf("Stepper: Above maximal path length!\n");
+            std::cout << "Stepper: Above maximal path length!\n"
+                      << stepping.dist_to_path_limit() << std::endl;
             // State is broken
             return navigation.abort();
         }

--- a/core/include/detray/tools/rk_stepper.hpp
+++ b/core/include/detray/tools/rk_stepper.hpp
@@ -18,12 +18,11 @@ namespace detray {
 
 /** Runge-Kutta-Nystrom 4th order stepper implementation */
 template <typename magnetic_field_t, typename track_t,
-          template <typename...> class tuple_t = dtuple,
           template <typename, std::size_t> class array_t = darray>
-class rk_stepper final : public base_stepper<track_t, tuple_t> {
+class rk_stepper final : public base_stepper<track_t> {
 
     public:
-    using base_type = base_stepper<track_t, tuple_t>;
+    using base_type = base_stepper<track_t>;
     using point3 = __plugin::point3<scalar>;
     using vector3 = __plugin::vector3<scalar>;
     using context_type = typename magnetic_field_t::context_type;

--- a/core/include/detray/tools/rk_stepper.hpp
+++ b/core/include/detray/tools/rk_stepper.hpp
@@ -143,7 +143,8 @@ class rk_stepper final : public base_stepper<track_t> {
                 std::abs(stepping._step_size_cutoff)) {
                 // Not moving due to too low momentum needs an aborter
                 printf("Stepper: step size is too small. will break. \n");
-                return false;
+                // State is broken
+                return navigation.abort();
             }
 
             // If the parameter is off track too much or given step_size is not
@@ -151,7 +152,8 @@ class rk_stepper final : public base_stepper<track_t> {
             if (n_step_trials > stepping._max_rk_step_trials) {
                 // Too many trials, have to abort
                 printf("Stepper: too many rk4 trials. will break. \n");
-                return false;
+                // State is broken
+                return navigation.abort();
             }
             n_step_trials++;
         }
@@ -173,8 +175,7 @@ class rk_stepper final : public base_stepper<track_t> {
         if (not stepping.check_path_limit()) {
             printf("Stepper: Above maximal path length!\n");
             // State is broken
-            navigation.set_no_trust();
-            return false;
+            return navigation.abort();
         }
 
         // Update track state

--- a/core/include/detray/tools/rk_stepper.hpp
+++ b/core/include/detray/tools/rk_stepper.hpp
@@ -145,7 +145,7 @@ class rk_stepper final : public base_stepper<track_t> {
             if (std::abs(stepping._step_size) <
                 std::abs(stepping._step_size_cutoff)) {
                 // Not moving due to too low momentum needs an aborter
-                printf("step size is too small. will break. \n");
+                printf("Stepper: step size is too small. will break. \n");
                 return false;
             }
 
@@ -153,7 +153,7 @@ class rk_stepper final : public base_stepper<track_t> {
             // appropriate
             if (n_step_trials > stepping._max_rk_step_trials) {
                 // Too many trials, have to abort
-                printf("too many rk4 trials. will break. \n");
+                printf("Stepper: too many rk4 trials. will break. \n");
                 return false;
             }
             n_step_trials++;
@@ -173,7 +173,7 @@ class rk_stepper final : public base_stepper<track_t> {
 
         // Update and check path limit
         if (not stepping.check_path_limit()) {
-            printf("Above maximal path length!\n");
+            printf("Stepper: Above maximal path length!\n");
             // State is broken
             navigation.set_no_trust();
             return false;

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -87,7 +87,7 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
 
         for (auto &track : tracks) {
 
-            void_propagator_inspector vi;
+            propagation::void_inspector vi;
 
             // Create the propagator state
             propagator_host_type::state p_state(track);

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
@@ -38,7 +38,7 @@ __global__ void propagator_benchmark_kernel(
     // Create propagator
     propagator_device_type p(std::move(s), std::move(n));
 
-    void_propagator_inspector vi;
+    propagation::void_inspector vi;
 
     // Create the propagator state
     propagator_device_type::state p_state(tracks.at(gid), candidates.at(gid));

--- a/tests/common/include/tests/common/check_geometry_navigation.inl
+++ b/tests/common/include/tests/common/check_geometry_navigation.inl
@@ -77,10 +77,10 @@ struct print_inspector {
 
         switch (static_cast<int>(state.status())) {
             case -3:
-                debug_stream << "status\t\t\t\t\ton_target" << std::endl;
+                debug_stream << "status\t\t\t\t\tabort" << std::endl;
                 break;
             case -2:
-                debug_stream << "status\t\t\t\t\tabort" << std::endl;
+                debug_stream << "status\t\t\t\t\texit" << std::endl;
                 break;
             case -1:
                 debug_stream << "status\t\t\t\t\tunknowm" << std::endl;
@@ -167,8 +167,8 @@ TEST(ALGEBRA_PLUGIN, geometry_discovery) {
     detray_navigator n(d);
     detray_stepper s;
 
-    unsigned int theta_steps = 100;
-    unsigned int phi_steps = 100;
+    unsigned int theta_steps = 1;
+    unsigned int phi_steps = 1;
 
     const point3 ori{0., 0., 0.};
     // dindex start_index = n.detector.volume_by_pos(ori).index();
@@ -203,13 +203,11 @@ TEST(ALGEBRA_PLUGIN, geometry_discovery) {
             n_state.set_volume(0u);
 
             bool heartbeat = true;
-
+            n.init(n_state, s_state);
             // Run while there is a heartbeat
             while (heartbeat) {
-                // (Re-)target
-                heartbeat &= n.target(n_state, s_state);
                 // Take the step
-                heartbeat &= s.step(s_state, n_state());
+                heartbeat &= s.step(s_state, n_state);
                 // And check the status
                 heartbeat &= n.status(n_state, s_state);
             }

--- a/tests/common/include/tests/common/check_geometry_navigation.inl
+++ b/tests/common/include/tests/common/check_geometry_navigation.inl
@@ -8,147 +8,16 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
-#include <string>
-#include <tuple>
-#include <type_traits>
-#include <utility>
 #include <vecmem/memory/host_memory_resource.hpp>
 
-#include "detray/definitions/detail/accessor.hpp"
 #include "detray/tools/line_stepper.hpp"
 #include "detray/tools/navigator.hpp"
 #include "detray/tools/track.hpp"
 #include "tests/common/tools/create_toy_geometry.hpp"
+#include "tests/common/tools/inspectors.hpp"
 #include "tests/common/tools/ray_gun.hpp"
 
 using namespace detray;
-
-/** A navigation inspector that relays information about the encountered
- *  objects the way we need them to compare with the ray
- */
-template <int navigation_status = 0,
-          template <typename...> class vector_t = dvector>
-struct object_tracer {
-
-    // record all object id the navigator encounters
-    vector_t<intersection> object_trace = {};
-
-    template <typename state_type>
-    auto operator()(state_type &state, const char * /*message*/) {
-        // Record the candidate of an encountered object
-        if (state.status() == navigation_status) {
-            object_trace.push_back(std::move(*(state.current())));
-        }
-    }
-
-    auto operator[](std::size_t i) { return object_trace[i]; }
-};
-
-/** A navigation inspector that prints information about the current navigation
- * state. Meant for debugging.
- */
-struct print_inspector {
-
-    // Debug output if an error in the trace is discovered
-    std::stringstream debug_stream;
-
-    template <typename state_type>
-    auto operator()(state_type &state, const char *message) {
-        std::string msg(message);
-
-        debug_stream << msg << std::endl;
-
-        debug_stream << "Volume\t\t\t\t\t\t" << state.volume() << std::endl;
-        debug_stream << "surface kernel size\t\t" << state.candidates().size()
-                     << std::endl;
-
-        debug_stream << "Surface candidates: " << std::endl;
-        for (const auto &sf_cand : state.candidates()) {
-            debug_stream << sf_cand.to_string();
-        }
-        if (not state.candidates().empty()) {
-            debug_stream << "=> next: ";
-            if (state.is_exhausted()) {
-                debug_stream << "exhausted" << std::endl;
-            } else {
-                debug_stream << " -> " << state.next()->index << std::endl;
-            }
-        }
-
-        switch (static_cast<int>(state.status())) {
-            case -3:
-                debug_stream << "status\t\t\t\t\tabort" << std::endl;
-                break;
-            case -2:
-                debug_stream << "status\t\t\t\t\texit" << std::endl;
-                break;
-            case -1:
-                debug_stream << "status\t\t\t\t\tunknowm" << std::endl;
-                break;
-            case 0:
-                debug_stream << "status\t\t\t\t\ttowards_surface" << std::endl;
-                break;
-            case 1:
-                debug_stream << "status\t\t\t\t\ton_surface" << std::endl;
-                break;
-            case 2:
-                debug_stream << "status\t\t\t\t\ttowards_portal" << std::endl;
-                break;
-            case 3:
-                debug_stream << "status\t\t\t\t\ton_portal" << std::endl;
-                break;
-        };
-        debug_stream << "current object\t\t" << state.on_object() << std::endl;
-        debug_stream << "distance to next\t";
-        if (std::abs(state()) < state.tolerance()) {
-            debug_stream << "on obj (within tol)" << std::endl;
-        } else {
-            debug_stream << state() << std::endl;
-        }
-        switch (state.trust_level()) {
-            case 0:
-                debug_stream << "trust\t\t\t\t\tno_trust" << std::endl;
-                break;
-            case 1:
-                debug_stream << "trust\t\t\t\t\tfair_trust" << std::endl;
-                break;
-            case 3:
-                debug_stream << "trust\t\t\t\t\thigh_trust" << std::endl;
-                break;
-            case 4:
-                debug_stream << "trust\t\t\t\t\tfull_trust" << std::endl;
-                break;
-        };
-        debug_stream << std::endl;
-    }
-
-    std::string to_string() { return debug_stream.str(); }
-};
-
-/** A navigation inspector that aggregates a number of different inspectors.*/
-template <typename... Inspectors>
-struct aggregate_inspector {
-
-    using inspector_tuple_t = std::tuple<Inspectors...>;
-    inspector_tuple_t _inspectors{};
-
-    template <unsigned int current_id = 0, typename state_type>
-    auto operator()(state_type &state, const char *message) {
-        // Call inspector
-        std::get<current_id>(_inspectors)(state, message);
-
-        // Next mask type
-        if constexpr (current_id <
-                      std::tuple_size<inspector_tuple_t>::value - 1) {
-            return operator()<current_id + 1>(state, message);
-        }
-    }
-
-    template <typename inspector_t>
-    decltype(auto) get() {
-        return std::get<inspector_t>(_inspectors);
-    }
-};
 
 // This test runs intersection with all portals of the TrackML detector
 TEST(ALGEBRA_PLUGIN, geometry_discovery) {
@@ -159,19 +28,19 @@ TEST(ALGEBRA_PLUGIN, geometry_discovery) {
     auto d = create_toy_geometry(host_mr);
 
     // Create the navigator
-    using detray_inspector =
-        aggregate_inspector<object_tracer<1>, print_inspector>;
-    using detray_navigator = navigator<decltype(d), detray_inspector>;
-    using detray_stepper = line_stepper<free_track_parameters>;
+    using inspector_t = aggregate_inspector<navigation::object_tracer<1>,
+                                            navigation::print_inspector>;
+    using navigator_t = navigator<decltype(d), inspector_t>;
+    using stepper_t = line_stepper<free_track_parameters>;
 
-    detray_navigator n(d);
-    detray_stepper s;
+    navigator_t n(d);
+    stepper_t s;
 
-    unsigned int theta_steps = 1;
-    unsigned int phi_steps = 1;
+    unsigned int theta_steps = 100;
+    unsigned int phi_steps = 100;
 
     const point3 ori{0., 0., 0.};
-    // dindex start_index = n.detector.volume_by_pos(ori).index();
+    dindex start_index = 0;  // d.volume_by_pos(ori).index();
 
     // Loops of theta values ]0,pi[
     for (unsigned int itheta = 0; itheta < theta_steps; ++itheta) {
@@ -191,31 +60,30 @@ TEST(ALGEBRA_PLUGIN, geometry_discovery) {
             // Now follow that ray and check, if we find the same
             // volumes and distances along the way
             ray r{ori, dir};
-
             const auto intersection_trace = shoot_ray(d, r);
 
             free_track_parameters track(ori, 0, dir, -1);
 
-            detray_stepper::state s_state(track);
-            detray_navigator::state n_state;
+            stepper_t::state s_state(track);
+            navigator_t::state n_state{};
 
             // Always start a new ray at detector origin
-            n_state.set_volume(0u);
+            n_state.set_volume(start_index);
 
-            bool heartbeat = true;
-            n.init(n_state, s_state);
+            bool heartbeat = n.init(n_state, s_state);
             // Run while there is a heartbeat
             while (heartbeat) {
                 // Take the step
                 heartbeat &= s.step(s_state, n_state);
                 // And check the status
-                heartbeat &= n.status(n_state, s_state);
+                heartbeat &= n.update(n_state, s_state);
             }
 
             auto &obj_tracer =
-                n_state.inspector().template get<object_tracer<1>>();
+                n_state.inspector()
+                    .template get<navigation::object_tracer<1>>();
             auto &debug_printer =
-                n_state.inspector().template get<print_inspector>();
+                n_state.inspector().template get<navigation::print_inspector>();
 
             std::stringstream debug_stream;
             for (std::size_t intr_idx = 0; intr_idx < intersection_trace.size();

--- a/tests/common/include/tests/common/check_geometry_navigation.inl
+++ b/tests/common/include/tests/common/check_geometry_navigation.inl
@@ -36,8 +36,8 @@ TEST(ALGEBRA_PLUGIN, geometry_discovery) {
     navigator_t n(d);
     stepper_t s;
 
-    unsigned int theta_steps = 100;
-    unsigned int phi_steps = 100;
+    unsigned int theta_steps = 1;
+    unsigned int phi_steps = 1;
 
     const point3 ori{0., 0., 0.};
     dindex start_index = 0;  // d.volume_by_pos(ori).index();

--- a/tests/common/include/tests/common/tools/inspectors.hpp
+++ b/tests/common/include/tests/common/tools/inspectors.hpp
@@ -73,7 +73,7 @@ struct print_inspector {
     std::stringstream debug_stream;
 
     template <typename state_type>
-    auto operator()(state_type &state, const char *message) {
+    auto operator()(const state_type &state, const char *message) {
         std::string msg(message);
         std::string tabs = "\t\t\t\t\t";
 
@@ -118,7 +118,8 @@ struct print_inspector {
                 std::endl; break; case e_on_target: debug_stream << "status" <<
                 tabs << "on_portal" << std::endl; break;*/
         };
-        debug_stream << "current object\t\t" << state.on_object() << std::endl;
+        debug_stream << "current object\t\t" << state.current_object()
+                     << std::endl;
         debug_stream << "distance to next\t";
         if (std::abs(state()) < state.tolerance()) {
             debug_stream << "on obj (within tol)" << std::endl;
@@ -181,10 +182,11 @@ struct print_inspector {
             stream << "volume: " << std::setw(10) << navigation.volume();
         }
 
-        if (navigation.on_object() == dindex_invalid) {
+        if (navigation.current_object() == dindex_invalid) {
             stream << "surface: " << std::setw(14) << "invalid";
         } else {
-            stream << "surface: " << std::setw(14) << navigation.on_object();
+            stream << "surface: " << std::setw(14)
+                   << navigation.current_object();
         }
 
         stream << "step_size: " << std::setw(10) << stepping._step_size;

--- a/tests/common/include/tests/common/tools/inspectors.hpp
+++ b/tests/common/include/tests/common/tools/inspectors.hpp
@@ -152,10 +152,11 @@ namespace propagation {
 
 struct print_inspector {
 
+    std::stringstream stream;
+
     template <typename navigator_state_t, typename stepper_state_t>
     DETRAY_HOST_DEVICE void operator()(const navigator_state_t &navigation,
                                        const stepper_state_t &stepping) {
-        std::stringstream stream;
 
         stream << std::left << std::setw(30);
         switch (static_cast<int>(navigation.status())) {
@@ -190,9 +191,9 @@ struct print_inspector {
         }
 
         stream << "step_size: " << std::setw(10) << stepping._step_size;
-
-        std::cout << stream.str() << std::endl;
     }
+
+    std::string to_string() { return stream.str(); }
 };
 
 }  // namespace propagation

--- a/tests/common/include/tests/common/tools/inspectors.hpp
+++ b/tests/common/include/tests/common/tools/inspectors.hpp
@@ -1,0 +1,199 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "detray/definitions/detail/accessor.hpp"
+
+namespace detray {
+
+/** An inspector that aggregates a number of different inspectors.*/
+template <typename... Inspectors>
+struct aggregate_inspector {
+
+    using inspector_tuple_t = std::tuple<Inspectors...>;
+    inspector_tuple_t _inspectors{};
+
+    template <unsigned int current_id = 0, typename state_type>
+    auto operator()(state_type &state, const char *message) {
+        // Call inspector
+        std::get<current_id>(_inspectors)(state, message);
+
+        // Next mask type
+        if constexpr (current_id <
+                      std::tuple_size<inspector_tuple_t>::value - 1) {
+            return operator()<current_id + 1>(state, message);
+        }
+    }
+
+    template <typename inspector_t>
+    decltype(auto) get() {
+        return std::get<inspector_t>(_inspectors);
+    }
+};
+
+namespace navigation {
+
+/** A navigation inspector that relays information about the encountered
+ *  objects the way we need them to compare with the ray
+ */
+template <int navigation_status = 0,
+          template <typename...> class vector_t = dvector>
+struct object_tracer {
+
+    // record all object id the navigator encounters
+    vector_t<intersection> object_trace = {};
+
+    template <typename state_type>
+    auto operator()(state_type &state, const char * /*message*/) {
+        // Record the candidate of an encountered object
+        if (state.status() == navigation_status) {
+            object_trace.push_back(std::move(*(state.current())));
+        }
+    }
+
+    auto operator[](std::size_t i) { return object_trace[i]; }
+};
+
+/** A navigation inspector that prints information about the current navigation
+ * state. Meant for debugging.
+ */
+struct print_inspector {
+
+    // Debug output if an error in the trace is discovered
+    std::stringstream debug_stream;
+
+    template <typename state_type>
+    auto operator()(state_type &state, const char *message) {
+        std::string msg(message);
+        std::string tabs = "\t\t\t\t\t";
+
+        debug_stream << msg << std::endl;
+
+        debug_stream << "Volume" << tabs << state.volume() << std::endl;
+        debug_stream << "surface kernel size\t\t" << state.candidates().size()
+                     << std::endl;
+
+        debug_stream << "Surface candidates: " << std::endl;
+        for (const auto &sf_cand : state.candidates()) {
+            debug_stream << sf_cand.to_string();
+        }
+        if (not state.candidates().empty()) {
+            debug_stream << "=> next: ";
+            if (state.is_exhausted()) {
+                debug_stream << "exhausted" << std::endl;
+            } else {
+                debug_stream << " -> " << state.next()->index << std::endl;
+            }
+        }
+
+        switch (state.status()) {
+            case e_abort:
+                debug_stream << "status" << tabs << "abort" << std::endl;
+                break;
+            case e_exit:
+                debug_stream << "status" << tabs << "exit" << std::endl;
+                break;
+            case e_unknown:
+                debug_stream << "status" << tabs << "unknowm" << std::endl;
+                break;
+            case e_towards_object:
+                debug_stream << "status" << tabs << "towards_surface"
+                             << std::endl;
+                break;
+            case e_on_target:
+                debug_stream << "status" << tabs << "on_surface" << std::endl;
+                break;
+                /*case e_towards_object:
+                    debug_stream << "status" << tabs << "towards_portal" <<
+                std::endl; break; case e_on_target: debug_stream << "status" <<
+                tabs << "on_portal" << std::endl; break;*/
+        };
+        debug_stream << "current object\t\t" << state.on_object() << std::endl;
+        debug_stream << "distance to next\t";
+        if (std::abs(state()) < state.tolerance()) {
+            debug_stream << "on obj (within tol)" << std::endl;
+        } else {
+            debug_stream << state() << std::endl;
+        }
+        switch (state.trust_level()) {
+            case e_no_trust:
+                debug_stream << "trust" << tabs << "no_trust" << std::endl;
+                break;
+            case e_fair_trust:
+                debug_stream << "trust" << tabs << "fair_trust" << std::endl;
+                break;
+            case e_high_trust:
+                debug_stream << "trust" << tabs << "high_trust" << std::endl;
+                break;
+            case e_full_trust:
+                debug_stream << "trust" << tabs << "full_trust" << std::endl;
+                break;
+        };
+        debug_stream << std::endl;
+    }
+
+    std::string to_string() { return debug_stream.str(); }
+};
+
+}  // namespace navigation
+
+namespace propagation {
+
+struct print_inspector {
+
+    template <typename navigator_state_t, typename stepper_state_t>
+    DETRAY_HOST_DEVICE void operator()(const navigator_state_t &navigation,
+                                       const stepper_state_t &stepping) {
+        std::stringstream stream;
+
+        stream << std::left << std::setw(30);
+        switch (static_cast<int>(navigation.status())) {
+            case navigation::e_abort:
+                stream << "status: abort";
+                break;
+            case navigation::e_exit:
+                stream << "status: exit";
+                break;
+            case navigation::e_unknown:
+                stream << "status: unknowm";
+                break;
+            case navigation::e_towards_object:
+                stream << "status: towards_surface";
+                break;
+            case navigation::e_on_target:
+                stream << "status: on_surface";
+                break;
+        };
+
+        if (navigation.volume() == dindex_invalid) {
+            stream << "volume: " << std::setw(10) << "invalid";
+        } else {
+            stream << "volume: " << std::setw(10) << navigation.volume();
+        }
+
+        if (navigation.on_object() == dindex_invalid) {
+            stream << "surface: " << std::setw(14) << "invalid";
+        } else {
+            stream << "surface: " << std::setw(14) << navigation.on_object();
+        }
+
+        stream << "step_size: " << std::setw(10) << stepping._step_size;
+
+        std::cout << stream.str() << std::endl;
+    }
+};
+
+}  // namespace propagation
+
+namespace stepper {}  // namespace stepper
+}  // namespace detray

--- a/tests/common/include/tests/common/tools/inspectors.hpp
+++ b/tests/common/include/tests/common/tools/inspectors.hpp
@@ -70,7 +70,7 @@ struct object_tracer {
 struct print_inspector {
 
     // Debug output if an error in the trace is discovered
-    std::stringstream debug_stream;
+    std::stringstream debug_stream{};
 
     template <typename state_type>
     auto operator()(const state_type &state, const char *message) {
@@ -152,7 +152,7 @@ namespace propagation {
 
 struct print_inspector {
 
-    std::stringstream stream;
+    std::stringstream stream{};
 
     template <typename navigator_state_t, typename stepper_state_t>
     DETRAY_HOST_DEVICE void operator()(const navigator_state_t &navigation,

--- a/tests/common/include/tests/common/tools_line_stepper.inl
+++ b/tests/common/include/tests/common/tools_line_stepper.inl
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "detray/core/transform_store.hpp"
+#include "detray/definitions/units.hpp"
 #include "detray/tools/line_stepper.hpp"
 #include "detray/tools/track.hpp"
 

--- a/tests/common/include/tests/common/tools_line_stepper.inl
+++ b/tests/common/include/tests/common/tools_line_stepper.inl
@@ -20,25 +20,37 @@ TEST(ALGEBRA_PLUGIN, line_stepper) {
 
     using detray_track = free_track_parameters;
 
+    // dummy navigation struct
+    struct nav_state {
+        scalar operator()() const { return 1. * unit_constants::mm; }
+        inline void set_full_trust() {}
+        inline void set_high_trust() {}
+        inline void set_fair_trust() {}
+        inline void set_no_trust() {}
+    };
+
     point3<scalar> pos{0., 0., 0.};
     vector3<scalar> mom{1., 1., 0.};
     detray_track traj(pos, 0, mom, -1);
 
     line_stepper<detray_track>::state lstate(traj);
+    nav_state n_state{};
 
-    /*line_stepper<detray_track> lstepper;
-    bool heartbeat = lstepper.step(lstate, 10.);
-    ASSERT_TRUE(heartbeat);
+    line_stepper<detray_track> lstepper;
+    ASSERT_TRUE(lstepper.step(lstate, n_state));
 
-    ASSERT_FLOAT_EQ(traj.pos()[0], 10. / sqrt(2));
-    ASSERT_FLOAT_EQ(traj.pos()[1], 10. / sqrt(2));
+    ASSERT_FLOAT_EQ(traj.pos()[0], 1. / std::sqrt(2));
+    ASSERT_FLOAT_EQ(traj.pos()[1], 1. / std::sqrt(2));
     ASSERT_FLOAT_EQ(traj.pos()[2], 0.);
 
-    // Step with limit
-    lstate.set_limit(20.);
-    //heartbeat = lstepper.step(lstate, 10.);
-    ASSERT_TRUE(heartbeat);
+    // Only step 1.5 mm further, then break
+    lstate.set_path_limit(1.5);
+    ASSERT_TRUE(lstepper.step(lstate, n_state));
 
-    //heartbeat = lstepper.step(lstate, 10.);
-    ASSERT_FALSE(heartbeat);*/
+    ASSERT_FLOAT_EQ(traj.pos()[0], std::sqrt(2));
+    ASSERT_FLOAT_EQ(traj.pos()[1], std::sqrt(2));
+    ASSERT_FLOAT_EQ(traj.pos()[2], 0.);
+
+    // breaks
+    ASSERT_FALSE(lstepper.step(lstate, n_state));
 }

--- a/tests/common/include/tests/common/tools_line_stepper.inl
+++ b/tests/common/include/tests/common/tools_line_stepper.inl
@@ -28,6 +28,7 @@ TEST(ALGEBRA_PLUGIN, line_stepper) {
         inline void set_high_trust() {}
         inline void set_fair_trust() {}
         inline void set_no_trust() {}
+        inline bool abort() { return false; }
     };
 
     point3<scalar> pos{0., 0., 0.};

--- a/tests/common/include/tests/common/tools_line_stepper.inl
+++ b/tests/common/include/tests/common/tools_line_stepper.inl
@@ -26,7 +26,7 @@ TEST(ALGEBRA_PLUGIN, line_stepper) {
 
     line_stepper<detray_track>::state lstate(traj);
 
-    line_stepper<detray_track> lstepper;
+    /*line_stepper<detray_track> lstepper;
     bool heartbeat = lstepper.step(lstate, 10.);
     ASSERT_TRUE(heartbeat);
 
@@ -36,9 +36,9 @@ TEST(ALGEBRA_PLUGIN, line_stepper) {
 
     // Step with limit
     lstate.set_limit(20.);
-    heartbeat = lstepper.step(lstate, 10.);
+    //heartbeat = lstepper.step(lstate, 10.);
     ASSERT_TRUE(heartbeat);
 
-    heartbeat = lstepper.step(lstate, 10.);
-    ASSERT_FALSE(heartbeat);
+    //heartbeat = lstepper.step(lstate, 10.);
+    ASSERT_FALSE(heartbeat);*/
 }

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -75,7 +75,7 @@ inline void check_step(navigator_t &n, stepper_t &s, nav_state_t &n_state,
     // Step onto the surface in volume
     s.step(s_state, n_state);
     // Stepper reduced trust level
-    ASSERT_EQ(n_state.trust_level(), navigation::e_high_trust);
+    ASSERT_TRUE(n_state.trust_level() == navigation::e_high_trust);
     ASSERT_TRUE(n.update(n_state, s_state));
     // Trust level is restored
     ASSERT_EQ(n_state.trust_level(), navigation::e_full_trust);
@@ -148,8 +148,8 @@ TEST(ALGEBRA_PLUGIN, navigator) {
 
     // Let's make half the step towards the beampipe
     s.step(s_state, n_state, n_state() * 0.5);
-    // Stepper reduced trust level
-    ASSERT_EQ(n_state.trust_level(), e_high_trust);
+    // Stepper reduced trust level (hit step constrint -> only fair trust)
+    ASSERT_TRUE(n_state.trust_level() == e_fair_trust);
     // Re-navigate
     ASSERT_TRUE(n.update(n_state, s_state));
     // Trust level is restored
@@ -171,7 +171,7 @@ TEST(ALGEBRA_PLUGIN, navigator) {
 
     // Step onto portal 7 in volume 0
     s.step(s_state, n_state);
-    ASSERT_EQ(n_state.trust_level(), e_high_trust);
+    ASSERT_TRUE(n_state.trust_level() == e_high_trust);
     ASSERT_TRUE(n.update(n_state, s_state));
     ASSERT_EQ(n_state.trust_level(), e_full_trust);
 

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -38,15 +38,16 @@ inline void check_towards_surface(state_t &state, dindex vol_id,
 /** Checks for a correct 'on_surface' state */
 template <typename navigator_t, typename state_t = typename navigator_t::state>
 inline void check_on_surface(state_t &state, dindex vol_id,
-                             std::size_t n_candidates, dindex current_id,
+                             std::size_t n_candidates, dindex /*current_id*/,
                              dindex next_id) {
-    // The status is: on surface
-    ASSERT_EQ(state.status(), navigation::e_on_target);
+    // The status is: on surface/towards surface if the next candidate is
+    // immediately updated and set in the same update call
+    ASSERT_EQ(state.status(), navigation::e_towards_object);
     // Points towards next candidate
     ASSERT_TRUE(std::abs(state()) > state.tolerance());
     ASSERT_EQ(state.volume(), vol_id);
     ASSERT_EQ(state.candidates().size(), n_candidates);
-    ASSERT_EQ(state.current_object(), current_id);
+    ASSERT_EQ(state.current_object(), dindex_invalid /*current_id*/);
     // points to the next surface now
     ASSERT_EQ(state.next()->index, next_id);
     ASSERT_EQ(state.trust_level(), navigation::e_full_trust);

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -28,7 +28,7 @@ inline void check_towards_surface(state_t &state, dindex vol_id,
     ASSERT_EQ(state.candidates().size(), n_candidates);
     // If we are towards some object, we have no current one (even if we are
     // geometrically still there)
-    ASSERT_EQ(state.on_object(), dindex_invalid);
+    ASSERT_EQ(state.current_object(), dindex_invalid);
     // the portal is still the next object, since we did not step
     ASSERT_EQ(state.next()->index, next_id);
     ASSERT_TRUE((state.trust_level() == navigation::e_full_trust) or
@@ -46,7 +46,7 @@ inline void check_on_surface(state_t &state, dindex vol_id,
     ASSERT_TRUE(std::abs(state()) > state.tolerance());
     ASSERT_EQ(state.volume(), vol_id);
     ASSERT_EQ(state.candidates().size(), n_candidates);
-    ASSERT_EQ(state.on_object(), current_id);
+    ASSERT_EQ(state.current_object(), current_id);
     // points to the next surface now
     ASSERT_EQ(state.next()->index, next_id);
     ASSERT_EQ(state.trust_level(), navigation::e_full_trust);

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -119,42 +119,42 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
     using propagator_t = propagator<stepper_t, navigator_t>;
 
     // Constant magnetic field
-    // vector3 B{0, 0, 2 * unit_constants::T};
     vector3 B = GetParam();
     b_field_t b_field(B);
-
-    // Set initial position and momentum of tracks
-    const point3 ori{0., 0., 0.};
 
     stepper_t s(b_field);
     navigator_t n(d);
     propagator_t p(std::move(s), std::move(n));
 
+    // Set origin position of tracks
+    const point3 ori{0., 0., 0.};
+    
     // Loops of theta values ]0,pi[
     for (unsigned int itheta = 0; itheta < theta_steps; ++itheta) {
         scalar theta = 0.001 + itheta * (M_PI - 0.001) / theta_steps;
         scalar sin_theta = std::sin(theta);
         scalar cos_theta = std::cos(theta);
-
         // Loops of phi values [-pi, pi]
         for (unsigned int iphi = 0; iphi < phi_steps; ++iphi) {
             // The direction
             scalar phi = -M_PI + iphi * (2 * M_PI) / phi_steps;
             scalar sin_phi = std::sin(phi);
             scalar cos_phi = std::cos(phi);
-            vector3 mom{cos_phi * sin_theta, sin_phi * sin_theta, cos_theta};
-            mom = 10. * mom;
 
             // intialize a track
+            vector3 mom{cos_phi * sin_theta, sin_phi * sin_theta, cos_theta};
+            mom = 10. * mom;
             free_track_parameters traj(ori, 0, mom, -1);
+            traj.set_overstep_tolerance(-5. * unit_constants::mm);
+
             helix_gun helix(traj, B);
             combined_inspector ci{helix_inspector(helix),
                                     propagation::print_inspector{}};
+
             propagator_t::state state(traj);
             state._stepping.set_path_limit(path_limit);
-
-            EXPECT_TRUE(p.propagate(state, ci))
-                << state._navigation.inspector().to_string() << std::endl;
+            std::cout << "<<<<<<<<<<<<<<<<<<<<<<<<<" << std::endl;
+            EXPECT_TRUE(p.propagate(state, ci)) << state._navigation.inspector().to_string() << std::endl;
         }
     }
 }

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -161,15 +161,22 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(PropagatorValidation, PropagatorWithRkStepper,
+INSTANTIATE_TEST_SUITE_P(PropagatorValidation1, PropagatorWithRkStepper,
                          ::testing::Values(__plugin::vector3<scalar>{
-                             0., 1. * unit_constants::T,
+                             0. * unit_constants::T, 0. * unit_constants::T,
+                             2. * unit_constants::T}));
+
+/*INSTANTIATE_TEST_SUITE_P(PropagatorValidation2, PropagatorWithRkStepper,
+                         ::testing::Values(__plugin::vector3<scalar>{
+                             0. * unit_constants::T, 1. * unit_constants::T,
                              1. * unit_constants::T}));
 
-/*
-INSTANTIATE_TEST_SUITE_P(
-    PropagatorValidation, PropagatorWithRkStepper,
-    ::testing::Values(__plugin::vector3<scalar>{0, 0, 2 * unit_constants::T},
-__plugin::vector3<scalar>{1 * unit_constants::T, 1 * unit_constants::T, 1 *
-unit_constants::T}));
-*/
+INSTANTIATE_TEST_SUITE_P(PropagatorValidation3, PropagatorWithRkStepper,
+                         ::testing::Values(__plugin::vector3<scalar>{
+                             1. * unit_constants::T, 0. * unit_constants::T,
+                             1. * unit_constants::T}));
+
+INSTANTIATE_TEST_SUITE_P(PropagatorValidation4, PropagatorWithRkStepper,
+                         ::testing::Values(__plugin::vector3<scalar>{
+                             1. * unit_constants::T, 1. * unit_constants::T,
+                             1. * unit_constants::T}));*/

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -57,7 +57,7 @@ TEST(ALGEBRA_PLUGIN, propagator_line_stepper) {
 
     detray_propagator::state state(traj);
 
-    /*auto end = */ p.propagate(state, vi);
+    /*auto end = */  // p.propagate(state, vi);
 }
 
 struct helix_inspector {
@@ -127,10 +127,116 @@ struct combined_inspector {
     print_inspector _pi;
 
     template <typename navigator_state_t, typename stepper_state_t>
-    DETRAY_HOST_DEVICE void operator()(const navigator_state_t& navigation,
+    DETRAY_HOST_DEVICE void operator()(navigator_state_t& navigation,
                                        const stepper_state_t& stepping) {
         _hi(navigation, stepping);
         _pi(navigation, stepping);
+    }
+};
+
+/** A navigation inspector that prints information about the current navigation
+ * state. Meant for debugging.
+ */
+struct navigator_print_inspector {
+
+    // Debug output if an error in the trace is discovered
+    std::stringstream debug_stream;
+
+    template <typename state_type>
+    auto operator()(state_type& state, const char* message) {
+        std::string msg(message);
+
+        debug_stream << msg << std::endl;
+
+        debug_stream << "Volume\t\t\t\t\t\t" << state.volume() << std::endl;
+        debug_stream << "surface kernel size\t\t" << state.candidates().size()
+                     << std::endl;
+
+        debug_stream << "Surface candidates: " << std::endl;
+        for (const auto& sf_cand : state.candidates()) {
+            debug_stream << sf_cand.to_string();
+        }
+        if (not state.candidates().empty()) {
+            debug_stream << "=> next: ";
+            if (state.is_exhausted()) {
+                debug_stream << "exhausted" << std::endl;
+            } else {
+                debug_stream << " -> " << state.next()->index << std::endl;
+            }
+        }
+
+        switch (static_cast<int>(state.status())) {
+            case -3:
+                debug_stream << "status\t\t\t\t\ton_target" << std::endl;
+                break;
+            case -2:
+                debug_stream << "status\t\t\t\t\tabort" << std::endl;
+                break;
+            case -1:
+                debug_stream << "status\t\t\t\t\tunknowm" << std::endl;
+                break;
+            case 0:
+                debug_stream << "status\t\t\t\t\ttowards_surface" << std::endl;
+                break;
+            case 1:
+                debug_stream << "status\t\t\t\t\ton_surface" << std::endl;
+                break;
+            case 2:
+                debug_stream << "status\t\t\t\t\ttowards_portal" << std::endl;
+                break;
+            case 3:
+                debug_stream << "status\t\t\t\t\ton_portal" << std::endl;
+                break;
+        };
+        debug_stream << "current object\t\t" << state.on_object() << std::endl;
+        debug_stream << "distance to next\t";
+        if (std::abs(state()) < state.tolerance()) {
+            debug_stream << "on obj (within tol)" << std::endl;
+        } else {
+            debug_stream << state() << std::endl;
+        }
+        switch (state.trust_level()) {
+            case 0:
+                debug_stream << "trust\t\t\t\t\tno_trust" << std::endl;
+                break;
+            case 1:
+                debug_stream << "trust\t\t\t\t\tfair_trust" << std::endl;
+                break;
+            case 3:
+                debug_stream << "trust\t\t\t\t\thigh_trust" << std::endl;
+                break;
+            case 4:
+                debug_stream << "trust\t\t\t\t\tfull_trust" << std::endl;
+                break;
+        };
+        debug_stream << std::endl;
+    }
+
+    std::string to_string() { return debug_stream.str(); }
+};
+
+/** A navigation inspector that aggregates a number of different inspectors.*/
+template <typename... Inspectors>
+struct aggregate_inspector {
+
+    using inspector_tuple_t = std::tuple<Inspectors...>;
+    inspector_tuple_t _inspectors{};
+
+    template <unsigned int current_id = 0, typename state_type>
+    auto operator()(state_type& state, const char* message) {
+        // Call inspector
+        std::get<current_id>(_inspectors)(state, message);
+
+        // Next mask type
+        if constexpr (current_id <
+                      std::tuple_size<inspector_tuple_t>::value - 1) {
+            return operator()<current_id + 1>(state, message);
+        }
+    }
+
+    template <typename inspector_t>
+    decltype(auto) get() {
+        return std::get<inspector_t>(_inspectors);
     }
 };
 
@@ -156,7 +262,7 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
     auto d = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
 
     // Create the navigator
-    using detray_navigator = navigator<decltype(d)>;
+    using detray_navigator = navigator<decltype(d), navigator_print_inspector>;
     using detray_b_field = constant_magnetic_field<>;
     using detray_stepper = rk_stepper<detray_b_field, free_track_parameters>;
     using detray_propagator = propagator<detray_stepper, detray_navigator>;

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -102,12 +102,12 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
     using vector3 = __plugin::vector3<scalar>;
 
     // geomery navigation configurations
-    constexpr unsigned int theta_steps = 100;
-    constexpr unsigned int phi_steps = 100;
+    constexpr unsigned int theta_steps = 10;
+    constexpr unsigned int phi_steps = 10;
 
     // detector configuration
     constexpr std::size_t n_brl_layers = 4;
-    constexpr std::size_t n_edc_layers = 7;
+    constexpr std::size_t n_edc_layers = 1;
 
     vecmem::host_memory_resource host_mr;
     auto d = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
@@ -128,7 +128,7 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
 
     // Set origin position of tracks
     const point3 ori{0., 0., 0.};
-    
+
     // Loops of theta values ]0,pi[
     for (unsigned int itheta = 0; itheta < theta_steps; ++itheta) {
         scalar theta = 0.001 + itheta * (M_PI - 0.001) / theta_steps;
@@ -145,23 +145,25 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
             vector3 mom{cos_phi * sin_theta, sin_phi * sin_theta, cos_theta};
             mom = 10. * mom;
             free_track_parameters traj(ori, 0, mom, -1);
-            traj.set_overstep_tolerance(-5. * unit_constants::mm);
+            traj.set_overstep_tolerance(-0.01 * unit_constants::mm);
 
             helix_gun helix(traj, B);
             combined_inspector ci{helix_inspector(helix),
-                                    propagation::print_inspector{}};
+                                  propagation::print_inspector{}};
 
             propagator_t::state state(traj);
             state._stepping.set_path_limit(path_limit);
             std::cout << "<<<<<<<<<<<<<<<<<<<<<<<<<" << std::endl;
-            EXPECT_TRUE(p.propagate(state, ci)) << state._navigation.inspector().to_string() << std::endl;
+            EXPECT_TRUE(p.propagate(state, ci))
+                << state._navigation.inspector().to_string() << std::endl;
         }
     }
 }
 
 INSTANTIATE_TEST_SUITE_P(PropagatorValidation, PropagatorWithRkStepper,
                          ::testing::Values(__plugin::vector3<scalar>{
-                             0, 0, 2 * unit_constants::T}));
+                             0., 1. * unit_constants::T,
+                             1. * unit_constants::T}));
 
 /*
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -73,7 +73,7 @@ struct helix_inspector {
 
         auto relative_error = 1 / path_accumulated * (pos - true_pos);
 
-        EXPECT_NEAR(getter::norm(relative_error), 0, epsilon);
+        ASSERT_NEAR(getter::norm(relative_error), 0, epsilon);
     }
 
     helix_gun _helix;
@@ -144,9 +144,9 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
             // intialize a track
             vector3 mom{cos_phi * sin_theta, sin_phi * sin_theta, cos_theta};
             vector::normalize(mom);
-            mom = 10. * mom;
+            mom = 10. * unit_constants::GeV * mom;
             free_track_parameters traj(ori, 0, mom, -1);
-            traj.set_overstep_tolerance(-0.01 * unit_constants::mm);
+            traj.set_overstep_tolerance(-10 * unit_constants::um);
 
             helix_gun helix(traj, B);
             combined_inspector ci{helix_inspector(helix),
@@ -154,8 +154,9 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
 
             propagator_t::state state(traj);
             state._stepping.set_path_limit(path_limit);
-            std::cout << "<<<<<<<<<<<<<<<<<<<<<<<<<" << std::endl;
-            EXPECT_TRUE(p.propagate(state, ci, 5. * unit_constants::mm))
+
+            ASSERT_TRUE(p.propagate(state, ci, 5. * unit_constants::mm))
+                << ci._pi.to_string() << std::endl
                 << state._navigation.inspector().to_string() << std::endl;
         }
     }
@@ -166,7 +167,7 @@ INSTANTIATE_TEST_SUITE_P(PropagatorValidation1, PropagatorWithRkStepper,
                              0. * unit_constants::T, 0. * unit_constants::T,
                              2. * unit_constants::T}));
 
-/*INSTANTIATE_TEST_SUITE_P(PropagatorValidation2, PropagatorWithRkStepper,
+INSTANTIATE_TEST_SUITE_P(PropagatorValidation2, PropagatorWithRkStepper,
                          ::testing::Values(__plugin::vector3<scalar>{
                              0. * unit_constants::T, 1. * unit_constants::T,
                              1. * unit_constants::T}));
@@ -179,4 +180,4 @@ INSTANTIATE_TEST_SUITE_P(PropagatorValidation3, PropagatorWithRkStepper,
 INSTANTIATE_TEST_SUITE_P(PropagatorValidation4, PropagatorWithRkStepper,
                          ::testing::Values(__plugin::vector3<scalar>{
                              1. * unit_constants::T, 1. * unit_constants::T,
-                             1. * unit_constants::T}));*/
+                             1. * unit_constants::T}));

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -22,7 +22,7 @@
 #include "tests/common/tools/read_geometry.hpp"
 
 constexpr scalar epsilon = 1e-4;
-constexpr scalar path_limit = 10 * unit_constants::cm;
+constexpr scalar path_limit = 100 * unit_constants::cm;
 
 // This tests the basic functionality of the propagator
 TEST(ALGEBRA_PLUGIN, propagator_line_stepper) {
@@ -67,10 +67,11 @@ struct helix_inspector {
     DETRAY_HOST_DEVICE void operator()(const navigator_state_t& /*navigation*/,
                                        const stepper_state_t& stepping) {
         auto pos = stepping().pos();
-        // const scalar accumulated_path = path_limit - stepping.path_limit();
-        auto true_pos = _helix(stepping._path_accumulated);
+        const scalar path_accumulated =
+            path_limit - stepping.dist_to_path_limit();
+        auto true_pos = _helix(path_accumulated);
 
-        auto relative_error = 1 / stepping._path_accumulated * (pos - true_pos);
+        auto relative_error = 1 / path_accumulated * (pos - true_pos);
 
         EXPECT_NEAR(getter::norm(relative_error), 0, epsilon);
     }

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -21,7 +21,7 @@
 #include "tests/common/tools/inspectors.hpp"
 #include "tests/common/tools/read_geometry.hpp"
 
-constexpr scalar epsilon = 1e-4;
+constexpr scalar epsilon = 5e-4;
 constexpr scalar path_limit = 2 * unit_constants::m;
 
 // This tests the basic functionality of the propagator

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -22,7 +22,7 @@
 #include "tests/common/tools/read_geometry.hpp"
 
 constexpr scalar epsilon = 1e-4;
-constexpr scalar path_limit = 100 * unit_constants::cm;
+constexpr scalar path_limit = 2 * unit_constants::m;
 
 // This tests the basic functionality of the propagator
 TEST(ALGEBRA_PLUGIN, propagator_line_stepper) {
@@ -102,12 +102,12 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
     using vector3 = __plugin::vector3<scalar>;
 
     // geomery navigation configurations
-    constexpr unsigned int theta_steps = 10;
-    constexpr unsigned int phi_steps = 10;
+    constexpr unsigned int theta_steps = 100;
+    constexpr unsigned int phi_steps = 100;
 
     // detector configuration
     constexpr std::size_t n_brl_layers = 4;
-    constexpr std::size_t n_edc_layers = 1;
+    constexpr std::size_t n_edc_layers = 7;
 
     vecmem::host_memory_resource host_mr;
     auto d = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
@@ -143,6 +143,7 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
 
             // intialize a track
             vector3 mom{cos_phi * sin_theta, sin_phi * sin_theta, cos_theta};
+            vector::normalize(mom);
             mom = 10. * mom;
             free_track_parameters traj(ori, 0, mom, -1);
             traj.set_overstep_tolerance(-0.01 * unit_constants::mm);
@@ -154,7 +155,7 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
             propagator_t::state state(traj);
             state._stepping.set_path_limit(path_limit);
             std::cout << "<<<<<<<<<<<<<<<<<<<<<<<<<" << std::endl;
-            EXPECT_TRUE(p.propagate(state, ci))
+            EXPECT_TRUE(p.propagate(state, ci, 5. * unit_constants::mm))
                 << state._navigation.inspector().to_string() << std::endl;
         }
     }

--- a/tests/common/include/tests/common/tools_rk_stepper.inl
+++ b/tests/common/include/tests/common/tools_rk_stepper.inl
@@ -32,7 +32,7 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
     // RK stepper configurations
     constexpr unsigned int theta_steps = 100;
     constexpr unsigned int phi_steps = 100;
-    constexpr unsigned int rk_steps = 100;
+    //constexpr unsigned int rk_steps = 100;
 
     // Constant magnetic field
     vector3 B{1 * unit_constants::T, 1 * unit_constants::T,

--- a/tests/common/include/tests/common/tools_rk_stepper.inl
+++ b/tests/common/include/tests/common/tools_rk_stepper.inl
@@ -69,7 +69,7 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
             helix_gun helix(traj, B);
 
             // RK Stepping into forward direction
-            rk_stepper_type::state forward_state(traj);
+            /*rk_stepper_type::state forward_state(traj);
             for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
                 rk_stepper.step(forward_state, forward_state._max_step_size);
             }
@@ -98,7 +98,7 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
                 1. / path_accumulated * (backward_pos - ori);
 
             // Make sure that relative error is smaller than epsion
-            EXPECT_NEAR(getter::norm(backward_relative_error), 0, epsilon);
+            EXPECT_NEAR(getter::norm(backward_relative_error), 0, epsilon);*/
         }
     }
 }

--- a/tests/common/include/tests/common/tools_rk_stepper.inl
+++ b/tests/common/include/tests/common/tools_rk_stepper.inl
@@ -71,7 +71,7 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
             // RK Stepping into forward direction
             rk_stepper_type::state forward_state(traj);
             for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
-                rk_stepper.step(forward_state);
+                rk_stepper.step(forward_state, forward_state._max_step_size);
             }
 
             // get relative error by dividing error with path length
@@ -88,7 +88,7 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
             traj.flip();
             rk_stepper_type::state backward_state(traj);
             for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
-                rk_stepper.step(backward_state);
+                rk_stepper.step(backward_state, backward_state._max_step_size);
             }
 
             // get relative error by dividing error with path length

--- a/tests/common/include/tests/common/tools_rk_stepper.inl
+++ b/tests/common/include/tests/common/tools_rk_stepper.inl
@@ -18,9 +18,18 @@ using namespace detray;
 using namespace __plugin;
 
 constexpr scalar epsilon = 1e-4;
+constexpr scalar path_limit = 100 * unit_constants::cm;
 
 // This tests the base functionality of the Runge-Kutta stepper
 TEST(ALGEBRA_PLUGIN, rk_stepper) {
+    // dummy navigation struct
+    struct nav_state {
+        scalar operator()() const { return 1. * unit_constants::mm; }
+        inline void set_full_trust() {}
+        inline void set_high_trust() {}
+        inline void set_fair_trust() {}
+        inline void set_no_trust() {}
+    };
 
     // type definitions
     using vector3 = vector3<scalar>;
@@ -32,7 +41,7 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
     // RK stepper configurations
     constexpr unsigned int theta_steps = 100;
     constexpr unsigned int phi_steps = 100;
-    //constexpr unsigned int rk_steps = 100;
+    constexpr unsigned int rk_steps = 100;
 
     // Constant magnetic field
     vector3 B{1 * unit_constants::T, 1 * unit_constants::T,
@@ -41,6 +50,7 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
 
     // RK stepper
     rk_stepper_type rk_stepper(mag_field);
+    nav_state n_state{};
 
     // Set origin position of tracks
     const point3 ori{0., 0., 0.};
@@ -69,13 +79,15 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
             helix_gun helix(traj, B);
 
             // RK Stepping into forward direction
-            /*rk_stepper_type::state forward_state(traj);
+            rk_stepper_type::state forward_state(traj);
+            forward_state.set_path_limit(path_limit);
             for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
-                rk_stepper.step(forward_state, forward_state._max_step_size);
+                rk_stepper.step(forward_state, n_state);
             }
 
             // get relative error by dividing error with path length
-            auto path_accumulated = forward_state._path_accumulated;
+            auto path_accumulated =
+                path_limit - forward_state.dist_to_path_limit();
             auto helix_pos = helix(path_accumulated);
             auto forward_pos = forward_state().pos();
             auto forward_relative_error =
@@ -87,18 +99,20 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
             // RK Stepping into backward direction
             traj.flip();
             rk_stepper_type::state backward_state(traj);
+            backward_state.set_path_limit(path_limit);
             for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
-                rk_stepper.step(backward_state, backward_state._max_step_size);
+                rk_stepper.step(backward_state, n_state);
             }
 
             // get relative error by dividing error with path length
-            path_accumulated += backward_state._path_accumulated;
+            path_accumulated +=
+                path_limit - backward_state.dist_to_path_limit();
             auto backward_pos = backward_state().pos();
             auto backward_relative_error =
                 1. / path_accumulated * (backward_pos - ori);
 
             // Make sure that relative error is smaller than epsion
-            EXPECT_NEAR(getter::norm(backward_relative_error), 0, epsilon);*/
+            EXPECT_NEAR(getter::norm(backward_relative_error), 0, epsilon);
         }
     }
 }

--- a/tests/common/include/tests/common/tools_rk_stepper.inl
+++ b/tests/common/include/tests/common/tools_rk_stepper.inl
@@ -29,6 +29,7 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
         inline void set_high_trust() {}
         inline void set_fair_trust() {}
         inline void set_no_trust() {}
+        inline bool abort() { return false; }
     };
 
     // type definitions

--- a/tests/unit_tests/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/cuda/navigator_cuda.cpp
@@ -79,18 +79,13 @@ TEST(navigator_cuda, navigator) {
         navigator_host_t::state state(mng_mr);
         stepper_t::state stepping(traj);
 
-        // Set initial volume
-        state.set_volume(0u);
-
         // Start propagation and record volume IDs
-        bool heartbeat = true;
-
+        bool heartbeat = n.init(state, stepping);
         while (heartbeat) {
-            heartbeat = n.target(state, stepping);
 
             stepping().set_pos(stepping().pos() + state() * stepping().dir());
 
-            heartbeat = n.status(state, stepping);
+            heartbeat = n.update(state, stepping);
 
             // Record volume
             volume_records_host[i].push_back(state.volume());

--- a/tests/unit_tests/cuda/navigator_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/navigator_cuda_kernel.cu
@@ -41,14 +41,12 @@ __global__ void navigator_test_kernel(
     state.set_volume(0u);
 
     // Start propagation and record volume IDs
-    bool heartbeat = true;
-
+    bool heartbeat = n.init(state, stepping);
     while (heartbeat) {
-        heartbeat = n.target(state, stepping);
 
         stepping().set_pos(stepping().pos() + state() * stepping().dir());
 
-        heartbeat = n.status(state, stepping);
+        heartbeat = n.update(state, stepping);
 
         // Record volume
         volume_records[gid].push_back(state.volume());

--- a/tests/unit_tests/cuda/propagator_cuda.cpp
+++ b/tests/unit_tests/cuda/propagator_cuda.cpp
@@ -13,7 +13,10 @@
 #include "propagator_cuda_kernel.hpp"
 #include "vecmem/utils/cuda/copy.hpp"
 
-TEST(propagator_cuda, propagator) {
+class CudaPropagatorWithRkStepper
+    : public ::testing::TestWithParam<__plugin::vector3<scalar>> {};
+
+TEST_P(CudaPropagatorWithRkStepper, propagator) {
 
     // Helper object for performing memory copies.
     vecmem::cuda::copy copy;
@@ -64,7 +67,7 @@ TEST(propagator_cuda, propagator) {
      */
 
     // Set the magnetic field
-    const vector3 B{0, 0, 2 * unit_constants::T};
+    vector3 B = GetParam();
     field_type B_field(B);
 
     // Create RK stepper
@@ -91,9 +94,6 @@ TEST(propagator_cuda, propagator) {
 
         // push back the intersection record
         host_intersection_records.push_back(ti._intersections);
-
-        // Ensure that the tracks reach the end of the world
-        EXPECT_EQ(state._navigation.volume(), dindex_invalid);
     }
 
     /**
@@ -147,3 +147,23 @@ TEST(propagator_cuda, propagator) {
         }
     }
 }
+
+INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation1, CudaPropagatorWithRkStepper,
+                         ::testing::Values(__plugin::vector3<scalar>{
+                             0. * unit_constants::T, 0. * unit_constants::T,
+                             2. * unit_constants::T}));
+
+INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation2, CudaPropagatorWithRkStepper,
+                         ::testing::Values(__plugin::vector3<scalar>{
+                             0. * unit_constants::T, 1. * unit_constants::T,
+                             1. * unit_constants::T}));
+
+INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation3, CudaPropagatorWithRkStepper,
+                         ::testing::Values(__plugin::vector3<scalar>{
+                             1. * unit_constants::T, 0. * unit_constants::T,
+                             1. * unit_constants::T}));
+
+INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation4, CudaPropagatorWithRkStepper,
+                         ::testing::Values(__plugin::vector3<scalar>{
+                             1. * unit_constants::T, 1. * unit_constants::T,
+                             1. * unit_constants::T}));

--- a/tests/unit_tests/cuda/rk_stepper_cuda.cpp
+++ b/tests/unit_tests/cuda/rk_stepper_cuda.cpp
@@ -33,6 +33,7 @@ TEST(rk_stepper_cuda, rk_stepper) {
 
     // Define RK stepper
     rk_stepper_type rk(B);
+    nav_state n_state{};
 
     // Loops of theta values ]0,pi[
     for (unsigned int itheta = 0; itheta < theta_steps; ++itheta) {
@@ -62,16 +63,15 @@ TEST(rk_stepper_cuda, rk_stepper) {
 
         // Forward direction
         rk_stepper_type::state forward_state(traj);
-
         for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
-            rk.step(forward_state);
+            rk.step(forward_state, n_state);
         }
 
         // Backward direction
         traj.flip();
         rk_stepper_type::state backward_state(traj);
         for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
-            rk.step(backward_state);
+            rk.step(backward_state, n_state);
         }
 
         path_lengths.push_back(forward_state._path_accumulated +

--- a/tests/unit_tests/cuda/rk_stepper_cuda.cpp
+++ b/tests/unit_tests/cuda/rk_stepper_cuda.cpp
@@ -74,8 +74,9 @@ TEST(rk_stepper_cuda, rk_stepper) {
             rk.step(backward_state, n_state);
         }
 
-        path_lengths.push_back(forward_state._path_accumulated +
-                               backward_state._path_accumulated);
+        path_lengths.push_back(2 * path_limit -
+                               forward_state.dist_to_path_limit() -
+                               backward_state.dist_to_path_limit());
     }
 
     // Get tracks data

--- a/tests/unit_tests/cuda/rk_stepper_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/rk_stepper_cuda_kernel.cu
@@ -26,6 +26,7 @@ __global__ void rk_stepper_test_kernel(
 
     // Define RK stepper
     rk_stepper_type rk(B);
+    nav_state n_state{};
 
     // Get a track
     auto& traj = tracks.at(gid);
@@ -33,14 +34,14 @@ __global__ void rk_stepper_test_kernel(
     // Forward direction
     rk_stepper_type::state forward_state(traj);
     for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
-        rk.step(forward_state);
+        rk.step(forward_state, n_state);
     }
 
     // Backward direction
     traj.flip();
     rk_stepper_type::state backward_state(traj);
     for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
-        rk.step(backward_state);
+        rk.step(backward_state, n_state);
     }
 }
 

--- a/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
@@ -43,12 +43,14 @@ namespace detray {
 
 // dummy navigation struct
 struct nav_state {
-    scalar operator()() const { return 1. * unit_constants::mm; }
-    inline void set_full_trust() {}
-    inline void set_high_trust() {}
-    inline void set_fair_trust() {}
-    inline void set_no_trust() {}
-    inline bool abort() { return false; }
+    DETRAY_HOST_DEVICE scalar operator()() const {
+        return 1. * unit_constants::mm;
+    }
+    DETRAY_HOST_DEVICE inline void set_full_trust() {}
+    DETRAY_HOST_DEVICE inline void set_high_trust() {}
+    DETRAY_HOST_DEVICE inline void set_fair_trust() {}
+    DETRAY_HOST_DEVICE inline void set_no_trust() {}
+    DETRAY_HOST_DEVICE inline bool abort() { return false; }
 };
 
 // test function for Runge-Kutta stepper

--- a/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
@@ -37,6 +37,7 @@ constexpr unsigned int phi_steps = 100;
 constexpr unsigned int rk_steps = 100;
 
 constexpr scalar epsilon = 1e-5;
+constexpr scalar path_limit = 2 * unit_constants::m;
 
 namespace detray {
 

--- a/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
@@ -17,6 +17,7 @@
 #include "detray/plugins/algebra/vc_array_definitions.hpp"
 #endif
 
+#include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/field/constant_magnetic_field.hpp"
 #include "detray/tools/rk_stepper.hpp"

--- a/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
@@ -47,6 +47,7 @@ struct nav_state {
     inline void set_high_trust() {}
     inline void set_fair_trust() {}
     inline void set_no_trust() {}
+    inline bool abort() { return false; }
 };
 
 // test function for Runge-Kutta stepper

--- a/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
@@ -40,6 +40,15 @@ constexpr scalar epsilon = 1e-5;
 
 namespace detray {
 
+// dummy navigation struct
+struct nav_state {
+    scalar operator()() const { return 1. * unit_constants::mm; }
+    inline void set_full_trust() {}
+    inline void set_high_trust() {}
+    inline void set_fair_trust() {}
+    inline void set_no_trust() {}
+};
+
 // test function for Runge-Kutta stepper
 void rk_stepper_test(
     vecmem::data::vector_view<free_track_parameters>& tracks_data,


### PR DESCRIPTION
In this PR, the ```navigator``` and the ```stepper```s are adapted to use a fully ```trust_level``` based communication. The navigator's intersection cache is updated according to different trust levels, which are set by a stepper (or in general actor):
- ```no_trust```: full (re-)initialization of the volume ([discard everything] and intersect every surface in that volume). Needed at least in ```init()``` call of the navigator or when entering a new volume.
- ```high_trust```: The track state was probably only altered a little, so that we can still trust that the intersections in the cache are still ordered. In this case, we only update our current target.
- ```fair_trust```: The track state was altered a lot: Re-evaluate all present intersections and re-sort them. Then disregard all candidates that are not valid anymore.
Note, that in the last two trust levels, no new intersections are computed, so that the cache can become invalid altogether. In this case the navigator goes into ```no_trust``` automatically and re-initializes the volume. In general, this navigator is written for readability and correctness (or not, see below :)) and not for performance.

There were quite a few extra modifications in the steppers, which now set the distance to the next target at the beginning of every step, before the step size adjustment of the RK, discarding the previous step size. In cases where the magnetic field is not strictly aligned in z direction, the step size is additionally capped by a max step size to force a more fine-grained re-evaluation of the navigation state. This should probably be solved by a better heuristic when to go from ```high_trust``` to ```no_trust``` in the future. There are still a lot of non-working edge cases left, but together with the ```trust_level``` heuristics, I would like to address that in a future PR, since this one is already quite big.

The host side propagation is also now tested against a number of B-field configurations. Some trivial changes were made in the inspector while debugging and the navigator's unittest had to be adapted all over again. The execution speed of the propagation of the different algebra-plugins is now the same on my laptop, while also for me Eigen was previously the fastest.