### PR TITLE
CMake Requirement Update, main branch (2022.06.10.)

### DIFF
--- a/tests/benchmarks/cuda/CMakeLists.txt
+++ b/tests/benchmarks/cuda/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# C++17 support for CUDA requires CMake 3.18.
+cmake_minimum_required( VERSION 3.18 )
+
 # Enable CUDA as a language.
 enable_language( CUDA )
 

--- a/tests/unit_tests/cuda/CMakeLists.txt
+++ b/tests/unit_tests/cuda/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# C++17 support for CUDA requires CMake 3.18.
+cmake_minimum_required( VERSION 3.18 )
+
 # Enable CUDA as a language.
 enable_language( CUDA )
 


### PR DESCRIPTION
Updated Detray's CMake requirement to 3.18. It is needed for C++17 support in the CUDA code, as described in:

https://cmake.org/cmake/help/latest/prop_tgt/CUDA_STANDARD.html

As we found with @niermann999, using an older CMake version like 3.17 will silently set the CUDA build to C\+\+14, leading to mysterious build failures. :frowning:

I could've set the requirement just for the subdirectories that deal with CUDA. But I thought it would probably not be worth complicating the code like that. Hopefully every user is okay with using CMake 3.18+, even if they're not using CUDA...