### PR TITLE
ref: use templated struct for units

### DIFF
--- a/core/include/detray/definitions/units.hpp
+++ b/core/include/detray/definitions/units.hpp
@@ -9,59 +9,83 @@
 
 namespace detray {
 
-namespace unit_constants {
+/// Unit conversion factors
+template <typename scalar_t>
+struct unit {
 
-// Length, native unit mm
-constexpr double um = 0.001;
-constexpr double mm = 1.0;
-constexpr double cm = 10.0;
-constexpr double m = 1000.0;
+    /// Length, native unit mm
+    /// @{
+    static constexpr scalar_t um{0.001};
+    static constexpr scalar_t mm{1.0};
+    static constexpr scalar_t cm{10.0};
+    static constexpr scalar_t m{1000.0};
+    /// @}
 
-// Volume, native unit mm3
-constexpr double mm3 = mm * mm * mm;
-constexpr double cm2 = cm * cm;
-constexpr double cm3 = cm * cm * cm;
+    /// Volume, native unit mm3
+    /// @{
+    static constexpr scalar_t mm3{mm * mm * mm};
+    static constexpr scalar_t cm2{cm * cm};
+    static constexpr scalar_t cm3{cm * cm * cm};
+    /// @}
 
-// Time, native unit mm = [speed-of-light * time] = mm/s * s
-constexpr double s = 299792458000.0;
-constexpr double fs = 1e-15 * s;
-constexpr double ps = 1e-12 * s;
-constexpr double ns = 1e-9 * s;
-constexpr double us = 1e-6 * s;
-constexpr double ms = 1e-3 * s;
-constexpr double min = 60.0 * s;
-constexpr double h = 3600.0 * s;
+    /// Time, native unit mm{[speed-of-light * time]{mm/s * s}}
+    /// @{
+    static constexpr scalar_t s{299792458000.0};
+    static constexpr scalar_t fs{1e-15 * s};
+    static constexpr scalar_t ps{1e-12 * s};
+    static constexpr scalar_t ns{1e-9 * s};
+    static constexpr scalar_t us{1e-6 * s};
+    static constexpr scalar_t ms{1e-3 * s};
+    static constexpr scalar_t min{60.0 * s};
+    static constexpr scalar_t h{3600.0 * s};
+    /// @}
 
-// Energy, native unit GeV
-constexpr double eV = 1e-9;
-constexpr double keV = 1e-6;
-constexpr double MeV = 1e-3;
-constexpr double GeV = 1.0;
-constexpr double TeV = 1e3;
+    /// Energy, native unit GeV
+    /// @{
+    static constexpr scalar_t eV{1e-9};
+    static constexpr scalar_t keV{1e-6};
+    static constexpr scalar_t MeV{1e-3};
+    static constexpr scalar_t GeV{1.0};
+    static constexpr scalar_t TeV{1e3};
+    /// @}
 
-// Atomic mass unit u
-// 1u == 0.93149410242 GeV/c
-constexpr double u = 0.93149410242;
+    /// Atomic mass unit u
+    /// 1u == 0.93149410242 GeV/c
+    static constexpr scalar_t u{0.93149410242};
 
-// Mass
-//     1eV/c² == 1.782662e-36kg
-//    1GeV/c² == 1.782662e-27kg
-// ->     1kg == (1/1.782662e-27)GeV/c²
-// ->      1g == (1/(1e3*1.782662e-27))GeV/c²
-constexpr double g = 1.0 / 1.782662e-24;
-constexpr double kg = 1.0 / 1.782662e-27;
+    /// Mass
+    ///     1eV/c² == 1.782662e-36kg
+    ///    1GeV/c² == 1.782662e-27kg
+    /// ->     1kg == (1/1.782662e-27)GeV/c²
+    /// ->      1g == (1/(1e3*1.782662e-27))GeV/c²
+    /// @{
+    static constexpr scalar_t g{1.0 / 1.782662e-24};
+    static constexpr scalar_t kg{1.0 / 1.782662e-27};
+    /// @}
 
-// Amount of substance, native unit mol
-constexpr double mol = 1.0;
-// Avogadro constant
-constexpr double kAvogadro = 6.02214076e23 / unit_constants::mol;
+    /// Amount of substance, native unit mol
+    static constexpr scalar_t mol{1.0};
 
-// Charge, native unit e (elementary charge)
-constexpr double e = 1.0;
+    /// Charge, native unit e (elementary charge)
+    static constexpr scalar_t e{1.0};
 
-// Magnetic field, native unit GeV/(e*mm)
-constexpr double T = 0.000299792458;  // equivalent to c in appropriate SI units
+    /// Magnetic field, native unit GeV/(e*mm)
+    static constexpr scalar_t T{
+        0.000299792458};  // equivalent to c in appropriate SI units
+};
 
-}  // namespace unit_constants
+/// Physical constants
+template <typename scalar_t>
+struct constant {
+
+    /// Avogadro constant
+    static constexpr scalar_t avogadro{6.02214076e23 / unit<scalar_t>::mol};
+
+    /// Reduced Planck constant h/2*pi.
+    ///
+    /// Computed from CODATA 2018 constants to double precision.
+    static constexpr scalar_t hbar{6.582119569509066e-25 * unit<scalar_t>::GeV *
+                                   unit<scalar_t>::s};
+};
 
 }  // namespace detray

