### PR TITLE
Thrust Setup Update, main branch (2022.09.13.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,6 @@ if( DETRAY_SETUP_ACTSVG )
    endif()
 endif()
 
-
 # Set up dfelibs.
 option( DETRAY_SETUP_DFELIBS
    "Set up the dfelibs target(s) explicitly" TRUE )
@@ -132,13 +131,13 @@ if( DETRAY_SETUP_THRUST )
    else()
       add_subdirectory( extern/thrust )
    endif()
-   # Set up an IMPORTED library on top of the Thrust library/libraries. One that
-   # the Detray code could depend on publicly.
-   set( DETRAY_THRUST_OPTIONS "" CACHE STRING
-      "Extra options for configuring how Thrust should be used" )
-   mark_as_advanced( DETRAY_THRUST_OPTIONS )
-   thrust_create_target( detray::Thrust ${DETRAY_THRUST_OPTIONS} )
 endif()
+# Set up an IMPORTED library on top of the Thrust library/libraries. One that
+# the Detray code could depend on publicly.
+set( DETRAY_THRUST_OPTIONS "" CACHE STRING
+   "Extra options for configuring how Thrust should be used" )
+mark_as_advanced( DETRAY_THRUST_OPTIONS )
+thrust_create_target( detray::Thrust ${DETRAY_THRUST_OPTIONS} )
 
 # Set up GoogleTest.
 option( DETRAY_SETUP_GOOGLETEST


### PR DESCRIPTION
Made the code set up the `detray::Thrust` target under all circumstances.

If [Thrust](https://github.com/NVIDIA/thrust) is provided by the project that is building Detray "as a part of itself", we still need to create the `detray::Thrust` target. (At that point the `thrust_create_target(...)` function needs to be provided by the "parent project".)

This is in preparation of [traccc](https://github.com/acts-project/traccc) making use of [Thrust](https://github.com/NVIDIA/thrust) as well.