### PR TITLE
Incidence angle and interaction length

### DIFF
--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -86,7 +86,7 @@ struct cylinder_intersector {
                                        : intersection::direction::e_opposite;
                 is.link = mask.volume_link();
 
-                // Get incidecne angle
+                // Get incidence angle
                 const scalar phi = algebra::getter::phi(local3);
                 const vector3 normal = {std::cos(phi), std::sin(phi), 0};
                 is.cos_incidence_angle = vector::dot(rd, normal);

--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -85,6 +85,12 @@ struct cylinder_intersector {
                 is.direction = rdr > r ? intersection::direction::e_along
                                        : intersection::direction::e_opposite;
                 is.link = mask.volume_link();
+
+                // Get incidecne angle
+                scalar sin_incidence_angle =
+                    vector::dot(rd, sz) / (getter::norm(rd) * getter::norm(sz));
+                is.cos_incidence_angle =
+                    std::sqrt(1 - sin_incidence_angle * sin_incidence_angle);
             }
         }
 

--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -87,10 +87,9 @@ struct cylinder_intersector {
                 is.link = mask.volume_link();
 
                 // Get incidecne angle
-                scalar sin_incidence_angle =
-                    vector::dot(rd, sz) / (getter::norm(rd) * getter::norm(sz));
-                is.cos_incidence_angle =
-                    std::sqrt(1 - sin_incidence_angle * sin_incidence_angle);
+                const scalar phi = algebra::getter::phi(local3);
+                const vector3 normal = {std::cos(phi), std::sin(phi), 0};
+                is.cos_incidence_angle = vector::dot(rd, normal);
             }
         }
 

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -66,6 +66,9 @@ struct line_plane_intersection {
     // TODO: rename the variable properly
     dindex link = dindex_invalid;
 
+    // cosine of incidence angle
+    scalar cos_incidence_angle = 1.;
+
     /** @param rhs is the right hand side intersection for comparison
      **/
     DETRAY_HOST_DEVICE

--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -106,6 +106,12 @@ struct line_intersector {
                            : intersection::direction::e_opposite;
         is.link = mask.volume_link();
 
+        // Get incidecne angle
+        scalar sin_incidence_angle =
+            vector::dot(_d, _z) / (getter::norm(_d) * getter::norm(_z));
+        is.cos_incidence_angle =
+            std::sqrt(1 - sin_incidence_angle * sin_incidence_angle);
+
         return ret;
     }
 };

--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -106,12 +106,6 @@ struct line_intersector {
                            : intersection::direction::e_opposite;
         is.link = mask.volume_link();
 
-        // Get incidecne angle
-        scalar sin_incidence_angle =
-            vector::dot(_d, _z) / (getter::norm(_d) * getter::norm(_z));
-        is.cos_incidence_angle =
-            std::sqrt(1 - sin_incidence_angle * sin_incidence_angle);
-
         return ret;
     }
 };

--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -106,6 +106,9 @@ struct line_intersector {
                            : intersection::direction::e_opposite;
         is.link = mask.volume_link();
 
+        // Get incidence angle
+        is.cos_incidence_angle = std::abs(vector::dot(_d, _z));
+
         return ret;
     }
 };

--- a/core/include/detray/intersection/plane_intersector.hpp
+++ b/core/include/detray/intersection/plane_intersector.hpp
@@ -71,6 +71,10 @@ struct plane_intersector {
                                ? intersection::direction::e_along
                                : intersection::direction::e_opposite;
             is.link = mask.volume_link();
+
+            // Get incidecne angle
+            is.cos_incidence_angle =
+                vector::dot(rd, sn) / (getter::norm(rd) * getter::norm(sn));
         }
         return ret;
     }

--- a/core/include/detray/intersection/plane_intersector.hpp
+++ b/core/include/detray/intersection/plane_intersector.hpp
@@ -72,9 +72,8 @@ struct plane_intersector {
                                : intersection::direction::e_opposite;
             is.link = mask.volume_link();
 
-            // Get incidecne angle
-            const vector3 &normal = sn;
-            is.cos_incidence_angle = vector::dot(rd, normal);
+            // Get incidene angle
+            is.cos_incidence_angle = denom;
         }
         return ret;
     }

