### PR TITLE
Ref: move intersection enum to own namespace

### DIFF
--- a/core/include/detray/intersection/concentric_cylinder_intersector.hpp
+++ b/core/include/detray/intersection/concentric_cylinder_intersector.hpp
@@ -25,6 +25,8 @@ struct unbound;
 template <template <typename, std::size_t> class array_t = darray>
 struct concentric_cylinder_intersector {
 
+    using intersection_t = line_plane_intersection;
+
     using transform3 = __plugin::transform3<detray::scalar>;
     using point3 = __plugin::point3<detray::scalar>;
     using vector3 = __plugin::vector3<detray::scalar>;
@@ -53,7 +55,7 @@ struct concentric_cylinder_intersector {
             std::is_same_v<typename mask_t::local_type, cylindrical2> or
                 std::is_same_v<typename mask_t::local_type, detray::unbound>,
             bool> = true>
-    DETRAY_HOST_DEVICE inline intersection intersect(
+    DETRAY_HOST_DEVICE inline intersection_t intersect(
         const transform3 &trf, const track_t &track, const mask_t &mask,
         const typename mask_t::mask_tolerance &tolerance =
             mask_t::within_epsilon) const {
@@ -83,7 +85,7 @@ struct concentric_cylinder_intersector {
             std::is_same_v<typename mask_t::local_type, cylindrical2> or
                 std::is_same_v<typename mask_t::local_type, detray::unbound>,
             bool> = true>
-    DETRAY_HOST_DEVICE inline intersection intersect(
+    DETRAY_HOST_DEVICE inline intersection_t intersect(
         const transform3 & /*trf*/, const point3 &ro, const vector3 &rd,
         const mask_t &mask, const dindex /*volume_index*/ = dindex_invalid,
         const typename mask_t::mask_tolerance & /*tolerance*/ =
@@ -132,19 +134,20 @@ struct concentric_cylinder_intersector {
                                     ? 1
                                     : 0);
             if (t01[0] > overstep_tolerance or t01[1] > overstep_tolerance) {
-                intersection is;
+                intersection_t is;
                 is.p3 = candidates[cindex];
                 is.path = t01[cindex];
 
                 is.p2 = point2{r * getter::phi(is.p3), is.p3[2]};
                 is.status = mask.template is_inside<local_frame>(is.p3);
                 scalar rdir = getter::perp(is.p3 + 0.1 * rd);
-                is.direction = rdir > r ? e_along : e_opposite;
+                is.direction = rdir > r ? intersection::direction::e_along
+                                        : intersection::direction::e_opposite;
                 is.link = mask.volume_link();
                 return is;
             }
         }
-        return intersection{};
+        return intersection_t{};
     }
 };
 

--- a/core/include/detray/intersection/concentric_cylinder_intersector.hpp
+++ b/core/include/detray/intersection/concentric_cylinder_intersector.hpp
@@ -25,7 +25,7 @@ struct unbound;
 template <template <typename, std::size_t> class array_t = darray>
 struct concentric_cylinder_intersector {
 
-    using intersection_t = line_plane_intersection;
+    using intersection_type = line_plane_intersection;
 
     using transform3 = __plugin::transform3<detray::scalar>;
     using point3 = __plugin::point3<detray::scalar>;
@@ -55,7 +55,7 @@ struct concentric_cylinder_intersector {
             std::is_same_v<typename mask_t::local_type, cylindrical2> or
                 std::is_same_v<typename mask_t::local_type, detray::unbound>,
             bool> = true>
-    DETRAY_HOST_DEVICE inline intersection_t intersect(
+    DETRAY_HOST_DEVICE inline intersection_type intersect(
         const transform3 &trf, const track_t &track, const mask_t &mask,
         const typename mask_t::mask_tolerance &tolerance =
             mask_t::within_epsilon) const {
@@ -85,7 +85,7 @@ struct concentric_cylinder_intersector {
             std::is_same_v<typename mask_t::local_type, cylindrical2> or
                 std::is_same_v<typename mask_t::local_type, detray::unbound>,
             bool> = true>
-    DETRAY_HOST_DEVICE inline intersection_t intersect(
+    DETRAY_HOST_DEVICE inline intersection_type intersect(
         const transform3 & /*trf*/, const point3 &ro, const vector3 &rd,
         const mask_t &mask, const dindex /*volume_index*/ = dindex_invalid,
         const typename mask_t::mask_tolerance & /*tolerance*/ =
@@ -134,7 +134,7 @@ struct concentric_cylinder_intersector {
                                     ? 1
                                     : 0);
             if (t01[0] > overstep_tolerance or t01[1] > overstep_tolerance) {
-                intersection_t is;
+                intersection_type is;
                 is.p3 = candidates[cindex];
                 is.path = t01[cindex];
 
@@ -147,7 +147,7 @@ struct concentric_cylinder_intersector {
                 return is;
             }
         }
-        return intersection_t{};
+        return intersection_type{};
     }
 };
 

--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -21,6 +21,8 @@ struct unbound;
  */
 struct cylinder_intersector {
 
+    using intersection_t = line_plane_intersection;
+
     using transform3 = __plugin::transform3<detray::scalar>;
     using point3 = __plugin::point3<detray::scalar>;
     using vector3 = __plugin::vector3<detray::scalar>;
@@ -48,7 +50,7 @@ struct cylinder_intersector {
             std::is_same_v<typename mask_t::local_type, cylindrical2> or
                 std::is_same_v<typename mask_t::local_type, detray::unbound>,
             bool> = true>
-    DETRAY_HOST_DEVICE inline intersection intersect(
+    DETRAY_HOST_DEVICE inline intersection_t intersect(
         const transform3 &trf, const track_t &track, const mask_t &mask,
         const typename mask_t::mask_tolerance tolerance =
             mask_t::within_epsilon) const {
@@ -79,7 +81,7 @@ struct cylinder_intersector {
             std::is_same_v<typename mask_t::local_type, cylindrical2> or
                 std::is_same_v<typename mask_t::local_type, detray::unbound>,
             bool> = true>
-    DETRAY_HOST_DEVICE inline intersection intersect(
+    DETRAY_HOST_DEVICE inline intersection_t intersect(
         const transform3 &trf, const point3 &ro, const vector3 &rd,
         const mask_t &mask,
         const typename mask_t::mask_tolerance tolerance =
@@ -106,7 +108,7 @@ struct cylinder_intersector {
             auto t01 = std::get<1>(qe_solution);
             scalar t = (t01[0] > overstep_tolerance) ? t01[0] : t01[1];
             if (t > overstep_tolerance) {
-                intersection is;
+                intersection_t is;
                 is.path = t;
                 is.p3 = ro + is.path * rd;
                 constexpr local_frame local_converter{};
@@ -115,12 +117,13 @@ struct cylinder_intersector {
                 is.status =
                     mask.template is_inside<local_frame>(local3, tolerance);
                 scalar rdr = getter::perp(local3 + 0.1 * rd);
-                is.direction = rdr > r ? e_along : e_opposite;
+                is.direction = rdr > r ? intersection::direction::e_along
+                                       : intersection::direction::e_opposite;
                 is.link = mask.volume_link();
                 return is;
             }
         }
-        return intersection{};
+        return intersection_t{};
     }
 };
 

--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -21,7 +21,7 @@ struct unbound;
  */
 struct cylinder_intersector {
 
-    using intersection_t = line_plane_intersection;
+    using intersection_type = line_plane_intersection;
 
     using transform3 = __plugin::transform3<detray::scalar>;
     using point3 = __plugin::point3<detray::scalar>;
@@ -50,7 +50,7 @@ struct cylinder_intersector {
             std::is_same_v<typename mask_t::local_type, cylindrical2> or
                 std::is_same_v<typename mask_t::local_type, detray::unbound>,
             bool> = true>
-    DETRAY_HOST_DEVICE inline intersection_t intersect(
+    DETRAY_HOST_DEVICE inline intersection_type intersect(
         const transform3 &trf, const track_t &track, const mask_t &mask,
         const typename mask_t::mask_tolerance tolerance =
             mask_t::within_epsilon) const {
@@ -81,7 +81,7 @@ struct cylinder_intersector {
             std::is_same_v<typename mask_t::local_type, cylindrical2> or
                 std::is_same_v<typename mask_t::local_type, detray::unbound>,
             bool> = true>
-    DETRAY_HOST_DEVICE inline intersection_t intersect(
+    DETRAY_HOST_DEVICE inline intersection_type intersect(
         const transform3 &trf, const point3 &ro, const vector3 &rd,
         const mask_t &mask,
         const typename mask_t::mask_tolerance tolerance =
@@ -108,7 +108,7 @@ struct cylinder_intersector {
             auto t01 = std::get<1>(qe_solution);
             scalar t = (t01[0] > overstep_tolerance) ? t01[0] : t01[1];
             if (t > overstep_tolerance) {
-                intersection_t is;
+                intersection_type is;
                 is.path = t;
                 is.p3 = ro + is.path * rd;
                 constexpr local_frame local_converter{};
@@ -123,7 +123,7 @@ struct cylinder_intersector {
                 return is;
             }
         }
-        return intersection_t{};
+        return intersection_type{};
     }
 };
 

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -18,22 +18,26 @@ using point3 = __plugin::point3<detray::scalar>;
 using vector3 = __plugin::vector3<detray::scalar>;
 using point2 = __plugin::point2<detray::scalar>;
 
+namespace intersection {
+
 /** Intersection direction with respect to the
  *  normal of the surface
  */
-enum intersection_direction : int {
+enum class direction {
     e_undefined = -1,  //!< the undefined direction at intersection
     e_opposite = 0,    //!< opposite the surface normal at the intersection
     e_along = 1        //!< along the surface normal at the intersection
 };
 
 /** Intersection status: outside, missed, inside, hit ( w/o maks status) */
-enum intersection_status : int {
+enum class status {
     e_outside = -1,  //!< surface hit but outside
     e_missed = 0,    //!< surface missed
     e_hit = 1,       //!< surface hit but status not checked
     e_inside = 2     //!< surface hit and inside confirmed
 };
+
+}  // namespace intersection
 
 /** This templated class holds the intersection information
  *
@@ -41,7 +45,7 @@ enum intersection_status : int {
  * @tparam point2 is the type of the local intersection vector
  *
  **/
-struct intersection {
+struct line_plane_intersection {
 
     scalar path = std::numeric_limits<scalar>::infinity();
     point3 p3 = point3{std::numeric_limits<scalar>::infinity(),
@@ -50,8 +54,10 @@ struct intersection {
 
     point2 p2 = {std::numeric_limits<scalar>::infinity(),
                  std::numeric_limits<scalar>::infinity()};
-    intersection_status status = e_missed;
-    intersection_direction direction = e_undefined;
+
+    intersection::status status = intersection::status::e_missed;
+    intersection::direction direction = intersection::direction::e_undefined;
+
     // Primitive this intersection belongs to
     dindex index = dindex_invalid;
     // Navigation information
@@ -60,17 +66,21 @@ struct intersection {
     /** @param rhs is the right hand side intersection for comparison
      **/
     DETRAY_HOST_DEVICE
-    bool operator<(const intersection &rhs) const { return (path < rhs.path); }
+    bool operator<(const line_plane_intersection &rhs) const {
+        return (path < rhs.path);
+    }
 
     /** @param rhs is the left hand side intersection for comparison
      **/
     DETRAY_HOST_DEVICE
-    bool operator>(const intersection &rhs) const { return (path > rhs.path); }
+    bool operator>(const line_plane_intersection &rhs) const {
+        return (path > rhs.path);
+    }
 
     /** @param rhs is the left hand side intersection for comparison
      **/
     DETRAY_HOST_DEVICE
-    bool operator==(const intersection &rhs) const {
+    bool operator==(const line_plane_intersection &rhs) const {
         return (path == rhs.path);
     }
 
@@ -82,27 +92,27 @@ struct intersection {
         out_stream << "dist:" << path << " [r:" << r << ", z:" << p3[2]
                    << "], (index:" << index << ", links to:" << link << ")";
         switch (status) {
-            case e_outside:
+            case intersection::status::e_outside:
                 out_stream << ", status: outside";
                 break;
-            case e_missed:
+            case intersection::status::e_missed:
                 out_stream << ", status: missed";
                 break;
-            case e_hit:
+            case intersection::status::e_hit:
                 out_stream << ", status: hit";
                 break;
-            case e_inside:
+            case intersection::status::e_inside:
                 out_stream << ", status: inside";
                 break;
         };
         switch (direction) {
-            case e_undefined:
+            case intersection::direction::e_undefined:
                 out_stream << ", direction: undefined";
                 break;
-            case e_opposite:
+            case intersection::direction::e_opposite:
                 out_stream << ", direction: opposite";
                 break;
-            case e_along:
+            case intersection::direction::e_along:
                 out_stream << ", direction: along";
                 break;
         };

--- a/core/include/detray/intersection/intersection_kernel.hpp
+++ b/core/include/detray/intersection/intersection_kernel.hpp
@@ -59,7 +59,7 @@ DETRAY_HOST_DEVICE inline auto unroll_intersect(
             auto sfi =
                 std::move(mask.intersector().intersect(ctf, track, mask));
 
-            if (sfi.status == e_inside) {
+            if (sfi.status == intersection::status::e_inside) {
                 sfi.index = volume_index;
                 return sfi;
             }
@@ -76,7 +76,7 @@ DETRAY_HOST_DEVICE inline auto unroll_intersect(
     }
 
     // No intersection was found
-    return intersection{};
+    return line_plane_intersection{};
 }
 
 /** Kernel method that updates the intersections

--- a/core/include/detray/intersection/planar_intersector.hpp
+++ b/core/include/detray/intersection/planar_intersector.hpp
@@ -18,7 +18,7 @@ namespace detray {
  */
 struct planar_intersector {
 
-    using intersection_t = line_plane_intersection;
+    using intersection_type = line_plane_intersection;
 
     using transform3 = __plugin::transform3<detray::scalar>;
     using point3 = __plugin::point3<detray::scalar>;
@@ -45,7 +45,7 @@ struct planar_intersector {
     template <typename track_t, typename mask_t,
               std::enable_if_t<std::is_class_v<typename mask_t::local_type>,
                                bool> = true>
-    DETRAY_HOST_DEVICE inline intersection_t intersect(
+    DETRAY_HOST_DEVICE inline intersection_type intersect(
         const transform3 &trf, const track_t &track, const mask_t &mask,
         const typename mask_t::mask_tolerance tolerance =
             mask_t::within_epsilon) const {
@@ -72,7 +72,7 @@ struct planar_intersector {
     template <typename mask_t,
               std::enable_if_t<std::is_class_v<typename mask_t::local_type>,
                                bool> = true>
-    DETRAY_HOST_DEVICE inline intersection_t intersect(
+    DETRAY_HOST_DEVICE inline intersection_type intersect(
         const transform3 &trf, const point3 &ro, const vector3 &rd,
         const mask_t &mask,
         const typename mask_t::mask_tolerance tolerance =
@@ -89,7 +89,7 @@ struct planar_intersector {
         // Intersection code
         scalar denom = vector::dot(rd, sn);
         if (denom != 0.0) {
-            intersection_t is;
+            intersection_type is;
             is.path = vector::dot(sn, st - ro) / denom;
             is.p3 = ro + is.path * rd;
             constexpr local_frame local_converter{};
@@ -101,7 +101,7 @@ struct planar_intersector {
             is.link = mask.volume_link();
             return is;
         }
-        return intersection_t{};
+        return intersection_type{};
     }
 };
 

--- a/core/include/detray/masks/annulus2.hpp
+++ b/core/include/detray/masks/annulus2.hpp
@@ -109,8 +109,8 @@ struct annulus2 {
      * @return an intersection status e_inside / e_outside
      **/
     template <typename inside_local_t>
-    DETRAY_HOST_DEVICE intersection_status
-    is_inside(const point2 &p, const mask_tolerance t = within_epsilon) const {
+    DETRAY_HOST_DEVICE intersection::status is_inside(
+        const point2 &p, const mask_tolerance t = within_epsilon) const {
         // The two quantities to check: r^2 in module system, phi in strips
         // system
 
@@ -127,14 +127,14 @@ struct annulus2 {
             scalar maxR_tol = _values[1] + t[0];
 
             if (r_mod2 < minR_tol * minR_tol or r_mod2 > maxR_tol * maxR_tol)
-                return e_outside;
+                return intersection::status::e_outside;
 
             scalar phi_strp = getter::phi(p) - _values[6];
             // Check phi boundaries, which are well def. in local frame
             return (phi_strp >= _values[2] - t[1] and
                     phi_strp <= _values[3] + t[1])
-                       ? e_inside
-                       : e_outside;
+                       ? intersection::status::e_inside
+                       : intersection::status::e_outside;
         }
         // polar strip coordinates given
         else {
@@ -143,7 +143,7 @@ struct annulus2 {
 
             // Check phi boundaries, which are well def. in local frame
             if (phi_strp < _values[2] - t[1] || phi_strp > _values[3] + t[1])
-                return e_outside;
+                return intersection::status::e_outside;
 
             // Now go to module frame to check r boundaries. Use the origin
             // shift in polar coordinates for that
@@ -160,8 +160,8 @@ struct annulus2 {
 
             return (r_mod2 >= minR_tol * minR_tol and
                     r_mod2 <= maxR_tol * maxR_tol)
-                       ? e_inside
-                       : e_outside;
+                       ? intersection::status::e_inside
+                       : intersection::status::e_outside;
         }
     }
 

--- a/core/include/detray/masks/cylinder3.hpp
+++ b/core/include/detray/masks/cylinder3.hpp
@@ -92,18 +92,18 @@ struct cylinder3 {
      * @return an intersection status e_inside / e_outside
      **/
     template <typename inside_local_t>
-    DETRAY_HOST_DEVICE intersection_status
-    is_inside(const point3 &p, const mask_tolerance t = within_epsilon) const {
+    DETRAY_HOST_DEVICE intersection::status is_inside(
+        const point3 &p, const mask_tolerance t = within_epsilon) const {
         if constexpr (kRadialCheck) {
             scalar r = getter::perp(p);
             if (std::abs(r - _values[0]) >=
                 t[0] + 5 * std::numeric_limits<scalar>::epsilon()) {
-                return e_missed;
+                return intersection::status::e_missed;
             }
         }
         return (_values[1] - t[1] <= p[2] and p[2] <= _values[2] + t[1])
-                   ? e_inside
-                   : e_outside;
+                   ? intersection::status::e_inside
+                   : intersection::status::e_outside;
     }
 
     /** Equality operator from an array, convenience function

--- a/core/include/detray/masks/rectangle2.hpp
+++ b/core/include/detray/masks/rectangle2.hpp
@@ -85,12 +85,12 @@ struct rectangle2 {
      * @return an intersection status e_inside / e_outside
      **/
     template <typename inside_local_t>
-    DETRAY_HOST_DEVICE intersection_status
-    is_inside(const point2 &p, const mask_tolerance t = within_epsilon) const {
+    DETRAY_HOST_DEVICE intersection::status is_inside(
+        const point2 &p, const mask_tolerance t = within_epsilon) const {
         return (std::abs(p[0]) <= _values[0] + t[0] and
                 std::abs(p[1]) <= _values[1] + t[1])
-                   ? e_inside
-                   : e_outside;
+                   ? intersection::status::e_inside
+                   : intersection::status::e_outside;
     }
 
     /** Equality operator from an array, convenience function

--- a/core/include/detray/masks/ring2.hpp
+++ b/core/include/detray/masks/ring2.hpp
@@ -82,17 +82,19 @@ struct ring2 {
      * @return an intersection status e_inside / e_outside
      **/
     template <typename inside_local_t>
-    DETRAY_HOST_DEVICE intersection_status
-    is_inside(const point2 &p, const mask_tolerance t = within_epsilon) const {
+    DETRAY_HOST_DEVICE intersection::status is_inside(
+        const point2 &p, const mask_tolerance t = within_epsilon) const {
         if constexpr (std::is_same_v<inside_local_t,
                                      __plugin::cartesian2<detray::scalar>>) {
             scalar r = getter::perp(p);
-            return (r + t >= _values[0] and r <= _values[1] + t) ? e_inside
-                                                                 : e_outside;
+            return (r + t >= _values[0] and r <= _values[1] + t)
+                       ? intersection::status::e_inside
+                       : intersection::status::e_outside;
         }
 
-        return (p[0] + t >= _values[0] and p[0] <= _values[1] + t) ? e_inside
-                                                                   : e_outside;
+        return (p[0] + t >= _values[0] and p[0] <= _values[1] + t)
+                   ? intersection::status::e_inside
+                   : intersection::status::e_outside;
     }
 
     /** Equality operator from an array, convenience function

--- a/core/include/detray/masks/single3.hpp
+++ b/core/include/detray/masks/single3.hpp
@@ -73,12 +73,12 @@ struct single3 {
      * @return an intersection status e_inside / e_outside
      **/
     template <typename inside_local_t>
-    DETRAY_HOST_DEVICE intersection_status
-    is_inside(const point3 &p, const mask_tolerance t = within_epsilon) const {
+    DETRAY_HOST_DEVICE intersection::status is_inside(
+        const point3 &p, const mask_tolerance t = within_epsilon) const {
         return (_values[0] - t <= p[kCheckIndex] and
                 p[kCheckIndex] <= _values[1] + t)
-                   ? e_inside
-                   : e_outside;
+                   ? intersection::status::e_inside
+                   : intersection::status::e_outside;
     }
 
     /** Equality operator from an array, convenience function

--- a/core/include/detray/masks/trapezoid2.hpp
+++ b/core/include/detray/masks/trapezoid2.hpp
@@ -92,14 +92,14 @@ struct trapezoid2 {
      * @return an intersection status e_inside / e_outside
      **/
     template <typename inside_local_t>
-    DETRAY_HOST_DEVICE intersection_status
-    is_inside(const point2 &p, const mask_tolerance t = within_epsilon) const {
+    DETRAY_HOST_DEVICE intersection::status is_inside(
+        const point2 &p, const mask_tolerance t = within_epsilon) const {
         scalar rel_y = (_values[2] + p[1]) * _values[3];
         return (std::abs(p[0]) <=
                     _values[0] + rel_y * (_values[1] - _values[0]) + t[0] and
                 std::abs(p[1]) <= _values[2] + t[1])
-                   ? e_inside
-                   : e_outside;
+                   ? intersection::status::e_inside
+                   : intersection::status::e_outside;
     }
 
     /** Equality operator from an array, convenience function

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -43,10 +43,11 @@ struct unmasked {
      * @return an intersection status e_inside / e_outside
      **/
     template <typename local_t>
-    DETRAY_HOST_DEVICE inline intersection_status is_inside(
+    DETRAY_HOST_DEVICE inline intersection::status is_inside(
         const point2 & /*ignored*/,
         const mask_tolerance &t = within_epsilon) const {
-        return t ? e_inside : e_outside;
+        return t ? intersection::status::e_inside
+                 : intersection::status::e_outside;
     }
 
     /** Mask operation

--- a/core/include/detray/propagator/navigator.hpp
+++ b/core/include/detray/propagator/navigator.hpp
@@ -77,6 +77,7 @@ template <typename detector_t,
 class navigator {
 
     public:
+    using intersection_t = line_plane_intersection;
     using inspector_type = inspector_t;
     using detector_type = detector_t;
     using volume_type = typename detector_t::volume_type;
@@ -92,7 +93,7 @@ class navigator {
     class state {
         friend class navigator;
 
-        using candidate_itr_t = typename vector_type<intersection>::iterator;
+        using candidate_itr_t = typename vector_type<intersection_t>::iterator;
 
         public:
         /** Default constructor
@@ -106,7 +107,7 @@ class navigator {
 
         /** Constructor from candidates vector_view
          **/
-        DETRAY_HOST_DEVICE state(vector_type<intersection> candidates)
+        DETRAY_HOST_DEVICE state(vector_type<intersection_t> candidates)
             : _candidates(candidates) {}
 
         /** Scalar representation of the navigation state,
@@ -117,13 +118,13 @@ class navigator {
 
         /** @returns current candidates - const */
         DETRAY_HOST_DEVICE
-        inline auto candidates() const -> const vector_type<intersection> & {
+        inline auto candidates() const -> const vector_type<intersection_t> & {
             return _candidates;
         }
 
         /** @returns current candidates */
         DETRAY_HOST_DEVICE
-        inline auto candidates() -> vector_type<intersection> & {
+        inline auto candidates() -> vector_type<intersection_t> & {
             return _candidates;
         }
 
@@ -251,7 +252,8 @@ class navigator {
         /** Helper method to check if a kernel is exhausted - const */
         template <typename track_t>
         DETRAY_HOST_DEVICE inline auto is_on_object(
-            const track_t &track, const intersection &candidate) const -> bool {
+            const track_t &track, const intersection_t &candidate) const
+            -> bool {
             if ((candidate.path < _on_object_tolerance) and
                 (candidate.path > track.overstep_tolerance())) {
                 return true;
@@ -308,7 +310,7 @@ class navigator {
 
         private:
         /// Our list of candidates (intersections with object)
-        vector_type<intersection> _candidates = {};
+        vector_type<intersection_t> _candidates = {};
 
         /// The next best candidate
         candidate_itr_t _next = _candidates.end();
@@ -460,7 +462,7 @@ class navigator {
             navigation.candidates().size() == 1) {
             while (not navigation.is_exhausted()) {
 
-                intersection &candidate = *navigation.next();
+                intersection_t &candidate = *navigation.next();
                 update_candidate(track, candidate);
 
                 // This is likely the next target
@@ -624,7 +626,7 @@ class navigator {
      */
     template <typename track_t>
     DETRAY_HOST_DEVICE inline void update_candidate(
-        const track_t &track, intersection &candidate) const {
+        const track_t &track, intersection_t &candidate) const {
         const dindex obj_idx = candidate.index;
         candidate =
             intersect(track, _detector->surface_by_index(obj_idx),
@@ -640,7 +642,7 @@ class navigator {
      * @param candidate the candidate to be invalidated
      */
     DETRAY_HOST_DEVICE
-    inline void invalidate_candidate(intersection &candidate) const {
+    inline void invalidate_candidate(intersection_t &candidate) const {
         candidate.path = std::numeric_limits<scalar>::max();
     }
 
@@ -650,9 +652,9 @@ class navigator {
      * @returns true if is reachable by track
      */
     template <typename track_t>
-    DETRAY_HOST_DEVICE inline bool is_reachable(intersection &candidate,
+    DETRAY_HOST_DEVICE inline bool is_reachable(intersection_t &candidate,
                                                 track_t &track) const {
-        return candidate.status == e_inside and
+        return candidate.status == intersection::status::e_inside and
                candidate.path >= track.overstep_tolerance() and
                candidate.path < std::numeric_limits<scalar>::max();
     }
@@ -664,7 +666,7 @@ class navigator {
     template <typename cache_t>
     DETRAY_HOST_DEVICE inline auto find_invalid(cache_t &candidates) const {
         // Member functions cannot be used here easily (?)
-        auto not_reachable = [](intersection &candidate) {
+        auto not_reachable = [](intersection_t &candidate) {
             return candidate.path == std::numeric_limits<scalar>::max();
         };
 
@@ -681,11 +683,11 @@ class navigator {
     // candidates size allocation. With the local navigation, the size can be
     // restricted to much smaller value
     DETRAY_HOST
-    vecmem::data::jagged_vector_buffer<intersection> create_candidates_buffer(
+    vecmem::data::jagged_vector_buffer<intersection_t> create_candidates_buffer(
         const unsigned int n_tracks,
         vecmem::memory_resource &device_resource) const {
 
-        return vecmem::data::jagged_vector_buffer<intersection>(
+        return vecmem::data::jagged_vector_buffer<intersection_t>(
             std::vector<std::size_t>(n_tracks, 0),
             std::vector<std::size_t>(n_tracks,
                                      _detector->get_n_max_objects_per_volume()),
@@ -702,10 +704,10 @@ class navigator {
 // candidates size allocation. With the local navigation, the size can be
 // restricted to much smaller value
 template <typename detector_t>
-DETRAY_HOST vecmem::data::jagged_vector_buffer<intersection>
+DETRAY_HOST vecmem::data::jagged_vector_buffer<line_plane_intersection>
 create_candidates_buffer(const detector_t &det, const unsigned int n_tracks,
                          vecmem::memory_resource &device_resource) {
-    return vecmem::data::jagged_vector_buffer<intersection>(
+    return vecmem::data::jagged_vector_buffer<line_plane_intersection>(
         std::vector<std::size_t>(n_tracks, 0),
         std::vector<std::size_t>(n_tracks, det.get_n_max_objects_per_volume()),
         device_resource, det.resource());

--- a/core/include/detray/propagator/navigator.hpp
+++ b/core/include/detray/propagator/navigator.hpp
@@ -77,7 +77,7 @@ template <typename detector_t,
 class navigator {
 
     public:
-    using intersection_t = line_plane_intersection;
+    using intersection_type = line_plane_intersection;
     using inspector_type = inspector_t;
     using detector_type = detector_t;
     using volume_type = typename detector_t::volume_type;
@@ -93,7 +93,8 @@ class navigator {
     class state {
         friend class navigator;
 
-        using candidate_itr_t = typename vector_type<intersection_t>::iterator;
+        using candidate_itr_t =
+            typename vector_type<intersection_type>::iterator;
 
         public:
         /** Default constructor
@@ -107,7 +108,7 @@ class navigator {
 
         /** Constructor from candidates vector_view
          **/
-        DETRAY_HOST_DEVICE state(vector_type<intersection_t> candidates)
+        DETRAY_HOST_DEVICE state(vector_type<intersection_type> candidates)
             : _candidates(candidates) {}
 
         /** Scalar representation of the navigation state,
@@ -118,13 +119,14 @@ class navigator {
 
         /** @returns current candidates - const */
         DETRAY_HOST_DEVICE
-        inline auto candidates() const -> const vector_type<intersection_t> & {
+        inline auto candidates() const
+            -> const vector_type<intersection_type> & {
             return _candidates;
         }
 
         /** @returns current candidates */
         DETRAY_HOST_DEVICE
-        inline auto candidates() -> vector_type<intersection_t> & {
+        inline auto candidates() -> vector_type<intersection_type> & {
             return _candidates;
         }
 
@@ -252,7 +254,7 @@ class navigator {
         /** Helper method to check if a kernel is exhausted - const */
         template <typename track_t>
         DETRAY_HOST_DEVICE inline auto is_on_object(
-            const track_t &track, const intersection_t &candidate) const
+            const track_t &track, const intersection_type &candidate) const
             -> bool {
             if ((candidate.path < _on_object_tolerance) and
                 (candidate.path > track.overstep_tolerance())) {
@@ -310,7 +312,7 @@ class navigator {
 
         private:
         /// Our list of candidates (intersections with object)
-        vector_type<intersection_t> _candidates = {};
+        vector_type<intersection_type> _candidates = {};
 
         /// The next best candidate
         candidate_itr_t _next = _candidates.end();
@@ -462,7 +464,7 @@ class navigator {
             navigation.candidates().size() == 1) {
             while (not navigation.is_exhausted()) {
 
-                intersection_t &candidate = *navigation.next();
+                intersection_type &candidate = *navigation.next();
                 update_candidate(track, candidate);
 
                 // This is likely the next target
@@ -626,7 +628,7 @@ class navigator {
      */
     template <typename track_t>
     DETRAY_HOST_DEVICE inline void update_candidate(
-        const track_t &track, intersection_t &candidate) const {
+        const track_t &track, intersection_type &candidate) const {
         const dindex obj_idx = candidate.index;
         candidate =
             intersect(track, _detector->surface_by_index(obj_idx),
@@ -642,7 +644,7 @@ class navigator {
      * @param candidate the candidate to be invalidated
      */
     DETRAY_HOST_DEVICE
-    inline void invalidate_candidate(intersection_t &candidate) const {
+    inline void invalidate_candidate(intersection_type &candidate) const {
         candidate.path = std::numeric_limits<scalar>::max();
     }
 
@@ -652,7 +654,7 @@ class navigator {
      * @returns true if is reachable by track
      */
     template <typename track_t>
-    DETRAY_HOST_DEVICE inline bool is_reachable(intersection_t &candidate,
+    DETRAY_HOST_DEVICE inline bool is_reachable(intersection_type &candidate,
                                                 track_t &track) const {
         return candidate.status == intersection::status::e_inside and
                candidate.path >= track.overstep_tolerance() and
@@ -666,7 +668,7 @@ class navigator {
     template <typename cache_t>
     DETRAY_HOST_DEVICE inline auto find_invalid(cache_t &candidates) const {
         // Member functions cannot be used here easily (?)
-        auto not_reachable = [](intersection_t &candidate) {
+        auto not_reachable = [](intersection_type &candidate) {
             return candidate.path == std::numeric_limits<scalar>::max();
         };
 
@@ -683,11 +685,11 @@ class navigator {
     // candidates size allocation. With the local navigation, the size can be
     // restricted to much smaller value
     DETRAY_HOST
-    vecmem::data::jagged_vector_buffer<intersection_t> create_candidates_buffer(
-        const unsigned int n_tracks,
-        vecmem::memory_resource &device_resource) const {
+    vecmem::data::jagged_vector_buffer<intersection_type>
+    create_candidates_buffer(const unsigned int n_tracks,
+                             vecmem::memory_resource &device_resource) const {
 
-        return vecmem::data::jagged_vector_buffer<intersection_t>(
+        return vecmem::data::jagged_vector_buffer<intersection_type>(
             std::vector<std::size_t>(n_tracks, 0),
             std::vector<std::size_t>(n_tracks,
                                      _detector->get_n_max_objects_per_volume()),

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -20,7 +20,7 @@ struct void_inspector {
 
     /** void operator **/
     template <typename... args>
-    DETRAY_HOST_DEVICE void operator()(const args &.../*ignored*/) {
+    DETRAY_HOST_DEVICE void operator()(const args &... /*ignored*/) {
         return;
     }
 };

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -20,7 +20,7 @@ struct void_inspector {
 
     /** void operator **/
     template <typename... args>
-    DETRAY_HOST_DEVICE void operator()(const args &... /*ignored*/) {
+    DETRAY_HOST_DEVICE void operator()(const args &.../*ignored*/) {
         return;
     }
 };
@@ -59,8 +59,8 @@ struct propagator {
     struct state {
 
         template <typename track_t>
-        DETRAY_HOST_DEVICE state(track_t &t_in,
-                                 vector_type<intersection> candidates = {})
+        DETRAY_HOST_DEVICE state(
+            track_t &t_in, vector_type<line_plane_intersection> candidates = {})
             : _stepping(t_in), _navigation(candidates) {}
 
         typename stepper_t::state _stepping;

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
@@ -13,13 +13,13 @@ namespace detray {
 __global__ void propagator_benchmark_kernel(
     detector_view<detector_host_type> det_data,
     vecmem::data::vector_view<free_track_parameters> tracks_data,
-    vecmem::data::jagged_vector_view<intersection> candidates_data) {
+    vecmem::data::jagged_vector_view<intersection_t> candidates_data) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
 
     detector_device_type det(det_data);
     vecmem::device_vector<free_track_parameters> tracks(tracks_data);
-    vecmem::jagged_device_vector<intersection> candidates(candidates_data);
+    vecmem::jagged_device_vector<intersection_t> candidates(candidates_data);
 
     if (gid >= tracks.size()) {
         return;
@@ -50,7 +50,7 @@ __global__ void propagator_benchmark_kernel(
 void propagator_benchmark(
     detector_view<detector_host_type> det_data,
     vecmem::data::vector_view<free_track_parameters>& tracks_data,
-    vecmem::data::jagged_vector_view<intersection>& candidates_data) {
+    vecmem::data::jagged_vector_view<intersection_t>& candidates_data) {
 
     constexpr int thread_dim = 2 * WARP_SIZE;
     int block_dim = tracks_data.size() / thread_dim + 1;

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
@@ -27,6 +27,8 @@
 
 using namespace detray;
 
+using intersection_t = line_plane_intersection;
+
 using detector_host_type =
     detector<detector_registry::toy_detector, darray, thrust::tuple,
              vecmem::vector, vecmem::jagged_vector>;
@@ -50,6 +52,6 @@ namespace detray {
 void propagator_benchmark(
     detector_view<detector_host_type> det_data,
     vecmem::data::vector_view<free_track_parameters>& tracks_data,
-    vecmem::data::jagged_vector_view<intersection>& candidates_data);
+    vecmem::data::jagged_vector_view<intersection_t>& candidates_data);
 
 }  // namespace detray

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -86,7 +86,7 @@ static void BM_INTERSECT_ALL(benchmark::State &state) {
 
                         benchmark::DoNotOptimize(hits);
                         benchmark::DoNotOptimize(missed);
-                        if (sfi.status == intersection_status::e_inside) {
+                        if (sfi.status == intersection::status::e_inside) {
                             /* state.PauseTiming();
                             if (stream_file)
                             {

--- a/tests/common/include/tests/common/benchmark_intersect_surfaces.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_surfaces.inl
@@ -76,7 +76,7 @@ static void BM_INTERSECT_PLANES(benchmark::State &state) {
 
                     benchmark::DoNotOptimize(sfhit);
                     benchmark::DoNotOptimize(sfmiss);
-                    if (is.status == e_inside) {
+                    if (is.status == intersection::status::e_inside) {
                         ++sfhit;
                     } else {
                         ++sfmiss;
@@ -141,7 +141,7 @@ static void BM_INTERSECT_CYLINDERS(benchmark::State &state) {
 
                     benchmark::DoNotOptimize(sfhit);
                     benchmark::DoNotOptimize(sfmiss);
-                    if (is.status == e_inside) {
+                    if (is.status == intersection::status::e_inside) {
                         ++sfhit;
                     } else {
                         ++sfmiss;
@@ -202,7 +202,7 @@ static void BM_INTERSECT_CONCETRIC_CYLINDERS(benchmark::State &state) {
 
                     benchmark::DoNotOptimize(sfhit);
                     benchmark::DoNotOptimize(sfmiss);
-                    if (is.status == e_inside) {
+                    if (is.status == intersection::status::e_inside) {
                         ++sfhit;
                     } else {
                         ++sfmiss;

--- a/tests/common/include/tests/common/benchmark_masks.inl
+++ b/tests/common/include/tests/common/benchmark_masks.inl
@@ -61,7 +61,8 @@ static void BM_RECTANGLE2_MASK(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(inside);
                 benchmark::DoNotOptimize(outside);
-                if (r.is_inside<local_type>(point2{x, y}) == e_inside) {
+                if (r.is_inside<local_type>(point2{x, y}) ==
+                    intersection::status::e_inside) {
                     ++inside;
                 } else {
                     ++outside;
@@ -103,7 +104,8 @@ static void BM_TRAPEZOID2_MASK(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(inside);
                 benchmark::DoNotOptimize(outside);
-                if (t.is_inside<local_type>(point2{x, y}) == e_inside) {
+                if (t.is_inside<local_type>(point2{x, y}) ==
+                    intersection::status::e_inside) {
                     ++inside;
                 } else {
                     ++outside;
@@ -145,7 +147,8 @@ static void BM_RING2_MASK(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(inside);
                 benchmark::DoNotOptimize(outside);
-                if (r.is_inside<local_type>(point2{x, y}) == e_inside) {
+                if (r.is_inside<local_type>(point2{x, y}) ==
+                    intersection::status::e_inside) {
                     ++inside;
                 } else {
                     ++outside;
@@ -186,7 +189,8 @@ static void BM_DISC2_MASK(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(inside);
                 benchmark::DoNotOptimize(outside);
-                if (r.is_inside<local_type>(point2{x, y}) == e_inside) {
+                if (r.is_inside<local_type>(point2{x, y}) ==
+                    intersection::status::e_inside) {
                     ++inside;
                 } else {
                     ++outside;
@@ -230,7 +234,7 @@ static void BM_CYLINDER3_MASK(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     if (c.is_inside<local_type>(point3{x, y, z}, {0.1, 0.}) ==
-                        e_inside) {
+                        intersection::status::e_inside) {
                         ++inside;
                     } else {
                         ++outside;
@@ -270,7 +274,8 @@ static void BM_ANNULUS_MASK(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(inside);
                 benchmark::DoNotOptimize(outside);
-                if (ann.is_inside<local_type>(point2{x, y}) == e_inside) {
+                if (ann.is_inside<local_type>(point2{x, y}) ==
+                    intersection::status::e_inside) {
                     ++inside;
                 } else {
                     ++outside;

--- a/tests/common/include/tests/common/masks_annulus2.inl
+++ b/tests/common/include/tests/common/masks_annulus2.inl
@@ -49,34 +49,34 @@ TEST(mask, annulus2) {
     ASSERT_EQ(ann2[6], static_cast<scalar>(0.));
 
     ASSERT_TRUE(ann2.is_inside<cartesian>(p2_in + offset) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out1 + offset) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out2 + offset) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out3 + offset) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out4 + offset) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     // Move outside point inside using a tolerance
     ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out1 + offset, {1.3, 0.}) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out4 + offset, {0., 0.07}) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
 
     ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_in)) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out1)) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out2)) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out3)) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out4)) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     // Move outside point inside using a tolerance
     ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out1), {1.3, 0.}) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out4), {0., 0.07}) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_cylinder3.inl
+++ b/tests/common/include/tests/common/masks_cylinder3.inl
@@ -33,14 +33,14 @@ TEST(mask, cylinder3) {
     ASSERT_EQ(c[2], hz);
 
     ASSERT_TRUE(c.is_inside<local_type>(p3_in) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(c.is_inside<local_type>(p3_edge) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(c.is_inside<local_type>(p3_out) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     ASSERT_TRUE(c.is_inside<local_type>(p3_off) ==
-                intersection_status::e_missed);
+                intersection::status::e_missed);
     // Move outside point inside using a tolerance
     ASSERT_TRUE(c.is_inside<local_type>(p3_out, {0., 0.6}) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_rectangle2.inl
+++ b/tests/common/include/tests/common/masks_rectangle2.inl
@@ -32,12 +32,12 @@ TEST(mask, rectangle2) {
     ASSERT_EQ(r2[1], hy);
 
     ASSERT_TRUE(r2.is_inside<local_type>(p2_in) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(r2.is_inside<local_type>(p2_edge) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(r2.is_inside<local_type>(p2_out) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     // Move outside point inside using a tolerance
     ASSERT_TRUE(r2.is_inside<local_type>(p2_out, {1., 0.5}) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_ring2.inl
+++ b/tests/common/include/tests/common/masks_ring2.inl
@@ -29,22 +29,23 @@ TEST(mask, ring2) {
     ASSERT_EQ(r2[0], 0.);
     ASSERT_EQ(r2[1], 3.5);
 
-    ASSERT_TRUE(r2.is_inside<polar>(p2_pl_in) == intersection_status::e_inside);
+    ASSERT_TRUE(r2.is_inside<polar>(p2_pl_in) ==
+                intersection::status::e_inside);
     ASSERT_TRUE(r2.is_inside<polar>(p2_pl_edge) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(r2.is_inside<polar>(p2_pl_out) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     // Move outside point inside using a tolerance
     ASSERT_TRUE(r2.is_inside<polar>(p2_pl_out, 1.2) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
 
     ASSERT_TRUE(r2.is_inside<cartesian>(p2_c_in) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(r2.is_inside<cartesian>(p2_c_edge) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(r2.is_inside<cartesian>(p2_c_out) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     // Move outside point inside using a tolerance
     ASSERT_TRUE(r2.is_inside<cartesian>(p2_c_out, 1.45) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_single3.inl
+++ b/tests/common/include/tests/common/masks_single3.inl
@@ -30,14 +30,14 @@ TEST(mask, single3_0) {
     ASSERT_EQ(m1_0[1], h0);
 
     ASSERT_TRUE(m1_0.is_inside<local_type>(p3_in) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(m1_0.is_inside<local_type>(p3_edge) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(m1_0.is_inside<local_type>(p3_out) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     // Move outside point inside using a tolerance - take t0 not t1
     ASSERT_TRUE(m1_0.is_inside<local_type>(p3_out, 0.6) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
 }
 
 // This tests the basic function of a rectangle
@@ -56,14 +56,14 @@ TEST(mask, single3_1) {
     ASSERT_EQ(m1_1[1], h1);
 
     ASSERT_TRUE(m1_1.is_inside<local_type>(p3_in) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(m1_1.is_inside<local_type>(p3_edge) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(m1_1.is_inside<local_type>(p3_out) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     // Move outside point inside using a tolerance - take t1 not t1
     ASSERT_TRUE(m1_1.is_inside<local_type>(p3_out, 0.6) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
 }
 
 // This tests the basic function of a rectangle
@@ -82,12 +82,12 @@ TEST(mask, single3_2) {
     ASSERT_EQ(m1_2[1], h2);
 
     ASSERT_TRUE(m1_2.is_inside<local_type>(p3_in) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(m1_2.is_inside<local_type>(p3_edge) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(m1_2.is_inside<local_type>(p3_out) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     // Move outside point inside using a tolerance - take t1 not t1
     ASSERT_TRUE(m1_2.is_inside<local_type>(p3_out, 6.1) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_trapezoid2.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2.inl
@@ -34,12 +34,12 @@ TEST(mask, trapezoid2) {
     ASSERT_EQ(t2[3], divisor);
 
     ASSERT_TRUE(t2.is_inside<local_type>(p2_in) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(t2.is_inside<local_type>(p2_edge) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
     ASSERT_TRUE(t2.is_inside<local_type>(p2_out) ==
-                intersection_status::e_outside);
+                intersection::status::e_outside);
     // Move outside point inside using a tolerance
     ASSERT_TRUE(t2.is_inside<local_type>(p2_out, {1., 0.5}) ==
-                intersection_status::e_inside);
+                intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_unmasked.inl
+++ b/tests/common/include/tests/common/masks_unmasked.inl
@@ -17,7 +17,9 @@ TEST(mask, unmasked) {
     point2 p2 = {0.5, -9.};
 
     unmasked u;
-    ASSERT_TRUE(u.is_inside<local_type>(p2) == e_inside);
-    ASSERT_TRUE(u.is_inside<local_type>(p2, true) == e_inside);
-    ASSERT_TRUE(u.is_inside<local_type>(p2, false) == e_outside);
+    ASSERT_TRUE(u.is_inside<local_type>(p2) == intersection::status::e_inside);
+    ASSERT_TRUE(u.is_inside<local_type>(p2, true) ==
+                intersection::status::e_inside);
+    ASSERT_TRUE(u.is_inside<local_type>(p2, false) ==
+                intersection::status::e_outside);
 }

--- a/tests/common/include/tests/common/test_core.inl
+++ b/tests/common/include/tests/common/test_core.inl
@@ -45,16 +45,18 @@ TEST(ALGEBRA_PLUGIN, surface) {
 // This tests the construction of a intresection
 TEST(ALGEBRA_PLUGIN, intersection) {
 
-    intersection i0 = {2., point3{0.3, 0.5, 0.7}, point2{0.2, 0.4},
-                       intersection_status::e_hit};
+    using intersection_t = line_plane_intersection;
 
-    intersection i1 = {1.7, point3{0.2, 0.3, 0.}, point2{0.2, 0.4},
-                       intersection_status::e_inside};
+    intersection_t i0 = {2., point3{0.3, 0.5, 0.7}, point2{0.2, 0.4},
+                         intersection::status::e_hit};
 
-    intersection invalid;
-    ASSERT_TRUE(invalid.status == intersection_status::e_missed);
+    intersection_t i1 = {1.7, point3{0.2, 0.3, 0.}, point2{0.2, 0.4},
+                         intersection::status::e_inside};
 
-    dvector<intersection> intersections = {invalid, i0, i1};
+    intersection_t invalid;
+    ASSERT_TRUE(invalid.status == intersection::status::e_missed);
+
+    dvector<intersection_t> intersections = {invalid, i0, i1};
     std::sort(intersections.begin(), intersections.end());
 
     ASSERT_NEAR(intersections[0].path, 1.7, epsilon);

--- a/tests/common/include/tests/common/tools/inspectors.hpp
+++ b/tests/common/include/tests/common/tools/inspectors.hpp
@@ -51,7 +51,7 @@ template <status navigation_status = status::e_unknown,
 struct object_tracer {
 
     // record all object id the navigator encounters
-    vector_t<intersection> object_trace = {};
+    vector_t<line_plane_intersection> object_trace = {};
 
     template <typename state_type>
     auto operator()(state_type &state, const char * /*message*/) {

--- a/tests/common/include/tests/common/tools/ray_gun.hpp
+++ b/tests/common/include/tests/common/tools/ray_gun.hpp
@@ -40,7 +40,9 @@ struct ray {
 template <typename detector_t>
 inline auto shoot_ray(const detector_t &detector, const ray &r) {
 
-    std::vector<std::pair<dindex, intersection>> intersection_record;
+    using intersection_t = line_plane_intersection;
+
+    std::vector<std::pair<dindex, intersection_t>> intersection_record;
 
     // Loop over volumes
     for (const auto &volume : detector.volumes()) {
@@ -54,7 +56,7 @@ inline auto shoot_ray(const detector_t &detector, const ray &r) {
                 continue;
             }
             // Accept if inside
-            if (sfi.status == e_inside) {
+            if (sfi.status == intersection::status::e_inside) {
                 // object the candidate belongs to
                 sfi.index = volume.index();
                 intersection_record.emplace_back(sf_idx, sfi);
@@ -63,8 +65,8 @@ inline auto shoot_ray(const detector_t &detector, const ray &r) {
     }
 
     // Sort intersections by distance to origin of the ray
-    auto sort_path = [&](std::pair<dindex, intersection> a,
-                         std::pair<dindex, intersection> b) -> bool {
+    auto sort_path = [&](std::pair<dindex, intersection_t> a,
+                         std::pair<dindex, intersection_t> b) -> bool {
         return (a.second < b.second);
     };
     std::sort(intersection_record.begin(), intersection_record.end(),

--- a/tests/common/include/tests/common/tools/ray_scan_utils.hpp
+++ b/tests/common/include/tests/common/tools/ray_scan_utils.hpp
@@ -145,7 +145,8 @@ inline bool check_connectivity(
  * @return a set of volume connections that were found by portal intersection
  *         of a ray.
  */
-template <typename record_container = dvector<std::pair<dindex, line_plane_intersection>>>
+template <typename record_container =
+              dvector<std::pair<dindex, line_plane_intersection>>>
 inline auto trace_intersections(const record_container &intersection_records,
                                 dindex start_volume = 0) {
     // obj id and obj mother volume
@@ -178,8 +179,8 @@ inline auto trace_intersections(const record_container &intersection_records,
             return entry.second.index != entry.second.link;
         }
 
-        inline bool is_portal(
-            const std::pair<dindex, line_plane_intersection> &inters_pair) const {
+        inline bool is_portal(const std::pair<dindex, line_plane_intersection>
+                                  &inters_pair) const {
             const record rec{inters_pair};
             return rec.volume_id() != rec.volume_link();
         }

--- a/tests/common/include/tests/common/tools/ray_scan_utils.hpp
+++ b/tests/common/include/tests/common/tools/ray_scan_utils.hpp
@@ -145,7 +145,7 @@ inline bool check_connectivity(
  * @return a set of volume connections that were found by portal intersection
  *         of a ray.
  */
-template <typename record_container = dvector<std::pair<dindex, intersection>>>
+template <typename record_container = dvector<std::pair<dindex, line_plane_intersection>>>
 inline auto trace_intersections(const record_container &intersection_records,
                                 dindex start_volume = 0) {
     // obj id and obj mother volume
@@ -179,7 +179,7 @@ inline auto trace_intersections(const record_container &intersection_records,
         }
 
         inline bool is_portal(
-            const std::pair<dindex, intersection> &inters_pair) const {
+            const std::pair<dindex, line_plane_intersection> &inters_pair) const {
             const record rec{inters_pair};
             return rec.volume_id() != rec.volume_link();
         }

--- a/tests/common/include/tests/common/tools_cylinder_intersection.inl
+++ b/tests/common/include/tests/common/tools_cylinder_intersection.inl
@@ -37,7 +37,7 @@ TEST(ALGEBRA_PLUGIN, translated_cylinder) {
     // Unbound local frame test
     auto hit_unbound = ci.intersect(shifted, point3{3., 2., 5.},
                                     vector3{1., 0., 0.}, cylinder_unbound);
-    ASSERT_TRUE(hit_unbound.status == intersection_status::e_inside);
+    ASSERT_TRUE(hit_unbound.status == intersection::status::e_inside);
     ASSERT_NEAR(hit_unbound.p3[0], 7., epsilon);
     ASSERT_NEAR(hit_unbound.p3[1], 2., epsilon);
     ASSERT_NEAR(hit_unbound.p3[2], 5., epsilon);
@@ -50,7 +50,7 @@ TEST(ALGEBRA_PLUGIN, translated_cylinder) {
         cylinder_bound{4., -10., 10., 0u};
     auto hit_bound = ci.intersect(shifted, point3{3., 2., 5.},
                                   vector3{1., 0., 0.}, cylinder_bound);
-    ASSERT_TRUE(hit_bound.status == intersection_status::e_inside);
+    ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
     ASSERT_NEAR(hit_bound.p3[0], 7., epsilon);
     ASSERT_NEAR(hit_bound.p3[1], 2., epsilon);
     ASSERT_NEAR(hit_bound.p3[2], 5., epsilon);
@@ -78,10 +78,11 @@ TEST(ALGEBRA_PLUGIN, concentric_cylinders) {
     auto hit_cylinrical = ci.intersect(identity, ori, dir, cylinder);
     auto hit_cocylindrical = cci.intersect(identity, ori, dir, cylinder);
 
-    ASSERT_TRUE(hit_cylinrical.status == intersection_status::e_inside);
-    ASSERT_TRUE(hit_cocylindrical.status == intersection_status::e_inside);
-    ASSERT_TRUE(hit_cylinrical.direction == intersection_direction::e_along);
-    ASSERT_TRUE(hit_cocylindrical.direction == intersection_direction::e_along);
+    ASSERT_TRUE(hit_cylinrical.status == intersection::status::e_inside);
+    ASSERT_TRUE(hit_cocylindrical.status == intersection::status::e_inside);
+    ASSERT_TRUE(hit_cylinrical.direction == intersection::direction::e_along);
+    ASSERT_TRUE(hit_cocylindrical.direction ==
+                intersection::direction::e_along);
 
     ASSERT_NEAR(getter::perp(hit_cylinrical.p3), r, isclose);
     ASSERT_NEAR(getter::perp(hit_cocylindrical.p3), r, isclose);

--- a/tests/common/include/tests/common/tools_planar_intersection.inl
+++ b/tests/common/include/tests/common/tools_planar_intersection.inl
@@ -37,8 +37,8 @@ TEST(ALGEBRA_PLUGIN, translated_plane) {
 
     auto hit_unbound = pi.intersect(shifted, point3{2., 1., 0.},
                                     vector3{0., 0., 1.}, unmasked_unbound);
-    ASSERT_TRUE(hit_unbound.status == intersection_status::e_inside);
-    ASSERT_TRUE(hit_unbound.direction == intersection_direction::e_along);
+    ASSERT_TRUE(hit_unbound.status == intersection::status::e_inside);
+    ASSERT_TRUE(hit_unbound.direction == intersection::direction::e_along);
     // Global intersection information
     ASSERT_NEAR(hit_unbound.p3[0], 2., epsilon);
     ASSERT_NEAR(hit_unbound.p3[1], 1., epsilon);
@@ -51,7 +51,7 @@ TEST(ALGEBRA_PLUGIN, translated_plane) {
         unmasked_bound{};
     auto hit_bound = pi.intersect(shifted, point3{2., 1., 0.},
                                   vector3{0., 0., 1.}, unmasked_bound);
-    ASSERT_TRUE(hit_bound.status == intersection_status::e_inside);
+    ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
     // Global intersection information - unchanged
     ASSERT_NEAR(hit_bound.p3[0], 2., epsilon);
     ASSERT_NEAR(hit_bound.p3[1], 1., epsilon);
@@ -64,7 +64,7 @@ TEST(ALGEBRA_PLUGIN, translated_plane) {
     rectangle2<> rect_for_inside{3., 3., 0u};
     auto hit_bound_inside = pi.intersect(shifted, point3{2., 1., 0.},
                                          vector3{0., 0., 1.}, rect_for_inside);
-    ASSERT_TRUE(hit_bound_inside.status == intersection_status::e_inside);
+    ASSERT_TRUE(hit_bound_inside.status == intersection::status::e_inside);
     // Global intersection information - unchanged
     ASSERT_NEAR(hit_bound_inside.p3[0], 2., epsilon);
     ASSERT_NEAR(hit_bound_inside.p3[1], 1., epsilon);
@@ -77,7 +77,7 @@ TEST(ALGEBRA_PLUGIN, translated_plane) {
     rectangle2<> rect_for_outside{0.5, 3.5, 0u};
     auto hit_bound_outside = pi.intersect(
         shifted, point3{2., 1., 0.}, vector3{0., 0., 1.}, rect_for_outside);
-    ASSERT_TRUE(hit_bound_outside.status == intersection_status::e_outside);
+    ASSERT_TRUE(hit_bound_outside.status == intersection::status::e_outside);
     // Global intersection information - unchanged
     ASSERT_NEAR(hit_bound_outside.p3[0], 2., epsilon);
     ASSERT_NEAR(hit_bound_outside.p3[1], 1., epsilon);

--- a/tests/unit_tests/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/cuda/mask_store_cuda.cpp
@@ -62,7 +62,7 @@ TEST(mask_store_cuda, mask_store) {
     }
 
     /** host output for intersection status **/
-    vecmem::jagged_vector<intersection_status> output_host(5, &mng_mr);
+    vecmem::jagged_vector<intersection::status> output_host(5, &mng_mr);
 
     /** get mask objects **/
     const auto& rectangle_mask = store.group<e_rectangle2>()[0];
@@ -89,7 +89,7 @@ TEST(mask_store_cuda, mask_store) {
     vecmem::cuda::copy copy;
 
     /** device output for intersection status **/
-    vecmem::data::jagged_vector_buffer<intersection_status> output_buffer(
+    vecmem::data::jagged_vector_buffer<intersection::status> output_buffer(
         {0, 0, 0, 0, 0}, {n_points, n_points, n_points, n_points, n_points},
         mng_mr);
 
@@ -102,7 +102,7 @@ TEST(mask_store_cuda, mask_store) {
     /** run the kernel **/
     mask_test(store_data, input_point2_data, input_point3_data, output_buffer);
 
-    vecmem::jagged_vector<intersection_status> output_device(&mng_mr);
+    vecmem::jagged_vector<intersection::status> output_device(&mng_mr);
     copy(output_buffer, output_device);
 
     /** Compare the values **/

--- a/tests/unit_tests/cuda/mask_store_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/mask_store_cuda_kernel.cu
@@ -18,7 +18,7 @@ __global__ void mask_test_kernel(
         store_data,
     vecmem::data::vector_view<point2> input_point2_data,
     vecmem::data::vector_view<point3> input_point3_data,
-    vecmem::data::jagged_vector_view<intersection_status> output_data) {
+    vecmem::data::jagged_vector_view<intersection::status> output_data) {
 
     using cartesian2 = __plugin::cartesian2<detray::scalar>;
 
@@ -30,7 +30,7 @@ __global__ void mask_test_kernel(
     /** get mask objects **/
     vecmem::device_vector<point2> input_point2(input_point2_data);
     vecmem::device_vector<point3> input_point3(input_point3_data);
-    vecmem::jagged_device_vector<intersection_status> output_device(
+    vecmem::jagged_device_vector<intersection::status> output_device(
         output_data);
 
     const auto& rectangle_mask = store.group<e_rectangle2>()[0];
@@ -61,7 +61,7 @@ void mask_test(
         store_data,
     vecmem::data::vector_view<point2>& input_point2_data,
     vecmem::data::vector_view<point3>& input_point3_data,
-    vecmem::data::jagged_vector_view<intersection_status>& output_data) {
+    vecmem::data::jagged_vector_view<intersection::status>& output_data) {
 
     int block_dim = 1;
     int thread_dim = 1;

--- a/tests/unit_tests/cuda/mask_store_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/mask_store_cuda_kernel.hpp
@@ -57,6 +57,6 @@ void mask_test(
         store_data,
     vecmem::data::vector_view<point2>& input_point2_data,
     vecmem::data::vector_view<point3>& input_point3_data,
-    vecmem::data::jagged_vector_view<intersection_status>& output_data);
+    vecmem::data::jagged_vector_view<intersection::status>& output_data);
 
 }  // namespace detray

--- a/tests/unit_tests/cuda/navigator_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/navigator_cuda_kernel.cu
@@ -13,7 +13,7 @@ namespace detray {
 __global__ void navigator_test_kernel(
     detector_view<detector_host_t> det_data,
     vecmem::data::vector_view<free_track_parameters> tracks_data,
-    vecmem::data::jagged_vector_view<intersection> candidates_data,
+    vecmem::data::jagged_vector_view<intersection_t> candidates_data,
     vecmem::data::jagged_vector_view<dindex> volume_records_data,
     vecmem::data::jagged_vector_view<point3> position_records_data) {
 
@@ -21,7 +21,7 @@ __global__ void navigator_test_kernel(
 
     detector_device_t det(det_data);
     vecmem::device_vector<free_track_parameters> tracks(tracks_data);
-    vecmem::jagged_device_vector<intersection> candidates(candidates_data);
+    vecmem::jagged_device_vector<intersection_t> candidates(candidates_data);
     vecmem::jagged_device_vector<dindex> volume_records(volume_records_data);
     vecmem::jagged_device_vector<point3> position_records(
         position_records_data);
@@ -58,7 +58,7 @@ __global__ void navigator_test_kernel(
 void navigator_test(
     detector_view<detector_host_t> det_data,
     vecmem::data::vector_view<free_track_parameters>& tracks_data,
-    vecmem::data::jagged_vector_view<intersection>& candidates_data,
+    vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,
     vecmem::data::jagged_vector_view<point3>& position_records_data) {
 

--- a/tests/unit_tests/cuda/navigator_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/navigator_cuda_kernel.hpp
@@ -23,6 +23,8 @@
 
 using namespace detray;
 
+using intersection_t = line_plane_intersection;
+
 // some useful type declarations
 using detector_host_t =
     detector<detector_registry::toy_detector, darray, thrust::tuple,
@@ -51,7 +53,7 @@ namespace detray {
 void navigator_test(
     detector_view<detector_host_t> det_data,
     vecmem::data::vector_view<free_track_parameters>& tracks_data,
-    vecmem::data::jagged_vector_view<intersection>& candidates_data,
+    vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,
     vecmem::data::jagged_vector_view<point3>& position_records_data);
 

--- a/tests/unit_tests/cuda/propagator_cuda.cpp
+++ b/tests/unit_tests/cuda/propagator_cuda.cpp
@@ -80,7 +80,7 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
     propagator_host_type p(std::move(s), std::move(n));
 
     // Create vector for track recording
-    vecmem::jagged_vector<intersection> host_intersection_records(&mng_mr);
+    vecmem::jagged_vector<intersection_t> host_intersection_records(&mng_mr);
 
     for (unsigned int i = 0; i < theta_steps * phi_steps; i++) {
 
@@ -112,7 +112,7 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
     copy.setup(candidates_buffer);
 
     // Create vector for track recording
-    vecmem::jagged_vector<intersection> device_intersection_records(&mng_mr);
+    vecmem::jagged_vector<intersection_t> device_intersection_records(&mng_mr);
 
     // Create vector buffer for track recording
     std::vector<std::size_t> sizes(theta_steps * phi_steps, 0);
@@ -121,7 +121,7 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
         capacities.push_back(r.size());
     }
 
-    vecmem::data::jagged_vector_buffer<intersection> intersections_buffer(
+    vecmem::data::jagged_vector_buffer<intersection_t> intersections_buffer(
         sizes, capacities, dev_mr, &mng_mr);
     copy.setup(intersections_buffer);
 

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.cu
@@ -13,15 +13,15 @@ namespace detray {
 __global__ void propagator_test_kernel(
     detector_view<detector_host_type> det_data,
     vecmem::data::vector_view<free_track_parameters> tracks_data,
-    vecmem::data::jagged_vector_view<intersection> candidates_data,
-    vecmem::data::jagged_vector_view<intersection> intersections_data) {
+    vecmem::data::jagged_vector_view<intersection_t> candidates_data,
+    vecmem::data::jagged_vector_view<intersection_t> intersections_data) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
 
     detector_device_type det(det_data);
     vecmem::device_vector<free_track_parameters> tracks(tracks_data);
-    vecmem::jagged_device_vector<intersection> candidates(candidates_data);
-    vecmem::jagged_device_vector<intersection> intersections(
+    vecmem::jagged_device_vector<intersection_t> candidates(candidates_data);
+    vecmem::jagged_device_vector<intersection_t> intersections(
         intersections_data);
 
     if (gid >= tracks.size()) {
@@ -54,8 +54,8 @@ __global__ void propagator_test_kernel(
 void propagator_test(
     detector_view<detector_host_type> det_data,
     vecmem::data::vector_view<free_track_parameters>& tracks_data,
-    vecmem::data::jagged_vector_view<intersection>& candidates_data,
-    vecmem::data::jagged_vector_view<intersection>& intersections_data) {
+    vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
+    vecmem::data::jagged_vector_view<intersection_t>& intersections_data) {
 
     constexpr int thread_dim = 2 * WARP_SIZE;
     constexpr int block_dim = theta_steps * phi_steps / thread_dim + 1;

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
@@ -27,6 +27,8 @@
 
 using namespace detray;
 
+using intersection_t = line_plane_intersection;
+
 using detector_host_type =
     detector<detector_registry::toy_detector, darray, thrust::tuple,
              vecmem::vector, vecmem::jagged_vector>;
@@ -63,7 +65,7 @@ struct track_inspector {
         : _intersections(&resource) {}
 
     DETRAY_HOST_DEVICE
-    track_inspector(vector_type<intersection> intersection_record)
+    track_inspector(vector_type<intersection_t> intersection_record)
         : _intersections(intersection_record) {}
 
     template <typename navigator_state_t, typename stepper_state_t>
@@ -75,14 +77,14 @@ struct track_inspector {
         }
     }
 
-    vector_type<intersection> _intersections;
+    vector_type<intersection_t> _intersections;
 };
 
 /// test function for propagator with single state
 void propagator_test(
     detector_view<detector_host_type> det_data,
     vecmem::data::vector_view<free_track_parameters>& tracks_data,
-    vecmem::data::jagged_vector_view<intersection>& candidates_data,
-    vecmem::data::jagged_vector_view<intersection>& intersections_data);
+    vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
+    vecmem::data::jagged_vector_view<intersection_t>& intersections_data);
 
 }  // namespace detray


### PR DESCRIPTION
Following the design of the other classes, the ```enum``` in the ```intersection``` struct were moved from the global scope to their own namespace and the ```intersection``` struct renamed accordingly.