### PR TITLE
feat: add pathlimit aborter

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -53,6 +53,7 @@ detray_add_library( detray_core core
    "include/detray/masks/trapezoid2.hpp"
    "include/detray/masks/unmasked.hpp"   
    # propagator include(s)
+   "include/detray/propagator/aborters.hpp"
    "include/detray/propagator/actor_chain.hpp"
    "include/detray/propagator/base_actor.hpp"
    "include/detray/propagator/base_stepper.hpp"

--- a/core/include/detray/propagator/aborters.hpp
+++ b/core/include/detray/propagator/aborters.hpp
@@ -41,8 +41,8 @@ struct pathlimit_aborter : actor {
     /// @param abrt_state contains the path limit
     /// @param prop_state state of the propagation
     template <typename propagator_state_t>
-    void operator()(state_type &abrt_state,
-                    propagator_state_t &prop_state) const {
+    DETRAY_HOST_DEVICE void operator()(state_type &abrt_state,
+                                       propagator_state_t &prop_state) const {
         auto &step_state = prop_state._stepping;
         auto &nav_state = prop_state._navigation;
 

--- a/core/include/detray/propagator/aborters.hpp
+++ b/core/include/detray/propagator/aborters.hpp
@@ -9,23 +9,20 @@
 
 // detray definitions
 #include <climits>
+#include <iostream>
 
 #include "detray/definitions/qualifiers.hpp"
-#include "detray/propagator/actor_chain.hpp"
+#include "detray/propagator/base_actor.hpp"
+#include "detray/propagator/base_stepper.hpp"
 
 namespace detray {
 
 /// Aborter that checks whether the track has exceeded its pathlimit
-///
-/// @tparam ID the actor id for this aborter ties its state instance
-template <std::size_t ID>
-struct pathlimit_aborter : actor<ID> {
-
-    // Tag this actor
-    using actor_type = pathlimit_aborter<ID>;
+struct pathlimit_aborter : actor {
 
     // Pathlimit for a single propagation workflow
-    struct state : actor<ID>::state {
+    struct aborter_state {
+        // Absolute path limit
         scalar _path_limit = std::numeric_limits<scalar>::max();
 
         /// Set the path limit to a scalar @param pl
@@ -35,10 +32,18 @@ struct pathlimit_aborter : actor<ID> {
         /// @returns this states remaining path length.
         DETRAY_HOST_DEVICE
         inline scalar path_limit() const { return _path_limit; }
-    }
+    };
 
+    /// Broadcast state type to actor chain
+    using state_type = aborter_state;
+
+    /// Enforces the path limit on a stepper state
+    ///
+    /// @param abrt_state contains the path limit
+    /// @param prop_state state of the propagation
     template <typename propagator_state_t>
-    void operator()(actor_type::state &state, propagator_state_t &prop_state) {
+    void operator()(const state_type &abrt_state,
+                    propagator_state_t &prop_state) const {
         auto &step_state = prop_state._stepping;
         auto &nav_state = prop_state._navigation;
 
@@ -46,16 +51,21 @@ struct pathlimit_aborter : actor<ID> {
         if (nav_state.is_complete()) {
             return;
         }
+        // std::cout << "Path limit: " << abrt_state.path_limit() << ", track
+        // length: "
+        //<< std::abs(prop_state._stepping.path_length()) << std::endl;
 
-        state.path_limit() -= std::abs(_step_size);
-        if (state.path_limit() <= 0.) {
+        if (abrt_state.path_limit() <=
+            std::abs(prop_state._stepping.path_length())) {
             printf("Abort: Stepper above maximal path length!\n");
             // Stop navigation
-            nav_state.abort();
+            prop_state._heartbeat &= nav_state.abort();
         }
 
+        // Don't go over the path limit in the next step
         step_state.template set_constraint<step::constraint::e_aborter>(
-            state._path_limit);
+            abrt_state.path_limit() -
+            std::abs(prop_state._stepping.path_length()));
     }
 };
 

--- a/core/include/detray/propagator/aborters.hpp
+++ b/core/include/detray/propagator/aborters.hpp
@@ -54,8 +54,8 @@ struct pathlimit_aborter : actor {
         // Check the path limit
         abrt_state._path_limit -= std::abs(prop_state._stepping.step_size());
         if (abrt_state.path_limit() <= 0) {
-            //printf("Abort: Stepper above maximal path length!\n");
-            // Stop navigation
+            // printf("Abort: Stepper above maximal path length!\n");
+            //  Stop navigation
             prop_state._heartbeat &= nav_state.abort();
         }
 

--- a/core/include/detray/propagator/aborters.hpp
+++ b/core/include/detray/propagator/aborters.hpp
@@ -8,17 +8,17 @@
 #pragma once
 
 // detray definitions
+#include <climits>
+
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/propagator/actor_chain.hpp"
-
-#include <climits>
 
 namespace detray {
 
 /// Aborter that checks whether the track has exceeded its pathlimit
 ///
 /// @tparam ID the actor id for this aborter ties its state instance
-template<std::size_t ID>
+template <std::size_t ID>
 struct pathlimit_aborter : actor<ID> {
 
     // Tag this actor
@@ -38,7 +38,7 @@ struct pathlimit_aborter : actor<ID> {
     }
 
     template <typename propagator_state_t>
-    void operator()(actor_type::state & state, propagator_state_t& prop_state) {
+    void operator()(actor_type::state &state, propagator_state_t &prop_state) {
         auto &step_state = prop_state._stepping;
         auto &nav_state = prop_state._navigation;
 
@@ -54,7 +54,8 @@ struct pathlimit_aborter : actor<ID> {
             nav_state.abort();
         }
 
-        step_state.template set_constraint<step::constraint::e_aborter>(state._path_limit);
+        step_state.template set_constraint<step::constraint::e_aborter>(
+            state._path_limit);
     }
 };
 

--- a/core/include/detray/propagator/aborters.hpp
+++ b/core/include/detray/propagator/aborters.hpp
@@ -9,7 +9,6 @@
 
 // detray definitions
 #include <climits>
-#include <iostream>
 
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/propagator/base_actor.hpp"

--- a/core/include/detray/propagator/aborters.hpp
+++ b/core/include/detray/propagator/aborters.hpp
@@ -1,0 +1,61 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// detray definitions
+#include "detray/definitions/qualifiers.hpp"
+#include "detray/propagator/actor_chain.hpp"
+
+#include <climits>
+
+namespace detray {
+
+/// Aborter that checks whether the track has exceeded its pathlimit
+///
+/// @tparam ID the actor id for this aborter ties its state instance
+template<std::size_t ID>
+struct pathlimit_aborter : actor<ID> {
+
+    // Tag this actor
+    using actor_type = pathlimit_aborter<ID>;
+
+    // Pathlimit for a single propagation workflow
+    struct state : actor<ID>::state {
+        scalar _path_limit = std::numeric_limits<scalar>::max();
+
+        /// Set the path limit to a scalar @param pl
+        DETRAY_HOST_DEVICE
+        inline void set_path_limit(const scalar pl) { _path_limit = pl; }
+
+        /// @returns this states remaining path length.
+        DETRAY_HOST_DEVICE
+        inline scalar path_limit() const { return _path_limit; }
+    }
+
+    template <typename propagator_state_t>
+    void operator()(actor_type::state & state, propagator_state_t& prop_state) {
+        auto &step_state = prop_state._stepping;
+        auto &nav_state = prop_state._navigation;
+
+        // Nothing left to do. Propagation will exit successfully
+        if (nav_state.is_complete()) {
+            return;
+        }
+
+        state.path_limit() -= std::abs(_step_size);
+        if (state.path_limit() <= 0.) {
+            printf("Abort: Stepper above maximal path length!\n");
+            // Stop navigation
+            nav_state.abort();
+        }
+
+        step_state.template set_constraint<step::constraint::e_aborter>(state._path_limit);
+    }
+};
+
+}  // namespace detray

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -67,16 +67,16 @@ class base_stepper {
         DETRAY_HOST_DEVICE
         const track_t &operator()() const { return _track; }
 
-        step::direction _direction = step::direction::e_forward;
+        step::direction _direction{step::direction::e_forward};
 
         // Stepping constraints
         constraint_t _constraint = {};
 
-        /// Remaining path length
-        scalar _path_limit = std::numeric_limits<scalar>::max();
+        /// Track path length
+        scalar _path_length{0};
 
         /// Current step size
-        scalar _step_size = std::numeric_limits<scalar>::infinity();
+        scalar _step_size{std::numeric_limits<scalar>::infinity()};
 
         /// Set new step constraint
         template <step::constraint type = step::constraint::e_actor>
@@ -103,24 +103,6 @@ class base_stepper {
             _constraint.template release<type>();
         }
 
-        /// Set the path limit to a scalar @param pl
-        DETRAY_HOST_DEVICE
-        inline void set_path_limit(const scalar pl) { _path_limit = pl; }
-
-        /// @returns this states remaining path length.
-        DETRAY_HOST_DEVICE
-        inline scalar dist_to_path_limit() const { return _path_limit; }
-
-        /// Update and check the path limit against a new @param step size.
-        DETRAY_HOST_DEVICE
-        inline bool check_path_limit() {
-            _path_limit -= _step_size;
-            if (_path_limit <= 0.) {
-                return false;
-            }
-            return true;
-        }
-
         /// Set next step size
         DETRAY_HOST_DEVICE
         inline void set_step_size(const scalar step) { _step_size = step; }
@@ -128,6 +110,10 @@ class base_stepper {
         /// @returns the current step size of this state.
         DETRAY_HOST_DEVICE
         inline scalar step_size() const { return _step_size; }
+
+        /// @returns this states remaining path length.
+        DETRAY_HOST_DEVICE
+        inline scalar path_length() const { return _path_length; }
     };
 };
 

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -31,9 +31,6 @@ class line_stepper final : public base_stepper<track_t, constraint_t> {
         DETRAY_HOST_DEVICE
         state(track_t &t) : base_type::state(t) {}
 
-        /// Accumulated path length
-        scalar _path_length = 0.;
-
         /// Update the track state in a straight line.
         DETRAY_HOST_DEVICE
         inline void advance_track() {
@@ -80,13 +77,6 @@ class line_stepper final : public base_stepper<track_t, constraint_t> {
                 stepping.constraints().template size<>(stepping.direction()));
             // Re-evaluate all candidates
             navigation.set_fair_trust();
-        }
-
-        // Update and check path limit
-        if (not stepping.check_path_limit()) {
-            printf("Stepper: Above maximal path length!\n");
-            // State is broken
-            return navigation.abort();
         }
 
         // Update track state

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <climits>
+#include <iostream>
 
 #include "detray/definitions/qualifiers.hpp"
 
@@ -58,6 +59,9 @@ struct propagator {
               _navigation(std::move(candidates)),
               _actor_states(actor_states) {}
 
+        // Is the propagation still alive?
+        bool _heartbeat = false;
+
         typename stepper_t::state _stepping;
         typename navigator_t::state _navigation;
         typename actor_chain_t::state _actor_states;
@@ -80,16 +84,16 @@ struct propagator {
         auto actor_states = p_state._actor_states;
 
         // initialize the navigation
-        bool heartbeat = _navigator.init(n_state, s_state);
+        p_state._heartbeat = _navigator.init(n_state, s_state);
 
         // Run while there is a heartbeat
-        while (heartbeat) {
+        while (p_state._heartbeat) {
 
             // Take the step
-            heartbeat &= _stepper.step(s_state, n_state);
+            p_state._heartbeat &= _stepper.step(s_state, n_state);
 
             // And check the status
-            heartbeat &= _navigator.update(n_state, s_state);
+            p_state._heartbeat &= _navigator.update(n_state, s_state);
 
             // Run all registered actors
             run_actors(actor_states, p_state);

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <climits>
-#include <iostream>
 
 #include "detray/definitions/qualifiers.hpp"
 

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -12,6 +12,7 @@
 
 // detray definitions
 #include <cmath>
+#include <iostream>
 
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
@@ -104,8 +105,8 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
             // State the square and half of the step size
             const scalar h2 = h * h;
             const scalar half_h = h * 0.5;
-            auto pos = stepping().pos();
-            auto dir = stepping().dir();
+            const auto pos = stepping().pos();
+            const auto dir = stepping().dir();
 
             // Second Runge-Kutta point
             const vector3 pos1 = pos + half_h * dir + h2 * 0.125 * sd.k1;
@@ -114,7 +115,6 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
 
             // Third Runge-Kutta point
             sd.k3 = evaluate_k(stepping, sd.b_middle, 2, half_h, sd.k2);
-
             // Last Runge-Kutta point
             const vector3 pos2 = pos + h * dir + h2 * 0.5 * sd.k3;
             sd.b_last = _magnetic_field.get_field(pos2, context_type{});
@@ -202,8 +202,8 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
                               const int i, const scalar h = 0.,
                               const vector3& k_prev = vector3{0, 0, 0}) {
         vector3 k_new;
-        auto qop = stepping().qop();
-        auto dir = stepping().dir();
+        const auto qop = stepping().qop();
+        const auto dir = stepping().dir();
 
         if (i == 0) {
             k_new = qop * vector::cross(dir, b_field);

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -50,9 +50,6 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
         /// maximum trial number of RK stepping
         size_t _max_rk_step_trials = 10000;
 
-        /// Accumulated path length
-        scalar _path_length = 0.;
-
         /// stepping data required for RKN4
         struct stepping_data {
             vector3 b_first, b_middle, b_last;
@@ -189,13 +186,6 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
                 stepping.constraints().template size<>(stepping.direction()));
             // Re-evaluate all candidates
             navigation.set_fair_trust();
-        }
-
-        // Update and check path limit
-        if (not stepping.check_path_limit()) {
-            printf("Stepper: Above maximal path length!\n");
-            // State is broken
-            return navigation.abort();
         }
 
         // Update track state

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -10,10 +10,10 @@
 // detray tools
 #include "detray/propagator/base_stepper.hpp"
 
-// detray definitions
+// system include
 #include <cmath>
-#include <iostream>
 
+// detray definitions
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -100,8 +100,8 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
     using vector3 = __plugin::vector3<scalar>;
 
     // geomery navigation configurations
-    constexpr unsigned int theta_steps = 100;
-    constexpr unsigned int phi_steps = 100;
+    constexpr unsigned int theta_steps = 50;
+    constexpr unsigned int phi_steps = 50;
 
     // detector configuration
     constexpr std::size_t n_brl_layers = 4;

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -46,11 +46,12 @@ struct helix_inspector : actor {
         const state_type &inspector_state,
         const propagator_state_t &prop_state) const {
 
-        auto &stepping = prop_state._stepping;
-        auto pos = stepping().pos();
-        auto true_pos = inspector_state._helix(stepping.path_length());
+        const auto &stepping = prop_state._stepping;
+        const auto pos = stepping().pos();
+        const auto true_pos = inspector_state._helix(stepping.path_length());
 
-        point3 relative_error{1 / stepping.path_length() * (pos - true_pos)};
+        const point3 relative_error{1 / stepping.path_length() *
+                                    (pos - true_pos)};
 
         ASSERT_NEAR(getter::norm(relative_error), 0, epsilon);
     }

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -115,7 +115,8 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
     using constraints_t = constrained_step<>;
     using stepper_t =
         rk_stepper<b_field_t, free_track_parameters, constraints_t>;
-    using actor_chain_t = actor_chain<dtuple, helix_inspector, print_inspector, pathlimit_aborter>;
+    using actor_chain_t = actor_chain<dtuple, helix_inspector, print_inspector,
+                                      pathlimit_aborter>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     // Constant magnetic field
@@ -150,22 +151,22 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
             traj.set_overstep_tolerance(-10 * unit_constants::um);
             lim_traj.set_overstep_tolerance(-10 * unit_constants::um);
 
+            // Build actor states: the helix inspector can be shared
             helix_inspector::state_type helix_insp_state{helix_gun{traj, &B}};
             print_inspector::state_type print_insp_state{};
             print_inspector::state_type lim_print_insp_state{};
             pathlimit_aborter::state_type unlimted_aborter_state{};
             pathlimit_aborter::state_type pathlimit_aborter_state{path_limit};
 
+            // Create actor states tuples
             actor_chain_t::state actor_states = std::tie(
                 helix_insp_state, print_insp_state, unlimted_aborter_state);
-
             actor_chain_t::state lim_actor_states =
                 std::tie(helix_insp_state, lim_print_insp_state,
                          pathlimit_aborter_state);
 
             // Init propagator states
             propagator_t::state state(traj, actor_states);
-
             propagator_t::state lim_state(lim_traj, lim_actor_states);
 
             // Set step constraints
@@ -176,7 +177,7 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
                 .template set_constraint<step::constraint::e_accuracy>(
                     5. * unit_constants::mm);
 
-            // Propagate
+            // Propagate the entire detector
             ASSERT_TRUE(p.propagate(state))
                 << print_insp_state.to_string() << std::endl;
 

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -154,9 +154,7 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
             print_inspector::state_type print_insp_state{};
             print_inspector::state_type lim_print_insp_state{};
             pathlimit_aborter::state_type unlimted_aborter_state{};
-            pathlimit_aborter::state_type pathlimit_aborter_state{};
-            // Set maximal path length
-            pathlimit_aborter_state.set_path_limit(path_limit);
+            pathlimit_aborter::state_type pathlimit_aborter_state{path_limit};
 
             actor_chain_t::state actor_states =
                 std::tie(helix_insp_state, print_insp_state, unlimted_aborter_state);

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -187,7 +187,8 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
                 path_limit, epsilon);
             ASSERT_FALSE(p.propagate(lim_state))
                 << lim_print_insp_state.to_string() << std::endl;
-            ASSERT_TRUE(lim_state._stepping.path_length() <= path_limit);
+            ASSERT_TRUE(lim_state._stepping.path_length() <
+                        path_limit + epsilon);
         }
     }
 }

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -82,7 +82,7 @@ TEST(ALGEBRA_PLUGIN, propagator_line_stepper) {
     propagator_t p(std::move(s), std::move(n));
 
     propagator_t::state state(traj);
-    
+
     EXPECT_TRUE(p.propagate(state))
         << state._navigation.inspector().to_string() << std::endl;
 }
@@ -156,11 +156,12 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
             pathlimit_aborter::state_type unlimted_aborter_state{};
             pathlimit_aborter::state_type pathlimit_aborter_state{path_limit};
 
-            actor_chain_t::state actor_states =
-                std::tie(helix_insp_state, print_insp_state, unlimted_aborter_state);
+            actor_chain_t::state actor_states = std::tie(
+                helix_insp_state, print_insp_state, unlimted_aborter_state);
 
             actor_chain_t::state lim_actor_states =
-                std::tie(helix_insp_state, lim_print_insp_state, pathlimit_aborter_state);
+                std::tie(helix_insp_state, lim_print_insp_state,
+                         pathlimit_aborter_state);
 
             // Init propagator states
             propagator_t::state state(traj, actor_states);
@@ -180,9 +181,8 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
                 << print_insp_state.to_string() << std::endl;
 
             // Propagate with path limit
-            ASSERT_NEAR(
-                pathlimit_aborter_state.path_limit(),
-                path_limit, epsilon);
+            ASSERT_NEAR(pathlimit_aborter_state.path_limit(), path_limit,
+                        epsilon);
             ASSERT_FALSE(p.propagate(lim_state))
                 << lim_print_insp_state.to_string() << std::endl;
             ASSERT_TRUE(lim_state._stepping.path_length() <

--- a/tests/common/include/tests/common/tools_stepper.inl
+++ b/tests/common/include/tests/common/tools_stepper.inl
@@ -174,17 +174,17 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
                             rk_state.path_length(),
                         0, epsilon);
 
-            point3 helix_pos = helix(rk_state.path_length());
-            point3 forward_pos = rk_state().pos();
-            auto forward_relative_error =
-                (1. / rk_state.path_length()) * (forward_pos - helix_pos);
+            const auto helix_pos = helix(rk_state.path_length());
+            const auto forward_pos = rk_state().pos();
+            const point3 forward_relative_error{(1. / rk_state.path_length()) *
+                                                (forward_pos - helix_pos)};
 
             // Make sure that relative error is smaller than epsion
             EXPECT_NEAR(getter::norm(forward_relative_error), 0, epsilon);
 
             // Roll the same track back to the origin
             // Use the same path length, since there is no overstepping
-            scalar path_length = rk_state.path_length();
+            const scalar path_length = rk_state.path_length();
             n_state._step_size *= -1. * unit_constants::mm;
             for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
                 rk_stepper.step(rk_state, n_state);
@@ -198,9 +198,9 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
                             (2 * path_length),
                         0, epsilon);
 
-            point3 backward_pos = rk_state().pos();
-            auto backward_relative_error =
-                (1. / (2. * path_length)) * (backward_pos - ori);
+            const auto backward_pos = rk_state().pos();
+            const point3 backward_relative_error{1. / (2. * path_length) *
+                                                 (backward_pos - ori)};
 
             // Make sure that relative error is smaller than epsion
             EXPECT_NEAR(getter::norm(backward_relative_error), 0, epsilon);

--- a/tests/unit_tests/cuda/propagator_cuda.cpp
+++ b/tests/unit_tests/cuda/propagator_cuda.cpp
@@ -72,22 +72,21 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
 
     // Create RK stepper
     rk_stepper_type s(B_field);
-
     // Create navigator
     navigator_host_type n(det);
-
     // Create propagator
     propagator_host_type p(std::move(s), std::move(n));
 
     // Create vector for track recording
     vecmem::jagged_vector<intersection_t> host_intersection_records(&mng_mr);
+    
     for (unsigned int i = 0; i < theta_steps * phi_steps; i++) {
 
-        inspector_host_t::state_type insp_state{mng_mr};
-
         // Create the propagator state
-        propagator_host_type::state state(tracks_host[i],
-                                          thrust::tie(insp_state));
+        inspector_host_t::state_type insp_state{mng_mr};
+        pathlimit_aborter::state_type pathlimit_state{path_limit};
+
+        propagator_host_type::state state(tracks_host[i], thrust::tie(insp_state, pathlimit_state));
 
         // Run propagation
         p.propagate(state);

--- a/tests/unit_tests/cuda/propagator_cuda.cpp
+++ b/tests/unit_tests/cuda/propagator_cuda.cpp
@@ -79,14 +79,15 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
 
     // Create vector for track recording
     vecmem::jagged_vector<intersection_t> host_intersection_records(&mng_mr);
-    
+
     for (unsigned int i = 0; i < theta_steps * phi_steps; i++) {
 
         // Create the propagator state
         inspector_host_t::state_type insp_state{mng_mr};
         pathlimit_aborter::state_type pathlimit_state{path_limit};
 
-        propagator_host_type::state state(tracks_host[i], thrust::tie(insp_state, pathlimit_state));
+        propagator_host_type::state state(
+            tracks_host[i], thrust::tie(insp_state, pathlimit_state));
 
         // Run propagation
         p.propagate(state);

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.cu
@@ -41,12 +41,13 @@ __global__ void propagator_test_kernel(
     // Create propagator
     propagator_device_type p(std::move(s), std::move(n));
 
-    // Create track inspector
+    // Create actor states
     inspector_device_t::state_type insp_state(intersections.at(gid));
+    pathlimit_aborter::state_type aborter_state{path_limit};
 
     // Create the propagator state
-    propagator_device_type::state state(tracks[gid], thrust::tie(insp_state),
-                                        candidates.at(gid));
+    propagator_device_type::state state(
+        tracks[gid], thrust::tie(insp_state, aborter_state), candidates.at(gid));
 
     // Run propagation
     p.propagate(state);

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.cu
@@ -46,8 +46,9 @@ __global__ void propagator_test_kernel(
     pathlimit_aborter::state_type aborter_state{path_limit};
 
     // Create the propagator state
-    propagator_device_type::state state(
-        tracks[gid], thrust::tie(insp_state, aborter_state), candidates.at(gid));
+    propagator_device_type::state state(tracks[gid],
+                                        thrust::tie(insp_state, aborter_state),
+                                        candidates.at(gid));
 
     // Run propagation
     p.propagate(state);

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
@@ -19,6 +19,7 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/field/constant_magnetic_field.hpp"
+#include "detray/propagator/aborters.hpp"
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/propagator/navigator.hpp"
@@ -53,6 +54,7 @@ constexpr unsigned int theta_steps = 100;
 constexpr unsigned int phi_steps = 100;
 
 constexpr scalar pos_diff_tolerance = 1e-3;
+constexpr scalar path_limit = 2 * unit_constants::m;
 
 namespace detray {
 
@@ -68,6 +70,7 @@ struct track_inspector : actor {
         track_inspector_state(vector_t<intersection_t> intersection_record)
             : _intersections(intersection_record) {}
 
+        // Intersections per track
         vector_t<intersection_t> _intersections;
     };
 
@@ -90,8 +93,8 @@ struct track_inspector : actor {
 // Assemble propagator type
 using inspector_host_t = track_inspector<vecmem::vector>;
 using inspector_device_t = track_inspector<vecmem::device_vector>;
-using actor_chain_host_t = actor_chain<thrust::tuple, inspector_host_t>;
-using actor_chain_device_t = actor_chain<thrust::tuple, inspector_device_t>;
+using actor_chain_host_t = actor_chain<thrust::tuple, inspector_host_t, pathlimit_aborter>;
+using actor_chain_device_t = actor_chain<thrust::tuple, inspector_device_t, pathlimit_aborter>;
 using propagator_host_type =
     propagator<rk_stepper_type, navigator_host_type, actor_chain_host_t>;
 using propagator_device_type =

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
@@ -93,8 +93,10 @@ struct track_inspector : actor {
 // Assemble propagator type
 using inspector_host_t = track_inspector<vecmem::vector>;
 using inspector_device_t = track_inspector<vecmem::device_vector>;
-using actor_chain_host_t = actor_chain<thrust::tuple, inspector_host_t, pathlimit_aborter>;
-using actor_chain_device_t = actor_chain<thrust::tuple, inspector_device_t, pathlimit_aborter>;
+using actor_chain_host_t =
+    actor_chain<thrust::tuple, inspector_host_t, pathlimit_aborter>;
+using actor_chain_device_t =
+    actor_chain<thrust::tuple, inspector_device_t, pathlimit_aborter>;
 using propagator_host_type =
     propagator<rk_stepper_type, navigator_host_type, actor_chain_host_t>;
 using propagator_device_type =

--- a/tests/unit_tests/cuda/rk_stepper_cuda.cpp
+++ b/tests/unit_tests/cuda/rk_stepper_cuda.cpp
@@ -66,7 +66,7 @@ TEST(rk_stepper_cuda, rk_stepper) {
         rk_stepper_t::state rk_state(traj);
         crk_stepper_t::state crk_state(traj);
 
-        crk_state.template set_constraint<constraint::e_user>(
+        crk_state.template set_constraint<step::constraint::e_user>(
             0.5 * unit_constants::mm);
         n_state._step_size = 1. * unit_constants::mm;
         ASSERT_NEAR(crk_state.constraints().template size<>(),
@@ -82,7 +82,6 @@ TEST(rk_stepper_cuda, rk_stepper) {
 
         // Backward direction
         // Roll the same track back to the origin
-        scalar path_length = rk_state.path_length();
         n_state._step_size *= -1. * unit_constants::mm;
         for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
             rk_stepper.step(rk_state, n_state);
@@ -92,7 +91,7 @@ TEST(rk_stepper_cuda, rk_stepper) {
 
         EXPECT_NEAR(rk_state.path_length(), crk_state.path_length(), epsilon);
 
-        path_lengths.push_back(crk_stepper.path_length());
+        path_lengths.push_back(crk_state.path_length());
     }
 
     // Get tracks data

--- a/tests/unit_tests/cuda/rk_stepper_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/rk_stepper_cuda_kernel.cu
@@ -31,9 +31,10 @@ __global__ void rk_stepper_test_kernel(
 
     // Get a track
     auto& traj = tracks.at(gid);
+    free_track_parameters c_traj(traj);
 
     rk_stepper_t::state rk_state(traj);
-    crk_stepper_t::state crk_state(traj);
+    crk_stepper_t::state crk_state(c_traj);
 
     // Forward direction
     crk_state.template set_constraint<step::constraint::e_user>(
@@ -47,7 +48,6 @@ __global__ void rk_stepper_test_kernel(
 
     // Backward direction
     // Roll the same track back to the origin
-    scalar path_length = rk_state.path_length();
     n_state._step_size *= -1. * unit_constants::mm;
     for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
         rk_stepper.step(rk_state, n_state);

--- a/tests/unit_tests/cuda/rk_stepper_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/rk_stepper_cuda_kernel.cu
@@ -36,8 +36,8 @@ __global__ void rk_stepper_test_kernel(
     crk_stepper_t::state crk_state(traj);
 
     // Forward direction
-    crk_state.template set_constraint<constraint::e_user>(0.5 *
-                                                          unit_constants::mm);
+    crk_state.template set_constraint<step::constraint::e_user>(
+        0.5 * unit_constants::mm);
     n_state._step_size = 1. * unit_constants::mm;
     for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
         rk_stepper.step(rk_state, n_state);

--- a/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
@@ -29,8 +29,10 @@ using namespace detray;
 using vector3 = __plugin::vector3<scalar>;
 using point3 = __plugin::point3<scalar>;
 
-using mag_field_type = constant_magnetic_field<>;
-using rk_stepper_type = rk_stepper<mag_field_type, free_track_parameters>;
+using mag_field_t = constant_magnetic_field<>;
+using rk_stepper_t = rk_stepper<mag_field_t, free_track_parameters>;
+using crk_stepper_t =
+    rk_stepper<mag_field_t, free_track_parameters, constrained_step<>>;
 
 // geomery navigation configurations
 constexpr unsigned int theta_steps = 100;
@@ -44,14 +46,14 @@ namespace detray {
 
 // dummy navigation struct
 struct nav_state {
-    DETRAY_HOST_DEVICE scalar operator()() const {
-        return 1. * unit_constants::mm;
-    }
+    DETRAY_HOST_DEVICE scalar operator()() const { return _step_size; }
     DETRAY_HOST_DEVICE inline void set_full_trust() {}
     DETRAY_HOST_DEVICE inline void set_high_trust() {}
     DETRAY_HOST_DEVICE inline void set_fair_trust() {}
     DETRAY_HOST_DEVICE inline void set_no_trust() {}
     DETRAY_HOST_DEVICE inline bool abort() { return false; }
+
+    scalar _step_size = 1. * unit_constants::mm;
 };
 
 // test function for Runge-Kutta stepper

--- a/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/rk_stepper_cuda_kernel.hpp
@@ -39,7 +39,7 @@ constexpr unsigned int theta_steps = 100;
 constexpr unsigned int phi_steps = 100;
 constexpr unsigned int rk_steps = 100;
 
-constexpr scalar epsilon = 1e-5;
+constexpr scalar epsilon = 1e-4;
 constexpr scalar path_limit = 2 * unit_constants::m;
 
 namespace detray {


### PR DESCRIPTION
Adds a ```pathlimit_aborter``` as an actor in the ```actor_chain``` and removes the ```path_limit``` checking from the steppers. Also updates the CUDA stepper and propagator unittests to use constrained stepping. The detray and CUDA propagator tests are furthermore extended to use a ```pathlimit_aborter```, although with a limit that should not prevent the propagation of the entire toy detector.