### PR TITLE
Make `is_inside` function take Cartesian point only

### DIFF
--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -83,10 +83,6 @@ struct line_intersector {
         const scalar A =
             detray::scalar{1.} / denom * (t2l_on_track - t2l_on_line * zd);
 
-        // distance to the point of closest approarch on the
-        // line from line center
-        const scalar B = zd * A - t2l_on_line;
-
         // point of closest approach on the track
         const vector3 m = _p + _d * A;
 
@@ -98,8 +94,8 @@ struct line_intersector {
         const auto loc = trf.point_to_local(is.p3);
         is.status = mask.is_inside(loc, mask_tolerance);
 
-        is.p2[0] = getter::perp(loc);
-        is.p2[1] = B;
+        // Get intersection in local coordinate
+        is.p2 = typename mask_t::local_type()(loc);
 
         is.direction = is.path > overstep_tolerance
                            ? intersection::direction::e_along

--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -94,12 +94,12 @@ struct line_intersector {
         is.path = A;
         is.p3 = m;
 
-        // global to local transform in cartesian coordinate
-        auto loc = trf.point_to_local(is.p3);
+        // Global to local transform in cartesian coordinate
+        const auto loc = trf.point_to_local(is.p3);
+        is.status = mask.is_inside(loc, mask_tolerance);
+
         is.p2[0] = getter::perp(loc);
         is.p2[1] = B;
-
-        is.status = mask.is_inside(loc, mask_tolerance);
 
         is.direction = is.path > overstep_tolerance
                            ? intersection::direction::e_along

--- a/core/include/detray/masks/cylinder3.hpp
+++ b/core/include/detray/masks/cylinder3.hpp
@@ -81,20 +81,16 @@ class cylinder3 final
 
     /** Mask operation
      *
-     * @tparam inside_local_type::point3 is the deduced type of the point to be
-     *checked w.r.t. to the mask bounds, it's assumed to be within the cylinder
-     *3D frame
-     *
      * @param p the point to be checked
      * @param t is the tolerance tuple in (radius, z)
      *
      * @return an intersection status e_inside / e_outside
      **/
-    template <typename inside_local_t, bool is_rad_check = kRadialCheck>
+    template <typename cartesian_point_t>
     DETRAY_HOST_DEVICE intersection::status is_inside(
-        const point3 &p,
+        const cartesian_point_t &p,
         const scalar t = std::numeric_limits<scalar>::epsilon()) const {
-        if constexpr (is_rad_check) {
+        if constexpr (kRadialCheck) {
             scalar r = getter::perp(p);
             if (std::abs(r - this->_values[0]) >=
                 t + 5 * std::numeric_limits<scalar>::epsilon()) {

--- a/core/include/detray/masks/cylinder3.hpp
+++ b/core/include/detray/masks/cylinder3.hpp
@@ -86,11 +86,11 @@ class cylinder3 final
      *
      * @return an intersection status e_inside / e_outside
      **/
-    template <typename cartesian_point_t>
+    template <bool is_rad_check = kRadialCheck, typename cartesian_point_t>
     DETRAY_HOST_DEVICE intersection::status is_inside(
         const cartesian_point_t &p,
         const scalar t = std::numeric_limits<scalar>::epsilon()) const {
-        if constexpr (kRadialCheck) {
+        if constexpr (is_rad_check) {
             scalar r = getter::perp(p);
             if (std::abs(r - this->_values[0]) >=
                 t + 5 * std::numeric_limits<scalar>::epsilon()) {

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -66,15 +66,14 @@ class line final
 
     /** Mask operation
      *
-     * @tparam inside_local_t is the local type for inside checking
-     *
      * @param p is the intersection point in local cartesian coordinate
      * @param t is the tolerance in r
      *
      * @return an intersection status e_inside / e_outside
      **/
+    template <typename cartesian_point_t>
     DETRAY_HOST_DEVICE intersection::status is_inside(
-        const point3 &p,
+        const cartesian_point_t &p,
         const scalar t = std::numeric_limits<scalar>::epsilon()) const {
 
         // For square cross section, we check if (1) the x and y of transverse
@@ -88,14 +87,14 @@ class line final
                        ? intersection::status::e_inside
                        : intersection::status::e_outside;
 
-            // For circular cross section, we check if (1) the radial distance
-            // is within the scope and (2) the distance to the point of closest
-            // approach on line from the line center is less than the half line
-            // length
-        } else {
+        }
+        // For circular cross section, we check if (1) the radial distance
+        // is within the scope and (2) the distance to the point of closest
+        // approach on line from the line center is less than the half line
+        // length
+        else {
             return (getter::perp(p) <= this->_values[0] + t &&
                     std::abs(p[2]) <= this->_values[1] + t)
-
                        ? intersection::status::e_inside
                        : intersection::status::e_outside;
         }

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -23,7 +23,7 @@ namespace detray {
 /** This is a simple mask for a line defined with a line length and its scope
  *
  **/
-template <typename local_t = __plugin::cartesian2<detray::scalar>,
+template <typename local_t = __plugin::polar2<detray::scalar>,
           typename links_t = dindex, bool kSquareScope = false,
           template <typename, std::size_t> class array_t = darray>
 class line final

--- a/core/include/detray/masks/rectangle2.hpp
+++ b/core/include/detray/masks/rectangle2.hpp
@@ -50,6 +50,7 @@ class rectangle2 final
     using local_type = typename base_type::local_type;
     using intersector_type = typename base_type::intersector_type;
     using point2 = __plugin::point2<scalar>;
+    using point3 = __plugin::point3<scalar>;
 
     /* Default constructor */
     rectangle2()
@@ -79,16 +80,14 @@ class rectangle2 final
 
     /** Mask operation
      *
-     * @tparam inside_local_t is the local type for inside checking
-     *
      * @param p the point to be checked
      * @param t is the tolerance tuple in (l0, l1)
      *
      * @return an intersection status e_inside / e_outside
      **/
-    template <typename inside_local_t>
+    template <typename cartesian_point_t>
     DETRAY_HOST_DEVICE intersection::status is_inside(
-        const point2 &p,
+        const cartesian_point_t &p,
         const scalar t = std::numeric_limits<scalar>::epsilon()) const {
         return (std::abs(p[0]) <= this->_values[0] + t and
                 std::abs(p[1]) <= this->_values[1] + t)

--- a/core/include/detray/masks/ring2.hpp
+++ b/core/include/detray/masks/ring2.hpp
@@ -49,6 +49,7 @@ class ring2 final
     using local_type = typename base_type::local_type;
     using intersector_type = typename base_type::intersector_type;
     using point2 = __plugin::point2<scalar>;
+    using point3 = __plugin::point3<scalar>;
 
     /* Default constructor */
     ring2() : base_type({0., std::numeric_limits<scalar>::infinity()}, {}) {}
@@ -74,26 +75,17 @@ class ring2 final
 
     /** Mask operation
      *
-     * @tparam inside_local_t is the local type for inside checking
-     *
      * @param p the point to be checked
      * @param t is the tolerance in r
      *
      * @return an intersection status e_inside / e_outside
      **/
-    template <typename inside_local_t>
+    template <typename cartesian_point_t>
     DETRAY_HOST_DEVICE intersection::status is_inside(
-        const point2 &p,
+        const cartesian_point_t &p,
         const scalar t = std::numeric_limits<scalar>::epsilon()) const {
-        if constexpr (std::is_same_v<inside_local_t,
-                                     __plugin::cartesian2<detray::scalar>>) {
-            scalar r = getter::perp(p);
-            return (r + t >= this->_values[0] and r <= this->_values[1] + t)
-                       ? intersection::status::e_inside
-                       : intersection::status::e_outside;
-        }
-
-        return (p[0] + t >= this->_values[0] and p[0] <= this->_values[1] + t)
+        const scalar r = getter::perp(p);
+        return (r + t >= this->_values[0] and r <= this->_values[1] + t)
                    ? intersection::status::e_inside
                    : intersection::status::e_outside;
     }

--- a/core/include/detray/masks/single3.hpp
+++ b/core/include/detray/masks/single3.hpp
@@ -69,16 +69,14 @@ class single3 final
 
     /** Mask operation
      *
-     * @tparam inside_local_type is the global type for checking (ignored)
-     *
      * @param p the point to be checked
      * @param t is the tolerance of the single parameter
      *
      * @return an intersection status e_inside / e_outside
      **/
-    template <typename inside_local_t>
+    template <typename cartesian_point_t>
     DETRAY_HOST_DEVICE intersection::status is_inside(
-        const point3 &p,
+        const cartesian_point_t &p,
         const scalar t = std::numeric_limits<scalar>::epsilon()) const {
         return (this->_values[0] - t <= p[kCheckIndex] and
                 p[kCheckIndex] <= this->_values[1] + t)

--- a/core/include/detray/masks/trapezoid2.hpp
+++ b/core/include/detray/masks/trapezoid2.hpp
@@ -51,6 +51,7 @@ class trapezoid2 final
     using local_type = typename base_type::local_type;
     using intersector_type = typename base_type::intersector_type;
     using point2 = __plugin::point2<scalar>;
+    using point3 = __plugin::point3<scalar>;
 
     /* Default constructor */
     trapezoid2()
@@ -86,16 +87,14 @@ class trapezoid2 final
 
     /** Mask operation
      *
-     * @tparam inside_local_t is the type of the local frame (ignored here)
-     *
      * @param p the point to be checked
      * @param t us the tolerance tuple (l0,l1)
      *
      * @return an intersection status e_inside / e_outside
      **/
-    template <typename inside_local_t>
+    template <typename cartesian_point_t>
     DETRAY_HOST_DEVICE intersection::status is_inside(
-        const point2 &p,
+        const cartesian_point_t &p,
         const scalar t = std::numeric_limits<scalar>::epsilon()) const {
         scalar rel_y = (this->_values[2] + p[1]) * this->_values[3];
         return (std::abs(p[0]) <=

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -30,7 +30,7 @@ class unmasked final
     using links_type = typename base_type::links_type;
     using local_type = typename base_type::local_type;
     using intersector_type = typename base_type::intersector_type;
-    using point2 = __plugin::point2<scalar>;
+    using point3 = __plugin::point3<scalar>;
 
     /* Default constructor */
     unmasked() = default;
@@ -48,9 +48,9 @@ class unmasked final
      *
      * @return true
      **/
-    template <typename inside_local_t>
+    template <typename cartesian_point_t>
     DETRAY_HOST_DEVICE inline intersection::status is_inside(
-        const point2& /*ignored*/, const scalar /*ignored*/) const {
+        const cartesian_point_t& /*ignored*/, const scalar /*ignored*/) const {
         return intersection::status::e_inside;
     }
 

--- a/tests/common/include/tests/common/benchmark_masks.inl
+++ b/tests/common/include/tests/common/benchmark_masks.inl
@@ -39,7 +39,6 @@ namespace {
 
 // This test runs a rectangle2 maks test operation
 static void BM_RECTANGLE2_MASK(benchmark::State &state) {
-    using local_type = __plugin::cartesian2<detray::scalar>;
     using point2 = __plugin::point2<detray::scalar>;
 
     rectangle2<> r{3, 4, 0u};
@@ -61,7 +60,7 @@ static void BM_RECTANGLE2_MASK(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(inside);
                 benchmark::DoNotOptimize(outside);
-                if (r.is_inside<local_type>(point2{x, y}) ==
+                if (r.is_inside(point2{x, y}) ==
                     intersection::status::e_inside) {
                     ++inside;
                 } else {
@@ -82,7 +81,6 @@ static void BM_RECTANGLE2_MASK(benchmark::State &state) {
 
 // This test runs intersection a trapezoid2 mask operation
 static void BM_TRAPEZOID2_MASK(benchmark::State &state) {
-    using local_type = __plugin::cartesian2<detray::scalar>;
     using point2 = __plugin::point2<detray::scalar>;
 
     trapezoid2<> t{2, 3, 4, 0u};
@@ -104,7 +102,7 @@ static void BM_TRAPEZOID2_MASK(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(inside);
                 benchmark::DoNotOptimize(outside);
-                if (t.is_inside<local_type>(point2{x, y}) ==
+                if (t.is_inside(point2{x, y}) ==
                     intersection::status::e_inside) {
                     ++inside;
                 } else {
@@ -125,7 +123,6 @@ static void BM_TRAPEZOID2_MASK(benchmark::State &state) {
 
 // This test runs a ring2 mask operation
 static void BM_RING2_MASK(benchmark::State &state) {
-    using local_type = __plugin::cartesian2<detray::scalar>;
     using point2 = __plugin::point2<detray::scalar>;
 
     ring2<> r{0., 5., 0u};
@@ -147,7 +144,7 @@ static void BM_RING2_MASK(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(inside);
                 benchmark::DoNotOptimize(outside);
-                if (r.is_inside<local_type>(point2{x, y}) ==
+                if (r.is_inside(point2{x, y}) ==
                     intersection::status::e_inside) {
                     ++inside;
                 } else {
@@ -167,7 +164,6 @@ static void BM_RING2_MASK(benchmark::State &state) {
 
 // This test runs mask oeration on a disc2
 static void BM_DISC2_MASK(benchmark::State &state) {
-    using local_type = __plugin::cartesian2<detray::scalar>;
     using point2 = __plugin::point2<detray::scalar>;
 
     ring2<> r{2., 5., 0u};
@@ -189,7 +185,7 @@ static void BM_DISC2_MASK(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(inside);
                 benchmark::DoNotOptimize(outside);
-                if (r.is_inside<local_type>(point2{x, y}) ==
+                if (r.is_inside(point2{x, y}) ==
                     intersection::status::e_inside) {
                     ++inside;
                 } else {
@@ -209,7 +205,6 @@ static void BM_DISC2_MASK(benchmark::State &state) {
 
 // This test runs masking operations on a cylinder3 mask
 static void BM_CYLINDER3_MASK(benchmark::State &state) {
-    using local_type = __plugin::transform3<detray::scalar>;
     using point3 = __plugin::point3<detray::scalar>;
 
     cylinder3<> c{3., 5., 0., 0u};
@@ -233,7 +228,7 @@ static void BM_CYLINDER3_MASK(benchmark::State &state) {
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
-                    if (c.is_inside<local_type>(point3{x, y, z}, 0.1) ==
+                    if (c.is_inside(point3{x, y, z}, 0.1) ==
                         intersection::status::e_inside) {
                         ++inside;
                     } else {
@@ -254,7 +249,6 @@ static void BM_CYLINDER3_MASK(benchmark::State &state) {
 
 // This test runs a annulus mask operation
 static void BM_ANNULUS_MASK(benchmark::State &state) {
-    using local_type = __plugin::cartesian2<detray::scalar>;
     using point2 = __plugin::point2<detray::scalar>;
 
     annulus2<> ann{2.5, 5., -0.64299, 4.13173, 1., 0.5, 0., 0u};
@@ -274,7 +268,7 @@ static void BM_ANNULUS_MASK(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(inside);
                 benchmark::DoNotOptimize(outside);
-                if (ann.is_inside<local_type>(point2{x, y}) ==
+                if (ann.is_inside(point2{x, y}) ==
                     intersection::status::e_inside) {
                     ++inside;
                 } else {

--- a/tests/common/include/tests/common/masks_annulus2.inl
+++ b/tests/common/include/tests/common/masks_annulus2.inl
@@ -14,8 +14,6 @@ using namespace __plugin;
 
 // This tests the basic function of a rectangle
 TEST(mask, annulus2) {
-    using polar = __plugin::polar2<detray::scalar>;
-    using cartesian = __plugin::cartesian2<detray::scalar>;
     using point2 = __plugin::point2<detray::scalar>;
 
     scalar minR = 7.2;
@@ -31,13 +29,6 @@ TEST(mask, annulus2) {
     point2 p2_out3 = {10., 10.};
     point2 p2_out4 = {4., 10.};
 
-    auto toStripFrame = [&](const point2& xy) -> point2 {
-        auto shifted = xy + offset;
-        scalar r = getter::perp(shifted);
-        scalar phi = getter::phi(shifted);
-        return point2{r, phi};
-    };
-
     annulus2<> ann2{minR, maxR, minPhi, maxPhi, offset[0], offset[1], 0., 0u};
 
     ASSERT_EQ(ann2[0], static_cast<scalar>(7.2));
@@ -48,35 +39,19 @@ TEST(mask, annulus2) {
     ASSERT_EQ(ann2[5], static_cast<scalar>(2.0));
     ASSERT_EQ(ann2[6], static_cast<scalar>(0.));
 
-    ASSERT_TRUE(ann2.is_inside<cartesian>(p2_in + offset) ==
+    ASSERT_TRUE(ann2.is_inside(point2(p2_in + offset)) ==
                 intersection::status::e_inside);
-    ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out1 + offset) ==
+    ASSERT_TRUE(ann2.is_inside(point2(p2_out1 + offset)) ==
                 intersection::status::e_outside);
-    ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out2 + offset) ==
+    ASSERT_TRUE(ann2.is_inside(point2(p2_out2 + offset)) ==
                 intersection::status::e_outside);
-    ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out3 + offset) ==
+    ASSERT_TRUE(ann2.is_inside(point2(p2_out3 + offset)) ==
                 intersection::status::e_outside);
-    ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out4 + offset) ==
+    ASSERT_TRUE(ann2.is_inside(point2(p2_out4 + offset)) ==
                 intersection::status::e_outside);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out1 + offset, 1.3) ==
+    ASSERT_TRUE(ann2.is_inside(point2(p2_out1 + offset), 1.3) ==
                 intersection::status::e_inside);
-    ASSERT_TRUE(ann2.is_inside<cartesian>(p2_out4 + offset, 0.07) ==
-                intersection::status::e_inside);
-
-    ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_in)) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out1)) ==
-                intersection::status::e_outside);
-    ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out2)) ==
-                intersection::status::e_outside);
-    ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out3)) ==
-                intersection::status::e_outside);
-    ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out4)) ==
-                intersection::status::e_outside);
-    // Move outside point inside using a tolerance
-    ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out1), 1.3) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(ann2.is_inside<polar>(toStripFrame(p2_out4), 0.07) ==
+    ASSERT_TRUE(ann2.is_inside(point2(p2_out4 + offset), 0.07) ==
                 intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_cylinder3.inl
+++ b/tests/common/include/tests/common/masks_cylinder3.inl
@@ -34,15 +34,10 @@ TEST(mask, cylinder3) {
     ASSERT_EQ(c[1], -hz);
     ASSERT_EQ(c[2], hz);
 
-    ASSERT_TRUE(c.is_inside<local_type>(p3_in) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(c.is_inside<local_type>(p3_edge) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(c.is_inside<local_type>(p3_out) ==
-                intersection::status::e_outside);
-    ASSERT_TRUE(c.is_inside<local_type>(p3_off) ==
-                intersection::status::e_missed);
+    ASSERT_TRUE(c.is_inside(p3_in) == intersection::status::e_inside);
+    ASSERT_TRUE(c.is_inside(p3_edge) == intersection::status::e_inside);
+    ASSERT_TRUE(c.is_inside(p3_out) == intersection::status::e_outside);
+    ASSERT_TRUE(c.is_inside(p3_off) == intersection::status::e_missed);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(c.is_inside<local_type>(p3_out, 0.6) ==
-                intersection::status::e_inside);
+    ASSERT_TRUE(c.is_inside(p3_out, 0.6) == intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_rectangle2.inl
+++ b/tests/common/include/tests/common/masks_rectangle2.inl
@@ -16,7 +16,6 @@ using namespace __plugin;
 
 // This tests the basic function of a rectangle
 TEST(mask, rectangle2) {
-    using local_type = __plugin::cartesian2<detray::scalar>;
     using point2 = __plugin::point2<detray::scalar>;
 
     point2 p2_in = {0.5, -9.};
@@ -31,13 +30,9 @@ TEST(mask, rectangle2) {
     ASSERT_EQ(r2[0], hx);
     ASSERT_EQ(r2[1], hy);
 
-    ASSERT_TRUE(r2.is_inside<local_type>(p2_in) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(r2.is_inside<local_type>(p2_edge) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(r2.is_inside<local_type>(p2_out) ==
-                intersection::status::e_outside);
+    ASSERT_TRUE(r2.is_inside(p2_in) == intersection::status::e_inside);
+    ASSERT_TRUE(r2.is_inside(p2_edge) == intersection::status::e_inside);
+    ASSERT_TRUE(r2.is_inside(p2_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(r2.is_inside<local_type>(p2_out, 1.) ==
-                intersection::status::e_inside);
+    ASSERT_TRUE(r2.is_inside(p2_out, 1.) == intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_ring2.inl
+++ b/tests/common/include/tests/common/masks_ring2.inl
@@ -14,12 +14,6 @@ using point2 = __plugin::point2<scalar>;
 
 // This tests the basic function of a rectangle
 TEST(mask, ring2) {
-    using cartesian = __plugin::cartesian2<detray::scalar>;
-    using polar = __plugin::polar2<detray::scalar>;
-
-    point2 p2_pl_in = {0.5, -2.};
-    point2 p2_pl_edge = {0., 3.5};
-    point2 p2_pl_out = {3.6, 5.};
 
     point2 p2_c_in = {0.5, -2.};
     point2 p2_c_edge = {0., 3.5};
@@ -30,23 +24,9 @@ TEST(mask, ring2) {
     ASSERT_EQ(r2[0], 0.);
     ASSERT_EQ(r2[1], 3.5);
 
-    ASSERT_TRUE(r2.is_inside<polar>(p2_pl_in) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(r2.is_inside<polar>(p2_pl_edge) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(r2.is_inside<polar>(p2_pl_out) ==
-                intersection::status::e_outside);
+    ASSERT_TRUE(r2.is_inside(p2_c_in) == intersection::status::e_inside);
+    ASSERT_TRUE(r2.is_inside(p2_c_edge) == intersection::status::e_inside);
+    ASSERT_TRUE(r2.is_inside(p2_c_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(r2.is_inside<polar>(p2_pl_out, 1.2) ==
-                intersection::status::e_inside);
-
-    ASSERT_TRUE(r2.is_inside<cartesian>(p2_c_in) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(r2.is_inside<cartesian>(p2_c_edge) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(r2.is_inside<cartesian>(p2_c_out) ==
-                intersection::status::e_outside);
-    // Move outside point inside using a tolerance
-    ASSERT_TRUE(r2.is_inside<cartesian>(p2_c_out, 1.45) ==
-                intersection::status::e_inside);
+    ASSERT_TRUE(r2.is_inside(p2_c_out, 1.45) == intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_single3.inl
+++ b/tests/common/include/tests/common/masks_single3.inl
@@ -16,7 +16,6 @@ using namespace __plugin;
 
 // This tests the basic function of a rectangle
 TEST(mask, single3_0) {
-    using local_type = __plugin::transform3<detray::scalar>;
     using point3 = __plugin::point3<detray::scalar>;
 
     point3 p3_in = {0.5, -9., 0.};
@@ -29,20 +28,15 @@ TEST(mask, single3_0) {
     ASSERT_EQ(m1_0[0], -h0);
     ASSERT_EQ(m1_0[1], h0);
 
-    ASSERT_TRUE(m1_0.is_inside<local_type>(p3_in) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(m1_0.is_inside<local_type>(p3_edge) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(m1_0.is_inside<local_type>(p3_out) ==
-                intersection::status::e_outside);
+    ASSERT_TRUE(m1_0.is_inside(p3_in) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_0.is_inside(p3_edge) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_0.is_inside(p3_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance - take t0 not t1
-    ASSERT_TRUE(m1_0.is_inside<local_type>(p3_out, 0.6) ==
-                intersection::status::e_inside);
+    ASSERT_TRUE(m1_0.is_inside(p3_out, 0.6) == intersection::status::e_inside);
 }
 
 // This tests the basic function of a rectangle
 TEST(mask, single3_1) {
-    using local_type = __plugin::transform3<detray::scalar>;
     using point3 = __plugin::point3<detray::scalar>;
 
     point3 p3_in = {0.5, -9., 0.};
@@ -55,20 +49,15 @@ TEST(mask, single3_1) {
     ASSERT_EQ(m1_1[0], -h1);
     ASSERT_EQ(m1_1[1], h1);
 
-    ASSERT_TRUE(m1_1.is_inside<local_type>(p3_in) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(m1_1.is_inside<local_type>(p3_edge) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(m1_1.is_inside<local_type>(p3_out) ==
-                intersection::status::e_outside);
+    ASSERT_TRUE(m1_1.is_inside(p3_in) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_1.is_inside(p3_edge) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_1.is_inside(p3_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance - take t1 not t1
-    ASSERT_TRUE(m1_1.is_inside<local_type>(p3_out, 0.6) ==
-                intersection::status::e_inside);
+    ASSERT_TRUE(m1_1.is_inside(p3_out, 0.6) == intersection::status::e_inside);
 }
 
 // This tests the basic function of a rectangle
 TEST(mask, single3_2) {
-    using local_type = __plugin::transform3<detray::scalar>;
     using point3 = __plugin::point3<detray::scalar>;
 
     point3 p3_in = {0.5, -9., 0.};
@@ -81,13 +70,9 @@ TEST(mask, single3_2) {
     ASSERT_EQ(m1_2[0], -h2);
     ASSERT_EQ(m1_2[1], h2);
 
-    ASSERT_TRUE(m1_2.is_inside<local_type>(p3_in) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(m1_2.is_inside<local_type>(p3_edge) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(m1_2.is_inside<local_type>(p3_out) ==
-                intersection::status::e_outside);
+    ASSERT_TRUE(m1_2.is_inside(p3_in) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_2.is_inside(p3_edge) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_2.is_inside(p3_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance - take t1 not t1
-    ASSERT_TRUE(m1_2.is_inside<local_type>(p3_out, 6.1) ==
-                intersection::status::e_inside);
+    ASSERT_TRUE(m1_2.is_inside(p3_out, 6.1) == intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_trapezoid2.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2.inl
@@ -14,7 +14,6 @@ using namespace __plugin;
 
 // This tests the basic function of a trapezoid
 TEST(mask, trapezoid2) {
-    using local_type = __plugin::cartesian2<detray::scalar>;
     using point2 = __plugin::point2<detray::scalar>;
 
     point2 p2_in = {1., -0.5};
@@ -33,13 +32,9 @@ TEST(mask, trapezoid2) {
     ASSERT_EQ(t2[2], hy);
     ASSERT_EQ(t2[3], divisor);
 
-    ASSERT_TRUE(t2.is_inside<local_type>(p2_in) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(t2.is_inside<local_type>(p2_edge) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(t2.is_inside<local_type>(p2_out) ==
-                intersection::status::e_outside);
+    ASSERT_TRUE(t2.is_inside(p2_in) == intersection::status::e_inside);
+    ASSERT_TRUE(t2.is_inside(p2_edge) == intersection::status::e_inside);
+    ASSERT_TRUE(t2.is_inside(p2_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(t2.is_inside<local_type>(p2_out, 1.) ==
-                intersection::status::e_inside);
+    ASSERT_TRUE(t2.is_inside(p2_out, 1.) == intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_unmasked.inl
+++ b/tests/common/include/tests/common/masks_unmasked.inl
@@ -14,16 +14,8 @@ using point2 = __plugin::point2<scalar>;
 
 // This tests the construction of a surface
 TEST(mask, unmasked) {
-    using local_type = __plugin::cartesian2<detray::scalar>;
     point2 p2 = {0.5, -9.};
 
     unmasked u;
-    ASSERT_TRUE(u.is_inside<local_type>(p2, 0) ==
-                intersection::status::e_inside);
-    /*
-    ASSERT_TRUE(u.is_inside<local_type>() ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(u.is_inside<local_type>(p2, false) ==
-                intersection::status::e_outside);
-    */
+    ASSERT_TRUE(u.is_inside(p2, 0) == intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
@@ -103,7 +103,7 @@ struct helix_cylinder_intersector {
 
         // Global to local transform in cartesian coordinate
         const auto loc = trf.point_to_local(is.p3);
-        is.status = mask.is_inside(loc, mask_tolerance);
+        is.status = mask.template is_inside<true>(loc, mask_tolerance);
 
         // Get intersection in local coordinate
         is.p2 = typename mask_t::local_type()(loc);

--- a/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
@@ -50,8 +50,6 @@ struct helix_cylinder_intersector {
 
         output_type ret;
 
-        using local_frame = typename mask_t::local_type;
-
         // Guard against inifinite loops
         constexpr std::size_t max_n_tries{100};
         // Tolerance for convergence
@@ -102,13 +100,14 @@ struct helix_cylinder_intersector {
 
         is.path = getter::norm(helix_pos);
         is.p3 = helix_pos;
-        constexpr local_frame local_converter{};
-        is.p2 = local_converter(trf, is.p3);
 
-        auto local3 = trf.point_to_local(is.p3);
-        // Explicitly check for radial match
-        is.status =
-            mask.template is_inside<local_frame, true>(local3, mask_tolerance);
+        // Global to local transform in cartesian coordinate
+        const auto loc = trf.point_to_local(is.p3);
+        is.status = mask.is_inside(loc, mask_tolerance);
+
+        // Get intersection in local coordinate
+        is.p2 = typename mask_t::local_type()(loc);
+
         is.direction = vector::dot(is.p3, h.dir(s)) > scalar{0.}
                            ? intersection::direction::e_along
                            : intersection::direction::e_opposite;

--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -48,8 +48,6 @@ struct helix_plane_intersector {
         const detail::helix &h, const mask_t &mask, const transform_t &trf,
         const scalar mask_tolerance = 0) const {
 
-        using local_frame = typename mask_t::local_type;
-
         output_type ret;
 
         // Guard against inifinite loops
@@ -94,10 +92,14 @@ struct helix_plane_intersector {
 
         is.path = getter::norm(helix_pos);
         is.p3 = helix_pos;
-        constexpr local_frame local_converter{};
-        is.p2 = local_converter(trf, is.p3);
 
-        is.status = mask.template is_inside<local_frame>(is.p2, mask_tolerance);
+        // Global to local transform in cartesian coordinate
+        const auto loc = trf.point_to_local(is.p3);
+        is.status = mask.is_inside(loc, mask_tolerance);
+
+        // Get intersection in local coordinate
+        is.p2 = typename mask_t::local_type()(loc);
+
         is.direction = vector::dot(st, h.dir(s)) > scalar{0.}
                            ? intersection::direction::e_along
                            : intersection::direction::e_opposite;

--- a/tests/common/include/tests/common/tools_line_intersection.inl
+++ b/tests/common/include/tests/common/tools_line_intersection.inl
@@ -23,7 +23,7 @@
 using namespace detray;
 
 // Three-dimensional definitions
-using cartesian = __plugin::cartesian2<detray::scalar>;
+using polar = __plugin::polar2<detray::scalar>;
 using transform3 = __plugin::transform3<detray::scalar>;
 using vector3 = __plugin::vector3<scalar>;
 using point3 = __plugin::point3<scalar>;
@@ -64,14 +64,15 @@ TEST(tools, line_intersector_case1) {
     EXPECT_EQ(is[1].status, intersection::status::e_inside);
     EXPECT_EQ(is[1].path, 1);
     EXPECT_EQ(is[1].p3, point3({-1, 0, 0}));
-    EXPECT_EQ(is[1].p2, point2({1, 0}));
+    EXPECT_NEAR(is[1].p2[0], 1., tolerance);
+    EXPECT_NEAR(is[1].p2[1], M_PI, tolerance);
     EXPECT_EQ(is[2].status, intersection::status::e_inside);
     EXPECT_NEAR(is[2].path, std::sqrt(2), tolerance);
     EXPECT_NEAR(is[2].p3[0], 1., tolerance);
     EXPECT_NEAR(is[2].p3[1], 0., tolerance);
     EXPECT_NEAR(is[2].p3[2], 1., tolerance);
     EXPECT_NEAR(is[2].p2[0], 1., tolerance);
-    EXPECT_NEAR(is[2].p2[1], 1., tolerance);
+    EXPECT_NEAR(is[2].p2[1], 0, tolerance);
 }
 
 // Test inclined wire
@@ -101,7 +102,7 @@ TEST(tools, line_intersector_case2) {
     EXPECT_NEAR(is.p3[1], 1., tolerance);
     EXPECT_NEAR(is.p3[2], 0., tolerance);
     EXPECT_NEAR(is.p2[0], 1. / std::sqrt(2), tolerance);
-    EXPECT_NEAR(is.p2[1], -1. / std::sqrt(2), tolerance);
+    EXPECT_NEAR(is.p2[1], 0., tolerance);
 }
 
 TEST(tools, line_intersector_square_scope) {
@@ -133,8 +134,8 @@ TEST(tools, line_intersector_square_scope) {
     trks.emplace_back(point3{0, -2.1, 0}, 0, vector3{1, 1, 0}, -1);
 
     // Infinite wire with 1 mm square cell size
-    line<cartesian, dindex, true> ln{
-        1., std::numeric_limits<scalar>::infinity(), 0u};
+    line<polar, dindex, true> ln{1., std::numeric_limits<scalar>::infinity(),
+                                 0u};
 
     // Test intersect
     std::vector<line_plane_intersection> is;
@@ -148,7 +149,7 @@ TEST(tools, line_intersector_square_scope) {
     EXPECT_NEAR(is[0].p3[1], 1, tolerance);
     EXPECT_NEAR(is[0].p3[2], 0, tolerance);
     EXPECT_NEAR(is[0].p2[0], std::sqrt(2), tolerance);
-    EXPECT_NEAR(is[0].p2[1], 0, tolerance);
+    EXPECT_NEAR(is[0].p2[1], M_PI / 4., tolerance);
 
     EXPECT_EQ(is[1].status, intersection::status::e_inside);
     EXPECT_EQ(is[2].status, intersection::status::e_outside);

--- a/tests/unit_tests/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/cuda/mask_store_cuda.cpp
@@ -73,16 +73,11 @@ TEST(mask_store_cuda, mask_store) {
 
     /** get host results from is_inside function **/
     for (int i = 0; i < n_points; i++) {
-        output_host[0].push_back(
-            rectangle_mask.is_inside<cartesian2>(input_point2[i]));
-        output_host[1].push_back(
-            trapezoid_mask.is_inside<cartesian2>(input_point2[i]));
-        output_host[2].push_back(
-            ring_mask.is_inside<cartesian2>(input_point2[i]));
-        output_host[3].push_back(
-            cylinder_mask.is_inside<cartesian2>(input_point3[i]));
-        output_host[4].push_back(
-            annulus_mask.is_inside<cartesian2>(input_point2[i]));
+        output_host[0].push_back(rectangle_mask.is_inside(input_point2[i]));
+        output_host[1].push_back(trapezoid_mask.is_inside(input_point2[i]));
+        output_host[2].push_back(ring_mask.is_inside(input_point2[i]));
+        output_host[3].push_back(cylinder_mask.is_inside(input_point3[i]));
+        output_host[4].push_back(annulus_mask.is_inside(input_point2[i]));
     }
 
     /** Helper object for performing memory copies. **/

--- a/tests/unit_tests/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/cuda/mask_store_cuda.cpp
@@ -15,8 +15,6 @@
 
 TEST(mask_store_cuda, mask_store) {
 
-    using cartesian2 = __plugin::cartesian2<detray::scalar>;
-
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;
 

--- a/tests/unit_tests/cuda/mask_store_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/mask_store_cuda_kernel.cu
@@ -44,16 +44,11 @@ __global__ void mask_test_kernel(
     /** get device results from is_inside function **/
     for (int i = 0; i < n_points; i++) {
 
-        output_device[0].push_back(
-            rectangle_mask.is_inside<cartesian2>(input_point2[i]));
-        output_device[1].push_back(
-            trapezoid_mask.is_inside<cartesian2>(input_point2[i]));
-        output_device[2].push_back(
-            ring_mask.is_inside<cartesian2>(input_point2[i]));
-        output_device[3].push_back(
-            cylinder_mask.is_inside<cartesian2>(input_point3[i]));
-        output_device[4].push_back(
-            annulus_mask.is_inside<cartesian2>(input_point2[i]));
+        output_device[0].push_back(rectangle_mask.is_inside(input_point2[i]));
+        output_device[1].push_back(trapezoid_mask.is_inside(input_point2[i]));
+        output_device[2].push_back(ring_mask.is_inside(input_point2[i]));
+        output_device[3].push_back(cylinder_mask.is_inside(input_point3[i]));
+        output_device[4].push_back(annulus_mask.is_inside(input_point2[i]));
     }
 }
 


### PR DESCRIPTION
This PR makes `is_inside` take Cartesian local point. The function used to take different types of coordinates which was a bit confusing to me, and template parameter of `inside_local_t` was also redundant for most cases.

