### PR TITLE
Fix a bug in cuda navigator

### DIFF
--- a/core/include/detray/tools/line_stepper.hpp
+++ b/core/include/detray/tools/line_stepper.hpp
@@ -23,6 +23,7 @@ class line_stepper final : public base_stepper<track_t> {
     using base_type = base_stepper<track_t>;
 
     struct state : public base_type::state {
+        DETRAY_HOST_DEVICE
         state(track_t &t) : base_type::state(t) {}
 
         /// Accumulated path length

--- a/tests/unit_tests/cuda/navigator_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/navigator_cuda_kernel.cu
@@ -33,6 +33,7 @@ __global__ void navigator_test_kernel(
     navigator_device_t n(det);
 
     auto& traj = tracks.at(gid);
+    stepper_t stepper;
     stepper_t::state stepping(traj);
 
     navigator_device_t::state state(candidates.at(gid));
@@ -44,7 +45,7 @@ __global__ void navigator_test_kernel(
     bool heartbeat = n.init(state, stepping);
     while (heartbeat) {
 
-        stepping().set_pos(stepping().pos() + state() * stepping().dir());
+        heartbeat &= stepper.step(stepping, state);
 
         heartbeat = n.update(state, stepping);
 

--- a/tests/unit_tests/cuda/navigator_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/navigator_cuda_kernel.hpp
@@ -17,7 +17,7 @@
 #include "detray/plugins/algebra/vc_array_definitions.hpp"
 #endif
 
-#include "detray/tools/base_stepper.hpp"
+#include "detray/tools/line_stepper.hpp"
 #include "detray/tools/navigator.hpp"
 #include "tests/common/tools/create_toy_geometry.hpp"
 
@@ -32,7 +32,7 @@ using detector_device_t =
              vecmem::device_vector, vecmem::jagged_device_vector>;
 using navigator_host_t = navigator<detector_host_t>;
 using navigator_device_t = navigator<detector_device_t>;
-using stepper_t = base_stepper<free_track_parameters>;
+using stepper_t = line_stepper<free_track_parameters>;
 using nav_context = detector_host_t::context;
 
 // detector configuration


### PR DESCRIPTION
Currently, cuda navigator test is running in the infinite loop.
I fixed it by replacing `stepper::state::set_pos()` with `stepper::step()`