### PR TITLE
Change CMake logic for integrating covfie

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,19 @@ if( DETRAY_SETUP_BENCHMARK )
    endif()
 endif()
 
-add_subdirectory( extern/covfie )
+# Set up covfie.
+option( DETRAY_SETUP_COVFIE
+   "Set up the covfie target(s) explicitly" TRUE )
+option( DETRAY_USE_SYSTEM_COVFIE
+   "Pick up an existing installation of covfie from the build environment"
+   FALSE )
+if( DETRAY_SETUP_COVFIE )
+   if( DETRAY_USE_SYSTEM_COVFIE )
+      find_package( covfie REQUIRED )
+   else()
+      add_subdirectory( extern/covfie )
+   endif()
+endif()
 
 # Set up all of the libraries of the project.
 add_subdirectory( core )

--- a/extern/covfie/CMakeLists.txt
+++ b/extern/covfie/CMakeLists.txt
@@ -13,20 +13,21 @@ message( STATUS "Fetching covfie as part of the Detray project" )
 
 # Declare where to get covfie from.
 set( DETRAY_COVFIE_SOURCE
-   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.2.0.tar.gz;URL_MD5;7cf83f2a4d5dcc3dad8fb952cef36fd4"
+   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.3.0.tar.gz;URL_MD5;1b0052deb194978e34b583ba5084cb1f"
    CACHE STRING "Source for covfie, when built as part of this project" )
 mark_as_advanced( DETRAY_COVFIE_SOURCE )
 FetchContent_Declare( covfie ${DETRAY_COVFIE_SOURCE} )
 
 # Options used for covfie.
-set( COVFIE_BUILD_EXAMPLES Off CACHE BOOL "Build covfie examples")
-set( COVFIE_BUILD_TESTS Off CACHE BOOL "Build covfie tests")
-set( COVFIE_BUILD_BENCHMARKS Off CACHE BOOL "Build covfie benchmarks")
+set( COVFIE_BUILD_EXAMPLES OFF CACHE BOOL "Build covfie examples")
+set( COVFIE_BUILD_TESTS OFF CACHE BOOL "Build covfie tests")
+set( COVFIE_BUILD_BENCHMARKS OFF CACHE BOOL "Build covfie benchmarks")
 
-set( COVFIE_PLATFORM_CPU On CACHE BOOL "Enable covfie CPU platform")
-set( COVFIE_PLATFORM_CUDA On CACHE BOOL "Enable covfie CUDA platform")
+set( COVFIE_PLATFORM_CPU ON CACHE BOOL "Enable covfie CPU platform")
+set( COVFIE_PLATFORM_CUDA ON CACHE BOOL "Enable covfie CUDA platform")
 
-set( COVFIE_REQUIRE_CXX20 Off CACHE BOOL "Enable covfie C++20 requirement")
+set( COVFIE_REQUIRE_CXX20 OFF CACHE BOOL "Enable covfie C++20 requirement")
+set( COVFIE_QUIET ON CACHE BOOL "Quiet covfie feature warnings")
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( covfie )


### PR DESCRIPTION
By request of @krasznaa, this commit makes three changes:

1. Updates covfie to version 0.3.0;
2. Silences warnings about missing compiler features;
3. Allow use of existing covfie installations.