### PR TITLE
Grid2 Const Conversion, main branch (2022.04.27.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,17 +18,17 @@ detray_add_library( detray_core core
    # definitions include(s)
    "include/detray/definitions/containers.hpp"
    "include/detray/definitions/cuda_definitions.hpp"
-   "include/detray/definitions/indexing.hpp"  
+   "include/detray/definitions/indexing.hpp"
    "include/detray/definitions/qualifiers.hpp"
    "include/detray/definitions/track_parameterization.hpp"
    "include/detray/definitions/units.hpp"
-   "include/detray/definitions/detail/accessor.hpp"  
+   "include/detray/definitions/detail/accessor.hpp"
    # field include(s)
    "include/detray/field/constant_magnetic_field.hpp"
    # geometry include(s)
    "include/detray/geometry/surface.hpp"
    "include/detray/geometry/volume_connector.hpp"
-   "include/detray/geometry/volume_graph.hpp"      
+   "include/detray/geometry/volume_graph.hpp"
    "include/detray/geometry/volume.hpp"
    # grids include(s)
    "include/detray/grids/axis.hpp"
@@ -41,8 +41,8 @@ detray_add_library( detray_core core
    "include/detray/intersection/intersection_kernel.hpp"
    "include/detray/intersection/intersection.hpp"
    "include/detray/intersection/planar_intersector.hpp"
-   "include/detray/intersection/quadratic_equation.hpp"   
-   "include/detray/intersection/unbound.hpp"   
+   "include/detray/intersection/quadratic_equation.hpp"
+   "include/detray/intersection/unbound.hpp"
    # masks include(s)
    "include/detray/masks/annulus2.hpp"
    "include/detray/masks/cylinder3.hpp"
@@ -51,7 +51,7 @@ detray_add_library( detray_core core
    "include/detray/masks/ring2.hpp"
    "include/detray/masks/single3.hpp"
    "include/detray/masks/trapezoid2.hpp"
-   "include/detray/masks/unmasked.hpp"   
+   "include/detray/masks/unmasked.hpp"
    # propagator include(s)
    "include/detray/propagator/aborters.hpp"
    "include/detray/propagator/actor_chain.hpp"
@@ -63,15 +63,16 @@ detray_add_library( detray_core core
    "include/detray/propagator/navigator.hpp"
    "include/detray/propagator/propagator.hpp"
    "include/detray/propagator/rk_stepper.hpp"
-   "include/detray/propagator/track.hpp"   
+   "include/detray/propagator/track.hpp"
    # tools include(s)
    "include/detray/tools/associator.hpp"
    "include/detray/tools/bin_association.hpp"
    "include/detray/tools/generators.hpp"
    "include/detray/tools/grid_array_helper.hpp"
    "include/detray/tools/local_object_finder.hpp"
-   # utils include(s)   
+   # utils include(s)
    "include/detray/utils/algebra_helpers.hpp"
    "include/detray/utils/enumerate.hpp"
-   "include/detray/utils/invalid_values.hpp" )
+   "include/detray/utils/invalid_values.hpp"
+   "include/detray/utils/type_traits.hpp" )
 target_link_libraries( detray_core INTERFACE vecmem::core detray::Thrust)

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/utils/invalid_values.hpp"
+#include "detray/utils/type_traits.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/data/vector_view.hpp>
@@ -617,6 +618,22 @@ struct axis_data<axis_t, scalar_t,
                  typename std::enable_if_t<(axis_t::axis_identifier == 0) ||
                                            (axis_t::axis_identifier == 1)>> {
 
+    /// Declare that a default constructor can/should be generated
+    axis_data() = default;
+    /// Constructor with the 3 member values
+    DETRAY_HOST_DEVICE
+    axis_data(dindex _n_bins, std::remove_cv_t<scalar_t> _min,
+              std::remove_cv_t<scalar_t> _max)
+        : n_bins(_n_bins), min(_min), max(_max) {}
+    /// Construct a const data object from a non-const one
+    template <
+        typename other_scalar_t,
+        std::enable_if_t<details::is_same_nc<scalar_t, other_scalar_t>::value,
+                         bool> = true>
+    DETRAY_HOST_DEVICE axis_data(
+        const axis_data<axis_t, other_scalar_t, void> &parent)
+        : n_bins(parent.n_bins), min(parent.min), max(parent.max) {}
+
     dindex n_bins;
     std::remove_cv_t<scalar_t> min;
     std::remove_cv_t<scalar_t> max;
@@ -625,6 +642,26 @@ struct axis_data<axis_t, scalar_t,
 template <typename axis_t, typename scalar_t>
 struct axis_data<axis_t, scalar_t,
                  typename std::enable_if_t<axis_t::axis_identifier == 2>> {
+
+    /// Declare that a default constructor can/should be generated
+    axis_data() = default;
+    /// Constructor with the 4 member values
+    DETRAY_HOST_DEVICE
+    axis_data(dindex _n_bins, std::remove_cv_t<scalar_t> _min,
+              std::remove_cv_t<scalar_t> _max,
+              const vecmem::data::vector_view<scalar_t> &_boundaries)
+        : n_bins(_n_bins), min(_min), max(_max), boundaries(_boundaries) {}
+    /// Construct a const data object from a non-const one
+    template <
+        typename other_scalar_t,
+        std::enable_if_t<details::is_same_nc<scalar_t, other_scalar_t>::value,
+                         bool> = true>
+    DETRAY_HOST_DEVICE axis_data(
+        const axis_data<axis_t, other_scalar_t, void> &parent)
+        : n_bins(parent.n_bins),
+          min(parent.min),
+          max(parent.max),
+          boundaries(parent.boundaries) {}
 
     dindex n_bins;
     std::remove_cv_t<scalar_t> min;

--- a/core/include/detray/grids/grid2.hpp
+++ b/core/include/detray/grids/grid2.hpp
@@ -416,6 +416,28 @@ struct grid2_view {
  **/
 template <typename grid2_t>
 struct const_grid2_view {
+
+    /// Declare that a default constructor can/should be generated
+    const_grid2_view() = default;
+    /// Constructor with the 3 member variables
+    DETRAY_HOST_DEVICE
+    const_grid2_view(
+        const axis_data<typename grid2_t::axis_p0_type, const scalar>
+            &axis_p0_view,
+        const axis_data<typename grid2_t::axis_p1_type, const scalar>
+            &axis_p1_view,
+        const typename grid2_t::populator_type::const_vector_view_type
+            &data_view)
+        : _axis_p0_view(axis_p0_view),
+          _axis_p1_view(axis_p1_view),
+          _data_view(data_view) {}
+    /// Construct a const data object from a non-const one
+    DETRAY_HOST_DEVICE
+    const_grid2_view(const grid2_view<grid2_t> &parent)
+        : _axis_p0_view(parent._axis_p0_view),
+          _axis_p1_view(parent._axis_p1_view),
+          _data_view(parent._data_view) {}
+
     axis_data<typename grid2_t::axis_p0_type, const scalar> _axis_p0_view;
     axis_data<typename grid2_t::axis_p1_type, const scalar> _axis_p1_view;
     typename grid2_t::populator_type::const_vector_view_type _data_view;

--- a/core/include/detray/utils/type_traits.hpp
+++ b/core/include/detray/utils/type_traits.hpp
@@ -1,0 +1,27 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace detray::details {
+
+/// Helper trait for detecting when a type is a non-const version of another
+///
+/// This comes into play multiple times to enable certain constructors
+/// conditionally through SFINAE.
+///
+template <typename CTYPE, typename NCTYPE>
+struct is_same_nc {
+    static constexpr bool value = false;
+};
+
+template <typename TYPE>
+struct is_same_nc<const TYPE, TYPE> {
+    static constexpr bool value = true;
+};
+
+}  // namespace detray::details

--- a/tests/unit_tests/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/cuda/grids_grid2_cuda.cpp
@@ -198,12 +198,8 @@ TEST(grids_cuda, grid2_attach_populator) {
         }
     }
 
-    // get grid_data
-    const host_grid2_attach& const_g2 = g2;
-    auto g2_data = get_data(const_g2, mng_mr);
-
     // Read the grid
-    grid_attach_read_test(g2_data);
+    grid_attach_read_test(get_data(g2, mng_mr));
 }
 
 /// This test demonstrates how to call grid buffer without calling host grid
@@ -249,6 +245,10 @@ TEST(grids_cuda, grid2_buffer_attach_populator) {
     EXPECT_EQ(g2.data()[1].size(), 100);
     EXPECT_EQ(g2.data()[2].size(), 100);
     EXPECT_EQ(g2.data()[3].size(), 100);
+
+    // Check that we can give a non-const buffer to a function expecting
+    // a const view.
+    grid_attach_read_test(g2_buffer);
 }
 
 TEST(grids_cuda, grid2_buffer_attach_populator2) {


### PR DESCRIPTION
Made it possible to use non-const grid2 data with a const_grid2_view. Which can make life a lot easier for passing non-const objects to functions that "only" need a const view of the data.

I bumped into this while working with the [traccc](https://github.com/acts-project/traccc) code, and trying to update it to be "more const correct".

I copied the `is_same_nc` trait from [vecmem](https://github.com/acts-project/vecmem) to do this for `traccc::axis_data` in the same way in which this auto-conversion is set up for `vecmem::data::vector_view` and friends.

Finally I updated the CUDA test to exercise this auto-conversion explicitly. Though I guess it should also be added to a host-only test... :thinking: