### PR TITLE
exp: Runge-Kutta stepper policy

### DIFF
--- a/core/include/detray/propagator/navigation_policies.hpp
+++ b/core/include/detray/propagator/navigation_policies.hpp
@@ -66,7 +66,7 @@ struct stepper_default_policy : actor {
     /// @param propagation state of the propagation
     template <typename propagator_state_t>
     DETRAY_HOST_DEVICE inline void operator()(
-        state &pol_state, propagator_state_t &propagation) const {
+        const state &pol_state, propagator_state_t &propagation) const {
 
         const auto &stepping = propagation._stepping;
         auto &navigation = propagation._navigation;
@@ -84,6 +84,46 @@ struct stepper_default_policy : actor {
         else {
             // Re-evaluate all candidates
             navigation.set_fair_trust();
+        }
+    }
+};
+
+/// Specific navigation policy for the Runge-Kutta stepper: Use the relative
+/// amount of step size correction as a measure for the change in direction of
+/// the track state.
+struct stepper_rk_policy : actor {
+
+    struct state {
+        const scalar m_threshold_fair_trust{0.05};
+        const scalar m_threshold_no_trust{0.1};
+    };
+
+    /// Sets the navigation trust level depending on the step size limit
+    ///
+    /// @param pol_state not used
+    /// @param propagation state of the propagation
+    template <typename propagator_state_t>
+    DETRAY_HOST_DEVICE inline void operator()(
+        const state &pol_state, propagator_state_t &propagation) const {
+
+        const auto &stepping = propagation._stepping;
+        auto &navigation = propagation._navigation;
+
+        scalar rel_correction =
+            (stepping.step_size() - navigation()) / navigation();
+
+        // Not a severe change to track state expected
+        if (rel_correction > pol_state.m_threshold_no_trust) {
+            // Re-evaluate only next candidate
+            navigation.set_no_trust();
+        }
+        // Step size hit a constraint - the track state was probably changed a
+        // lot
+        else if (rel_correction > pol_state.m_threshold_fair_trust) {
+            // Re-evaluate all candidates
+            navigation.set_no_trust();
+        } else {
+            navigation.set_high_trust();
         }
     }
 };

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -68,7 +68,7 @@ class rk_stepper final : public base_stepper<track_t, constraint_t, policy_t> {
             array_t<scalar, 4> k_qop;
         } _step_data;
 
-        // Set the local error tolerenace
+        /// Set the local error tolerenace
         DETRAY_HOST_DEVICE
         inline void set_tolerance(scalar tol) { _tolerance = tol; };
 
@@ -80,27 +80,30 @@ class rk_stepper final : public base_stepper<track_t, constraint_t, policy_t> {
         DETRAY_HOST_DEVICE
         inline void advance_track();
 
-        // Update the jacobian transport from free propagation
+        /// Update the jacobian transport from free propagation
         DETRAY_HOST_DEVICE
         inline void advance_jacobian();
 
-        // evaulate k_n for runge kutta stepping
+        /// evaulate k_n for runge kutta stepping
         DETRAY_HOST_DEVICE
         inline vector3 evaluate_k(const vector3& b_field, const int i,
                                   const scalar h, const vector3& k_prev);
     };
 
-    /** Take a step, using an adaptive Runge-Kutta algorithm.
-     *
-     * @return returning the heartbeat, indicating if the stepping is alive
-     */
+    /// Take a step, using an adaptive Runge-Kutta algorithm.
+    ///
+    /// @param propagation contains the states of the rk stepper and navigator
+    ///
+    /// @returns the heartbeat, indicating if the stepping is alive
     template <typename propagation_state_t>
     DETRAY_HOST_DEVICE bool step(propagation_state_t& propagation);
 
-    /** Get the bound state at the surface
-     *
-     * @return returning the bound track parameter
-     */
+    /// Get the bound state at the surface
+    ///
+    /// @param propagation contains the states of the rk stepper and navigator
+    /// @param trf placement of the surface
+    ///
+    /// @return returning the bound track parameter
     template <typename propagation_state_t>
     DETRAY_HOST_DEVICE bound_track_parameters
     bound_state(propagation_state_t& propagation, const transform3& trf);

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -40,6 +40,7 @@ void fill_tracks(vecmem::vector<free_track_parameters> &tracks,
     }
 }
 
