### PR TITLE
Add line mask and its intersector

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -47,10 +47,12 @@ detray_add_library( detray_core core
    "include/detray/intersection/intersection.hpp"
    "include/detray/intersection/ray_concentric_cylinder_intersector.hpp"
    "include/detray/intersection/ray_cylinder_intersector.hpp"
+   "include/detray/intersection/ray_line_intersector.hpp"
    "include/detray/intersection/ray_plane_intersector.hpp"
    # masks include(s)
    "include/detray/masks/annulus2.hpp"
    "include/detray/masks/cylinder3.hpp"
+   "include/detray/masks/line.hpp"
    "include/detray/masks/masks.hpp"
    "include/detray/masks/masks_base.hpp"
    "include/detray/masks/rectangle2.hpp"

--- a/core/include/detray/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/intersection/ray_line_intersector.hpp
@@ -1,0 +1,82 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include "detray/definitions/qualifiers.hpp"
+#include "detray/intersection/intersection.hpp"
+#include "detray/intersection/ray_plane_intersector.hpp"
+#include "detray/propagator/track.hpp"
+
+namespace detray {
+
+/** This is an intersector struct for line surface
+ */
+struct ray_line_intersector {
+
+    using intersection_type = line_plane_intersection;
+    using transform3 = __plugin::transform3<detray::scalar>;
+    using vector3 = __plugin::vector3<detray::scalar>;
+
+    template <typename track_t>
+    transform3 line_to_planar_transform3(const transform3 &trf,
+                                         const track_t &track) const {
+
+        // z direction of virtual plane parallel to the track direction
+        const vector3 new_z = track.dir();
+
+        // y direction of virtual plane identical to line direction
+        const vector3 new_y = getter::vector<3>(trf.matrix(), 0, 2);
+
+        // x direction of virtual plane
+        const vector3 new_x = vector::cross(new_y, new_z);
+
+        scalar y_dist =
+            std::abs(vector::dot(trf.translation() - track.pos(), new_y));
+
+        const vector3 new_t = trf.translation() - y_dist * new_y;
+
+        return transform3{new_t, new_x, new_y, new_z};
+    }
+
+    /** Intersection method for planar surfaces
+     *
+     * @tparam track_t The type of the track (which carries the context
+     *         object)
+     * @tparam mask_t The mask type applied to the local frame
+     * @tparam local_frame The local frame type to be intersected
+     *
+     * Contextual part:
+     * @param trf the surface to be intersected
+     * @param track the track information
+     *
+     * Non-contextual part:
+     * @param mask the local mask
+     * @param tolerance is the mask specific tolerance
+     *
+     * @return the intersection with optional parameters
+     **/
+    template <typename track_t, typename mask_t,
+              std::enable_if_t<std::is_class_v<typename mask_t::local_type>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE inline intersection_type intersect(
+        const transform3 &trf, const track_t &track, const mask_t &mask,
+        const typename mask_t::mask_tolerance tolerance =
+            mask_t::within_epsilon) const {
+
+        // Convert line transform3 to planar transform3
+        const transform3 planar_trf = line_to_planar_transform3(trf, track);
+
+        // return planar intersector result
+        return ray_plane_intersector().intersect(planar_trf, track, mask,
+                                                 tolerance);
+    }
+};
+
+}  // namespace detray

--- a/core/include/detray/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/intersection/ray_line_intersector.hpp
@@ -17,6 +17,9 @@
 namespace detray {
 
 /** This is an intersector struct for line surface
+ * The intersectino point is obtained by calculating a transform3 object of
+ * virtual plane Virtual plane has a normal vector same with the direction of
+ * the track
  */
 struct ray_line_intersector {
 
@@ -24,6 +27,14 @@ struct ray_line_intersector {
     using transform3 = __plugin::transform3<detray::scalar>;
     using vector3 = __plugin::vector3<detray::scalar>;
 
+    /** Function to obtain the virtual plane whose normal vector is same with
+     * direction of the track
+     *
+     * @param trf the surface to be intersected
+     * @param track the track information
+     *
+     * @return the transform3 of the virtual plane
+     */
     template <typename track_t>
     transform3 line_to_planar_transform3(const transform3 &trf,
                                          const track_t &track) const {

--- a/core/include/detray/intersection/ray_plane_intersector.hpp
+++ b/core/include/detray/intersection/ray_plane_intersector.hpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include <iostream>
 #include <type_traits>
 
 #include "detray/definitions/qualifiers.hpp"

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -17,6 +17,10 @@
 
 namespace detray {
 
+/** This is a simple mask for a line which is defined with a line length and its
+ * radial scope
+ *
+ **/
 template <typename intersector_t = ray_line_intersector,
           typename local_t = __plugin::cartesian2<detray::scalar>,
           typename links_t = dindex,
@@ -45,7 +49,7 @@ class line final
     /** Construction from boundary values
      *
      * @param half_length is the half length of line
-     * @param scope is the detector scope length of line detector
+     * @param scope is the radial scope length of line detector
      */
     DETRAY_HOST_DEVICE
     line(scalar half_length, scalar scope, links_type links)

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -1,0 +1,98 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <climits>
+#include <cmath>
+
+#include "detray/definitions/qualifiers.hpp"
+#include "detray/intersection/intersection.hpp"
+#include "detray/intersection/ray_line_intersector.hpp"
+#include "detray/masks/mask_base.hpp"
+
+namespace detray {
+
+template <typename intersector_t = ray_line_intersector,
+          typename local_t = __plugin::cartesian2<detray::scalar>,
+          typename links_t = dindex,
+          template <typename, std::size_t> class array_t = darray>
+class line final
+    : public mask_base<intersector_t, local_t, links_t, array_t, 2> {
+    public:
+    using base_type = mask_base<intersector_t, local_t, links_t, array_t, 2>;
+    using base_type::base_type;
+    using mask_tolerance = scalar;
+    using mask_values = typename base_type::mask_values;
+    using links_type = typename base_type::links_type;
+    using local_type = typename base_type::local_type;
+    using intersector_type = typename base_type::intersector_type;
+    using point2 = __plugin::point2<scalar>;
+
+    static constexpr mask_tolerance within_epsilon =
+        std::numeric_limits<scalar>::epsilon();
+
+    /* Default constructor */
+    line() {
+        this->_values[0] = std::numeric_limits<scalar>::infinity();
+        this->_values[1] = 0.;
+    }
+
+    /** Construction from boundary values
+     *
+     * @param half_length is the half length of line
+     * @param scope is the detector scope length of line detector
+     */
+    DETRAY_HOST_DEVICE
+    line(scalar half_length, scalar scope, links_type links)
+        : base_type({half_length, scope}, links) {}
+
+    /** Assignment operator from an array, convenience function
+     *
+     * @param rhs is the right hand side object
+     **/
+    DETRAY_HOST_DEVICE
+    line<intersector_t, local_type, links_type, array_t> &operator=(
+        const array_t<scalar, 2> &rhs) {
+        this->_values = rhs;
+        return (*this);
+    }
+
+    /** Mask operation
+     *
+     * @tparam inside_local_t is the local type for inside checking
+     *
+     * @param p the point to be checked
+     * @param t is the tolerance in r
+     *
+     * @return an intersection status e_inside / e_outside
+     **/
+    template <typename inside_local_t>
+    DETRAY_HOST_DEVICE intersection::status is_inside(
+        const point2 &p, const mask_tolerance t = within_epsilon) const {
+
+        if constexpr (std::is_same_v<inside_local_t,
+                                     __plugin::cartesian2<detray::scalar>>) {
+            scalar r = getter::perp(p);
+
+            // if the point is whithin the scope, return e_inside
+            return (r <= this->_values[1] + t)
+                       ? intersection::status::e_inside
+                       : intersection::status::e_outside;
+        }
+
+        else if constexpr (std::is_same_v<inside_local_t,
+                                          __plugin::polar2<detray::scalar>>) {
+            // if the point is whithin the scope, return e_inside
+            return (p[0] <= this->_values[1] + t)
+                       ? intersection::status::e_inside
+                       : intersection::status::e_outside;
+        }
+    }
+};
+
+}  // namespace detray

--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -9,6 +9,7 @@
 
 #include "detray/masks/annulus2.hpp"
 #include "detray/masks/cylinder3.hpp"
+#include "detray/masks/line.hpp"
 #include "detray/masks/rectangle2.hpp"
 #include "detray/masks/ring2.hpp"
 #include "detray/masks/single3.hpp"

--- a/tests/common/include/tests/common/masks_line.inl
+++ b/tests/common/include/tests/common/masks_line.inl
@@ -1,0 +1,51 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include "detray/masks/line.hpp"
+
+using namespace detray;
+using point2 = __plugin::point2<scalar>;
+
+// This tests the basic function of a line
+TEST(mask, line) {
+    using cartesian = __plugin::cartesian2<detray::scalar>;
+    using polar = __plugin::polar2<detray::scalar>;
+
+    point2 ln_p_in = {0.1, 0.0};
+    point2 ln_p_edge1 = {1., 2.};
+    point2 ln_p_edge2 = {1., 3.};
+    point2 ln_p_out = {1.1, 0.};
+
+    point2 ln_c_in = {0.1, 0.5};
+    point2 ln_c_edge1 = {1, 0};
+    point2 ln_c_edge2 = {0, 1};
+    point2 ln_c_out = {0.8, 0.9};
+
+    line<> ln{50., 1., 0u};
+
+    ASSERT_FLOAT_EQ(ln[0], 50.);
+    ASSERT_FLOAT_EQ(ln[1], 1.);
+
+    ASSERT_TRUE(ln.is_inside<polar>(ln_p_in) == intersection::status::e_inside);
+    ASSERT_TRUE(ln.is_inside<polar>(ln_p_edge1) ==
+                intersection::status::e_inside);
+    ASSERT_TRUE(ln.is_inside<polar>(ln_p_edge2) ==
+                intersection::status::e_inside);
+    ASSERT_TRUE(ln.is_inside<polar>(ln_p_out) ==
+                intersection::status::e_outside);
+
+    ASSERT_TRUE(ln.is_inside<cartesian>(ln_c_in) ==
+                intersection::status::e_inside);
+    ASSERT_TRUE(ln.is_inside<cartesian>(ln_c_edge1) ==
+                intersection::status::e_inside);
+    ASSERT_TRUE(ln.is_inside<cartesian>(ln_c_edge2) ==
+                intersection::status::e_inside);
+    ASSERT_TRUE(ln.is_inside<cartesian>(ln_c_out) ==
+                intersection::status::e_outside);
+}

--- a/tests/common/include/tests/common/tools_line_intersection.inl
+++ b/tests/common/include/tests/common/tools_line_intersection.inl
@@ -1,0 +1,107 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/intersection/intersection.hpp"
+#include "detray/intersection/ray_line_intersector.hpp"
+#include "detray/masks/line.hpp"
+#include "detray/propagator/track.hpp"
+
+// GTest include(s)
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <climits>
+#include <cmath>
+
+/// @note __plugin has to be defined with a preprocessor command
+using namespace detray;
+
+// Three-dimensional definitions
+using transform3 = __plugin::transform3<detray::scalar>;
+using vector3 = __plugin::vector3<scalar>;
+using point3 = __plugin::point3<scalar>;
+using point2 = __plugin::point2<scalar>;
+constexpr scalar tolerance = 1e-5;
+
+// This defines the local frame test suite
+TEST(tools, line_intersector_straight_wire) {
+
+    // tf3 with Identity rotation and no translation
+    vector3 x{1, 0, 0};
+    vector3 y{0, 1, 0};
+    vector3 z{0, 0, 1};
+    vector3 t{0, 0, 0};
+
+    const transform3 tf{t, x, y, z};
+
+    /// Create a track
+    point3 pos{1, -1, 0};
+    vector3 dir{0, 1, 0};
+    free_track_parameters trk(pos, 0, dir, -1);
+
+    // Infinite wire with 10 mm and 0.1 mm radial scope
+    std::vector<line<>> lines(2);
+    lines[0] = line<>{std::numeric_limits<scalar>::infinity(), 10., 0u};
+    lines[1] = line<>{std::numeric_limits<scalar>::infinity(), 0.1, 0u};
+
+    // Test line to planar transform
+    const auto new_tf =
+        ray_line_intersector().line_to_planar_transform3(tf, trk);
+
+    const vector3 new_x = getter::vector<3>(new_tf.matrix(), 0, 0);
+    const vector3 new_y = getter::vector<3>(new_tf.matrix(), 0, 1);
+    const vector3 new_z = getter::vector<3>(new_tf.matrix(), 0, 2);
+    const vector3 new_tsl = new_tf.translation();
+
+    EXPECT_EQ(new_x, vector3({-1, 0, 0}));
+    EXPECT_EQ(new_y, vector3({0, 0, 1}));
+    EXPECT_EQ(new_z, vector3({0, 1, 0}));
+    EXPECT_EQ(new_tsl, vector3({0, 0, 0}));
+
+    // Test intersect
+    std::vector<ray_line_intersector::intersection_type> is(2);
+    is[0] = ray_line_intersector().intersect(tf, trk, lines[0]);
+    is[1] = ray_line_intersector().intersect(tf, trk, lines[1]);
+
+    EXPECT_EQ(is[0].status, intersection::status::e_inside);
+    EXPECT_EQ(is[0].p3, point3({1, 0, 0}));
+    EXPECT_EQ(is[0].p2, point2({-1, 0}));
+
+    EXPECT_EQ(is[1].status, intersection::status::e_outside);
+    EXPECT_EQ(is[1].p3, point3({1, 0, 0}));
+    EXPECT_EQ(is[1].p2, point2({-1, 0}));
+}
+
+TEST(tools, line_intersector_stereo_wire) {
+
+    // tf3 with skewed axis
+    vector3 x{1, 0, -1};
+    vector3 z{1, 0, 1};
+    vector3 t{1, 1, 1};
+    const transform3 tf{t, vector::normalize(z), vector::normalize(x)};
+
+    // Create a track
+    point3 pos{1, -1, 0};
+    vector3 dir{0, 1, 0};
+    free_track_parameters trk(pos, 0, dir, -1);
+
+    // Infinite wire with 10 mm radial scope length
+    line<> ln{std::numeric_limits<scalar>::infinity(), 10., 0u};
+
+    // Test intersect
+    std::vector<ray_line_intersector::intersection_type> is(2);
+    is[0] = ray_line_intersector().intersect(tf, trk, ln);
+
+    EXPECT_EQ(is[0].status, intersection::status::e_inside);
+    EXPECT_NEAR(is[0].p3[0], 1., tolerance);
+    EXPECT_NEAR(is[0].p3[1], 1., tolerance);
+    EXPECT_NEAR(is[0].p3[2], 0., tolerance);
+
+    EXPECT_NEAR(is[0].p2[0], -0.5 * sqrt(2), tolerance);
+    EXPECT_NEAR(is[0].p2[1], 0, tolerance);
+}

--- a/tests/unit_tests/array/CMakeLists.txt
+++ b/tests/unit_tests/array/CMakeLists.txt
@@ -14,7 +14,7 @@ detray_add_test( array
    "array_guided_navigator.cpp" "array_helix_trajectory.cpp"
    "array_intersection_kernel.cpp" "array_particle_gun.cpp"
    "array_mask_store.cpp" "array_materials.cpp" "array_navigator.cpp"
-   "array_planar_intersection.cpp" "array_propagator.cpp"
+   "array_planar_intersection.cpp" "array_line_intersection.cpp" "array_line.cpp" "array_propagator.cpp"
    "array_rectangle2.cpp" "array_ring2.cpp" "array_single3.cpp"
    "array_stepper.cpp" "array_surfaces_finder.cpp"
    "array_telescope_detector.cpp" "array_toy_geometry.cpp" "array_track.cpp" 

--- a/tests/unit_tests/array/array_line.cpp
+++ b/tests/unit_tests/array/array_line.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/array_definitions.hpp"
+#include "tests/common/masks_line.inl"

--- a/tests/unit_tests/array/array_line_intersection.cpp
+++ b/tests/unit_tests/array/array_line_intersection.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/array_definitions.hpp"
+#include "tests/common/tools_line_intersection.inl"

--- a/tests/unit_tests/eigen/CMakeLists.txt
+++ b/tests/unit_tests/eigen/CMakeLists.txt
@@ -14,7 +14,7 @@ detray_add_test( eigen
    "eigen_guided_navigator.cpp" "eigen_helix_trajectory.cpp"
    "eigen_intersection_kernel.cpp" "eigen_mask_store.cpp" "eigen_materials.cpp"
    "eigen_navigator.cpp" "eigen_particle_gun.cpp"
-   "eigen_planar_intersection.cpp" "eigen_propagator.cpp"
+   "eigen_planar_intersection.cpp" "eigen_line_intersection.cpp" "eigen_line.cpp" "eigen_propagator.cpp"
    "eigen_rectangle2.cpp" "eigen_ring2.cpp" "eigen_single3.cpp"
    "eigen_stepper.cpp" "eigen_surfaces_finder.cpp"
    "eigen_telescope_detector.cpp" "eigen_toy_geometry.cpp" "eigen_track.cpp"

--- a/tests/unit_tests/eigen/eigen_line.cpp
+++ b/tests/unit_tests/eigen/eigen_line.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/eigen_definitions.hpp"
+#include "tests/common/masks_line.inl"

--- a/tests/unit_tests/eigen/eigen_line_intersection.cpp
+++ b/tests/unit_tests/eigen/eigen_line_intersection.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/eigen_definitions.hpp"
+#include "tests/common/tools_line_intersection.inl"

--- a/tests/unit_tests/smatrix/CMakeLists.txt
+++ b/tests/unit_tests/smatrix/CMakeLists.txt
@@ -14,7 +14,7 @@ detray_add_test( smatrix
    "smatrix_geometry_scan.cpp" "smatrix_guided_navigator.cpp"
    "smatrix_helix_trajectory.cpp" "smatrix_intersection_kernel.cpp"
    "smatrix_mask_store.cpp" "smatrix_materials.cpp" "smatrix_navigator.cpp"
-   "smatrix_particle_gun.cpp" "smatrix_planar_intersection.cpp"
+   "smatrix_particle_gun.cpp" "smatrix_line_intersection.cpp" "smatrix_line.cpp" "smatrix_planar_intersection.cpp"
    "smatrix_propagator.cpp" "smatrix_rectangle2.cpp" "smatrix_ring2.cpp"
    "smatrix_single3.cpp" "smatrix_stepper.cpp" "smatrix_surfaces_finder.cpp"
    "smatrix_telescope_detector.cpp" "smatrix_toy_geometry.cpp"

--- a/tests/unit_tests/smatrix/smatrix_line.cpp
+++ b/tests/unit_tests/smatrix/smatrix_line.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/smatrix_definitions.hpp"
+#include "tests/common/masks_line.inl"

--- a/tests/unit_tests/smatrix/smatrix_line_intersection.inl
+++ b/tests/unit_tests/smatrix/smatrix_line_intersection.inl
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/smatrix_definitions.hpp"
+#include "tests/common/tools_line_intersection.inl"

--- a/tests/unit_tests/vc/CMakeLists.txt
+++ b/tests/unit_tests/vc/CMakeLists.txt
@@ -11,7 +11,7 @@ detray_add_test( vc_array
    "vc_array_cylinder3.cpp" "vc_array_detector.cpp" "vc_array_geometry_volume_graph.cpp"
    "vc_array_geometry_linking.cpp" "vc_array_geometry_navigation.cpp"
    "vc_array_geometry_scan.cpp" "vc_array_guided_navigator.cpp"
-   "vc_array_helix_trajectory.cpp" "vc_array_intersection_kernel.cpp"
+   "vc_array_helix_trajectory.cpp" "vc_array_intersection_kernel.cpp" "vc_array_line_intersection.cpp" "vc_array_line.cpp" 
    "vc_array_mask_store.cpp" "vc_array_materials.cpp" "vc_array_navigator.cpp"
    "vc_array_particle_gun.cpp" "vc_array_planar_intersection.cpp"
    "vc_array_propagator.cpp" "vc_array_rectangle2.cpp" "vc_array_ring2.cpp"

--- a/tests/unit_tests/vc/vc_array_line.cpp
+++ b/tests/unit_tests/vc/vc_array_line.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/vc_array_definitions.hpp"
+#include "tests/common/masks_line.inl"

--- a/tests/unit_tests/vc/vc_array_line_intersection.cpp
+++ b/tests/unit_tests/vc/vc_array_line_intersection.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/vc_array_definitions.hpp"
+#include "tests/common/tools_line_intersection.inl"


### PR DESCRIPTION
This PR adds a mask for line (wire detector) and its corresponding intersector.

The line mask is defined with its half length and radial scope length. The intersection point is `inside` if its radial position is less than the radial scope length.

The intersection point is obtained by using the virtual plane:
1. every line detector unit has its own transform3 (z' is the line direction) but we can not use this transform3 to get the intersection point.
2. Instead, new transform3 for planar surface (a.k.a virtual plane) is created where z' is the direction of track and y' is the line direction.
3. Run `ray_plane_intersection::intersect` to obtain the intersection.