--- a/core/include/detray/materials/detail/density_effect_data.hpp
+++ b/core/include/detray/materials/detail/density_effect_data.hpp
@@ -33,7 +33,7 @@ struct density_effect_data {
           m_m(m),
           m_X0(X0),
           m_X1(X1),
-          m_I(I * unit_constants::eV),
+          m_I(I * unit<scalar_type>::eV),
           m_nC(nC),
           m_delta0(delta0) {}
 

--- a/core/include/detray/materials/detail/relativistic_quantities.hpp
+++ b/core/include/detray/materials/detail/relativistic_quantities.hpp
@@ -21,11 +21,12 @@ struct relativistic_quantities {
 
     // values from RPP2018 table 33.1
     // electron mass
-    const scalar_type Me = 0.5109989461 * unit_constants::MeV;
+    const scalar_type Me = 0.5109989461 * unit<scalar_type>::MeV;
     // Bethe formular prefactor. 1/mol unit is just a factor 1 here.
-    const scalar_type K = 0.307075 * unit_constants::MeV * unit_constants::cm2;
+    const scalar_type K =
+        0.307075 * unit<scalar_type>::MeV * unit<scalar_type>::cm2;
     // Energy scale for plasma energy.
-    const scalar_type PlasmaEnergyScale = 28.816 * unit_constants::eV;
+    const scalar_type PlasmaEnergyScale = 28.816 * unit<scalar_type>::eV;
 
     scalar_type m_q2OverBeta2 = 0.0;
     scalar_type m_beta2 = 0.0;

--- a/core/include/detray/materials/interaction.hpp
+++ b/core/include/detray/materials/interaction.hpp
@@ -165,7 +165,7 @@ struct interaction {
         const scalar_type t = std::sqrt(xOverX0 * q2OverBeta2);
         // log((x/X0) * (q²/beta²)) = log((sqrt(x/X0) * (q/beta))²)
         //                          = 2 * log(sqrt(x/X0) * (q/beta))
-        return 13.6 * unit_constants::MeV * momentumInv * t *
+        return 13.6 * unit<scalar_type>::MeV * momentumInv * t *
                (1.0 + 0.038 * 2. * std::log(t));
     }
 
@@ -175,7 +175,7 @@ struct interaction {
                        const scalar_type q2OverBeta2) const {
         // TODO add source paper/ resource
         const scalar_type t = std::sqrt(xOverX0 * q2OverBeta2);
-        return 17.5 * unit_constants::MeV * momentumInv * t *
+        return 17.5 * unit<scalar_type>::MeV * momentumInv * t *
                (1.0 + 0.125 * std::log10(10.0 * xOverX0));
     }
 

--- a/core/include/detray/materials/material.hpp
+++ b/core/include/detray/materials/material.hpp
@@ -91,7 +91,7 @@ struct material {
         // use approximative computation as defined in ATL-SOFT-PUB-2008-003
         if (m_density ==
             detail::density_effect_data<scalar_type>(0, 0, 0, 0, 0, 0, 0)) {
-            return scalar_type(16 * unit_constants::eV) *
+            return scalar_type(16 * unit<scalar_type>::eV) *
                    std::pow(m_z, scalar_type(0.9));
         } else {
             return m_density.get_mean_excitation_energy();
@@ -110,11 +110,11 @@ struct material {
             return 0;
         }
 
-        double atomic_mass = static_cast<double>(ar) * unit_constants::u;
+        double atomic_mass = static_cast<double>(ar) * unit<scalar_type>::u;
 
         return static_cast<scalar_type>(
             static_cast<double>(mass_rho) /
-            (atomic_mass * unit_constants::kAvogadro));
+            (atomic_mass * constant<scalar_type>::avogadro));
     }
 
     // Material properties

--- a/core/include/detray/materials/predefined_materials.hpp
+++ b/core/include/detray/materials/predefined_materials.hpp
@@ -33,96 +33,91 @@ DETRAY_DECLARE_MATERIAL(vacuum, std::numeric_limits<scalar>::infinity(),
                         material_state::e_gas, 0, 0, 0, 0, 0, 0, 0);
 
 // H₂ (1): Hydrogen Gas
-DETRAY_DECLARE_MATERIAL(hydrogen_gas, 7.526E6 * unit_constants::mm,
-                        6.209E6 * unit_constants::mm, 1.008 * 2, 1 * 2,
-                        8.376E-5 * unit_constants::g /
-                            (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(hydrogen_gas, 7.526E6 * unit<scalar>::mm,
+                        6.209E6 * unit<scalar>::mm, 1.008 * 2, 1 * 2,
+                        8.376E-5 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_gas, 0.1409, 5.7273, 1.8639, 3.2718,
                         19.2, 9.5834, 0.00);
 
 // H₂ (1): Hydrogen Liquid
-DETRAY_DECLARE_MATERIAL(hydrogen_liquid, 8904 * unit_constants::mm,
-                        7346 * unit_constants::mm, 1.008 * 2, 1 * 2,
-                        0.07080 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(hydrogen_liquid, 8904 * unit<scalar>::mm,
+                        7346 * unit<scalar>::mm, 1.008 * 2, 1 * 2,
+                        0.07080 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_liquid, 0.1348, 5.6249, 0.4400,
                         1.8856, 21.8, 3.0977, 0.00);
 
 // He (2): Helium Gas
-DETRAY_DECLARE_MATERIAL(helium_gas, 5.671E6 * unit_constants::mm,
-                        4.269E6 * unit_constants::mm, 4.003, 2,
-                        1.663E-4 * unit_constants::g /
-                            (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(helium_gas, 5.671E6 * unit<scalar>::mm,
+                        4.269E6 * unit<scalar>::mm, 4.003, 2,
+                        1.663E-4 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_gas, 0.1344, 5.8347, 2.2017, 3.6122,
                         41.8, 11.1393, 0.00);
 
 // Be (4)
-DETRAY_DECLARE_MATERIAL(beryllium, 352.8 * unit_constants::mm,
-                        421.0 * unit_constants::mm, 9.012, 4.0,
-                        1.848 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(beryllium, 352.8 * unit<scalar>::mm,
+                        421.0 * unit<scalar>::mm, 9.012, 4.0,
+                        1.848 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_solid, 0.8039, 2.4339, 0.0592, 1.6922,
                         63.7, 2.7847, 0.14);
 
 // C (6): Carbon (amorphous)
-DETRAY_DECLARE_MATERIAL(carbon_gas, 213.5 * unit_constants::mm,
-                        429.0 * unit_constants::mm, 12.01, 6,
-                        2.0 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(carbon_gas, 213.5 * unit<scalar>::mm,
+                        429.0 * unit<scalar>::mm, 12.01, 6,
+                        2.0 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_gas, 0, 0, 0, 0, 0, 0, 0);
 
 // N₂ (7): Nitrogen Gas
-DETRAY_DECLARE_MATERIAL(nitrogen_gas, 3.260E+05 * unit_constants::mm,
-                        7.696E+05 * unit_constants::mm, 14.007 * 2, 7 * 2,
-                        1.165E-03 * unit_constants::g /
-                            (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(nitrogen_gas, 3.260E+05 * unit<scalar>::mm,
+                        7.696E+05 * unit<scalar>::mm, 14.007 * 2, 7 * 2,
+                        1.165E-03 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_gas, 0.1535, 3.2125, 1.7378, 4.1323,
                         82.0, 10.5400, 0.00);
 
 // O₂ (8): Oxygen Gas
-DETRAY_DECLARE_MATERIAL(oxygen_gas, 2.571E+05 * unit_constants::mm,
-                        6.772E+05 * unit_constants::mm, 15.999 * 2, 8 * 2,
-                        1.332E-3 * unit_constants::g /
-                            (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(oxygen_gas, 2.571E+05 * unit<scalar>::mm,
+                        6.772E+05 * unit<scalar>::mm, 15.999 * 2, 8 * 2,
+                        1.332E-3 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_gas, 0.1178, 3.2913, 1.7541, 4.3213,
                         95.0, 10.7004, 0.00);
 
 // O₂ (8): Oxygen liquid
-DETRAY_DECLARE_MATERIAL(oxygen_liquid, 300.1 * unit_constants::mm,
-                        790.3 * unit_constants::mm, 15.999 * 2, 8 * 2,
-                        1.141 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(oxygen_liquid, 300.1 * unit<scalar>::mm,
+                        790.3 * unit<scalar>::mm, 15.999 * 2, 8 * 2,
+                        1.141 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_liquid, 0, 0, 0, 0, 0, 0, 0);
 
 // Al (13)
-DETRAY_DECLARE_MATERIAL(aluminium, 88.97 * unit_constants::mm,
-                        397.0 * unit_constants::mm, 26.98, 13,
-                        2.699 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(aluminium, 88.97 * unit<scalar>::mm,
+                        397.0 * unit<scalar>::mm, 26.98, 13,
+                        2.699 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_solid, 0.0802, 3.6345, 0.1708, 3.0127,
                         166.0, 4.2395, 0.12);
 
 // Si (14)
-DETRAY_DECLARE_MATERIAL(silicon, 93.7 * unit_constants::mm,
-                        465.2 * unit_constants::mm, 28.0855, 14.,
-                        2.329 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(silicon, 93.7 * unit<scalar>::mm,
+                        465.2 * unit<scalar>::mm, 28.0855, 14.,
+                        2.329 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_solid, 0.1492, 3.2546, 0.2015, 2.8716,
                         173.0, 4.4355, 0.14);
 
 // Ar (18): Argon gas
-DETRAY_DECLARE_MATERIAL(argon_gas, 1.176E+05 * unit_constants::mm,
-                        7.204E+05 * unit_constants::mm, 39.948, 18.,
-                        1.662E-03 * unit_constants::g /
-                            (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(argon_gas, 1.176E+05 * unit<scalar>::mm,
+                        7.204E+05 * unit<scalar>::mm, 39.948, 18.,
+                        1.662E-03 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_gas, 0.1971, 2.9618, 1.7635, 4.4855,
                         188.0, 11.9480, 0.00);
 
 // W (74)
-DETRAY_DECLARE_MATERIAL(tungsten, 3.504 * unit_constants::mm,
-                        99.46 * unit_constants::mm, 183.84, 74,
-                        19.3 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(tungsten, 3.504 * unit<scalar>::mm,
+                        99.46 * unit<scalar>::mm, 183.84, 74,
+                        19.3 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_solid, 0.1551, 2.8447, 0.2167, 3.4960,
                         727.0, 5.4059, 0.14);
 
 // Au (79)
-DETRAY_DECLARE_MATERIAL(gold, 3.344 * unit_constants::mm,
-                        101.6 * unit_constants::mm, 196.97, 79,
-                        19.32 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(gold, 3.344 * unit<scalar>::mm,
+                        101.6 * unit<scalar>::mm, 196.97, 79,
+                        19.32 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_solid, 0.0976, 3.1101, 0.2021, 3.6979,
                         790.0, 5.5747, 0.14);
 
@@ -132,16 +127,16 @@ DETRAY_DECLARE_MATERIAL(gold, 3.344 * unit_constants::mm,
  */
 
 // Be (4)
-DETRAY_DECLARE_MATERIAL(beryllium_tml, 352.8 * unit_constants::mm,
-                        407.0 * unit_constants::mm, 9.012, 4.0,
-                        1.848 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(beryllium_tml, 352.8 * unit<scalar>::mm,
+                        407.0 * unit<scalar>::mm, 9.012, 4.0,
+                        1.848 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_solid, 0.8039, 2.4339, 0.0592, 1.6922,
                         63.7, 2.7847, 0.14);
 
 // Si (14)
-DETRAY_DECLARE_MATERIAL(silicon_tml, 95.7 * unit_constants::mm,
-                        465.2 * unit_constants::mm, 28.03, 14.,
-                        2.32 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(silicon_tml, 95.7 * unit<scalar>::mm,
+                        465.2 * unit<scalar>::mm, 28.03, 14.,
+                        2.32 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_solid, 0.1492, 3.2546, 0.2015, 2.8716,
                         173.0, 4.4355, 0.14);
 
@@ -153,10 +148,9 @@ DETRAY_DECLARE_MATERIAL(silicon_tml, 95.7 * unit_constants::mm,
 // @note:
 // https://pdg.lbl.gov/2020/AtomicNuclearProperties/HTML/air_dry_1_atm.html
 // @note: Ar from Wikipedia (https://en.wikipedia.org/wiki/Molar_mass)
-DETRAY_DECLARE_MATERIAL(air, 3.039E+05 * unit_constants::mm,
-                        7.477E+05 * unit_constants::mm, 28.97, 14.46,
-                        1.205E-03 * unit_constants::g /
-                            (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(air, 3.039E+05 * unit<scalar>::mm,
+                        7.477E+05 * unit<scalar>::mm, 28.97, 14.46,
+                        1.205E-03 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_gas, 0, 0, 0, 0, 0, 0, 0);
 
 // (CH3)2CHCH3 Gas
@@ -165,19 +159,18 @@ DETRAY_DECLARE_MATERIAL(air, 3.039E+05 * unit_constants::mm,
 // @note: Z was caculated by simply summing the number of atoms. Surprisingly
 // it seems the right value because Z/A is 0.58496, which is the same with <Z/A>
 // in the pdg refernce
-DETRAY_DECLARE_MATERIAL(isobutane, 169300 * unit_constants::mm,
-                        288.3 * unit_constants::mm, 58.124, 34.,
-                        2.67 * unit_constants::g / (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(isobutane, 169300 * unit<scalar>::mm,
+                        288.3 * unit<scalar>::mm, 58.124, 34.,
+                        2.67 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_gas, 0, 0, 0, 0, 0, 0, 0);
 
 // C3H8 Gas
 // @note: (X0, L0, mass_rho) from
 // https://pdg.lbl.gov/2020/AtomicNuclearProperties/HTML/propane.html
 // @note: Ar from Wikipedia (https://en.wikipedia.org/wiki/Propane)
-DETRAY_DECLARE_MATERIAL(propane, 2.429E+05 * unit_constants::mm,
-                        4.106E+05 * unit_constants::mm, 44.097, 26,
-                        1.868E-03 * unit_constants::g /
-                            (1 * unit_constants::cm3),
+DETRAY_DECLARE_MATERIAL(propane, 2.429E+05 * unit<scalar>::mm,
+                        4.106E+05 * unit<scalar>::mm, 44.097, 26,
+                        1.868E-03 * unit<scalar>::g / (1 * unit<scalar>::cm3),
                         material_state::e_gas, 0, 0, 0, 0, 0, 0, 0);
 
 }  // namespace detray

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -32,7 +32,7 @@ struct pointwise_material_interactor : actor {
         using vector3 = __plugin::vector3<scalar>;
 
         /// The particle mass
-        scalar_type mass = 105.7 * unit_constants::MeV;
+        scalar_type mass = 105.7 * unit<scalar_type>::MeV;
         /// The particle pdg
         int pdg = 13;  // default muon
 

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -128,7 +128,7 @@ class base_stepper {
 
         /// TODO: Use options?
         /// hypothetical mass of particle (assume pion by default)
-        /// scalar _mass = 139.57018 * unit_constants::MeV;
+        /// scalar _mass = 139.57018 * unit<scalar_type>::MeV;
 
         /// Set new step constraint
         template <step::constraint type = step::constraint::e_actor>

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -228,7 +228,7 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
     while (!try_rk4(stepping._step_size)) {
 
         step_size_scaling = std::min(
-            std::max(0.25 * unit_constants::mm,
+            std::max(0.25 * unit<scalar>::mm,
                      std::sqrt(std::sqrt((stepping._tolerance /
                                           std::abs(2. * error_estimate))))),
             4.);

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -32,7 +32,7 @@ void fill_tracks(vecmem::vector<free_track_parameters<transform3>> &tracks,
                  const unsigned int theta_steps, const unsigned int phi_steps) {
     // Set origin position of tracks
     const point3 ori{0., 0., 0.};
-    const scalar mom_mag = 10. * unit_constants::GeV;
+    const scalar mom_mag = 10. * unit<scalar>::GeV;
 
     // Iterate through uniformly distributed momentum directions
     for (auto traj : uniform_track_generator<free_track_parameters<transform3>>(
@@ -47,7 +47,7 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
     detector_host_type det = create_toy_geometry<host_container_types>(
         host_mr,
         field_type(field_type::backend_t::configuration_t{
-            0.f, 0.f, 2.f * unit_constants::T}),
+            0.f, 0.f, 2.f * unit<scalar>::T}),
         n_brl_layers, n_edc_layers);
 
     // Create RK stepper

--- a/tests/common/include/tests/common/check_geometry_navigation.inl
+++ b/tests/common/include/tests/common/check_geometry_navigation.inl
@@ -131,8 +131,8 @@ TEST(ALGEBRA_PLUGIN, helix_navigation) {
         create_toy_geometry(std::declval<vecmem::host_memory_resource &>(),
                             n_brl_layers, n_edc_layers))::bfield_type;
 
-    const vector3 B{0. * unit_constants::T, 0. * unit_constants::T,
-                    2. * unit_constants::T};
+    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                    2. * unit<scalar>::T};
 
     auto det = create_toy_geometry(
         host_mr,
@@ -153,10 +153,10 @@ TEST(ALGEBRA_PLUGIN, helix_navigation) {
 
     // det.volume_by_pos(ori).index();
     const point3 ori{0., 0., 0.};
-    const scalar p_mag{10. * unit_constants::GeV};
+    const scalar p_mag{10. * unit<scalar>::GeV};
 
     // Overstepping
-    constexpr scalar overstep_tol{-7. * unit_constants::um};
+    constexpr scalar overstep_tol{-7. * unit<scalar>::um};
 
     // Iterate through uniformly distributed momentum directions
     for (auto track : uniform_track_generator<free_track_parameters_type>(

--- a/tests/common/include/tests/common/check_simulation.inl
+++ b/tests/common/include/tests/common/check_simulation.inl
@@ -66,7 +66,7 @@ TEST(check_simulation, toy_geometry) {
     vecmem::host_memory_resource host_mr;
 
     // Create B field
-    const vector3 B{0, 0, 2 * unit_constants::T};
+    const vector3 B{0, 0, 2 * unit<scalar>::T};
 
     // Create geometry
     using b_field_t = decltype(create_toy_geometry(host_mr))::bfield_type;
@@ -79,11 +79,11 @@ TEST(check_simulation, toy_geometry) {
     constexpr unsigned int phi_steps{50};
     const vector3 ori{0, 0, 0};
     auto generator = uniform_track_generator<free_track_parameters<transform3>>(
-        theta_steps, phi_steps, ori, 1 * unit_constants::GeV);
+        theta_steps, phi_steps, ori, 1 * unit<scalar>::GeV);
 
     // Create smearer
-    measurement_smearer<scalar> smearer(67 * unit_constants::um,
-                                        170 * unit_constants::um);
+    measurement_smearer<scalar> smearer(67 * unit<scalar>::um,
+                                        170 * unit<scalar>::um);
 
     std::size_t n_events = 10;
     auto sim = simulator(n_events, detector, generator, smearer);

--- a/tests/common/include/tests/common/masks_annulus2D.inl
+++ b/tests/common/include/tests/common/masks_annulus2D.inl
@@ -17,8 +17,8 @@ using namespace __plugin;
 TEST(mask, annulus2D) {
     using point_t = typename mask<annulus2D<>>::loc_point_t;
 
-    constexpr scalar minR{7.2 * unit_constants::mm};
-    constexpr scalar maxR{12.0 * unit_constants::mm};
+    constexpr scalar minR{7.2 * unit<scalar>::mm};
+    constexpr scalar maxR{12.0 * unit<scalar>::mm};
     constexpr scalar minPhi{0.74195};
     constexpr scalar maxPhi{1.33970};
     point_t offset = {-2., 2.};

--- a/tests/common/include/tests/common/masks_cylinder.inl
+++ b/tests/common/include/tests/common/masks_cylinder.inl
@@ -13,8 +13,8 @@
 using namespace detray;
 using namespace __plugin;
 
-constexpr scalar r{3. * unit_constants::mm};
-constexpr scalar hz{4. * unit_constants::mm};
+constexpr scalar r{3. * unit<scalar>::mm};
+constexpr scalar hz{4. * unit<scalar>::mm};
 
 /// This tests the basic functionality of a 3D cylinder
 TEST(mask, cylinder3D) {

--- a/tests/common/include/tests/common/masks_line.inl
+++ b/tests/common/include/tests/common/masks_line.inl
@@ -16,8 +16,8 @@ using namespace __plugin;
 namespace {
 
 // 50 mm wire with 1 mm radial cell size
-constexpr scalar cell_size{1. * unit_constants::mm};
-constexpr scalar hz{50. * unit_constants::mm};
+constexpr scalar cell_size{1. * unit<scalar>::mm};
+constexpr scalar hz{50. * unit<scalar>::mm};
 
 }  // anonymous namespace
 
@@ -32,9 +32,8 @@ TEST(mask, line_radial_cross_sect) {
 
     const mask<line<>> ln{0UL, cell_size, hz};
 
-    ASSERT_FLOAT_EQ(ln[line<>::e_cross_section],
-                    scalar{1. * unit_constants::mm});
-    ASSERT_FLOAT_EQ(ln[line<>::e_half_z], scalar{50. * unit_constants::mm});
+    ASSERT_FLOAT_EQ(ln[line<>::e_cross_section], scalar{1. * unit<scalar>::mm});
+    ASSERT_FLOAT_EQ(ln[line<>::e_half_z], scalar{50. * unit<scalar>::mm});
 
     ASSERT_TRUE(ln.is_inside(ln_in) == intersection::status::e_inside);
     ASSERT_TRUE(ln.is_inside(ln_edge) == intersection::status::e_inside);
@@ -65,9 +64,8 @@ TEST(mask, line_square_cross_sect) {
     // 50 mm wire with 1 mm square cell sizes
     const mask<line<true>> ln{0UL, cell_size, hz};
 
-    ASSERT_FLOAT_EQ(ln[line<>::e_cross_section],
-                    scalar{1. * unit_constants::mm});
-    ASSERT_FLOAT_EQ(ln[line<>::e_half_z], scalar{50. * unit_constants::mm});
+    ASSERT_FLOAT_EQ(ln[line<>::e_cross_section], scalar{1. * unit<scalar>::mm});
+    ASSERT_FLOAT_EQ(ln[line<>::e_half_z], scalar{50. * unit<scalar>::mm});
 
     ASSERT_TRUE(ln.is_inside(ln_in) == intersection::status::e_inside);
     ASSERT_TRUE(ln.is_inside(ln_edge, 1e-5) == intersection::status::e_inside);

--- a/tests/common/include/tests/common/masks_rectangle2D.inl
+++ b/tests/common/include/tests/common/masks_rectangle2D.inl
@@ -13,9 +13,9 @@
 using namespace detray;
 using namespace __plugin;
 
-constexpr scalar hx{1. * unit_constants::mm};
-constexpr scalar hy{9.3 * unit_constants::mm};
-constexpr scalar hz{0.5 * unit_constants::mm};
+constexpr scalar hx{1. * unit<scalar>::mm};
+constexpr scalar hy{9.3 * unit<scalar>::mm};
+constexpr scalar hz{0.5 * unit<scalar>::mm};
 
 /// This tests the basic functionality of a rectangle
 TEST(mask, rectangle2D) {

--- a/tests/common/include/tests/common/masks_ring2D.inl
+++ b/tests/common/include/tests/common/masks_ring2D.inl
@@ -20,8 +20,8 @@ TEST(mask, ring2D) {
     point_t p2_pl_edge = {0., 3.5};
     point_t p2_pl_out = {3.6, 5.};
 
-    constexpr scalar inner_r{0. * unit_constants::mm};
-    constexpr scalar outer_r{3.5 * unit_constants::mm};
+    constexpr scalar inner_r{0. * unit<scalar>::mm};
+    constexpr scalar outer_r{3.5 * unit<scalar>::mm};
 
     mask<ring2D<>> r2{0UL, inner_r, outer_r};
 

--- a/tests/common/include/tests/common/masks_single3D.inl
+++ b/tests/common/include/tests/common/masks_single3D.inl
@@ -21,7 +21,7 @@ TEST(mask, single3_0) {
     point_t p3_edge = {1., 9.3, 2.};
     point_t p3_out = {1.5, -9.8, 8.};
 
-    constexpr scalar h0{1. * unit_constants::mm};
+    constexpr scalar h0{1. * unit<scalar>::mm};
     mask<single3D<>> m1_0{0UL, -h0, h0};
 
     ASSERT_FLOAT_EQ(m1_0[single3D<>::e_lower], -h0);
@@ -42,7 +42,7 @@ TEST(mask, single3_1) {
     point_t p3_edge = {1., 9.3, 2.};
     point_t p3_out = {1.5, -9.8, 8.};
 
-    constexpr scalar h1{9.3 * unit_constants::mm};
+    constexpr scalar h1{9.3 * unit<scalar>::mm};
     mask<single3D<1>> m1_1{0UL, -h1, h1};
 
     ASSERT_FLOAT_EQ(m1_1[single3D<>::e_lower], -h1);
@@ -75,7 +75,7 @@ TEST(mask, single3_2) {
     point_t p3_edge = {1., 9.3, 2.};
     point_t p3_out = {1.5, -9.8, 8.};
 
-    constexpr scalar h2{2. * unit_constants::mm};
+    constexpr scalar h2{2. * unit<scalar>::mm};
     mask<single3D<2>> m1_2{0UL, -h2, h2};
 
     ASSERT_FLOAT_EQ(m1_2[single3D<>::e_lower], -h2);

--- a/tests/common/include/tests/common/masks_trapezoid2D.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2D.inl
@@ -21,9 +21,9 @@ TEST(mask, trapezoid2D) {
     point_t p2_edge = {2.5, 1.};
     point_t p2_out = {3., 1.5};
 
-    constexpr scalar hx_miny{1. * unit_constants::mm};
-    constexpr scalar hx_maxy{3. * unit_constants::mm};
-    constexpr scalar hy{2. * unit_constants::mm};
+    constexpr scalar hx_miny{1. * unit<scalar>::mm};
+    constexpr scalar hx_maxy{3. * unit<scalar>::mm};
+    constexpr scalar hy{2. * unit<scalar>::mm};
     constexpr scalar divisor{1. / (2. * hy)};
 
     mask<trapezoid2D<>> t2{0UL, hx_miny, hx_maxy, hy, divisor};

--- a/tests/common/include/tests/common/material_interaction.inl
+++ b/tests/common/include/tests/common/material_interaction.inl
@@ -53,13 +53,13 @@ TEST_P(EnergyLossBetheValidation, bethe_energy_loss) {
     line_plane_intersection is;
 
     // H2 liquid with a unit thickness
-    material_slab<scalar> slab(std::get<0>(GetParam()), 1 * unit_constants::cm);
+    material_slab<scalar> slab(std::get<0>(GetParam()), 1 * unit<scalar>::cm);
 
     // muon
     const int pdg = pdg_particle::eMuon;
 
     // mass
-    const scalar m = 105.7 * unit_constants::MeV;
+    const scalar m = 105.7 * unit<scalar>::MeV;
 
     // qOverP
     const scalar qOverP = -1. / std::get<1>(GetParam());
@@ -68,7 +68,7 @@ TEST_P(EnergyLossBetheValidation, bethe_energy_loss) {
     const scalar dEdx =
         I.compute_energy_loss_bethe(is, slab, pdg, m, qOverP, -1.) /
         slab.path_segment(is) / slab.get_material().mass_density() /
-        (unit_constants::MeV * unit_constants::cm2 / unit_constants::g);
+        (unit<scalar>::MeV * unit<scalar>::cm2 / unit<scalar>::g);
 
     // Check if difference is within 5% error
     EXPECT_TRUE(std::abs(std::get<2>(GetParam()) - dEdx) / dEdx < 0.05);
@@ -77,82 +77,82 @@ TEST_P(EnergyLossBetheValidation, bethe_energy_loss) {
 INSTANTIATE_TEST_SUITE_P(
     Bethe_0p1GeV_H2Liquid, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(hydrogen_liquid<scalar>(),
-                                      0.1003 * unit_constants::GeV, 6.539)));
+                                      0.1003 * unit<scalar>::GeV, 6.539)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_1GeV_H2Liquid, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(hydrogen_liquid<scalar>(),
-                                      1.101 * unit_constants::GeV, 4.182)));
+                                      1.101 * unit<scalar>::GeV, 4.182)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_10GeV_H2Liquid, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(hydrogen_liquid<scalar>(),
-                                      10.11 * unit_constants::GeV, 4.777)));
+                                      10.11 * unit<scalar>::GeV, 4.777)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_H2Liquid, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(hydrogen_liquid<scalar>(),
-                                      100.1 * unit_constants::GeV, 5.305)));
+                                      100.1 * unit<scalar>::GeV, 5.305)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_0p1GeV_HeGas, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(helium_gas<scalar>(),
-                                      0.1003 * unit_constants::GeV, 3.082)));
+                                      0.1003 * unit<scalar>::GeV, 3.082)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_1GeV_HeGas, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(helium_gas<scalar>(),
-                                      1.101 * unit_constants::GeV, 2.133)));
+                                      1.101 * unit<scalar>::GeV, 2.133)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_10GeV_HeGas, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(helium_gas<scalar>(),
-                                      10.11 * unit_constants::GeV, 2.768)));
+                                      10.11 * unit<scalar>::GeV, 2.768)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_HeGas, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(helium_gas<scalar>(),
-                                      100.1 * unit_constants::GeV, 3.188)));
+                                      100.1 * unit<scalar>::GeV, 3.188)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_0p1GeV_Al, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(aluminium<scalar>(),
-                                      0.1003 * unit_constants::GeV, 2.533)));
+                                      0.1003 * unit<scalar>::GeV, 2.533)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_1GeV_Al, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(aluminium<scalar>(),
-                                      1.101 * unit_constants::GeV, 1.744)));
+                                      1.101 * unit<scalar>::GeV, 1.744)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_10GeV_Al, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(aluminium<scalar>(),
-                                      10.11 * unit_constants::GeV, 2.097)));
+                                      10.11 * unit<scalar>::GeV, 2.097)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_Al, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(aluminium<scalar>(),
-                                      100.1 * unit_constants::GeV, 2.360)));
+                                      100.1 * unit<scalar>::GeV, 2.360)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_0p1GeV_Si, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
-                                      0.1003 * unit_constants::GeV, 2.608)));
+                                      0.1003 * unit<scalar>::GeV, 2.608)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_1GeV_Si, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
-                                      1.101 * unit_constants::GeV, 1.803)));
+                                      1.101 * unit<scalar>::GeV, 1.803)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_10GeV_Si, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
-                                      10.11 * unit_constants::GeV, 2.177)));
+                                      10.11 * unit<scalar>::GeV, 2.177)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_Si, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
-                                      100.1 * unit_constants::GeV, 2.451)));
+                                      100.1 * unit<scalar>::GeV, 2.451)));
 
 // Test class for MUON energy loss with Landau function
 // Input tuple: < material / energy / expected energy loss  / expected fwhm  >
