### PR TITLE
ref: Add new stepper policy and benchmark it

### DIFF
--- a/tests/benchmarks/cuda/CMakeLists.txt
+++ b/tests/benchmarks/cuda/CMakeLists.txt
@@ -13,6 +13,9 @@ enable_language( CUDA )
 # Set the CUDA build flags.
 include( detray-compiler-options-cuda )
 
+# Look for openMP, which is used for the CPU benchmark
+find_package(OpenMP)
+
 # make unit tests for multiple algebras
 # Currently vc and smatrix is not supported
 set( algebras "array" )
@@ -25,7 +28,7 @@ foreach(algebra ${algebras})
 detray_add_executable( ${algebra}_propagator_cuda
    "benchmark_propagator_cuda.cpp" "benchmark_propagator_cuda_kernel.hpp"
    "benchmark_propagator_cuda_kernel.cu" 
-   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::${algebra} vecmem::cuda )
+   LINK_LIBRARIES benchmark::benchmark detray_tests_common detray::${algebra} vecmem::cuda OpenMP::OpenMP_CXX)
 
    target_compile_definitions( detray_${algebra}_propagator_cuda
       PRIVATE ${algebra}=${algebra} )

--- a/tests/common/include/tests/common/tools/create_toy_geometry.hpp
+++ b/tests/common/include/tests/common/tools/create_toy_geometry.hpp
@@ -398,6 +398,8 @@ inline auto module_positions_ring(scalar z, scalar radius, scalar phi_stagger,
     scalar pi{static_cast<scalar>(M_PI)};
     scalar phi_step{scalar{2} * pi / (n_phi_bins)};
     scalar min_phi{-pi + scalar{0.5} * phi_step};
+    // std::array<scalar, 4> z_stagger3{z - 0.5f * phi_stagger, 0.f, z + 0.5f *
+    // phi_stagger, 0.f};
 
     for (size_t iphi = 0; iphi < size_t(n_phi_bins); ++iphi) {
         // if we have a phi sub stagger presents
@@ -416,6 +418,7 @@ inline auto module_positions_ring(scalar z, scalar radius, scalar phi_stagger,
         // the module phi
         scalar phi{min_phi + iphi * phi_step};
         // main z position depending on phi bin
+        // scalar rz{z_stagger3[iphi % 4]};
         scalar rz{iphi % 2 ? z - scalar{0.5} * phi_stagger
                            : z + scalar{0.5} * phi_stagger};
         r_positions.push_back(
@@ -472,6 +475,7 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
         // sum up the total length of the modules along r
         scalar tot_length{0};
         for (auto &m_hlength : cfg.m_half_y) {
+            // tot_length += 2 * m_hlength + 3.5;
             tot_length += 2 * m_hlength + 0.5;
         }
         // now calculate the overlap (equal pay)

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -212,7 +212,7 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
     // Iterate through uniformly distributed momentum directions
     for (auto track :
          uniform_track_generator<track_t>(theta_steps, phi_steps, ori, mom)) {
-        // Genrate second track state used for propagation with pathlimit
+        // Generate second track state used for propagation with pathlimit
         track_t lim_track(track);
 
         track.set_overstep_tolerance(overstep_tol);


### PR DESCRIPTION
Adds a Runge-Kutta specific stepper policy and allows to switch policies in the propagator benchmark. I am also trying to get openMP running for a meaningful comparision between host and device