--- a/core/include/detray/intersection/plane_intersector.hpp
+++ b/core/include/detray/intersection/plane_intersector.hpp
@@ -73,7 +73,7 @@ struct plane_intersector {
             is.link = mask.volume_link();
 
             // Get incidene angle
-            is.cos_incidence_angle = denom;
+            is.cos_incidence_angle = std::abs(denom);
         }
         return ret;
     }

--- a/core/include/detray/intersection/plane_intersector.hpp
+++ b/core/include/detray/intersection/plane_intersector.hpp
@@ -73,8 +73,8 @@ struct plane_intersector {
             is.link = mask.volume_link();
 
             // Get incidecne angle
-            is.cos_incidence_angle =
-                vector::dot(rd, sn) / (getter::norm(rd) * getter::norm(sn));
+            const vector3 &normal = sn;
+            is.cos_incidence_angle = vector::dot(rd, normal);
         }
         return ret;
     }

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/intersection/intersection.hpp"
 #include "detray/materials/material.hpp"
 
 namespace detray {
@@ -21,33 +22,39 @@ struct material_rod {
 
     material_rod() = default;
 
-    material_rod(const material_type& material, scalar_type outer_r,
-                 scalar_type inner_r = 0)
-        : m_material(material), m_outer_r(outer_r), m_inner_r(inner_r) {}
+    material_rod(const material_type& material, scalar_type radius)
+        : m_material(material), m_radius(radius) {}
 
     /// Equality operator
     ///
     /// @param rhs is the right hand side to be compared to
     DETRAY_HOST_DEVICE
     bool operator==(const material_rod<scalar_t>& rhs) const {
-        return (m_material == rhs.get_material() &&
-                m_outer_r == rhs.outer_r() && m_inner_r == rhs.inner_r());
+        return (m_material == rhs.get_material() && m_radius == rhs.radius());
     }
 
     /// Access the (average) material parameters.
     DETRAY_HOST_DEVICE
     constexpr const material_type& get_material() const { return m_material; }
-    /// Return the outer radius
+    /// Return the radius
     DETRAY_HOST_DEVICE
-    constexpr scalar_type outer_r() const { return m_outer_r; }
-    /// Return the inner radius
+    constexpr scalar_type radius() const { return m_radius; }
+    /// Return the pre interaction length
     DETRAY_HOST_DEVICE
-    constexpr scalar_type inner_r() const { return m_inner_r; }
+    constexpr scalar_type pre_interaction_length(
+        const line_plane_intersection& is) const {
+        return m_radius * is.cos_incidence_angle;
+    }
+    /// Return the post interaction length
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type post_interaction_length(
+        const line_plane_intersection& is) const {
+        return m_radius * is.cos_incidence_angle;
+    }
 
     private:
     material_type m_material = {};
-    scalar_type m_outer_r = std::numeric_limits<scalar>::epsilon();
-    scalar_type m_inner_r = std::numeric_limits<scalar>::epsilon();
+    scalar_type m_radius = std::numeric_limits<scalar>::epsilon();
 };
 
 }  // namespace detray

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -44,9 +44,9 @@ struct material_rod {
     DETRAY_HOST_DEVICE
     constexpr scalar_type radius() const { return m_radius; }
 
-    /// Return the interaction length
+    /// Return the path segment
     DETRAY_HOST_DEVICE
-    scalar_type interaction_length(const line_plane_intersection& is) const {
+    scalar_type path_segment(const line_plane_intersection& is) const {
         // Assume that is.p2[0] is radial distance of line intersector
         if (is.p2[0] > m_radius) {
             return 0;
@@ -54,15 +54,13 @@ struct material_rod {
         return scalar_type(2.) *
                std::sqrt(m_radius * m_radius - is.p2[0] * is.p2[0]);
     }
-    /// Return the interaction length in X0
-    scalar_type interaction_length_in_X0(
-        const line_plane_intersection& is) const {
-        return this->interaction_length(is) / m_material.X0();
+    /// Return the path segment in X0
+    scalar_type path_segment_in_X0(const line_plane_intersection& is) const {
+        return this->path_segment(is) / m_material.X0();
     }
-    /// Return the interaction length in L0
-    scalar_type interaction_length_in_L0(
-        const line_plane_intersection& is) const {
-        return this->interaction_length(is) / m_material.L0();
+    /// Return the path segment in L0
+    scalar_type path_segment_in_L0(const line_plane_intersection& is) const {
+        return this->path_segment(is) / m_material.L0();
     }
 
     private:

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -51,8 +51,13 @@ struct material_rod {
         if (is.p2[0] > m_radius) {
             return 0;
         }
+
+        auto const sin_incidence_angle =
+            std::sqrt(scalar_type(1.) - std::pow(is.cos_incidence_angle, 2));
+
         return scalar_type(2.) *
-               std::sqrt(m_radius * m_radius - is.p2[0] * is.p2[0]);
+               std::sqrt(m_radius * m_radius - is.p2[0] * is.p2[0]) /
+               sin_incidence_angle;
     }
     /// Return the path segment in X0
     scalar_type path_segment_in_X0(const line_plane_intersection& is) const {

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -52,8 +52,8 @@ struct material_rod {
             return 0;
         }
 
-        auto const sin_incidence_angle =
-            std::sqrt(scalar_type(1.) - std::pow(is.cos_incidence_angle, 2));
+        const scalar_type sin_incidence_angle = std::sqrt(
+            scalar_type(1.) - is.cos_incidence_angle * is.cos_incidence_angle);
 
         return scalar_type(2.) *
                std::sqrt(m_radius * m_radius - is.p2[0] * is.p2[0]) /

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -55,19 +55,17 @@ struct material_slab {
     /// Return the nuclear interaction length fraction.
     DETRAY_HOST_DEVICE
     constexpr scalar_type thickness_in_L0() const { return m_thickness_in_L0; }
-    /// Return the interaction length
+    /// Return the path segment
     DETRAY_HOST_DEVICE
-    scalar_type interaction_length(const line_plane_intersection& is) const {
+    scalar_type path_segment(const line_plane_intersection& is) const {
         return m_thickness / is.cos_incidence_angle;
     }
-    /// Return the interaction length in X0
-    scalar_type interaction_length_in_X0(
-        const line_plane_intersection& is) const {
+    /// Return the path segment in X0
+    scalar_type path_segment_in_X0(const line_plane_intersection& is) const {
         return m_thickness_in_X0 / is.cos_incidence_angle;
     }
-    /// Return the interaction length in L0
-    scalar_type interaction_length_in_L0(
-        const line_plane_intersection& is) const {
+    /// Return the path segment in L0
+    scalar_type path_segment_in_L0(const line_plane_intersection& is) const {
         return m_thickness_in_L0 / is.cos_incidence_angle;
     }
 

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/intersection/intersection.hpp"
 #include "detray/materials/material.hpp"
 
 // System include(s)
@@ -24,11 +25,26 @@ struct material_slab {
 
     material_slab() = default;
 
+    /// Constructor
+    /// @param material is the elemental or mixture material
+    /// @param thickness is the thickness of the slab
     material_slab(const material_type& material, scalar_type thickness)
         : m_material(material),
           m_thickness(thickness),
           m_thickness_in_X0(thickness / material.X0()),
           m_thickness_in_L0(thickness / material.L0()) {}
+
+    /// Constructor
+    /// @param material is the elemental or mixture material
+    /// @param thickness is the thickness of the slab
+    /// @param interaction_point is the interaction point of the line
+    material_slab(const material_type& material, scalar_type thickness,
+                  scalar_type interaction_point)
+        : m_material(material),
+          m_thickness(thickness),
+          m_thickness_in_X0(thickness / material.X0()),
+          m_thickness_in_L0(thickness / material.L0()),
+          m_interaction_point(interaction_point) {}
 
     /// Equality operator
     ///
@@ -51,12 +67,41 @@ struct material_slab {
     /// Return the nuclear interaction length fraction.
     DETRAY_HOST_DEVICE
     constexpr scalar_type thickness_in_L0() const { return m_thickness_in_L0; }
+    /// Return the pre interaction length
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type pre_interaction_length(
+        const line_plane_intersection& is) const {
+        if (is.direction == intersection::direction::e_along) {
+            return (m_thickness / scalar_type(2) + m_interaction_point) /
+                   is.cos_incidence_angle;
+        } else if (is.direction == intersection::direction::e_opposite) {
+            return (m_thickness / scalar_type(2) - m_interaction_point) /
+                   is.cos_incidence_angle;
+        } else {
+            return 0;
+        }
+    }
+    /// Return the post interaction length
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type post_interaction_length(
+        const line_plane_intersection& is) const {
+        if (is.direction == intersection::direction::e_along) {
+            return (m_thickness / scalar_type(2) - m_interaction_point) /
+                   is.cos_incidence_angle;
+        } else if (is.direction == intersection::direction::e_opposite) {
+            return (m_thickness / scalar_type(2) + m_interaction_point) /
+                   is.cos_incidence_angle;
+        } else {
+            return 0;
+        }
+    }
 
     private:
     material_type m_material = {};
     scalar_type m_thickness = std::numeric_limits<scalar>::epsilon();
     scalar_type m_thickness_in_X0 = std::numeric_limits<scalar>::epsilon();
     scalar_type m_thickness_in_L0 = std::numeric_limits<scalar>::epsilon();
+    scalar_type m_interaction_point = std::numeric_limits<scalar>::epsilon();
 };
 
 }  // namespace detray

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -17,7 +17,7 @@
 
 namespace detray {
 
-// Slab structure to be mapped on the mask
+// Slab structure to be mapped on the mask (plane, cylinder)
 template <typename scalar_t>
 struct material_slab {
     using scalar_type = scalar_t;
@@ -33,18 +33,6 @@ struct material_slab {
           m_thickness(thickness),
           m_thickness_in_X0(thickness / material.X0()),
           m_thickness_in_L0(thickness / material.L0()) {}
-
-    /// Constructor
-    /// @param material is the elemental or mixture material
-    /// @param thickness is the thickness of the slab
-    /// @param interaction_point is the interaction point of the line
-    material_slab(const material_type& material, scalar_type thickness,
-                  scalar_type interaction_point)
-        : m_material(material),
-          m_thickness(thickness),
-          m_thickness_in_X0(thickness / material.X0()),
-          m_thickness_in_L0(thickness / material.L0()),
-          m_interaction_point(interaction_point) {}
 
     /// Equality operator
     ///
@@ -67,33 +55,20 @@ struct material_slab {
     /// Return the nuclear interaction length fraction.
     DETRAY_HOST_DEVICE
     constexpr scalar_type thickness_in_L0() const { return m_thickness_in_L0; }
-    /// Return the pre interaction length
+    /// Return the interaction length
     DETRAY_HOST_DEVICE
-    constexpr scalar_type pre_interaction_length(
-        const line_plane_intersection& is) const {
-        if (is.direction == intersection::direction::e_along) {
-            return (m_thickness / scalar_type(2) + m_interaction_point) /
-                   is.cos_incidence_angle;
-        } else if (is.direction == intersection::direction::e_opposite) {
-            return (m_thickness / scalar_type(2) - m_interaction_point) /
-                   is.cos_incidence_angle;
-        } else {
-            return 0;
-        }
+    scalar_type interaction_length(const line_plane_intersection& is) const {
+        return m_thickness / is.cos_incidence_angle;
     }
-    /// Return the post interaction length
-    DETRAY_HOST_DEVICE
-    constexpr scalar_type post_interaction_length(
+    /// Return the interaction length in X0
+    scalar_type interaction_length_in_X0(
         const line_plane_intersection& is) const {
-        if (is.direction == intersection::direction::e_along) {
-            return (m_thickness / scalar_type(2) - m_interaction_point) /
-                   is.cos_incidence_angle;
-        } else if (is.direction == intersection::direction::e_opposite) {
-            return (m_thickness / scalar_type(2) + m_interaction_point) /
-                   is.cos_incidence_angle;
-        } else {
-            return 0;
-        }
+        return m_thickness_in_X0 / is.cos_incidence_angle;
+    }
+    /// Return the interaction length in L0
+    scalar_type interaction_length_in_L0(
+        const line_plane_intersection& is) const {
+        return m_thickness_in_L0 / is.cos_incidence_angle;
     }
 
     private:
@@ -101,7 +76,6 @@ struct material_slab {
     scalar_type m_thickness = std::numeric_limits<scalar>::epsilon();
     scalar_type m_thickness_in_X0 = std::numeric_limits<scalar>::epsilon();
     scalar_type m_thickness_in_L0 = std::numeric_limits<scalar>::epsilon();
-    scalar_type m_interaction_point = std::numeric_limits<scalar>::epsilon();
 };
 
 }  // namespace detray

--- a/tests/common/include/tests/common/materials.inl
+++ b/tests/common/include/tests/common/materials.inl
@@ -6,7 +6,9 @@
  */
 
 /// Detray include(s)
+#include "detray/definitions/units.hpp"
 #include "detray/materials/material.hpp"
+#include "detray/materials/material_rod.hpp"
 #include "detray/materials/material_slab.hpp"
 #include "detray/materials/mixture.hpp"
 #include "detray/materials/predefined_materials.hpp"
@@ -111,7 +113,31 @@ TEST(materials, mixture) {
 }
 
 // This tests the material slab functionalities
-TEST(materials, material_slab) {}
+TEST(materials, material_slab) {
+
+    material_slab<scalar> slab(oxygen_gas<scalar>(), 2 * unit_constants::mm);
+
+    line_plane_intersection is;
+    is.cos_incidence_angle = scalar(0.3);
+
+    EXPECT_FLOAT_EQ(slab.interaction_length(is), 2 * unit_constants::mm / 0.3);
+    EXPECT_FLOAT_EQ(slab.interaction_length_in_X0(is),
+                    slab.interaction_length(is) / slab.get_material().X0());
+    EXPECT_FLOAT_EQ(slab.interaction_length_in_L0(is),
+                    slab.interaction_length(is) / slab.get_material().L0());
+}
 
 // This tests the material rod functionalities
-TEST(materials, material_rod) {}
+TEST(materials, material_rod) {
+
+    material_rod<scalar> rod(oxygen_gas<scalar>(), 2 * unit_constants::mm);
+
+    line_plane_intersection is;
+    is.p2[0] = 1. * unit_constants::mm;
+
+    EXPECT_FLOAT_EQ(rod.interaction_length(is), 2 * std::sqrt(3));
+    EXPECT_FLOAT_EQ(rod.interaction_length_in_X0(is),
+                    rod.interaction_length(is) / rod.get_material().X0());
+    EXPECT_FLOAT_EQ(rod.interaction_length_in_L0(is),
+                    rod.interaction_length(is) / rod.get_material().L0());
+}

--- a/tests/common/include/tests/common/materials.inl
+++ b/tests/common/include/tests/common/materials.inl
@@ -115,12 +115,14 @@ TEST(materials, mixture) {
 // This tests the material slab functionalities
 TEST(materials, material_slab) {
 
-    material_slab<scalar> slab(oxygen_gas<scalar>(), 2 * unit_constants::mm);
+    material_slab<scalar> slab(oxygen_gas<scalar>(),
+                               scalar(2) * scalar(unit_constants::mm));
 
     line_plane_intersection is;
     is.cos_incidence_angle = scalar(0.3);
 
-    EXPECT_FLOAT_EQ(slab.interaction_length(is), 2 * unit_constants::mm / 0.3);
+    EXPECT_FLOAT_EQ(slab.interaction_length(is),
+                    scalar(2) * scalar(unit_constants::mm) / scalar(0.3));
     EXPECT_FLOAT_EQ(slab.interaction_length_in_X0(is),
                     slab.interaction_length(is) / slab.get_material().X0());
     EXPECT_FLOAT_EQ(slab.interaction_length_in_L0(is),
@@ -130,12 +132,14 @@ TEST(materials, material_slab) {
 // This tests the material rod functionalities
 TEST(materials, material_rod) {
 
-    material_rod<scalar> rod(oxygen_gas<scalar>(), 2 * unit_constants::mm);
+    material_rod<scalar> rod(oxygen_gas<scalar>(),
+                             scalar(2) * scalar(unit_constants::mm));
 
     line_plane_intersection is;
     is.p2[0] = 1. * unit_constants::mm;
 
-    EXPECT_FLOAT_EQ(rod.interaction_length(is), 2 * std::sqrt(3));
+    EXPECT_FLOAT_EQ(rod.interaction_length(is),
+                    scalar(2.) * scalar(std::sqrt(3)));
     EXPECT_FLOAT_EQ(rod.interaction_length_in_X0(is),
                     rod.interaction_length(is) / rod.get_material().X0());
     EXPECT_FLOAT_EQ(rod.interaction_length_in_L0(is),

--- a/tests/common/include/tests/common/materials.inl
+++ b/tests/common/include/tests/common/materials.inl
@@ -121,12 +121,12 @@ TEST(materials, material_slab) {
     line_plane_intersection is;
     is.cos_incidence_angle = scalar(0.3);
 
-    EXPECT_FLOAT_EQ(slab.interaction_length(is),
+    EXPECT_FLOAT_EQ(slab.path_segment(is),
                     scalar(2) * scalar(unit_constants::mm) / scalar(0.3));
-    EXPECT_FLOAT_EQ(slab.interaction_length_in_X0(is),
-                    slab.interaction_length(is) / slab.get_material().X0());
-    EXPECT_FLOAT_EQ(slab.interaction_length_in_L0(is),
-                    slab.interaction_length(is) / slab.get_material().L0());
+    EXPECT_FLOAT_EQ(slab.path_segment_in_X0(is),
+                    slab.path_segment(is) / slab.get_material().X0());
+    EXPECT_FLOAT_EQ(slab.path_segment_in_L0(is),
+                    slab.path_segment(is) / slab.get_material().L0());
 }
 
 // This tests the material rod functionalities
@@ -138,10 +138,9 @@ TEST(materials, material_rod) {
     line_plane_intersection is;
     is.p2[0] = 1. * unit_constants::mm;
 
-    EXPECT_FLOAT_EQ(rod.interaction_length(is),
-                    scalar(2.) * scalar(std::sqrt(3)));
-    EXPECT_FLOAT_EQ(rod.interaction_length_in_X0(is),
-                    rod.interaction_length(is) / rod.get_material().X0());
-    EXPECT_FLOAT_EQ(rod.interaction_length_in_L0(is),
-                    rod.interaction_length(is) / rod.get_material().L0());
+    EXPECT_FLOAT_EQ(rod.path_segment(is), scalar(2.) * scalar(std::sqrt(3)));
+    EXPECT_FLOAT_EQ(rod.path_segment_in_X0(is),
+                    rod.path_segment(is) / rod.get_material().X0());
+    EXPECT_FLOAT_EQ(rod.path_segment_in_L0(is),
+                    rod.path_segment(is) / rod.get_material().L0());
 }

--- a/tests/common/include/tests/common/materials.inl
+++ b/tests/common/include/tests/common/materials.inl
@@ -113,5 +113,5 @@ TEST(materials, mixture) {
 // This tests the material slab functionalities
 TEST(materials, material_slab) {}
 
-// This tests the material slab functionalities
+// This tests the material rod functionalities
 TEST(materials, material_rod) {}

--- a/tests/common/include/tests/common/materials.inl
+++ b/tests/common/include/tests/common/materials.inl
@@ -109,3 +109,9 @@ TEST(materials, mixture) {
     EXPECT_FLOAT_EQ(slab_vec[2].thickness_in_X0(),
                     slab3.thickness() / slab3.get_material().X0());
 }
+
+// This tests the material slab functionalities
+TEST(materials, material_slab) {}
+
+// This tests the material slab functionalities
+TEST(materials, material_rod) {}

--- a/tests/common/include/tests/common/materials.inl
+++ b/tests/common/include/tests/common/materials.inl
@@ -5,8 +5,10 @@
  * Mozilla Public License Version 2.0
  */
 
-/// Detray include(s)
+/// Project include(s)
 #include "detray/definitions/units.hpp"
+#include "detray/intersection/line_intersector.hpp"
+#include "detray/masks/line.hpp"
 #include "detray/materials/material.hpp"
 #include "detray/materials/material_rod.hpp"
 #include "detray/materials/material_slab.hpp"
@@ -20,6 +22,8 @@ using namespace detray;
 
 using point2 = __plugin::point2<scalar>;
 using point3 = __plugin::point3<scalar>;
+using transform3 = __plugin::transform3<detray::scalar>;
+using vector3 = __plugin::vector3<scalar>;
 
 // This tests the material functionalities
 TEST(materials, material) {
@@ -132,13 +136,30 @@ TEST(materials, material_slab) {
 // This tests the material rod functionalities
 TEST(materials, material_rod) {
 
+    // Rod with 1 mm radius
     material_rod<scalar> rod(oxygen_gas<scalar>(),
-                             scalar(2) * scalar(unit_constants::mm));
+                             scalar(1.) * scalar(unit_constants::mm));
 
-    line_plane_intersection is;
-    is.p2[0] = 1. * unit_constants::mm;
+    // tf3 with Identity rotation and no translation
+    const vector3 x{1, 0, 0};
+    const vector3 z{0, 0, 1};
+    const vector3 t{0, 0, 0};
+    const transform3 tf{t, vector::normalize(z), vector::normalize(x)};
 
-    EXPECT_FLOAT_EQ(rod.path_segment(is), scalar(2.) * scalar(std::sqrt(3)));
+    // Create a track
+    const point3 pos{-1. / 6., -10., 0};
+    const vector3 dir{0, 1., 3.};
+    const free_track_parameters trk(pos, 0, dir, -1);
+
+    // Infinite wire with 1 mm radial cell size
+    const line<> ln{1. * unit_constants::mm,
+                    std::numeric_limits<scalar>::infinity(), 0u};
+
+    line_plane_intersection is =
+        line_intersector()(detail::ray(trk), ln, tf)[0];
+
+    EXPECT_NEAR(rod.path_segment(is),
+                scalar(2.) * std::sqrt(1. - 1. / 36) * std::sqrt(10), 1e-5);
     EXPECT_FLOAT_EQ(rod.path_segment_in_X0(is),
                     rod.path_segment(is) / rod.get_material().X0());
     EXPECT_FLOAT_EQ(rod.path_segment_in_L0(is),

--- a/tests/common/include/tests/common/tools_cylinder_intersection.inl
+++ b/tests/common/include/tests/common/tools_cylinder_intersection.inl
@@ -55,6 +55,26 @@ TEST(ALGEBRA_PLUGIN, translated_cylinder) {
                 hit_bound.p2[1] != not_defined);
     ASSERT_NEAR(hit_bound.p2[0], 0., isclose);
     ASSERT_NEAR(hit_bound.p2[1], -5., isclose);
+    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1., isclose);
+}
+
+// This defines the local frame test suite
+TEST(ALGEBRA_PLUGIN, cylinder_incidence_angle) {
+    // Create a translated cylinder and test untersection
+    const transform3 shifted(vector3{0., 0., 0.});
+    cylinder_intersector ci;
+
+    // Test ray
+    const point3 ori = {0., 1., 0.};
+    const point3 dir = {1., 0., 0.};
+    const detail::ray ray(ori, 0., dir, 0.);
+
+    // Check intersection
+    cylinder3<cylinder_intersector, __plugin::cylindrical2<detray::scalar>,
+              unsigned int>
+        cylinder_bound{4., -10., 10., 0u};
+    const auto hit_bound = ci(ray, cylinder_bound, shifted)[0];
+    ASSERT_NEAR(hit_bound.cos_incidence_angle, std::sqrt(15) / 4., isclose);
 }
 
 // This defines the local frame test suite

--- a/tests/common/include/tests/common/tools_cylinder_intersection.inl
+++ b/tests/common/include/tests/common/tools_cylinder_intersection.inl
@@ -60,8 +60,7 @@ TEST(ALGEBRA_PLUGIN, translated_cylinder) {
 
 // This defines the local frame test suite
 TEST(ALGEBRA_PLUGIN, cylinder_incidence_angle) {
-    // Create a translated cylinder and test untersection
-    const transform3 shifted(vector3{0., 0., 0.});
+    const transform3 tf(vector3{0., 0., 0.});
     cylinder_intersector ci;
 
     // Test ray
@@ -73,7 +72,7 @@ TEST(ALGEBRA_PLUGIN, cylinder_incidence_angle) {
     cylinder3<cylinder_intersector, __plugin::cylindrical2<detray::scalar>,
               unsigned int>
         cylinder_bound{4., -10., 10., 0u};
-    const auto hit_bound = ci(ray, cylinder_bound, shifted)[0];
+    const auto hit_bound = ci(ray, cylinder_bound, tf)[0];
     ASSERT_NEAR(hit_bound.cos_incidence_angle, std::sqrt(15) / 4., isclose);
 }
 

--- a/tests/common/include/tests/common/tools_line_intersection.inl
+++ b/tests/common/include/tests/common/tools_line_intersection.inl
@@ -60,11 +60,14 @@ TEST(tools, line_intersector_case1) {
     EXPECT_EQ(is[0].path, 1);
     EXPECT_EQ(is[0].p3, point3({1, 0, 0}));
     EXPECT_EQ(is[0].p2, point2({1, 0}));
+    EXPECT_NEAR(is[0].cos_incidence_angle, 0, tolerance);
 
     EXPECT_EQ(is[1].status, intersection::status::e_inside);
     EXPECT_EQ(is[1].path, 1);
     EXPECT_EQ(is[1].p3, point3({-1, 0, 0}));
     EXPECT_EQ(is[1].p2, point2({1, 0}));
+    EXPECT_NEAR(is[1].cos_incidence_angle, 0, tolerance);
+
     EXPECT_EQ(is[2].status, intersection::status::e_inside);
     EXPECT_NEAR(is[2].path, std::sqrt(2), tolerance);
     EXPECT_NEAR(is[2].p3[0], 1., tolerance);
@@ -72,6 +75,7 @@ TEST(tools, line_intersector_case1) {
     EXPECT_NEAR(is[2].p3[2], 1., tolerance);
     EXPECT_NEAR(is[2].p2[0], 1., tolerance);
     EXPECT_NEAR(is[2].p2[1], 1., tolerance);
+    EXPECT_NEAR(is[2].cos_incidence_angle, 1. / sqrt(2), tolerance);
 }
 
 // Test inclined wire

--- a/tests/common/include/tests/common/tools_planar_intersection.inl
+++ b/tests/common/include/tests/common/tools_planar_intersection.inl
@@ -54,6 +54,8 @@ TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
     // Local intersection information
     ASSERT_NEAR(hit_bound.p2[0], -1., epsilon);
     ASSERT_NEAR(hit_bound.p2[1], -1., epsilon);
+    // Incidence angle
+    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1., epsilon);
 
     // The same test but bound to local frame & masked - inside
     rectangle2<> rect_for_inside{3., 3., 0u};
@@ -81,6 +83,29 @@ TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
 }
 
 // This defines the local frame test suite
+TEST(ALGEBRA_PLUGIN, plane_incidence_angle) {
+    // tf3 with rotated axis
+    const vector3 x{1, 0, -1};
+    const vector3 z{1, 0, 1};
+    const vector3 t{0, 0, 0};
+
+    const transform3 rotated{t, vector::normalize(z), vector::normalize(x)};
+    plane_intersector pi;
+
+    // Test ray
+    const point3 pos{-1., 0., 0.};
+    const vector3 mom{1., 0., 0.};
+    const detail::ray r(pos, 0., mom, 0.);
+
+    // The same test but bound to local frame & masked - inside
+    rectangle2<> rect{3., 3., 0u};
+
+    const line_plane_intersection is = pi(r, rect, rotated)[0];
+
+    ASSERT_NEAR(is.cos_incidence_angle, std::cos(M_PI / 4), epsilon);
+}
+
+// This defines the local frame test suite
 TEST(ALGEBRA_PLUGIN, translated_plane_helix) {
     // Create a shifted plane
     const transform3 shifted(vector3{3., 2., 10.});
@@ -104,6 +129,8 @@ TEST(ALGEBRA_PLUGIN, translated_plane_helix) {
     // Local intersection information
     ASSERT_NEAR(hit_bound.p2[0], -1., epsilon);
     ASSERT_NEAR(hit_bound.p2[1], -1., epsilon);
+    // Incidence angle
+    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1., epsilon);
 
     // The same test but bound to local frame & masked - inside
     rectangle2<> rect_for_inside{3., 3., 0u};


### PR DESCRIPTION
This PR adds the incidence angle calculation in `plane_intersector` and `cylinder_intersector`. It is used in the calculation of interaction length of `material_slab`. (Similar functionality already exists in ACTS as `pathCorrection` function)

For `line_intersector` with `material_rod`, the incidence angle is not required as the interaction length is simply given by `2 * sqrt(R^2 - d^2)`.



