### PR TITLE
Add sign to line intersection

### DIFF
--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -96,7 +96,14 @@ struct line_intersector {
 
         // global to local transform in cartesian coordinate
         auto loc = trf.point_to_local(is.p3);
-        is.p2[0] = getter::perp(loc);
+
+        // assign the sign depending on the position w.r.t line surface
+        // Right: -1
+        // Left: 1
+        const auto r = vector::cross(_z, _d);
+        const scalar sign = vector::dot(r, t2l) > 0. ? -1. : 1.;
+
+        is.p2[0] = sign * getter::perp(loc);
         is.p2[1] = B;
 
         is.status = mask.is_inside(loc, mask_tolerance);

--- a/tests/common/include/tests/common/tools_line_intersection.inl
+++ b/tests/common/include/tests/common/tools_line_intersection.inl
@@ -59,13 +59,13 @@ TEST(tools, line_intersector_case1) {
     EXPECT_EQ(is[0].status, intersection::status::e_inside);
     EXPECT_EQ(is[0].path, 1);
     EXPECT_EQ(is[0].p3, point3({1, 0, 0}));
-    EXPECT_EQ(is[0].p2, point2({1, 0}));
+    EXPECT_EQ(is[0].p2, point2({-1, 0}));  // right
     EXPECT_NEAR(is[0].cos_incidence_angle, 0, tolerance);
 
     EXPECT_EQ(is[1].status, intersection::status::e_inside);
     EXPECT_EQ(is[1].path, 1);
     EXPECT_EQ(is[1].p3, point3({-1, 0, 0}));
-    EXPECT_EQ(is[1].p2, point2({1, 0}));
+    EXPECT_EQ(is[1].p2, point2({1, 0}));  // left
     EXPECT_NEAR(is[1].cos_incidence_angle, 0, tolerance);
 
     EXPECT_EQ(is[2].status, intersection::status::e_inside);
@@ -73,7 +73,7 @@ TEST(tools, line_intersector_case1) {
     EXPECT_NEAR(is[2].p3[0], 1., tolerance);
     EXPECT_NEAR(is[2].p3[1], 0., tolerance);
     EXPECT_NEAR(is[2].p3[2], 1., tolerance);
-    EXPECT_NEAR(is[2].p2[0], 1., tolerance);
+    EXPECT_NEAR(is[2].p2[0], -1., tolerance);  // right
     EXPECT_NEAR(is[2].p2[1], 1., tolerance);
     EXPECT_NEAR(is[2].cos_incidence_angle, 1. / sqrt(2), tolerance);
 }
@@ -104,7 +104,7 @@ TEST(tools, line_intersector_case2) {
     EXPECT_NEAR(is.p3[0], 1., tolerance);
     EXPECT_NEAR(is.p3[1], 1., tolerance);
     EXPECT_NEAR(is.p3[2], 0., tolerance);
-    EXPECT_NEAR(is.p2[0], 1. / std::sqrt(2), tolerance);
+    EXPECT_NEAR(is.p2[0], -1. / std::sqrt(2), tolerance);  // right
     EXPECT_NEAR(is.p2[1], -1. / std::sqrt(2), tolerance);
 }
 
@@ -151,21 +151,32 @@ TEST(tools, line_intersector_square_scope) {
     EXPECT_NEAR(is[0].p3[0], 1, tolerance);
     EXPECT_NEAR(is[0].p3[1], 1, tolerance);
     EXPECT_NEAR(is[0].p3[2], 0, tolerance);
-    EXPECT_NEAR(is[0].p2[0], std::sqrt(2), tolerance);
+    EXPECT_NEAR(is[0].p2[0], -1 * std::sqrt(2), tolerance);
     EXPECT_NEAR(is[0].p2[1], 0, tolerance);
 
     EXPECT_EQ(is[1].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[1].p2[0] < 0);
     EXPECT_EQ(is[2].status, intersection::status::e_outside);
+    EXPECT_TRUE(is[2].p2[0] < 0);
 
     EXPECT_EQ(is[3].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[3].p2[0] > 0);
     EXPECT_EQ(is[4].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[4].p2[0] > 0);
     EXPECT_EQ(is[5].status, intersection::status::e_outside);
+    EXPECT_TRUE(is[5].p2[0] > 0);
 
     EXPECT_EQ(is[6].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[6].p2[0] > 0);
     EXPECT_EQ(is[7].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[7].p2[0] > 0);
     EXPECT_EQ(is[8].status, intersection::status::e_outside);
+    EXPECT_TRUE(is[8].p2[0] > 0);
 
     EXPECT_EQ(is[9].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[9].p2[0] < 0);
     EXPECT_EQ(is[10].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[10].p2[0] < 0);
     EXPECT_EQ(is[11].status, intersection::status::e_outside);
+    EXPECT_TRUE(is[11].p2[0] < 0);
 }


### PR DESCRIPTION
Added a sign to line intersection as ACTS does. This is required when we recover the global position from local-to-global transform.
negative sign is given when the track intersects the line in the right side, and vice versa.