@@ -170,13 +170,13 @@ TEST_P(EnergyLossLandauValidation, landau_energy_loss) {
 
     // H2 liquid with a unit thickness
     material_slab<scalar> slab(std::get<0>(GetParam()),
-                               0.17 * unit_constants::cm);
+                               0.17 * unit<scalar>::cm);
 
     // muon
     const int pdg = pdg_particle::eMuon;
 
     // mass
-    const scalar m = 105.7 * unit_constants::MeV;
+    const scalar m = 105.7 * unit<scalar>::MeV;
 
     // qOverP
     const scalar qOverP = -1. / std::get<1>(GetParam());
@@ -184,7 +184,7 @@ TEST_P(EnergyLossLandauValidation, landau_energy_loss) {
     // Landau Energy loss in MeV
     const scalar dE =
         I.compute_energy_loss_landau(is, slab, pdg, m, qOverP, -1) /
-        (unit_constants::MeV);
+        (unit<scalar>::MeV);
 
     // Check if difference is within 5% error
     EXPECT_TRUE(std::abs(std::get<2>(GetParam()) - dE) / dE < 0.05);
@@ -192,7 +192,7 @@ TEST_P(EnergyLossLandauValidation, landau_energy_loss) {
     // Landau Energy loss Fluctuation
     const scalar fwhm =
         I.compute_energy_loss_landau_fwhm(is, slab, pdg, m, qOverP, -1) /
-        (unit_constants::MeV);
+        (unit<scalar>::MeV);
 
     // Check if difference is within 10% error
     EXPECT_TRUE(std::abs(std::get<3>(GetParam()) - fwhm) / fwhm < 0.1);
@@ -202,7 +202,7 @@ TEST_P(EnergyLossLandauValidation, landau_energy_loss) {
 INSTANTIATE_TEST_SUITE_P(
     Landau_10GeV_Silicon, EnergyLossLandauValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
-                                      10. * unit_constants::GeV, 0.525, 0.13)));
+                                      10. * unit<scalar>::GeV, 0.525, 0.13)));
 
 // Material interaction test with telescope Geometry
 TEST(material_interaction, telescope_geometry_energy_loss) {
@@ -215,11 +215,11 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
                                      300., 350, 400,  450., 500.};
 
     const auto mat = silicon_tml<scalar>();