+template <typename stepper_policy_t>
 static void BM_PROPAGATOR_CPU(benchmark::State &state) {
 
     // Create the toy geometry
@@ -53,13 +54,13 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
     field_type B_field(B);
 
     // Create RK stepper
-    rk_stepper_type s(B_field);
+    rk_stepper_type<stepper_policy_t> s(B_field);
 
     // Create navigator
     navigator_host_type n(det);
 
     // Create propagator
-    propagator_host_type p(std::move(s), std::move(n));
+    propagator_host_type<stepper_policy_t> p(std::move(s), std::move(n));
 
     for (auto _ : state) {
 
@@ -75,7 +76,7 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
         for (auto &track : tracks) {
 
             // Create the propagator state
-            propagator_host_type::state p_state(track);
+            typename propagator_host_type<stepper_policy_t>::state p_state(track);
 
             // Run propagation
             p.propagate(p_state);
@@ -83,6 +84,7 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
     }
 }
 
+template <typename stepper_policy_t>
 static void BM_PROPAGATOR_CUDA(benchmark::State &state) {
 
     // Create the toy geometry
@@ -116,11 +118,23 @@ static void BM_PROPAGATOR_CUDA(benchmark::State &state) {
         copy.setup(candidates_buffer);
 
         // Run the propagator test for GPU device
-        propagator_benchmark(det_data, tracks_data, candidates_buffer);
+        propagator_benchmark<stepper_policy_t>(det_data, tracks_data, candidates_buffer);
     }
 }
 
-BENCHMARK(BM_PROPAGATOR_CPU)->RangeMultiplier(2)->Range(8, 256);
-BENCHMARK(BM_PROPAGATOR_CUDA)->RangeMultiplier(2)->Range(8, 256);
+BENCHMARK(BM_PROPAGATOR_CPU<always_init>)->RangeMultiplier(2)->Range(8, 256);
+BENCHMARK(BM_PROPAGATOR_CUDA<always_init>)->RangeMultiplier(2)->Range(8, 256);
+BENCHMARK(BM_PROPAGATOR_CPU<stepper_default_policy>)
+    ->RangeMultiplier(2)
+    ->Range(8, 256);
+BENCHMARK(BM_PROPAGATOR_CUDA<stepper_default_policy>)
+    ->RangeMultiplier(2)
+    ->Range(8, 256);
+BENCHMARK(BM_PROPAGATOR_CPU<stepper_rk_policy>)
+    ->RangeMultiplier(2)
+    ->Range(8, 256);
+BENCHMARK(BM_PROPAGATOR_CUDA<stepper_rk_policy>)
+    ->RangeMultiplier(2)
+    ->Range(8, 256);
 
 BENCHMARK_MAIN();

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
@@ -21,6 +21,7 @@
 #include "detray/field/constant_magnetic_field.hpp"
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/base_actor.hpp"
+#include "detray/propagator/navigation_policies.hpp"
 #include "detray/propagator/navigator.hpp"
 #include "detray/propagator/propagator.hpp"
 #include "detray/propagator/rk_stepper.hpp"
@@ -41,16 +42,20 @@ using detector_device_type =
 using navigator_host_type = navigator<detector_host_type>;
 using navigator_device_type = navigator<detector_device_type>;
 
-using field_type = constant_magnetic_field<>;
-using rk_stepper_type = rk_stepper<field_type, free_track_parameters>;
-using propagator_host_type =
-    propagator<rk_stepper_type, navigator_host_type, actor_chain<>>;
-using propagator_device_type =
-    propagator<rk_stepper_type, navigator_device_type, actor_chain<>>;
+template <typename policy_t>
+using rk_stepper_type =
+    rk_stepper<field_type, free_track_parameters, unconstrained_step, policy_t>;
+template <typename stepper_policy_t>
+using propagator_host_type = propagator<rk_stepper_type<stepper_policy_t>,
+                                        navigator_host_type, actor_chain<>>;
+template <typename stepper_policy_t>
+using propagator_device_type = propagator<rk_stepper_type<stepper_policy_t>,
+                                          navigator_device_type, actor_chain<>>;
 
 namespace detray {
 
 /// test function for propagator with single state
+template <typename stepper_policy_t>
 void propagator_benchmark(
     detector_view<detector_host_type> det_data,
     vecmem::data::vector_view<free_track_parameters>& tracks_data,


### PR DESCRIPTION
Adds an experimental navigation policy that relies on the amount of step size correction done by the adaptive Runge-Kutta in order to set navigation trust levels. Also templates the propagation benchmarks to the navigation policy, in order to be able to compare their performance.