### PR TITLE
Integrate covfie into the build system and add tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,8 @@ if( DETRAY_SETUP_BENCHMARK )
    endif()
 endif()
 
+add_subdirectory( extern/covfie )
+
 # Set up all of the libraries of the project.
 add_subdirectory( core )
 add_subdirectory( plugins )

--- a/extern/covfie/CMakeLists.txt
+++ b/extern/covfie/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.14 )
+include( FetchContent )
+
+# Tell the user what's happening.
+message( STATUS "Fetching covfie as part of the Detray project" )
+
+# Declare where to get covfie from.
+set( DETRAY_COVFIE_SOURCE
+   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.1.0.tar.gz;URL_MD5;e5eafed7746a86bb353b6c4ee60fa373"
+   CACHE STRING "Source for covfie, when built as part of this project" )
+mark_as_advanced( DETRAY_COVFIE_SOURCE )
+FetchContent_Declare( covfie ${DETRAY_COVFIE_SOURCE} )
+
+# Options used for covfie.
+set( COVFIE_BUILD_EXAMPLES Off CACHE BOOL "Build covfie examples")
+set( COVFIE_BUILD_TESTS Off CACHE BOOL "Build covfie tests")
+set( COVFIE_BUILD_BENCHMARKS Off CACHE BOOL "Build covfie benchmarks")
+
+set( COVFIE_PLATFORM_CPU On CACHE BOOL "Enable covfie CPU platform")
+set( COVFIE_PLATFORM_CUDA On CACHE BOOL "Enable covfie CUDA platform")
+
+set( COVFIE_REQUIRE_CXX20 Off CACHE BOOL "Enable covfie C++20 requirement")
+
+# Get it into the current directory.
+FetchContent_MakeAvailable( covfie )

--- a/extern/covfie/CMakeLists.txt
+++ b/extern/covfie/CMakeLists.txt
@@ -13,7 +13,7 @@ message( STATUS "Fetching covfie as part of the Detray project" )
 
 # Declare where to get covfie from.
 set( DETRAY_COVFIE_SOURCE
-   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.1.0.tar.gz;URL_MD5;e5eafed7746a86bb353b6c4ee60fa373"
+   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.2.0.tar.gz;URL_MD5;7cf83f2a4d5dcc3dad8fb952cef36fd4"
    CACHE STRING "Source for covfie, when built as part of this project" )
 mark_as_advanced( DETRAY_COVFIE_SOURCE )
 FetchContent_Declare( covfie ${DETRAY_COVFIE_SOURCE} )

--- a/extern/covfie/README.md
+++ b/extern/covfie/README.md
@@ -1,0 +1,4 @@
+# Build Recipe for covfie
+
+This directory holds a simple build recipe for the
+[covfie](https://github.com/acts-project/covfie) project.

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -21,3 +21,5 @@ endif()
 if( DETRAY_BUILD_CUDA )
    add_subdirectory( cuda )
 endif()
+
+add_subdirectory( covfie )

--- a/tests/unit_tests/covfie/CMakeLists.txt
+++ b/tests/unit_tests/covfie/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Set up the covfie tests.
+detray_add_test( covfie
+   "constant_field.cpp"
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common covfie_core )

--- a/tests/unit_tests/covfie/constant_field.cpp
+++ b/tests/unit_tests/covfie/constant_field.cpp
@@ -1,0 +1,64 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+// detray test
+#include "tests/common/test_defs.hpp"
+
+// covfie core
+#include <covfie/core/backend/initial/constant.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/field_view.hpp>
+
+TEST(Covfie, ConstantField1D) {
+    using field_t =
+        covfie::field<covfie::backend::constant<covfie::vector::float1,
+                                                covfie::vector::float1>>;
+
+    field_t f(field_t::backend_t::configuration_t{2.f});
+    field_t::view_t v(f);
+
+    for (float x = -100.f; x <= 100.f; x += 1.) {
+        EXPECT_EQ(v.at(x)[0], 2.f);
+    }
+}
+
+TEST(Covfie, ConstantField2D) {
+    using field_t =
+        covfie::field<covfie::backend::constant<covfie::vector::float2,
+                                                covfie::vector::float2>>;
+
+    field_t f(field_t::backend_t::configuration_t{2.f, 5.f});
+    field_t::view_t v(f);
+
+    for (float x = -100.f; x <= 100.f; x += 1.) {
+        for (float y = -100.f; y <= 100.f; y += 1.) {
+            EXPECT_EQ(v.at(x, y)[0], 2.f);
+            EXPECT_EQ(v.at(x, y)[1], 5.f);
+        }
+    }
+}
+
+TEST(Covfie, ConstantField3D) {
+    using field_t =
+        covfie::field<covfie::backend::constant<covfie::vector::float3,
+                                                covfie::vector::float3>>;
+
+    field_t f(field_t::backend_t::configuration_t{2.f, 5.f, -4.f});
+    field_t::view_t v(f);
+
+    for (float x = -10.f; x <= 10.f; x += 1.) {
+        for (float y = -10.f; y <= 10.f; y += 1.) {
+            for (float z = -10.f; z <= 10.f; z += 1.) {
+                EXPECT_EQ(v.at(x, y, z)[0], 2.f);
+                EXPECT_EQ(v.at(x, y, z)[1], 5.f);
+                EXPECT_EQ(v.at(x, y, z)[2], -4.f);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull requests serves as the first step towards integrating covfie into detray. To that end, it adds covfie as a fetched dependency in the detray build system, so that the necessary source code is automatically downloaded and integrated into detray's CMake configuration. On top of that, we also add a very simple test application which shows that the code compiles correctly, and gives some hints on how it can be used.