### PR TITLE
Project Version Update, main branch (2022.05.03.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Set up the project.
 cmake_minimum_required( VERSION 3.11 )
-project( detray VERSION 0.6 LANGUAGES CXX )
+project( detray VERSION 0.8 LANGUAGES CXX )
 
 # Set up the used C++ standard(s).
 set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (host) C++ standard to use" )


### PR DESCRIPTION
Updated the project version to `0.8`.

I only noticed while creating a new VecMem tag that the project version in this repo was not kept up to date with the releases/tags made in the repository. :frowning:

It's not a tragedy, but let's keep this version updated in the future. :wink: