### PR TITLE
feat: Add surface finder container to detector

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -85,6 +85,10 @@ detray_add_library( detray_core core
    "include/detray/propagator/navigator.hpp"
    "include/detray/propagator/propagator.hpp"
    "include/detray/propagator/rk_stepper.hpp"
+   # surface finder include(s)
+   "include/detray/surface_finders/brute_force_finder.hpp"
+   "include/detray/surface_finders/grid2_finder.hpp"
+   "include/detray/surface_finders/neighborhood_kernel.hpp"
    # tools include(s)
    "include/detray/tools/associator.hpp"
    "include/detray/tools/bin_association.hpp"

--- a/core/include/detray/core/detail/tuple_array_container.hpp
+++ b/core/include/detray/core/detail/tuple_array_container.hpp
@@ -56,6 +56,8 @@ class tuple_array_container<tuple_t, array_t, id_t, std::index_sequence<Ns...>,
 
     using container_type = typename base_type::container_type;
 
+    tuple_array_container() = default;
+
     /**
      * Constructor with a vecmem memory resource. (host-side only)
      *

--- a/core/include/detray/core/detail/tuple_vector_container.hpp
+++ b/core/include/detray/core/detail/tuple_vector_container.hpp
@@ -37,6 +37,7 @@ class tuple_vector_container final
     using base_type = tuple_container<tuple_t, id_t, vector_t<Ts>...>;
     using base_type::base_type;
     using id_type = typename base_type::id_type;
+    using base_type::to_index;
 
     static constexpr std::size_t m_tuple_size = base_type::m_tuple_size;
 
@@ -107,7 +108,7 @@ class tuple_vector_container final
     template <id_t ID, typename... Args>
     DETRAY_HOST auto &add_value(Args &&... args) noexcept(false) {
 
-        auto &gr = detail::get<ID>(this->m_container);
+        auto &gr = detail::get<to_index(ID)>(this->m_container);
 
         return gr.emplace_back(std::forward<Args>(args)...);
     }
@@ -157,21 +158,20 @@ class tuple_vector_container final
 
     /** Append a container to the current one
      *
-     * @tparam current_id is the index to start unrolling (if th index is known,
-     *         unrolling can be started there)
+     * @tparam current_idx is the index to start unrolling
      *
      * @param other The other container
      *
      * @note in general can throw an exception
      */
-    template <std::size_t current_id = 0>
+    template <std::size_t current_idx = 0>
     DETRAY_HOST inline void append_container(
         tuple_vector_container &other) noexcept(false) {
-        auto &gr = detail::get<current_id>(other);
+        auto &gr = detail::get<current_idx>(other);
         add_vector(gr);
 
-        if constexpr (current_id < sizeof...(Ts) - 1) {
-            append_container<current_id + 1>(other);
+        if constexpr (current_idx < sizeof...(Ts) - 1) {
+            append_container<current_idx + 1>(other);
         }
     }
 };

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -16,11 +16,7 @@
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/geometry/surface.hpp"
 #include "detray/geometry/volume.hpp"
-#include "detray/grids/axis.hpp"
-#include "detray/grids/grid2.hpp"
-#include "detray/grids/populator.hpp"
-#include "detray/grids/serializer2.hpp"
-#include "detray/intersection/intersection.hpp"
+#include "detray/tools/bin_association.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/memory_resource.hpp>
@@ -32,17 +28,17 @@
 
 namespace detray {
 
-/** The detector definition.
- *
- * This class is a heavy templated detector definition class, that sets the
- * interface between geometry, navigator and grid.
- *
- * @tparam metadata helper that defines collection and link types centrally
- * @tparam array_type the type of the internal array, must have STL semantics
- * @tparam tuple_type the type of the internal tuple, must have STL semantics
- * @tparam vector_type the type of the internal array, must have STL semantics
- * @tparam source_link the surface source link
- */
+/// @brief The detector definition.
+///
+/// This class is a heavily templated container aggregation, that owns all data
+/// and sets the interface between geometry, navigator and surface finder
+/// structures. Its view type is used to move the data between host and device.
+///
+/// @tparam metadata helper that defines collection and link types centrally
+/// @tparam array_t the type of the internal array, must have STL semantics
+/// @tparam tuple_t the type of the internal tuple, must have STL semantics
+/// @tparam vector_t the type of the internal array, must have STL semantics
+/// @tparam source_link the surface source link
 template <typename metadata,
           template <typename, std::size_t> class array_t = darray,
           template <typename...> class tuple_t = dtuple,
@@ -52,64 +48,70 @@ template <typename metadata,
 class detector {
 
     public:
+    /// Algebra types
     using scalar_type = scalar;
 
     using point3 = __plugin::point3<scalar_type>;
     using vector3 = __plugin::vector3<scalar_type>;
     using point2 = __plugin::point2<scalar_type>;
 
+    /// Raw container types
     template <typename T>
     using vector_type = vector_t<T>;
 
+    /// In case the detector needs to be printed
     using name_map = std::map<dindex, std::string>;
 
-    /// Forward the alignable container and context
+    /// Forward the alignable transform container (surface placements) and
+    /// the geo context (e.g. for alignment)
     using transform_container =
         typename metadata::template transform_store<vector_t>;
     using transform3 = typename transform_container::transform3;
-
     using transform_link = typename transform_container::link_type;
     using context = typename transform_container::context;
 
-    /// Forward mask types
+    /// Forward mask types that are present in this detector
     using masks = typename metadata::mask_definitions;
     using mask_container =
         typename masks::template store_type<tuple_t, vector_t>;
 
-    /// Forward material types
+    /// Forward material types that are present in this detector
     using materials = typename metadata::material_definitions;
     using material_container =
         typename materials::template store_type<tuple_t, vector_t>;
 
-    /// volume index: volume the surface belongs to
-    using volume_link = dindex;
-    using surface_type =
-        surface<masks, materials, transform_link, volume_link, source_link>;
+    /// Surface Finders: structures that enable neigborhood searches in the
+    /// detector geometry during navigation. Can be different in each volume
+    using sf_finders = typename metadata::template sf_finder_definitions<
+        array_t, vector_t, tuple_t, jagged_vector_t>;
+    using sf_finder_container =
+        typename sf_finders::template store_type<tuple_t, array_t>;
 
+    // TODO: Move to the following to volume builder
+
+    /// The surface takes a mask (defines the local coordinates and the surface
+    /// extent), its material, a link to an element in the transform container
+    /// to define its placement and a source link to the object it represents.
+    using surface_type = surface<masks, materials, transform_link, source_link>;
+    /// Define the different kinds of surfaces that are present in the detector
+    /// Can model the distinction between portals and sensitive surfaces
     using objects =
         typename metadata::template object_definitions<surface_type>;
     using surface_container = vector_t<surface_type>;
-    // Volume type
-    using volume_type = volume<objects, scalar_type, dindex_range, array_t>;
+    /// Volume type
+    using volume_type =
+        volume<objects, scalar_type, typename sf_finders::link_type, array_t>;
 
-    /// Accelerator structures
-
-    /// Volume finder definition
+    /// Volume finder definition: Make volume index available from track
+    /// position
     using volume_finder =
         typename metadata::template volume_finder<array_t, vector_t, tuple_t,
                                                   jagged_vector_t>;
 
-    /// Surface finder definition
-    // TODO: Move to volume builder
-    using surfaces_finder_type =
-        typename metadata::template surface_finder<array_t, vector_t, tuple_t,
-                                                   jagged_vector_t>;
-
     detector() = delete;
 
-    /** Allowed costructor
-     * @param resource memory resource for the allocation of members
-     */
+    /// Allowed costructor
+    /// @param resource memory resource for the allocation of members
     DETRAY_HOST
     detector(vecmem::memory_resource &resource)
         : _volumes(&resource),
@@ -117,14 +119,14 @@ class detector {
           _transforms(resource),
           _masks(resource),
           _materials(resource),
+          //_sf_finders(resource),
           _volume_finder(
               std::move(typename volume_finder::axis_p0_type{resource}),
               std::move(typename volume_finder::axis_p1_type{resource}),
               resource),
-          _surfaces_finder(resource),
           _resource(&resource) {}
 
-    /** Constructor with detector_data **/
+    /// Constructor with detector_data
     template <typename detector_data_type,
               std::enable_if_t<!std::is_base_of_v<vecmem::memory_resource,
                                                   detector_data_type>,
@@ -135,142 +137,147 @@ class detector {
           _transforms(det_data._transforms_data),
           _masks(det_data._masks_data),
           _materials(det_data._materials_data),
-          _volume_finder(det_data._volume_finder_view),
-          _surfaces_finder(det_data._surfaces_finder_view) {}
+          _volume_finder(det_data._volume_finder_view) {}
 
-    /** Add a new volume and retrieve a reference to it
-     *
-     * @param bounds of the volume, they are expected to be already attaching
-     * @param surfaces_finder_entry of the volume, where to entry the surface
-     * finder
-     *
-     * @return non-const reference of the new volume
-     */
+    /// Add a new volume and retrieve a reference to it
+    ///
+    /// @param bounds of the volume, they are expected to be already attaching
+    /// @param sf_finder_link of the volume, where to entry the surface finder
+    ///
+    /// @return non-const reference to the new volume
     DETRAY_HOST
-    volume_type &new_volume(const array_t<scalar_type, 6> &bounds,
-                            dindex surfaces_finder_entry = dindex_invalid) {
+    volume_type &new_volume(
+        const array_t<scalar, 6> &bounds,
+        typename volume_type::sf_finder_link_type sf_finder_link = {
+            sf_finders::id::e_default, dindex_invalid}) {
         volume_type &cvolume = _volumes.emplace_back(bounds);
         cvolume.set_index(_volumes.size() - 1);
-        cvolume.set_surfaces_finder(surfaces_finder_entry);
+        cvolume.set_sf_finder(sf_finder_link);
 
         return cvolume;
     }
 
-    /** @return the contained volumes of the detector - const access */
+    /// @return the sub-volumes of the detector - const access
     DETRAY_HOST_DEVICE
-    inline auto &volumes() const { return _volumes; }
+    inline auto volumes() const -> const vector_t<volume_type> & {
+        return _volumes;
+    }
 
-    /** @return the contained volumes of the detector - non-const access */
+    /// @return the sub-volumes of the detector - non-const access
     DETRAY_HOST_DEVICE
-    inline auto &volumes() { return _volumes; }
+    inline auto volumes() -> vector_t<volume_type> & { return _volumes; }
 
-    /** @return the volume by @param volume_index - const access */
+    /// @return the volume by @param volume_index - const access
     DETRAY_HOST_DEVICE
-    inline auto &volume_by_index(dindex volume_index) const {
+    inline auto volume_by_index(dindex volume_index) const
+        -> const volume_type & {
         return _volumes[volume_index];
     }
 
-    /** @return the volume by @param volume_index - non-const access */
+    /// @return the volume by @param volume_index - non-const access
     DETRAY_HOST_DEVICE
-    inline auto &volume_by_index(dindex volume_index) {
+    inline auto volume_by_index(dindex volume_index) -> volume_type & {
         return _volumes[volume_index];
     }
 
-    /** @return the volume by @param position - const access */
+    /// @return the volume by @param position - const access
     DETRAY_HOST_DEVICE
-    inline auto &volume_by_pos(const point3 &p) const {
+    inline auto volume_by_pos(const point3 &p) const -> const volume_type & {
         point2 p2 = {getter::perp(p), p[2]};
         dindex volume_index = _volume_finder.bin(p2);
         return _volumes[volume_index];
     }
 
-    /** @return all surfaces - const access */
+    /// @return all surfaces - const access
     DETRAY_HOST_DEVICE
-    inline const auto &surfaces() const { return _surfaces; }
+    inline auto surfaces() const -> const surface_container & {
+        return _surfaces;
+    }
 
-    /** @return all surfaces - non-const access */
+    /// @return all surfaces - non-const access
     DETRAY_HOST_DEVICE
-    inline auto &surfaces() { return _surfaces; }
+    inline auto surfaces() -> surface_container & { return _surfaces; }
 
-    /** @return a surface by index - const access */
+    /// @return a surface by index - const access
     DETRAY_HOST_DEVICE
-    inline const auto &surface_by_index(dindex sfidx) const {
+    inline auto surface_by_index(dindex sfidx) const -> const surface_type & {
         return _surfaces[sfidx];
     }
 
-    /** @return a surface by index - non-const access */
+    /// @return a surface by index - non-const access
     DETRAY_HOST_DEVICE
-    inline auto &surface_by_index(dindex sfidx) { return _surfaces[sfidx]; }
+    inline auto surface_by_index(dindex sfidx) -> surface_type & {
+        return _surfaces[sfidx];
+    }
 
-    /** @return all surface/portal masks in the geometry - const access */
+    /// @return all surface/portal masks in the geometry - const access
     DETRAY_HOST_DEVICE
-    inline const auto &mask_store() const { return _masks; }
+    inline auto mask_store() const -> const mask_container & { return _masks; }
 
-    /** @return all surface/portal masks in the geometry - non-const access */
+    /// @return all surface/portal masks in the geometry - non-const access
     DETRAY_HOST_DEVICE
-    inline auto &mask_store() { return _masks; }
+    inline auto mask_store() -> mask_container & { return _masks; }
 
-    /** @return all materials in the geometry - const access */
-    DETRAY_HOST_DEVICE
-    inline const auto &material_store() const { return _materials; }
-
-    /** @return all materials in the geometry - non-const access */
-    DETRAY_HOST_DEVICE
-    inline auto &material_store() { return _materials; }
-
-    /** Add pre-built mask store
-     *
-     * @param masks the conatiner for surface masks
-     */
+    /// Add pre-built mask store
+    ///
+    /// @param masks the conatiner for surface masks
     DETRAY_HOST
     inline void add_mask_store(mask_container &&msks) {
         _masks = std::move(msks);
     }
 
-    /** Get all transform in an index range from the detector
-     *
-     * @param range The range of surfaces/portals in the transform store
-     * @param ctx The context of the call
-     *
-     * @return ranged iterator to the object transforms
-     */
+    /// @return all materials in the geometry - const access
     DETRAY_HOST_DEVICE
+    inline auto material_store() const -> const material_container & {
+        return _materials;
+    }
+
+    /// @return all materials in the geometry - non-const access
+    DETRAY_HOST_DEVICE
+    inline auto material_store() -> material_container & { return _materials; }
+
+    /// Get all transform in an index range from the detector
+    ///
+    /// @param range The range of surfaces in the transform store
+    /// @param ctx The context of the call
+    ///
+    /// @return ranged iterator to the surface transforms
+    /*DETRAY_HOST_DEVICE
     inline auto transform_store(const dindex_range &range,
                                 const context &ctx = {}) const {
         return _transforms.range(range, ctx);
-    }
+    }*/
 
-    /** Get all transform in an index range from the detector - const
-     *
-     * @param ctx The context of the call
-     *
-     * @return detector transform store
-     */
+    /// Get all transform in an index range from the detector - const
+    ///
+    /// @param ctx The context of the call
+    ///
+    /// @return detector transform store
     DETRAY_HOST_DEVICE
-    inline const auto &transform_store(const context & /*ctx*/ = {}) const {
+    inline auto transform_store(const context & /*ctx*/ = {}) const
+        -> const transform_container & {
         return _transforms;
     }
 
     DETRAY_HOST_DEVICE
-    inline auto &transform_store(const context & /*ctx*/ = {}) {
+    inline auto transform_store(const context & /*ctx*/ = {})
+        -> transform_container & {
         return _transforms;
     }
 
-    /** Add pre-built transform store
-     *
-     * @param transf the constianer for surface transforms
-     */
+    /// Add pre-built transform store
+    ///
+    /// @param transf the constianer for surface transforms
     DETRAY_HOST
-    inline void add_transform_store(transform_container &&transf) {
+    inline auto add_transform_store(transform_container &&transf) -> void {
         _transforms = std::move(transf);
     }
 
-    /** Get all available data from the detector without std::tie
-     *
-     * @param ctx The context of the call
-     *
-     * @return a struct that contains references to all relevant containers.
-     */
+    /// Get all available data from the detector without std::tie
+    ///
+    /// @param ctx The context of the call
+    ///
+    /// @return a struct that contains references to all relevant containers.
     DETRAY_HOST_DEVICE
     auto data(const context & /*ctx*/ = {}) const {
         struct data_core {
@@ -282,43 +289,70 @@ class detector {
         return data_core{_volumes, _transforms, _masks, _surfaces};
     }
 
-    template <typename grid_type>
-    DETRAY_HOST inline void add_surfaces_grid(const context ctx,
-                                              volume_type &vol,
-                                              grid_type &surfaces_grid) {
-        // iterate over surfaces to fill the grid
-        for (const auto [surf_idx, surf] : enumerate(_surfaces, vol)) {
-            if (surf.get_grid_status() == true) {
-                auto sidx = surf_idx;
+    /// Add a grid to the surface finder store of the detector
+    ///
+    /// New surface finder id can be been given explicitly. That is helpful, if
+    /// multiple sf finders have the same type in the tuple container. Otherwise
+    /// it is determined automatically.
+    ///
+    /// @param vol the volume the surface finder should be added to
+    /// @param grid the grid that should be added
+    // TODO: Provide grid builder structure separate from the detector
+    /*template <typename grid_t, typename sf_finders::id grid_id =
+                                   sf_finders::template get_id<grid_t>()>
+    DETRAY_HOST auto add_grid(volume_type &vol, grid_t &grid) -> void {
 
-                auto &trf =
-                    _transforms.contextual_transform(ctx, surf.transform());
-                auto tsl = trf.translation();
+        // Add surfaces grid to surfaces finder container
+        auto &grid_group = _sf_finders.template group<grid_id>();
 
-                if (vol.get_grid_type() ==
-                    volume_type::grid_type::e_z_phi_grid) {
-
-                    point2 location{tsl[2], algebra::getter::phi(tsl)};
-                    surfaces_grid.populate(location, std::move(sidx));
-
-                } else if (vol.get_grid_type() ==
-                           volume_type::grid_type::e_r_phi_grid) {
-
-                    point2 location{algebra::getter::perp(tsl),
-                                    algebra::getter::phi(tsl)};
-                    surfaces_grid.populate(location, std::move(sidx));
-                }
+        // Find correct index for this surface finder
+        std::size_t grid_idx = 0;
+        for (unsigned int i_s = 0; i_s < grid_group.size(); i_s++) {
+            if (!grid_group.at(i_s).data().empty()) {
+                grid_idx++;
             }
         }
-
-        // add surfaces grid into surfaces finder
-        auto n_grids = _surfaces_finder.effective_size();
-        _surfaces_finder[n_grids] = surfaces_grid;
-        vol.set_surfaces_finder(n_grids);
+        grid_group.at(grid_idx) = std::move(grid);
+        vol.set_sf_finder(grid_id, grid_idx);
     }
 
+    /// Fill a grid surface finder by bin association, then add it to the
+    /// detector.
+    ///
+    /// New surface finder id can be been given explicitly. That is helpful, if
+    /// multiple sf finders have the same type in the tuple container. Otherwise
+    /// it is determined automatically.
+    ///
+    /// @param ctx the geometry context
+    /// @param vol the volume the surface finder should be added to
+    /// @param grid the grid that should be added
+    // TODO: Provide grid builder structure separate from the detector
+    template <typename grid_t>
+    DETRAY_HOST auto fill_grid(const context ctx, volume_type &vol,
+                               grid_t &grid) -> void {
+
+        // Fill the volumes surfaces into the grid
+        bin_association(ctx, *this, vol, grid, {0.1, 0.1}, false);
+    }
+
+    /// Detector interface to add surface finders
+    ///
+    /// @param ctx the geometry context
+    /// @param vol the volume the surface finder should be added to
+    /// @param grid the grid that should be added
+    template <typename sf_finder_t,
+              typename sf_finders::id sf_finder_id =
+                  sf_finders::template get_id<sf_finder_t>()>
+    DETRAY_HOST auto add_sf_finder(const context ctx, volume_type &vol,
+                                   sf_finder_t &sf_finder) -> void {
+
+        // For now, only implemented for grids
+        fill_grid(ctx, vol, sf_finder);
+        add_grid<sf_finder_t, sf_finder_id>(vol, sf_finder);
+    }*/
+
     /// Add a new full set of detector components (e.g. transforms or volumes)
-    ///  according to given context.
+    /// according to given context.
     ///
     /// @param ctx is the context of the call
     /// @param vol is the target volume
@@ -328,11 +362,13 @@ class detector {
     /// @param trfs_per_vol is the transform vector per volume
     ///
     /// @note can throw an exception if input data is inconsistent
-    DETRAY_HOST inline void add_objects_per_volume(
+    // TODO: Provide volume builder structure separate from the detector
+    DETRAY_HOST
+    auto add_objects_per_volume(
         const context ctx, volume_type &vol,
         surface_container &surfaces_per_vol, mask_container &masks_per_vol,
         material_container &materials_per_vol,
-        transform_container &trfs_per_vol) noexcept(false) {
+        transform_container &trfs_per_vol) noexcept(false) -> void {
 
         // Append transforms
         const auto trf_offset = _transforms.size(ctx);
@@ -340,9 +376,8 @@ class detector {
 
         // Update mask, material and transform index of surfaces
         for (auto &sf : surfaces_per_vol) {
-            _masks.template execute<mask_index_update>(sf.mask_type(), sf);
-            _materials.template execute<material_index_update>(
-                sf.material_type(), sf);
+            _masks.template call<mask_index_update>(sf.mask(), sf);
+            _materials.template call<material_index_update>(sf.material(), sf);
             sf.update_transform(trf_offset);
         }
 
@@ -364,48 +399,55 @@ class detector {
             std::max(_n_max_objects_per_volume, vol.n_objects());
     }
 
-    /** Add the volume grid - move semantics
-     *
-     * @param v_grid the volume grid to be added
-     */
+    /// Add the volume grid - move semantics
+    ///
+    /// @param v_grid the volume grid to be added
     DETRAY_HOST
-    inline void add_volume_finder(volume_finder &&v_grid) {
+    inline auto add_volume_finder(volume_finder &&v_grid) -> void {
         _volume_finder = std::move(v_grid);
     }
 
-    /** @return the volume grid - const access */
+    /// @return the volume grid - const access
     DETRAY_HOST_DEVICE
-    inline const volume_finder &volume_search_grid() const {
+    inline auto volume_search_grid() const -> const volume_finder & {
         return _volume_finder;
     }
 
+    /// @returns const access to the detector's volume search structure
     DETRAY_HOST_DEVICE
-    inline volume_finder &volume_search_grid() { return _volume_finder; }
-
-    DETRAY_HOST_DEVICE
-    inline const surfaces_finder_type &get_surfaces_finder() const {
-        return _surfaces_finder;
+    inline auto volume_search_grid() -> volume_finder & {
+        return _volume_finder;
     }
 
-    DETRAY_HOST_DEVICE
-    inline surfaces_finder_type &get_surfaces_finder() {
-        return _surfaces_finder;
+    /// @returns access to the surface finder container - non-const access
+    // TODO: remove once possible
+    /*DETRAY_HOST_DEVICE
+    inline auto sf_finder_store() -> sf_finder_container & {
+        return _sf_finders;
     }
 
+    /// @returns access to the surface finder container
     DETRAY_HOST_DEVICE
-    inline dindex get_n_max_objects_per_volume() const {
+    inline auto sf_finder_store() const -> const sf_finder_container & {
+        return _sf_finders;
+    }*/
+
+    /// @returns the maximum number of surfaces (sensitive + portal) in all
+    /// volumes.
+    DETRAY_HOST_DEVICE
+    inline auto get_n_max_objects_per_volume() const -> dindex {
         return _n_max_objects_per_volume;
     }
 
-    /** Output to string */
+    /// @param names maps a volume to its string representation.
+    /// @returns a string representation of the detector.
     DETRAY_HOST
-    const std::string to_string(const name_map &names) const {
+    auto to_string(const name_map &names) const -> std::string {
         std::stringstream ss;
 
         ss << "[>] Detector '" << names.at(0) << "' has " << _volumes.size()
            << " volumes." << std::endl;
-        // ss << "    contains  " << _surfaces_finders.size()
-        //   << " local surface finders." << std::endl;
+        ss << " local surface finders." << std::endl;
 
         for (const auto &[i, v] : enumerate(_volumes)) {
             ss << "[>>] Volume at index " << i << ": " << std::endl;
@@ -419,9 +461,13 @@ class detector {
                << v.template n_objects<objects::e_portal>() << " portals "
                << std::endl;
 
-            if (v.surfaces_finder_entry() != dindex_invalid) {
-                ss << "  sf finders idx " << v.surfaces_finder_entry()
-                   << std::endl;
+            ss << "                 " << /*_sf_finders.size(v.sf_finder_type())
+               << " surface finders " <<*/
+                std::endl;
+
+            if (v.sf_finder_index() != dindex_invalid) {
+                ss << "  sf finder id " << v.sf_finder_type()
+                   << "  sf finders idx " << v.sf_finder_index() << std::endl;
             }
 
             const auto &bounds = v.bounds();
@@ -434,40 +480,49 @@ class detector {
         return ss.str();
     }
 
-    /** @return the pointer of memoery resource */
+    /// @return the pointer of memoery resource - non-const access
     DETRAY_HOST
-    auto resource() const { return _resource; }
+    auto resource() -> vecmem::memory_resource * { return _resource; }
+
+    /// @return the pointer of memoery resource
+    DETRAY_HOST
+    auto resource() const -> const vecmem::memory_resource * {
+        return _resource;
+    }
 
     private:
-    /** Contains the geometrical relations */
+    /// Contains the detector sub-volumes.
     vector_t<volume_type> _volumes;
 
-    /** All surfaces and portals in the geometry in contiguous memory */
+    /// All surfaces (sensitive and portal) in the geometry in contiguous memory
     surface_container _surfaces;
 
-    /** Keeps all of the transform data in contiguous memory*/
+    /// Keeps all of the transform data in contiguous memory
     transform_container _transforms;
 
-    /** Surface and portal masks of the detector in contiguous memory */
+    /// Masks of all surfaces in the geometry in contiguous memory
     mask_container _masks;
 
-    /** Materials in contiguous memory */
+    /// Materials of all surfaces in the geometry in contiguous memory
     material_container _materials;
 
+    /// All surface finder data structures that are used in the detector volumes
+    // sf_finder_container _sf_finders;
+
+    /// Search structure for volumes
     volume_finder _volume_finder;
 
-    /* TODO: surfaces_finder needs to be refactored */
-    surfaces_finder_type _surfaces_finder;
-
+    /// The memory resource represents how and where (host, device, managed)
+    /// the memory for the detector containers is allocated
     vecmem::memory_resource *_resource = nullptr;
 
-    // maximum number of surfaces per volume for navigation kernel candidates
+    /// Maximum number of surfaces per volume. Used to estimate size of
+    /// candidates vector in the navigator. Is determined during detector
+    /// building.
     dindex _n_max_objects_per_volume = 0;
 };
 
-/** A static inplementation of detector data for device
- *
- */
+/// @brief A static inplementation of detector data for device
 template <typename detector_type>
 struct detector_data {
 
@@ -478,7 +533,7 @@ struct detector_data {
     using material_container_t = typename detector_type::material_container;
     using transform_container_t = typename detector_type::transform_container;
     using volume_finder_t = typename detector_type::volume_finder;
-    using surfaces_finder_t = typename detector_type::surfaces_finder_type;
+    // using surfaces_finder_t = typename detector_type::surfaces_finder_type;
 
     detector_data(detector_type &det)
         : _volumes_data(vecmem::get_data(det.volumes())),
@@ -487,9 +542,7 @@ struct detector_data {
           _materials_data(get_data(det.material_store())),
           _transforms_data(get_data(det.transform_store())),
           _volume_finder_data(
-              get_data(det.volume_search_grid(), *det.resource())),
-          _surfaces_finder_data(
-              get_data(det.get_surfaces_finder(), *det.resource())) {}
+              get_data(det.volume_search_grid(), *det.resource())) {}
 
     // members
     vecmem::data::vector_view<volume_t> _volumes_data;
@@ -498,11 +551,9 @@ struct detector_data {
     tuple_vector_container_data<material_container_t> _materials_data;
     static_transform_store_data<transform_container_t> _transforms_data;
     grid2_data<volume_finder_t> _volume_finder_data;
-    surfaces_finder_data<surfaces_finder_t> _surfaces_finder_data;
 };
 
-/** A static inplementation of detector view for device
- */
+/// @brief A static inplementation of detector view for device
 template <typename detector_type>
 struct detector_view {
 
@@ -513,7 +564,6 @@ struct detector_view {
     using material_container_t = typename detector_type::material_container;
     using transform_container_t = typename detector_type::transform_container;
     using volume_finder_t = typename detector_type::volume_finder;
-    using surfaces_finder_t = typename detector_type::surfaces_finder_type;
 
     detector_view(detector_data<detector_type> &det_data)
         : _volumes_data(det_data._volumes_data),
@@ -521,8 +571,7 @@ struct detector_view {
           _masks_data(det_data._masks_data),
           _materials_data(det_data._materials_data),
           _transforms_data(det_data._transforms_data),
-          _volume_finder_view(det_data._volume_finder_data),
-          _surfaces_finder_view(det_data._surfaces_finder_data) {}
+          _volume_finder_view(det_data._volume_finder_data) {}
 
     // members
     vecmem::data::vector_view<volume_t> _volumes_data;
@@ -531,19 +580,20 @@ struct detector_view {
     tuple_vector_container_data<material_container_t> _materials_data;
     static_transform_store_data<transform_container_t> _transforms_data;
     grid2_view<volume_finder_t> _volume_finder_view;
-    surfaces_finder_view<surfaces_finder_t> _surfaces_finder_view;
 };
 
-/** stand alone function for detector_data get function
- **/
-template <
-    typename detector_registry, template <typename, std::size_t> class array_t,
-    template <typename...> class tuple_t, template <typename...> class vector_t,
-    template <typename...> class jagged_vector_t, typename source_link>
-inline detector_data<detector<detector_registry, array_t, tuple_t, vector_t,
+/// stand alone function for that @returns the detector data for transfer to
+/// device.
+///
+/// @param detector the detector to be tranferred
+template <typename metadata, template <typename, std::size_t> class array_t,
+          template <typename...> class tuple_t,
+          template <typename...> class vector_t,
+          template <typename...> class jagged_vector_t, typename source_link>
+inline detector_data<detector<metadata, array_t, tuple_t, vector_t,
                               jagged_vector_t, source_link> >
-get_data(detector<detector_registry, array_t, tuple_t, vector_t,
-                  jagged_vector_t, source_link> &det) {
+get_data(detector<metadata, array_t, tuple_t, vector_t, jagged_vector_t,
+                  source_link> &det) {
     return det;
 }
 

--- a/core/include/detray/core/detector_kernel.hpp
+++ b/core/include/detray/core/detector_kernel.hpp
@@ -16,8 +16,9 @@ namespace detray {
 struct mask_index_update {
     using output_type = bool;
 
-    template <typename group_t, typename surface_t>
+    template <typename group_t, typename index_t, typename surface_t>
     DETRAY_HOST inline output_type operator()(const group_t& group,
+                                              const index_t& /*index*/,
                                               surface_t& sf) const {
         sf.update_mask(group.size());
         return true;
@@ -28,8 +29,9 @@ struct mask_index_update {
 struct material_index_update {
     using output_type = bool;
 
-    template <typename group_t, typename surface_t>
+    template <typename group_t, typename index_t, typename surface_t>
     DETRAY_HOST inline output_type operator()(const group_t& group,
+                                              const index_t& /*index*/,
                                               surface_t& sf) const {
         sf.update_material(group.size());
         return true;

--- a/core/include/detray/definitions/indexing.hpp
+++ b/core/include/detray/definitions/indexing.hpp
@@ -18,24 +18,27 @@ dindex constexpr dindex_invalid = std::numeric_limits<dindex>::max();
 using dindex_range = darray<dindex, 2>;
 using dindex_sequence = dvector<dindex>;
 
-/** Small type to tie an object type and an index into a container together.
- *
- * @tparam id_type Represents the indexed type
- * @tparam intex_type The type of indexing needed for the indexed types
- * container
- */
-template <typename id_type = unsigned int, typename index_type = dindex>
+/// @brief Ties an object type and an index into a container together.
+///
+/// @tparam id_type Represents the type of object that is being indexed
+/// @tparam index_type The type of indexing needed for the indexed type's
+///         container (e.g. single index, range, multiindex)
+template <typename id_t = unsigned int, typename index_t = dindex>
 struct typed_index {
+
+    using id_type = id_t;
+    using index_type = index_t;
+
     id_type _object_id;
     index_type _index;
 
-    /** Equality operator */
+    /// Equality operator
     DETRAY_HOST_DEVICE
     bool operator==(const typed_index<id_type, index_type>& rhs) const {
         return (_object_id == rhs._object_id && _index == rhs._index);
     }
 
-    /** Arithmetic operators*/
+    /// Arithmetic operators
     DETRAY_HOST_DEVICE
     typed_index<id_type, index_type> operator+(
         const typed_index<id_type, index_type>& rhs) const {
@@ -84,7 +87,7 @@ struct typed_index {
         return *this;
     }
 
-    /** Only make the prefix operator available */
+    /// Only make the prefix operator available
     DETRAY_HOST_DEVICE
     typed_index<id_type, index_type>& operator++() {
         ++_index;
@@ -94,12 +97,13 @@ struct typed_index {
 
 namespace detail {
 
+/// Stub function to get a single index
 template <std::size_t ID>
 dindex get(dindex idx) noexcept {
     return idx;
 }
 
-/** Custom get function for the typed_index struct. Get the type. */
+/// Custom get function for the typed_index struct. Get the type.
 template <std::size_t ID, typename id_type, typename index_type,
           std::enable_if_t<ID == 0, bool> = true>
 DETRAY_HOST_DEVICE constexpr auto& get(
@@ -107,7 +111,7 @@ DETRAY_HOST_DEVICE constexpr auto& get(
     return index._object_id;
 }
 
-/** Custom get function for the typed_index struct. Get the index. */
+/// Custom get function for the typed_index struct. Get the index.
 template <std::size_t ID, typename id_type, typename index_type,
           std::enable_if_t<ID == 1, bool> = true>
 DETRAY_HOST_DEVICE constexpr auto& get(

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -1,3 +1,4 @@
+
 /** Detray library, part of the ACTS project (R&D line)
  *
  * (c) 2020-2022 CERN for the benefit of the ACTS project
@@ -14,189 +15,197 @@
 
 namespace detray {
 
-/** Templated surface class for detector surfaces and portals
- *
- * @tparam mask_registry_t the type of the mask link representation
- * @tparam material_registry_t the type of the material link representation
- * @tparam transform_link_t the type of the transform link representation
- * @tparam volume_link_t the typ eof the volume link representation
- * @tparam source_link_t the type of the source link representation
- */
+/// Templated surface class for detector surfaces and portals.
+///
+/// @note might be holding multiple surfaces in the future
+///
+/// @tparam mask_regsitry_t the type collection of masks that can be linked
+///                         to the surface
+/// @tparam material_registry_t the type collection of material that can be
+///                             linked to the surface
+/// @tparam transform_link_t how to reference the surfaces transforms
+/// @tparam source_link_t the type of the source link representation
 template <typename mask_regsitry_t, typename material_registry_t,
-          typename transform_link_t = dindex, typename volume_link_t = dindex,
-          typename source_link_t = bool>
+          typename transform_link_t = dindex, typename source_link_t = bool>
 class surface {
 
     public:
     // Broadcast the type of links
     using transform_link = transform_link_t;
     using mask_defs = mask_regsitry_t;
+    /// might be a single mask, a range of masks or a multiindex in the future
     using mask_link = typename mask_defs::link_type;
-    // At least one mask type is present in any geometry
-    using edge_type = typename mask_defs::template get_type<mask_defs::to_id(
-        0)>::type::links_type;
+    /// Link type of the mask to a volume. At least one mask type is present in
+    /// any geometry
+    using volume_link_type =
+        typename mask_defs::template get_type<mask_defs::to_id(
+            0)>::type::links_type;
     using material_defs = material_registry_t;
     using material_link = typename material_defs::link_type;
-    using volume_link = volume_link_t;
     using source_link = source_link_t;
 
-    /** Constructor with full arguments - move semantics
-     *
-     * @param trf the transform for positioning and 3D local frame
-     * @param msk the mask/mask link for this surface
-     * @param vol the volume link for this surface
-     * @param src the source object/source link this surface is representing
-     * @param is_pt remember whether this is a portal or not
-     *
-     **/
+    /// Constructor with full arguments - move semantics
+    ///
+    /// @param trf the transform for positioning and 3D local frame
+    /// @param mask the type and index of the mask for this surface
+    /// @param material the type and index of the material for this surface
+    /// @param vol the volume this surface belongs to
+    /// @param src the source object/source link this surface is representing
+    /// @param is_portal remember whether this is a portal or not
     surface(transform_link &&trf, mask_link &&mask, material_link &&material,
-            volume_link &&vol, source_link &&src, bool is_pt)
+            dindex volume, source_link &&src, bool is_portal)
         : _trf(std::move(trf)),
           _mask(std::move(mask)),
           _material(std::move(material)),
-          _vol(std::move(vol)),
+          _volume(volume),
           _src(std::move(src)),
-          _is_portal(std::move(is_pt)) {}
+          _is_portal(is_portal) {}
 
-    /** Constructor with full arguments - copy semantics
-     *
-     * @param trf the transform for positioning and 3D local frame
-     * @param msk the mask/mask link for this surface
-     * @param vol the volume link for this surface
-     * @param src the source object/source link this surface is representing
-     * @param is_pt remember whether this is a portal or not
-     *
-     **/
-    surface(const transform_link &trf, const mask_link &mask,
-            const material_link &material, const volume_link vol,
-            const source_link &src, bool is_pt)
+    /// Constructor with full arguments - copy semantics
+    ///
+    /// @param trf the transform for positioning and 3D local frame
+    /// @param mask the type and index of the mask for this surface
+    /// @param material the type and index of the material for this surface
+    /// @param vol the volume this surface belongs to
+    /// @param src the source object/source link this surface is representing
+    /// @param is_portal remember whether this is a portal or not
+    surface(const transform_link trf, const mask_link &mask,
+            const material_link &material, const dindex volume,
+            const source_link &src, bool is_portal)
         : _trf(trf),
           _mask(mask),
           _material(material),
-          _vol(vol),
+          _volume(volume),
           _src(src),
-          _is_portal(is_pt) {}
+          _is_portal(is_portal) {}
 
-    // Portal vs module decision must be made explicitly
+    /// Portal vs module decision must be made explicitly
     surface() = default;
     surface(const surface &lhs) = default;
     ~surface() = default;
 
-    /** Equality operator
-     *
-     * @param rhs is the right hand side to be compared to
-     */
+    /// Equality operator
+    ///
+    /// @param rhs is the right hand side to be compared to
     DETRAY_HOST_DEVICE
-    bool operator==(const surface &rhs) const {
-        return (_trf == rhs._trf and _mask == rhs._mask and _vol == rhs._vol and
-                _src == rhs._src and _is_portal == rhs._is_portal);
+    auto operator==(const surface &rhs) const -> bool {
+        return (_trf == rhs._trf and _mask == rhs._mask and
+                _volume == rhs._volume and _src == rhs._src and
+                _is_portal == rhs._is_portal);
     }
 
-    /** Update the transform index
-     *
-     * @param offset update the position when move into new collection
-     */
+    /// Update the transform index
+    ///
+    /// @param offset update the position when move into new collection
     DETRAY_HOST
-    void update_transform(dindex offset) { _trf += offset; }
+    auto update_transform(dindex offset) -> void { _trf += offset; }
 
-    /** Access to the transform index */
+    /// Access to the transform index
     DETRAY_HOST_DEVICE
-    const transform_link &transform() { return _trf; }
+    auto transform() -> const transform_link & { return _trf; }
 
-    /** @return the transform index */
+    /// @return the transform index
     DETRAY_HOST_DEVICE
-    const transform_link &transform() const { return _trf; }
+    auto transform() const -> const transform_link & { return _trf; }
 
     /// Update the mask link
     ///
     /// @param offset update the position when move into new collection
     DETRAY_HOST
-    void update_mask(dindex offset) { _mask += offset; }
+    auto update_mask(dindex offset) -> void { _mask += offset; }
 
-    /** Access to the mask  */
+    /// Access to the mask
     DETRAY_HOST_DEVICE
-    const mask_link &mask() { return _mask; }
+    auto mask() -> const mask_link & { return _mask; }
 
-    /** @return the mask link */
+    /// @return the mask link
     DETRAY_HOST_DEVICE
-    const mask_link &mask() const { return _mask; }
+    auto mask() const -> const mask_link & { return _mask; }
 
-    /** Access to the mask id */
+    /// Access to the mask id
     DETRAY_HOST_DEVICE
-    auto mask_type() { return detail::get<0>(_mask); }
+    auto mask_type() -> typename mask_link::id_type {
+        return detail::get<0>(_mask);
+    }
 
-    /** @return the mask link */
-    DETRAY_HOST_DEVICE
-    auto mask_type() const { return detail::get<0>(_mask); }
+    /// @return the mask link
+    auto mask_type() const -> typename mask_link::id_type {
+        return detail::get<0>(_mask);
+    }
 
-    /** Access to the mask  */
+    /// Access to the mask
     DETRAY_HOST_DEVICE
-    const auto &mask_range() { return detail::get<1>(_mask); }
+    auto mask_range() -> typename mask_link::index_type & {
+        return detail::get<1>(_mask);
+    }
 
-    /** @return the mask link */
+    /// @return the mask link
     DETRAY_HOST_DEVICE
-    const auto &mask_range() const { return detail::get<1>(_mask); }
+    auto mask_range() const -> const typename mask_link::index_type & {
+        return detail::get<1>(_mask);
+    }
 
     /// Update the material link
     ///
     /// @param offset update the position when move into new collection
     DETRAY_HOST
-    void update_material(dindex offset) { _material += offset; }
+    auto update_material(dindex offset) -> void { _material += offset; }
 
     /// Access to the material
     DETRAY_HOST_DEVICE
-    const material_link &material() { return _material; }
+    auto material() -> const material_link & { return _material; }
 
     /// @return the material link
     DETRAY_HOST_DEVICE
-    const material_link &material() const { return _material; }
+    auto material() const -> const material_link & { return _material; }
 
     /// Access to the material id
     DETRAY_HOST_DEVICE
-    auto material_type() { return detail::get<0>(_material); }
+    auto material_type() -> typename material_link::id_type & {
+        return detail::get<0>(_material);
+    }
 
     /// @return the material link
     DETRAY_HOST_DEVICE
-    auto material_type() const { return detail::get<0>(_material); }
+    auto material_type() const -> const typename material_link::id_type & {
+        return detail::get<0>(_material);
+    }
 
     /// Access to the material
     DETRAY_HOST_DEVICE
-    const auto &material_range() { return detail::get<1>(_material); }
+    auto material_range() -> typename material_link::index_type & {
+        return detail::get<1>(_material);
+    }
 
     /// @return the material link
     DETRAY_HOST_DEVICE
-    const auto &material_range() const { return detail::get<1>(_material); }
+    auto material_range() const -> const typename material_link::index_type & {
+        return detail::get<1>(_material);
+    }
 
-    /** Access to the volume */
+    /// Access to the volume
     DETRAY_HOST_DEVICE
-    volume_link volume() { return _vol; }
+    auto volume() -> dindex { return _volume; }
 
-    /** @return the volume index */
+    /// @return the volume index
     DETRAY_HOST_DEVICE
-    const volume_link volume() const { return _vol; }
+    auto volume() const -> dindex { return _volume; }
 
-    /** @return the source link */
+    /// @return the source link
     DETRAY_HOST_DEVICE
-    const source_link &source() const { return _src; }
+    auto source() const -> const source_link & { return _src; }
 
-    /** @return if the surface belongs to grid **/
-    auto get_grid_status() const { return _in_grid; }
-
-    /** set if the surface belongs to grid **/
-    void set_grid_status(bool status) { _in_grid = status; }
-
-    /** Is this instance a portal in the sense of the unified_index_geometry? */
+    /// Is this instance a portal in the sense of the unified_index_geometry?
     DETRAY_HOST_DEVICE
-    bool is_portal() const { return _is_portal; }
+    auto is_portal() const -> bool { return _is_portal; }
 
     private:
-    transform_link_t _trf;
-    mask_link _mask;
-    material_link _material;
-    volume_link_t _vol;
-    source_link_t _src;
-    bool _is_portal;
-    bool _in_grid = false;
+    transform_link_t _trf{};
+    mask_link _mask{};
+    material_link _material{};
+    dindex _volume{dindex_invalid};
+    source_link_t _src{};
+    bool _is_portal = false;
 };
 
 }  // namespace detray

--- a/core/include/detray/geometry/volume.hpp
+++ b/core/include/detray/geometry/volume.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,91 +12,123 @@
 
 namespace detray {
 
-/** Volume class that acts as a logical container in the geometry for geometry
- *  objects, such as module surfaces or portals. The information is kept as
- *  index ranges into larger containers that are owned by the detector
- *  implementation.
- *
- * @tparam array_t the type of the internal array, must have STL semantics
- */
-template <typename object_registry_t, typename scalar_t = scalar,
-          typename range_t = dindex_range,
+/// The detray detector volume.
+///
+/// Volume class that acts as a logical container in the geometry for geometry
+/// objects, such as module surfaces or portals. The information is kept as
+/// index ranges into larger containers that are owned by the detector
+/// implementation. For every object type a different range can be set (e.g
+/// for sensitive surfaces or portals).
+///
+/// @tparam object_registry_t the type of objects contained in the volume
+/// @tparam scalar_t type of scalar used in the volume
+/// @tparam sf_finder_link_t the type of link to the volumes surfaces finder
+///         (geometry surface finder structure). The surface finder types
+///         cannot be given directly, since the containers differ between host
+///         and device. The surface finders reside in an 'unrollable
+///         container' and are called per volume in the navigator during local
+///         navigation.
+/// @tparam array_t the type of the internal array, must have STL semantics
+template <typename object_registry_t, typename scalar_t,
+          typename sf_finder_link_t = dindex,
           template <typename, std::size_t> class array_t = darray>
 class volume {
 
     public:
-    // The type of objects a volume can contain
+    /// The types of surfaces a volume can contain (modules, portals)
     using objects = object_registry_t;
-    // In case the geometry needs to be printed
+    /// ID type of a surface
+    using obj_link_type = typename objects::link_type;
+    /// How to address objects in a container. Can be a range or might become
+    /// an index if surfaces are addressed as batches
+    using obj_range_type = typename objects::range_type;
+    /// Type and index of the surface finder strucure used by this volume
+    using sf_finder_link_type = sf_finder_link_t;
+
+    /// In case the geometry needs to be printed
     using name_map = std::map<dindex, std::string>;
-    // used for sfinae
-    using volume_def = volume<object_registry_t, scalar_t, range_t, array_t>;
+    /// Voume tag, used for sfinae
+    using volume_def = volume<objects, scalar_t, sf_finder_link_type, array_t>;
 
-    enum grid_type : unsigned int {
-        e_no_grid = 0,
-        e_z_phi_grid = 1,  // barrel
-        e_r_phi_grid = 2,  // endcap
-    };
-
-    /** Default constructor**/
+    /// Default constructor
     volume() = default;
 
-    /** Contructor with bounds
-     * @param bounds of the volume
-     */
+    /// Constructor from boundary values.
+    ///
+    /// @param bounds values of volume boundaries. They depend on the volume
+    ///               shape, which is defined by its portals and are chosen in
+    ///               the detector builder
     volume(const array_t<scalar_t, 6> &bounds) : _bounds(bounds) {}
 
-    /** @return the bounds - const access */
+    /// @return the bounds - const access
     DETRAY_HOST_DEVICE
-    inline const array_t<scalar_t, 6> &bounds() const { return _bounds; }
+    auto bounds() const -> const array_t<scalar_t, 6> & { return _bounds; }
 
-    /** @return the name (add an offset for the detector name)*/
+    /// @return the name (add an offset for the detector name)
     DETRAY_HOST_DEVICE
-    inline const std::string &name(const name_map &names) const {
+    auto name(const name_map &names) const -> const std::string & {
         return names.at(_index + 1);
     }
 
-    /** @return the index */
+    /// @return the index of the volume in the detector container
     DETRAY_HOST_DEVICE
-    inline dindex index() const { return _index; }
+    auto index() const -> dindex { return _index; }
 
-    /** @param index the index */
+    /// @param index the index of the volume in the detector container
     DETRAY_HOST
-    inline void set_index(const dindex index) { _index = index; }
+    auto set_index(const dindex index) -> void { _index = index; }
 
-    /** @return the entry into the local surface finders */
+    /// set surface finder during detector building
+    DETRAY_HOST
+    auto set_sf_finder(const sf_finder_link_type &link) -> void {
+        _sf_finder = link;
+    }
+
+    /// set surface finder during detector building
+    DETRAY_HOST
+    auto set_sf_finder(const typename sf_finder_link_t::id_type id,
+                       const typename sf_finder_link_t::index_type index)
+        -> void {
+        _sf_finder = {id, index};
+    }
+
+    /// @return the surface finder link associated with the volume
     DETRAY_HOST_DEVICE
-    inline dindex surfaces_finder_entry() const {
-        return _surfaces_finder_entry;
+    auto sf_finder_link() const -> const sf_finder_link_type & {
+        return _sf_finder;
     }
 
-    /** @param entry the entry into the local surface finders */
-    DETRAY_HOST
-    inline void set_surfaces_finder(const dindex entry) {
-        _surfaces_finder_entry = entry;
+    /// @return the type of surface finder associated with the volume
+    DETRAY_HOST_DEVICE
+    auto sf_finder_type() const -> typename sf_finder_link_t::id_type {
+        return detail::get<0>(_sf_finder);
     }
 
-    /** @return if the volume is empty or not */
-    DETRAY_HOST_DEVICE inline bool empty() const {
-        return n_objects<objects::e_surface>() == 0;
+    /// @return the index of the surface finder associated with volume
+    DETRAY_HOST_DEVICE
+    auto sf_finder_index() const -> typename sf_finder_link_t::index_type {
+        return detail::get<1>(_sf_finder);
     }
 
-    /** @return the number of surfaces in the volume */
+    /// @return if the volume is empty or not
+    DETRAY_HOST_DEVICE
+    auto empty() const -> bool { return n_objects<objects::e_surface>() == 0; }
+
+    /// @return the number of surfaces in the volume
     template <typename objects::id range_id = objects::e_surface>
-    DETRAY_HOST_DEVICE inline auto n_objects() const {
+    DETRAY_HOST_DEVICE auto n_objects() const -> dindex {
         return n_in_range(range<range_id>());
     }
 
-    /** Set or update the index into a geometry container identified by the
-     *  range_id.
-     *
-     * @param other Surface index range
-     */
+    /// Set or update the index into a geometry container identified by the
+    /// range_id.
+    ///
+    /// @param other Surface index range
     template <typename objects::id range_id = objects::e_surface>
-    DETRAY_HOST inline void update_range(const range_t &other) {
+    DETRAY_HOST auto update_range(const obj_range_type &other) -> void {
         auto &rg = detail::get<range_id>(_ranges);
         // Range not set yet - initialize
-        constexpr range_t empty{};
+        constexpr obj_range_type empty{};
         if (rg == empty) {
             rg = other;
         } else {
@@ -106,49 +138,45 @@ class volume {
         }
     }
 
-    /** @return range of surfaces by surface type - const access */
+    /// @return range of surfaces by surface type - const access.
     template <typename object_t>
-    DETRAY_HOST_DEVICE inline constexpr const auto &range() const {
+    DETRAY_HOST_DEVICE inline constexpr auto range() const
+        -> const obj_range_type & {
         constexpr auto index = objects::template get_index<object_t>::value;
         return detail::get<index>(_ranges);
     }
 
-    /** @return range of surfaces- const access */
+    /// @return range of surfaces- const access.
     template <typename objects::id range_id = objects::e_surface>
-    DETRAY_HOST_DEVICE inline constexpr const auto &range() const {
+    DETRAY_HOST_DEVICE inline constexpr auto range() const
+        -> const obj_range_type & {
         return detail::get<range_id>(_ranges);
     }
 
-    /** @return _ranges */
-    DETRAY_HOST_DEVICE inline constexpr const auto &ranges() const {
+    /// @return all ranges in the volume.
+    DETRAY_HOST_DEVICE
+    inline constexpr auto ranges() const
+        -> const array_t<obj_range_type, objects::n_types> & {
         return _ranges;
     }
 
-    /** @return the number of elements in a given range */
+    /// @return the number of elements in a given range
     template <typename range_type>
-    DETRAY_HOST_DEVICE inline dindex n_in_range(range_type &&rg) const {
+    DETRAY_HOST_DEVICE inline auto n_in_range(range_type &&rg) const -> dindex {
         return detail::get<1>(rg) - detail::get<0>(rg);
     }
 
-    /** set grid type associated with volume */
-    void set_grid_type(grid_type val) { _grid_type = val; }
-
-    /** get grid type associated with volume */
-    auto get_grid_type() const { return _grid_type; }
-
-    /** Equality operator
-     *
-     * @param rhs is the right hand side to be compared to
-     */
+    /// Equality operator
+    ///
+    /// @param rhs is the right hand side to be compared to
     DETRAY_HOST_DEVICE
-    bool operator==(const volume &rhs) const {
+    auto operator==(const volume &rhs) const -> bool {
         return (_bounds == rhs._bounds && _index == rhs._index &&
-                _ranges == rhs._ranges &&
-                _surfaces_finder_entry == rhs._surfaces_finder_entry);
+                _ranges == rhs._ranges && _sf_finder == rhs._sf_finder);
     }
 
     private:
-    /** Bounds section, default for r, z, phi */
+    /// Bounds section, default for r, z, phi
     array_t<scalar_t, 6> _bounds = {0.,
                                     std::numeric_limits<scalar_t>::max(),
                                     -std::numeric_limits<scalar_t>::max(),
@@ -156,18 +184,15 @@ class volume {
                                     -M_PI,
                                     M_PI};
 
-    /** Volume index */
+    /// Volume index in the detector's volume container
     dindex _index = dindex_invalid;
 
-    /** Ranges in geometry containers for different objects types that belong
-     * to this volume */
-    array_t<range_t, objects::n_types> _ranges = {};
+    /// Indices in geometry containers for different objects types are
+    /// contained in this volume
+    array_t<obj_range_type, objects::n_types> _ranges = {};
 
-    /** Index into the surface finder container */
-    dindex _surfaces_finder_entry = dindex_invalid;
-
-    /** grid type associated with volume **/
-    grid_type _grid_type = e_no_grid;
+    /// Links to a specific sf_finder structure for this volume
+    sf_finder_link_type _sf_finder = {};
 };
 
 }  // namespace detray

--- a/core/include/detray/geometry/volume_connector.hpp
+++ b/core/include/detray/geometry/volume_connector.hpp
@@ -248,7 +248,7 @@ void connect_cylindrical_volumes(
                     &portals_info,
                 dindex bound_index) -> void {
             using portal_t = typename detector_t::surface_type;
-            using edge_t = typename portal_t::edge_type;
+            using volume_link_t = typename portal_t::volume_link_type;
             // Fill in the left side portals
             if (not portals_info.empty()) {
                 // The portal transfrom is given from the left
@@ -266,9 +266,10 @@ void connect_cylindrical_volumes(
                 // Create a stub mask for every unique index
                 for (auto &info_ : portals_info) {
                     // Add new mask to container
-                    edge_t edge{std::get<1>(info_), dindex_invalid};
+                    volume_link_t volume_link{std::get<1>(info_)};
                     portal_masks.template add_value<disc_id>(
-                        std::get<0>(info_)[0], std::get<0>(info_)[1], edge);
+                        std::get<0>(info_)[0], std::get<0>(info_)[1],
+                        volume_link);
 
                     mask_index = {disc_id,
                                   portal_masks.template size<disc_id>()};
@@ -298,7 +299,7 @@ void connect_cylindrical_volumes(
                     &portals_info,
                 dindex bound_index) -> void {
             using portal_t = typename detector_t::surface_type;
-            using edge_t = typename portal_t::edge_type;
+            using volume_link_t = typename portal_t::volume_link_type;
             // Fill in the upper side portals
             if (not portals_info.empty()) {
                 // Get the mask context group and fill it
@@ -310,12 +311,12 @@ void connect_cylindrical_volumes(
 
                 for (auto &info_ : portals_info) {
                     // Add new mask to container
-                    edge_t edge{std::get<1>(info_), dindex_invalid};
+                    volume_link_t volume_link{std::get<1>(info_)};
                     const auto cylinder_range = std::get<0>(info_);
 
                     portal_masks.template add_value<cylinder_id>(
                         volume_bounds[bound_index], cylinder_range[0],
-                        cylinder_range[1], edge);
+                        cylinder_range[1], volume_link);
 
                     mask_index = {cylinder_id,
                                   portal_masks.template size<cylinder_id>()};

--- a/core/include/detray/grids/grid2.hpp
+++ b/core/include/detray/grids/grid2.hpp
@@ -60,7 +60,7 @@ class grid2 {
     static constexpr array_t<dindex, 2> hermit1 = {0u, 0u};
     static constexpr neighborhood<dindex> hermit2 = {hermit1, hermit1};
 
-    grid2() = delete;
+    grid2() = default;
 
     DETRAY_HOST
     grid2(vecmem::memory_resource &mr,
@@ -227,6 +227,15 @@ class grid2 {
         return _data_serialized[_serializer.template serialize<axis_p0_type,
                                                                axis_p1_type>(
             _axis_p0, _axis_p1, _axis_p0.bin(p2[0]), _axis_p1.bin(p2[1]))];
+    }
+
+    /// Stub function until the zone call is working correctly
+    template <typename detector_t, typename track_t>
+    DETRAY_HOST_DEVICE dindex_range
+    search(const detector_t & /*det*/,
+           const typename detector_t::volume_type &volume,
+           const track_t & /*track*/) const {
+        return volume.range();
     }
 
     /** Return a zone around a single bin, either with binned or scalar

--- a/core/include/detray/intersection/intersection_kernel.hpp
+++ b/core/include/detray/intersection/intersection_kernel.hpp
@@ -37,17 +37,18 @@ struct intersection_initialize {
      *
      * @return the number of valid intersections
      */
-    template <typename mask_group_t, typename is_container_t, typename traj_t,
-              typename surface_t, typename transform_container_t>
+    template <typename mask_group_t, typename mask_range_t,
+              typename is_container_t, typename traj_t, typename surface_t,
+              typename transform_container_t>
     DETRAY_HOST_DEVICE inline output_type operator()(
-        const mask_group_t &mask_group, is_container_t &is_container,
-        const traj_t &traj, const surface_t &surface,
+        const mask_group_t &mask_group, const mask_range_t &mask_range,
+        is_container_t &is_container, const traj_t &traj,
+        const surface_t &surface,
         const transform_container_t &contextual_transforms,
         const scalar mask_tolerance = 0.) const {
 
         int count = 0;
 
-        const auto &mask_range = surface.mask_range();
         const auto &ctf = contextual_transforms[surface.transform()];
 
         // Run over the masks belonged to the surface
@@ -90,6 +91,8 @@ struct intersection_update {
      * @tparam transform_container_t is the input transform store type
      *
      * @param mask_group is the input mask group
+     * @param mask_range is the range of masks in the group that belong to the
+     *                   surface
      * @param traj is the input trajectory
      * @param surface is the input surface
      * @param contextual_transforms is the input transform container
@@ -97,18 +100,17 @@ struct intersection_update {
      *
      * @return the intersection
      */
-    template <typename mask_group_t, typename traj_t, typename surface_t,
-              typename transform_container_t>
+    template <typename mask_group_t, typename mask_range_t, typename traj_t,
+              typename surface_t, typename transform_container_t>
     DETRAY_HOST_DEVICE inline output_type operator()(
-        const mask_group_t &mask_group, const traj_t &traj,
-        const surface_t &surface,
+        const mask_group_t &mask_group, const mask_range_t &mask_range,
+        const traj_t &traj, const surface_t &surface,
         const transform_container_t &contextual_transforms,
         const scalar mask_tolerance = 0.) const {
 
-        const auto &mask_range = surface.mask_range();
         const auto &ctf = contextual_transforms[surface.transform()];
 
-        // Run over the masks belonged to the surface
+        // Run over the masks belonging to the surface
         for (const auto &mask : range(mask_group, mask_range)) {
 
             auto sfi = std::move(mask.intersector()(

--- a/core/include/detray/masks/annulus2.hpp
+++ b/core/include/detray/masks/annulus2.hpp
@@ -47,7 +47,6 @@ namespace detray {
  * mask type once for all.
  *
  **/
-
 template <typename transform3_t = __plugin::transform3<scalar>,
           template <class> typename intersector_t = plane_intersector,
           template <class> typename local_t = polar2, typename links_t = dindex,

--- a/core/include/detray/masks/mask_base.hpp
+++ b/core/include/detray/masks/mask_base.hpp
@@ -13,11 +13,34 @@
 
 namespace detray {
 
+/// @brief Base class for all masks.
+///
+/// Masks are lightweight types that define any special behaviour of different
+/// surfaces geometries: They give the surface class its 'shape'.
+/// A mask defines a local coordinate system on a surface geometry (e.g. a
+/// plane surface or a cylinder surface) and defines the surface's extent in
+/// that geometry. Masks are consequently used to make the inside/outside
+/// decision during an intersection operation.
+/// Masks can be (shared) boundary surfaces for detector volumes and therefore
+/// hold the links to adjacent volumes that are needed during navigation. For
+/// sensitive surfaces those links point to the mother volume.
+///
+/// @note Might contain multiple masks in the future.
+///
+/// @tparam intersector_t the intersection implementation for the surface
+///                       geometry the mask belongs to. Can also be different,
+///                       if the intersection is not done with a straight line.
+/// @tparam locat_t the local coordinate system in which the surface extent is
+///                 defined.
+/// @tparam links_t the type of links that are used to tie detector volumes
+///                 together. Might be multiindex in the future.
+/// @tparam kDIM the number of values needed to define a surfaces extent.
 template <typename transform3_t, template <class> typename intersector_t,
           template <class> typename local_t, typename links_t,
           template <typename, std::size_t> class array_t, std::size_t kDIM>
 class mask_base {
     public:
+    // Make template parameters accessible
     using intersector_type = intersector_t<transform3_t>;
     using local_type = local_t<transform3_t>;
     using links_type = links_t;
@@ -26,12 +49,12 @@ class mask_base {
     using array_type = array_t<T, I>;
     using mask_values = array_type<scalar, kDIM>;
 
-    /* Default constructor */
+    /// Default constructor
     mask_base() = default;
 
     DETRAY_HOST_DEVICE
     mask_base(const mask_values& val, const links_type& links)
-        : _values(val), _links(links) {}
+        : _values(val), _volume_link(links) {}
 
     DETRAY_HOST_DEVICE
     mask_base& operator=(const mask_values& rhs) {
@@ -39,75 +62,59 @@ class mask_base {
         return (*this);
     }
 
-    /** Equality operator from an array, convenience function
-     *
-     * @param rhs is the rectangle to be compared with
-     *
-     * checks identity within epsilon and @return s a boolean*
-     **/
+    /// Equality operator from an array, convenience function
+    ///
+    /// @param rhs is the mask to be compared with
+    ///
+    /// @returns true if equal
     DETRAY_HOST_DEVICE
     bool operator==(const mask_values& rhs) { return (_values == rhs); }
 
-    /** Equality operator
-     *
-     * @param rhs is the rectangle to be compared with
-     *
-     * checks identity within epsilon and @return s a boolean*
-     **/
+    /// Equality operator
+    ///
+    /// @param rhs is the mask to be compared with
+    ///
+    /// @returns true if equal
     DETRAY_HOST_DEVICE
     bool operator==(const mask_base& rhs) {
-        return (_values == rhs._values && _links == rhs._links);
+        return (_values == rhs._values && _volume_link == rhs._volume_link);
     }
 
-    /** Access operator - non-const
-     * @return the reference to the member variable
-     */
+    /// Access operator - non-const
+    /// @returns the reference to the requested mask value
     DETRAY_HOST_DEVICE
     scalar& operator[](std::size_t value_index) { return _values[value_index]; }
 
-    /** Access operator - const
-     * @return a copy of the member variable
-     */
+    /// Access operator - const
+    /// @returns the reference to the requested mask value
     DETRAY_HOST_DEVICE
     scalar operator[](std::size_t value_index) const {
         return _values[value_index];
     }
 
-    /** Return the values */
+    /// @return the mask values
     DETRAY_HOST_DEVICE
     const mask_values& values() const { return _values; }
 
-    /// Return an associated intersector type
+    /// @return an associated intersector functor
     DETRAY_HOST_DEVICE
     intersector_type intersector() const { return intersector_type{}; };
 
-    /// Return the local frame type
+    /// @return the local frame type
     DETRAY_HOST_DEVICE
     constexpr local_type local() const { return local_type{}; }
 
-    /// @return the links - const reference
-    DETRAY_HOST_DEVICE
-    const links_type& links() const { return _links; }
-
     /// @return the volume link - const reference
     DETRAY_HOST_DEVICE
-    auto volume_link() const { return detail::get<0>(_links); }
+    auto volume_link() const { return _volume_link; }
 
     /// @return the volume link - non-const access
     DETRAY_HOST_DEVICE
-    auto volume_link() { return detail::get<0>(_links); }
-
-    /// @return the surface finder link - const reference
-    DETRAY_HOST_DEVICE
-    auto finder_link() const { return detail::get<1>(_links); }
-
-    /// @return the surface finder link - non-const access
-    DETRAY_HOST_DEVICE
-    auto finder_link() { return detail::get<1>(_links); }
+    auto volume_link() { return _volume_link; }
 
     protected:
     mask_values _values;
-    links_type _links;
+    links_type _volume_link;
 };
 
 }  // namespace detray

--- a/core/include/detray/surface_finders/brute_force_finder.hpp
+++ b/core/include/detray/surface_finders/brute_force_finder.hpp
@@ -1,0 +1,47 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Detray include(s).
+#include "detray/definitions/indexing.hpp"
+#include "detray/definitions/qualifiers.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/memory_resource.hpp>
+
+namespace detray {
+
+/// @brief A surface finder that returns all surfaces in a volume (brute force)
+struct brute_force_finder {
+
+    /// Default constructor
+    brute_force_finder() = default;
+
+    /// Constructor from memory resource: Not needed
+    DETRAY_HOST
+    brute_force_finder(vecmem::memory_resource & /*mr*/) {}
+
+    /// Constructor from a vecmem view: Not needed
+    template <typename view_t,
+              std::enable_if_t<
+                  !std::is_same_v<brute_force_finder, view_t> &&
+                      !std::is_base_of_v<vecmem::memory_resource, view_t>,
+                  bool> = true>
+    DETRAY_HOST_DEVICE brute_force_finder(const view_t & /*view*/) {}
+
+    /// @returns the complete surface range of the search volume
+    template <typename detector_t, typename track_t>
+    DETRAY_HOST_DEVICE dindex_range
+    search(const detector_t & /*det*/,
+           const typename detector_t::volume_type &volume,
+           const track_t & /*track*/) const {
+        return volume.range();
+    }
+};
+
+}  // namespace detray

--- a/core/include/detray/surface_finders/grid2_finder.hpp
+++ b/core/include/detray/surface_finders/grid2_finder.hpp
@@ -1,0 +1,41 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/grids/axis.hpp"
+#include "detray/grids/grid2.hpp"
+#include "detray/grids/populator.hpp"
+#include "detray/grids/serializer2.hpp"
+
+namespace detray {
+
+template <template <typename...> class vector_t = dvector,
+          template <typename...> class jagged_vector_t = djagged_vector,
+          template <typename, std::size_t> class array_t = darray,
+          template <typename...> class tuple_t = dtuple>
+using regular_circular_grid =
+    grid2<attach_populator, axis::regular, axis::circular, serializer2,
+          vector_t, jagged_vector_t, array_t, tuple_t, dindex, false>;
+
+template <template <typename...> class vector_t = dvector,
+          template <typename...> class jagged_vector_t = djagged_vector,
+          template <typename, std::size_t> class array_t = darray,
+          template <typename...> class tuple_t = dtuple>
+using regular_circular_grid2 =
+    grid2<replace_populator, axis::regular, axis::circular, serializer2,
+          vector_t, jagged_vector_t, array_t, tuple_t, dindex, false>;
+
+template <template <typename...> class vector_t = dvector,
+          template <typename...> class jagged_vector_t = djagged_vector,
+          template <typename, std::size_t> class array_t = darray,
+          template <typename...> class tuple_t = dtuple>
+using regular_regular_grid =
+    grid2<attach_populator, axis::regular, axis::regular, serializer2, vector_t,
+          jagged_vector_t, array_t, tuple_t, dindex, false>;
+
+}  // namespace detray

--- a/core/include/detray/surface_finders/neighborhood_kernel.hpp
+++ b/core/include/detray/surface_finders/neighborhood_kernel.hpp
@@ -1,0 +1,37 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/qualifiers.hpp"
+
+namespace detray {
+
+/// A functor to find surfaces in the neighborhood of a track position
+struct neighborhood_getter {
+
+    using output_type = dindex_range;
+
+    /// Call operator that forwards the neighborhood search call in a volume
+    /// to a surface finder data structure
+    template <typename sf_finder_group_t, typename sf_finder_index_t,
+              typename detector_t, typename track_t>
+    DETRAY_HOST_DEVICE inline output_type operator()(
+        const sf_finder_group_t &group, const sf_finder_index_t index,
+        const detector_t &detector,
+        const typename detector_t::volume_type &volume,
+        const track_t &track) const {
+
+        // Get surface finder for volume and perform the surface neighborhood
+        // lookup
+        const auto &sf_finder = group[index];
+        return sf_finder.search(detector, volume, track);
+    }
+};
+
+}  // namespace detray

--- a/core/include/detray/tools/generators.hpp
+++ b/core/include/detray/tools/generators.hpp
@@ -11,15 +11,6 @@
 
 namespace detray {
 
-namespace {
-
-using transform3 = __plugin::transform3<detray::scalar>;
-using point2 = __plugin::point2<detray::scalar>;
-using point3 = __plugin::point3<detray::scalar>;
-using vector3 = __plugin::vector3<detray::scalar>;
-
-}  // anonymous namespace
-
 /** Generate phi values
  *
  * @param start_phi is the start for the arc generation
@@ -28,16 +19,18 @@ using vector3 = __plugin::vector3<detray::scalar>;
  *
  * @return a vector of phi values for the arc
  */
-static inline dvector<scalar> phi_values(scalar start_phi, scalar end_phi,
-                                         unsigned int lseg) {
-    dvector<scalar> values;
+template <typename scalar_t>
+static inline dvector<scalar_t> phi_values(scalar_t start_phi, scalar_t end_phi,
+                                           unsigned int lseg) {
+    dvector<scalar_t> values;
     values.reserve(lseg + 1);
-    scalar step_phi = (end_phi - start_phi) / lseg;
+    scalar_t step_phi = (end_phi - start_phi) / lseg;
     for (unsigned int istep = 0; istep <= lseg; ++istep) {
         values.push_back(start_phi + istep * step_phi);
     }
     return values;
 }
+
 /** Generate vertices, specialized for masks: annulus2
  *
  * @note template types are simply forwarded to mask
@@ -47,26 +40,30 @@ static inline dvector<scalar> phi_values(scalar start_phi, scalar end_phi,
  *
  * @return a generated list of vertices
  */
-template <typename transform3_t, template <class> typename intersector_t,
+template <typename point2_t, typename point3_t, typename transform3_t,
+          template <class> typename intersector_t,
           template <class> typename local_t, typename links_t>
-dvector<point3> vertices(
+dvector<point3_t> vertices(
     const annulus2<transform3_t, intersector_t, local_t, links_t> &annulus_mask,
     unsigned int lseg) {
 
+    using scalar_t = typename transform3_t::scalar_type;
+
     const auto &m_values = annulus_mask.values();
 
-    scalar min_r = m_values[0];
-    scalar max_r = m_values[1];
-    scalar min_phi_rel = m_values[2];
-    scalar max_phi_rel = m_values[3];
-    // scalar avg_phi = m_values[4];
-    scalar origin_x = m_values[5];
-    scalar origin_y = m_values[6];
+    scalar_t min_r = m_values[0];
+    scalar_t max_r = m_values[1];
+    scalar_t min_phi_rel = m_values[2];
+    scalar_t max_phi_rel = m_values[3];
+    // scalar_t avg_phi = m_values[4];
+    scalar_t origin_x = m_values[5];
+    scalar_t origin_y = m_values[6];
 
-    point2 origin_m = {origin_x, origin_y};
+    point2_t origin_m = {origin_x, origin_y};
 
     /// Helper method: find inner outer radius at edges in STRIP PC
-    auto circIx = [](scalar O_x, scalar O_y, scalar r, scalar phi) -> point2 {
+    auto circIx = [](scalar_t O_x, scalar_t O_y, scalar_t r,
+                     scalar_t phi) -> point2_t {
         //                      _____________________________________________
         //                     /      2  2                    2    2  2    2
         //     O_x + O_y*m - \/  - O_x *m  + 2*O_x*O_y*m - O_y  + m *r  + r
@@ -76,50 +73,50 @@ dvector<point3> vertices(
         //
         // y = m*x
         //
-        scalar m = std::tan(phi);
-        point2 dir = {std::cos(phi), std::sin(phi)};
-        scalar x1 =
+        scalar_t m = std::tan(phi);
+        point2_t dir = {std::cos(phi), std::sin(phi)};
+        scalar_t x1 =
             (O_x + O_y * m -
              std::sqrt(-std::pow(O_x, 2) * std::pow(m, 2) + 2 * O_x * O_y * m -
                        std::pow(O_y, 2) + std::pow(m, 2) * std::pow(r, 2) +
                        std::pow(r, 2))) /
             (std::pow(m, 2) + 1);
-        scalar x2 =
+        scalar_t x2 =
             (O_x + O_y * m +
              std::sqrt(-std::pow(O_x, 2) * std::pow(m, 2) + 2 * O_x * O_y * m -
                        std::pow(O_y, 2) + std::pow(m, 2) * std::pow(r, 2) +
                        std::pow(r, 2))) /
             (std::pow(m, 2) + 1);
 
-        point2 v1 = {x1, m * x1};
+        point2_t v1 = {x1, m * x1};
         if (vector::dot(v1, dir) > 0)
             return v1;
         return {x2, m * x2};
     };
 
     // calculate corners in STRIP XY, keep them we need them for minDistance()
-    point2 ul_xy = circIx(origin_x, origin_y, max_r, max_phi_rel);
-    point2 ll_xy = circIx(origin_x, origin_y, min_r, max_phi_rel);
-    point2 ur_xy = circIx(origin_x, origin_y, max_r, min_phi_rel);
-    point2 lr_xy = circIx(origin_x, origin_y, min_r, min_phi_rel);
+    point2_t ul_xy = circIx(origin_x, origin_y, max_r, max_phi_rel);
+    point2_t ll_xy = circIx(origin_x, origin_y, min_r, max_phi_rel);
+    point2_t ur_xy = circIx(origin_x, origin_y, max_r, min_phi_rel);
+    point2_t lr_xy = circIx(origin_x, origin_y, min_r, min_phi_rel);
 
     auto inner_phi = phi_values(getter::phi(ll_xy - origin_m),
                                 getter::phi(lr_xy - origin_m), lseg);
     auto outer_phi = phi_values(getter::phi(ur_xy - origin_m),
                                 getter::phi(ul_xy - origin_m), lseg);
 
-    dvector<point3> annulus_vertices;
+    dvector<point3_t> annulus_vertices;
     annulus_vertices.reserve(inner_phi.size() + outer_phi.size());
     for (auto iphi : inner_phi) {
-        annulus_vertices.push_back(point3{min_r * std::cos(iphi) + origin_x,
-                                          min_r * std::sin(iphi) + origin_y,
-                                          0.});
+        annulus_vertices.push_back(point3_t{min_r * std::cos(iphi) + origin_x,
+                                            min_r * std::sin(iphi) + origin_y,
+                                            0.});
     }
 
     for (auto ophi : outer_phi) {
-        annulus_vertices.push_back(point3{max_r * std::cos(ophi) + origin_x,
-                                          max_r * std::sin(ophi) + origin_y,
-                                          0.});
+        annulus_vertices.push_back(point3_t{max_r * std::cos(ophi) + origin_x,
+                                            max_r * std::sin(ophi) + origin_y,
+                                            0.});
     }
 
     return annulus_vertices;
@@ -134,10 +131,10 @@ dvector<point3> vertices(
  *
  * @return a generated list of vertices
  */
-template <bool kRadialCheck, typename transform3_t,
-          template <class> typename intersector_t,
+template <typename point2_t, typename point3_t, typename transform3_t,
+          bool kRadialCheck, template <class> typename intersector_t,
           template <class> typename local_t, typename links_t>
-dvector<point3> vertices(
+dvector<point3_t> vertices(
     const cylinder3<transform3_t, intersector_t, local_t, links_t, kRadialCheck>
         & /*cylinder_mask*/,
     unsigned int /*lseg*/) {
@@ -154,20 +151,22 @@ dvector<point3> vertices(
  *
  * @return a generated list of vertices
  */
-template <typename transform3_t, template <class> typename intersector_t,
+template <typename point2_t, typename point3_t, typename transform3_t,
+          template <class> typename intersector_t,
           template <class> typename local_t, typename links_t>
-dvector<point3> vertices(const rectangle2<transform3_t, intersector_t, local_t,
-                                          links_t> &rectangle_mask,
-                         unsigned int /*ignored*/) {
+dvector<point3_t> vertices(const rectangle2<transform3_t, intersector_t,
+                                            local_t, links_t> &rectangle_mask,
+                           unsigned int /*ignored*/) {
+
     const auto &m_values = rectangle_mask.values();
     // left hand lower corner
-    point3 lh_lc = {-m_values[0], -m_values[1], 0.};
+    point3_t lh_lc = {-m_values[0], -m_values[1], 0.};
     // right hand lower corner
-    point3 rh_lc = {m_values[0], -m_values[1], 0.};
+    point3_t rh_lc = {m_values[0], -m_values[1], 0.};
     // right hand upper corner
-    point3 rh_uc = {m_values[0], m_values[1], 0.};
+    point3_t rh_uc = {m_values[0], m_values[1], 0.};
     // left hand upper corner
-    point3 lh_uc = {-m_values[0], m_values[1], 0.};
+    point3_t lh_uc = {-m_values[0], m_values[1], 0.};
     return {lh_lc, rh_lc, rh_uc, lh_uc};
     // Return the confining vertices
 }
@@ -181,9 +180,10 @@ dvector<point3> vertices(const rectangle2<transform3_t, intersector_t, local_t,
  *
  * @return a generated list of vertices
  */
-template <typename transform3_t, template <class> typename intersector_t,
+template <typename point2_t, typename point3_t, typename transform3_t,
+          template <class> typename intersector_t,
           template <class> typename local_t, typename links_t>
-dvector<point3> vertices(
+dvector<point3_t> vertices(
     const ring2<transform3_t, intersector_t, local_t, links_t> & /*ring_mask*/,
     unsigned int /*lseg*/) {
     return {};
@@ -198,111 +198,53 @@ dvector<point3> vertices(
  *
  * @return a generated list of vertices
  */
-template <typename transform3_t, template <class> typename intersector_t,
+template <typename point2_t, typename point3_t, typename transform3_t,
+          template <class> typename intersector_t,
           template <class> typename local_t, typename links_t>
-dvector<point3> vertices(const trapezoid2<transform3_t, intersector_t, local_t,
-                                          links_t> &trapezoid_mask,
-                         unsigned int /* ignored */) {
+dvector<point3_t> vertices(const trapezoid2<transform3_t, intersector_t,
+                                            local_t, links_t> &trapezoid_mask,
+                           unsigned int /* ignored */) {
 
     const auto &m_values = trapezoid_mask.values();
     // left hand lower corner
-    point3 lh_lc = {-m_values[0], -m_values[2], 0.};
+    point3_t lh_lc = {-m_values[0], -m_values[2], 0.};
     // right hand lower corner
-    point3 rh_lc = {m_values[0], -m_values[2], 0.};
+    point3_t rh_lc = {m_values[0], -m_values[2], 0.};
     // right hand upper corner
-    point3 rh_uc = {m_values[1], m_values[2], 0.};
+    point3_t rh_uc = {m_values[1], m_values[2], 0.};
     // left hand upper corner
-    point3 lh_uc = {-m_values[1], m_values[2], 0.};
+    point3_t lh_uc = {-m_values[1], m_values[2], 0.};
     // Return the confining vertices
     return {lh_lc, rh_lc, rh_uc, lh_uc};
 }
 
-/** Specialized method to generate vertices per maks group
- *
- * @tparam mask_group_t is the type of the split out mask group from all masks
- * @tparam mask_range_t is the type of the according mask range object
- *
- * @param masks is the associated (and split out) mask group
- * @param range is the range list of masks to be processed
- *
- * @return a jagged vector of points of the mask vertices (one per maks)
- **/
-template <typename mask_group_t, typename mask_range_t>
-auto vertices_for_mask_group(const mask_group_t &masks,
-                             const mask_range_t &range, dindex n_segments = 1) {
-    dvector<dvector<point3>> mask_vertices = {};
-    for (auto i : sequence(range)) {
-        const auto &mask = masks[i];
-        mask_vertices.push_back(vertices(mask, n_segments));
-    }
-    return mask_vertices;
-}
+/// Functor to produce vertices on a mask collection in a mask tuple container.
+template <typename point2_t, typename point3_t>
+struct vertexer {
 
-/** Variadic unrolled intersection - last entry
- *
- * @tparam mask_container_t is the type of the type of the mask container
- * @tparam mask_range_t is the mask range type
- * @tparam last_mask_id is the last mask group id
- *
- * @param masks the masks container
- * @param range the range within the mask group to be checked
- * @param mask_id the last mask group id
- *
- * @return a jagged vector of points of the mask vertices (one per maks)
- **/
-template <typename mask_container_t, typename mask_range_t, dindex last_mask_id>
-auto vertices_for_last_mask_group(const mask_container_t &masks,
-                                  const mask_range_t &range, dindex mask_id) {
-    dvector<dvector<point3>> mask_vertices = {};
-    if (mask_id == last_mask_id) {
-        mask_vertices = vertices_for_mask_group(
-            masks.template group<mask_container_t::to_id(last_mask_id)>(),
-            range);
-    }
-    return mask_vertices;
-}
+    using output_type = dvector<dvector<point3_t>>;
 
-/** Variadic unrolled intersection - any integer sequence
- *
- * @tparam mask_container_t is the type of the type of the mask container
- * @tparam mask_range_t is the mask range type
- * @tparam first_mask_id is the first mask group id
- *
- * @param masks the masks container
- * @param range the range within the mask group to be checked
- * @param mask_id the last mask group id
- * @param available_ids the mask contices to be checked
- *
- * @return a jagged vector of points of the mask vertices (one per maks)
- **/
-template <typename mask_container_t, typename mask_range_t,
-          dindex first_mask_id, dindex... remaining_mask_ids>
-auto unroll_masks_for_vertices(
-    const mask_container_t &masks, const mask_range_t &range, dindex mask_id,
-    std::integer_sequence<dindex, first_mask_id, remaining_mask_ids...>
-    /*available_ids*/) {
-    // Pick the first one for interseciton
-    if (mask_id == first_mask_id) {
-        return vertices_for_mask_group(
-            masks.template group<mask_container_t::to_id(first_mask_id)>(),
-            range);
-    }
-    // The reduced integer sequence
-    std::integer_sequence<dindex, remaining_mask_ids...> remaining;
-    // Unroll as long as you have at least 2 entries
-    if constexpr (remaining.size() > 1) {
-        auto mask_vertices =
-            unroll_masks_for_vertices(masks, range, mask_id, remaining);
-        if (not mask_vertices.empty()) {
-            return mask_vertices;
+    /// Specialized method to generate vertices per maks group
+    ///
+    /// @tparam mask_group_t is the type of the mask collection in a mask cont.
+    /// @tparam mask_range_t is the type of the according mask range object
+    ///
+    /// @param masks is the associated (and split out) mask group
+    /// @param range is the range list of masks to be processed
+    ///
+    /// @return a jagged vector of points of the mask vertices (one per maks)
+    template <typename mask_group_t, typename mask_range_t>
+    output_type operator()(const mask_group_t &masks, const mask_range_t &range,
+                           dindex n_segments = 1) {
+        output_type mask_vertices = {};
+        for (auto i : sequence(range)) {
+            const auto &mask = masks[i];
+            mask_vertices.push_back(
+                vertices<point2_t, point3_t>(mask, n_segments));
         }
+        return mask_vertices;
     }
-    // Last chance - intersect the last index if possible
-    return vertices_for_last_mask_group<
-        mask_container_t, mask_range_t,
-        std::tuple_size_v<typename mask_container_t::container_type> - 1>(
-        masks, range, mask_id);
-}
+};
 
 /** Create a r-phi polygon from principle parameters
  *
@@ -313,16 +255,18 @@ auto unroll_masks_for_vertices(
  *
  * @return a polygon representation of the bin
  **/
-std::vector<point2> r_phi_polygon(scalar rmin, scalar rmax, scalar phimin,
-                                  scalar phimax, unsigned int nsegments = 1) {
+template <typename scalar_t, typename point2_t>
+std::vector<point2_t> r_phi_polygon(scalar_t rmin, scalar_t rmax,
+                                    scalar_t phimin, scalar_t phimax,
+                                    unsigned int nsegments = 1) {
 
-    std::vector<point2> r_phi_poly;
+    std::vector<point2_t> r_phi_poly;
     r_phi_poly.reserve(2 * nsegments + 2);
 
-    scalar cos_min_phi = std::cos(phimin);
-    scalar sin_min_phi = std::sin(phimin);
-    scalar cos_max_phi = std::cos(phimax);
-    scalar sin_max_phi = std::sin(phimax);
+    scalar_t cos_min_phi = std::cos(phimin);
+    scalar_t sin_min_phi = std::sin(phimin);
+    scalar_t cos_max_phi = std::cos(phimax);
+    scalar_t sin_max_phi = std::sin(phimax);
 
     // @TODO add phi generators
     r_phi_poly.push_back({rmin * cos_min_phi, rmin * sin_min_phi});

--- a/core/include/detray/utils/enumerate.hpp
+++ b/core/include/detray/utils/enumerate.hpp
@@ -38,7 +38,12 @@ struct iterator_range {
     DETRAY_HOST_DEVICE iterator_range(const container_t &iterable,
                                       const range_t &range)
         : _start(std::begin(iterable) + detail::get<0>(range)),
-          _end(std::begin(iterable) + detail::get<1>(range)) {}
+          _end(std::begin(iterable) + detail::get<1>(range)) {
+        // Observe end of the iterable
+        if (std::distance(_end, std::end(iterable)) <= 0) {
+            _end = std::end(iterable);
+        }
+    }
 
     /** @return start position of range on container. */
     DETRAY_HOST_DEVICE

--- a/io/csv/include/detray/io/csv_io.hpp
+++ b/io/csv/include/detray/io/csv_io.hpp
@@ -11,10 +11,9 @@
 #include "detray/core/detector.hpp"
 #include "detray/geometry/volume_connector.hpp"
 #include "detray/grids/axis.hpp"
-#include "detray/grids/grid2.hpp"
-#include "detray/grids/populator.hpp"
-#include "detray/grids/serializer2.hpp"
 #include "detray/io/csv_io_types.hpp"
+#include "detray/surface_finders/brute_force_finder.hpp"
+#include "detray/surface_finders/grid2_finder.hpp"
 #include "detray/tools/bin_association.hpp"
 
 // Vecmem include(s)
@@ -26,6 +25,58 @@
 #include <vector>
 
 namespace detray {
+
+namespace {
+
+/// Functor that writes grid entries from the surface finder
+/// container to file
+struct grid_writer {
+    using output_type = bool;
+
+    template <
+        typename grid_group_t, typename grid_index_t, typename grid_entry_t,
+        typename writer_t,
+        std::enable_if_t<not std::is_same_v<typename grid_group_t::value_type,
+                                            brute_force_finder>,
+                         bool> = true>
+    inline output_type operator()(const grid_group_t &grid_group,
+                                  const grid_index_t &grid_idx,
+                                  grid_entry_t &csv_ge,
+                                  writer_t &sge_writer) const {
+
+        const auto &grid = grid_group.at(grid_idx);
+
+        size_t nbins0 = grid.axis_p0().bins();
+        size_t nbins1 = grid.axis_p1().bins();
+        for (size_t b0 = 0; b0 < nbins0; ++b0) {
+            for (size_t b1 = 0; b1 < nbins1; ++b1) {
+                csv_ge.detray_bin0 = b0;
+                csv_ge.detray_bin1 = b1;
+                for (auto e : grid.bin(b0, b1)) {
+                    csv_ge.detray_entry = e;
+                    sge_writer.append(csv_ge);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /// Call for the brute force type (do nothing)
+    template <typename grid_group_t, typename grid_index_t,
+              typename grid_entry_t, typename writer_t,
+              std::enable_if_t<std::is_same_v<typename grid_group_t::value_type,
+                                              brute_force_finder>,
+                               bool> = true>
+    inline output_type operator()(const grid_group_t & /*grid_group*/,
+                                  const grid_index_t & /*grid_idx*/,
+                                  const grid_entry_t & /*csv_ge*/,
+                                  writer_t & /*sge_writer*/) {
+        return true;
+    }
+};
+
+}  // anonymous namespace
 
 /// Function to read the detector from the CSV file
 ///
@@ -67,6 +118,7 @@ detector_from_csv(const std::string &detector_name,
     using alignable_store = static_transform_store<vector_type>;
     using detector_t = detector<detector_registry, array_type, tuple_type,
                                 vector_type, jagged_vector_type>;
+    using vector3_t = typename detector_t::vector3;
 
     name_map[0] = detector_name;
     detector_t d(resource);
@@ -228,81 +280,8 @@ detector_from_csv(const std::string &detector_name,
         return {_r_min, _r_max, _z_min, _z_max, _phi_min, _phi_max};
     };
 
-    // Create the surface finders & reserve
-    std::map<volume_layer_index, dindex> surface_finder_entries;
-
-    using surfaces_finder = typename detector_t::surfaces_finder_type;
-    using surfaces_regular_circular_grid =
-        typename surfaces_finder::surfaces_regular_circular_grid;
-
-    using surfaces_r_axis =
-        typename surfaces_regular_circular_grid::axis_p0_type;
-    using surfaces_z_axis =
-        typename surfaces_regular_circular_grid::axis_p0_type;
-    using surfaces_phi_axis =
-        typename surfaces_regular_circular_grid::axis_p1_type;
-
-    using surfaces_r_phi_grid = surfaces_regular_circular_grid;
-    using surfaces_z_phi_grid = surfaces_regular_circular_grid;
-
-    surfaces_finder &detector_surfaces_finders = d.get_surfaces_finder();
-
-    // (B) Pre-read the grids & create local object finders
-    int sg_counts = 0;
-
-    while (sg_reader.read(io_surface_grid)) {
-        assert(sg_counts <
-               static_cast<int>(detector_t::surfaces_finder_type::N_GRIDS));
-
-        volume_layer_index c_index = {io_surface_grid.volume_id,
-                                      io_surface_grid.layer_id};
-
-        surface_finder_entries[c_index] = detector_surfaces_finders.size();
-
-        bool is_disk = (io_surface_grid.type_loc0 == 3);
-
-        // Prepare z axis parameters
-        scalar _z_min = is_disk ? std::numeric_limits<scalar>::min()
-                                : io_surface_grid.min_loc1;
-        scalar _z_max = is_disk ? std::numeric_limits<scalar>::max()
-                                : io_surface_grid.max_loc1;
-        dindex _z_bins =
-            is_disk ? 1u : static_cast<dindex>(io_surface_grid.nbins_loc1);
-
-        // Prepare r axis parameters
-        scalar _r_min = is_disk ? io_surface_grid.min_loc0 : 0.;
-        scalar _r_max = is_disk ? io_surface_grid.max_loc0
-                                : std::numeric_limits<scalar>::max();
-        dindex _r_bins =
-            is_disk ? static_cast<dindex>(io_surface_grid.nbins_loc0) : 1u;
-
-        // Prepare phi axis parameters
-        scalar _phi_min =
-            is_disk ? io_surface_grid.min_loc1 : io_surface_grid.min_loc0;
-        scalar _phi_max =
-            is_disk ? io_surface_grid.max_loc1 : io_surface_grid.max_loc0;
-        dindex _phi_bins =
-            is_disk ? static_cast<dindex>(io_surface_grid.nbins_loc1)
-                    : static_cast<dindex>(io_surface_grid.nbins_loc0);
-
-        surfaces_z_axis z_axis{_z_bins, _z_min, _z_max, resource};
-        surfaces_r_axis r_axis{_r_bins, _r_min, _r_max, resource};
-        surfaces_phi_axis phi_axis{_phi_bins, _phi_min, _phi_max, resource};
-
-        // negative / positive / inner / outer
-        surfaces_r_phi_grid rphi_grid_n(r_axis, phi_axis, resource);
-        surfaces_r_phi_grid rphi_grid_p(r_axis, phi_axis, resource);
-        surfaces_z_phi_grid zphi_grid_i{z_axis, phi_axis, resource};
-        surfaces_z_phi_grid zphi_grid_o{z_axis, phi_axis, resource};
-
-        detector_surfaces_finders[sg_counts++] = std::move(rphi_grid_n);
-        detector_surfaces_finders[sg_counts++] = std::move(rphi_grid_p);
-        detector_surfaces_finders[sg_counts++] = std::move(zphi_grid_i);
-        detector_surfaces_finders[sg_counts++] = std::move(zphi_grid_o);
-    }
-
     using mask_defs = typename detector_t::masks;
-    typename detector_t::surface_type::edge_type mask_edge{};
+    typename detector_t::surface_type::volume_link_type mask_volume_link{};
     typename mask_defs::link_type mask_index{};
     constexpr auto cylinder_id = mask_defs::id::e_cylinder3;
     constexpr auto rectangle_id = mask_defs::id::e_rectangle2;
@@ -347,21 +326,13 @@ detector_from_csv(const std::string &detector_name,
             auto _volume_bounds =
                 synchronize_bounds(unsynchronized_volume_bounds, is_gap);
 
-            // Check if this volume has a surface finder entry associated
-            dindex surfaces_finder_entry = dindex_invalid;
-            auto surface_finder_itr = surface_finder_entries.find(c_index);
-            if (surface_finder_itr != surface_finder_entries.end()) {
-                surfaces_finder_entry = surface_finder_itr->second;
-            }
-
             std::string volume_name = detector_name;
             volume_name +=
                 std::string("_vol_") + std::to_string(io_surface.volume_id);
             volume_name +=
                 std::string("_lay_") + std::to_string(io_surface.layer_id);
 
-            auto &new_volume =
-                d.new_volume(_volume_bounds, surfaces_finder_entry);
+            auto &new_volume = d.new_volume(_volume_bounds);
 
             name_map[new_volume.index() + 1] = volume_name;
 
@@ -388,9 +359,11 @@ detector_from_csv(const std::string &detector_name,
             const bool is_portal = false;
 
             // Read the transform
-            vector3 t{io_surface.cx, io_surface.cy, io_surface.cz};
-            vector3 x{io_surface.rot_xu, io_surface.rot_yu, io_surface.rot_zu};
-            vector3 z{io_surface.rot_xw, io_surface.rot_yw, io_surface.rot_zw};
+            vector3_t t{io_surface.cx, io_surface.cy, io_surface.cz};
+            vector3_t x{io_surface.rot_xu, io_surface.rot_yu,
+                        io_surface.rot_zu};
+            vector3_t z{io_surface.rot_xw, io_surface.rot_yw,
+                        io_surface.rot_zw};
 
             // Translate the mask & add it to the mask container
             unsigned int bounds_type = io_surface.bounds_type;
@@ -409,11 +382,11 @@ detector_from_csv(const std::string &detector_name,
 
                 // Add a new cylinder mask
                 dindex cylinder_index = c_masks.template size<cylinder_id>();
-                mask_edge = {c_volume->index(), dindex_invalid};
+                mask_volume_link = c_volume->index();
                 c_masks.template add_value<cylinder_id>(
                     io_surface.bound_param0,
                     io_surface.cz - io_surface.bound_param1,
-                    io_surface.cz + io_surface.bound_param1, mask_edge);
+                    io_surface.cz + io_surface.bound_param1, mask_volume_link);
                 // The read is valid: set the index
                 mask_index = {cylinder_id, cylinder_index};
 
@@ -440,7 +413,7 @@ detector_from_csv(const std::string &detector_name,
                 scalar half_y =
                     0.5 * (io_surface.bound_param3 - io_surface.bound_param1);
                 c_masks.template add_value<rectangle_id>(half_x, half_y,
-                                                         mask_edge);
+                                                         mask_volume_link);
                 // The read is valid: set the index
                 mask_index = {rectangle_id, rectangle_index};
 
@@ -462,7 +435,7 @@ detector_from_csv(const std::string &detector_name,
                 dindex trapezoid_index = c_masks.template size<trapezoid_id>();
                 c_masks.template add_value<trapezoid_id>(
                     io_surface.bound_param0, io_surface.bound_param1,
-                    io_surface.bound_param2, mask_edge);
+                    io_surface.bound_param2, mask_volume_link);
 
                 // The read is valid: set the index
                 mask_index = {trapezoid_id, trapezoid_index};
@@ -487,7 +460,7 @@ detector_from_csv(const std::string &detector_name,
                     io_surface.bound_param0, io_surface.bound_param1,
                     io_surface.bound_param2, io_surface.bound_param3,
                     io_surface.bound_param4, io_surface.bound_param5,
-                    io_surface.bound_param6, mask_edge);
+                    io_surface.bound_param6, mask_volume_link);
 
                 // The read is valid: set the index
                 mask_index = {annulus_id, annulus_index};
@@ -505,6 +478,142 @@ detector_from_csv(const std::string &detector_name,
                     is_portal);
             }
         }  // end of exclusion for navigation layers
+    }
+
+    // Create the surface finders & reserve
+    // std::map<volume_layer_index, std::pair<dindex, dindex>>
+    //    surface_finder_entries;
+
+    constexpr auto r_phi_grid_id = detector_t::sf_finders::id::e_r_phi_grid;
+    constexpr auto z_phi_grid_id = detector_t::sf_finders::id::e_z_phi_grid;
+
+    using surfaces_r_phi_grid =
+        typename detector_t::sf_finders::template get_type<r_phi_grid_id>::type;
+    using surfaces_z_phi_grid =
+        typename detector_t::sf_finders::template get_type<z_phi_grid_id>::type;
+
+    using surfaces_r_axis = typename surfaces_r_phi_grid::axis_p0_type;
+    using surfaces_z_axis = typename surfaces_r_phi_grid::axis_p0_type;
+    using surfaces_phi_axis = typename surfaces_r_phi_grid::axis_p1_type;
+
+    const auto &detector_surface_finders = d.sf_finder_store();
+
+    // (B) Pre-read the grids & create local object finders
+    int sg_counts = 0;
+
+    surface_grid_entries_writer sge_writer("grid-entries.csv");
+    bool write_grid_entries =
+        (grid_entries_file_name.find("write") != std::string::npos);
+    bool read_grid_entries =
+        not grid_entries_file_name.empty() and not write_grid_entries and
+        not(grid_entries_file_name.find("none") != std::string::npos);
+
+    while (sg_reader.read(io_surface_grid)) {
+
+        /*volume_layer_index c_index = {io_surface_grid.volume_id,
+                                      io_surface_grid.layer_id};
+
+        surface_finder_entries[c_index] = std::make_pair<dindex, dindex>(
+             io_surface_grid.type_loc0, detector_surfaces_finders.size());*/
+
+        bool is_disk = (io_surface_grid.type_loc0 == 3);
+
+        // Prepare z axis parameters
+        scalar _z_min = is_disk ? std::numeric_limits<scalar>::min()
+                                : io_surface_grid.min_loc1;
+        scalar _z_max = is_disk ? std::numeric_limits<scalar>::max()
+                                : io_surface_grid.max_loc1;
+        dindex _z_bins =
+            is_disk ? 1u : static_cast<dindex>(io_surface_grid.nbins_loc1);
+
+        // Prepare r axis parameters
+        scalar _r_min = is_disk ? io_surface_grid.min_loc0 : 0.;
+        scalar _r_max = is_disk ? io_surface_grid.max_loc0
+                                : std::numeric_limits<scalar>::max();
+        dindex _r_bins =
+            is_disk ? static_cast<dindex>(io_surface_grid.nbins_loc0) : 1u;
+
+        // Prepare phi axis parameters
+        scalar _phi_min =
+            is_disk ? io_surface_grid.min_loc1 : io_surface_grid.min_loc0;
+        scalar _phi_max =
+            is_disk ? io_surface_grid.max_loc1 : io_surface_grid.max_loc0;
+        dindex _phi_bins =
+            is_disk ? static_cast<dindex>(io_surface_grid.nbins_loc1)
+                    : static_cast<dindex>(io_surface_grid.nbins_loc0);
+
+        surfaces_z_axis z_axis{_z_bins, _z_min, _z_max, resource};
+        surfaces_r_axis r_axis{_r_bins, _r_min, _r_max, resource};
+        surfaces_phi_axis phi_axis{_phi_bins, _phi_min, _phi_max, resource};
+
+        typename detector_t::volume_type &vol =
+            d.volume_by_index(io_surface_grid.volume_id);
+        if (is_disk) {
+            assert(
+                sg_counts <
+                static_cast<int>(
+                    detector_surface_finders.template size<r_phi_grid_id>()));
+            surfaces_r_phi_grid r_phi_grid(r_axis, phi_axis, resource);
+            d.template add_grid<surfaces_r_phi_grid, r_phi_grid_id>(vol,
+                                                                    r_phi_grid);
+
+            // Fast option, read the grid entries back in
+            if (read_grid_entries) {
+                surface_grid_entries_reader sge_reader(grid_entries_file_name);
+                csv_surface_grid_entry surface_grid_entry;
+                while (sge_reader.read(surface_grid_entry)) {
+                    // Get the volume bounds for filling
+                    assert(vol.index() ==
+                           static_cast<dindex>(
+                               surface_grid_entry.detray_volume_id));
+                    r_phi_grid.populate(
+                        static_cast<dindex>(surface_grid_entry.detray_bin0),
+                        static_cast<dindex>(surface_grid_entry.detray_bin1),
+                        static_cast<dindex>(surface_grid_entry.detray_entry));
+                }
+            } else {
+                // Auto-fill the grids using the bin association
+                d.fill_grid(surface_default_context, vol, r_phi_grid);
+            }
+        } else {
+            assert(
+                sg_counts <
+                static_cast<int>(
+                    detector_surface_finders.template size<z_phi_grid_id>()));
+            surfaces_z_phi_grid z_phi_grid(z_axis, phi_axis, resource);
+            d.template add_grid<surfaces_z_phi_grid, z_phi_grid_id>(vol,
+                                                                    z_phi_grid);
+
+            // Fast option, read the grid entries back in
+            if (read_grid_entries) {
+                surface_grid_entries_reader sge_reader(grid_entries_file_name);
+                csv_surface_grid_entry surface_grid_entry;
+                while (sge_reader.read(surface_grid_entry)) {
+                    // Get the volume bounds for filling
+                    assert(vol.index() ==
+                           static_cast<dindex>(
+                               surface_grid_entry.detray_volume_id));
+                    z_phi_grid.populate(
+                        static_cast<dindex>(surface_grid_entry.detray_bin0),
+                        static_cast<dindex>(surface_grid_entry.detray_bin1),
+                        static_cast<dindex>(surface_grid_entry.detray_entry));
+                }
+            } else {
+                // Auto-fill the grids using the bin association
+                d.fill_grid(surface_default_context, vol, z_phi_grid);
+            }
+        }
+        ++sg_counts;
+        // negative / positive / inner / outer
+        /*surfaces_r_phi_grid rphi_grid_n(r_axis, phi_axis, resource);
+        surfaces_r_phi_grid rphi_grid_p(r_axis, phi_axis, resource);
+        surfaces_z_phi_grid zphi_grid_i{z_axis, phi_axis, resource};
+        surfaces_z_phi_grid zphi_grid_o{z_axis, phi_axis, resource};
+
+        detector_surfaces_finders[sg_counts++] = std::move(rphi_grid_n);
+        detector_surfaces_finders[sg_counts++] = std::move(rphi_grid_p);
+        detector_surfaces_finders[sg_counts++] = std::move(zphi_grid_i);
+        detector_surfaces_finders[sg_counts++] = std::move(zphi_grid_o);*/
     }
 
     /** Helper method to sort and remove duplicates
@@ -542,14 +651,6 @@ detector_from_csv(const std::string &detector_name,
     // difference
     scalar stepsilon = 1.;
 
-    // Run the bin association and write out
-    surface_grid_entries_writer sge_writer("grid-entries.csv");
-    bool write_grid_entries =
-        (grid_entries_file_name.find("write") != std::string::npos);
-    bool read_grid_entries =
-        not grid_entries_file_name.empty() and not write_grid_entries and
-        not(grid_entries_file_name.find("none") != std::string::npos);
-
     // Loop over the volumes
     // - fill the volume grid
     // - run the bin association
@@ -568,65 +669,26 @@ detector_from_csv(const std::string &detector_name,
         auto z_low = v_grid.axis_p1().borders(izl)[0];
         auto z_high = v_grid.axis_p1().borders(izh)[1];*/
 
-        bool is_cylinder = std::abs(v_bounds[1] - v_bounds[0]) <
-                           std::abs(v_bounds[3] - v_bounds[2]);
-
         for (dindex ir = irl; ir <= irh; ++ir) {
             for (dindex iz = izl; iz <= izh; ++iz) {
                 v_grid.populate(ir, iz, std::move(volume_index));
             }
         }
 
-        dindex sfi = v.surfaces_finder_entry();
+        dindex sfi = v.sf_finder_index();
         if (sfi != dindex_invalid and write_grid_entries) {
-            auto &grid = is_cylinder ? detector_surfaces_finders[sfi + 2]
-                                     : detector_surfaces_finders[sfi];
-            bin_association(surface_default_context, d, v, grid, {0.1, 0.1},
-                            false);
+
+            // bin_association(surface_default_context, d, v, grid, {0.1, 0.1},
+            //                 false);
 
             csv_surface_grid_entry csv_ge;
             csv_ge.detray_volume_id = static_cast<int>(iv);
-            size_t nbins0 = grid.axis_p0().bins();
-            size_t nbins1 = grid.axis_p1().bins();
-            for (size_t b0 = 0; b0 < nbins0; ++b0) {
-                for (size_t b1 = 0; b1 < nbins1; ++b1) {
-                    csv_ge.detray_bin0 = b0;
-                    csv_ge.detray_bin1 = b1;
-                    for (auto e : grid.bin(b0, b1)) {
-                        csv_ge.detray_entry = e;
-                        sge_writer.append(csv_ge);
-                    }
-                }
-            }
+            d.sf_finder_store().template call<grid_writer>(v.sf_finder_link(),
+                                                           csv_ge, sge_writer);
         }
     }
 
-    // Fast option, read the grid entries back in
-    if (read_grid_entries) {
-
-        surface_grid_entries_reader sge_reader(grid_entries_file_name);
-        csv_surface_grid_entry surface_grid_entry;
-        while (sge_reader.read(surface_grid_entry)) {
-            // Get the volume bounds for fillind
-            const auto &v =
-                d.volume_by_index(surface_grid_entry.detray_volume_id);
-            const auto &v_bounds = v.bounds();
-            dindex sfi = v.surfaces_finder_entry();
-            if (sfi != dindex_invalid) {
-                bool is_cylinder = std::abs(v_bounds[1] - v_bounds[0]) <
-                                   std::abs(v_bounds[3] - v_bounds[2]);
-                auto &grid = is_cylinder ? detector_surfaces_finders[sfi + 2]
-                                         : detector_surfaces_finders[sfi];
-                // Fill the entry
-                grid.populate(
-                    static_cast<dindex>(surface_grid_entry.detray_bin0),
-                    static_cast<dindex>(surface_grid_entry.detray_bin1),
-                    static_cast<dindex>(surface_grid_entry.detray_entry));
-            }
-        }
-    }
-
-    // Connect the cylindrical volumes
+    // Connect the cylindrical volumes via portals
     connect_cylindrical_volumes<detector_t, array_type, tuple_type,
                                 vector_type>(d, v_grid);
 

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -112,7 +112,7 @@ static void BM_PROPAGATOR_CUDA(benchmark::State &state) {
 
         // Create navigator candidates buffer
         auto candidates_buffer =
-            create_candidates_buffer(det, tracks.size(), dev_mr);
+            create_candidates_buffer(det, tracks.size(), dev_mr, &mng_mr);
         copy.setup(candidates_buffer);
 
         // Run the propagator test for GPU device

--- a/tests/common/include/tests/common/benchmark_find_volume.inl
+++ b/tests/common/include/tests/common/benchmark_find_volume.inl
@@ -12,10 +12,20 @@
 #include <string>
 #include <vecmem/memory/host_memory_resource.hpp>
 
+#include "tests/common/tools/create_toy_geometry.hpp"
 #include "tests/common/tools/detector_metadata.hpp"
-#include "tests/common/tools/read_geometry.hpp"
+//#include "tests/common/tools/read_geometry.hpp"
 
 using namespace detray;
+
+namespace {
+
+using transform3 = __plugin::transform3<detray::scalar>;
+using point2 = __plugin::point2<detray::scalar>;
+using point3 = __plugin::point3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
+
+}  // namespace
 
 #ifdef DETRAY_BENCHMARKS_REP
 unsigned int gbench_repetitions = DETRAY_BENCHMARKS_REP;
@@ -23,9 +33,13 @@ unsigned int gbench_repetitions = DETRAY_BENCHMARKS_REP;
 unsigned int gbench_repetitions = 0;
 #endif
 
+// Detector configuration
+constexpr std::size_t n_brl_layers{4};
+constexpr std::size_t n_edc_layers{7};
 vecmem::host_memory_resource host_mr;
-auto [d, name_map] =
-    read_from_csv<detector_registry::tml_detector>(tml_files, host_mr);
+auto d = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
+// auto [d, name_map] =
+//     read_from_csv<detector_registry::tml_detector>(tml_files, host_mr);
 
 const unsigned int itest = 10000;
 

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -10,8 +10,9 @@
 #include "detray/intersection/intersection_kernel.hpp"
 #include "detray/tracks/tracks.hpp"
 #include "detray/utils/enumerate.hpp"
+#include "tests/common/tools/create_toy_geometry.hpp"
 #include "tests/common/tools/detector_metadata.hpp"
-#include "tests/common/tools/read_geometry.hpp"
+//#include "tests/common/tools/read_geometry.hpp"
 #include "tests/common/tools/track_generators.hpp"
 
 // Vecmem include(s)
@@ -38,9 +39,13 @@ unsigned int theta_steps = 100;
 unsigned int phi_steps = 100;
 bool stream_file = false;
 
+// Detector configuration
+constexpr std::size_t n_brl_layers{4};
+constexpr std::size_t n_edc_layers{7};
 vecmem::host_memory_resource host_mr;
-auto [d, name_map] =
-    read_from_csv<detector_registry::tml_detector>(tml_files, host_mr);
+auto d = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
+// auto [d, name_map] =
+//     read_from_csv<detector_registry::tml_detector>(tml_files, host_mr);
 
 using detector_t = decltype(d);
 constexpr auto k_surfaces = detector_t::objects::e_surface;
@@ -79,8 +84,8 @@ static void BM_INTERSECT_ALL(benchmark::State &state) {
                 for (const auto sf : range(data_core.surfaces, v)) {
 
                     auto sfi =
-                        data_core.masks.template execute<intersection_update>(
-                            sf.mask_type(), detail::ray(track), sf,
+                        data_core.masks.template call<intersection_update>(
+                            sf.mask(), detail::ray(track), sf,
                             data_core.transforms);
 
                     benchmark::DoNotOptimize(hits);

--- a/tests/common/include/tests/common/core_container.inl
+++ b/tests/common/include/tests/common/core_container.inl
@@ -30,7 +30,7 @@ struct test_func {
     using output_type = std::size_t;
 
     template <typename container_t>
-    output_type operator()(const container_t& gr) {
+    output_type operator()(const container_t& gr, const int /*index*/) {
         return gr.size();
     }
 };
@@ -97,9 +97,9 @@ TEST(container, tuple_vector_container) {
     EXPECT_FLOAT_EQ(container.group<2>()[3], 7.6);
 
     // unrolling test
-    EXPECT_EQ(container.execute<test_func>(0), 5);
-    EXPECT_EQ(container.execute<test_func>(1), 3);
-    EXPECT_EQ(container.execute<test_func>(2), 4);
+    EXPECT_EQ(container.call<test_func>(std::make_pair(0, 0)), 5);
+    EXPECT_EQ(container.call<test_func>(std::make_pair(1, 0)), 3);
+    EXPECT_EQ(container.call<test_func>(std::make_pair(2, 0)), 4);
 }
 
 using grid2r =

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -41,25 +41,23 @@ TEST(detector, detector_kernel) {
     detector_t::mask_container masks(host_mr);
     detector_t::material_container materials(host_mr);
 
-    typename detector_t::surface_type::edge_type mask_edge{0, 0};
-
     /// Surface 0
     point3 t0{0., 0., 0.};
     trfs.emplace_back(ctx0, t0);
-    masks.template add_value<mask_ids::e_rectangle2>(-3., 3., mask_edge);
+    masks.template add_value<mask_ids::e_rectangle2>(-3., 3., 0);
     materials.template add_value<material_ids::e_slab>(gold<scalar>(), 3.);
 
     /// Surface 1
     point3 t1{1., 0., 0.};
     trfs.emplace_back(ctx0, t1);
     masks.template add_value<mask_ids::e_annulus2>(1., 2., 3., 4., 5., 6., 7.,
-                                                   mask_edge);
+                                                   0);
     materials.template add_value<material_ids::e_slab>(tungsten<scalar>(), 12.);
 
     /// Surface 2
     point3 t2{2., 0., 0.};
     trfs.emplace_back(ctx0, t2);
-    masks.template add_value<mask_ids::e_trapezoid2>(1., 2., 3., mask_edge);
+    masks.template add_value<mask_ids::e_trapezoid2>(1., 2., 3., 0);
     materials.template add_value<material_ids::e_rod>(aluminium<scalar>(), 4.);
 
     detector_t d(host_mr);

--- a/tests/common/include/tests/common/geometry_volume.inl
+++ b/tests/common/include/tests/common/geometry_volume.inl
@@ -17,28 +17,36 @@ TEST(ALGEBRA_PLUGIN, volume) {
     using namespace detray;
     using namespace __plugin;
 
-    // dummy types
+    // dummy types for testing
+    enum sf_finder_ids : unsigned int {
+        e_default = 0,
+    };
+
     using surface_t = dindex;
-    // using sf_finder_t = dindex;
+    using sf_finder_t = dindex;
     using object_defs = object_registry<surface_t>;
-    // using sf_finder_defs = default_sf_finder_registry<sf_finder_t>;
-    using volume = volume<object_defs, detray::scalar>;
+    using sf_finder_defs =
+        tuple_array_registry<sf_finder_ids, std::index_sequence<1>,
+                             sf_finder_t>;
+    using volume = volume<object_defs, scalar, sf_finder_defs::link_type>;
 
     // Check construction, setters and getters
     darray<scalar, 6> bounds = {0., 10., -5., 5., -M_PI, M_PI};
     volume v1 = volume(bounds);
     v1.set_index(12345);
-    v1.set_surfaces_finder(12);
+    v1.set_sf_finder({sf_finder_defs::id::e_default, 12});
 
     ASSERT_TRUE(v1.empty());
     ASSERT_TRUE(v1.index() == 12345);
     ASSERT_TRUE(v1.bounds() == bounds);
-    ASSERT_TRUE(v1.surfaces_finder_entry() == 12);
+    ASSERT_TRUE(v1.sf_finder_type() == sf_finder_defs::id::e_default);
+    ASSERT_TRUE(v1.sf_finder_index() == 12);
 
     // Check surface and portal ranges
     dindex_range surface_range{2, 8};
     dindex_range portal_range{8, 24};
     dindex_range full_range{2, 24};
+    sf_finder_defs::link_type sf_finder_link{sf_finder_defs::id::e_default, 12};
     v1.update_range<object_defs::e_surface>(surface_range);
     v1.update_range<object_defs::e_portal>(portal_range);
     ASSERT_TRUE(v1.range<object_defs::e_surface>() == full_range);
@@ -46,12 +54,13 @@ TEST(ALGEBRA_PLUGIN, volume) {
     ASSERT_FALSE(v1.empty());
     ASSERT_EQ(v1.template n_objects<object_defs::e_surface>(), 22);
     ASSERT_EQ(v1.template n_objects<object_defs::e_portal>(), 22);
+    ASSERT_TRUE(v1.sf_finder_link() == sf_finder_link);
 
     // Check copy constructor
     const auto v2 = volume(v1);
     ASSERT_TRUE(v2.index() == 12345);
     ASSERT_TRUE(v2.bounds() == bounds);
-    ASSERT_TRUE(v2.surfaces_finder_entry() == 12);
+    ASSERT_TRUE(v2.sf_finder_link() == sf_finder_link);
     ASSERT_TRUE(v2.template range<object_defs::e_surface>() == full_range);
     ASSERT_TRUE(v2.template range<object_defs::e_portal>() == full_range);
 }

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -13,25 +13,75 @@
 
 using namespace detray;
 
-template <std::size_t current_id = 0, std::size_t n_types = 4,
-          typename container_t, typename link_t>
-inline auto get_edge(const container_t& collection, const link_t& links) {
+namespace {
 
-    if (current_id == detail::get<0>(links)) {
-        auto& group = detail::get<current_id>(collection);
-        return group[detail::get<1>(links)].links();
+/// Functor that returns the volume/sf_finder links of a particluar mask
+/// instance in the mask container of a detector
+struct volume_link_getter {
+    using output_type = dindex;
+
+    template <typename mask_group_t, typename mask_range_t>
+    inline output_type operator()(mask_group_t& mask_group,
+                                  mask_range_t& mask_range) {
+        return mask_group[mask_range].volume_link();
+    }
+};
+
+/// Functor that tests the volume indices of surfaces in the grid
+struct surface_grid_tester {
+    using output_type = bool;
+
+    /// Call for grid types
+    template <
+        typename grid_group_t, typename surface_container_t,
+        std::enable_if_t<not std::is_same_v<typename grid_group_t::value_type,
+                                            brute_force_finder>,
+                         bool> = true>
+    inline output_type operator()(const grid_group_t& grid_group,
+                                  const dindex grid_index,
+                                  const dindex volume_index,
+                                  const surface_container_t& surfaces,
+                                  const darray<dindex, 2>& /*range*/) {
+
+        const auto& sf_grid = grid_group.at(grid_index);
+
+        std::vector<dindex> indices;
+
+        // Check if right volume is linked to surface in grid
+        for (unsigned int i = 0; i < sf_grid.axis_p0().bins(); ++i) {
+            for (unsigned int j = 0; j < sf_grid.axis_p1().bins(); ++j) {
+                auto sf_indices = sf_grid.bin(i, j);
+                for (const auto sf_idx : sf_indices) {
+                    EXPECT_EQ(surfaces.at(sf_idx).volume(), volume_index);
+                    indices.push_back(sf_idx);
+                }
+            }
+        }
+
+        // Check if surface indices are consistent with given range of
+        // modules
+        /*EXPECT_EQ(indices.size(), range[1] - range[0]);
+        for (dindex pti = range[0]; pti < range[1]; ++pti) {
+            EXPECT_TRUE(std::find(indices.begin(), indices.end(), pti) !=
+                        indices.end());
+        }*/
+
+        return true;
     }
 
-    // Next type
-    if constexpr (current_id < n_types - 1) {
-        return get_edge<current_id + 1>(collection, links);
+    /// Call for the brute force type (do nothing)
+    template <typename grid_group_t, typename surface_container_t,
+              std::enable_if_t<std::is_same_v<typename grid_group_t::value_type,
+                                              brute_force_finder>,
+                               bool> = true>
+    inline output_type operator()(const grid_group_t&, const dindex,
+                                  const dindex, const surface_container_t&,
+                                  const darray<dindex, 2>&) {
+        return true;
     }
-    // Group no 0 will always exist
-    using group_t =
-        std::remove_reference_t<decltype(detail::get<0>(collection))>;
-    using edge_t = typename group_t::value_type::links_type;
-    return edge_t{};
-}
+};
+
+}  // anonymous namespace
 
 // This test check the building of the tml based toy geometry
 TEST(ALGEBRA_PLUGIN, toy_geometry) {
@@ -40,7 +90,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     std::size_t n_brl_layers = 4;
     std::size_t n_edc_layers = 3;
 
-    auto toy_det = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
+    const auto toy_det =
+        create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
 
     using detector_t = decltype(toy_det);
     using volume_t = typename detector_t::volume_type;
@@ -49,10 +100,13 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     using mask_link_t = typename detector_t::surface_type::mask_link;
     using material_link_t = typename detector_t::surface_type::material_link;
     using material_ids = typename detector_t::materials::id;
+    using sf_finder_ids = typename detector_t::sf_finders::id;
+    using sf_finder_link_t = typename volume_t::sf_finder_link_type;
+
     context_t ctx{};
     auto& volumes = toy_det.volumes();
     auto& surfaces = toy_det.surfaces();
-    auto& surfaces_finder = toy_det.get_surfaces_finder();
+    // auto& sf_finders = toy_det.sf_finder_store();
     auto& transforms = toy_det.transform_store();
     auto& masks = toy_det.mask_store();
     auto& materials = toy_det.material_store();
@@ -65,24 +119,41 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     auto pixel_mat =
         material_slab<scalar>(silicon_tml<scalar>(), 0.15 * unit_constants::mm);
 
-    /** source link */
-    const dindex inv_sf_finder = dindex_invalid;
-
     /** Link to outer world (leaving detector) */
     const dindex leaving_world = dindex_invalid;
 
     // Check number of geomtery objects
     EXPECT_EQ(volumes.size(), 20);
     EXPECT_EQ(surfaces.size(), 3244);
-    EXPECT_EQ(surfaces_finder.size(), detector_registry::toy_detector::n_grids);
-    EXPECT_EQ(surfaces_finder.effective_size(),
-              n_brl_layers + 2 * n_edc_layers);
+    /*EXPECT_EQ(sf_finders.template size<sf_finder_ids::e_brute_force>(), 1);
+    EXPECT_EQ(sf_finders.template size<sf_finder_ids::e_z_phi_grid>(),
+              n_brl_layers);
+    EXPECT_EQ(sf_finders.template size<sf_finder_ids::e_r_phi_grid>(), 14);*/
     EXPECT_EQ(transforms.size(ctx), 3244);
     EXPECT_EQ(masks.template size<mask_ids::e_rectangle2>(), 2492);
     EXPECT_EQ(masks.template size<mask_ids::e_trapezoid2>(), 648);
     EXPECT_EQ(masks.template size<mask_ids::e_portal_cylinder3>(), 52);
     EXPECT_EQ(masks.template size<mask_ids::e_portal_ring2>(), 52);
     EXPECT_EQ(materials.template size<material_ids::e_slab>(), 3244);
+
+    /** Test the links of a volume.
+     *
+     * @param vol_index volume the modules belong to
+     * @param sf_itr iterator into the surface container, start of the modules
+     * @param range index range of the modules in the surface container
+     * @param trf_index index of the transform (trf container) for the module
+     * @param mask_index type and index of module mask in respective mask cont
+     * @param volume_links links to next volume and next surfaces finder
+     */
+    auto test_volume_links =
+        [&](decltype(volumes.begin())& vol_itr, const dindex vol_index,
+            const darray<scalar, 6>& bounds, const darray<dindex, 2>& range,
+            const sf_finder_link_t& /*sf_finder_link*/) {
+            EXPECT_EQ(vol_itr->index(), vol_index);
+            EXPECT_EQ(vol_itr->bounds(), bounds);
+            EXPECT_EQ(vol_itr->range(), range);
+            // EXPECT_EQ(vol_itr->sf_finder_link(), sf_finder_link);
+        };
 
     /** Test the links of portals (into the next volume or invalid if we leave
      * the detector).
@@ -92,21 +163,22 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
      * @param range index range of the portals in the surface container
      * @param trf_index index of the transform (trf container) for the portal
      * @param mask_index type and index of portal mask in respective mask cont
-     * @param edges links to next volume and next surfaces finder
+     * @param volume_links links to next volume contained in the masks
      */
-    auto test_portal_links = [&](dindex vol_index,
+    auto test_portal_links = [&](const dindex vol_index,
                                  decltype(surfaces.begin())&& sf_itr,
-                                 darray<dindex, 2>& range, dindex trf_index,
-                                 mask_link_t&& mask_index,
+                                 const darray<dindex, 2>& range,
+                                 dindex trf_index, mask_link_t&& mask_link,
                                  material_link_t&& material_index,
                                  const material_slab<scalar>& mat,
-                                 dvector<darray<dindex, 2>>&& edges) {
+                                 const dvector<dindex>&& volume_links) {
         for (dindex pti = range[0]; pti < range[1]; ++pti) {
             EXPECT_EQ(sf_itr->volume(), vol_index);
             EXPECT_EQ(sf_itr->transform(), trf_index);
-            EXPECT_EQ(sf_itr->mask(), mask_index);
-            EXPECT_EQ(get_edge(masks, sf_itr->mask()), edges[pti - range[0]]);
-
+            EXPECT_EQ(sf_itr->mask(), mask_link);
+            const auto volume_link =
+                masks.template call<volume_link_getter>(sf_itr->mask());
+            EXPECT_EQ(volume_link, volume_links[pti - range[0]]);
             EXPECT_EQ(
                 materials
                     .group<material_ids::e_slab>()[sf_itr->material_range()],
@@ -114,7 +186,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
             ++sf_itr;
             ++trf_index;
-            ++mask_index;
+            ++mask_link;
             ++material_index;
         }
     };
@@ -126,21 +198,23 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
      * @param range index range of the modules in the surface container
      * @param trf_index index of the transform (trf container) for the module
      * @param mask_index type and index of module mask in respective mask cont
-     * @param edges links to next volume and next surfaces finder
+     * @param volume_links links to next volume contained in the masks
      */
-    auto test_module_links = [&](dindex vol_index,
+    auto test_module_links = [&](const dindex vol_index,
                                  decltype(surfaces.begin())&& sf_itr,
-                                 darray<dindex, 2>& range, dindex trf_index,
-                                 mask_link_t&& mask_index,
+                                 const darray<dindex, 2>& range,
+                                 dindex trf_index, mask_link_t&& mask_index,
                                  material_link_t&& material_index,
                                  const material_slab<scalar>& mat,
-                                 dvector<darray<dindex, 2>>&& edges) {
+                                 const dvector<dindex>&& volume_links) {
         for (dindex pti = range[0]; pti < range[1]; ++pti) {
             EXPECT_EQ(sf_itr->volume(), vol_index);
             EXPECT_EQ(sf_itr->transform(), trf_index);
             EXPECT_EQ(sf_itr->mask(), mask_index);
             EXPECT_EQ(sf_itr->material(), material_index);
-            EXPECT_EQ(get_edge(masks, sf_itr->mask()), edges[0]);
+            const auto volume_link =
+                masks.template call<volume_link_getter>(sf_itr->mask());
+            EXPECT_EQ(volume_link, volume_links[0]);
             EXPECT_EQ(
                 materials
                     .group<material_ids::e_slab>()[sf_itr->material_range()],
@@ -155,39 +229,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     /** Test the surface grid.
      *
      * @param volume volume of detector being tested
-     * @param sf_finder surface finder of detector
-     * @param sf_container surface container of detector
+     * @param sf_finders surface finder container of detector
+     * @param surfaces surface container of detector
      * @param range index range of the modules in the surface container
      */
-    auto test_surfaces_grid =
+    /*auto test_surfaces_grid =
         [](decltype(volumes.begin())& vol_itr,
-           const typename detector_t::surfaces_finder_type& sf_finder,
-           const typename detector_t::surface_container& sf_container,
+           const typename detector_t::sf_finder_container& sf_finder_cont,
+           const typename detector_t::surface_container& surface_cont,
            darray<dindex, 2>& range) {
-            auto sf_grid = sf_finder[vol_itr->surfaces_finder_entry()];
-
-            std::vector<dindex> indices;
-
-            // Check if right volume is linked to surface in grid
-            for (unsigned int i = 0; i < sf_grid.axis_p0().bins(); ++i) {
-                for (unsigned int j = 0; j < sf_grid.axis_p1().bins(); ++j) {
-                    auto sf_indices = sf_grid.bin(i, j);
-                    for (auto sf_idx : sf_indices) {
-                        EXPECT_EQ(sf_container[sf_idx].volume(),
-                                  vol_itr->index());
-                        indices.push_back(sf_idx);
-                    }
-                }
-            }
-
-            // Check if surface indices are consistent with given range of
-            // modules
-            EXPECT_EQ(indices.size(), range[1] - range[0]);
-            for (dindex pti = range[0]; pti < range[1]; ++pti) {
-                EXPECT_TRUE(std::find(indices.begin(), indices.end(), pti) !=
-                            indices.end());
-            }
-        };
+            // Call test functor
+            sf_finder_cont.template call<surface_grid_tester>(
+                vol_itr->sf_finder_link(), vol_itr->index(), surface_cont,
+                range);
+        };*/
 
     //
     // beampipe
@@ -197,17 +252,16 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     auto vol_itr = volumes.begin();
     darray<scalar, 6> bounds = {0., 27., -825., 825., -M_PI, M_PI};
     darray<dindex, 2> range = {0, 16};
-    EXPECT_EQ(vol_itr->index(), 0);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
-    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
+    sf_finder_link_t sf_finder_link{sf_finder_ids::e_brute_force, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 0, bounds, range, sf_finder_link);
 
     // Check links of beampipe itself
     range = {0, 1};
     test_module_links(vol_itr->index(), surfaces.begin(), range, range[0],
                       {mask_ids::e_cylinder3, 0}, {material_ids::e_slab, 0},
-                      beampipe_mat, {{vol_itr->index(), inv_sf_finder}});
+                      beampipe_mat, {vol_itr->index()});
 
     // Check links of portals
     // cylinder portals
@@ -215,30 +269,19 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 1},
                       {material_ids::e_slab, 1}, portal_mat,
-                      {{1, inv_sf_finder},
-                       {2, inv_sf_finder},
-                       {3, inv_sf_finder},
-                       {4, inv_sf_finder},
-                       {5, inv_sf_finder},
-                       {6, inv_sf_finder},
-                       {7, inv_sf_finder}});
+                      {1, 2, 3, 4, 5, 6, 7});
     range = {8, 14};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 8},
                       {material_ids::e_slab, 8}, portal_mat,
-                      {{14, inv_sf_finder},
-                       {15, inv_sf_finder},
-                       {16, inv_sf_finder},
-                       {17, inv_sf_finder},
-                       {18, inv_sf_finder},
-                       {19, inv_sf_finder}});
+                      {14, 15, 16, 17, 18, 19});
 
     // disc portals
     range = {14, 16};
-    test_portal_links(
-        vol_itr->index(), surfaces.begin() + range[0], range, range[0],
-        {mask_ids::e_portal_ring2, 0}, {material_ids::e_slab, 14}, portal_mat,
-        {{leaving_world, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
+                      range[0], {mask_ids::e_portal_ring2, 0},
+                      {material_ids::e_slab, 14}, portal_mat,
+                      {leaving_world, leaving_world});
 
     //
     // neg endcap (layer 3)
@@ -248,20 +291,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., -825., -815., -M_PI, M_PI};
     range = {16, 128};
-    EXPECT_EQ(vol_itr->index(), 1);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
+    sf_finder_link = {sf_finder_ids::e_r_phi_grid, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 1, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
     range = {16, 124};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_trapezoid2, 0},
                       {material_ids::e_slab, 16}, pixel_mat,
-                      {{vol_itr->index(), inv_sf_finder}});
+                      {vol_itr->index()});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
+    // test_surfaces_grid(vol_itr, sf_finders, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -269,13 +312,13 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 14},
                       {material_ids::e_slab, 124}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {126, 128};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 2},
                       {material_ids::e_slab, 126}, portal_mat,
-                      {{leaving_world, inv_sf_finder}, {2, inv_sf_finder}});
+                      {leaving_world, 2});
 
     //
     // gap
@@ -285,11 +328,10 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., -815., -705., -M_PI, M_PI};
     range = {128, 132};
-    EXPECT_EQ(vol_itr->index(), 2);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
-    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 2, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
@@ -297,13 +339,12 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 16},
                       {material_ids::e_slab, 128}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {130, 132};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 4},
-                      {material_ids::e_slab, 130}, portal_mat,
-                      {{1, inv_sf_finder}, {3, inv_sf_finder}});
+                      {material_ids::e_slab, 130}, portal_mat, {1, 3});
 
     //
     // neg endcap (layer 2)
@@ -313,20 +354,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., -705., -695., -M_PI, M_PI};
     range = {132, 244};
-    EXPECT_EQ(vol_itr->index(), 3);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
+    sf_finder_link = {sf_finder_ids::e_r_phi_grid, 1};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 3, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
     range = {132, 240};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_trapezoid2, 108},
                       {material_ids::e_slab, 132}, pixel_mat,
-                      {{vol_itr->index(), inv_sf_finder}});
+                      {vol_itr->index()});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
+    // test_surfaces_grid(vol_itr, sf_finders, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -334,13 +375,12 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 18},
                       {material_ids::e_slab, 240}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {242, 244};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 6},
-                      {material_ids::e_slab, 242}, portal_mat,
-                      {{2, inv_sf_finder}, {4, inv_sf_finder}});
+                      {material_ids::e_slab, 242}, portal_mat, {2, 4});
 
     //
     // gap
@@ -350,11 +390,10 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., -695., -605., -M_PI, M_PI};
     range = {244, 248};
-    EXPECT_EQ(vol_itr->index(), 4);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
-    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 4, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
@@ -362,13 +401,12 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 20},
                       {material_ids::e_slab, 244}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {246, 248};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 8},
-                      {material_ids::e_slab, 246}, portal_mat,
-                      {{3, inv_sf_finder}, {5, inv_sf_finder}});
+                      {material_ids::e_slab, 246}, portal_mat, {3, 5});
 
     //
     // neg endcap (layer 1)
@@ -378,20 +416,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., -605., -595., -M_PI, M_PI};
     range = {248, 360};
-    EXPECT_EQ(vol_itr->index(), 5);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
+    sf_finder_link = {sf_finder_ids::e_r_phi_grid, 2};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 5, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
     range = {248, 356};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_trapezoid2, 216},
                       {material_ids::e_slab, 248}, pixel_mat,
-                      {{vol_itr->index(), inv_sf_finder}});
+                      {vol_itr->index()});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
+    // test_surfaces_grid(vol_itr, sf_finders, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -399,13 +437,12 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 22},
                       {material_ids::e_slab, 356}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {358, 360};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 10},
-                      {material_ids::e_slab, 358}, portal_mat,
-                      {{4, inv_sf_finder}, {6, inv_sf_finder}});
+                      {material_ids::e_slab, 358}, portal_mat, {4, 6});
 
     //
     // gap
@@ -415,11 +452,10 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., -595., -500., -M_PI, M_PI};
     range = {360, 370};
-    EXPECT_EQ(vol_itr->index(), 6);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
-    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 6, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
@@ -427,20 +463,13 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 24},
                       {material_ids::e_slab, 360}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {362, 370};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 12},
                       {material_ids::e_slab, 362}, portal_mat,
-                      {{5, inv_sf_finder},
-                       {7, inv_sf_finder},
-                       {8, inv_sf_finder},
-                       {9, inv_sf_finder},
-                       {10, inv_sf_finder},
-                       {11, inv_sf_finder},
-                       {12, inv_sf_finder},
-                       {13, inv_sf_finder}});
+                      {5, 7, 8, 9, 10, 11, 12, 13});
 
     //
     // barrel
@@ -454,35 +483,33 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 38., -500., 500, -M_PI, M_PI};
     range = {370, 598};
-    EXPECT_EQ(vol_itr->index(), 7);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_z_phi_grid);
+    sf_finder_link = {sf_finder_ids::e_z_phi_grid, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 7, bounds, range, sf_finder_link);
 
     // Check links of modules
     range = {370, 594};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_rectangle2, 0},
                       {material_ids::e_slab, 370}, pixel_mat,
-                      {{vol_itr->index(), inv_sf_finder}});
+                      {vol_itr->index()});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
+    // test_surfaces_grid(vol_itr, sf_finders, surfaces, range);
 
     // Check links of portals
     // cylinder portals
     range = {594, 596};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 26},
-                      {material_ids::e_slab, 594}, portal_mat,
-                      {{0, inv_sf_finder}, {8, inv_sf_finder}});
+                      {material_ids::e_slab, 594}, portal_mat, {0, 8});
 
     // disc portals
     range = {596, 598};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 20},
-                      {material_ids::e_slab, 596}, portal_mat,
-                      {{6, inv_sf_finder}, {14, inv_sf_finder}});
+                      {material_ids::e_slab, 596}, portal_mat, {6, 14});
 
     //
     // gap
@@ -492,25 +519,22 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {38., 64., -500., 500, -M_PI, M_PI};
     range = {598, 602};
-    EXPECT_EQ(vol_itr->index(), 8);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
-    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 8, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
     range = {598, 600};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 28},
-                      {material_ids::e_slab, 598}, portal_mat,
-                      {{7, inv_sf_finder}, {9, inv_sf_finder}});
+                      {material_ids::e_slab, 598}, portal_mat, {7, 9});
     // disc portals
     range = {600, 602};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 22},
-                      {material_ids::e_slab, 600}, portal_mat,
-                      {{6, inv_sf_finder}, {14, inv_sf_finder}});
+                      {material_ids::e_slab, 600}, portal_mat, {6, 14});
 
     //
     // second layer
@@ -520,35 +544,33 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {64., 80., -500., 500, -M_PI, M_PI};
     range = {602, 1054};
-    EXPECT_EQ(vol_itr->index(), 9);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_z_phi_grid);
+    sf_finder_link = {sf_finder_ids::e_z_phi_grid, 1};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 9, bounds, range, sf_finder_link);
 
     // Check links of modules
     range = {602, 1050};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_rectangle2, 224},
                       {material_ids::e_slab, 602}, pixel_mat,
-                      {{vol_itr->index(), inv_sf_finder}});
+                      {vol_itr->index()});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
+    // test_surfaces_grid(vol_itr, sf_finders, surfaces, range);
 
     // Check links of portals
     // cylinder portals
     range = {1050, 1052};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 30},
-                      {material_ids::e_slab, 1050}, portal_mat,
-                      {{8, inv_sf_finder}, {10, inv_sf_finder}});
+                      {material_ids::e_slab, 1050}, portal_mat, {8, 10});
 
     // disc portals
     range = {1052, 1054};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 24},
-                      {material_ids::e_slab, 1052}, portal_mat,
-                      {{6, inv_sf_finder}, {14, inv_sf_finder}});
+                      {material_ids::e_slab, 1052}, portal_mat, {6, 14});
 
     //
     // gap
@@ -558,25 +580,22 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {80., 108., -500., 500, -M_PI, M_PI};
     range = {1054, 1058};
-    EXPECT_EQ(vol_itr->index(), 10);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
-    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 10, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
     range = {1054, 1056};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 32},
-                      {material_ids::e_slab, 1054}, portal_mat,
-                      {{9, inv_sf_finder}, {11, inv_sf_finder}});
+                      {material_ids::e_slab, 1054}, portal_mat, {9, 11});
     // disc portals
     range = {1056, 1058};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 26},
-                      {material_ids::e_slab, 1056}, portal_mat,
-                      {{6, inv_sf_finder}, {14, inv_sf_finder}});
+                      {material_ids::e_slab, 1056}, portal_mat, {6, 14});
 
     //
     // third layer
@@ -586,35 +605,33 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {108., 124., -500., 500, -M_PI, M_PI};
     range = {1058, 1790};
-    EXPECT_EQ(vol_itr->index(), 11);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_z_phi_grid);
+    sf_finder_link = {sf_finder_ids::e_z_phi_grid, 2};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 11, bounds, range, sf_finder_link);
 
     // Check links of modules
     range = {1058, 1786};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_rectangle2, 672},
                       {material_ids::e_slab, 1058}, pixel_mat,
-                      {{vol_itr->index(), inv_sf_finder}});
+                      {vol_itr->index()});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
+    // test_surfaces_grid(vol_itr, sf_finders, surfaces, range);
 
     // Check links of portals
     // cylinder portals
     range = {1786, 1788};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 34},
-                      {material_ids::e_slab, 1786}, portal_mat,
-                      {{10, inv_sf_finder}, {12, inv_sf_finder}});
+                      {material_ids::e_slab, 1786}, portal_mat, {10, 12});
 
     // disc portals
     range = {1788, 1790};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 28},
-                      {material_ids::e_slab, 1788}, portal_mat,
-                      {{6, inv_sf_finder}, {14, inv_sf_finder}});
+                      {material_ids::e_slab, 1788}, portal_mat, {6, 14});
 
     //
     // gap
@@ -624,25 +641,22 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {124., 164., -500., 500, -M_PI, M_PI};
     range = {1790, 1794};
-    EXPECT_EQ(vol_itr->index(), 12);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
-    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 12, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
     range = {1790, 1792};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 36},
-                      {material_ids::e_slab, 1790}, portal_mat,
-                      {{11, inv_sf_finder}, {13, inv_sf_finder}});
+                      {material_ids::e_slab, 1790}, portal_mat, {11, 13});
     // disc portals
     range = {1792, 1794};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 30},
-                      {material_ids::e_slab, 1792}, portal_mat,
-                      {{6, inv_sf_finder}, {14, inv_sf_finder}});
+                      {material_ids::e_slab, 1792}, portal_mat, {6, 14});
 
     //
     // fourth layer
@@ -652,20 +666,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {164., 180., -500., 500, -M_PI, M_PI};
     range = {1794, 2890};
-    EXPECT_EQ(vol_itr->index(), 13);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_z_phi_grid);
+    sf_finder_link = {sf_finder_ids::e_z_phi_grid, 3};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 13, bounds, range, sf_finder_link);
 
     // Check links of modules
     range = {1794, 2886};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_rectangle2, 1400},
                       {material_ids::e_slab, 1794}, pixel_mat,
-                      {{vol_itr->index(), inv_sf_finder}});
+                      {vol_itr->index()});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
+    // test_surfaces_grid(vol_itr, sf_finders, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -673,14 +687,13 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 38},
                       {material_ids::e_slab, 2886}, portal_mat,
-                      {{12, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {12, leaving_world});
 
     // disc portals
     range = {2888, 2890};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 32},
-                      {material_ids::e_slab, 2888}, portal_mat,
-                      {{6, inv_sf_finder}, {14, inv_sf_finder}});
+                      {material_ids::e_slab, 2888}, portal_mat, {6, 14});
 
     //
     // positive endcap
@@ -694,11 +707,10 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., 500., 595., -M_PI, M_PI};
     range = {2890, 2900};
-    EXPECT_EQ(vol_itr->index(), 14);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
-    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 14, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
@@ -706,20 +718,13 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 40},
                       {material_ids::e_slab, 2890}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {2892, 2900};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 34},
                       {material_ids::e_slab, 2892}, portal_mat,
-                      {{15, inv_sf_finder},
-                       {7, inv_sf_finder},
-                       {8, inv_sf_finder},
-                       {9, inv_sf_finder},
-                       {10, inv_sf_finder},
-                       {11, inv_sf_finder},
-                       {12, inv_sf_finder},
-                       {13, inv_sf_finder}});
+                      {15, 7, 8, 9, 10, 11, 12, 13});
 
     //
     // pos endcap (layer 1)
@@ -729,20 +734,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., 595., 605., -M_PI, M_PI};
     range = {2900, 3012};
-    EXPECT_EQ(vol_itr->index(), 15);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
+    sf_finder_link = {sf_finder_ids::e_r_phi_grid, 3};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 15, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
     range = {2900, 3008};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_trapezoid2, 324},
                       {material_ids::e_slab, 2900}, pixel_mat,
-                      {{vol_itr->index(), inv_sf_finder}});
+                      {vol_itr->index()});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
+    // test_surfaces_grid(vol_itr, sf_finders, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -750,13 +755,12 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 42},
                       {material_ids::e_slab, 3008}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {3010, 3012};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 42},
-                      {material_ids::e_slab, 3010}, portal_mat,
-                      {{14, inv_sf_finder}, {16, inv_sf_finder}});
+                      {material_ids::e_slab, 3010}, portal_mat, {14, 16});
 
     //
     // gap
@@ -766,11 +770,10 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., 605., 695., -M_PI, M_PI};
     range = {3012, 3016};
-    EXPECT_EQ(vol_itr->index(), 16);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
-    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 16, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
@@ -778,13 +781,12 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 44},
                       {material_ids::e_slab, 3012}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {3014, 3016};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 44},
-                      {material_ids::e_slab, 3014}, portal_mat,
-                      {{15, inv_sf_finder}, {17, inv_sf_finder}});
+                      {material_ids::e_slab, 3014}, portal_mat, {15, 17});
 
     //
     // pos endcap (layer 2)
@@ -794,20 +796,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., 695., 705., -M_PI, M_PI};
     range = {3016, 3128};
-    EXPECT_EQ(vol_itr->index(), 17);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
+    sf_finder_link = {sf_finder_ids::e_r_phi_grid, 4};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 17, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
     range = {3016, 3124};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_trapezoid2, 432},
                       {material_ids::e_slab, 3016}, pixel_mat,
-                      {{vol_itr->index(), inv_sf_finder}});
+                      {vol_itr->index()});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
+    // test_surfaces_grid(vol_itr, sf_finders, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -815,13 +817,12 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 46},
                       {material_ids::e_slab, 3124}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {3126, 3128};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 46},
-                      {material_ids::e_slab, 3126}, portal_mat,
-                      {{16, inv_sf_finder}, {18, inv_sf_finder}});
+                      {material_ids::e_slab, 3126}, portal_mat, {16, 18});
 
     //
     // gap
@@ -831,11 +832,10 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., 705., 815., -M_PI, M_PI};
     range = {3128, 3132};
-    EXPECT_EQ(vol_itr->index(), 18);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_no_grid);
-    EXPECT_EQ(vol_itr->surfaces_finder_entry(), dindex_invalid);
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 18, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
@@ -843,13 +843,12 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 48},
                       {material_ids::e_slab, 3128}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {3130, 3132};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 48},
-                      {material_ids::e_slab, 3130}, portal_mat,
-                      {{17, inv_sf_finder}, {19, inv_sf_finder}});
+                      {material_ids::e_slab, 3130}, portal_mat, {17, 19});
 
     //
     // pos endcap (layer 3)
@@ -859,20 +858,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     ++vol_itr;
     bounds = {27., 180., 815., 825., -M_PI, M_PI};
     range = {3132, 3244};
