### PR TITLE
ref: Remove std::iterator inheritance as it is deprecated in c++17

### DIFF
--- a/core/include/detray/utils/ranges/iota.hpp
+++ b/core/include/detray/utils/ranges/iota.hpp
@@ -32,8 +32,13 @@ class iota_view : public detray::ranges::view_interface<iota_view<incr_t>> {
 
     private:
     /// @brief Nested iterator to generate a range of values on demand.
-    struct iterator : public std::iterator<detray::ranges::input_iterator_tag,
-                                           incr_t, incr_t> {
+    struct iterator {
+
+        using difference_type = incr_t;
+        using value_type = incr_t;
+        using pointer = incr_t *;
+        using reference = incr_t &;
+        using iterator_category = detray::ranges::input_iterator_tag;
 
         /// Default construction only works if incr_t is default constructible
         iterator() = default;

--- a/tests/common/include/tests/common/tools/track_generators.hpp
+++ b/tests/common/include/tests/common/tools/track_generators.hpp
@@ -33,7 +33,13 @@ class uniform_track_generator
     using vector3 = __plugin::vector3<detray::scalar>;
 
     /// @brief Nested iterator type that generates track states.
-    struct iterator : public std::iterator<std::input_iterator_tag, track_t> {
+    struct iterator {
+
+        using difference_type = std::ptrdiff_t;
+        using value_type = track_t;
+        using pointer = track_t *;
+        using reference = track_t &;
+        using iterator_category = detray::ranges::input_iterator_tag;
 
         iterator() = default;
 


### PR DESCRIPTION
This should fix the clang deprecation warning about std::iterator inheritance. The required typedefs are set by hand for the track generator and iota views, the same way as for the other views