### PR TITLE
Option1: Remove `std::iterator` inheritance deprecated in macos-12

### DIFF
--- a/tests/common/include/tests/common/tools/track_generators.hpp
+++ b/tests/common/include/tests/common/tools/track_generators.hpp
@@ -33,7 +33,7 @@ class uniform_track_generator
     using vector3 = __plugin::vector3<detray::scalar>;
 
     /// @brief Nested iterator type that generates track states.
-    struct iterator : public std::iterator<std::input_iterator_tag, track_t> {
+    struct iterator {
 
         iterator() = default;
 


### PR DESCRIPTION
@niermann999 Looks like inheriting `std::iterator` has been deprecated as proposed in [P1074](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0174r1.html#2.1)

It seems the `macos-latest` of github action starts not allowing it from today or yesterday. You will see the build error in every PR.

Problem is that I don't know how to deal with `iota.hpp` which also contains `std::iterator` inheritance