-    const scalar thickness = 0.17 * unit_constants::cm;
+    const scalar thickness = 0.17 * unit<scalar>::cm;
 
     const auto det = create_telescope_detector(
-        host_mr, positions, traj, 20. * unit_constants::mm,
-        20. * unit_constants::mm, mat, thickness);
+        host_mr, positions, traj, 20. * unit<scalar>::mm,
+        20. * unit<scalar>::mm, mat, thickness);
 
     using navigator_t = navigator<decltype(det)>;
     using constraints_t = constrained_step<>;
@@ -236,7 +236,7 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
     propagator_t p({}, {});
 
     const scalar q = -1.;
-    const scalar iniP = 10 * unit_constants::GeV;
+    const scalar iniP = 10 * unit<scalar>::GeV;
 
     typename bound_track_parameters<transform3>::vector_type bound_vector;
     getter::element(bound_vector, e_bound_loc0, 0) = 0.;
@@ -329,17 +329,17 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
 
     // Build from given module positions
     detail::ray<transform3> traj{{0, 0, 0}, 0, {1, 0, 0}, -1};
-    std::vector<scalar> positions = {0., 1000. * unit_constants::cm,
-                                     2000. * unit_constants::cm};
+    std::vector<scalar> positions = {0., 1000. * unit<scalar>::cm,
+                                     2000. * unit<scalar>::cm};
 
     const auto mat = silicon_tml<scalar>();
-    const scalar thickness = 500 * unit_constants::cm;
+    const scalar thickness = 500 * unit<scalar>::cm;
     // Use unbounded surfaces
     constexpr bool unbounded = true;
 
     const auto det = create_telescope_detector<unbounded>(
-        host_mr, positions, traj, 2000. * unit_constants::mm,
-        2000. * unit_constants::mm, mat, thickness);
+        host_mr, positions, traj, 2000. * unit<scalar>::mm,
+        2000. * unit<scalar>::mm, mat, thickness);
 
     using navigator_t = navigator<decltype(det)>;
     using constraints_t = constrained_step<>;
@@ -358,7 +358,7 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
     propagator_t p({}, {});
 
     const scalar q = -1.;
-    const scalar iniP = 10 * unit_constants::GeV;
+    const scalar iniP = 10 * unit<scalar>::GeV;
 
     typename bound_track_parameters<transform3>::vector_type bound_vector;
     getter::element(bound_vector, e_bound_loc0, 0) = 0.;
@@ -398,7 +398,7 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
 
         propagator_t::state state(bound_param, det);
 
-        state._stepping().set_overstep_tolerance(-1000. * unit_constants::um);
+        state._stepping().set_overstep_tolerance(-1000. * unit<scalar>::um);
 
         // Propagate the entire detector
         ASSERT_TRUE(p.propagate(state, actor_states))