-    EXPECT_EQ(vol_itr->index(), 19);
-    EXPECT_EQ(vol_itr->bounds(), bounds);
-    EXPECT_EQ(vol_itr->range(), range);
-    EXPECT_EQ(vol_itr->get_grid_type(), volume_t::grid_type::e_r_phi_grid);
+    sf_finder_link = {sf_finder_ids::e_r_phi_grid, 5};
+
+    // Test the links in the volumes
+    test_volume_links(vol_itr, 19, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
     range = {3132, 3240};
     test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_trapezoid2, 540},
                       {material_ids::e_slab, 3132}, pixel_mat,
-                      {{vol_itr->index(), inv_sf_finder}});
+                      {vol_itr->index()});
 
     // Check link of surfaces in surface finder
-    test_surfaces_grid(vol_itr, surfaces_finder, surfaces, range);
+    // test_surfaces_grid(vol_itr, sf_finders, surfaces, range);
 
     // Check links of portals
     // cylinder portals
@@ -880,11 +879,11 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_cylinder3, 50},
                       {material_ids::e_slab, 3240}, portal_mat,
-                      {{0, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {0, leaving_world});
     // disc portals
     range = {3242, 3244};
     test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
                       range[0], {mask_ids::e_portal_ring2, 50},
                       {material_ids::e_slab, 3242}, portal_mat,
-                      {{18, inv_sf_finder}, {leaving_world, inv_sf_finder}});
+                      {18, leaving_world});
 }

