### PR TITLE
feat: add example of chained actors

### DIFF
--- a/core/include/detray/propagator/aborters.hpp
+++ b/core/include/detray/propagator/aborters.hpp
@@ -20,7 +20,7 @@ namespace detray {
 struct pathlimit_aborter : actor {
 
     /// Pathlimit for a single propagation workflow
-    struct aborter_state {
+    struct state {
         /// Absolute path limit
         scalar _path_limit = std::numeric_limits<scalar>::max();
 
@@ -33,15 +33,12 @@ struct pathlimit_aborter : actor {
         inline scalar path_limit() const { return _path_limit; }
     };
 
-    /// Broadcast state type to actor chain
-    using state_type = aborter_state;
-
     /// Enforces the path limit on a stepper state
     ///
     /// @param abrt_state contains the path limit
     /// @param prop_state state of the propagation
     template <typename propagator_state_t>
-    DETRAY_HOST_DEVICE void operator()(state_type &abrt_state,
+    DETRAY_HOST_DEVICE void operator()(state &abrt_state,
                                        propagator_state_t &prop_state) const {
         auto &step_state = prop_state._stepping;
         auto &nav_state = prop_state._navigation;

--- a/core/include/detray/propagator/actor_chain.hpp
+++ b/core/include/detray/propagator/actor_chain.hpp
@@ -29,7 +29,7 @@ class actor_chain {
     /// Types of the actors that are registered in the chain
     using actor_list_type = tuple_t<actors_t...>;
     // Type of states tuple that is used in the propagator
-    using state = tuple_t<typename actors_t::state_type &...>;
+    using state = tuple_t<typename actors_t::state &...>;
 
     /// Call all actors in the chain.
     ///
@@ -57,7 +57,7 @@ class actor_chain {
                                        actor_states_t &states,
                                        propagator_state_t &p_state) const {
         if constexpr (not typename actor_t::is_comp_actor()) {
-            actr(detail::get<typename actor_t::state_type &>(states), p_state);
+            actr(detail::get<typename actor_t::state &>(states), p_state);
         } else {
             actr(states, p_state);
         }

--- a/core/include/detray/propagator/base_actor.hpp
+++ b/core/include/detray/propagator/base_actor.hpp
@@ -20,15 +20,8 @@ struct actor {
     /// Tag whether this is a composite type
     struct is_comp_actor : public std::false_type {};
 
-    /// Defines the actors state
+    /// Defines the actors state. Used as default template argument.
     struct base_state {};
-
-    // Implicit tag as actor that is inherited by all actors (needed only to
-    // compile the conditional in composite_actor)
-    struct actor_type {
-        using type = actor;
-        using state_type = base_state;
-    };
 };
 
 /// Composition of actors
@@ -42,19 +35,15 @@ struct actor {
 ///         actor state of the compositions actor implementation.
 template <template <typename...> class tuple_t = dtuple,
           class actor_impl_t = actor, typename... observers>
-class composite_actor : public actor_impl_t {
+class composite_actor final : public actor_impl_t {
 
     public:
     /// Tag whether this is a composite type (hides the def in the actor)
     struct is_comp_actor : public std::true_type {};
 
-    /// The composite is an actor in itself. If it is derived from another
-    /// composition, it will just implement the same actor as its base class.
-    /// I.e. it is impossible to observe another composition's observers.
-    using actor_type =
-        std::conditional_t<static_cast<bool>(
-                               typename actor_impl_t::is_comp_actor()),
-                           typename actor_impl_t::actor_type, actor_impl_t>;
+    /// The composite is an actor in itself. For simplicity, it cannot be
+    /// derived from another composition (final).
+    using actor_type = actor_impl_t;
     using state_type = typename actor_type::state_type;
 
     /// Call to the implementation of the actor (the actor possibly being an
@@ -77,26 +66,22 @@ class composite_actor : public actor_impl_t {
         auto &actor_state = detail::get<state_type &>(states);
 
         // Do your own work ...
-        // Two cases: simple actor or observing actor (needs subject state)
+        // Two cases: This is a simple actor or observing actor (pass on its
+        // subject's state)
         if constexpr (std::is_same_v<subj_state_t,
                                      typename actor::base_state>) {
-            static_cast<actor_type const *>(this)->operator()(actor_state,
-                                                              p_state);
+            actor_type::operator()(actor_state, p_state);
         } else {
-            static_cast<actor_type const *>(this)->operator()(
-                actor_state, p_state, subject_state);
+            actor_type::operator()(actor_state, p_state, subject_state);
         }
 
-        // Then run the observers on the updated state
+        // ... then run the observers on the updated state
         notify(_observers, states, actor_state, p_state,
                std::make_index_sequence<sizeof...(observers)>{});
     }
 
     private:
-    /// Notifies the observing actors
-    ///
-    /// In order to distinguish between actors and composite actors, the
-    /// template signature is resolved.
+    /// Notifies the observing actors for composite and simple actor case.
     ///
     /// @param observer one of the observers
     /// @param states the states of all actors in the chain

--- a/core/include/detray/propagator/base_actor.hpp
+++ b/core/include/detray/propagator/base_actor.hpp
@@ -44,7 +44,6 @@ class composite_actor final : public actor_impl_t {
     /// The composite is an actor in itself. For simplicity, it cannot be
     /// derived from another composition (final).
     using actor_type = actor_impl_t;
-    using state = typename actor_type::state;
 
     /// Call to the implementation of the actor (the actor possibly being an
     /// observer itself)
@@ -63,7 +62,7 @@ class composite_actor final : public actor_impl_t {
         subj_state_t &&subject_state = {}) const {
 
         // State of the primary actor that is implement by this composite actor
-        auto &actor_state = detail::get<state &>(states);
+        auto &actor_state = detail::get<typename actor_type::state &>(states);
 
         // Do your own work ...
         // Two cases: This is a simple actor or observing actor (pass on its

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -93,7 +93,7 @@ class base_stepper {
         constraint_t _constraint = {};
 
         // Navigation policy state
-        typename policy_t::state_type _policy_state = {};
+        typename policy_t::state _policy_state = {};
 
         /// Track path length
         scalar _path_length = 0;
@@ -122,7 +122,7 @@ class base_stepper {
 
         /// @returns access to this states step constraints
         DETRAY_HOST_DEVICE
-        inline typename policy_t::state_type &policy_state() {
+        inline typename policy_t::state &policy_state() {
             return _policy_state;
         }
 

--- a/core/include/detray/propagator/navigation_policies.hpp
+++ b/core/include/detray/propagator/navigation_policies.hpp
@@ -20,7 +20,7 @@ namespace detray {
 /// initialize the current volume
 struct always_init : actor {
 
-    struct state_type {};
+    struct state {};
 
     /// Sets the navigation trust level to 'no trust'
     ///
@@ -28,8 +28,7 @@ struct always_init : actor {
     /// @param propagation state of the propagation
     template <typename propagator_state_t>
     DETRAY_HOST_DEVICE inline void operator()(
-        const state_type & /*pol_state*/,
-        propagator_state_t &propagation) const {
+        const state & /*pol_state*/, propagator_state_t &propagation) const {
         propagation._navigation.set_no_trust();
     }
 };
@@ -38,7 +37,7 @@ struct always_init : actor {
 /// maps to the 'high trust' level in the navigator
 struct guided_navigation : actor {
 
-    struct state_type {};
+    struct state {};
 
     /// Sets the navigation trust level to 'no trust'
     ///
@@ -46,8 +45,7 @@ struct guided_navigation : actor {
     /// @param propagation state of the propagation
     template <typename propagator_state_t>
     DETRAY_HOST_DEVICE inline void operator()(
-        const state_type & /*pol_state*/,
-        propagator_state_t &propagation) const {
+        const state & /*pol_state*/, propagator_state_t &propagation) const {
         propagation._navigation.set_high_trust();
     }
 };
@@ -58,7 +56,7 @@ struct guided_navigation : actor {
 /// constraint was triggered.
 struct stepper_default_policy : actor {
 
-    struct state_type {};
+    struct state {};
 
     /// Sets the navigation trust level depending on the step size limit
     ///
@@ -66,7 +64,7 @@ struct stepper_default_policy : actor {
     /// @param propagation state of the propagation
     template <typename propagator_state_t>
     DETRAY_HOST_DEVICE inline void operator()(
-        state_type & /*pol_state*/, propagator_state_t &propagation) const {
+        state & /*pol_state*/, propagator_state_t &propagation) const {
 
         const auto &stepping = propagation._stepping;
         auto &navigation = propagation._navigation;

--- a/tests/common/include/tests/common/tools/inspectors.hpp
+++ b/tests/common/include/tests/common/tools/inspectors.hpp
@@ -150,17 +150,15 @@ namespace propagation {
 
 struct print_inspector : actor {
 
-    struct print_inspector_state {
+    struct state {
         std::stringstream stream{};
 
         std::string to_string() const { return stream.str(); }
     };
 
-    using state_type = print_inspector_state;
-
     template <typename propagation_state_t>
     DETRAY_HOST_DEVICE void operator()(
-        state_type &printer, const propagation_state_t &prop_state) const {
+        state &printer, const propagation_state_t &prop_state) const {
         const auto &navigation = prop_state._navigation;
         const auto &stepping = prop_state._stepping;
 

--- a/tests/common/include/tests/common/tools_actor_chain.inl
+++ b/tests/common/include/tests/common/tools_actor_chain.inl
@@ -94,9 +94,9 @@ using composite1 =
 // Implements example_actor with one print observer
 using composite2 = composite_actor<dtuple, example_actor_t, print_actor>;
 // Implements example_actor through composite2 and has composite1 as observer
-using composite3 = composite_actor<dtuple, composite2, composite1>;
+using composite3 = composite_actor<dtuple, example_actor_t, composite1>;
 // Implements example_actor through composite2<-composite3 with composite1 obs.
-using composite4 = composite_actor<dtuple, composite3, composite1>;
+using composite4 = composite_actor<dtuple, example_actor_t, composite1>;
 
 /* Test chaining of multiple actors
  * The chain goes as follows (depth first):

--- a/tests/common/include/tests/common/tools_actor_chain.inl
+++ b/tests/common/include/tests/common/tools_actor_chain.inl
@@ -98,18 +98,19 @@ using composite3 = composite_actor<dtuple, composite2, composite1>;
 // Implements example_actor through composite2<-composite3 with composite1 obs.
 using composite4 = composite_actor<dtuple, composite3, composite1>;
 
-// Test chaining of multiple actors
-// The chain goes as follows (depth first):
-//                          example_actor1
-//                              1.|
-//                          observer_lvl1 (print)
-//                               2.|
-//                          observer_lvl2 (example_actor observing print actor)
-//                       3./    5.|     6.\\
-//            observer_lvl3 example_actor2  print
-//          (example_actor3)
-//                 4.|
-//                 print
+/* Test chaining of multiple actors
+ * The chain goes as follows (depth first):
+ *                          example_actor1
+ *                              1.|
+ *                          observer_lvl1 (print)
+ *                              2.|
+ *                          observer_lvl2 (example_actor observing print actor)
+ *                      3./     5.|     6.\
+ *            observer_lvl3 example_actor2 print
+ *          (example_actor3)
+ *               4.|
+ *               print
+ */
 using observer_lvl3 = composite_actor<dtuple, example_actor_t, print_actor>;
 using observer_lvl2 = composite_actor<dtuple, example_actor_t, observer_lvl3,
                                       example_actor_t, print_actor>;

--- a/tests/common/include/tests/common/tools_actor_chain.inl
+++ b/tests/common/include/tests/common/tools_actor_chain.inl
@@ -72,12 +72,19 @@ struct example_actor : detray::actor {
     }
 
     /// Observing actor implementation: Counts vector elements (division)
-    template <typename subj_state_t, typename propagator_state_t>
-    void operator()(state_type &example_state,
-                    const subj_state_t &subject_state,
+    template <typename propagator_state_t>
+    void operator()(state_type &example_state, const state_type &subject_state,
                     const propagator_state_t & /*p_state*/) const {
         example_state.buffer.push_back(subject_state.buffer.size() / 10.);
     }
+
+    /// Observing actor implementation to printer: do nothing
+    template <typename subj_state_t, typename propagator_state_t,
+              std::enable_if_t<not std::is_same_v<subj_state_t, state_type>,
+                               bool> = true>
+    void operator()(state_type & /*example_state*/,
+                    const subj_state_t & /*subject_state*/,
+                    const propagator_state_t & /*p_state*/) const {}
 };
 
 using example_actor_t = example_actor<std::vector>;
@@ -90,6 +97,24 @@ using composite2 = composite_actor<dtuple, example_actor_t, print_actor>;
 using composite3 = composite_actor<dtuple, composite2, composite1>;
 // Implements example_actor through composite2<-composite3 with composite1 obs.
 using composite4 = composite_actor<dtuple, composite3, composite1>;
+
+// Test chaining of multiple actors
+// The chain goes as follows (depth first):
+//                          example_actor1
+//                              1.|
+//                          observer_lvl1 (print)
+//                               2.|
+//                          observer_lvl2 (example_actor observing print actor)
+//                       3./    5.|     6.\\
+//            observer_lvl3 example_actor2  print
+//          (example_actor3)
+//                 4.|
+//                 print
+using observer_lvl3 = composite_actor<dtuple, example_actor_t, print_actor>;
+using observer_lvl2 = composite_actor<dtuple, example_actor_t, observer_lvl3,
+                                      example_actor_t, print_actor>;
+using observer_lvl1 = composite_actor<dtuple, print_actor, observer_lvl2>;
+using chain = composite_actor<dtuple, example_actor_t, observer_lvl1>;
 
 }  // anonymous namespace
 
@@ -118,5 +143,21 @@ TEST(ALGEBRA_PLUGIN, actor_chain) {
                     "[print actor obs 1]:[print actor obs 1]:[print actor obs "
                     "2]:[print actor obs 0.4]:[print actor obs 0.4]:[print "
                     "actor obs 0.6]:[print actor obs 0.6]:") == 0)
+        << "Printer call chain: " << printer_state.to_string() << std::endl;
+
+    // Test chaining of multiple actors
+
+    // Reset example actor state
+    example_state.buffer.clear();
+    printer_state.stream.str("");
+    printer_state.stream.clear();
+
+    // Run the chain
+    actor_chain<dtuple, chain> run_chain{};
+    run_chain(actor_states, prop_state);
+
+    ASSERT_TRUE(printer_state.to_string().compare(
+                    "[print actor obs 0]:[print actor obs 0.1]:[print actor "
+                    "obs 0.2]:") == 0)
         << "Printer call chain: " << printer_state.to_string() << std::endl;
 }

--- a/tests/common/include/tests/common/tools_guided_navigator.inl
+++ b/tests/common/include/tests/common/tools_guided_navigator.inl
@@ -58,7 +58,7 @@ TEST(ALGEBRA_PLUGIN, guided_navigator) {
     b_field_t b_field(B);
 
     // Actors
-    pathlimit_aborter::state_type pathlimit{1. * unit_constants::m};
+    pathlimit_aborter::state pathlimit{1. * unit_constants::m};
 
     // Propagator
     propagator_t p(runge_kutta_stepper{b_field},

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -37,19 +37,18 @@ constexpr scalar path_limit = 5 * unit_constants::cm;
 struct helix_inspector : actor {
 
     /// Keeps the state of a helix gun to calculate track positions
-    struct helix_inspector_state {
-        helix_inspector_state(helix_gun &&h) : _helix(h) {}
+    struct state {
+        state(helix_gun &&h) : _helix(h) {}
         helix_gun _helix;
     };
 
     using size_type = __plugin::size_type;
     using matrix_operator = standard_matrix_operator<scalar>;
-    using state_type = helix_inspector_state;
 
     /// Check that the stepper remains on the right helical track for its pos.
     template <typename propagator_state_t>
     DETRAY_HOST_DEVICE void operator()(
-        const state_type &inspector_state,
+        const state &inspector_state,
         const propagator_state_t &prop_state) const {
 
         const auto &stepping = prop_state._stepping;
@@ -156,11 +155,11 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
             lim_traj.set_overstep_tolerance(-10 * unit_constants::um);
 
             // Build actor states: the helix inspector can be shared
-            helix_inspector::state_type helix_insp_state{helix_gun{traj, &B}};
-            propagation::print_inspector::state_type print_insp_state{};
-            propagation::print_inspector::state_type lim_print_insp_state{};
-            pathlimit_aborter::state_type unlimted_aborter_state{};
-            pathlimit_aborter::state_type pathlimit_aborter_state{path_limit};
+            helix_inspector::state helix_insp_state{helix_gun{traj, &B}};
+            propagation::print_inspector::state print_insp_state{};
+            propagation::print_inspector::state lim_print_insp_state{};
+            pathlimit_aborter::state unlimted_aborter_state{};
+            pathlimit_aborter::state pathlimit_aborter_state{path_limit};
 
             // Create actor states tuples
             actor_chain_t::state actor_states = std::tie(

--- a/tests/unit_tests/cuda/propagator_cuda.cpp
+++ b/tests/unit_tests/cuda/propagator_cuda.cpp
@@ -85,8 +85,8 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
     for (unsigned int i = 0; i < theta_steps * phi_steps; i++) {
 
         // Create the propagator state
-        inspector_host_t::state_type insp_state{mng_mr};
-        pathlimit_aborter::state_type pathlimit_state{path_limit};
+        inspector_host_t::state insp_state{mng_mr};
+        pathlimit_aborter::state pathlimit_state{path_limit};
 
         propagator_host_type::state state(
             tracks_host[i], thrust::tie(insp_state, pathlimit_state));

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.cu
@@ -45,9 +45,9 @@ __global__ void propagator_test_kernel(
     propagator_device_type p(std::move(s), std::move(n));
 
     // Create actor states
-    inspector_device_t::state_type insp_state(
+    inspector_device_t::state insp_state(
         path_lengths.at(gid), positions.at(gid), jac_transports.at(gid));
-    pathlimit_aborter::state_type aborter_state{path_limit};
+    pathlimit_aborter::state aborter_state{path_limit};
 
     // Create the propagator state
     propagator_device_type::state state(tracks[gid],

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
@@ -68,17 +68,16 @@ namespace detray {
 template <template <typename...> class vector_t>
 struct track_inspector : actor {
 
-    struct track_inspector_state {
+    struct state {
 
-        track_inspector_state(vecmem::memory_resource &resource)
+        state(vecmem::memory_resource &resource)
             : _path_lengths(&resource),
               _positions(&resource),
               _jac_transports(&resource) {}
 
         DETRAY_HOST_DEVICE
-        track_inspector_state(vector_t<scalar> path_lengths,
-                              vector_t<vector3> positions,
-                              vector_t<free_matrix> jac_transports)
+        state(vector_t<scalar> path_lengths, vector_t<vector3> positions,
+              vector_t<free_matrix> jac_transports)
             : _path_lengths(path_lengths),
               _positions(positions),
               _jac_transports(jac_transports) {}
@@ -88,12 +87,9 @@ struct track_inspector : actor {
         vector_t<free_matrix> _jac_transports;
     };
 
-    using state_type = track_inspector_state;
-
     template <typename propagator_state_t>
     DETRAY_HOST_DEVICE void operator()(
-        state_type &inspector_state,
-        const propagator_state_t &prop_state) const {
+        state &inspector_state, const propagator_state_t &prop_state) const {
 
         const auto &stepping = prop_state._stepping;
 


### PR DESCRIPTION
Adds a call of chained actors to the ```actor_chain``` test as an example