--- a/tests/common/include/tests/common/materials.inl
+++ b/tests/common/include/tests/common/materials.inl
@@ -38,25 +38,25 @@ TEST(materials, material) {
     EXPECT_FLOAT_EQ(vacuum<scalar>().molar_electron_density(), 0);
 
     // beryllium
-    EXPECT_FLOAT_EQ(beryllium_tml<scalar>().X0(), 352.8 * unit_constants::mm);
-    EXPECT_FLOAT_EQ(beryllium_tml<scalar>().L0(), 407.0 * unit_constants::mm);
+    EXPECT_FLOAT_EQ(beryllium_tml<scalar>().X0(), 352.8 * unit<scalar>::mm);
+    EXPECT_FLOAT_EQ(beryllium_tml<scalar>().L0(), 407.0 * unit<scalar>::mm);
     EXPECT_FLOAT_EQ(beryllium_tml<scalar>().Ar(), 9.012);
     EXPECT_FLOAT_EQ(beryllium_tml<scalar>().Z(), 4.0);
 
     // @note molar density is obtained by the following equation:
     // molar_density = mass_density [GeV/c²] / molar_mass [GeV/c²] * mol / cm³
     EXPECT_FLOAT_EQ(beryllium_tml<scalar>().molar_density(),
-                    1.848 / beryllium_tml<scalar>().Ar() * unit_constants::mol /
-                        unit_constants::cm3);
+                    1.848 / beryllium_tml<scalar>().Ar() * unit<scalar>::mol /
+                        unit<scalar>::cm3);
 
     // silicon
