### PR TITLE
fix: b field access

### DIFF
--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -35,8 +35,7 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
     using context_type = typename magnetic_field_t::context_type;
 
     DETRAY_HOST_DEVICE
-    rk_stepper(const magnetic_field_t& mag_field)
-        : _magnetic_field(mag_field) {}
+    rk_stepper(const magnetic_field_t mag_field) : _magnetic_field(mag_field) {}
 
     struct state : public base_type::state {
         DETRAY_HOST_DEVICE
@@ -226,7 +225,7 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
     }
 
     private:
-    const magnetic_field_t& _magnetic_field;
+    const magnetic_field_t _magnetic_field;
 };
 
 }  // namespace detray


### PR DESCRIPTION
Using a reference to the B-field caused undefined behavior in the host-side rk-stepper test when using the array plugin. Using pointers works, but I don't really know what the lifetimes of the stepper and the B-field are supposed to be, so lets keep it as it was and copy the B-field, until we know what the B-field access will look like eventually.