### PR TITLE
CMake 3.24 Compatibility, main branch (2022.09.13.)

### DIFF
--- a/extern/actsvg/CMakeLists.txt
+++ b/extern/actsvg/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building actsvg as part of the Detray project" )
 

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building Algebra Plugins as part of the Detray project" )
 

--- a/extern/benchmark/CMakeLists.txt
+++ b/extern/benchmark/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.11 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building Google Benchmark as part of the Detray project" )
 

--- a/extern/covfie/CMakeLists.txt
+++ b/extern/covfie/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Fetching covfie as part of the Detray project" )
 

--- a/extern/dfelibs/CMakeLists.txt
+++ b/extern/dfelibs/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.11 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building dfelibs as part of the Detray project" )
 

--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.11 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building GoogleTest as part of the Detray project" )
 

--- a/extern/thrust/CMakeLists.txt
+++ b/extern/thrust/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building Thrust as part of the Detray project" )
 

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.14 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building VecMem as part of the Detray project" )
 


### PR DESCRIPTION
Explicitly set the [CMP0135 policy](https://cmake.org/cmake/help/latest/policy/CMP0135.html). This is to silence the following new warning that showed up when using CMake 3.24.

```
CMake Warning (dev) at /atlas/software/cmake/3.24.1/x86_64-ubuntu2004-gcc9-opt/share/cmake-3.24/Modules/FetchContent.cmake:1264 (message):                                                                        
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is                              
  not set.  The policy's OLD behavior will be used.  When using a URL                                    
  download, the timestamps of extracted files should preferably be that of                               
  the time of extraction, otherwise code that depends on the extracted                                   
  contents might not be rebuilt if the URL changes.  The OLD behavior                                    
  preserves the timestamps from the archive instead, but this is usually not                             
  what you want.  Update your project to the NEW behavior or specify the                                 
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this                                   
  robustness issue.                                                                                      
Call Stack (most recent call first):                                                                     
  extern/covfie/CMakeLists.txt:19 (FetchContent_Declare)                                                 
This warning is for project developers.  Use -Wno-dev to suppress it.
```