### PR TITLE
Grid2 Const Correctness, main branch (2022.04.28.)

### DIFF
--- a/core/include/detray/grids/grid2.hpp
+++ b/core/include/detray/grids/grid2.hpp
@@ -176,27 +176,28 @@ class grid2 {
      * @return the const reference to the value in this bin
      **/
     DETRAY_HOST_DEVICE
-    const auto &bin(dindex bin0, dindex bin1) const {
+    typename serialized_storage::const_reference bin(dindex bin0,
+                                                     dindex bin1) const {
         return _data_serialized[_serializer.template serialize<
             axis_p0_type, axis_p1_type>(_axis_p0, _axis_p1, bin0, bin1)];
     }
 
     DETRAY_HOST_DEVICE
-    auto bin(dindex bin0, dindex bin1) {
+    typename serialized_storage::reference bin(dindex bin0, dindex bin1) {
         return _data_serialized.at(
             _serializer.template serialize<axis_p0_type, axis_p1_type>(
                 _axis_p0, _axis_p1, bin0, bin1));
     }
 
     DETRAY_HOST_DEVICE
-    const auto &bin(dindex gbin) const {
+    typename serialized_storage::const_reference bin(dindex gbin) const {
         dindex bin0 = gbin % _axis_p0.bins();
         dindex bin1 = gbin / _axis_p0.bins();
         return bin(bin0, bin1);
     }
 
     DETRAY_HOST_DEVICE
-    auto bin(dindex gbin) {
+    typename serialized_storage::reference bin(dindex gbin) {
         dindex bin0 = gbin % _axis_p0.bins();
         dindex bin1 = gbin / _axis_p0.bins();
         return bin(bin0, bin1);
@@ -209,7 +210,7 @@ class grid2 {
      * @return the const reference to the value in this bin
      **/
     DETRAY_HOST_DEVICE
-    const auto &bin(const point2 &p2) const {
+    typename serialized_storage::const_reference bin(const point2 &p2) const {
         return _data_serialized[_serializer.template serialize<axis_p0_type,
                                                                axis_p1_type>(
             _axis_p0, _axis_p1, _axis_p0.bin(p2[0]), _axis_p1.bin(p2[1]))];
@@ -222,7 +223,7 @@ class grid2 {
      * @return the const reference to the value in this bin
      **/
     DETRAY_HOST_DEVICE
-    auto &bin(const point2 &p2) {
+    typename serialized_storage::reference bin(const point2 &p2) {
         return _data_serialized[_serializer.template serialize<axis_p0_type,
                                                                axis_p1_type>(
             _axis_p0, _axis_p1, _axis_p0.bin(p2[0]), _axis_p1.bin(p2[1]))];

--- a/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/grids_grid2_cuda_kernel.cu
@@ -146,8 +146,8 @@ __global__ void grid_attach_read_test_kernel(
     const_grid2_view<host_grid2_attach> grid_view) {
 
     // Let's try building the grid object
-    const_device_grid2_attach g2_device(grid_view,
-                                        test::point3<detray::scalar>{0, 0, 0});
+    const const_device_grid2_attach g2_device(
+        grid_view, test::point3<detray::scalar>{0, 0, 0});
 
     auto data = g2_device.bin(threadIdx.x, threadIdx.y);
 


### PR DESCRIPTION
Made the `grid2::bin` functions return correct types in "every situation". The constant versions of these functions in device code were not returning the correct types so far. Resulting in the following warning (in this case from CUDA/nvcc) when the constant versions of these functions got called:

```
/home/krasznaa/ATLAS/projects/detray/detray/core/include/detray/grids/grid2.hpp(180): warning #430-D: returning reference to local temporary
          detected during instantiation of "const auto &detray::grid2<populator_t, axis_p0_t, axis_p1_t, serializer_t, vector_t, jagged_vector_t, array_t, tuple_t, value_t, kSORT, kDIM>::bin(detray::dindex, detray::dindex) const [with populator_t=detray::attach_populator, axis_p0_t=detray::axis::circular, axis_p1_t=detray::axis::regular, serializer_t=detray::serializer2, vector_t=vecmem::device_vector, jagged_vector_t=vecmem::jagged_device_vector, array_t=detray::darray, tuple_t=std::tuple, value_t=const std::array<detray::scalar, 3UL>, kSORT=false, kDIM=1U]"
```

(None of these functions were ever called before, I had to update the CUDA test to trigger this issue.)

This is because of the same thing that I had to handle in https://github.com/acts-project/traccc/pull/165. That `vecmem::jagged_device_vector::at(...)` returns a `vecmem::device_vector` object by value, and not by reference. So we need to use the typedefs provided by the vecmem/std classes to have the `grid2::bin` functions declare the correct interface in all situations. :wink: