### PR TITLE
Add covariance transport in RK stepper

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -69,6 +69,7 @@ detray_add_library( detray_core core
    "include/detray/tools/grid_array_helper.hpp"
    "include/detray/tools/local_object_finder.hpp"
    # utils include(s)   
+   "include/detray/utils/algebra_helpers.hpp"
    "include/detray/utils/enumerate.hpp"
    "include/detray/utils/invalid_values.hpp" )
 target_link_libraries( detray_core INTERFACE vecmem::core detray::Thrust)

--- a/core/include/detray/definitions/track_parameterization.hpp
+++ b/core/include/detray/definitions/track_parameterization.hpp
@@ -9,7 +9,7 @@ namespace detray {
 
 /// Components of a bound track parameters vector.
 ///
-enum bound_indices : unsigned int {
+enum bound_indices : __plugin::size_type {
     // Local position on the reference surface.
     // This is intentionally named different from the position components in
     // the other data vectors, to clarify that this is defined on a surface
@@ -37,7 +37,7 @@ enum bound_indices : unsigned int {
 /// This must be a regular `enum` and not a scoped `enum class` to allow
 /// implicit conversion to an integer. The enum value are thus visible directly
 /// in `namespace Acts` and are prefixed to avoid naming collisions.
-enum free_indices : unsigned int {
+enum free_indices : __plugin::size_type {
     // Spatial position
     // The spatial position components must be stored as one continous block.
     e_free_pos0 = 0u,

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -55,6 +55,10 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
             array_t<scalar, 4> k_qop;
         } _step_data;
 
+        // Set the local error tolerenace
+        DETRAY_HOST_DEVICE
+        inline void set_tolerance(scalar tol) { _tolerance = tol; };
+
         /// Update the track state by Runge-Kutta-Nystrom integration.
         DETRAY_HOST_DEVICE
         inline void advance_track();

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -7,14 +7,10 @@
 
 #pragma once
 
-// detray tools
-#include "detray/propagator/base_stepper.hpp"
-
-// detray definitions
-#include <cmath>
-
+// detray include(s)
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/propagator/base_stepper.hpp"
 
 namespace detray {
 
@@ -31,7 +27,9 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
     public:
     using base_type = base_stepper<track_t, constraint_t>;
     using point3 = __plugin::point3<scalar>;
+    using vector2 = __plugin::vector2<scalar>;
     using vector3 = __plugin::vector3<scalar>;
+    using matrix_operator = standard_matrix_operator<scalar>;
     using context_type = typename magnetic_field_t::context_type;
 
     DETRAY_HOST_DEVICE
@@ -50,37 +48,24 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
         /// maximum trial number of RK stepping
         size_t _max_rk_step_trials = 10000;
 
-        /// Accumulated path length
-        scalar _path_length = 0.;
-
         /// stepping data required for RKN4
-        struct stepping_data {
+        struct {
             vector3 b_first, b_middle, b_last;
             vector3 k1, k2, k3, k4;
             array_t<scalar, 4> k_qop;
-        };
-
-        stepping_data _step_data;
+        } _step_data;
 
         /// Update the track state by Runge-Kutta-Nystrom integration.
         DETRAY_HOST_DEVICE
-        inline void advance_track() {
-            const auto& sd = this->_step_data;
-            const auto& h = this->_step_size;
-            auto& track = this->_track;
-            auto pos = track.pos();
-            auto dir = track.dir();
+        inline void advance_track();
 
-            // Update the track parameters according to the equations of motion
-            pos = pos + h * dir + h * h / 6. * (sd.k1 + sd.k2 + sd.k3);
-            track.set_pos(pos);
+        // Update the jacobian transport from free propagation
+        DETRAY_HOST_DEVICE
+        inline void advance_jacobian();
 
-            dir = dir + h / 6. * (sd.k1 + 2. * (sd.k2 + sd.k3) + sd.k4);
-            dir = vector::normalize(dir);
-            track.set_dir(dir);
-
-            this->_path_length += h;
-        }
+        DETRAY_HOST_DEVICE
+        inline vector3 evaluate_k(const vector3& b_field, const int i,
+                                  const scalar h, const vector3& k_prev);
     };
 
     /** Take a step, using an adaptive Runge-Kutta algorithm.
@@ -93,139 +78,12 @@ class rk_stepper final : public base_stepper<track_t, constraint_t> {
      */
     template <typename navigation_state_t>
     DETRAY_HOST_DEVICE bool step(state& stepping,
-                                 navigation_state_t& navigation) {
-        auto& sd = stepping._step_data;
-
-        scalar error_estimate = 0;
-
-        // First Runge-Kutta point
-        sd.b_first =
-            _magnetic_field.get_field(stepping().pos(), context_type{});
-        sd.k1 = evaluate_k(stepping, sd.b_first, 0);
-
-        const auto try_rk4 = [&](const scalar& h) -> bool {
-            // State the square and half of the step size
-            const scalar h2 = h * h;
-            const scalar half_h = h * 0.5;
-            auto pos = stepping().pos();
-            auto dir = stepping().dir();
-
-            // Second Runge-Kutta point
-            const vector3 pos1 = pos + half_h * dir + h2 * 0.125 * sd.k1;
-            sd.b_middle = _magnetic_field.get_field(pos1, context_type{});
-            sd.k2 = evaluate_k(stepping, sd.b_middle, 1, half_h, sd.k1);
-
-            // Third Runge-Kutta point
-            sd.k3 = evaluate_k(stepping, sd.b_middle, 2, half_h, sd.k2);
-
-            // Last Runge-Kutta point
-            const vector3 pos2 = pos + h * dir + h2 * 0.5 * sd.k3;
-            sd.b_last = _magnetic_field.get_field(pos2, context_type{});
-            sd.k4 = evaluate_k(stepping, sd.b_last, 3, h, sd.k3);
-
-            // Compute and check the local integration error estimate
-            // @Todo
-            const vector3 err_vec = h2 * (sd.k1 - sd.k2 - sd.k3 + sd.k4);
-            error_estimate =
-                std::max(getter::norm(err_vec), static_cast<scalar>(1e-20));
-
-            return (error_estimate <= stepping._tolerance);
-        };
-
-        // Initial step size estimate
-        stepping.set_step_size(navigation());
-        scalar step_size_scaling = 1.;
-        size_t n_step_trials = 0;
-
-        // Adjust initial step size to integration error
-        while (!try_rk4(stepping._step_size)) {
-
-            step_size_scaling = std::min(
-                std::max(0.25 * unit_constants::mm,
-                         std::sqrt(std::sqrt((stepping._tolerance /
-                                              std::abs(2. * error_estimate))))),
-                4.);
-
-            stepping._step_size *= step_size_scaling;
-
-            // If step size becomes too small the particle remains at the
-            // initial place
-            if (std::abs(stepping._step_size) <
-                std::abs(stepping._step_size_cutoff)) {
-                // Not moving due to too low momentum needs an aborter
-                printf("Stepper: step size is too small. will break. \n");
-                // State is broken
-                return navigation.abort();
-            }
-
-            // If the parameter is off track too much or given step_size is not
-            // appropriate
-            if (n_step_trials > stepping._max_rk_step_trials) {
-                // Too many trials, have to abort
-                printf("Stepper: too many rk4 trials. will break. \n");
-                // State is broken
-                return navigation.abort();
-            }
-            n_step_trials++;
-        }
-
-        // Update navigation direction
-        const step::direction dir = stepping._step_size >= 0
-                                        ? step::direction::e_forward
-                                        : step::direction::e_backward;
-        stepping.set_direction(dir);
-
-        // Decide final step size and inform navigator
-        // Not a severe change to track state expected
-        if (std::abs(stepping.step_size()) <
-            std::abs(
-                stepping.constraints().template size<>(stepping.direction()))) {
-            navigation.set_high_trust();
-        }
-        // Step size hit a constraint - the track state was probably changed a
-        // lot
-        else {
-            stepping.set_step_size(
-                stepping.constraints().template size<>(stepping.direction()));
-            // Re-evaluate all candidates
-            navigation.set_fair_trust();
-        }
-
-        // Update and check path limit
-        if (not stepping.check_path_limit()) {
-            printf("Stepper: Above maximal path length!\n");
-            // State is broken
-            return navigation.abort();
-        }
-
-        // Update track state
-        stepping.advance_track();
-
-        // state.stepping.derivative.template head<3>() = dir;
-        // state.stepping.derivative.template segment<3>(4) = sd.k4;
-
-        return true;
-    }
-
-    DETRAY_HOST_DEVICE
-    inline vector3 evaluate_k(const state& stepping, const vector3& b_field,
-                              const int i, const scalar h = 0.,
-                              const vector3& k_prev = vector3{0, 0, 0}) {
-        vector3 k_new;
-        auto qop = stepping().qop();
-        auto dir = stepping().dir();
-
-        if (i == 0) {
-            k_new = qop * vector::cross(dir, b_field);
-        } else {
-            k_new = qop * vector::cross(dir + h * k_prev, b_field);
-        }
-
-        return k_new;
-    }
+                                 navigation_state_t& navigation);
 
     private:
     const magnetic_field_t _magnetic_field;
 };
 
 }  // namespace detray
+
+#include "detray/propagator/rk_stepper.ipp"

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -86,13 +86,13 @@ void detray::rk_stepper<magnetic_field_t, track_t, constraint_t,
     auto dk3dT = matrix_operator().template identity<3, 3>();
     auto dk4dT = matrix_operator().template identity<3, 3>();
 
-    dk1dT = qop * vector_helpers<scalar>().cross(dk1dT, sd.b_first);
+    dk1dT = qop * column_wise_op<scalar>().cross(dk1dT, sd.b_first);
     dk2dT = dk2dT + half_h * dk1dT;
-    dk2dT = qop * vector_helpers<scalar>().cross(dk2dT, sd.b_middle);
+    dk2dT = qop * column_wise_op<scalar>().cross(dk2dT, sd.b_middle);
     dk3dT = dk3dT + half_h * dk2dT;
-    dk3dT = qop * vector_helpers<scalar>().cross(dk3dT, sd.b_middle);
+    dk3dT = qop * column_wise_op<scalar>().cross(dk3dT, sd.b_middle);
     dk4dT = dk4dT + h * dk3dT;
-    dk4dT = qop * vector_helpers<scalar>().cross(dk4dT, sd.b_last);
+    dk4dT = qop * column_wise_op<scalar>().cross(dk4dT, sd.b_last);
 
     // dFdT and dGdT are top-left 3x3 submatrix of equation (17)
     auto dFdT = matrix_operator().template identity<3, 3>();

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -1,0 +1,278 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// detray include(s)
+#include "detray/utils/algebra_helpers.hpp"
+
+// System include(s)
+#include <cmath>
+
+template <typename magnetic_field_t, typename track_t, typename constraint_t,
+          template <typename, std::size_t> class array_t>
+void detray::rk_stepper<magnetic_field_t, track_t, constraint_t,
+                        array_t>::state::advance_track() {
+
+    const auto& sd = this->_step_data;
+    const auto& h = this->_step_size;
+    auto& track = this->_track;
+    auto pos = track.pos();
+    auto dir = track.dir();
+
+    // Update the track parameters according to the equations of motion
+    pos = pos + h * dir + h * h / 6. * (sd.k1 + sd.k2 + sd.k3);
+    track.set_pos(pos);
+
+    dir = dir + h / 6. * (sd.k1 + 2. * (sd.k2 + sd.k3) + sd.k4);
+    dir = vector::normalize(dir);
+    track.set_dir(dir);
+
+    // Update path length
+    this->_path_length += h;
+}
+
+template <typename magnetic_field_t, typename track_t, typename constraint_t,
+          template <typename, std::size_t> class array_t>
+void detray::rk_stepper<magnetic_field_t, track_t, constraint_t,
+                        array_t>::state::advance_jacobian() {
+    /// The calculations are based on ATL-SOFT-PUB-2009-002. The update of the
+    /// Jacobian matrix is requires only the calculation of eq. 17 and 18.
+    /// Since the terms of eq. 18 are currently 0, this matrix is not needed
+    /// in the calculation. The matrix A from eq. 17 consists out of 3
+    /// different parts. The first one is given by the upper left 3x3 matrix
+    /// that are calculated by the derivatives dF/dT (called dFdT) and dG/dT
+    /// (calles dGdT). The second is given by the top 3 lines of the rightmost
+    /// column. This is calculated by dFdL and dGdL. The remaining non-zero term
+    /// is calculated directly. The naming of the variables is explained in eq.
+    /// 11 and are directly related to the initial problem in eq. 7.
+    /// The evaluation is based by propagating the parameters T and lambda as
+    /// given in eq. 16 and evaluating the derivations for matrix A.
+    /// @note The translation for u_{n+1} in eq. 7 is in this case a
+    /// 3-dimensional vector without a dependency of Lambda or lambda neither in
+    /// u_n nor in u_n'. The second and fourth eq. in eq. 14 have the constant
+    /// offset matrices h * Id and Id respectively. This involves that the
+    /// constant offset does not exist for rectangular matrix dGdu' (due to the
+    /// missing Lambda part) and only exists for dFdu' in dlambda/dlambda.
+
+    const auto& sd = this->_step_data;
+    const auto& h = this->_step_size;
+    // const auto& mass = this->_mass;
+    auto& track = this->_track;
+    auto dir = track.dir();
+    auto qop = track.qop();
+
+    // Half step length
+    scalar half_h = h * 0.5;
+
+    /*---------------------------------------------------------------------------
+     * k_{n} is always in the form of [ A(T) X B ] where A is a function of r'
+     * and B is magnetic field and X symbol is for cross product. Hence dk{n}dT
+     * can be represented as follows:
+     *
+     *  dk{n}dT =  d/dT [ A(T) X B ] = dA(T)/dr (X) B
+     *
+     *  where,
+     *  (X) symbol is column-wise cross product between matrix and vector,
+     *  k1 = qop * T X B_first,
+     *  k2 = qop * ( T + h / 2 * k1 ) X B_middle,
+     *  k3 = qop * ( T + h / 2 * k2 ) X B_middle,
+     *  k4 = qop * ( T + h * k3 ) * B_last.
+    ---------------------------------------------------------------------------*/
+    auto dk1dT = matrix_operator().template identity<3, 3>();
+    auto dk2dT = matrix_operator().template identity<3, 3>();
+    auto dk3dT = matrix_operator().template identity<3, 3>();
+    auto dk4dT = matrix_operator().template identity<3, 3>();
+
+    dk1dT = qop * vector_helpers<scalar>().cross(dk1dT, sd.b_first);
+    dk2dT = dk2dT + half_h * dk1dT;
+    dk2dT = qop * vector_helpers<scalar>().cross(dk2dT, sd.b_middle);
+    dk3dT = dk3dT + half_h * dk2dT;
+    dk3dT = qop * vector_helpers<scalar>().cross(dk3dT, sd.b_middle);
+    dk4dT = dk4dT + h * dk3dT;
+    dk4dT = qop * vector_helpers<scalar>().cross(dk4dT, sd.b_last);
+
+    // dFdT and dGdT are top-left 3x3 submatrix of equation (17)
+    auto dFdT = matrix_operator().template identity<3, 3>();
+    auto dGdT = matrix_operator().template identity<3, 3>();
+    dFdT = dFdT + h / 6. * (dk1dT + dk2dT + dk3dT);
+    dFdT = h * dFdT;
+    dGdT = dGdT + h / 6. * (dk1dT + 2. * (dk2dT + dk3dT) + dk4dT);
+
+    // Calculate dk{n}dL where L is qop
+    vector3 dk1dL = vector::cross(dir, sd.b_first);
+    vector3 dk2dL = vector::cross(dir + half_h * sd.k1, sd.b_middle) +
+                    qop * half_h * vector::cross(dk1dL, sd.b_middle);
+    vector3 dk3dL = vector::cross(dir + half_h * sd.k2, sd.b_middle) +
+                    qop * half_h * vector::cross(dk2dL, sd.b_middle);
+    vector3 dk4dL = vector::cross(dir + h * sd.k3, sd.b_last) +
+                    qop * h * vector::cross(dk3dL, sd.b_last);
+
+    // dFdL and dGdL are top-right 3x1 submatrix of equation (17)
+    vector3 dFdL = (h * h) / 6. * (dk1dL + dk2dL + dk3dL);
+    vector3 dGdL = h / 6. * (dk1dL + 2. * (dk2dL + dk3dL) + dk4dL);
+
+    // Set transport matrix (D) and update Jacobian transport
+    //( JacTransport = D * JacTransport )
+    auto D = matrix_operator().template identity<e_free_size, e_free_size>();
+    matrix_operator().set_block(D, dFdT, 0, 4);
+    matrix_operator().set_block(D, dFdL, 0, 7);
+    matrix_operator().set_block(D, dGdT, 4, 4);
+    matrix_operator().set_block(D, dGdL, 4, 7);
+
+    /// Calculate (4,4) element of equation (17)
+    /// NOTE: Let's skip this element for the moment
+    /// const auto p = getter::norm(track.mom());
+    /// matrix_operator().element(D, 3, 7) =
+    /// h * mass * mass * qop * getter::perp(vector2{1, mass / p});
+
+    this->_jac_transport = D * this->_jac_transport;
+}
+
+template <typename magnetic_field_t, typename track_t, typename constraint_t,
+          template <typename, std::size_t> class array_t>
+auto detray::rk_stepper<magnetic_field_t, track_t, constraint_t,
+                        array_t>::state::evaluate_k(const vector3& b_field,
+                                                    const int i, const scalar h,
+                                                    const vector3& k_prev)
+    -> vector3 {
+    auto& track = this->_track;
+
+    auto qop = track.qop();
+    auto dir = track.dir();
+
+    vector3 k_new;
+
+    if (i == 0) {
+        k_new = qop * vector::cross(dir, b_field);
+    } else {
+        k_new = qop * vector::cross(dir + h * k_prev, b_field);
+    }
+
+    return k_new;
+}
+
+template <typename magnetic_field_t, typename track_t, typename constraint_t,
+          template <typename, std::size_t> class array_t>
+template <typename navigation_state_t>
+bool detray::rk_stepper<magnetic_field_t, track_t, constraint_t, array_t>::step(
+    state& stepping, navigation_state_t& navigation) {
+
+    auto& sd = stepping._step_data;
+
+    scalar error_estimate = 0;
+
+    // First Runge-Kutta point
+    sd.b_first = _magnetic_field.get_field(stepping().pos(), context_type{});
+    sd.k1 = stepping.evaluate_k(sd.b_first, 0, 0, vector3{0, 0, 0});
+
+    const auto try_rk4 = [&](const scalar& h) -> bool {
+        // State the square and half of the step size
+        const scalar h2 = h * h;
+        const scalar half_h = h * 0.5;
+        auto pos = stepping().pos();
+        auto dir = stepping().dir();
+
+        // Second Runge-Kutta point
+        const vector3 pos1 = pos + half_h * dir + h2 * 0.125 * sd.k1;
+        sd.b_middle = _magnetic_field.get_field(pos1, context_type{});
+        sd.k2 = stepping.evaluate_k(sd.b_middle, 1, half_h, sd.k1);
+
+        // Third Runge-Kutta point
+        sd.k3 = stepping.evaluate_k(sd.b_middle, 2, half_h, sd.k2);
+
+        // Last Runge-Kutta point
+        const vector3 pos2 = pos + h * dir + h2 * 0.5 * sd.k3;
+        sd.b_last = _magnetic_field.get_field(pos2, context_type{});
+        sd.k4 = stepping.evaluate_k(sd.b_last, 3, h, sd.k3);
+
+        // Compute and check the local integration error estimate
+        // @Todo
+        const vector3 err_vec = h2 * (sd.k1 - sd.k2 - sd.k3 + sd.k4);
+        error_estimate =
+            std::max(getter::norm(err_vec), static_cast<scalar>(1e-20));
+
+        return (error_estimate <= stepping._tolerance);
+    };
+
+    // Initial step size estimate
+    stepping.set_step_size(navigation());
+    scalar step_size_scaling = 1.;
+    size_t n_step_trials = 0;
+
+    // Adjust initial step size to integration error
+    while (!try_rk4(stepping._step_size)) {
+
+        step_size_scaling = std::min(
+            std::max(0.25 * unit_constants::mm,
+                     std::sqrt(std::sqrt((stepping._tolerance /
+                                          std::abs(2. * error_estimate))))),
+            4.);
+
+        stepping._step_size *= step_size_scaling;
+
+        // If step size becomes too small the particle remains at the
+        // initial place
+        if (std::abs(stepping._step_size) <
+            std::abs(stepping._step_size_cutoff)) {
+            // Not moving due to too low momentum needs an aborter
+            printf("Stepper: step size is too small. will break. \n");
+            // State is broken
+            return navigation.abort();
+        }
+
+        // If the parameter is off track too much or given step_size is not
+        // appropriate
+        if (n_step_trials > stepping._max_rk_step_trials) {
+            // Too many trials, have to abort
+            printf("Stepper: too many rk4 trials. will break. \n");
+            // State is broken
+            return navigation.abort();
+        }
+        n_step_trials++;
+    }
+
+    // Update navigation direction
+    const step::direction step_dir = stepping._step_size >= 0
+                                         ? step::direction::e_forward
+                                         : step::direction::e_backward;
+    stepping.set_direction(step_dir);
+
+    // Decide final step size and inform navigator
+    // Not a severe change to track state expected
+    if (std::abs(stepping.step_size()) <
+        std::abs(
+            stepping.constraints().template size<>(stepping.direction()))) {
+        navigation.set_high_trust();
+    }
+    // Step size hit a constraint - the track state was probably changed a
+    // lot
+    else {
+        stepping.set_step_size(
+            stepping.constraints().template size<>(stepping.direction()));
+        // Re-evaluate all candidates
+        navigation.set_fair_trust();
+    }
+
+    // Update and check path limit
+    if (not stepping.check_path_limit()) {
+        printf("Stepper: Above maximal path length!\n");
+        // State is broken
+        return navigation.abort();
+    }
+
+    // Update the derivative
+    matrix_operator().set_block(stepping._derivative, stepping._track.dir(), 0,
+                                0);
+    matrix_operator().set_block(stepping._derivative, sd.k4, 4, 0);
+
+    // Advance track state
+    stepping.advance_track();
+
+    // Advance jacobian transport
+    stepping.advance_jacobian();
+
+    return true;
+}

--- a/core/include/detray/propagator/track.hpp
+++ b/core/include/detray/propagator/track.hpp
@@ -30,10 +30,16 @@ struct bound_track_parameters {
         : _surface_link(sf_idx), _vector(params), _covariance(cov) {}
 
     DETRAY_HOST_DEVICE
-    vector_type& vector() { return _vector; }
+    const vector_type& vector() const { return _vector; }
 
     DETRAY_HOST_DEVICE
-    covariance_type& covariance() { return _covariance; }
+    void set_vector(const vector_type& v) { _vector = v; }
+
+    DETRAY_HOST_DEVICE
+    const covariance_type& covariance() const { return _covariance; }
+
+    DETRAY_HOST_DEVICE
+    void set_covariance(const covariance_type& c) { _covariance = c; }
 
     DETRAY_HOST_DEVICE
     point2 local() const {
@@ -133,10 +139,16 @@ struct free_track_parameters {
     }
 
     DETRAY_HOST_DEVICE
-    vector_type& vector() { return _vector; }
+    const vector_type& vector() const { return _vector; }
 
     DETRAY_HOST_DEVICE
-    covariance_type& covariance() { return _covariance; }
+    void set_vector(const vector_type& v) { _vector = v; }
+
+    DETRAY_HOST_DEVICE
+    const covariance_type& covariance() const { return _covariance; }
+
+    DETRAY_HOST_DEVICE
+    void set_covariance(const covariance_type& c) { _covariance = c; }
 
     DETRAY_HOST_DEVICE
     scalar overstep_tolerance() const { return _overstep_tolerance; }

--- a/core/include/detray/utils/algebra_helpers.hpp
+++ b/core/include/detray/utils/algebra_helpers.hpp
@@ -1,0 +1,60 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/definitions/qualifiers.hpp"
+
+namespace detray {
+
+template <typename scalar_t>
+struct vector_helpers {
+
+    using vector3 = __plugin::vector3<scalar_t>;
+
+    using size_type = __plugin::size_type;
+
+    template <size_type ROWS, size_type COLS>
+    using matrix_type = __plugin::matrix_type<scalar_t, ROWS, COLS>;
+
+    using matrix_operator = standard_matrix_operator<scalar_t>;
+
+    /// Column-wise cross product between matrix (m) and vector (v)
+    DETRAY_HOST_DEVICE
+    inline matrix_type<3, 3> cross(const matrix_type<3, 3>& m,
+                                   const vector3& v) const {
+        matrix_type<3, 3> ret;
+
+        auto m_col0 = matrix_operator().template block<3, 1>(m, 0, 0);
+        auto m_col1 = matrix_operator().template block<3, 1>(m, 0, 1);
+        auto m_col2 = matrix_operator().template block<3, 1>(m, 0, 2);
+
+        matrix_operator().set_block(ret, vector::cross(m_col0, v), 0, 0);
+        matrix_operator().set_block(ret, vector::cross(m_col1, v), 0, 1);
+        matrix_operator().set_block(ret, vector::cross(m_col2, v), 0, 2);
+
+        return ret;
+    }
+
+    /// Column-wise dot product between matrix (m) and vector (v)
+    DETRAY_HOST_DEVICE
+    inline matrix_type<3, 3> dot(const matrix_type<3, 3>& m,
+                                 const vector3& v) const {
+        matrix_type<3, 3> ret;
+
+        for (size_type i = 0; i < 3; i++) {
+            for (size_type j = 0; j < 3; j++) {
+                matrix_operator().element(ret, j, i) =
+                    matrix_operator().element(m, j, i) * v[j];
+            }
+        }
+
+        return ret;
+    }
+};
+
+}  // namespace detray

--- a/core/include/detray/utils/algebra_helpers.hpp
+++ b/core/include/detray/utils/algebra_helpers.hpp
@@ -12,7 +12,7 @@
 namespace detray {
 
 template <typename scalar_t>
-struct vector_helpers {
+struct column_wise_op {
 
     using vector3 = __plugin::vector3<scalar_t>;
 
@@ -40,10 +40,10 @@ struct vector_helpers {
         return ret;
     }
 
-    /// Column-wise dot product between matrix (m) and vector (v)
+    /// Column-wise multiplication between matrix (m) and vector (v)
     DETRAY_HOST_DEVICE
-    inline matrix_type<3, 3> dot(const matrix_type<3, 3>& m,
-                                 const vector3& v) const {
+    inline matrix_type<3, 3> multiply(const matrix_type<3, 3>& m,
+                                      const vector3& v) const {
         matrix_type<3, 3> ret;
 
         for (size_type i = 0; i < 3; i++) {

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -12,11 +12,17 @@ include( FetchContent )
 message( STATUS "Building Algebra Plugins as part of the Detray project" )
 
 # Declare where to get Algebra Plugins from.
-set( DETRAY_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.8.0.tar.gz;URL_MD5;33554a09c16327078ceae1d70b525411"
-   CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
-mark_as_advanced( DETRAY_ALGEBRA_PLUGINS_SOURCE )
-FetchContent_Declare( AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE} )
+#set( DETRAY_ALGEBRA_PLUGINS_SOURCE
+#   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.9.2.tar.gz;URL_MD5;7965f746a28381a1bccaebd2133284bf"
+#   CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
+#mark_as_advanced( DETRAY_ALGEBRA_PLUGINS_SOURCE )
+#FetchContent_Declare( AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE} )
+
+FetchContent_Declare( AlgebraPlugins 
+ GIT_REPOSITORY https://github.com/beomki-yeo/algebra-plugins.git
+ GIT_TAG feat-matrix-vector-operations
+)
+
 
 # Options used in the build of Algebra Plugins.
 set( ALGEBRA_PLUGINS_BUILD_TESTING FALSE CACHE BOOL

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -12,17 +12,11 @@ include( FetchContent )
 message( STATUS "Building Algebra Plugins as part of the Detray project" )
 
 # Declare where to get Algebra Plugins from.
-#set( DETRAY_ALGEBRA_PLUGINS_SOURCE
-#   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.9.2.tar.gz;URL_MD5;7965f746a28381a1bccaebd2133284bf"
-#   CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
-#mark_as_advanced( DETRAY_ALGEBRA_PLUGINS_SOURCE )
-#FetchContent_Declare( AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE} )
-
-FetchContent_Declare( AlgebraPlugins 
- GIT_REPOSITORY https://github.com/beomki-yeo/algebra-plugins.git
- GIT_TAG feat-matrix-vector-operations
-)
-
+set( DETRAY_ALGEBRA_PLUGINS_SOURCE
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.10.0.tar.gz;URL_MD5;91e04307f2cdeda5dc541104fedb6860"
+   CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
+mark_as_advanced( DETRAY_ALGEBRA_PLUGINS_SOURCE )
+FetchContent_Declare( AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE} )
 
 # Options used in the build of Algebra Plugins.
 set( ALGEBRA_PLUGINS_BUILD_TESTING FALSE CACHE BOOL

--- a/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
@@ -22,9 +22,9 @@ namespace vector = algebra::vector;
 namespace matrix = algebra::matrix;
 
 // Define matrix operator
-template <typename T>
-using matrix_operator =
-    matrix::actor<std::size_t, T, matrix::determinant::preset0<std::size_t, T>,
-                  matrix::inverse::preset0<std::size_t, T>>;
+template <typename scalar_t>
+using standard_matrix_operator =
+    matrix::actor<scalar_t, matrix::determinant::preset0<scalar_t>,
+                  matrix::inverse::preset0<scalar_t>>;
 
 }  // namespace detray

--- a/plugins/algebra/eigen/include/detray/plugins/algebra/eigen_definitions.hpp
+++ b/plugins/algebra/eigen/include/detray/plugins/algebra/eigen_definitions.hpp
@@ -22,7 +22,7 @@ namespace vector = algebra::vector;
 namespace matrix = algebra::matrix;
 
 // Define matrix operator
-template <typename T>
-using matrix_operator = matrix::actor<T>;
+template <typename scalar_t>
+using standard_matrix_operator = matrix::actor<scalar_t>;
 
 }  // namespace detray

--- a/plugins/algebra/smatrix/include/detray/plugins/algebra/smatrix_definitions.hpp
+++ b/plugins/algebra/smatrix/include/detray/plugins/algebra/smatrix_definitions.hpp
@@ -22,7 +22,7 @@ namespace vector = algebra::vector;
 namespace matrix = algebra::matrix;
 
 // Define matrix operator
-template <typename T>
-using matrix_operator = matrix::actor<T>;
+template <typename scalar_t>
+using standard_matrix_operator = matrix::actor<scalar_t>;
 
 }  // namespace detray

--- a/plugins/algebra/vc/include/detray/plugins/algebra/vc_array_definitions.hpp
+++ b/plugins/algebra/vc/include/detray/plugins/algebra/vc_array_definitions.hpp
@@ -22,9 +22,9 @@ namespace vector = algebra::vector;
 namespace matrix = algebra::matrix;
 
 // Define matrix operator
-template <typename T>
-using matrix_operator =
-    matrix::actor<std::size_t, T, matrix::determinant::preset0<std::size_t, T>,
-                  matrix::inverse::preset0<std::size_t, T>>;
+template <typename scalar_t>
+using standard_matrix_operator =
+    matrix::actor<scalar_t, matrix::determinant::preset0<scalar_t>,
+                  matrix::inverse::preset0<scalar_t>>;
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools/helix_gun.hpp
+++ b/tests/common/include/tests/common/tools/helix_gun.hpp
@@ -6,9 +6,13 @@
  */
 #pragma once
 
-// detray tools
+// detray include(s)
 #include "detray/propagator/track.hpp"
+#include "detray/utils/algebra_helpers.hpp"
 
+/// Helix gun class for the analytical solution of track propagation in
+/// homogeneous B field. This Follows the notation of Eq (4.7) in
+/// DOI:10.1007/978-3-030-65771-0
 namespace detray {
 
 class helix_gun {
@@ -16,6 +20,10 @@ class helix_gun {
     using point3 = __plugin::point3<scalar>;
     using vector3 = __plugin::vector3<scalar>;
     using vector2 = __plugin::vector2<scalar>;
+    using matrix_operator = standard_matrix_operator<scalar>;
+    using size_type = __plugin::size_type;
+    template <size_type ROWS, size_type COLS>
+    using matrix_type = __plugin::matrix_type<scalar, ROWS, COLS>;
 
     helix_gun() = delete;
 
@@ -23,16 +31,29 @@ class helix_gun {
               vector3 const *const mag_field)
         : _vertex(vertex), _mag_field(mag_field) {
 
-        // get new z direction along the b field
-        _ez = vector::normalize(*_mag_field);
+        // Normalized B field
+        _h0 = vector::normalize(*_mag_field);
 
-        vector3 p = _vertex.mom();
+        // Normalized tangent vector
+        _t0 = vector::normalize(vertex.mom());
 
-        // get longitudinal momentum in new coordinate
-        scalar pz = vector::dot(p, _ez);
+        // Normalized _h0 X _t0
+        _n0 = vector::normalize(vector::cross(_h0, _t0));
 
-        // get transverse momentum in new coordinate
-        vector3 pT = p - pz * _ez;
+        // Magnitude of _h0 X _t0
+        _alpha = getter::norm(vector::cross(_h0, _t0));
+
+        // Dot product of _h0 X _t0
+        _delta = vector::dot(_h0, _t0);
+
+        // Path length scaler
+        _K = -1. * vertex.qop() * getter::norm(*_mag_field);
+
+        // Get longitudinal momentum parallel to B field
+        scalar pz = vector::dot(vertex.mom(), _h0);
+
+        // Get transverse momentum perpendicular to B field
+        vector3 pT = vertex.mom() - pz * _h0;
 
         // R [mm] =  pT [GeV] / B [T] in natrual unit
         _R = getter::norm(pT) / getter::norm(*_mag_field);
@@ -44,36 +65,106 @@ class helix_gun {
             // Get vz over vt in new coordinate
             _vz_over_vt = pz / getter::norm(pT);
         }
-
-        _scaler = _R * std::sqrt(1 + std::pow(_vz_over_vt, 2));
-
-        // get new y direction
-        scalar q = _vertex.qop() > 0 ? 1 : -1.;
-        vector3 y = -1 * q * vector::normalize(pT);
-        _ey = vector::normalize(y);
-
-        // get new x direction
-        _ex = vector::cross(_ey, _ez);
     }
 
     scalar radius() const { return _R; }
 
-    point3 operator()(scalar path_length) const {
+    point3 operator()(scalar s) const { return this->pos(s); }
+
+    // position after propagating the path length of s
+    point3 pos(scalar s) const {
 
         // Handle the case of pT ~ 0
         if (_vz_over_vt == std::numeric_limits<scalar>::infinity()) {
-            return _vertex.pos() + path_length * _ez;
+            return _vertex.pos() + s * _h0;
         }
 
-        // Requested path length is coverted to parameterized value (t) by
-        // dividing it with scaling factor
-        scalar t = path_length / _scaler;
+        point3 ret = _vertex.pos();
+        ret = ret + _delta / _K * (_K * s - std::sin(_K * s)) * _h0;
+        ret = ret + std::sin(_K * s) / _K * _t0;
+        ret = ret + _alpha / _K * (1 - std::cos(_K * s)) * _n0;
 
-        vector3 X = (_R * std::cos(t) - _R) * _ex;
-        vector3 Y = (_R * std::sin(t)) * _ey;
-        vector3 Z = (_R * _vz_over_vt * t) * _ez;
+        return ret;
+    }
 
-        return _vertex.pos() + X + Y + Z;
+    // tangentional vector after propagating the path length of s
+    vector3 dir(scalar s) const {
+
+        // Handle the case of pT ~ 0
+        if (_vz_over_vt == std::numeric_limits<scalar>::infinity()) {
+            return _vertex.dir();
+        }
+
+        vector3 ret{0, 0, 0};
+
+        ret = ret + _delta * (1 - std::cos(_K * s)) * _h0;
+        ret = ret + std::cos(_K * s) * _t0;
+        ret = ret + _alpha * std::sin(_K * s) * _n0;
+
+        return ret;
+    }
+
+    // transport jacobian after propagating the path length of s
+    free_matrix jacobian(scalar s) const {
+
+        free_matrix ret =
+            matrix_operator().template zero<e_free_size, e_free_size>();
+
+        const matrix_type<3, 3> I33 =
+            matrix_operator().template identity<3, 3>();
+        const matrix_type<3, 3> Z33 = matrix_operator().template zero<3, 3>();
+        /// Get drdr
+
+        auto drdr = I33;
+        matrix_operator().set_block(ret, drdr, 0, 0);
+
+        /// Get dtdr
+
+        auto dtdr = Z33;
+        matrix_operator().set_block(ret, dtdr, 4, 0);
+
+        /// Get drdt
+        auto drdt = Z33;
+
+        drdt = drdt + std::sin(_K * s) / _K * I33;
+
+        const auto H0 = vector_helpers<scalar>().dot(I33, _h0);
+        drdt = drdt + (_K * s - std::sin(_K * s)) / _K *
+                          vector_helpers<scalar>().dot(
+                              matrix_operator().transpose(H0), _h0);
+
+        drdt = drdt + (std::cos(_K * s) - 1) / _K *
+                          vector_helpers<scalar>().cross(I33, _h0);
+
+        matrix_operator().set_block(ret, drdt, 0, 4);
+
+        /// Get dtdt
+        auto dtdt = Z33;
+        dtdt = dtdt + std::cos(_K * s) * I33;
+        dtdt = dtdt + (1 - std::cos(_K * s)) *
+                          vector_helpers<scalar>().dot(
+                              matrix_operator().transpose(H0), _h0);
+        dtdt =
+            dtdt - std::sin(_K * s) * vector_helpers<scalar>().cross(I33, _h0);
+
+        matrix_operator().set_block(ret, dtdt, 4, 4);
+
+        /// Get drdl
+        vector3 drdl = 1 / _vertex.qop() *
+                       (s * this->dir(s) + _vertex.pos() - this->pos(s));
+
+        matrix_operator().set_block(ret, drdl, 0, 7);
+
+        /// Get dtdl
+        vector3 dtdl = _alpha * _K * s / _vertex.qop() * _n0;
+
+        matrix_operator().set_block(ret, dtdl, 4, 7);
+
+        /// 3x3 and 7x7 element is 1 (Maybe?)
+        matrix_operator().element(ret, 3, 3) = 1;
+        matrix_operator().element(ret, 7, 7) = 1;
+
+        return ret;
     }
 
     private:
@@ -83,18 +174,29 @@ class helix_gun {
     // B field
     vector3 const *_mag_field;
 
+    // Normalized b field
+    vector3 _h0;
+
+    // Normalized tangent vector
+    vector3 _t0;
+
+    // Normalized _h0 X _t0
+    vector3 _n0;
+
+    // Magnitude of _h0 X _t0
+    scalar _alpha;
+
+    // Dot product of _h0 X _t0
+    scalar _delta;
+
+    // Path length scaler
+    scalar _K;
+
     // Radius [mm] of helix
     scalar _R;
 
-    // new coordinated whose z axis is parallel to B field
-    vector3 _ex;
-    vector3 _ey;
-    vector3 _ez;
-
-    // velocity in new z axis divided by transverse velocity
+    // Velocity in new z axis divided by transverse velocity
     scalar _vz_over_vt;
-    // The scaling factor that convert arc length into parametrized length
-    scalar _scaler;
 };
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools/helix_gun.hpp
+++ b/tests/common/include/tests/common/tools/helix_gun.hpp
@@ -128,13 +128,13 @@ class helix_gun {
 
         drdt = drdt + std::sin(_K * s) / _K * I33;
 
-        const auto H0 = vector_helpers<scalar>().dot(I33, _h0);
+        const auto H0 = column_wise_op<scalar>().multiply(I33, _h0);
         drdt = drdt + (_K * s - std::sin(_K * s)) / _K *
-                          vector_helpers<scalar>().dot(
+                          column_wise_op<scalar>().multiply(
                               matrix_operator().transpose(H0), _h0);
 
         drdt = drdt + (std::cos(_K * s) - 1) / _K *
-                          vector_helpers<scalar>().cross(I33, _h0);
+                          column_wise_op<scalar>().cross(I33, _h0);
 
         matrix_operator().set_block(ret, drdt, 0, 4);
 
@@ -142,10 +142,10 @@ class helix_gun {
         auto dtdt = Z33;
         dtdt = dtdt + std::cos(_K * s) * I33;
         dtdt = dtdt + (1 - std::cos(_K * s)) *
-                          vector_helpers<scalar>().dot(
+                          column_wise_op<scalar>().multiply(
                               matrix_operator().transpose(H0), _h0);
         dtdt =
-            dtdt - std::sin(_K * s) * vector_helpers<scalar>().cross(I33, _h0);
+            dtdt - std::sin(_K * s) * column_wise_op<scalar>().cross(I33, _h0);
 
         matrix_operator().set_block(ret, dtdt, 4, 4);
 

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -37,6 +37,8 @@ struct helix_inspector : actor {
         helix_gun _helix;
     };
 
+    using size_type = __plugin::size_type;
+    using matrix_operator = standard_matrix_operator<scalar>;
     using state_type = helix_inspector_state;
 
     /// Check that the stepper remains on the right helical track for its pos.
@@ -56,6 +58,16 @@ struct helix_inspector : actor {
             static_cast<point3>(1 / path_accumulated * (pos - true_pos));
 
         ASSERT_NEAR(getter::norm(relative_error), 0, epsilon);
+
+        auto true_J = inspector_state._helix.jacobian(path_accumulated);
+        for (size_type i = 0; i < e_free_size; i++) {
+            for (size_type j = 0; j < e_free_size; j++) {
+                ASSERT_NEAR(
+                    matrix_operator().element(stepping._jac_transport, i, j),
+                    matrix_operator().element(true_J, i, j),
+                    stepping.path_length() * epsilon * 10);
+            }
+        }
     }
 };
 
@@ -103,8 +115,8 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
     using vector3 = __plugin::vector3<scalar>;
 
     // geomery navigation configurations
-    constexpr unsigned int theta_steps = 100;
-    constexpr unsigned int phi_steps = 100;
+    constexpr unsigned int theta_steps = 50;
+    constexpr unsigned int phi_steps = 50;
 
     // detector configuration
     constexpr std::size_t n_brl_layers = 4;

--- a/tests/unit_tests/cuda/propagator_cuda.cpp
+++ b/tests/unit_tests/cuda/propagator_cuda.cpp
@@ -166,7 +166,7 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
                     auto device_val =
                         matrix_operator().element(device_J, row, col);
 
-                    EXPECT_NEAR(host_val, device_val, pos_diff_tolerance);
+                    EXPECT_NEAR(host_val, device_val, error_diff_tolerance);
                 }
             }
         }

--- a/tests/unit_tests/cuda/propagator_cuda.cpp
+++ b/tests/unit_tests/cuda/propagator_cuda.cpp
@@ -19,11 +19,10 @@ class CudaPropagatorWithRkStepper
 TEST_P(CudaPropagatorWithRkStepper, propagator) {
 
     // Helper object for performing memory copies.
-    vecmem::cuda::copy copy;
+    vecmem::copy copy;
 
     // VecMem memory resource(s)
     vecmem::cuda::managed_memory_resource mng_mr;
-    vecmem::cuda::device_memory_resource dev_mr;
 
     // Create the toy geometry
     detector_host_type det =
@@ -67,7 +66,7 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
      */
 
     // Set the magnetic field
-    vector3 B = GetParam();
+    const vector3 B = GetParam();
     field_type B_field(B);
 
     // Create RK stepper
@@ -80,7 +79,9 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
     propagator_host_type p(std::move(s), std::move(n));
 
     // Create vector for track recording
-    vecmem::jagged_vector<intersection_t> host_intersection_records(&mng_mr);
+    vecmem::jagged_vector<vector3> host_positions(&mng_mr);
+    vecmem::jagged_vector<free_matrix> host_jac_transports(&mng_mr);
+
     for (unsigned int i = 0; i < theta_steps * phi_steps; i++) {
 
         inspector_host_t::state_type insp_state{mng_mr};
@@ -92,8 +93,9 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
         // Run propagation
         p.propagate(state);
 
-        // push back the intersection record
-        host_intersection_records.push_back(insp_state._intersections);
+        // Record the step information
+        host_positions.push_back(insp_state._positions);
+        host_jac_transports.push_back(insp_state._jac_transports);
     }
 
     /**
@@ -108,42 +110,65 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
 
     // Create navigator candidates buffer
     auto candidates_buffer =
-        create_candidates_buffer(det, theta_steps * phi_steps, dev_mr);
+        create_candidates_buffer(det, theta_steps * phi_steps, mng_mr);
     copy.setup(candidates_buffer);
-
-    // Create vector for track recording
-    vecmem::jagged_vector<intersection_t> device_intersection_records(&mng_mr);
 
     // Create vector buffer for track recording
     std::vector<std::size_t> sizes(theta_steps * phi_steps, 0);
     std::vector<std::size_t> capacities;
-    for (auto& r : host_intersection_records) {
+    for (auto& r : host_positions) {
         capacities.push_back(r.size());
     }
 
-    vecmem::data::jagged_vector_buffer<intersection_t> intersections_buffer(
-        sizes, capacities, dev_mr, &mng_mr);
-    copy.setup(intersections_buffer);
+    vecmem::data::jagged_vector_buffer<vector3> positions_buffer(
+        sizes, capacities, mng_mr);
+    copy.setup(positions_buffer);
+    vecmem::data::jagged_vector_buffer<free_matrix> jac_transports_buffer(
+        sizes, capacities, mng_mr);
+    copy.setup(jac_transports_buffer);
 
     // Run the propagator test for GPU device
-    propagator_test(det_data, tracks_data, candidates_buffer,
-                    intersections_buffer);
+    propagator_test(det_data, B, tracks_data, candidates_buffer,
+                    positions_buffer, jac_transports_buffer);
 
-    // copy back intersection record
-    copy(intersections_buffer, device_intersection_records);
+    // Compare the positions
+    vecmem::jagged_vector<vector3> device_positions(&mng_mr);
+    copy(positions_buffer, device_positions);
 
-    for (unsigned int i = 0; i < host_intersection_records.size(); i++) {
-        for (unsigned int j = 0; j < host_intersection_records[i].size(); j++) {
-            auto& host_intersection = host_intersection_records[i][j];
-            auto& device_intersection = device_intersection_records[i][j];
+    for (unsigned int i = 0; i < host_positions.size(); i++) {
+        ASSERT_TRUE(host_positions[i].size() > 0);
 
-            EXPECT_EQ(host_intersection.link, device_intersection.link);
-            EXPECT_NEAR(host_intersection.p3[0], device_intersection.p3[0],
-                        pos_diff_tolerance);
-            EXPECT_NEAR(host_intersection.p3[1], device_intersection.p3[1],
-                        pos_diff_tolerance);
-            EXPECT_NEAR(host_intersection.p3[2], device_intersection.p3[2],
-                        pos_diff_tolerance);
+        for (unsigned int j = 0; j < host_positions[i].size(); j++) {
+            auto& host_pos = host_positions[i][j];
+            auto& device_pos = device_positions[i][j];
+
+            EXPECT_NEAR(host_pos[0], device_pos[0], pos_diff_tolerance);
+            EXPECT_NEAR(host_pos[1], device_pos[1], pos_diff_tolerance);
+            EXPECT_NEAR(host_pos[2], device_pos[2], pos_diff_tolerance);
+        }
+    }
+
+    // Compare the jacobian transports
+    vecmem::jagged_vector<free_matrix> device_jac_transports(&mng_mr);
+    copy(jac_transports_buffer, device_jac_transports);
+
+    for (unsigned int i = 0; i < host_jac_transports.size(); i++) {
+        for (unsigned int j = 0; j < host_jac_transports[i].size(); j++) {
+
+            auto& host_J = host_jac_transports[i][j];
+            auto& device_J = device_jac_transports[i][j];
+
+            for (__plugin::size_type row = 0; row < e_free_size; row++) {
+                for (__plugin::size_type col = 0; col < e_free_size; col++) {
+
+                    auto host_val = matrix_operator().element(host_J, row, col);
+
+                    auto device_val =
+                        matrix_operator().element(device_J, row, col);
+
+                    EXPECT_NEAR(host_val, device_val, pos_diff_tolerance);
+                }
+            }
         }
     }
 }

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.cu
@@ -11,25 +11,26 @@
 namespace detray {
 
 __global__ void propagator_test_kernel(
-    detector_view<detector_host_type> det_data,
+    detector_view<detector_host_type> det_data, const vector3 B,
     vecmem::data::vector_view<free_track_parameters> tracks_data,
     vecmem::data::jagged_vector_view<intersection_t> candidates_data,
-    vecmem::data::jagged_vector_view<intersection_t> intersections_data) {
+    vecmem::data::jagged_vector_view<vector3> positions_data,
+    vecmem::data::jagged_vector_view<free_matrix> jac_transports_data) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
 
     detector_device_type det(det_data);
     vecmem::device_vector<free_track_parameters> tracks(tracks_data);
     vecmem::jagged_device_vector<intersection_t> candidates(candidates_data);
-    vecmem::jagged_device_vector<intersection_t> intersections(
-        intersections_data);
+    vecmem::jagged_device_vector<vector3> positions(positions_data);
+    vecmem::jagged_device_vector<free_matrix> jac_transports(
+        jac_transports_data);
 
     if (gid >= tracks.size()) {
         return;
     }
 
     // Set the magnetic field
-    const vector3 B{0, 0, 2 * unit_constants::T};
     field_type B_field(B);
 
     // Create RK stepper
@@ -42,7 +43,8 @@ __global__ void propagator_test_kernel(
     propagator_device_type p(std::move(s), std::move(n));
 
     // Create track inspector
-    inspector_device_t::state_type insp_state(intersections.at(gid));
+    inspector_device_t::state_type insp_state(positions.at(gid),
+                                              jac_transports.at(gid));
 
     // Create the propagator state
     propagator_device_type::state state(tracks[gid], thrust::tie(insp_state),
@@ -53,17 +55,19 @@ __global__ void propagator_test_kernel(
 }
 
 void propagator_test(
-    detector_view<detector_host_type> det_data,
+    detector_view<detector_host_type> det_data, const vector3 B,
     vecmem::data::vector_view<free_track_parameters>& tracks_data,
     vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
-    vecmem::data::jagged_vector_view<intersection_t>& intersections_data) {
+    vecmem::data::jagged_vector_view<vector3>& positions_data,
+    vecmem::data::jagged_vector_view<free_matrix>& jac_transports_data) {
 
     constexpr int thread_dim = 2 * WARP_SIZE;
     constexpr int block_dim = theta_steps * phi_steps / thread_dim + 1;
 
     // run the test kernel
     propagator_test_kernel<<<block_dim, thread_dim>>>(
-        det_data, tracks_data, candidates_data, intersections_data);
+        det_data, B, tracks_data, candidates_data, positions_data,
+        jac_transports_data);
 
     // cuda error check
     DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.cu
@@ -52,6 +52,11 @@ __global__ void propagator_test_kernel(
     propagator_device_type::state state(tracks[gid], thrust::tie(insp_state),
                                         candidates.at(gid));
 
+    state._stepping.set_tolerance(rk_tolerance);
+
+    state._stepping.template set_constraint<step::constraint::e_accuracy>(
+        constrainted_step_size);
+
     // Run propagation
     p.propagate(state);
 }

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
@@ -55,6 +55,7 @@ constexpr unsigned int theta_steps = 100;
 constexpr unsigned int phi_steps = 100;
 
 constexpr scalar pos_diff_tolerance = 1e-3;
+constexpr scalar error_diff_tolerance = 1;
 
 namespace detray {
 

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
@@ -41,8 +41,10 @@ using detector_device_type =
 using navigator_host_type = navigator<detector_host_type>;
 using navigator_device_type = navigator<detector_device_type>;
 
+using constraints_t = constrained_step<>;
 using field_type = constant_magnetic_field<>;
-using rk_stepper_type = rk_stepper<field_type, free_track_parameters>;
+using rk_stepper_type =
+    rk_stepper<field_type, free_track_parameters, constraints_t>;
 
 using matrix_operator = standard_matrix_operator<scalar>;
 
@@ -51,13 +53,13 @@ constexpr std::size_t n_brl_layers = 4;
 constexpr std::size_t n_edc_layers = 3;
 
 // geomery navigation configurations
-constexpr unsigned int theta_steps = 1;
-constexpr unsigned int phi_steps = 1;
+constexpr unsigned int theta_steps = 10;
+constexpr unsigned int phi_steps = 10;
 
-constexpr scalar pos_diff_tolerance = 1e-3;
-constexpr scalar error_diff_tolerance = 1;
-
-// constexpr scalar error_tolerance = 1e-4;
+constexpr scalar rk_tolerance = 1e-4;
+constexpr scalar overstep_tolerance = -1e-4;
+constexpr scalar constrainted_step_size = 1. * unit_constants::mm;
+constexpr scalar is_close = 1e-4;
 
 namespace detray {
 


### PR DESCRIPTION
This PR adds covariance transport in RK stepper. The unit test compares the RK jacobian and analytical jacobian under the assumption of uniform magnetic field. The PR also depends on acts-project/algebra-plugins#61

I could not figure out a good error tolerance expression between two jacobians, therefore, I just set it as `(path_length * epsilon)` but we will need to find out better expression...

References: DOI:10.1007/978-3-030-65771-0 and ATL-SOFT-PUB-2009-002

Now depends on #245 
~~Also found an issue (acts-project/vecmem#175) with `matrix<double,8,8>` type in device-to-host copy~~ << It was just my bad. It does work well after replacing `vecmem::cuda::copy` with `vecmem::copy`

### UPDATE (April 13)

Unit test has been updated. However, when I increased the number of test tracks with `theta_steps` and `phi_steps`, the unit test with **float scalar type** fails occasionally ending up with different number of steps. It's not surprising that the number of steps is different between CPU and CUDA considering their different precisions. 

It's going to be much better if we can just record the track information at the surface. But it is not easy because the propagator actor can not catch the `navigation::status::on_target` as pointed in #245. Propagator or navigator should be fixed to make it possible.