-    EXPECT_FLOAT_EQ(silicon_tml<scalar>().X0(), 95.7 * unit_constants::mm);
-    EXPECT_FLOAT_EQ(silicon_tml<scalar>().L0(), 465.2 * unit_constants::mm);
+    EXPECT_FLOAT_EQ(silicon_tml<scalar>().X0(), 95.7 * unit<scalar>::mm);
+    EXPECT_FLOAT_EQ(silicon_tml<scalar>().L0(), 465.2 * unit<scalar>::mm);
     EXPECT_FLOAT_EQ(silicon_tml<scalar>().Ar(), 28.03);
     EXPECT_FLOAT_EQ(silicon_tml<scalar>().Z(), 14.);
     EXPECT_FLOAT_EQ(silicon_tml<scalar>().molar_density(),
-                    2.32 / silicon_tml<scalar>().Ar() * unit_constants::mol /
-                        unit_constants::cm3);
+                    2.32 / silicon_tml<scalar>().Ar() * unit<scalar>::mol /
+                        unit<scalar>::cm3);
 }
 
 TEST(materials, mixture) {
@@ -120,13 +120,13 @@ TEST(materials, mixture) {
 TEST(materials, material_slab) {
 
     material_slab<scalar> slab(oxygen_gas<scalar>(),
-                               scalar(2) * scalar(unit_constants::mm));
+                               scalar(2) * scalar(unit<scalar>::mm));
 
     line_plane_intersection is;
     is.cos_incidence_angle = scalar(0.3);
 
     EXPECT_FLOAT_EQ(slab.path_segment(is),
-                    scalar(2) * scalar(unit_constants::mm) / scalar(0.3));
+                    scalar(2) * scalar(unit<scalar>::mm) / scalar(0.3));
     EXPECT_FLOAT_EQ(slab.path_segment_in_X0(is),
                     slab.path_segment(is) / slab.get_material().X0());
     EXPECT_FLOAT_EQ(slab.path_segment_in_L0(is),
@@ -138,7 +138,7 @@ TEST(materials, material_rod) {
 
     // Rod with 1 mm radius
     material_rod<scalar> rod(oxygen_gas<scalar>(),
-                             scalar(1.) * scalar(unit_constants::mm));
+                             scalar(1.) * scalar(unit<scalar>::mm));
 
     // tf3 with Identity rotation and no translation
     const vector3 x{1, 0, 0};
@@ -152,7 +152,7 @@ TEST(materials, material_rod) {
     const free_track_parameters<transform3> trk(pos, 0, dir, -1);
 
     // Infinite wire with 1 mm radial cell size
-    const mask<line<>> ln{0UL, static_cast<scalar>(1. * unit_constants::mm),
+    const mask<line<>> ln{0UL, static_cast<scalar>(1. * unit<scalar>::mm),
                           std::numeric_limits<scalar>::infinity()};
 
     line_plane_intersection is =

--- a/tests/common/include/tests/common/path_correction.inl
+++ b/tests/common/include/tests/common/path_correction.inl
@@ -98,7 +98,7 @@ constexpr scalar epsilon = 1e-2;
 constexpr scalar rk_tolerance = 1e-8;
 
 // B field
-const vector3 B{0, 0, 1. * unit_constants::T};
+const vector3 B{0, 0, 1. * unit<scalar>::T};
 mag_field_t mag_field(mag_field_t::backend_t::configuration_t{B[0], B[1],
                                                               B[2]});
 
@@ -143,13 +143,13 @@ TEST(path_correction, cartesian) {
     transforms.emplace_back(env::ctx, t, z, x);
 
     // Add a mask
-    const scalar hx = 100. * unit_constants::mm;
-    const scalar hy = 100. * unit_constants::mm;
+    const scalar hx = 100. * unit<scalar>::mm;
+    const scalar hy = 100. * unit<scalar>::mm;
     masks.template emplace_back<mask_id>(empty_context{}, 0UL, hx, hy);
 
     // Add a material
     const material<scalar> mat = silicon<scalar>();
-    const scalar thickness = 2 * unit_constants::mm;
+    const scalar thickness = 2 * unit<scalar>::mm;
     materials.template emplace_back<material_id>(empty_context{}, mat,
                                                  thickness);
 
@@ -159,7 +159,7 @@ TEST(path_correction, cartesian) {
 
     // Generate track starting point
     vector2 local{2, 3};
-    vector3 mom{1 * unit_constants::MeV, 0., 0.};
+    vector3 mom{1 * unit<scalar>::MeV, 0., 0.};
 
     scalar time = 0.;
     scalar q = -1.;
@@ -285,13 +285,13 @@ TEST(path_correction, polar) {
     transforms.emplace_back(env::ctx, t, z, x);
 
     // Add a mask
-    const scalar r_low = 0. * unit_constants::mm;
-    const scalar r_high = 100. * unit_constants::mm;
+    const scalar r_low = 0. * unit<scalar>::mm;
+    const scalar r_high = 100. * unit<scalar>::mm;
     masks.template emplace_back<mask_id>(empty_context{}, 0UL, r_low, r_high);
 
     // Add a material
     const material<scalar> mat = silicon<scalar>();
-    const scalar thickness = 2 * unit_constants::mm;
+    const scalar thickness = 2 * unit<scalar>::mm;
     materials.template emplace_back<material_id>(empty_context{}, mat,
                                                  thickness);
 
@@ -301,7 +301,7 @@ TEST(path_correction, polar) {
 
     // Generate track starting point
     vector2 local{2, M_PI / 6.};
-    vector3 mom{1 * unit_constants::MeV, 0., 0.};
+    vector3 mom{1 * unit<scalar>::MeV, 0., 0.};
 
     scalar time = 0.;
     scalar q = -1.;
@@ -407,21 +407,21 @@ TEST(path_correction, cylindrical) {
                           dindex_invalid, surface_id::e_sensitive);
 
     // Add a transform
-    const vector3 t{-50 * unit_constants::mm, 0, 0};
+    const vector3 t{-50 * unit<scalar>::mm, 0, 0};
     const vector3 z{0, 0, 1};
     const vector3 x{1, 0, 0};
     transforms.emplace_back(env::ctx, t, z, x);
 
     // Add a mask
-    const scalar r = 50 * unit_constants::mm;
-    const scalar half_length_1 = 1000. * unit_constants::mm;
-    const scalar half_length_2 = 1000. * unit_constants::mm;
+    const scalar r = 50 * unit<scalar>::mm;
+    const scalar half_length_1 = 1000. * unit<scalar>::mm;
+    const scalar half_length_2 = 1000. * unit<scalar>::mm;
     masks.template emplace_back<mask_id>(empty_context{}, 0UL, r, half_length_1,
                                          half_length_2);
 
     // Add a material
     const material<scalar> mat = silicon<scalar>();
-    const scalar thickness = 2 * unit_constants::mm;
+    const scalar thickness = 2 * unit<scalar>::mm;
     materials.template emplace_back<material_id>(empty_context{}, mat,
                                                  thickness);
 
@@ -431,7 +431,7 @@ TEST(path_correction, cylindrical) {
 
     // Generate track starting point
     vector2 local{0., 0.};
-    vector3 mom{1 * unit_constants::MeV, 0., 0.};
+    vector3 mom{1 * unit<scalar>::MeV, 0., 0.};
     scalar time = 0.;
     scalar q = -1.;
 

--- a/tests/common/include/tests/common/test_telescope_detector.inl
+++ b/tests/common/include/tests/common/test_telescope_detector.inl
@@ -64,8 +64,8 @@ TEST(ALGEBRA_PLUGIN, telescope_detector) {
     vecmem::host_memory_resource host_mr;
 
     // B-fields
-    vector3 B_z{0., 0., 1. * unit_constants::T};
-    vector3 B_x{1. * unit_constants::T, 0., 0.};
+    vector3 B_z{0., 0., 1. * unit<scalar>::T};
+    vector3 B_x{1. * unit<scalar>::T, 0., 0.};
     b_field_t b_field_z{
         b_field_t::backend_t::configuration_t{B_z[0], B_z[1], B_z[2]}};
     b_field_t b_field_x{
@@ -89,7 +89,7 @@ TEST(ALGEBRA_PLUGIN, telescope_detector) {
     // Build the same telescope detector with rectangular planes and given
     // length/number of surfaces
     dindex n_surfaces = 11;
-    scalar tel_length = 500. * unit_constants::mm;
+    scalar tel_length = 500. * unit<scalar>::mm;
     const auto z_tel_det2 =
         create_telescope_detector<rectangular>(host_mr, n_surfaces, tel_length);
 
@@ -200,7 +200,7 @@ TEST(ALGEBRA_PLUGIN, telescope_detector) {
     mom = {0., 1., 0.};
 
     auto pilot_track = free_track_parameters<transform3>(pos, 0, mom, -1);
-    pilot_track.set_overstep_tolerance(-10 * unit_constants::um);
+    pilot_track.set_overstep_tolerance(-10 * unit<scalar>::um);
 
     detail::helix<transform3> helix_bz(pilot_track, &B_z);
 

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -113,11 +113,11 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Materials
     auto portal_mat =
-        material_slab<scalar>(vacuum<scalar>(), 0. * unit_constants::mm);
-    auto beampipe_mat = material_slab<scalar>(beryllium_tml<scalar>(),
-                                              0.8 * unit_constants::mm);
+        material_slab<scalar>(vacuum<scalar>(), 0. * unit<scalar>::mm);
+    auto beampipe_mat =
+        material_slab<scalar>(beryllium_tml<scalar>(), 0.8 * unit<scalar>::mm);
     auto pixel_mat =
-        material_slab<scalar>(silicon_tml<scalar>(), 0.15 * unit_constants::mm);
+        material_slab<scalar>(silicon_tml<scalar>(), 0.15 * unit<scalar>::mm);
 
     /** Link to outer world (leaving detector) */
     const dindex leaving_world = dindex_invalid;

--- a/tests/common/include/tests/common/tools/create_telescope_detector.hpp
+++ b/tests/common/include/tests/common/tools/create_telescope_detector.hpp
@@ -200,10 +200,10 @@ auto create_telescope_detector(
     covfie::field<detector_registry::telescope_detector::bfield_backend_t>
         &&bfield,
     std::vector<scalar> pos, trajectory_t traj = {{0, 0, 0}, 0, {0, 0, 1}, -1},
-    scalar half_x = 20. * unit_constants::mm,
-    scalar half_y = 20. * unit_constants::mm,
+    scalar half_x = 20. * unit<scalar>::mm,
+    scalar half_y = 20. * unit<scalar>::mm,
     const material<scalar> mat = silicon_tml<scalar>(),
-    const scalar thickness = 80 * unit_constants::um) {
+    const scalar thickness = 80 * unit<scalar>::um) {
 
     // detector type
     using detector_t = detector<telescope_types, covfie::field, container_t>;
@@ -258,10 +258,10 @@ auto create_telescope_detector(
     vecmem::memory_resource &resource,
     covfie::field<detector_registry::telescope_detector::bfield_backend_t>
         &&bfield,
-    dindex n_surfaces = 10, scalar tel_length = 500. * unit_constants::mm,
+    dindex n_surfaces = 10, scalar tel_length = 500. * unit<scalar>::mm,
     trajectory_t traj = {{0, 0, 0}, 0, {0, 0, 1}, -1},
-    scalar half_x = 20. * unit_constants::mm,
-    scalar half_y = 20. * unit_constants::mm) {
+    scalar half_x = 20. * unit<scalar>::mm,
+    scalar half_y = 20. * unit<scalar>::mm) {
     // Generate equidistant positions
     std::vector<scalar> positions = {};
     scalar pos = 0.;
@@ -284,10 +284,10 @@ template <bool unbounded_planes = true,
 auto create_telescope_detector(
     vecmem::memory_resource &resource, std::vector<scalar> pos,
     trajectory_t traj = {{0, 0, 0}, 0, {0, 0, 1}, -1},
-    scalar half_x = 20. * unit_constants::mm,
-    scalar half_y = 20. * unit_constants::mm,
+    scalar half_x = 20. * unit<scalar>::mm,
+    scalar half_y = 20. * unit<scalar>::mm,
     const material<scalar> mat = silicon_tml<scalar>(),
-    const scalar thickness = 80 * unit_constants::um) {
+    const scalar thickness = 80 * unit<scalar>::um) {
 
     // Build the geometry
     return create_telescope_detector<unbounded_planes, trajectory_t,
@@ -304,10 +304,10 @@ template <bool unbounded_planes = true,
           typename container_t = host_container_types>
 auto create_telescope_detector(
     vecmem::memory_resource &resource, dindex n_surfaces = 10,
-    scalar tel_length = 500. * unit_constants::mm,
+    scalar tel_length = 500. * unit<scalar>::mm,
     trajectory_t traj = {{0, 0, 0}, 0, {0, 0, 1}, -1},
-    scalar half_x = 20. * unit_constants::mm,
-    scalar half_y = 20. * unit_constants::mm) {
+    scalar half_x = 20. * unit<scalar>::mm,
+    scalar half_y = 20. * unit<scalar>::mm) {
 
     // Build the geometry
     return create_telescope_detector<unbounded_planes, trajectory_t,

--- a/tests/common/include/tests/common/tools/create_toy_geometry.hpp
+++ b/tests/common/include/tests/common/tools/create_toy_geometry.hpp
@@ -203,16 +203,16 @@ void create_cyl_volume(
     // negative and positive, inner and outer portal surface
     add_cylinder_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
                          transforms, inner_r, lower_z, upper_z, volume_links[0],
-                         vacuum<scalar>(), 0. * unit_constants::mm);
+                         vacuum<scalar>(), 0. * unit<scalar>::mm);
     add_cylinder_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
                          transforms, outer_r, lower_z, upper_z, volume_links[1],
-                         vacuum<scalar>(), 0. * unit_constants::mm);
+                         vacuum<scalar>(), 0. * unit<scalar>::mm);
     add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
                      transforms, inner_r, outer_r, lower_z, volume_links[2],
-                     vacuum<scalar>(), 0. * unit_constants::mm);
+                     vacuum<scalar>(), 0. * unit<scalar>::mm);
     add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
                      transforms, inner_r, outer_r, upper_z, volume_links[3],
-                     vacuum<scalar>(), 0. * unit_constants::mm);
+                     vacuum<scalar>(), 0. * unit<scalar>::mm);
 
     det.add_objects_per_volume(ctx, cyl_volume, surfaces, masks, materials,
                                transforms);
@@ -593,7 +593,7 @@ inline void add_beampipe(
         beampipe_idx};
     add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
                          transforms, beampipe_r, min_z, max_z, volume_link,
-                         beryllium_tml<scalar>(), 0.8 * unit_constants::mm);
+                         beryllium_tml<scalar>(), 0.8 * unit<scalar>::mm);
 
     // Get vol sizes in z, including for gap volumes
     std::vector<std::pair<scalar, scalar>> vol_sizes{
@@ -612,15 +612,14 @@ inline void add_beampipe(
         add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
                              transforms, edc_inner_r, -vol_sizes[i].second,
                              -vol_sizes[i].first, volume_link, vacuum<scalar>(),
-                             0. * unit_constants::mm);
+                             0. * unit<scalar>::mm);
     }
 
     // barrel portals
     volume_link = n_brl_layers <= 0 ? leaving_world : link + 1;
     add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
                          transforms, edc_inner_r, -brl_half_z, brl_half_z,
-                         volume_link, vacuum<scalar>(),
-                         0. * unit_constants::mm);
+                         volume_link, vacuum<scalar>(), 0. * unit<scalar>::mm);
 
     // positive endcap portals
     link += 7;
@@ -629,17 +628,17 @@ inline void add_beampipe(
         add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
                              transforms, edc_inner_r, vol_sizes[i].second,
                              vol_sizes[i].first, volume_link, vacuum<scalar>(),
-                             0. * unit_constants::mm);
+                             0. * unit<scalar>::mm);
     }
 
     // disc portals
     volume_link = leaving_world;
     add_disc_surface(beampipe_idx, ctx, surfaces, masks, materials, transforms,
                      beampipe_vol_size.first, beampipe_vol_size.second, min_z,
-                     volume_link, vacuum<scalar>(), 0. * unit_constants::mm);
+                     volume_link, vacuum<scalar>(), 0. * unit<scalar>::mm);
     add_disc_surface(beampipe_idx, ctx, surfaces, masks, materials, transforms,
                      beampipe_vol_size.first, beampipe_vol_size.second, max_z,
-                     volume_link, vacuum<scalar>(), 0. * unit_constants::mm);
+                     volume_link, vacuum<scalar>(), 0. * unit<scalar>::mm);
 
     det.add_objects_per_volume(ctx, beampipe, surfaces, masks, materials,
                                transforms);
@@ -689,15 +688,15 @@ inline void add_endcap_barrel_connection(
         beampipe_idx};
     add_cylinder_surface(connector_gap_idx, ctx, surfaces, masks, materials,
                          transforms, edc_inner_r, min_z, max_z, volume_link,
-                         vacuum<scalar>(), 0. * unit_constants::mm);
+                         vacuum<scalar>(), 0. * unit<scalar>::mm);
     volume_link = leaving_world;
     add_cylinder_surface(connector_gap_idx, ctx, surfaces, masks, materials,
                          transforms, edc_outer_r, min_z, max_z, volume_link,
-                         vacuum<scalar>(), 0. * unit_constants::mm);
+                         vacuum<scalar>(), 0. * unit<scalar>::mm);
     volume_link = edc_vol_idx;
     add_disc_surface(connector_gap_idx, ctx, surfaces, masks, materials,
                      transforms, edc_inner_r, edc_outer_r, edc_disc_z,
-                     volume_link, vacuum<scalar>(), 0. * unit_constants::mm);
+                     volume_link, vacuum<scalar>(), 0. * unit<scalar>::mm);
 
     // Get vol sizes in z also for gap volumes
     std::vector<std::pair<scalar, scalar>> vol_sizes;
