### PR TITLE
feat: json detector io

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ option( DETRAY_EIGEN_PLUGIN "Build Eigen math plugin" ON )
 option( DETRAY_SMATRIX_PLUGIN "Build ROOT/SMatrix math plugin" OFF )
 option( DETRAY_VC_PLUGIN "Build Vc based math plugin" ON )
 option( DETRAY_IO_CSV "Build CSV IO module" ON )
+option( DETRAY_IO_JSON "Build JSON IO module" ON)
 option( DETRAY_SVG_DISPLAY "Build ActSVG display module" OFF)
 option( DETRAY_BUILD_CUDA "Build the CUDA sources included in detray"
    ${DETRAY_BUILD_CUDA_DEFAULT} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,13 +98,27 @@ endif()
 option( DETRAY_SETUP_ACTSVG
    "Set up the actsvg target(s) explicitly" TRUE )
 option( DETRAY_USE_SYSTEM_ACTSVG
-   "Pick up an existing installation of dfelibs from the build environment"
+   "Pick up an existing installation of actsvg from the build environment"
    ${DETRAY_USE_SYSTEM_LIBS} )
 if( DETRAY_SETUP_ACTSVG )
    if( DETRAY_USE_SYSTEM_ACTSVG )
       find_package( actsvg::core actsvg::meta REQUIRED )
    else()
       add_subdirectory( extern/actsvg )
+   endif()
+endif()
+
+# Set up JSON for I/O
+option( DETRAY_SETUP_NLOHMANN
+   "Set up the nlohmann::json target(s) explicitly" TRUE )
+option( DETRAY_USE_SYSTEM_NLOHMANN
+   "Pick up an existing installation of nlohman::json from the build environment"
+   ${DETRAY_USE_SYSTEM_LIBS} )
+if( DETRAY_SETUP_NLOHMANN )
+   if( DETRAY_USE_SYSTEM_NLOHMANN )
+      find_package( nlohmann_json REQUIRED )
+   else()
+      add_subdirectory( extern/nlohmann_json )
    endif()
 endif()
 

--- a/extern/nlohmann_json/CMakeLists.txt
+++ b/extern/nlohmann_json/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required( VERSION 3.11 )
+include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
+# Tell the user what's happening.
+message( STATUS "Building nlohmann_json as part of the detray project" )
+
+# Declare where to get VecMem from.
+set( DETRAY_NLOHMANN_JSON_GIT_TAG "v3.10.5" CACHE STRING "Version of nlohmann_json to build" )
+set( DETRAY_NLOHMANN_JSON_SHA1 "8969f5ad1a422e01f040ff48dcae9c0e6ad0811d" CACHE STRING "SHA1 hash of the downloaded zip" )
+mark_as_advanced( DETRAY_NLOHMANN_JSON_GIT_REPOSITORY DETRAT_NLOHMANN_JSON_GIT_TAG )
+FetchContent_Declare( nlohmann_json
+   URL "https://github.com/nlohmann/json/archive/refs/tags/${DETRAY_NLOHMANN_JSON_GIT_TAG}.tar.gz"
+   URL_HASH SHA1=${DETRAY_NLOHMANN_JSON_SHA1})
+
+# Now set up its build.
+set(JSON_BuildTests OFF CACHE INTERNAL "")
+set(JSON_Install ON CACHE INTERNAL "")
+FetchContent_MakeAvailable( nlohmann_json )

--- a/extern/nlohmann_json/CMakeLists.txt
+++ b/extern/nlohmann_json/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 # Tell the user what's happening.
 message( STATUS "Building nlohmann_json as part of the detray project" )
 
-# Declare where to get VecMem from.
+# Declare where to get nlohmann from.
 set( DETRAY_NLOHMANN_JSON_GIT_TAG "v3.10.5" CACHE STRING "Version of nlohmann_json to build" )
 set( DETRAY_NLOHMANN_JSON_SHA1 "8969f5ad1a422e01f040ff48dcae9c0e6ad0811d" CACHE STRING "SHA1 hash of the downloaded zip" )
 mark_as_advanced( DETRAY_NLOHMANN_JSON_GIT_REPOSITORY DETRAT_NLOHMANN_JSON_GIT_TAG )

--- a/extern/nlohmann_json/README.md
+++ b/extern/nlohmann_json/README.md
@@ -1,0 +1,2 @@
+This directory holds a simple build recipe for the `nlohmann::json` library. Used in case
+`DETRAY_USE_SYSTEM_NLOHMANN` is set to `FALSE` for the build.

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -14,3 +14,7 @@ detray_add_library( detray_io io )
 if( DETRAY_IO_CSV )
    add_subdirectory( csv )
 endif()
+
+if ( DETRAY_IO_JSON )
+   add_subdirectory( json )
+endif()

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -10,6 +10,8 @@ message(STATUS "Building 'detray::io' component")
 # Create the "main I/O library".
 detray_add_library( detray_io io )
 
+add_subdirectory ( payload )
+
 # Include all active components.
 if( DETRAY_IO_CSV )
    add_subdirectory( csv )

--- a/io/json/CMakeLists.txt
+++ b/io/json/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Set the CMake minimum version.
+cmake_minimum_required( VERSION 3.13 )
+
+# Set up the library.
+detray_add_library( detray_io_json io_json
+"include/detray/io/json_defs.hpp"
+"include/detray/io/json_io.hpp"
+"include/detray/io/json_algebra_io.hpp"
+"include/detray/io/json_geometry_io.hpp")
+target_link_libraries( detray_io_json INTERFACE nlohmann_json vecmem::core )
+
+# Make the "main I/O library" link against it.
+target_link_libraries( detray_io INTERFACE detray::io_json )

--- a/io/json/include/detray/io/json_algebra_io.hpp
+++ b/io/json/include/detray/io/json_algebra_io.hpp
@@ -7,20 +7,13 @@
 
 #pragma once
 
-#include <array>
-
+#include "detray/io/io_payload.hpp"
 #include "detray/io/json_defs.hpp"
 
 /// @brief  The detray JSON I/O is written in such a way that it
 /// can read/write ACTS files that are written with the Detray
 /// JSON I/O extension
 namespace detray {
-
-/// @brief  A small pa
-struct transform_payload {
-    std::array<real_io, 3u> tr;
-    std::array<real_io, 9u> rot;
-};
 
 void to_json(nlohmann::json& j, const transform_payload& t) {
     j["translation"] = t.tr;

--- a/io/json/include/detray/io/json_algebra_io.hpp
+++ b/io/json/include/detray/io/json_algebra_io.hpp
@@ -1,0 +1,35 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <array>
+
+#include "detray/io/json_defs.hpp"
+
+/// @brief  The detray JSON I/O is written in such a way that it
+/// can read/write ACTS files that are written with the Detray
+/// JSON I/O extension
+namespace detray {
+
+/// @brief  A small pa
+struct transform_payload {
+    std::array<real_io, 3u> tr;
+    std::array<real_io, 9u> rot;
+};
+
+void to_json(nlohmann::json& j, const transform_payload& t) {
+    j["translation"] = t.tr;
+    j["rotation"] = t.rot;
+}
+
+void from_json(const nlohmann::json& j, transform_payload& t) {
+    t.tr = j["translation"];
+    t.rot = j["rotation"];
+}
+
+}  // namespace detray

--- a/io/json/include/detray/io/json_defs.hpp
+++ b/io/json/include/detray/io/json_defs.hpp
@@ -1,0 +1,19 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// This header is used to disable GCC errors that could be occuring in
+// nlohmann/json.hpp
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#include <nlohmann/json.hpp>
+#pragma GCC diagnostic pop
+
+namespace detray {
+    using real_io = float;
+}

--- a/io/json/include/detray/io/json_defs.hpp
+++ b/io/json/include/detray/io/json_defs.hpp
@@ -13,7 +13,3 @@
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #include <nlohmann/json.hpp>
 #pragma GCC diagnostic pop
-
-namespace detray {
-using real_io = float;
-}

--- a/io/json/include/detray/io/json_defs.hpp
+++ b/io/json/include/detray/io/json_defs.hpp
@@ -15,5 +15,5 @@
 #pragma GCC diagnostic pop
 
 namespace detray {
-    using real_io = float;
+using real_io = float;
 }

--- a/io/json/include/detray/io/json_geometry_io.hpp
+++ b/io/json/include/detray/io/json_geometry_io.hpp
@@ -12,8 +12,8 @@
 #include "detray/io/io_payload.hpp"
 #include "detray/io/json_algebra_io.hpp"
 #include "detray/io/json_defs.hpp"
-#include "detray/io/json_material_io.hpp"
 #include "detray/io/json_grids_io.hpp"
+#include "detray/io/json_material_io.hpp"
 
 /// @brief  The detray JSON I/O is written in such a way that it
 /// can read/write ACTS files that are written with the Detray

--- a/io/json/include/detray/io/json_geometry_io.hpp
+++ b/io/json/include/detray/io/json_geometry_io.hpp
@@ -9,6 +9,7 @@
 
 #include <array>
 
+#include "detray/io/io_payload.hpp"
 #include "detray/io/json_algebra_io.hpp"
 #include "detray/io/json_defs.hpp"
 #include "detray/io/json_material_io.hpp"
@@ -19,23 +20,6 @@
 /// JSON I/O extension
 namespace detray {
 
-/// @brief  A payload object for masks
-struct mask_payload {
-    enum class mask_type : unsigned int {
-        annulus2 = 0u,
-        cuboid3 = 1u,
-        cylinder2 = 2u,
-        cylinder3 = 3u,
-        line = 4u,
-        rectangle2 = 5u,
-        ring2 = 6u,
-        single3 = 7u,
-        trapezoid2 = 8u
-    };
-    mask_type type = mask_type::ring2;
-    std::vector<real_io> boundaries;
-};
-
 void to_json(nlohmann::json& j, const mask_payload& m) {
     j["type"] = static_cast<unsigned int>(m.type);
     j["boundaries"] = m.boundaries;
@@ -45,14 +29,6 @@ void from_json(const nlohmann::json& j, mask_payload& m) {
     m.type = static_cast<mask_payload::mask_type>(j["type"]);
     m.boundaries = j["boundaries"].get<std::vector<real_io>>();
 }
-
-/// @brief  A payload for surfaces
-struct surface_payload {
-    transform_payload transform;
-    mask_payload mask;
-    material_slab_payload material;
-    std::size_t gid;
-};
 
 void to_json(nlohmann::json& j, const surface_payload& s) {
     j["transform"] = s.transform;
@@ -68,12 +44,6 @@ void from_json(const nlohmann::json& j, surface_payload& s) {
     s.material = j["material"];
 }
 
-/// @brief a payload for portals
-struct portal_payload {
-    surface_payload surface;
-    links_payload volume_links;
-};
-
 void to_json(nlohmann::json& j, const portal_payload& p) {
     j["surface"] = p.surface;
     j["volume_links"] = p.volume_links;
@@ -84,18 +54,6 @@ void from_json(const nlohmann::json& j, portal_payload& p) {
     p.volume_links = j["volume_links"];
 }
 
-/// @brief a payload for volume bounds
-struct volume_bounds_payload {
-    enum class volume_bounds_type {
-        cuboid = 0u,
-        cylindrical = 1u,
-        generic_cuboid = 2u,
-        trapezoid = 3u
-    };
-    volume_bounds_type type = volume_bounds_type::cylindrical;
-    std::vector<real_io> values = {};
-};
-
 void to_json(nlohmann::json& j, const volume_bounds_payload& vb) {
     j["values"] = vb.values;
     j["type"] = static_cast<unsigned int>(vb.type);
@@ -105,16 +63,6 @@ void from_json(const nlohmann::json& j, volume_bounds_payload& vb) {
     vb.values = j["values"].get<std::vector<real_io>>();
     vb.type = static_cast<volume_bounds_payload::volume_bounds_type>(j["type"]);
 }
-
-/// @brief a payload for volumes
-struct volume_payload {
-    std::string name = "";
-    transform_payload transform;
-    volume_bounds_payload volume_bounds;
-    std::vector<portal_payload> portals;
-    std::vector<surface_payload> surfaces;
-    links_payload surface_links;
-};
 
 void to_json(nlohmann::json& j, const volume_payload& v) {
     j["name"] = v.name;
@@ -151,13 +99,6 @@ void from_json(const nlohmann::json& j, volume_payload& v) {
         v.surface_links = j["surface_links"];
     }
 }
-
-/// @brief a payload for volumes
-struct detector_payload {
-    std::string name = "";
-    std::vector<volume_payload> volumes = {};
-    grid_objects_payload volume_grid;
-};
 
 void to_json(nlohmann::json& j, const detector_payload& d) {
     j["name"] = d.name;

--- a/io/json/include/detray/io/json_geometry_io.hpp
+++ b/io/json/include/detray/io/json_geometry_io.hpp
@@ -1,0 +1,184 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <array>
+
+#include "detray/io/json_algebra_io.hpp"
+#include "detray/io/json_defs.hpp"
+#include "detray/io/json_material_io.hpp"
+#include "detray/io/json_utilities_io.hpp"
+
+/// @brief  The detray JSON I/O is written in such a way that it
+/// can read/write ACTS files that are written with the Detray
+/// JSON I/O extension
+namespace detray {
+
+/// @brief  A payload object for masks
+struct mask_payload {
+    enum class mask_type : unsigned int {
+        annulus2 = 0u,
+        cuboid3 = 1u,
+        cylinder2 = 2u,
+        cylinder3 = 3u,
+        line = 4u,
+        rectangle2 = 5u,
+        ring2 = 6u,
+        single3 = 7u,
+        trapezoid2 = 8u
+    };
+    mask_type type = mask_type::ring2;
+    std::vector<real_io> boundaries;
+};
+
+void to_json(nlohmann::json& j, const mask_payload& m) {
+    j["type"] = static_cast<unsigned int>(m.type);
+    j["boundaries"] = m.boundaries;
+}
+
+void from_json(const nlohmann::json& j, mask_payload& m) {
+    m.type = static_cast<mask_payload::mask_type>(j["type"]);
+    m.boundaries = j["boundaries"].get<std::vector<real_io>>();
+}
+
+/// @brief  A payload for surfaces
+struct surface_payload {
+    transform_payload transform;
+    mask_payload mask;
+    material_slab_payload material;
+    std::size_t gid;
+};
+
+void to_json(nlohmann::json& j, const surface_payload& s) {
+    j["transform"] = s.transform;
+    j["mask"] = s.mask;
+    j["geoID"] = s.gid;
+    j["material"] = s.material;
+}
+
+void from_json(const nlohmann::json& j, surface_payload& s) {
+    s.transform = j["transform"];
+    s.mask = j["mask"];
+    s.gid = j["geoID"];
+    s.material = j["material"];
+}
+
+/// @brief a payload for portals
+struct portal_payload {
+    surface_payload surface;
+    links_payload volume_links;
+};
+
+void to_json(nlohmann::json& j, const portal_payload& p) {
+    j["surface"] = p.surface;
+    j["volume_links"] = p.volume_links;
+}
+
+void from_json(const nlohmann::json& j, portal_payload& p) {
+    p.surface = j["surface"];
+    p.volume_links = j["volume_links"];
+}
+
+/// @brief a payload for volume bounds
+struct volume_bounds_payload {
+    enum class volume_bounds_type {
+        cuboid = 0u,
+        cylindrical = 1u,
+        generic_cuboid = 2u,
+        trapezoid = 3u
+    };
+    volume_bounds_type type = volume_bounds_type::cylindrical;
+    std::vector<real_io> values = {};
+};
+
+void to_json(nlohmann::json& j, const volume_bounds_payload& vb) {
+    j["values"] = vb.values;
+    j["type"] = static_cast<unsigned int>(vb.type);
+}
+
+void from_json(const nlohmann::json& j, volume_bounds_payload& vb) {
+    vb.values = j["values"].get<std::vector<real_io>>();
+    vb.type = static_cast<volume_bounds_payload::volume_bounds_type>(j["type"]);
+}
+
+/// @brief a payload for volumes
+struct volume_payload {
+    std::string name = "";
+    transform_payload transform;
+    volume_bounds_payload volume_bounds;
+    std::vector<portal_payload> portals;
+    std::vector<surface_payload> surfaces;
+    links_payload surface_links;
+};
+
+void to_json(nlohmann::json& j, const volume_payload& v) {
+    j["name"] = v.name;
+    j["transform"] = v.transform;
+    j["volume_bounds"] = v.volume_bounds;
+    nlohmann::json pjson;
+    for (const auto& p : v.portals) {
+        pjson.push_back(p);
+    }
+    j["portals"] = pjson;
+    if (not v.surfaces.empty()) {
+        nlohmann::json sjson;
+        for (const auto& s : v.surfaces) {
+            sjson.push_back(s);
+        }
+        j["surfaces"] = sjson;
+        j["surface_links"] = v.surface_links;
+    }
+}
+
+void from_json(const nlohmann::json& j, volume_payload& v) {
+    v.name = j["name"];
+    v.transform = j["transform"];
+    v.volume_bounds = j["volume_bounds"];
+    for (auto jp : j["portals"]) {
+        portal_payload p = jp;
+        v.portals.push_back(p);
+    }
+    if (j.find("surfaces") != j.end()) {
+        for (auto js : j["surfaces"]) {
+            surface_payload s = js;
+            v.surfaces.push_back(s);
+        }
+        v.surface_links = j["surface_links"];
+    }
+}
+
+/// @brief a payload for volumes
+struct detector_payload {
+    std::string name = "";
+    std::vector<volume_payload> volumes = {};
+    grid_objects_payload volume_grid;
+};
+
+void to_json(nlohmann::json& j, const detector_payload& d) {
+    j["name"] = d.name;
+    if (not d.volumes.empty()) {
+        nlohmann::json jvolumes;
+        for (const auto& v : d.volumes) {
+            jvolumes.push_back(v);
+        }
+        j["volumes"] = jvolumes;
+        j["volume_grid"] = d.volume_grid;
+    }
+}
+
+void from_json(const nlohmann::json& j, detector_payload& d) {
+    d.name = j["name"];
+    if (j.find("volumes") != j.end()) {
+        for (auto jvolume : j["volumes"]) {
+            d.volumes.push_back(jvolume);
+        }
+        d.volume_grid = j["volume_grid"];
+    }
+}
+
+}  // namespace detray

--- a/io/json/include/detray/io/json_geometry_io.hpp
+++ b/io/json/include/detray/io/json_geometry_io.hpp
@@ -13,7 +13,7 @@
 #include "detray/io/json_algebra_io.hpp"
 #include "detray/io/json_defs.hpp"
 #include "detray/io/json_material_io.hpp"
-#include "detray/io/json_utilities_io.hpp"
+#include "detray/io/json_grids_io.hpp"
 
 /// @brief  The detray JSON I/O is written in such a way that it
 /// can read/write ACTS files that are written with the Detray
@@ -21,12 +21,12 @@
 namespace detray {
 
 void to_json(nlohmann::json& j, const mask_payload& m) {
-    j["type"] = static_cast<unsigned int>(m.type);
+    j["shape"] = static_cast<unsigned int>(m.shape);
     j["boundaries"] = m.boundaries;
 }
 
 void from_json(const nlohmann::json& j, mask_payload& m) {
-    m.type = static_cast<mask_payload::mask_type>(j["type"]);
+    m.shape = static_cast<mask_payload::mask_shape>(j["shape"]);
     m.boundaries = j["boundaries"].get<std::vector<real_io>>();
 }
 

--- a/io/json/include/detray/io/json_grids_io.hpp
+++ b/io/json/include/detray/io/json_grids_io.hpp
@@ -17,18 +17,18 @@
 namespace detray {
 
 void to_json(nlohmann::json& j, const axis_payload& a) {
-    j["type"] = static_cast<unsigned int>(a.type);
-    j["bracket"] = static_cast<unsigned int>(a.bracket);
-    j["lookup"] = static_cast<unsigned int>(a.lookup);
-    j["borders"] = a.borders;
+    j["label"] = static_cast<unsigned int>(a.label);
+    j["bounds"] = static_cast<unsigned int>(a.bounds);
+    j["binning"] = static_cast<unsigned int>(a.binning);
+    j["edges"] = a.edges;
     j["bins"] = a.bins;
 }
 
 void from_json(const nlohmann::json& j, axis_payload& a) {
-    a.type = static_cast<axis_payload::axis_type>(j["type"]);
-    a.bracket = static_cast<axis_payload::axis_bracket>(j["bracket"]);
-    a.lookup = static_cast<axis_payload::axis_lookup>(j["lookup"]);
-    a.borders = j["borders"].get<std::vector<real_io>>();
+    a.binning = static_cast<axis_payload::axis_binning>(j["binning"]);
+    a.bounds = static_cast<axis_payload::axis_bounds>(j["bounds"]);
+    a.label = static_cast<axis_payload::axis_label>(j["label"]);
+    a.edges = j["edges"].get<std::vector<real_io>>();
     a.bins = j["bins"];
 }
 

--- a/io/json/include/detray/io/json_io.hpp
+++ b/io/json/include/detray/io/json_io.hpp
@@ -1,0 +1,13 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/io/json_algebra_io.hpp"
+#include "detray/io/json_geometry_io.hpp"
+#include "detray/io/json_material_io.hpp"
+#include "detray/io/json_utilities_io.hpp"

--- a/io/json/include/detray/io/json_io.hpp
+++ b/io/json/include/detray/io/json_io.hpp
@@ -9,5 +9,5 @@
 
 #include "detray/io/json_algebra_io.hpp"
 #include "detray/io/json_geometry_io.hpp"
-#include "detray/io/json_material_io.hpp"
 #include "detray/io/json_grids_io.hpp"
+#include "detray/io/json_material_io.hpp"

--- a/io/json/include/detray/io/json_io.hpp
+++ b/io/json/include/detray/io/json_io.hpp
@@ -10,4 +10,4 @@
 #include "detray/io/json_algebra_io.hpp"
 #include "detray/io/json_geometry_io.hpp"
 #include "detray/io/json_material_io.hpp"
-#include "detray/io/json_utilities_io.hpp"
+#include "detray/io/json_grids_io.hpp"

--- a/io/json/include/detray/io/json_material_io.hpp
+++ b/io/json/include/detray/io/json_material_io.hpp
@@ -9,6 +9,7 @@
 
 #include <array>
 
+#include "detray/io/io_payload.hpp"
 #include "detray/io/json_algebra_io.hpp"
 #include "detray/io/json_defs.hpp"
 
@@ -16,11 +17,6 @@
 /// can read/write ACTS files that are written with the Detray
 /// JSON I/O extension
 namespace detray {
-
-/// @brief  A payload object for masks
-struct material_slab_payload {
-    std::array<real_io, 5u> slab;
-};
 
 void to_json(nlohmann::json& j, const material_slab_payload& m) {
     j = m.slab;

--- a/io/json/include/detray/io/json_material_io.hpp
+++ b/io/json/include/detray/io/json_material_io.hpp
@@ -1,0 +1,33 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <array>
+
+#include "detray/io/json_algebra_io.hpp"
+#include "detray/io/json_defs.hpp"
+
+/// @brief  The detray JSON I/O is written in such a way that it
+/// can read/write ACTS files that are written with the Detray
+/// JSON I/O extension
+namespace detray {
+
+/// @brief  A payload object for masks
+struct material_slab_payload {
+    std::array<real_io, 5u> slab;
+};
+
+void to_json(nlohmann::json& j, const material_slab_payload& m) {
+    j = m.slab;
+}
+
+void from_json(const nlohmann::json& j, material_slab_payload& m) {
+    m.slab = j.get<std::array<real_io, 5u> >();
+}
+
+}  // namespace detray

--- a/io/json/include/detray/io/json_utilities_io.hpp
+++ b/io/json/include/detray/io/json_utilities_io.hpp
@@ -91,6 +91,7 @@ void from_json(const nlohmann::json& j, single_object_payload& so) {
     so.link = j;
 }
 
+/// @brief grid objects
 struct grid_objects_payload {
     grid_payload grid;
     std::optional<transform_payload> transform;
@@ -110,7 +111,7 @@ void from_json(const nlohmann::json& j, grid_objects_payload& g) {
     }
 }
 
-/// @brief local navigation definition
+/// @brief navigation definition
 struct links_payload {
     std::vector<single_object_payload> single_links;
     std::optional<grid_objects_payload> grid_links;

--- a/io/json/include/detray/io/json_utilities_io.hpp
+++ b/io/json/include/detray/io/json_utilities_io.hpp
@@ -11,32 +11,10 @@
 #include <optional>
 #include <vector>
 
+#include "detray/io/io_payload.hpp"
 #include "detray/io/json_defs.hpp"
 
 namespace detray {
-
-/// @brief axis definition
-struct axis_payload {
-    /// axis lookup type
-    enum class axis_lookup : unsigned int {
-        x = 0u,
-        y = 1u,
-        z = 2u,
-        r = 3u,
-        phi = 4u
-    };
-    /// How the axis is done
-    enum class axis_type : unsigned int { equidistant = 0u, variable = 1u };
-    /// How the axis is bound
-    enum class axis_bracket : unsigned int { bound = 0u, closed = 1u };
-
-    axis_type type = axis_type::equidistant;
-    axis_bracket bracket = axis_bracket::bound;
-    axis_lookup lookup = axis_lookup::r;
-
-    std::vector<real_io> borders = {};
-    std::size_t bins = 0u;
-};
 
 void to_json(nlohmann::json& j, const axis_payload& a) {
     j["type"] = static_cast<unsigned int>(a.type);
@@ -53,12 +31,6 @@ void from_json(const nlohmann::json& j, axis_payload& a) {
     a.borders = j["borders"].get<std::vector<real_io>>();
     a.bins = j["bins"];
 }
-
-/// @brief axis definition
-struct grid_payload {
-    std::vector<axis_payload> axes = {};
-    std::vector<std::vector<unsigned int>> entries = {};
-};
 
 void to_json(nlohmann::json& j, const grid_payload& g) {
     nlohmann::json jaxes;
@@ -78,11 +50,6 @@ void from_json(const nlohmann::json& j, grid_payload& g) {
     g.entries = j["entries"];
 }
 
-/// @brief single object
-struct single_object_payload {
-    unsigned int link;
-};
-
 void to_json(nlohmann::json& j, const single_object_payload& so) {
     j = so.link;
 }
@@ -90,12 +57,6 @@ void to_json(nlohmann::json& j, const single_object_payload& so) {
 void from_json(const nlohmann::json& j, single_object_payload& so) {
     so.link = j;
 }
-
-/// @brief grid objects
-struct grid_objects_payload {
-    grid_payload grid;
-    std::optional<transform_payload> transform;
-};
 
 void to_json(nlohmann::json& j, const grid_objects_payload& g) {
     j["grid"] = g.grid;
@@ -110,12 +71,6 @@ void from_json(const nlohmann::json& j, grid_objects_payload& g) {
         g.transform = j["transform"];
     }
 }
-
-/// @brief navigation definition
-struct links_payload {
-    std::vector<single_object_payload> single_links;
-    std::optional<grid_objects_payload> grid_links;
-};
 
 void to_json(nlohmann::json& j, const links_payload& l) {
     nlohmann::json js;

--- a/io/json/include/detray/io/json_utilities_io.hpp
+++ b/io/json/include/detray/io/json_utilities_io.hpp
@@ -1,0 +1,141 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <array>
+#include <optional>
+#include <vector>
+
+#include "detray/io/json_defs.hpp"
+
+namespace detray {
+
+/// @brief axis definition
+struct axis_payload {
+    /// axis lookup type
+    enum class axis_lookup : unsigned int {
+        x = 0u,
+        y = 1u,
+        z = 2u,
+        r = 3u,
+        phi = 4u
+    };
+    /// How the axis is done
+    enum class axis_type : unsigned int { equidistant = 0u, variable = 1u };
+    /// How the axis is bound
+    enum class axis_bracket : unsigned int { bound = 0u, closed = 1u };
+
+    axis_type type = axis_type::equidistant;
+    axis_bracket bracket = axis_bracket::bound;
+    axis_lookup lookup = axis_lookup::r;
+
+    std::vector<real_io> borders = {};
+    std::size_t bins = 0u;
+};
+
+void to_json(nlohmann::json& j, const axis_payload& a) {
+    j["type"] = static_cast<unsigned int>(a.type);
+    j["bracket"] = static_cast<unsigned int>(a.bracket);
+    j["lookup"] = static_cast<unsigned int>(a.lookup);
+    j["borders"] = a.borders;
+    j["bins"] = a.bins;
+}
+
+void from_json(const nlohmann::json& j, axis_payload& a) {
+    a.type = static_cast<axis_payload::axis_type>(j["type"]);
+    a.bracket = static_cast<axis_payload::axis_bracket>(j["bracket"]);
+    a.lookup = static_cast<axis_payload::axis_lookup>(j["lookup"]);
+    a.borders = j["borders"].get<std::vector<real_io>>();
+    a.bins = j["bins"];
+}
+
+/// @brief axis definition
+struct grid_payload {
+    std::vector<axis_payload> axes = {};
+    std::vector<std::vector<unsigned int>> entries = {};
+};
+
+void to_json(nlohmann::json& j, const grid_payload& g) {
+    nlohmann::json jaxes;
+    for (const auto& a : g.axes) {
+        jaxes.push_back(a);
+    }
+    j["axes"] = jaxes;
+    j["entries"] = g.entries;
+}
+
+void from_json(const nlohmann::json& j, grid_payload& g) {
+    nlohmann::json jaxes = j["axes"];
+    for (auto jax : jaxes) {
+        axis_payload a = jax;
+        g.axes.push_back(a);
+    }
+    g.entries = j["entries"];
+}
+
+/// @brief single object
+struct single_object_payload {
+    unsigned int link;
+};
+
+void to_json(nlohmann::json& j, const single_object_payload& so) {
+    j = so.link;
+}
+
+void from_json(const nlohmann::json& j, single_object_payload& so) {
+    so.link = j;
+}
+
+struct grid_objects_payload {
+    grid_payload grid;
+    std::optional<transform_payload> transform;
+};
+
+void to_json(nlohmann::json& j, const grid_objects_payload& g) {
+    j["grid"] = g.grid;
+    if (g.transform.has_value()) {
+        j["transform"] = g.transform.value();
+    }
+}
+
+void from_json(const nlohmann::json& j, grid_objects_payload& g) {
+    g.grid = j["grid"];
+    if (j.find("transform") != j.end()) {
+        g.transform = j["transform"];
+    }
+}
+
+/// @brief local navigation definition
+struct links_payload {
+    std::vector<single_object_payload> single_links;
+    std::optional<grid_objects_payload> grid_links;
+};
+
+void to_json(nlohmann::json& j, const links_payload& l) {
+    nlohmann::json js;
+    for (const auto& so : l.single_links) {
+        js.push_back(so);
+    }
+    j["single_links"] = js;
+    if (l.grid_links.has_value()) {
+        j["grid_links"] = l.grid_links.value();
+    }
+}
+
+void from_json(const nlohmann::json& j, links_payload& l) {
+    nlohmann::json jsl = j["single_links"];
+    for (auto jl : jsl) {
+        single_object_payload sl = jl;
+        l.single_links.push_back(sl);
+    }
+    if (j.find("grid_links") != j.end()) {
+        l.grid_links = j["grid_links"];
+    }
+}
+
+}  // namespace detray

--- a/io/payload/CMakeLists.txt
+++ b/io/payload/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Set the CMake minimum version.
+cmake_minimum_required( VERSION 3.13 )
+
+# Set up the library.
+detray_add_library( detray_io_payload io_payload
+"include/detray/io/io_payload.hpp")
+target_link_libraries( detray_io_payload INTERFACE)
+
+# Make the "main I/O library" link against it.
+target_link_libraries( detray_io INTERFACE detray::io_payload )

--- a/io/payload/include/detray/io/io_payload.hpp
+++ b/io/payload/include/detray/io/io_payload.hpp
@@ -1,0 +1,134 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <array>
+#include <vector>
+
+namespace detray {
+
+using real_io = float;
+
+/// @brief  A small pa
+struct transform_payload {
+    std::array<real_io, 3u> tr;
+    std::array<real_io, 9u> rot;
+};
+
+/// @brief axis definition
+struct axis_payload {
+    /// axis lookup type
+    enum class axis_lookup : unsigned int {
+        x = 0u,
+        y = 1u,
+        z = 2u,
+        r = 3u,
+        phi = 4u
+    };
+    /// How the axis is done
+    enum class axis_type : unsigned int { equidistant = 0u, variable = 1u };
+    /// How the axis is bound
+    enum class axis_bracket : unsigned int { bound = 0u, closed = 1u };
+
+    axis_type type = axis_type::equidistant;
+    axis_bracket bracket = axis_bracket::bound;
+    axis_lookup lookup = axis_lookup::r;
+
+    std::vector<real_io> borders = {};
+    std::size_t bins = 0u;
+};
+
+/// @brief A payload for a grid definition
+struct grid_payload {
+    std::vector<axis_payload> axes = {};
+    std::vector<std::vector<unsigned int>> entries = {};
+};
+
+/// @brief A payload object for material
+struct material_slab_payload {
+    std::array<real_io, 5u> slab;
+};
+
+/// @brief A payload for a single object link
+struct single_object_payload {
+    unsigned int link;
+};
+
+/// @brief A payload for objects within a grid
+struct grid_objects_payload {
+    grid_payload grid;
+    std::optional<transform_payload> transform;
+};
+
+/// @brief navigation links definition
+struct links_payload {
+    std::vector<single_object_payload> single_links;
+    std::optional<grid_objects_payload> grid_links;
+};
+
+/// @brief A payload object for surface masks
+struct mask_payload {
+    enum class mask_type : unsigned int {
+        annulus2 = 0u,
+        cuboid3 = 1u,
+        cylinder2 = 2u,
+        cylinder3 = 3u,
+        line = 4u,
+        rectangle2 = 5u,
+        ring2 = 6u,
+        single3 = 7u,
+        trapezoid2 = 8u
+    };
+    mask_type type = mask_type::ring2;
+    std::vector<real_io> boundaries;
+};
+
+/// @brief  A payload for surfaces
+struct surface_payload {
+    transform_payload transform;
+    mask_payload mask;
+    material_slab_payload material;
+    std::size_t gid;
+};
+
+/// @brief A payload for portals
+struct portal_payload {
+    surface_payload surface;
+    links_payload volume_links;
+};
+
+/// @brief A payload for volume bounds
+struct volume_bounds_payload {
+    enum class volume_bounds_type {
+        cuboid = 0u,
+        cylindrical = 1u,
+        generic_cuboid = 2u,
+        trapezoid = 3u
+    };
+    volume_bounds_type type = volume_bounds_type::cylindrical;
+    std::vector<real_io> values = {};
+};
+
+/// @brief A payload for volumes
+struct volume_payload {
+    std::string name = "";
+    transform_payload transform;
+    volume_bounds_payload volume_bounds;
+    std::vector<portal_payload> portals;
+    std::vector<surface_payload> surfaces;
+    links_payload surface_links;
+};
+
+/// @brief A payload for a detector
+struct detector_payload {
+    std::string name = "";
+    std::vector<volume_payload> volumes = {};
+    grid_objects_payload volume_grid;
+};
+
+}  // namespace detray

--- a/io/payload/include/detray/io/io_payload.hpp
+++ b/io/payload/include/detray/io/io_payload.hpp
@@ -23,7 +23,7 @@ struct transform_payload {
 /// @brief axis definition
 struct axis_payload {
     /// axis lookup type
-    enum class axis_lookup : unsigned int {
+    enum class axis_label : unsigned int {
         x = 0u,
         y = 1u,
         z = 2u,
@@ -31,15 +31,15 @@ struct axis_payload {
         phi = 4u
     };
     /// How the axis is done
-    enum class axis_type : unsigned int { equidistant = 0u, variable = 1u };
+    enum class axis_binning : unsigned int { equidistant = 0u, variable = 1u };
     /// How the axis is bound
-    enum class axis_bracket : unsigned int { bound = 0u, closed = 1u };
+    enum class axis_bounds : unsigned int { closed = 0u, circular = 1u };
 
-    axis_type type = axis_type::equidistant;
-    axis_bracket bracket = axis_bracket::bound;
-    axis_lookup lookup = axis_lookup::r;
+    axis_binning binning = axis_binning::equidistant;
+    axis_bounds bounds = axis_bounds::closed;
+    axis_label label = axis_label::r;
 
-    std::vector<real_io> borders = {};
+    std::vector<real_io> edges = {};
     std::size_t bins = 0u;
 };
 
@@ -73,7 +73,7 @@ struct links_payload {
 
 /// @brief A payload object for surface masks
 struct mask_payload {
-    enum class mask_type : unsigned int {
+    enum class mask_shape : unsigned int {
         annulus2 = 0u,
         cuboid3 = 1u,
         cylinder2 = 2u,
@@ -84,7 +84,7 @@ struct mask_payload {
         single3 = 7u,
         trapezoid2 = 8u
     };
-    mask_type type = mask_type::ring2;
+    mask_shape shape = mask_shape::ring2;
     std::vector<real_io> boundaries;
 };
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 if( DETRAY_VC_PLUGIN )
    add_subdirectory( vc )
 endif()
+add_subdirectory( io )
 
 # Set up all of the "device" tests.
 if( DETRAY_BUILD_CUDA )

--- a/tests/unit_tests/io/CMakeLists.txt
+++ b/tests/unit_tests/io/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Set up the core tests.
+detray_add_test( io
+   "io_json_payload.cpp"
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::io )

--- a/tests/unit_tests/io/io_json_payload.cpp
+++ b/tests/unit_tests/io/io_json_payload.cpp
@@ -27,10 +27,10 @@ TEST(io, json_algebra_payload) {
 TEST(io, json_axis_payload) {
 
     detray::axis_payload ea;
-    ea.type = detray::axis_payload::axis_type::equidistant;
-    ea.bracket = detray::axis_payload::axis_bracket::closed;
-    ea.lookup = detray::axis_payload::axis_lookup::phi;
-    ea.borders = {-M_PI, M_PI};
+    ea.binning = detray::axis_payload::axis_binning::equidistant;
+    ea.bounds = detray::axis_payload::axis_bounds::circular;
+    ea.label = detray::axis_payload::axis_label::phi;
+    ea.edges = {-M_PI, M_PI};
     ea.bins = 10u;
 
     nlohmann::json je;
@@ -38,28 +38,28 @@ TEST(io, json_axis_payload) {
 
     detray::axis_payload pea = je["axis"];
 
-    EXPECT_EQ(ea.type, pea.type);
-    EXPECT_EQ(ea.bracket, pea.bracket);
-    EXPECT_EQ(ea.borders, pea.borders);
+    EXPECT_EQ(ea.binning, pea.binning);
+    EXPECT_EQ(ea.bounds, pea.bounds);
+    EXPECT_EQ(ea.edges, pea.edges);
 
     EXPECT_EQ(ea.bins, pea.bins);
 
     detray::axis_payload va;
-    va.type = detray::axis_payload::axis_type::variable;
-    va.bracket = detray::axis_payload::axis_bracket::bound;
-    va.lookup = detray::axis_payload::axis_lookup::r;
-    va.borders = {0, 1, 4, 5, 8, 10};
-    va.bins = va.borders.size() - 1;
+    va.binning = detray::axis_payload::axis_binning::variable;
+    va.bounds = detray::axis_payload::axis_bounds::closed;
+    va.label = detray::axis_payload::axis_label::r;
+    va.edges = {0, 1, 4, 5, 8, 10};
+    va.bins = va.edges.size() - 1;
 
     nlohmann::json jv;
     jv["axis"] = va;
 
     detray::axis_payload pva = jv["axis"];
 
-    EXPECT_EQ(va.type, pva.type);
-    EXPECT_EQ(va.bracket, pva.bracket);
-    EXPECT_EQ(va.lookup, pva.lookup);
-    EXPECT_EQ(va.borders, pva.borders);
+    EXPECT_EQ(va.binning, pva.binning);
+    EXPECT_EQ(va.bounds, pva.bounds);
+    EXPECT_EQ(va.label, pva.label);
+    EXPECT_EQ(va.edges, pva.edges);
     EXPECT_EQ(va.bins, pva.bins);
 }
 
@@ -68,14 +68,14 @@ TEST(io, json_grid_payload) {
     std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
                                                       {1, 2}, {2, 1}, {2, 2}};
 
-    detray::axis_payload a0{detray::axis_payload::axis_type::equidistant,
-                            detray::axis_payload::axis_bracket::closed,
-                            detray::axis_payload::axis_lookup::phi,
+    detray::axis_payload a0{detray::axis_payload::axis_binning::equidistant,
+                            detray::axis_payload::axis_bounds::circular,
+                            detray::axis_payload::axis_label::phi,
                             std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
 
-    detray::axis_payload a1{detray::axis_payload::axis_type::equidistant,
-                            detray::axis_payload::axis_bracket::bound,
-                            detray::axis_payload::axis_lookup::r,
+    detray::axis_payload a1{detray::axis_payload::axis_binning::equidistant,
+                            detray::axis_payload::axis_bounds::closed,
+                            detray::axis_payload::axis_label::r,
                             std::vector<detray::real_io>{0, 2u}, 2u};
 
     detray::grid_payload g;
@@ -109,14 +109,14 @@ TEST(io, grid_objects_payload) {
     std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
                                                       {1, 2}, {2, 1}, {2, 2}};
 
-    detray::axis_payload a0{detray::axis_payload::axis_type::equidistant,
-                            detray::axis_payload::axis_bracket::closed,
-                            detray::axis_payload::axis_lookup::phi,
+    detray::axis_payload a0{detray::axis_payload::axis_binning::equidistant,
+                            detray::axis_payload::axis_bounds::circular,
+                            detray::axis_payload::axis_label::phi,
                             std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
 
-    detray::axis_payload a1{detray::axis_payload::axis_type::equidistant,
-                            detray::axis_payload::axis_bracket::bound,
-                            detray::axis_payload::axis_lookup::r,
+    detray::axis_payload a1{detray::axis_payload::axis_binning::equidistant,
+                            detray::axis_payload::axis_bounds::closed,
+                            detray::axis_payload::axis_label::r,
                             std::vector<detray::real_io>{0, 2u}, 2u};
 
     detray::grid_payload g;
@@ -155,14 +155,14 @@ TEST(io, json_links_payload) {
     std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
                                                       {1, 2}, {2, 1}, {2, 2}};
 
-    detray::axis_payload a0{detray::axis_payload::axis_type::equidistant,
-                            detray::axis_payload::axis_bracket::closed,
-                            detray::axis_payload::axis_lookup::phi,
+    detray::axis_payload a0{detray::axis_payload::axis_binning::equidistant,
+                            detray::axis_payload::axis_bounds::circular,
+                            detray::axis_payload::axis_label::phi,
                             std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
 
-    detray::axis_payload a1{detray::axis_payload::axis_type::equidistant,
-                            detray::axis_payload::axis_bracket::bound,
-                            detray::axis_payload::axis_lookup::r,
+    detray::axis_payload a1{detray::axis_payload::axis_binning::equidistant,
+                            detray::axis_payload::axis_bounds::closed,
+                            detray::axis_payload::axis_label::r,
                             std::vector<detray::real_io>{0, 2u}, 2u};
 
     detray::grid_payload g;
@@ -194,7 +194,7 @@ TEST(io, json_links_payload) {
 TEST(io, json_mask_payload) {
 
     detray::mask_payload m;
-    m.type = detray::mask_payload::mask_type::cylinder3;
+    m.shape = detray::mask_payload::mask_shape::cylinder3;
     m.boundaries = {10., 100.};
 
     nlohmann::json j;
@@ -202,7 +202,7 @@ TEST(io, json_mask_payload) {
 
     detray::mask_payload pm = j["mask"];
 
-    EXPECT_EQ(m.type, pm.type);
+    EXPECT_EQ(m.shape, pm.shape);
     EXPECT_EQ(m.boundaries, pm.boundaries);
 }
 
@@ -228,7 +228,7 @@ TEST(io, json_surface_payload) {
     t.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
 
     detray::mask_payload m;
-    m.type = detray::mask_payload::mask_type::trapezoid2;
+    m.shape = detray::mask_payload::mask_shape::trapezoid2;
     m.boundaries = {10., 20., 34., 1.4};
 
     detray::material_slab_payload mat;
@@ -246,7 +246,7 @@ TEST(io, json_surface_payload) {
     EXPECT_EQ(s.transform.tr, ps.transform.tr);
     EXPECT_EQ(s.transform.rot, ps.transform.rot);
 
-    EXPECT_EQ(s.mask.type, ps.mask.type);
+    EXPECT_EQ(s.mask.shape, ps.mask.shape);
     EXPECT_EQ(s.mask.boundaries, ps.mask.boundaries);
 
     EXPECT_EQ(s.material.slab, ps.material.slab);
@@ -261,7 +261,7 @@ TEST(io, json_portal_payload) {
     t.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
 
     detray::mask_payload m;
-    m.type = detray::mask_payload::mask_type::trapezoid2;
+    m.shape = detray::mask_payload::mask_shape::trapezoid2;
     m.boundaries = {10., 20., 34., 1.4};
 
     detray::material_slab_payload mat;
@@ -326,7 +326,7 @@ TEST(io, json_volume_payload) {
     detray::surface_payload s;
 
     detray::mask_payload m;
-    m.type = detray::mask_payload::mask_type::trapezoid2;
+    m.shape = detray::mask_payload::mask_shape::trapezoid2;
     m.boundaries = {10., 20., 34., 1.4};
 
     detray::material_slab_payload mat;

--- a/tests/unit_tests/io/io_json_payload.cpp
+++ b/tests/unit_tests/io/io_json_payload.cpp
@@ -1,0 +1,374 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include "detray/io/json_io.hpp"
+
+TEST(io, json_algebra_payload) {
+
+    detray::transform_payload p;
+    p.tr = {100., 200., 300.};
+    p.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
+
+    nlohmann::json j;
+    j["transform"] = p;
+
+    detray::transform_payload pt = j["transform"];
+
+    EXPECT_EQ(p.tr, pt.tr);
+    EXPECT_EQ(p.rot, pt.rot);
+}
+
+TEST(io, json_axis_payload) {
+
+    detray::axis_payload ea;
+    ea.type = detray::axis_payload::axis_type::equidistant;
+    ea.bracket = detray::axis_payload::axis_bracket::closed;
+    ea.lookup = detray::axis_payload::axis_lookup::phi;
+    ea.borders = {-M_PI, M_PI};
+    ea.bins = 10u;
+
+    nlohmann::json je;
+    je["axis"] = ea;
+
+    detray::axis_payload pea = je["axis"];
+
+    EXPECT_EQ(ea.type, pea.type);
+    EXPECT_EQ(ea.bracket, pea.bracket);
+    EXPECT_EQ(ea.borders, pea.borders);
+
+    EXPECT_EQ(ea.bins, pea.bins);
+
+    detray::axis_payload va;
+    va.type = detray::axis_payload::axis_type::variable;
+    va.bracket = detray::axis_payload::axis_bracket::bound;
+    va.lookup = detray::axis_payload::axis_lookup::r;
+    va.borders = {0, 1, 4, 5, 8, 10};
+    va.bins = va.borders.size() - 1;
+
+    nlohmann::json jv;
+    jv["axis"] = va;
+
+    detray::axis_payload pva = jv["axis"];
+
+    EXPECT_EQ(va.type, pva.type);
+    EXPECT_EQ(va.bracket, pva.bracket);
+    EXPECT_EQ(va.lookup, pva.lookup);
+    EXPECT_EQ(va.borders, pva.borders);
+    EXPECT_EQ(va.bins, pva.bins);
+}
+
+TEST(io, json_grid_payload) {
+
+    std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
+                                                      {1, 2}, {2, 1}, {2, 2}};
+
+    detray::axis_payload a0{detray::axis_payload::axis_type::equidistant,
+                            detray::axis_payload::axis_bracket::closed,
+                            detray::axis_payload::axis_lookup::phi,
+                            std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
+
+    detray::axis_payload a1{detray::axis_payload::axis_type::equidistant,
+                            detray::axis_payload::axis_bracket::bound,
+                            detray::axis_payload::axis_lookup::r,
+                            std::vector<detray::real_io>{0, 2u}, 2u};
+
+    detray::grid_payload g;
+    g.axes = {a0, a1};
+    g.entries = entries;
+
+    nlohmann::json j;
+    j["grid"] = g;
+
+    detray::grid_payload pg = j["grid"];
+
+    EXPECT_EQ(g.axes.size(), pg.axes.size());
+    EXPECT_EQ(g.entries, pg.entries);
+}
+
+TEST(io, single_object_payload) {
+    detray::single_object_payload so;
+    so.link = 3u;
+
+    nlohmann::json j;
+    j["single_link"] = so;
+
+    detray::single_object_payload pso = j["single_link"];
+
+    EXPECT_EQ(so.link, pso.link);
+}
+
+TEST(io, grid_objects_payload) {
+    detray::grid_objects_payload go;
+
+    std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
+                                                      {1, 2}, {2, 1}, {2, 2}};
+
+    detray::axis_payload a0{detray::axis_payload::axis_type::equidistant,
+                            detray::axis_payload::axis_bracket::closed,
+                            detray::axis_payload::axis_lookup::phi,
+                            std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
+
+    detray::axis_payload a1{detray::axis_payload::axis_type::equidistant,
+                            detray::axis_payload::axis_bracket::bound,
+                            detray::axis_payload::axis_lookup::r,
+                            std::vector<detray::real_io>{0, 2u}, 2u};
+
+    detray::grid_payload g;
+    g.axes = {a0, a1};
+    g.entries = entries;
+
+    go.grid = g;
+
+    nlohmann::json j;
+    j["links"] = go;
+    detray::grid_objects_payload pgo = j["links"];
+
+    EXPECT_EQ(go.grid.axes.size(), pgo.grid.axes.size());
+    EXPECT_EQ(go.grid.entries, pgo.grid.entries);
+
+    detray::transform_payload p;
+    p.tr = {100., 200., 300.};
+    p.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
+
+    detray::grid_objects_payload got;
+    got.transform = p;
+
+    got.grid = g;
+
+    j["links_t"] = got;
+    detray::grid_objects_payload pgot = j["links_t"];
+
+    EXPECT_EQ(got.grid.axes.size(), pgot.grid.axes.size());
+    EXPECT_EQ(got.grid.entries, pgot.grid.entries);
+    EXPECT_EQ(got.transform.value().tr, pgot.transform.value().tr);
+    EXPECT_EQ(got.transform.value().rot, pgot.transform.value().rot);
+}
+
+TEST(io, json_links_payload) {
+
+    std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
+                                                      {1, 2}, {2, 1}, {2, 2}};
+
+    detray::axis_payload a0{detray::axis_payload::axis_type::equidistant,
+                            detray::axis_payload::axis_bracket::closed,
+                            detray::axis_payload::axis_lookup::phi,
+                            std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
+
+    detray::axis_payload a1{detray::axis_payload::axis_type::equidistant,
+                            detray::axis_payload::axis_bracket::bound,
+                            detray::axis_payload::axis_lookup::r,
+                            std::vector<detray::real_io>{0, 2u}, 2u};
+
+    detray::grid_payload g;
+    g.axes = {a0, a1};
+    g.entries = entries;
+
+    detray::grid_objects_payload go;
+    go.grid = g;
+
+    detray::single_object_payload so;
+    so.link = 3u;
+
+    detray::links_payload l;
+    l.grid_links = go;
+    l.single_links = {so};
+
+    nlohmann::json j;
+    j["links"] = l;
+
+    detray::links_payload pl = j["links"];
+
+    EXPECT_EQ(l.single_links.size(), pl.single_links.size());
+    EXPECT_EQ(l.grid_links.value().grid.axes.size(),
+              pl.grid_links.value().grid.axes.size());
+    EXPECT_EQ(l.grid_links.value().grid.entries,
+              pl.grid_links.value().grid.entries);
+}
+
+TEST(io, json_mask_payload) {
+
+    detray::mask_payload m;
+    m.type = detray::mask_payload::mask_type::cylinder3;
+    m.boundaries = {10., 100.};
+
+    nlohmann::json j;
+    j["mask"] = m;
+
+    detray::mask_payload pm = j["mask"];
+
+    EXPECT_EQ(m.type, pm.type);
+    EXPECT_EQ(m.boundaries, pm.boundaries);
+}
+
+TEST(io, json_material_slab_payload) {
+
+    detray::material_slab_payload m;
+    m.slab = {1., 2., 3., 4., 5.};
+
+    nlohmann::json j;
+    j["material"] = m;
+
+    detray::material_slab_payload pm = j["material"];
+
+    EXPECT_EQ(m.slab, pm.slab);
+}
+
+TEST(io, json_surface_payload) {
+
+    detray::surface_payload s;
+
+    detray::transform_payload t;
+    t.tr = {100., 200., 300.};
+    t.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
+
+    detray::mask_payload m;
+    m.type = detray::mask_payload::mask_type::trapezoid2;
+    m.boundaries = {10., 20., 34., 1.4};
+
+    detray::material_slab_payload mat;
+    mat.slab = {1., 2., 3., 4., 5.};
+
+    s.transform = t;
+    s.mask = m;
+    s.material = mat;
+
+    nlohmann::json j;
+    j["surface"] = s;
+
+    detray::surface_payload ps = j["surface"];
+
+    EXPECT_EQ(s.transform.tr, ps.transform.tr);
+    EXPECT_EQ(s.transform.rot, ps.transform.rot);
+
+    EXPECT_EQ(s.mask.type, ps.mask.type);
+    EXPECT_EQ(s.mask.boundaries, ps.mask.boundaries);
+
+    EXPECT_EQ(s.material.slab, ps.material.slab);
+}
+
+TEST(io, json_portal_payload) {
+
+    detray::surface_payload s;
+
+    detray::transform_payload t;
+    t.tr = {100., 200., 300.};
+    t.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
+
+    detray::mask_payload m;
+    m.type = detray::mask_payload::mask_type::trapezoid2;
+    m.boundaries = {10., 20., 34., 1.4};
+
+    detray::material_slab_payload mat;
+    mat.slab = {1., 2., 3., 4., 5.};
+
+    s.transform = t;
+    s.mask = m;
+    s.material = mat;
+
+    detray::single_object_payload so;
+    so.link = 3u;
+
+    detray::links_payload l;
+    l.single_links = {so};
+
+    detray::portal_payload p;
+    p.surface = s;
+    p.volume_links = l;
+
+    nlohmann::json j;
+    j["portal"] = p;
+
+    detray::portal_payload pp = j["portal"];
+
+    EXPECT_EQ(p.surface.transform.tr, pp.surface.transform.tr);
+    EXPECT_EQ(p.surface.transform.rot, pp.surface.transform.rot);
+    EXPECT_EQ(p.volume_links.single_links.size(),
+              pp.volume_links.single_links.size());
+}
+
+TEST(io, json_volume_bounds_payload) {
+
+    detray::volume_bounds_payload vb;
+    vb.type = detray::volume_bounds_payload::volume_bounds_type::cylindrical;
+    vb.values = {0., 100., 120.};
+
+    nlohmann::json j;
+    j["volume_bounds"] = vb;
+
+    detray::volume_bounds_payload pvb = j["volume_bounds"];
+
+    EXPECT_EQ(vb.type, pvb.type);
+    EXPECT_EQ(vb.values, pvb.values);
+}
+
+TEST(io, json_volume_payload) {
+
+    detray::transform_payload t;
+    t.tr = {100., 200., 300.};
+    t.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
+
+    detray::volume_bounds_payload vb;
+    vb.type = detray::volume_bounds_payload::volume_bounds_type::cylindrical;
+    vb.values = {0., 100., 120.};
+
+    detray::single_object_payload so;
+    so.link = 0u;
+
+    detray::links_payload l;
+    l.single_links = {so};
+
+    detray::surface_payload s;
+
+    detray::mask_payload m;
+    m.type = detray::mask_payload::mask_type::trapezoid2;
+    m.boundaries = {10., 20., 34., 1.4};
+
+    detray::material_slab_payload mat;
+    mat.slab = {1., 2., 3., 4., 5.};
+
+    s.transform = t;
+    s.mask = m;
+    s.material = mat;
+
+    detray::portal_payload p;
+    p.surface = s;
+    p.volume_links = l;
+
+    detray::volume_payload v;
+    v.name = "volume";
+    v.transform = t;
+    v.volume_bounds = vb;
+    v.portals = {p};
+    v.surfaces = {s};
+    v.surface_links = l;
+
+    nlohmann::json j;
+    j["volume"] = v;
+
+    detray::volume_payload pv = j["volume"];
+
+    EXPECT_EQ(v.name, pv.name);
+    EXPECT_EQ(v.surfaces.size(), pv.surfaces.size());
+    EXPECT_EQ(v.portals.size(), pv.portals.size());
+}
+
+TEST(io, json_detector_payload) {
+
+    detray::detector_payload d;
+    d.name = "detector";
+    d.volumes = {detray::volume_payload{}, detray::volume_payload{}};
+
+    nlohmann::json j;
+    j["detector"] = d;
+
+    detray::detector_payload pd = j["detector"];
+
+    EXPECT_EQ(d.name, pd.name);
+    EXPECT_EQ(d.volumes.size(), pd.volumes.size());
+}


### PR DESCRIPTION
This PR adds the necessary infrastructure to load detectors geometries from ACTS/Core to detray.

It adds the `nlohmann` library, and and io layer for payload objects that contain all the information that will allow us to construct the `detray::detector` representing an `Acts::Experimental::Detector` object to the same detail.

It will be followed by a PR adding the actual construction code which then will be templated into the `algebra-plugin` and `vecmem` backend. 