--- a/tests/common/include/tests/common/tools/create_telescope_detector.hpp
+++ b/tests/common/include/tests/common/tools/create_telescope_detector.hpp
@@ -118,13 +118,13 @@ inline void create_telescope(context_t &ctx, track_t &track, stepper_t &stepper,
                              material_container_t &materials,
                              transform_container_t &transforms, config_t &cfg) {
     using surface_type = typename surface_container_t::value_type;
-    using edge_t = typename surface_type::edge_type;
+    using volume_link_t = typename surface_type::volume_link_type;
     using mask_link_type = typename surface_type::mask_link;
     using material_defs = typename surface_type::material_defs;
     using material_link_type = typename surface_type::material_link;
 
     auto volume_id = volume.index();
-    edge_t mask_edge{volume_id, dindex_invalid};
+    volume_link_t mask_volume_link{volume_id};
     constexpr auto slab_id = material_defs::id::e_slab;
 
     // Create the module centers
@@ -141,24 +141,24 @@ inline void create_telescope(context_t &ctx, track_t &track, stepper_t &stepper,
         const auto trf_index = transforms.size(ctx);
         surfaces.emplace_back(trf_index, mask_link, material_link, volume_id,
                               dindex_invalid, false);
-        surfaces.back().set_grid_status(false);
 
         // The last surface acts as portal that leaves the telescope
         if (m_placement == m_placements.back()) {
-            mask_edge = {dindex_invalid, dindex_invalid};
+            mask_volume_link = dindex_invalid;
         }
 
         if constexpr (mask_id ==
                       telescope_types::mask_ids::e_unbounded_plane2) {
             // No bounds for this module
             masks.template add_value<
-                telescope_types::mask_ids::e_unbounded_plane2>(mask_edge);
+                telescope_types::mask_ids::e_unbounded_plane2>(
+                mask_volume_link);
             materials.template add_value<telescope_types::material_ids::e_slab>(
                 cfg.m_mat, cfg.m_thickness);
         } else {
             // The rectangle bounds for this module
             masks.template add_value<telescope_types::mask_ids::e_rectangle2>(
-                cfg.m_half_x, cfg.m_half_y, mask_edge);
+                cfg.m_half_x, cfg.m_half_y, mask_volume_link);
             materials.template add_value<telescope_types::material_ids::e_slab>(
                 cfg.m_mat, cfg.m_thickness);
         }

--- a/tests/common/include/tests/common/tools/create_toy_geometry.hpp
+++ b/tests/common/include/tests/common/tools/create_toy_geometry.hpp
@@ -41,17 +41,17 @@ using point2 = __plugin::point2<detray::scalar>;
  * @param r raius of the cylinder
  * @param lower_z lower extend in z
  * @param upper_z upper extend in z
- * @param edge link to next volume and surfaces finder
+ * @param volume_link link to next volume for the masks
  */
 template <typename context_t, typename surface_container_t,
           typename mask_container_t, typename material_container_t,
-          typename transform_container_t, typename edge_links>
+          typename transform_container_t, typename volume_links>
 inline void add_cylinder_surface(
     const dindex volume_id, context_t &ctx, surface_container_t &surfaces,
     mask_container_t &masks, material_container_t &materials,
     transform_container_t &transforms, const scalar r, const scalar lower_z,
-    const scalar upper_z, const edge_links edge, const material<scalar> &mat,
-    const scalar thickness) {
+    const scalar upper_z, const volume_links volume_link,
+    const material<scalar> &mat, const scalar thickness) {
     using surface_type = typename surface_container_t::value_type;
     using mask_defs = typename surface_type::mask_defs;
     using mask_link_type = typename surface_type::mask_link;
@@ -61,15 +61,15 @@ inline void add_cylinder_surface(
     constexpr auto cylinder_id = mask_defs::id::e_portal_cylinder3;
     constexpr auto slab_id = material_defs::id::e_slab;
 
-    const scalar min_z = std::min(lower_z, upper_z);
-    const scalar max_z = std::max(lower_z, upper_z);
+    const scalar min_z{std::min(lower_z, upper_z)};
+    const scalar max_z{std::max(lower_z, upper_z)};
 
     // translation
     point3 tsl{0., 0., 0};
 
     // add transform and masks
     transforms.emplace_back(ctx, tsl);
-    masks.template add_value<cylinder_id>(r, min_z, max_z, edge);
+    masks.template add_value<cylinder_id>(r, min_z, max_z, volume_link);
 
     // Add material slab
     materials.template add_value<slab_id>(mat, thickness);
@@ -79,7 +79,7 @@ inline void add_cylinder_surface(
                              masks.template size<cylinder_id>() - 1};
     material_link_type material_link{slab_id,
                                      materials.template size<slab_id>() - 1};
-    const bool is_portal = std::get<0>(edge) != volume_id;
+    const bool is_portal = (volume_link != volume_id);
     surfaces.emplace_back(transforms.size(ctx) - 1, mask_link, material_link,
                           volume_id, dindex_invalid, is_portal);
 }
@@ -96,16 +96,16 @@ inline void add_cylinder_surface(
  * @param min_r lower radius of the disc
  * @param max_r upper radius of the disc
  * @param z z position of the disc
- * @param edge link to next volume and surfaces finder
+ * @param volume_link link to next volume for the masks
  */
 template <typename context_t, typename surface_container_t,
           typename mask_container_t, typename material_container_t,
-          typename transform_container_t, typename edge_links>
+          typename transform_container_t, typename volume_links>
 inline void add_disc_surface(
     const dindex volume_id, context_t &ctx, surface_container_t &surfaces,
     mask_container_t &masks, material_container_t &materials,
     transform_container_t &transforms, const scalar inner_r,
-    const scalar outer_r, const scalar z, const edge_links edge,
+    const scalar outer_r, const scalar z, const volume_links volume_link,
     const material<scalar> &mat, const scalar thickness) {
     using surface_type = typename surface_container_t::value_type;
     using mask_defs = typename surface_type::mask_defs;
@@ -116,15 +116,15 @@ inline void add_disc_surface(
     constexpr auto disc_id = mask_defs::id::e_portal_ring2;
     constexpr auto slab_id = material_defs::id::e_slab;
 
-    const scalar min_r = std::min(inner_r, outer_r);
-    const scalar max_r = std::max(inner_r, outer_r);
+    const scalar min_r{std::min(inner_r, outer_r)};
+    const scalar max_r{std::max(inner_r, outer_r)};
 
     // translation
     point3 tsl{0., 0., z};
 
     // add transform and mask
     transforms.emplace_back(ctx, tsl);
-    masks.template add_value<disc_id>(min_r, max_r, edge);
+    masks.template add_value<disc_id>(min_r, max_r, volume_link);
 
     // Add material slab
     materials.template add_value<slab_id>(mat, thickness);
@@ -133,7 +133,7 @@ inline void add_disc_surface(
     mask_link_type mask_link{disc_id, masks.template size<disc_id>() - 1};
     material_link_type material_link{slab_id,
                                      materials.template size<slab_id>() - 1};
-    const bool is_portal = std::get<0>(edge) != volume_id;
+    const bool is_portal = (volume_link != volume_id);
     surfaces.emplace_back(transforms.size(ctx) - 1, mask_link, material_link,
                           volume_id, dindex_invalid, is_portal);
 }
@@ -151,7 +151,7 @@ inline void add_disc_surface(
  * @param lay_outer_r outer radius of volume
  * @param lay_neg_r lower extend of volume
  * @param lay_pos_r upper extend of volume
- * @param edges volume and surfaces finder links for the portals of the volume
+ * @param volume_links volume links for the portals of the volume
  * @param module_factory functor that adds module surfaces to volume
  */
 
@@ -168,7 +168,8 @@ void create_cyl_volume(
     detector_t &det, vecmem::memory_resource &resource,
     typename detector_t::context &ctx, const scalar lay_inner_r,
     const scalar lay_outer_r, const scalar lay_neg_z, const scalar lay_pos_z,
-    const std::vector<typename detector_t::surface_type::edge_type> &edges,
+    const std::vector<typename detector_t::surface_type::volume_link_type>
+        &volume_links,
     factory_t &module_factory) {
     // volume bounds
     const scalar inner_r = std::min(lay_inner_r, lay_outer_r);
@@ -178,8 +179,7 @@ void create_cyl_volume(
 
     auto &cyl_volume =
         det.new_volume({inner_r, outer_r, lower_z, upper_z, -M_PI, M_PI});
-    typename detector_t::surfaces_finder_type::surfaces_regular_circular_grid
-        cyl_surfaces_grid(resource);
+    cyl_volume.set_sf_finder(detector_t::sf_finders::id::e_default, 0);
 
     // Add module surfaces to volume
     typename detector_t::surface_container surfaces(&resource);
@@ -189,29 +189,23 @@ void create_cyl_volume(
 
     // fill the surfaces
     module_factory(ctx, cyl_volume, surfaces, masks, materials, transforms);
-    // create the surface grid
-    module_factory(cyl_surfaces_grid, *det.resource());
 
     // negative and positive, inner and outer portal surface
     add_cylinder_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
-                         transforms, inner_r, lower_z, upper_z, edges[0],
+                         transforms, inner_r, lower_z, upper_z, volume_links[0],
                          vacuum<scalar>(), 0. * unit_constants::mm);
     add_cylinder_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
-                         transforms, outer_r, lower_z, upper_z, edges[1],
+                         transforms, outer_r, lower_z, upper_z, volume_links[1],
                          vacuum<scalar>(), 0. * unit_constants::mm);
     add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
-                     transforms, inner_r, outer_r, lower_z, edges[2],
+                     transforms, inner_r, outer_r, lower_z, volume_links[2],
                      vacuum<scalar>(), 0. * unit_constants::mm);
     add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
-                     transforms, inner_r, outer_r, upper_z, edges[3],
+                     transforms, inner_r, outer_r, upper_z, volume_links[3],
                      vacuum<scalar>(), 0. * unit_constants::mm);
 
     det.add_objects_per_volume(ctx, cyl_volume, surfaces, masks, materials,
                                transforms);
-    if (cyl_volume.get_grid_type() !=
-        detector_t::volume_type::grid_type::e_no_grid) {
-        det.add_surfaces_grid(ctx, cyl_volume, cyl_surfaces_grid);
-    }
 }
 
 /** Helper function that creates a layer of rectangular barrel modules.
@@ -236,7 +230,7 @@ inline void create_barrel_modules(context_t &ctx, volume_type &vol,
                                   transform_container_t &transforms,
                                   config_t cfg) {
     using surface_type = typename surface_container_t::value_type;
-    using edge_t = typename surface_type::edge_type;
+    using volume_link_t = typename surface_type::volume_link_type;
     using mask_defs = typename surface_type::mask_defs;
     using mask_link_type = typename surface_type::mask_link;
     using material_defs = typename surface_type::material_defs;
@@ -246,9 +240,7 @@ inline void create_barrel_modules(context_t &ctx, volume_type &vol,
     constexpr auto slab_id = material_defs::id::e_slab;
 
     auto volume_id = vol.index();
-    edge_t mask_edge{volume_id, dindex_invalid};
-
-    vol.set_grid_type(volume_type::grid_type::e_z_phi_grid);
+    volume_link_t mask_volume_link{volume_id};
 
     // Create the module centers
 
@@ -260,25 +252,24 @@ inline void create_barrel_modules(context_t &ctx, volume_type &vol,
     m_centers.reserve(n_phi_bins * n_z_bins);
 
     // prep work
-    // scalar pi{static_cast<scalar>(M_PI)};
-    scalar phi_step = 2 * M_PI / (n_phi_bins);
-    scalar min_phi = -M_PI + 0.5 * phi_step;
+    scalar pi{static_cast<scalar>(M_PI)};
+    scalar phi_step{scalar{2} * pi / (n_phi_bins)};
+    scalar min_phi{-pi + scalar{0.5} * phi_step};
 
-    auto z_axis_info = cfg.get_z_axis_info();
-    auto &z_start = std::get<0>(z_axis_info);
-    // auto &z_end = std::get<1>(z_axis_info);
-    auto &z_step = std::get<2>(z_axis_info);
+    scalar z_start{scalar{-0.5} * (n_z_bins - 1) *
+                   (scalar{2} * cfg.m_half_y - cfg.m_long_overlap)};
+    scalar z_step{(std::abs(z_start) - z_start) / (n_z_bins - 1)};
 
     // loop over the z bins
     for (size_t z_bin = 0; z_bin < size_t(n_z_bins); ++z_bin) {
         // prepare z and r
-        scalar m_z = z_start + z_bin * z_step;
-        scalar m_r = (z_bin % 2) != 0u
-                         ? cfg.layer_r - 0.5 * cfg.m_radial_stagger
-                         : cfg.layer_r + 0.5 * cfg.m_radial_stagger;
+        scalar m_z{z_start + z_bin * z_step};
+        scalar m_r{(z_bin % 2) != 0u
+                       ? cfg.layer_r - scalar{0.5} * cfg.m_radial_stagger
+                       : cfg.layer_r + scalar{0.5} * cfg.m_radial_stagger};
         for (size_t phiBin = 0; phiBin < size_t(n_phi_bins); ++phiBin) {
             // calculate the current phi value
-            scalar m_phi = min_phi + phiBin * phi_step;
+            scalar m_phi{min_phi + phiBin * phi_step};
             m_centers.push_back(
                 point3{m_r * std::cos(m_phi), m_r * std::sin(m_phi), m_z});
         }
@@ -295,16 +286,15 @@ inline void create_barrel_modules(context_t &ctx, volume_type &vol,
         const auto trf_index = transforms.size(ctx);
         surfaces.emplace_back(trf_index, mask_link, material_link, volume_id,
                               dindex_invalid, false);
-        surfaces.back().set_grid_status(true);
 
         // The rectangle bounds for this module
         masks.template add_value<rectangle_id>(cfg.m_half_x, cfg.m_half_y,
-                                               mask_edge);
+                                               mask_volume_link);
         materials.template add_value<slab_id>(cfg.mat, cfg.thickness);
 
         // Build the transform
         // The local phi
-        scalar m_phi = algebra::getter::phi(m_center);
+        scalar m_phi{algebra::getter::phi(m_center)};
         // Local z axis is the normal vector
         vector3 m_local_z{std::cos(m_phi + cfg.m_tilt_phi),
                           std::sin(m_phi + cfg.m_tilt_phi), 0.};
@@ -323,24 +313,62 @@ inline void create_barrel_modules(context_t &ctx, volume_type &vol,
  * @param resource vecmem memory resource
  * @param cfg config struct for module creation
  */
-template <typename surfaces_grid_t, typename config_t>
-inline void create_barrel_grid(surfaces_grid_t &surfaces_grid,
-                               vecmem::memory_resource &resource,
-                               config_t cfg) {
-    auto z_axis_info = cfg.get_z_axis_info();
-    auto &z_start = std::get<0>(z_axis_info);
-    auto &z_end = std::get<1>(z_axis_info);
-    auto &z_step = std::get<2>(z_axis_info);
+/*template <typename detector_t, typename config_t>
+inline void add_z_phi_grid(const typename detector_t::context &ctx,
+                           typename detector_t::volume_type &vol,
+                           detector_t &det, vecmem::memory_resource &resource,
+                           const config_t &cfg) {
+    // Get correct grid type
+    constexpr auto grid_id = detector_t::sf_finders::id::e_z_phi_grid;
+    using surface_grid_t =
+        typename detector_t::sf_finders::template get_type<grid_id>::type;
+
+    // return the first z position of module
+    std::size_t n_z_bins = cfg.m_binning.second;
+    scalar z_start{scalar{-0.5} * (n_z_bins - 1) *
+                   (scalar{2} * cfg.m_half_y - cfg.m_long_overlap)};
+    scalar z_end{std::abs(z_start)};
+    scalar z_half_step{scalar{0.5} * (z_end - z_start) / (n_z_bins - 1)};
 
     // add surface grid
-    typename surfaces_grid_t::axis_p0_type z_axis(
-        cfg.m_binning.second, z_start - z_step * 0.5, z_end + z_step * 0.5,
-        resource);
-    typename surfaces_grid_t::axis_p1_type phi_axis(cfg.m_binning.first, -M_PI,
-                                                    M_PI, resource);
+    typename surface_grid_t::axis_p0_type z_axis(
+        n_z_bins, z_start - z_half_step, z_end + z_half_step, resource);
+    typename surface_grid_t::axis_p1_type phi_axis(cfg.m_binning.first, -M_PI,
+                                                   M_PI, resource);
 
-    surfaces_grid = surfaces_grid_t(z_axis, phi_axis, resource);
-}
+    // Add new grid to the detector
+    surface_grid_t z_phi_grid(z_axis, phi_axis, resource);
+    det.template add_sf_finder<surface_grid_t, grid_id>(ctx, vol, z_phi_grid);
+}*/
+
+/** Helper function that creates a surface grid of trapezoidal endcap modules.
+ *
+ * @param vol the detector volume that should be equipped with a grid
+ * @param surfaces_grid the grid to be created with proper axes
+ * @param resource vecmem memory resource
+ * @param cfg config struct for module creation
+ */
+/*template <typename detector_t, typename config_t>
+inline void add_r_phi_grid(const typename detector_t::context &ctx,
+                           typename detector_t::volume_type &vol,
+                           detector_t &det, vecmem::memory_resource &resource,
+                           const config_t &cfg) {
+    // Get correct grid type
+    constexpr auto grid_id = detector_t::sf_finders::id::e_r_phi_grid;
+    using surface_grid_t =
+        typename detector_t::sf_finders::template get_type<grid_id>::type;
+
+    // add surface grid
+    // TODO: What is the proper value of n_phi_bins?
+    typename surface_grid_t::axis_p0_type r_axis(
+        cfg.disc_binning.size(), cfg.inner_r, cfg.outer_r, resource);
+    typename surface_grid_t::axis_p1_type phi_axis(cfg.disc_binning.front(),
+                                                   -M_PI, M_PI, resource);
+
+    // Add new grid to the detector
+    surface_grid_t r_phi_grid(r_axis, phi_axis, resource);
+    det.template add_sf_finder<surface_grid_t, grid_id>(ctx, vol, r_phi_grid);
+}*/
 
 /** Helper method for positioning of modules in an endcap ring
  *
@@ -359,9 +387,9 @@ inline auto module_positions_ring(scalar z, scalar radius, scalar phi_stagger,
     r_positions.reserve(n_phi_bins);
 
     // prep work
-    // scalar pi{static_cast<scalar>(M_PI)};
-    scalar phi_step = scalar{2} * M_PI / (n_phi_bins);
-    scalar min_phi = -M_PI + 0.5 * phi_step;
+    scalar pi{static_cast<scalar>(M_PI)};
+    scalar phi_step{scalar{2} * pi / (n_phi_bins)};
+    scalar min_phi{-pi + scalar{0.5} * phi_step};
 
     for (size_t iphi = 0; iphi < size_t(n_phi_bins); ++iphi) {
         // if we have a phi sub stagger presents
@@ -378,9 +406,10 @@ inline auto module_positions_ring(scalar z, scalar radius, scalar phi_stagger,
             }
         }
         // the module phi
-        scalar phi = min_phi + iphi * phi_step;
+        scalar phi{min_phi + iphi * phi_step};
         // main z position depending on phi bin
-        scalar rz = iphi % 2 ? z - 0.5 * phi_stagger : z + 0.5 * phi_stagger;
+        scalar rz{iphi % 2 ? z - scalar{0.5} * phi_stagger
+                           : z + scalar{0.5} * phi_stagger};
         r_positions.push_back(
             vector3{radius * std::cos(phi), radius * std::sin(phi), rz + rzs});
     }
@@ -408,7 +437,7 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
                            material_container_t &materials,
                            transform_container_t &transforms, config_t cfg) {
     using surface_type = typename surface_container_t::value_type;
-    using edge_t = typename surface_type::edge_type;
+    using volume_link_t = typename surface_type::volume_link_type;
     using mask_defs = typename surface_type::mask_defs;
     using mask_link_type = typename surface_type::mask_link;
     using material_defs = typename surface_type::material_defs;
@@ -418,16 +447,14 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
     constexpr auto slab_id = material_defs::id::e_slab;
 
     auto volume_id = vol.index();
-    edge_t mask_edge{volume_id, dindex_invalid};
-
-    vol.set_grid_type(volume_type::grid_type::e_r_phi_grid);
+    volume_link_t mask_volume_link{volume_id};
 
     // calculate the radii of the rings
     std::vector<scalar> radii;
     // calculate the radial borders
     // std::vector<scalar> radial_boarders;
     // the radial span of the disc
-    scalar delta_r = cfg.outer_r - cfg.inner_r;
+    scalar delta_r{cfg.outer_r - cfg.inner_r};
 
     // Only one ring
     if (cfg.disc_binning.size() == 1) {
@@ -435,16 +462,16 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
         // radial_boarders = {inner_r, outer_r};
     } else {
         // sum up the total length of the modules along r
-        scalar tot_length = 0;
+        scalar tot_length{0};
         for (auto &m_hlength : cfg.m_half_y) {
             tot_length += 2 * m_hlength + 0.5;
         }
         // now calculate the overlap (equal pay)
-        scalar r_overlap = (tot_length - delta_r) / (cfg.m_half_y.size() - 1);
+        scalar r_overlap{(tot_length - delta_r) / (cfg.m_half_y.size() - 1)};
         // and now fill the radii and gaps
-        scalar prev_r = cfg.inner_r;
-        scalar prev_hl = 0.;
-        scalar prev_ol = 0.;
+        scalar prev_r{cfg.inner_r};
+        scalar prev_hl{0};
+        scalar prev_ol{0};
         // remember the radial boarders
         // radial_boarders.push_back(inner_r);
         for (auto &m_hlength : cfg.m_half_y) {
@@ -463,14 +490,14 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
     for (size_t ir = 0; ir < radii.size(); ++ir) {
         // generate the z value
         // convention inner ring is closer to origin : makes sense
-        scalar rz =
+        scalar rz{
             radii.size() == 1
                 ? cfg.edc_position
                 : (ir % 2 ? cfg.edc_position + scalar{0.5} * cfg.ring_stagger
-                          : cfg.edc_position - scalar{0.5} * cfg.ring_stagger);
+                          : cfg.edc_position - scalar{0.5} * cfg.ring_stagger)};
         // fill the ring module positions
-        scalar ps_stagger =
-            cfg.m_phi_sub_stagger.size() ? cfg.m_phi_sub_stagger[ir] : 0.;
+        scalar ps_stagger{
+            cfg.m_phi_sub_stagger.size() ? cfg.m_phi_sub_stagger[ir] : 0};
 
         std::vector<point3> r_postitions =
             module_positions_ring(rz, radii[ir], cfg.m_phi_stagger[ir],
@@ -484,9 +511,9 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
             material_link_type material_link{
                 slab_id, materials.template size<slab_id>()};
 
-            masks.template add_value<trapezoid_id>(cfg.m_half_x_min_y[ir],
-                                                   cfg.m_half_x_max_y[ir],
-                                                   cfg.m_half_y[ir], mask_edge);
+            masks.template add_value<trapezoid_id>(
+                cfg.m_half_x_min_y[ir], cfg.m_half_x_max_y[ir],
+                cfg.m_half_y[ir], mask_volume_link);
 
             materials.template add_value<slab_id>(cfg.mat, cfg.thickness);
 
@@ -494,10 +521,9 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
             surfaces.emplace_back(transforms.size(ctx), mask_link,
                                   material_link, volume_id, dindex_invalid,
                                   false);
-            surfaces.back().set_grid_status(true);
 
             // the module transform from the position
-            scalar m_phi = algebra::getter::phi(m_position);
+            scalar m_phi{algebra::getter::phi(m_position)};
             // the center position of the modules
             point3 m_center{static_cast<scalar>(cfg.side) * m_position};
             // the rotation matrix of the module
@@ -510,26 +536,6 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
             transforms.emplace_back(ctx, m_center, m_local_z, m_local_x);
         }
     }
-}
-
-/** Helper function that creates a surface grid of trapezoidal endcap modules.
- *
- * @param surfaces_grid the grid to be created with proper axes
- * @param resource vecmem memory resource
- * @param cfg config struct for module creation
- */
-template <typename surfaces_grid_t, typename config_t>
-inline void create_endcap_grid(surfaces_grid_t &surfaces_grid,
-                               vecmem::memory_resource &resource,
-                               config_t cfg) {
-    // add surface grid
-    // TODO: WHat is the proper value of n_phi_bins?
-    typename surfaces_grid_t::axis_p0_type r_axis(
-        cfg.disc_binning.size(), cfg.inner_r, cfg.outer_r, resource);
-    typename surfaces_grid_t::axis_p1_type phi_axis(cfg.disc_binning.front(),
-                                                    -M_PI, M_PI, resource);
-
-    surfaces_grid = surfaces_grid_t(r_axis, phi_axis, resource);
 }
 
 /** Helper method for creating a beampipe with enclosing volume.
@@ -552,7 +558,6 @@ inline void add_beampipe(
     const std::pair<scalar, scalar> &beampipe_vol_size, const scalar beampipe_r,
     const scalar brl_half_z, const scalar edc_inner_r) {
 
-    const dindex inv_sf_finder = dindex_invalid;
     const dindex leaving_world = dindex_invalid;
 
     scalar max_z =
@@ -568,12 +573,13 @@ inline void add_beampipe(
         det.new_volume({beampipe_vol_size.first, beampipe_vol_size.second,
                         min_z, max_z, -M_PI, M_PI});
     const auto beampipe_idx = beampipe.index();
+    beampipe.set_sf_finder(detector_t::sf_finders::id::e_default, 0);
 
     // This is the beampipe surface
-    typename detector_t::surface_type::edge_type edge = {beampipe_idx,
-                                                         inv_sf_finder};
+    typename detector_t::surface_type::volume_link_type volume_link{
+        beampipe_idx};
     add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
-                         transforms, beampipe_r, min_z, max_z, edge,
+                         transforms, beampipe_r, min_z, max_z, volume_link,
                          beryllium_tml<scalar>(), 0.8 * unit_constants::mm);
 
     // Get vol sizes in z, including for gap volumes
@@ -587,42 +593,40 @@ inline void add_beampipe(
     vol_sizes.pop_back();
 
     // negative endcap portals
-    unsigned int volume_link = beampipe_idx;
+    dindex link = beampipe_idx;
     for (int i = vol_sizes.size() - 1; i >= 0; --i) {
-        edge = {++volume_link, inv_sf_finder};
+        volume_link = ++link;
         add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
                              transforms, edc_inner_r, -vol_sizes[i].second,
-                             -vol_sizes[i].first, edge, vacuum<scalar>(),
+                             -vol_sizes[i].first, volume_link, vacuum<scalar>(),
                              0. * unit_constants::mm);
     }
+
     // barrel portals
-    if (n_brl_layers <= 0) {
-        edge = {leaving_world, inv_sf_finder};
-    } else {
-        edge = {volume_link + 1, inv_sf_finder};
-    }
+    volume_link = n_brl_layers <= 0 ? leaving_world : link + 1;
     add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
-                         transforms, edc_inner_r, -brl_half_z, brl_half_z, edge,
-                         vacuum<scalar>(), 0. * unit_constants::mm);
+                         transforms, edc_inner_r, -brl_half_z, brl_half_z,
+                         volume_link, vacuum<scalar>(),
+                         0. * unit_constants::mm);
 
     // positive endcap portals
-    volume_link += 7;
+    link += 7;
     for (std::size_t i = 0; i < vol_sizes.size(); ++i) {
-        edge = {++volume_link, inv_sf_finder};
+        volume_link = ++link;
         add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
                              transforms, edc_inner_r, vol_sizes[i].second,
-                             vol_sizes[i].first, edge, vacuum<scalar>(),
+                             vol_sizes[i].first, volume_link, vacuum<scalar>(),
                              0. * unit_constants::mm);
     }
 
     // disc portals
-    edge = {leaving_world, inv_sf_finder};
+    volume_link = leaving_world;
     add_disc_surface(beampipe_idx, ctx, surfaces, masks, materials, transforms,
                      beampipe_vol_size.first, beampipe_vol_size.second, min_z,
-                     edge, vacuum<scalar>(), 0. * unit_constants::mm);
+                     volume_link, vacuum<scalar>(), 0. * unit_constants::mm);
     add_disc_surface(beampipe_idx, ctx, surfaces, masks, materials, transforms,
                      beampipe_vol_size.first, beampipe_vol_size.second, max_z,
-                     edge, vacuum<scalar>(), 0. * unit_constants::mm);
+                     volume_link, vacuum<scalar>(), 0. * unit_constants::mm);
 
     det.add_objects_per_volume(ctx, beampipe, surfaces, masks, materials,
                                transforms);
@@ -664,22 +668,23 @@ inline void add_endcap_barrel_connection(
 
     auto &connector_gap =
         det.new_volume({edc_inner_r, edc_outer_r, min_z, max_z, -M_PI, M_PI});
-    dindex connector_gap_idx = det.volumes().back().index();
-    dindex leaving_world = dindex_invalid, inv_sf_finder = dindex_invalid;
+    connector_gap.set_sf_finder(detector_t::sf_finders::id::e_default, 0);
+    dindex connector_gap_idx{det.volumes().back().index()};
+    dindex leaving_world = dindex_invalid;
 
-    typename detector_t::surface_type::edge_type edge = {beampipe_idx,
-                                                         inv_sf_finder};
+    typename detector_t::surface_type::volume_link_type volume_link = {
+        beampipe_idx};
     add_cylinder_surface(connector_gap_idx, ctx, surfaces, masks, materials,
-                         transforms, edc_inner_r, min_z, max_z, edge,
+                         transforms, edc_inner_r, min_z, max_z, volume_link,
                          vacuum<scalar>(), 0. * unit_constants::mm);
-    edge = {leaving_world, inv_sf_finder};
+    volume_link = leaving_world;
     add_cylinder_surface(connector_gap_idx, ctx, surfaces, masks, materials,
-                         transforms, edc_outer_r, min_z, max_z, edge,
+                         transforms, edc_outer_r, min_z, max_z, volume_link,
                          vacuum<scalar>(), 0. * unit_constants::mm);
-    edge = {edc_vol_idx, inv_sf_finder};
+    volume_link = edc_vol_idx;
     add_disc_surface(connector_gap_idx, ctx, surfaces, masks, materials,
-                     transforms, edc_inner_r, edc_outer_r, edc_disc_z, edge,
-                     vacuum<scalar>(), 0. * unit_constants::mm);
+                     transforms, edc_inner_r, edc_outer_r, edc_disc_z,
+                     volume_link, vacuum<scalar>(), 0. * unit_constants::mm);
 
     // Get vol sizes in z also for gap volumes
     std::vector<std::pair<scalar, scalar>> vol_sizes;
@@ -689,12 +694,12 @@ inline void add_endcap_barrel_connection(
                                brl_lay_sizes[i + 1].first);
     }
 
-    edge = {brl_vol_idx, inv_sf_finder};
+    volume_link = brl_vol_idx;
     for (std::size_t i = 0; i < 2 * n_brl_layers - 1; ++i) {
-        edge = {brl_vol_idx++, inv_sf_finder};
+        volume_link = brl_vol_idx++;
         add_disc_surface(connector_gap_idx, ctx, surfaces, masks, materials,
                          transforms, vol_sizes[i].first, vol_sizes[i].second,
-                         brl_disc_z, edge, vacuum<scalar>(),
+                         brl_disc_z, volume_link, vacuum<scalar>(),
                          0. * unit_constants::mm);
     }
 
@@ -722,47 +727,38 @@ void add_endcap_detector(
     const std::vector<std::pair<scalar, scalar>> &lay_sizes,
     const std::vector<scalar> &lay_positions, config_t cfg) {
 
-    // Generate consecutive linking between volumes (all edges for every vol.)
-    using edge_t = typename detector_t::surface_type::edge_type;
-    std::vector<std::vector<edge_t>> edges_vec;
-    dindex leaving_world = dindex_invalid, inv_sf_finder = dindex_invalid;
+    // Generate consecutive linking between volumes (all volume_links for every
+    // vol.)
+    using volume_link_t = typename detector_t::surface_type::volume_link_type;
+    std::vector<std::vector<volume_link_t>> volume_links_vec;
+    dindex leaving_world = dindex_invalid;
     dindex first_vol_idx = det.volumes().back().index() + 1;
     dindex last_vol_idx = first_vol_idx + 2 * n_layers - 2;
     dindex prev_vol_idx = first_vol_idx - 1;
     dindex next_vol_idx = first_vol_idx + 1;
 
     for (int i = 0; i < 2 * static_cast<int>(n_layers) - 3; ++i) {
-        edges_vec.push_back({{beampipe_idx, inv_sf_finder},
-                             {leaving_world, inv_sf_finder},
-                             {++prev_vol_idx, inv_sf_finder},
-                             {++next_vol_idx, inv_sf_finder}});
+        volume_links_vec.push_back(
+            {beampipe_idx, leaving_world, ++prev_vol_idx, ++next_vol_idx});
     }
     // Edge of the world is flipped
     if (cfg.side < 0) {
-        edges_vec.insert(edges_vec.begin(),
-                         {{beampipe_idx, inv_sf_finder},
-                          {leaving_world, inv_sf_finder},
-                          {leaving_world, inv_sf_finder},
-                          {first_vol_idx + 1, inv_sf_finder}});
+        volume_links_vec.insert(
+            volume_links_vec.begin(),
+            {beampipe_idx, leaving_world, leaving_world, first_vol_idx + 1});
 
-        edges_vec.push_back({{beampipe_idx, inv_sf_finder},
-                             {leaving_world, inv_sf_finder},
-                             {last_vol_idx - 1, inv_sf_finder},
-                             {last_vol_idx + 1, inv_sf_finder}});
+        volume_links_vec.push_back(
+            {beampipe_idx, leaving_world, last_vol_idx - 1, last_vol_idx + 1});
     } else {
         // For n_layers=1 no extra gap layer is needed
         if (n_layers > 1) {
-            edges_vec.insert(edges_vec.begin(),
-                             {{beampipe_idx, inv_sf_finder},
-                              {leaving_world, inv_sf_finder},
-                              {first_vol_idx - 1, inv_sf_finder},
-                              {first_vol_idx + 1, inv_sf_finder}});
+            volume_links_vec.insert(volume_links_vec.begin(),
+                                    {beampipe_idx, leaving_world,
+                                     first_vol_idx - 1, first_vol_idx + 1});
         }
 
-        edges_vec.push_back({{beampipe_idx, inv_sf_finder},
-                             {leaving_world, inv_sf_finder},
-                             {last_vol_idx - 1, inv_sf_finder},
-                             {leaving_world, inv_sf_finder}});
+        volume_links_vec.push_back(
+            {beampipe_idx, leaving_world, last_vol_idx - 1, leaving_world});
     }
 
     // Get vol sizes in z, including gap volumes
@@ -791,14 +787,15 @@ void add_endcap_detector(
             create_cyl_volume(det, resource, ctx, cfg.inner_r, cfg.outer_r,
                               cfg.side * (vol_size_itr + cfg.side * i)->first,
                               cfg.side * (vol_size_itr + cfg.side * i)->second,
-                              edges_vec[i], empty_factory);
+                              volume_links_vec[i], empty_factory);
 
         } else {
             m_factory.cfg.edc_position = *(pos_itr + cfg.side * i / 2);
             create_cyl_volume(det, resource, ctx, cfg.inner_r, cfg.outer_r,
                               cfg.side * (vol_size_itr + cfg.side * i)->first,
                               cfg.side * (vol_size_itr + cfg.side * i)->second,
-                              edges_vec[i], m_factory);
+                              volume_links_vec[i], m_factory);
+            // add_r_phi_grid(ctx, det.volumes().back(), det, resource, cfg);
         }
     }
 }
@@ -826,7 +823,7 @@ void add_barrel_detector(
     const std::vector<std::pair<int, int>> &m_binning, config_t cfg) {
 
     // Generate consecutive linking between volumes
-    dindex leaving_world = dindex_invalid, inv_sf_finder = dindex_invalid;
+    dindex leaving_world = dindex_invalid;
     dindex first_vol_idx = det.volumes().back().index();
     dindex last_vol_idx = first_vol_idx + 2 * n_layers;
     dindex prev_vol_idx = first_vol_idx;
@@ -839,23 +836,17 @@ void add_barrel_detector(
     }
 
     // First barrel layer is connected to the beampipe
-    using edge_t = typename detector_t::surface_type::edge_type;
-    std::vector<std::vector<edge_t>> edges_vec{{{beampipe_idx, inv_sf_finder},
-                                                {next_vol_idx, inv_sf_finder},
-                                                {first_vol_idx, inv_sf_finder},
-                                                {last_vol_idx, inv_sf_finder}}};
+    using volume_link_t = typename detector_t::surface_type::volume_link_type;
+    std::vector<std::vector<volume_link_t>> volume_links_vec{
+        {beampipe_idx, next_vol_idx, first_vol_idx, last_vol_idx}};
 
     for (std::size_t i = 1; i < 2 * n_layers - 2; ++i) {
-        edges_vec.push_back({{++prev_vol_idx, inv_sf_finder},
-                             {++next_vol_idx, inv_sf_finder},
-                             {first_vol_idx, inv_sf_finder},
-                             {last_vol_idx, inv_sf_finder}});
+        volume_links_vec.push_back(
+            {++prev_vol_idx, ++next_vol_idx, first_vol_idx, last_vol_idx});
     }
     // Last barrel layer leaves detector world
-    edges_vec.push_back({{++prev_vol_idx, inv_sf_finder},
-                         {leaving_world, inv_sf_finder},
-                         {first_vol_idx, inv_sf_finder},
-                         {last_vol_idx, inv_sf_finder}});
+    volume_links_vec.push_back(
+        {++prev_vol_idx, leaving_world, first_vol_idx, last_vol_idx});
 
     // Get vol sizes in z, including gap volumes
     std::vector<std::pair<scalar, scalar>> vol_sizes{
@@ -875,13 +866,14 @@ void add_barrel_detector(
         if (is_gap) {
             create_cyl_volume(det, resource, ctx, vol_sizes[i].first,
                               vol_sizes[i].second, -brl_half_z, brl_half_z,
-                              edges_vec[i], empty_factory);
+                              volume_links_vec[i], empty_factory);
         } else {
             m_factory.cfg.m_binning = m_binning[j];
             m_factory.cfg.layer_r = lay_positions[j];
             create_cyl_volume(det, resource, ctx, vol_sizes[i].first,
                               vol_sizes[i].second, -brl_half_z, brl_half_z,
-                              edges_vec[i], m_factory);
+                              volume_links_vec[i], m_factory);
+            // add_z_phi_grid(ctx, det.volumes().back(), det, resource, cfg);
         }
     }
 }
@@ -933,17 +925,6 @@ auto create_toy_geometry(vecmem::memory_resource &resource,
         std::pair<int, int> m_binning = {16, 14};
         material<scalar> mat = silicon_tml<scalar>();
         scalar thickness = 0.15 * unit_constants::mm;
-
-        // return the first z position of module
-        std::tuple<scalar, scalar, scalar> get_z_axis_info() {
-            auto n_z_bins = m_binning.second;
-            scalar z_start{scalar{-0.5} * (n_z_bins - 1) *
-                           (scalar{2} * m_half_y - m_long_overlap)};
-            scalar z_end{std::abs(z_start)};
-            scalar z_step{(z_end - z_start) / (n_z_bins - 1)};
-
-            return {z_start, z_end, z_step};
-        }
     };
 
     //
@@ -984,9 +965,6 @@ auto create_toy_geometry(vecmem::memory_resource &resource,
             typename detector_t::mask_container & /*masks*/,
             typename detector_t::material_container & /*materials*/,
             typename detector_t::transform_container & /*transforms*/) {}
-        void operator()(typename detector_t::surfaces_finder_type::
-                            surfaces_regular_circular_grid & /*surfaces_grid*/,
-                        vecmem::memory_resource & /*resource*/) {}
     };
 
     // Fills volume with barrel layer
@@ -1002,11 +980,6 @@ auto create_toy_geometry(vecmem::memory_resource &resource,
             create_barrel_modules(ctx, volume, surfaces, masks, materials,
                                   transforms, cfg);
         }
-        void operator()(typename detector_t::surfaces_finder_type::
-                            surfaces_regular_circular_grid &surfaces_grid,
-                        vecmem::memory_resource &resource) {
-            create_barrel_grid(surfaces_grid, resource, cfg);
-        }
     };
 
     // Fills volume with endcap rings
@@ -1021,11 +994,6 @@ auto create_toy_geometry(vecmem::memory_resource &resource,
                         typename detector_t::transform_container &transforms) {
             create_endcap_modules(ctx, volume, surfaces, masks, materials,
                                   transforms, cfg);
-        }
-        void operator()(typename detector_t::surfaces_finder_type::
-                            surfaces_regular_circular_grid &surfaces_grid,
-                        vecmem::memory_resource &resource) {
-            create_endcap_grid(surfaces_grid, resource, cfg);
         }
     };
 

--- a/tests/common/include/tests/common/tools/detector_metadata.hpp
+++ b/tests/common/include/tests/common/tools/detector_metadata.hpp
@@ -12,15 +12,13 @@
 #include "detray/core/transform_store.hpp"
 #include "detray/core/type_registry.hpp"
 #include "detray/definitions/indexing.hpp"
-#include "detray/grids/axis.hpp"
-#include "detray/grids/grid2.hpp"
-#include "detray/grids/populator.hpp"
-#include "detray/grids/serializer2.hpp"
 #include "detray/intersection/cylinder_intersector.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/materials/material_rod.hpp"
 #include "detray/materials/material_slab.hpp"
+#include "detray/surface_finders/brute_force_finder.hpp"
+#include "detray/surface_finders/grid2_finder.hpp"
 
 namespace detray {
 
@@ -28,36 +26,36 @@ struct volume_stats {
     std::size_t n_max_objects_per_volume = 0;
 };
 
-/// edge links: next volume, next (local) object finder
-using edge_type = std::array<dindex, 2>;
+/// volume links: next volume during navigation
+using volume_link_type = dindex;
 
 /// mask types
 using rectangle = rectangle2<__plugin::transform3<detray::scalar>,
-                             plane_intersector, cartesian2, edge_type>;
+                             plane_intersector, cartesian2, volume_link_type>;
 using trapezoid = trapezoid2<__plugin::transform3<detray::scalar>,
-                             plane_intersector, cartesian2, edge_type>;
+                             plane_intersector, cartesian2, volume_link_type>;
+// @TODO: Use Polar2?
 using annulus = annulus2<__plugin::transform3<detray::scalar>,
-                         plane_intersector, polar2, edge_type>;
-using cylinder = cylinder3<__plugin::transform3<detray::scalar>,
-                           cylinder_intersector, cylindrical2, edge_type>;
+                         plane_intersector, polar2, volume_link_type>;
+using cylinder =
+    cylinder3<__plugin::transform3<detray::scalar>, cylinder_intersector,
+              cylindrical2, volume_link_type>;
+// @TODO: Use Polar2?
 using disc = ring2<__plugin::transform3<detray::scalar>, plane_intersector,
-                   polar2, edge_type>;
-using unbounded_plane = unmasked<__plugin::transform3<detray::scalar>,
-                                 plane_intersector, cartesian2, edge_type>;
+                   polar2, volume_link_type>;
+using unbounded_plane =
+    unmasked<__plugin::transform3<detray::scalar>, plane_intersector,
+             cartesian2, volume_link_type>;
 
 using slab = material_slab<detray::scalar>;
 using rod = material_rod<detray::scalar>;
 
 /// Defines all available types
-template <typename dynamic_data, std::size_t NGRIDS = 1>
+template <typename dynamic_data, std::size_t kBrlGrids = 1,
+          std::size_t kEdcGrids = 1, std::size_t kDefault = 1>
 struct full_metadata {
 
-    // How many grids have to be built
-    enum grids : std::size_t {
-        n_grids = NGRIDS,
-    };
-
-    // How to store and link transforms
+    /// How to store and link transforms
     template <template <typename...> class vector_t = dvector>
     using transform_store = static_transform_store<vector_t>;
 
@@ -66,7 +64,7 @@ struct full_metadata {
 
     /// Give your mask types a name (needs to be consecutive to be matched
     /// to a type!)
-    enum mask_ids : unsigned int {
+    enum class mask_ids {
         e_rectangle2 = 0,
         e_trapezoid2 = 1,
         e_annulus2 = 2,
@@ -77,14 +75,14 @@ struct full_metadata {
         e_single3 = 5,
     };
 
-    // How to store and link masks
+    /// How to store and link masks
     using mask_definitions =
         tuple_vector_registry<mask_ids, rectangle, trapezoid, annulus, cylinder,
                               disc>;
 
     /// Give your material types a name (needs to be consecutive to be matched
     /// to a type!)
-    enum material_ids : unsigned int {
+    enum class material_ids {
         e_slab = 0,
         e_rod = 1,
     };
@@ -92,7 +90,22 @@ struct full_metadata {
     // How to store and link materials
     using material_definitions = tuple_vector_registry<material_ids, slab, rod>;
 
-    // Accelerator types
+    /// How many grids have to be built
+    enum grids : std::size_t {
+        n_other = kDefault,
+        n_z_phi_grids = kBrlGrids,
+        n_r_phi_grids = kEdcGrids
+    };
+
+    /// Surface finders
+    enum class sf_finder_ids {
+        e_brute_force = 0,  // test all surfaces in a volume (brute force)
+        e_z_phi_grid = 1,   // barrel
+        e_r_phi_grid = 2,   // endcap
+        e_default = e_brute_force,
+    };
+
+    /// Surface finder types
     template <template <typename, std::size_t> class array_t = darray,
               template <typename...> class vector_t = dvector,
               template <typename...> class tuple_t = dtuple,
@@ -106,7 +119,19 @@ struct full_metadata {
               template <typename...> class tuple_t = dtuple,
               template <typename...> class jagged_vector_t = djagged_vector>
     using surface_finder =
-        surfaces_finder<n_grids, array_t, tuple_t, vector_t, jagged_vector_t>;
+        surfaces_finder<n_z_phi_grids + n_r_phi_grids, array_t, tuple_t,
+                        vector_t, jagged_vector_t>;
+
+    template <template <typename, std::size_t> class array_t = darray,
+              template <typename...> class vector_t = dvector,
+              template <typename...> class tuple_t = dtuple,
+              template <typename...> class jagged_vector_t = djagged_vector>
+    using sf_finder_definitions = tuple_array_registry<
+        sf_finder_ids,
+        std::index_sequence<n_other, n_z_phi_grids, n_r_phi_grids>,
+        brute_force_finder,
+        regular_circular_grid<vector_t, jagged_vector_t, array_t, tuple_t>,
+        regular_circular_grid<vector_t, jagged_vector_t, array_t, tuple_t>>;
 
     dynamic_data _data;
 };
@@ -114,12 +139,7 @@ struct full_metadata {
 /// Defines the data types needed for the toy detector
 struct toy_metadata {
 
-    // How many grids have to be built
-    enum grids : std::size_t {
-        n_grids = 20,
-    };
-
-    // How to store and link transforms
+    /// How to store and link transforms
     template <template <typename...> class vector_t = dvector>
     using transform_store = static_transform_store<vector_t>;
 
@@ -128,7 +148,7 @@ struct toy_metadata {
 
     /// Give your mask types a name (needs to be consecutive to be matched
     /// to a type!)
-    enum mask_ids : unsigned int {
+    enum class mask_ids {
         e_rectangle2 = 0,
         e_trapezoid2 = 1,
         e_cylinder3 = 2,         // Put the beampipe into the same container as
@@ -136,20 +156,35 @@ struct toy_metadata {
         e_portal_ring2 = 3,
     };
 
-    // How to store and link masks
+    /// How to store and link masks
     using mask_definitions =
         tuple_vector_registry<mask_ids, rectangle, trapezoid, cylinder, disc>;
 
     /// Give your material types a name (needs to be consecutive to be matched
     /// to a type!)
-    enum material_ids : unsigned int {
+    enum class material_ids {
         e_slab = 0,
     };
 
-    // How to store and link materials
+    /// How to store and link materials
     using material_definitions = tuple_vector_registry<material_ids, slab>;
 
-    // Accelerator types
+    /// How many grids have to be built
+    enum grids : std::size_t {
+        n_other = 1,
+        n_barrel_grids = 4,
+        n_endcap_grids = 14,
+    };
+
+    /// Surface finders
+    enum class sf_finder_ids {
+        e_brute_force = 0,  // test all surfaces in a volume (brute force)
+        e_z_phi_grid = 1,   // barrel
+        e_r_phi_grid = 2,   // endcap
+        e_default = e_brute_force,
+    };
+
+    ///  Surface finder types
     template <template <typename, std::size_t> class array_t = darray,
               template <typename...> class vector_t = dvector,
               template <typename...> class tuple_t = dtuple,
@@ -163,7 +198,19 @@ struct toy_metadata {
               template <typename...> class tuple_t = dtuple,
               template <typename...> class jagged_vector_t = djagged_vector>
     using surface_finder =
-        surfaces_finder<n_grids, array_t, tuple_t, vector_t, jagged_vector_t>;
+        surfaces_finder<n_barrel_grids + n_endcap_grids, array_t, tuple_t,
+                        vector_t, jagged_vector_t>;
+
+    template <template <typename, std::size_t> class array_t = darray,
+              template <typename...> class vector_t = dvector,
+              template <typename...> class tuple_t = dtuple,
+              template <typename...> class jagged_vector_t = djagged_vector>
+    using sf_finder_definitions = tuple_array_registry<
+        sf_finder_ids,
+        std::index_sequence<n_other, n_barrel_grids, n_endcap_grids>,
+        brute_force_finder,
+        regular_circular_grid<vector_t, jagged_vector_t, array_t, tuple_t>,
+        regular_circular_grid<vector_t, jagged_vector_t, array_t, tuple_t>>;
 
     volume_stats _data;
 };
@@ -171,12 +218,7 @@ struct toy_metadata {
 /// Defines a detector with only rectangle/unbounded surfaces
 struct telescope_metadata {
 
-    // How many grids have to be built
-    enum grids : std::size_t {
-        n_grids = 0,
-    };
-
-    // How to store and link transforms
+    /// How to store and link transforms
     template <template <typename...> class vector_t = dvector>
     using transform_store = static_transform_store<vector_t>;
 
@@ -185,25 +227,36 @@ struct telescope_metadata {
 
     /// Give your mask types a name (needs to be consecutive to be matched
     /// to a type!)
-    enum mask_ids : unsigned int {
+    enum class mask_ids {
         e_rectangle2 = 0,
         e_unbounded_plane2 = 1,
     };
 
-    // How to store and link masks
+    /// How to store and link masks
     using mask_definitions =
         tuple_vector_registry<mask_ids, rectangle, unbounded_plane>;
 
     /// Give your material types a name (needs to be consecutive to be matched
     /// to a type!)
-    enum material_ids : unsigned int {
+    enum class material_ids {
         e_slab = 0,
     };
 
-    // How to store and link materials
+    /// How to store and link materials
     using material_definitions = tuple_vector_registry<material_ids, slab>;
 
-    // Accelerator types (are not used)
+    /// How many grids have to be built
+    enum grids : std::size_t {
+        n_other = 1,
+    };
+
+    /// Surface finders
+    enum class sf_finder_ids {
+        e_brute_force = 0,  // test all surfaces in a volume (brute force)
+        e_default = e_brute_force,
+    };
+
+    ///  Surface finder types (are not used in telescope detector)
     template <template <typename, std::size_t> class array_t = darray,
               template <typename...> class vector_t = dvector,
               template <typename...> class tuple_t = dtuple,
@@ -217,7 +270,15 @@ struct telescope_metadata {
               template <typename...> class tuple_t = dtuple,
               template <typename...> class jagged_vector_t = djagged_vector>
     using surface_finder =
-        surfaces_finder<n_grids, array_t, tuple_t, vector_t, jagged_vector_t>;
+        surfaces_finder<n_other, array_t, tuple_t, vector_t, jagged_vector_t>;
+
+    template <template <typename, std::size_t> class array_t = darray,
+              template <typename...> class vector_t = dvector,
+              template <typename...> class tuple_t = dtuple,
+              template <typename...> class jagged_vector_t = djagged_vector>
+    using sf_finder_definitions =
+        tuple_array_registry<sf_finder_ids, std::index_sequence<n_other>,
+                             brute_force_finder>;
 };
 
 struct detector_registry {

--- a/tests/common/include/tests/common/tools/intersectors/helix_intersection_kernel.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_intersection_kernel.hpp
@@ -36,11 +36,11 @@ struct helix_intersection_update {
     ///
     /// @return the intersection
     ///
-    template <typename mask_group_t, typename traj_t, typename surface_t,
-              typename transform_container_t>
+    template <typename mask_group_t, typename mask_range_t, typename traj_t,
+              typename surface_t, typename transform_container_t>
     DETRAY_HOST_DEVICE inline output_type operator()(
-        const mask_group_t &mask_group, const traj_t &traj,
-        const surface_t &surface,
+        const mask_group_t &mask_group, const mask_range_t &mask_range,
+        const traj_t &traj, const surface_t &surface,
         const transform_container_t &contextual_transforms,
         const scalar mask_tolerance = 0.) const {
 
@@ -54,7 +54,6 @@ struct helix_intersection_update {
         using plane_intersector_type = plane_intersector<transform3_type>;
         using cylinder_intersector_type = cylinder_intersector<transform3_type>;
 
-        const auto &mask_range = surface.mask_range();
         const auto &ctf = contextual_transforms[surface.transform()];
 
         // Run over the masks belonged to the surface

--- a/tests/common/include/tests/common/tools/particle_gun.hpp
+++ b/tests/common/include/tests/common/tools/particle_gun.hpp
@@ -57,12 +57,11 @@ struct particle_gun {
                 // NOTE: Change to interection_initialize
                 intersection_type sfi;
                 if constexpr (std::is_same_v<trajectory_t, helix_type>) {
-                    sfi =
-                        mask_store.template execute<helix_intersection_update>(
-                            sf.mask_type(), traj, sf, tf_store, 1e-4);
+                    sfi = mask_store.template call<helix_intersection_update>(
+                        sf.mask(), traj, sf, tf_store, 1e-4);
                 } else {
-                    sfi = mask_store.template execute<intersection_update>(
-                        sf.mask_type(), traj, sf, tf_store);
+                    sfi = mask_store.template call<intersection_update>(
+                        sf.mask(), traj, sf, tf_store);
                 }
                 // Candidate is invalid if it oversteps too far (this is neg!)
                 if (sfi.path < traj.overstep_tolerance()) {

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -72,8 +72,7 @@ TEST(tools, intersection_kernel_ray) {
 
     /// The Surface definition:
     /// <transform_link, volume_link, source_link, link_type_in_mask>
-    using surface_t =
-        surface<mask_defs, material_defs, dindex, dindex, source_link_t>;
+    using surface_t = surface<mask_defs, material_defs, dindex, source_link_t>;
     using surface_container_t = dvector<surface_t>;
 
     // The transforms & their store
@@ -124,17 +123,17 @@ TEST(tools, intersection_kernel_ray) {
     std::vector<line_plane_intersection> sfi_init;
 
     for (const auto& [sf_idx, surface] : enumerate(surfaces)) {
-        mask_store.execute<intersection_initialize>(
-            surface.mask_type(), sfi_init, detail::ray(track), surface,
-            transform_store);
+        mask_store.call<intersection_initialize>(surface.mask(), sfi_init,
+                                                 detail::ray(track), surface,
+                                                 transform_store);
     }
 
     // Update kernel
     std::vector<line_plane_intersection> sfi_update;
 
     for (const auto& [sf_idx, surface] : enumerate(surfaces)) {
-        const auto sfi = mask_store.execute<intersection_update>(
-            surface.mask_type(), detail::ray(track), surface, transform_store);
+        const auto sfi = mask_store.call<intersection_update>(
+            surface.mask(), detail::ray(track), surface, transform_store);
 
         sfi_update.push_back(sfi);
 
@@ -165,8 +164,7 @@ TEST(tools, intersection_kernel_helix) {
 
     /// The Surface definition:
     /// <transform_link, volume_link, source_link, link_type_in_mask>
-    using surface_t =
-        surface<mask_defs, material_defs, dindex, dindex, source_link_t>;
+    using surface_t = surface<mask_defs, material_defs, dindex, source_link_t>;
     using surface_container_t = dvector<surface_t>;
 
     // The transforms & their store
@@ -215,8 +213,8 @@ TEST(tools, intersection_kernel_helix) {
 
     // Try the intersections - with automated dispatching via the kernel
     for (const auto& [sf_idx, surface] : enumerate(surfaces)) {
-        const auto sfi_helix = mask_store.execute<helix_intersection_update>(
-            surface.mask_type(), h, surface, transform_store);
+        const auto sfi_helix = mask_store.call<helix_intersection_update>(
+            surface.mask(), h, surface, transform_store);
 
         ASSERT_NEAR(sfi_helix.p3[0], expected_points[sf_idx][0], 1e-7);
         ASSERT_NEAR(sfi_helix.p3[1], expected_points[sf_idx][1], 1e-7);

--- a/tests/unit_tests/cuda/detector_cuda_kernel.cu
+++ b/tests/unit_tests/cuda/detector_cuda_kernel.cu
@@ -70,8 +70,8 @@ __global__ void detector_test_kernel(
     }
 
     // print output test for surface finder
-    auto& sf_finder_device = det_device.get_surfaces_finder();
-    for (unsigned int i_s = 0; i_s < sf_finder_device.effective_size(); i_s++) {
+    /*auto& sf_finder_device = det_device.sf_finders_store();
+    for (unsigned int i_s = 0; i_s < sf_finder_device.size(); i_s++) {
         auto& grid = sf_finder_device[i_s];
         for (unsigned int i = 0; i < grid.axis_p0().bins(); i++) {
             for (unsigned int j = 0; j < grid.axis_p1().bins(); j++) {
@@ -81,7 +81,7 @@ __global__ void detector_test_kernel(
                 }
             }
         }
-    }
+    }*/
 }
 
 /// implementation of the test function for detector

--- a/tests/unit_tests/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/cuda/navigator_cuda.cpp
@@ -116,7 +116,7 @@ TEST(navigator_cuda, navigator) {
 
     // Create navigator candidates buffer
     auto candidates_buffer =
-        create_candidates_buffer(det, theta_steps * phi_steps, dev_mr);
+        create_candidates_buffer(det, theta_steps * phi_steps, dev_mr, &mng_mr);
     copy.setup(candidates_buffer);
 
     // Run navigator test


### PR DESCRIPTION
Add the tuple array container to the detector and puts the toy detector grids inside (Only works on host so far). Apart from that, a brute force surface finder is also added. All can be accessed with custom type IDs, the same way as it is implemented for the masks. The surface finders can be called from the navigator using a ```neighborhood_kernel```, but for now they always return the complete volume range, until the ```zone``` function of the grid is properly adapted. The grids are built in the toy geometry in dedicated functions and the detector now uses the custom ```bin_association``` to fill surfaces into grids. For now, the grid building in the ```csv_io.hpp``` is commented out until properly implemented in a subsequent PR.

Further small changes:
- the previous ```surface_finder``` class is no longer used in favour of the ```tuple_array_container```. All typedefs are done by the ```type_registry```
- the type ID ```enum```s are no longer implicitly convertible to an index for type safety, but can be converted, if necessary
- Where possible, all code that contains 'unrolling' has been put into functors and is called in the ```tuple_container```.
- the volume index is now fixed to ```dindex```, since this is unlikely to change
- the surface finder link has been removed from the masks, since it is now part of the volume class
- Some minor refactoring (e.g. the edge types are renamed to ```volume_link``` for clarity)
- more elaborate comments on some geometry classes and their template arguments

Edit: For some reason the usage of the detector vecmem resource broke in the navigator jagged vector buffer, so it gets an external host accessible resource now...