@@ -713,7 +712,7 @@ inline void add_endcap_barrel_connection(
         add_disc_surface(connector_gap_idx, ctx, surfaces, masks, materials,
                          transforms, vol_sizes[i].first, vol_sizes[i].second,
                          brl_disc_z, volume_link, vacuum<scalar>(),
-                         0. * unit_constants::mm);
+                         0. * unit<scalar>::mm);
     }
 
     det.add_objects_per_volume(ctx, connector_gap, surfaces, masks, materials,
@@ -935,7 +934,7 @@ auto create_toy_geometry(
         scalar m_long_overlap{2.};     // 5.;
         std::pair<int, int> m_binning = {16, 14};
         material<scalar> mat = silicon_tml<scalar>();
-        scalar thickness = 0.15 * unit_constants::mm;
+        scalar thickness = 0.15 * unit<scalar>::mm;
     };
 
     //
@@ -964,7 +963,7 @@ auto create_toy_geometry(
         std::vector<scalar> m_half_x_max_y = {12.4, 12.4};
         std::vector<scalar> m_tilt = {0., 0.};
         material<scalar> mat = silicon_tml<scalar>();
-        scalar thickness = 0.15 * unit_constants::mm;
+        scalar thickness = 0.15 * unit<scalar>::mm;
     };
 
     // Don't create modules in gap volume

--- a/tests/common/include/tests/common/tools/track_generators.hpp
+++ b/tests/common/include/tests/common/tools/track_generators.hpp
@@ -46,11 +46,11 @@ class uniform_track_generator
         DETRAY_HOST_DEVICE
         iterator(std::size_t n_theta, std::size_t n_phi,
                  point3 trk_origin = {0., 0., 0.},
-                 scalar trk_mom = 1. * unit_constants::GeV,
+                 scalar trk_mom = 1. * unit<scalar>::GeV,
                  std::array<scalar, 2> theta_range = {0.01, M_PI},
                  std::array<scalar, 2> phi_range = {-M_PI, M_PI},
-                 scalar time = 0. * unit_constants::us,
-                 scalar charge = -1. * unit_constants::e, std::size_t iph = 1,
+                 scalar time = 0. * unit<scalar>::us,
+                 scalar charge = -1. * unit<scalar>::e, std::size_t iph = 1,
                  std::size_t ith = 0)
             : m_theta_steps{n_theta},
               m_phi_steps{n_phi},
@@ -134,7 +134,7 @@ class uniform_track_generator
 
         /// Magnitude of momentum: Default is one to keep directions normalized
         /// if no momentum information is needed (e.g. for a ray)
-        scalar m_mom_mag{1. * unit_constants::GeV};
+        scalar m_mom_mag{1. * unit<scalar>::GeV};
 
         /// Range for theta and phi
         std::array<scalar, 2> m_theta_range{0.01, M_PI};
@@ -169,11 +169,11 @@ class uniform_track_generator
     DETRAY_HOST_DEVICE
     uniform_track_generator(std::size_t n_theta, std::size_t n_phi,
                             point3 trk_origin = {0., 0., 0.},
-                            scalar trk_mom = 1. * unit_constants::GeV,
+                            scalar trk_mom = 1. * unit<scalar>::GeV,
                             std::array<scalar, 2> theta_range = {0.01, M_PI},
                             std::array<scalar, 2> phi_range = {-M_PI, M_PI},
-                            scalar time = 0. * unit_constants::us,
-                            scalar charge = -1. * unit_constants::e)
+                            scalar time = 0. * unit<scalar>::us,
+                            scalar charge = -1. * unit<scalar>::e)
         : m_begin{n_theta,   n_phi, trk_origin, trk_mom, theta_range,
                   phi_range, time,  charge,     1,       0},
           m_end{n_theta,   n_phi, trk_origin, trk_mom, theta_range,

--- a/tests/common/include/tests/common/tools_cylinder_intersection.inl
+++ b/tests/common/include/tests/common/tools_cylinder_intersection.inl
@@ -134,8 +134,8 @@ TEST(ALGEBRA_PLUGIN, helix_cylinder_intersector) {
     // Test helix
     const point3 pos{3., 2., 5.};
     const vector3 mom{1., 0., 0.};
-    const vector3 B{0. * unit_constants::T, 0. * unit_constants::T,
-                    epsilon * unit_constants::T};
+    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                    epsilon * unit<scalar>::T};
     const helix_type h({pos, 0, mom, -1}, &B);
 
     // Check intersection

--- a/tests/common/include/tests/common/tools_guided_navigator.inl
+++ b/tests/common/include/tests/common/tools_guided_navigator.inl
@@ -57,12 +57,12 @@ TEST(ALGEBRA_PLUGIN, guided_navigator) {
     const point3 pos{0., 0., 0.};
     const vector3 mom{0., 0., 1.};
     free_track_parameters<transform3_type> track(pos, 0, mom, -1);
-    const vector3 B{0, 0, 1 * unit_constants::T};
+    const vector3 B{0, 0, 1 * unit<scalar>::T};
     const b_field_t b_field(
         b_field_t::backend_t::configuration_t{B[0], B[1], B[2]});
 
     // Actors
-    pathlimit_aborter::state pathlimit{200. * unit_constants::cm};
+    pathlimit_aborter::state pathlimit{200. * unit<scalar>::cm};
 
     // Propagator
     propagator_t p(runge_kutta_stepper{}, guided_navigator{});

--- a/tests/common/include/tests/common/tools_helix_trajectory.inl
+++ b/tests/common/include/tests/common/tools_helix_trajectory.inl
@@ -32,7 +32,7 @@ TEST(tools, helix_trajectory) {
     free_track_parameters<transform3_type> vertex(pos, time, mom, q);
 
     // magnetic field
-    vector3 B{0, 0, 1 * unit_constants::T};
+    vector3 B{0, 0, 1 * unit<scalar>::T};
 
     scalar p_mag = getter::norm(mom);
     scalar B_mag = getter::norm(B);
@@ -76,7 +76,7 @@ TEST(tools, helix_trajectory_small_pT) {
     free_track_parameters<transform3_type> vertex(pos, time, mom, q);
 
     // magnetic field
-    vector3 B{0, 0, 1 * unit_constants::T};
+    vector3 B{0, 0, 1 * unit<scalar>::T};
 
     // helix trajectory
     detail::helix helix_traj(vertex, &B);

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -171,8 +171,8 @@ TEST(tools, intersection_kernel_helix) {
                                     annulus_surface};
     const point3 pos{0., 0., 0.};
     const vector3 mom{0.01, 0.01, 10.};
-    const vector3 B{0. * unit_constants::T, 0. * unit_constants::T,
-                    epsilon * unit_constants::T};
+    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                    epsilon * unit<scalar>::T};
     const detail::helix<transform3_type> h({pos, 0, mom, -1}, &B);
 
     // Validation data

--- a/tests/common/include/tests/common/tools_particle_gun.inl
+++ b/tests/common/include/tests/common/tools_particle_gun.inl
@@ -54,8 +54,8 @@ TEST(tools, particle_gun) {
     }
 
     // Simulate straight line track
-    const vector3 B{0. * unit_constants::T, 0. * unit_constants::T,
-                    epsilon * unit_constants::T};
+    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                    epsilon * unit<scalar>::T};
     // Iterate through uniformly distributed momentum directions with helix
     std::size_t n_tracks{0};
     for (const auto track :

--- a/tests/common/include/tests/common/tools_planar_intersection.inl
+++ b/tests/common/include/tests/common/tools_planar_intersection.inl
@@ -111,8 +111,8 @@ TEST(ALGEBRA_PLUGIN, translated_plane_helix) {
     // Test helix
     const point3 pos{2., 1., 0.};
     const vector3 mom{0., 0., 1.};
-    const vector3 B{0. * unit_constants::T, 0. * unit_constants::T,
-                    epsilon * unit_constants::T};
+    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                    epsilon * unit<scalar>::T};
     const detail::helix<transform3> h({pos, 0, mom, -1}, &B);
 
     // The same test but bound to local frame

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -32,7 +32,7 @@ using transform3 = __plugin::transform3<detray::scalar>;
 namespace {
 
 constexpr scalar epsilon{1e-3};
-constexpr scalar path_limit{5 * unit_constants::cm};
+constexpr scalar path_limit{5 * unit<scalar>::cm};
 
 /// Compare helical track positions for stepper
 struct helix_inspector : actor {
@@ -170,7 +170,7 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
 
     // Set origin position of tracks
     const point3 ori{0., 0., 0.};
-    constexpr scalar mom{10. * unit_constants::GeV};
+    constexpr scalar mom{10. * unit<scalar>::GeV};
 
     // detector configuration
     constexpr std::size_t n_brl_layers{4};
@@ -266,36 +266,32 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
 }
 
 // Realistic case
-INSTANTIATE_TEST_SUITE_P(PropagatorValidation1, PropagatorWithRkStepper,
-                         ::testing::Values(std::make_tuple(
-                             __plugin::vector3<scalar>{0. * unit_constants::T,
-                                                       0. * unit_constants::T,
-                                                       2. * unit_constants::T},
-                             -7. * unit_constants::um,
-                             std::numeric_limits<scalar>::max())));
+INSTANTIATE_TEST_SUITE_P(
+    PropagatorValidation1, PropagatorWithRkStepper,
+    ::testing::Values(std::make_tuple(
+        __plugin::vector3<scalar>{0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                                  2. * unit<scalar>::T},
+        -7. * unit<scalar>::um, std::numeric_limits<scalar>::max())));
 
 // Add some restrictions for more frequent navigation updates in the cases of
 // non-z-aligned B-fields
 INSTANTIATE_TEST_SUITE_P(PropagatorValidation2, PropagatorWithRkStepper,
                          ::testing::Values(std::make_tuple(
-                             __plugin::vector3<scalar>{0. * unit_constants::T,
-                                                       1. * unit_constants::T,
-                                                       1. * unit_constants::T},
-                             -10. * unit_constants::um,
-                             5. * unit_constants::mm)));
+                             __plugin::vector3<scalar>{0. * unit<scalar>::T,
+                                                       1. * unit<scalar>::T,
+                                                       1. * unit<scalar>::T},
+                             -10. * unit<scalar>::um, 5. * unit<scalar>::mm)));
 
 INSTANTIATE_TEST_SUITE_P(PropagatorValidation3, PropagatorWithRkStepper,
                          ::testing::Values(std::make_tuple(
-                             __plugin::vector3<scalar>{1. * unit_constants::T,
-                                                       0. * unit_constants::T,
-                                                       1. * unit_constants::T},
-                             -10. * unit_constants::um,
-                             5. * unit_constants::mm)));
+                             __plugin::vector3<scalar>{1. * unit<scalar>::T,
+                                                       0. * unit<scalar>::T,
+                                                       1. * unit<scalar>::T},
+                             -10. * unit<scalar>::um, 5. * unit<scalar>::mm)));
 
 INSTANTIATE_TEST_SUITE_P(PropagatorValidation4, PropagatorWithRkStepper,
                          ::testing::Values(std::make_tuple(
-                             __plugin::vector3<scalar>{1. * unit_constants::T,
-                                                       1. * unit_constants::T,
-                                                       1. * unit_constants::T},
-                             -10. * unit_constants::um,
-                             5. * unit_constants::mm)));
+                             __plugin::vector3<scalar>{1. * unit<scalar>::T,
+                                                       1. * unit<scalar>::T,
+                                                       1. * unit<scalar>::T},
+                             -10. * unit<scalar>::um, 5. * unit<scalar>::mm)));

--- a/tests/common/include/tests/common/tools_stepper.inl
+++ b/tests/common/include/tests/common/tools_stepper.inl
@@ -39,7 +39,7 @@ using crk_stepper_t =
 namespace {
 
 constexpr scalar epsilon = 1e-3;
-constexpr scalar path_limit = 100 * unit_constants::cm;
+constexpr scalar path_limit = 100 * unit<scalar>::cm;
 
 // dummy navigation struct
 struct nav_state {
@@ -52,7 +52,7 @@ struct nav_state {
     inline void set_no_trust() {}
     inline bool abort() { return false; }
 
-    scalar _step_size = 1. * unit_constants::mm;
+    scalar _step_size = 1. * unit<scalar>::mm;
 };
 
 // dummy propagator state
@@ -88,28 +88,27 @@ TEST(ALGEBRA_PLUGIN, line_stepper) {
     cline_stepper_t::state &cl_state = c_propagation._stepping;
 
     // Test the setting of step constraints
-    cl_state.template set_constraint<constraint::e_accuracy>(
-        10 * unit_constants::mm);
-    cl_state.template set_constraint<constraint::e_actor>(2 *
-                                                          unit_constants::mm);
+    cl_state.template set_constraint<constraint::e_accuracy>(10 *
+                                                             unit<scalar>::mm);
+    cl_state.template set_constraint<constraint::e_actor>(2 * unit<scalar>::mm);
     cl_state.template set_constraint<constraint::e_aborter>(5 *
-                                                            unit_constants::mm);
+                                                            unit<scalar>::mm);
     cl_state.template set_constraint<constraint::e_user>(0.5 *
-                                                         unit_constants::mm);
+                                                         unit<scalar>::mm);
     ASSERT_NEAR(cl_state.constraints().template size<>(),
-                0.5 * unit_constants::mm, epsilon);
+                0.5 * unit<scalar>::mm, epsilon);
 
     // Release all except 'actor', then set 'user' again
     cl_state.template release_step<constraint::e_accuracy>();
     cl_state.template release_step<constraint::e_aborter>();
     cl_state.template release_step<constraint::e_user>();
-    ASSERT_NEAR(cl_state.constraints().template size<>(),
-                2 * unit_constants::mm, epsilon);
+    ASSERT_NEAR(cl_state.constraints().template size<>(), 2 * unit<scalar>::mm,
+                epsilon);
 
     cl_state.template set_constraint<constraint::e_user>(0.5 *
-                                                         unit_constants::mm);
+                                                         unit<scalar>::mm);
     ASSERT_NEAR(cl_state.constraints().template size<>(),
-                0.5 * unit_constants::mm, epsilon);
+                0.5 * unit<scalar>::mm, epsilon);
 
     // Run a few steps
     ASSERT_TRUE(l_stepper.step(propagation));
@@ -145,8 +144,7 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
     constexpr unsigned int rk_steps = 100;
 
     // Constant magnetic field
-    vector3 B{1 * unit_constants::T, 1 * unit_constants::T,
-              1 * unit_constants::T};
+    vector3 B{1 * unit<scalar>::T, 1 * unit<scalar>::T, 1 * unit<scalar>::T};
     mag_field_t mag_field(
         typename mag_field_t::backend_t::configuration_t{B[0], B[1], B[2]});
 
@@ -181,12 +179,12 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
         nav_state &n_state = propagation._navigation;
         nav_state &cn_state = c_propagation._navigation;
 
-        crk_state.template set_constraint<constraint::e_user>(
-            0.5 * unit_constants::mm);
-        n_state._step_size = 1. * unit_constants::mm;
-        cn_state._step_size = 1. * unit_constants::mm;
+        crk_state.template set_constraint<constraint::e_user>(0.5 *
+                                                              unit<scalar>::mm);
+        n_state._step_size = 1. * unit<scalar>::mm;
+        cn_state._step_size = 1. * unit<scalar>::mm;
         ASSERT_NEAR(crk_state.constraints().template size<>(),
-                    0.5 * unit_constants::mm, epsilon);
+                    0.5 * unit<scalar>::mm, epsilon);
 
         for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
             rk_stepper.step(propagation);
@@ -211,8 +209,8 @@ TEST(ALGEBRA_PLUGIN, rk_stepper) {
         // Roll the same track back to the origin
         // Use the same path length, since there is no overstepping
         const scalar path_length = rk_state.path_length();
-        n_state._step_size *= -1. * unit_constants::mm;
-        cn_state._step_size *= -1. * unit_constants::mm;
+        n_state._step_size *= -1. * unit<scalar>::mm;
+        cn_state._step_size *= -1. * unit<scalar>::mm;
         for (unsigned int i_s = 0; i_s < rk_steps; i_s++) {
             rk_stepper.step(propagation);
             crk_stepper.step(c_propagation);

--- a/tests/common/include/tests/common/tools_track_generators.inl
+++ b/tests/common/include/tests/common/tools_track_generators.inl
@@ -83,8 +83,8 @@ TEST(tools, uniform_track_generator) {
     ASSERT_EQ(momenta.size(), n_tracks);
 
     // Generate helical trajectories
-    const vector3 B{0. * unit_constants::T, 0. * unit_constants::T,
-                    2. * unit_constants::T};
+    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                    2. * unit<scalar>::T};
     n_tracks = 0;
     for (const auto track :
          uniform_track_generator<free_track_parameters<transform3>>(
@@ -114,7 +114,7 @@ TEST(tools, uniform_track_generator_with_range) {
 
     for (const auto track :
          uniform_track_generator<free_track_parameters<transform3>>(
-             theta_steps, phi_steps, {0, 0, 0}, 1 * unit_constants::GeV, {1, 2},
+             theta_steps, phi_steps, {0, 0, 0}, 1 * unit<scalar>::GeV, {1, 2},
              {-2, 2})) {
         const auto dir = track.dir();
         theta_phi.push_back({getter::theta(dir), getter::phi(dir)});

--- a/tests/simulation/run_simulation.cpp
+++ b/tests/simulation/run_simulation.cpp
@@ -25,7 +25,7 @@ int main() {
     vecmem::host_memory_resource host_mr;
 
     // Create B field
-    const vector3 B{0, 0, 2 * unit_constants::T};
+    const vector3 B{0, 0, 2 * unit<scalar>::T};
 
     // Create geometry
     using b_field_t = decltype(create_toy_geometry(host_mr))::bfield_type;
@@ -37,13 +37,13 @@ int main() {
     constexpr unsigned int theta_steps{4};
     constexpr unsigned int phi_steps{4};
     const vector3 ori{0, 0, 0};
-    const scalar mom = 1 * unit_constants::GeV;
+    const scalar mom = 1 * unit<scalar>::GeV;
     auto generator = uniform_track_generator<free_track_parameters<transform3>>(
         theta_steps, phi_steps, ori, mom);
 
     // Create smearer
-    measurement_smearer<scalar> smearer(100 * unit_constants::um,
-                                        100 * unit_constants::um);
+    measurement_smearer<scalar> smearer(100 * unit<scalar>::um,
+                                        100 * unit<scalar>::um);
 
     std::size_t n_events = 2;
     auto sim = simulator(n_events, detector, generator, smearer);

--- a/tests/unit_tests/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/cuda/navigator_cuda.cpp
@@ -35,7 +35,7 @@ TEST(navigator_cuda, navigator) {
 
     // Set origin position of tracks
     const point3 ori{0., 0., 0.};
-    const scalar p_mag{10. * unit_constants::GeV};
+    const scalar p_mag{10. * unit<scalar>::GeV};
 
     // Iterate through uniformly distributed momentum directions
     for (auto track :

--- a/tests/unit_tests/cuda/propagator_cuda.cpp
+++ b/tests/unit_tests/cuda/propagator_cuda.cpp
@@ -39,7 +39,7 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
 
     // Set origin position of tracks
     const point3 ori{0., 0., 0.};
-    const scalar p_mag{10. * unit_constants::GeV};
+    const scalar p_mag{10. * unit<scalar>::GeV};
 
     // Iterate through uniformly distributed momentum directions
     for (auto track :
@@ -193,20 +193,20 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
 
 INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation1, CudaPropagatorWithRkStepper,
                          ::testing::Values(__plugin::vector3<scalar>{
-                             0. * unit_constants::T, 0. * unit_constants::T,
-                             2. * unit_constants::T}));
+                             0. * unit<scalar>::T, 0. * unit<scalar>::T,
+                             2. * unit<scalar>::T}));
 
 INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation2, CudaPropagatorWithRkStepper,
                          ::testing::Values(__plugin::vector3<scalar>{
-                             0. * unit_constants::T, 1. * unit_constants::T,
-                             1. * unit_constants::T}));
+                             0. * unit<scalar>::T, 1. * unit<scalar>::T,
+                             1. * unit<scalar>::T}));
 
 INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation3, CudaPropagatorWithRkStepper,
                          ::testing::Values(__plugin::vector3<scalar>{
-                             1. * unit_constants::T, 0. * unit_constants::T,
-                             1. * unit_constants::T}));
+                             1. * unit<scalar>::T, 0. * unit<scalar>::T,
+                             1. * unit<scalar>::T}));
 
 INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation4, CudaPropagatorWithRkStepper,
                          ::testing::Values(__plugin::vector3<scalar>{
-                             1. * unit_constants::T, 1. * unit_constants::T,
-                             1. * unit_constants::T}));
+                             1. * unit<scalar>::T, 1. * unit<scalar>::T,
+                             1. * unit<scalar>::T}));

--- a/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
+++ b/tests/unit_tests/cuda/propagator_cuda_kernel.hpp
@@ -64,10 +64,10 @@ constexpr unsigned int theta_steps{10};
 constexpr unsigned int phi_steps{10};
 
 constexpr scalar rk_tolerance{1e-4};
-constexpr scalar overstep_tolerance{-3 * unit_constants::um};
-constexpr scalar constrainted_step_size{2. * unit_constants::mm};
+constexpr scalar overstep_tolerance{-3 * unit<scalar>::um};
+constexpr scalar constrainted_step_size{2. * unit<scalar>::mm};
 constexpr scalar is_close{1e-4};
-constexpr scalar path_limit{2 * unit_constants::m};
+constexpr scalar path_limit{2 * unit<scalar>::m};
 
 namespace detray {
 


### PR DESCRIPTION
In order to control the conversions between ```float``` and ```double``` with our ```constexpr double``` unit scale factors, this PR defines the units in a templated struct instead.