### PR TITLE
ref: move geometry and axis enums to definitions

### DIFF
--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -172,10 +172,10 @@ class detector {
     /// @return non-const reference to the new volume
     DETRAY_HOST
     volume_type &new_volume(
-        const array_type<scalar, 6> &bounds,
+        const volume_id id, const array_type<scalar, 6> &bounds,
         typename volume_type::sf_finder_link_type srf_finder_link = {
             sf_finders::id::e_default, dindex_invalid}) {
-        volume_type &cvolume = _volumes.emplace_back(bounds);
+        volume_type &cvolume = _volumes.emplace_back(id, bounds);
         cvolume.set_index(_volumes.size() - 1);
         cvolume.set_sf_finder(srf_finder_link);
 

--- a/core/include/detray/definitions/geometry.hpp
+++ b/core/include/detray/definitions/geometry.hpp
@@ -1,0 +1,38 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace detray {
+
+/// Shape of a detector volume.
+///
+/// cylinder: cylinder and two disc portals (shape: cylinder2D or cylinder3D).
+/// cone: a cone portal and a disc portal (shape: missing).
+/// rectangle: six rectangular portals that form a box (shape: cuboid3D).
+/// trapezoid: six trapezoid portals (shape: cuboid3D).
+/// cuboid: general cuboid form, excluding the previous ones (shape: cuboid3D).
+enum class volume_id {
+    e_cylinder = 0,
+    e_rectangle = 1,
+    e_trapezoid = 2,
+    e_cone = 3,
+    e_cuboid = 4
+};
+
+/// surface type, resolved during navigation.
+///
+/// sensitive: can provide measurements and have material.
+/// passive: no measurements, but can have material.
+/// portal: boundary surface between two detector volumes, can have material.
+enum class surface_id {
+    e_sensitive = 0,
+    e_portal = 1,
+    e_passive = 2,
+};
+
+}  // namespace detray

--- a/core/include/detray/definitions/grid_axis.hpp
+++ b/core/include/detray/definitions/grid_axis.hpp
@@ -1,0 +1,62 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace detray::n_axis {
+
+/// axis bounds names.
+///
+/// open: adds additional over-/undeflow bins.
+/// closed: over-/underflow values are mapped into the bin range.
+/// circular: over-/underflow values wrap around.
+enum class bounds {
+    e_open = 0,
+    e_closed = 1,
+    e_circular = 2,
+};
+
+/// axis coordinate names. Used to get a specific axes from an axes collection.
+///
+/// x, y, z: cartesian coordinate axes.
+/// r, phi: polar coordinate axes.
+/// rphi, cyl_z: 2D cylinder axes (3D cylinder uses r, phi, z).
+enum class label {
+    e_x = 0,
+    e_y = 1,
+    e_z = 2,
+    e_r = 0,
+    e_phi = 1,
+    e_rphi = 0,
+    e_cyl_z = 1,
+};
+
+/// axis binning type names.
+///
+/// regular: same sized bins along the axis.
+/// irregular: every bin can have a different size along the axis.
+enum class binning {
+    e_regular = 0,
+    e_irregular = 1,
+};
+
+/// Determine axis bounds as either 'open' or 'closed' for non-circular axes.
+/// Used in the shape structs.
+/// @{
+template <n_axis::label L>
+struct open;
+
+template <n_axis::label L>
+struct closed;
+
+template <n_axis::bounds s, n_axis::label axis_label>
+using bounds_t =
+    std::conditional_t<s == n_axis::bounds::e_open, n_axis::open<axis_label>,
+                       n_axis::closed<axis_label>>;
+/// @}
+
+}  // namespace detray::n_axis

--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -9,6 +9,7 @@
 // Project include(s)
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/detail/accessor.hpp"
+#include "detray/definitions/geometry.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
@@ -57,16 +58,22 @@ class detector_volume {
     using volume_def = detector_volume<ID, obj_link_type, sf_finder_link_type,
                                        scalar_t, array_t>;
 
-    /// Default constructor
+    /// Default constructor builds an infinitely long cylinder
     constexpr detector_volume() = default;
 
     /// Constructor from boundary values.
     ///
+    /// @param id id values that determines how to interpret the bounds.
     /// @param bounds values of volume boundaries. They depend on the volume
     ///               shape, which is defined by its portals and are chosen in
-    ///               the detector builder
-    constexpr detector_volume(const array_t<scalar_t, 6> &bounds)
-        : _bounds(bounds) {}
+    ///               the detector builder.
+    constexpr detector_volume(const volume_id id,
+                              const array_t<scalar_t, 6> &bounds)
+        : _id{id}, _bounds(bounds) {}
+
+    /// @return the volume shape id
+    DETRAY_HOST_DEVICE
+    constexpr auto id() const -> volume_id { return _id; }
 
     /// @return the bounds - const access
     DETRAY_HOST_DEVICE
@@ -202,7 +209,10 @@ class detector_volume {
     }
 
     private:
-    /// Bounds section, default for r, z, phi
+    /// How to interpret the boundary values
+    volume_id _id = volume_id::e_cylinder;
+
+    /// Bounds section, default for cylinder volume
     array_t<scalar_t, 6> _bounds = {0.,
                                     std::numeric_limits<scalar_t>::max(),
                                     -std::numeric_limits<scalar_t>::max(),

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -10,16 +10,11 @@
 #include <memory>
 
 #include "detray/definitions/detail/accessor.hpp"
+#include "detray/definitions/geometry.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
 namespace detray {
-
-enum class surface_id {
-    e_sensitive = 0,
-    e_portal = 1,
-    e_passive = 2,
-};
 
 /// Templated surface class for detector surfaces and portals.
 ///

--- a/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "detray/definitions/detail/accessor.hpp"
+#include "detray/definitions/grid_axis.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
@@ -16,12 +17,6 @@
 #include <cstddef>
 
 namespace detray::n_axis {
-
-/// axis binning type names.
-enum class binning {
-    e_regular = 0,
-    e_irregular = 1,
-};
 
 /// @brief A regular binning scheme.
 ///

--- a/core/include/detray/surface_finders/grid/detail/axis_bounds.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_bounds.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/grid_axis.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
@@ -16,24 +17,6 @@
 #include <type_traits>
 
 namespace detray::n_axis {
-
-/// axis bounds names.
-enum class bounds {
-    e_open = 0,
-    e_closed = 1,
-    e_circular = 2,
-};
-
-/// axis coordinate names. Used to get a specific axes from an axes collection.
-enum class label {
-    e_x = 0,
-    e_y = 1,
-    e_z = 2,
-    e_r = 0,
-    e_phi = 1,
-    e_rphi = 0,
-    e_cyl_z = 1,
-};
 
 /// @brief Helper to tie two bin indices to a range.
 ///
@@ -266,11 +249,5 @@ struct circular {
         return (bins + (ibin % bins)) % bins;
     }
 };
-
-/// Determine axis bounds as either 'open' or 'closed' for non-circular axes
-template <n_axis::bounds s, n_axis::label axis_label>
-using bounds_t =
-    std::conditional_t<s == n_axis::bounds::e_open, n_axis::open<axis_label>,
-                       n_axis::closed<axis_label>>;
 
 }  // namespace detray::n_axis

--- a/io/json/include/detray/io/json_geometry_io.hpp
+++ b/io/json/include/detray/io/json_geometry_io.hpp
@@ -61,7 +61,7 @@ void to_json(nlohmann::json& j, const volume_bounds_payload& vb) {
 
 void from_json(const nlohmann::json& j, volume_bounds_payload& vb) {
     vb.values = j["values"].get<std::vector<real_io>>();
-    vb.type = static_cast<volume_bounds_payload::volume_bounds_type>(j["type"]);
+    vb.type = static_cast<detray::volume_id>(j["type"]);
 }
 
 void to_json(nlohmann::json& j, const volume_payload& v) {

--- a/io/json/include/detray/io/json_geometry_io.hpp
+++ b/io/json/include/detray/io/json_geometry_io.hpp
@@ -33,6 +33,7 @@ void from_json(const nlohmann::json& j, mask_payload& m) {
 void to_json(nlohmann::json& j, const surface_payload& s) {
     j["transform"] = s.transform;
     j["mask"] = s.mask;
+    j["type"] = static_cast<unsigned int>(s.type);
     j["geoID"] = s.gid;
     j["material"] = s.material;
 }
@@ -40,6 +41,7 @@ void to_json(nlohmann::json& j, const surface_payload& s) {
 void from_json(const nlohmann::json& j, surface_payload& s) {
     s.transform = j["transform"];
     s.mask = j["mask"];
+    s.type = static_cast<detray::surface_id>(j["type"]);
     s.gid = j["geoID"];
     s.material = j["material"];
 }

--- a/io/json/include/detray/io/json_grids_io.hpp
+++ b/io/json/include/detray/io/json_grids_io.hpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <vector>
 
+#include "detray/definitions/grid_axis.hpp"
 #include "detray/io/io_payload.hpp"
 #include "detray/io/json_defs.hpp"
 
@@ -25,9 +26,9 @@ void to_json(nlohmann::json& j, const axis_payload& a) {
 }
 
 void from_json(const nlohmann::json& j, axis_payload& a) {
-    a.binning = static_cast<axis_payload::axis_binning>(j["binning"]);
-    a.bounds = static_cast<axis_payload::axis_bounds>(j["bounds"]);
-    a.label = static_cast<axis_payload::axis_label>(j["label"]);
+    a.binning = static_cast<n_axis::binning>(j["binning"]);
+    a.bounds = static_cast<n_axis::bounds>(j["bounds"]);
+    a.label = static_cast<n_axis::label>(j["label"]);
     a.edges = j["edges"].get<std::vector<real_io>>();
     a.bins = j["bins"];
 }

--- a/io/payload/include/detray/io/io_payload.hpp
+++ b/io/payload/include/detray/io/io_payload.hpp
@@ -83,6 +83,7 @@ struct mask_payload {
 struct surface_payload {
     transform_payload transform;
     mask_payload mask;
+    detray::surface_id type = detray::surface_id::e_sensitive;
     material_slab_payload material;
     std::size_t gid;
 };
@@ -95,13 +96,7 @@ struct portal_payload {
 
 /// @brief A payload for volume bounds
 struct volume_bounds_payload {
-    /*enum class volume_bounds_type {
-        cuboid = 0u,
-        cylindrical = 1u,
-        generic_cuboid = 2u,
-        trapezoid = 3u
-    };*/
-    volume_id type = volume_id::e_cylinder;
+    detray::volume_id type = detray::volume_id::e_cylinder;
     std::vector<real_io> values = {};
 };
 

--- a/io/payload/include/detray/io/io_payload.hpp
+++ b/io/payload/include/detray/io/io_payload.hpp
@@ -10,6 +10,9 @@
 #include <array>
 #include <vector>
 
+#include "detray/definitions/geometry.hpp"
+#include "detray/definitions/grid_axis.hpp"
+
 namespace detray {
 
 using real_io = float;
@@ -23,21 +26,9 @@ struct transform_payload {
 /// @brief axis definition
 struct axis_payload {
     /// axis lookup type
-    enum class axis_label : unsigned int {
-        x = 0u,
-        y = 1u,
-        z = 2u,
-        r = 3u,
-        phi = 4u
-    };
-    /// How the axis is done
-    enum class axis_binning : unsigned int { equidistant = 0u, variable = 1u };
-    /// How the axis is bound
-    enum class axis_bounds : unsigned int { closed = 0u, circular = 1u };
-
-    axis_binning binning = axis_binning::equidistant;
-    axis_bounds bounds = axis_bounds::closed;
-    axis_label label = axis_label::r;
+    n_axis::binning binning = n_axis::binning::e_regular;
+    n_axis::bounds bounds = n_axis::bounds::e_closed;
+    n_axis::label label = n_axis::label::e_r;
 
     std::vector<real_io> edges = {};
     std::size_t bins = 0u;
@@ -104,13 +95,13 @@ struct portal_payload {
 
 /// @brief A payload for volume bounds
 struct volume_bounds_payload {
-    enum class volume_bounds_type {
+    /*enum class volume_bounds_type {
         cuboid = 0u,
         cylindrical = 1u,
         generic_cuboid = 2u,
         trapezoid = 3u
-    };
-    volume_bounds_type type = volume_bounds_type::cylindrical;
+    };*/
+    volume_id type = volume_id::e_cylinder;
     std::vector<real_io> values = {};
 };
 

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -67,6 +67,7 @@ TEST(detector, detector_kernel) {
 
     detector_t d(host_mr);
 
-    auto &v = d.new_volume({0., 10., -5., 5., -M_PI, M_PI});
+    auto &v =
+        d.new_volume(volume_id::e_cylinder, {0., 10., -5., 5., -M_PI, M_PI});
     d.add_objects_per_volume(ctx0, v, surfaces, masks, materials, trfs);
 }

--- a/tests/common/include/tests/common/geometry_volume.inl
+++ b/tests/common/include/tests/common/geometry_volume.inl
@@ -41,11 +41,12 @@ TEST(ALGEBRA_PLUGIN, detector_volume) {
 
     // Check construction, setters and getters
     darray<scalar, 6> bounds = {0., 10., -5., 5., -M_PI, M_PI};
-    volume_t v1(bounds);
+    volume_t v1(volume_id::e_cylinder, bounds);
     v1.set_index(12345);
     v1.set_sf_finder({sf_finder_ids::e_default, 12});
 
     ASSERT_TRUE(v1.empty());
+    ASSERT_TRUE(v1.id() == volume_id::e_cylinder);
     ASSERT_TRUE(v1.index() == 12345);
     ASSERT_TRUE(v1.bounds() == bounds);
     ASSERT_TRUE(v1.sf_finder_type() == sf_finder_ids::e_default);
@@ -78,6 +79,7 @@ TEST(ALGEBRA_PLUGIN, detector_volume) {
     const auto v2 = volume_t(v1);
     ASSERT_FALSE(v1.empty());
     ASSERT_EQ(v2.index(), 12345);
+    ASSERT_EQ(v2.id(), volume_id::e_cylinder);
     ASSERT_EQ(v2.bounds(), bounds);
     ASSERT_EQ(v2.sf_finder_link(), sf_finder_link);
     ASSERT_EQ(v2.template obj_link<geo_objects::e_sensitive>(),

--- a/tests/common/include/tests/common/path_correction.inl
+++ b/tests/common/include/tests/common/path_correction.inl
@@ -121,7 +121,7 @@ TEST(path_correction, cartesian) {
     constexpr auto material_id = registry_type::material_ids::e_slab;
 
     // Add a volume
-    det.new_volume({0., 0., 0., 0., -M_PI, M_PI});
+    det.new_volume(volume_id::e_cylinder, {0., 0., 0., 0., -M_PI, M_PI});
 
     typename detector_type::surface_container surfaces(&env::resource);
     typename detector_type::transform_container transforms(env::resource);
@@ -263,7 +263,7 @@ TEST(path_correction, polar) {
     constexpr auto material_id = registry_type::material_ids::e_slab;
 
     // Add a volume
-    det.new_volume({0., 0., 0., 0., -M_PI, M_PI});
+    det.new_volume(volume_id::e_cylinder, {0., 0., 0., 0., -M_PI, M_PI});
 
     typename detector_type::surface_container surfaces(&env::resource);
     typename detector_type::transform_container transforms(env::resource);
@@ -391,7 +391,7 @@ TEST(path_correction, cylindrical) {
     constexpr auto material_id = registry_type::material_ids::e_slab;
 
     // Add a volume
-    det.new_volume({0., 0., 0., 0., -M_PI, M_PI});
+    det.new_volume(volume_id::e_cylinder, {0., 0., 0., 0., -M_PI, M_PI});
 
     typename detector_type::surface_container surfaces(&env::resource);
     typename detector_type::transform_container transforms(env::resource);

--- a/tests/unit_tests/io/io_json_payload.cpp
+++ b/tests/unit_tests/io/io_json_payload.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include "detray/definitions/geometry.hpp"
+#include "detray/definitions/grid_axis.hpp"
 #include "detray/io/json_io.hpp"
 
 TEST(io, json_algebra_payload) {
@@ -27,9 +29,9 @@ TEST(io, json_algebra_payload) {
 TEST(io, json_axis_payload) {
 
     detray::axis_payload ea;
-    ea.binning = detray::axis_payload::axis_binning::equidistant;
-    ea.bounds = detray::axis_payload::axis_bounds::circular;
-    ea.label = detray::axis_payload::axis_label::phi;
+    ea.binning = detray::n_axis::binning::e_regular;
+    ea.bounds = detray::n_axis::bounds::e_circular;
+    ea.label = detray::n_axis::label::e_phi;
     ea.edges = {-M_PI, M_PI};
     ea.bins = 10u;
 
@@ -45,9 +47,9 @@ TEST(io, json_axis_payload) {
     EXPECT_EQ(ea.bins, pea.bins);
 
     detray::axis_payload va;
-    va.binning = detray::axis_payload::axis_binning::variable;
-    va.bounds = detray::axis_payload::axis_bounds::closed;
-    va.label = detray::axis_payload::axis_label::r;
+    va.binning = detray::n_axis::binning::e_irregular;
+    va.bounds = detray::n_axis::bounds::e_closed;
+    va.label = detray::n_axis::label::e_r;
     va.edges = {0, 1, 4, 5, 8, 10};
     va.bins = va.edges.size() - 1;
 
@@ -68,15 +70,14 @@ TEST(io, json_grid_payload) {
     std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
                                                       {1, 2}, {2, 1}, {2, 2}};
 
-    detray::axis_payload a0{detray::axis_payload::axis_binning::equidistant,
-                            detray::axis_payload::axis_bounds::circular,
-                            detray::axis_payload::axis_label::phi,
+    detray::axis_payload a0{detray::n_axis::binning::e_regular,
+                            detray::n_axis::bounds::e_circular,
+                            detray::n_axis::label::e_phi,
                             std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
 
-    detray::axis_payload a1{detray::axis_payload::axis_binning::equidistant,
-                            detray::axis_payload::axis_bounds::closed,
-                            detray::axis_payload::axis_label::r,
-                            std::vector<detray::real_io>{0, 2u}, 2u};
+    detray::axis_payload a1{
+        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_closed,
+        detray::n_axis::label::e_r, std::vector<detray::real_io>{0, 2u}, 2u};
 
     detray::grid_payload g;
     g.axes = {a0, a1};
@@ -109,15 +110,14 @@ TEST(io, grid_objects_payload) {
     std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
                                                       {1, 2}, {2, 1}, {2, 2}};
 
-    detray::axis_payload a0{detray::axis_payload::axis_binning::equidistant,
-                            detray::axis_payload::axis_bounds::circular,
-                            detray::axis_payload::axis_label::phi,
+    detray::axis_payload a0{detray::n_axis::binning::e_regular,
+                            detray::n_axis::bounds::e_circular,
+                            detray::n_axis::label::e_phi,
                             std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
 
-    detray::axis_payload a1{detray::axis_payload::axis_binning::equidistant,
-                            detray::axis_payload::axis_bounds::closed,
-                            detray::axis_payload::axis_label::r,
-                            std::vector<detray::real_io>{0, 2u}, 2u};
+    detray::axis_payload a1{
+        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_closed,
+        detray::n_axis::label::e_r, std::vector<detray::real_io>{0, 2u}, 2u};
 
     detray::grid_payload g;
     g.axes = {a0, a1};
@@ -155,15 +155,14 @@ TEST(io, json_links_payload) {
     std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
                                                       {1, 2}, {2, 1}, {2, 2}};
 
-    detray::axis_payload a0{detray::axis_payload::axis_binning::equidistant,
-                            detray::axis_payload::axis_bounds::circular,
-                            detray::axis_payload::axis_label::phi,
+    detray::axis_payload a0{detray::n_axis::binning::e_regular,
+                            detray::n_axis::bounds::e_circular,
+                            detray::n_axis::label::e_phi,
                             std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
 
-    detray::axis_payload a1{detray::axis_payload::axis_binning::equidistant,
-                            detray::axis_payload::axis_bounds::closed,
-                            detray::axis_payload::axis_label::r,
-                            std::vector<detray::real_io>{0, 2u}, 2u};
+    detray::axis_payload a1{
+        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_closed,
+        detray::n_axis::label::e_r, std::vector<detray::real_io>{0, 2u}, 2u};
 
     detray::grid_payload g;
     g.axes = {a0, a1};
@@ -295,7 +294,7 @@ TEST(io, json_portal_payload) {
 TEST(io, json_volume_bounds_payload) {
 
     detray::volume_bounds_payload vb;
-    vb.type = detray::volume_bounds_payload::volume_bounds_type::cylindrical;
+    vb.type = detray::volume_id::e_cylinder;
     vb.values = {0., 100., 120.};
 
     nlohmann::json j;
@@ -314,7 +313,7 @@ TEST(io, json_volume_payload) {
     t.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
 
     detray::volume_bounds_payload vb;
-    vb.type = detray::volume_bounds_payload::volume_bounds_type::cylindrical;
+    vb.type = detray::volume_id::e_cylinder;
     vb.values = {0., 100., 120.};
 
     detray::single_object_payload so;

--- a/tests/unit_tests/io/io_json_payload.cpp
+++ b/tests/unit_tests/io/io_json_payload.cpp
@@ -235,6 +235,7 @@ TEST(io, json_surface_payload) {
 
     s.transform = t;
     s.mask = m;
+    s.type = detray::surface_id::e_passive;
     s.material = mat;
 
     nlohmann::json j;
@@ -247,6 +248,8 @@ TEST(io, json_surface_payload) {
 
     EXPECT_EQ(s.mask.shape, ps.mask.shape);
     EXPECT_EQ(s.mask.boundaries, ps.mask.boundaries);
+
+    EXPECT_EQ(s.type, ps.type);
 
     EXPECT_EQ(s.material.slab, ps.material.slab);
 }
@@ -268,6 +271,7 @@ TEST(io, json_portal_payload) {
 
     s.transform = t;
     s.mask = m;
+    s.type = detray::surface_id::e_portal;
     s.material = mat;
 
     detray::single_object_payload so;
@@ -333,6 +337,7 @@ TEST(io, json_volume_payload) {
 
     s.transform = t;
     s.mask = m;
+    s.type = detray::surface_id::e_portal;
     s.material = mat;
 
     detray::portal_payload p;

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -10,9 +10,9 @@
 // Project include(s)
 #include "detray/core/detector.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/detectors/detector_metadata.hpp"
 #include "detray/materials/predefined_materials.hpp"
 #include "detray/propagator/line_stepper.hpp"
-#include "detray/detectors/detector_metadata.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -95,7 +95,7 @@ inline void create_telescope(context_t &ctx, const trajectory_t &traj,
     using mask_link_type = typename surface_type::mask_link;
     using material_link_type = typename surface_type::material_link;
 
-    auto volume_id = volume.index();
+    auto volume_idx = volume.index();
     constexpr auto slab_id = material_link_type::id_type::e_slab;
 
     // Create the module centers
@@ -105,14 +105,14 @@ inline void create_telescope(context_t &ctx, const trajectory_t &traj,
     // Create geometry data
     for (const auto &m_placement : m_placements) {
 
-        volume_link_t mask_volume_link{volume_id};
+        volume_link_t mask_volume_link{volume_idx};
 
         // Surfaces with the linking into the local containers
         mask_link_type mask_link{mask_id, masks.template size<mask_id>()};
         material_link_type material_link{slab_id,
                                          materials.template size<slab_id>()};
         const auto trf_index = transforms.size(ctx);
-        surfaces.emplace_back(trf_index, mask_link, material_link, volume_id,
+        surfaces.emplace_back(trf_index, mask_link, material_link, volume_idx,
                               dindex_invalid, surface_id::e_sensitive);
 
         // The first and last surface acts as portal that leaves the telescope
@@ -224,7 +224,7 @@ auto create_telescope_detector(
     plane_config pl_config{half_x, half_y, pos, mat, thickness};
 
     // volume boundaries are not needed. Same goes for portals
-    det.new_volume({0., 0., 0., 0., -M_PI, M_PI});
+    det.new_volume(volume_id::e_cylinder, {0., 0., 0., 0., -M_PI, M_PI});
     typename detector_t::volume_type &vol = det.volume_by_index(0);
 
     // Add module surfaces to volume

--- a/utils/include/detray/detectors/create_toy_geometry.hpp
+++ b/utils/include/detray/detectors/create_toy_geometry.hpp
@@ -10,8 +10,8 @@
 // Project include(s)
 #include "detray/core/detector.hpp"
 #include "detray/definitions/units.hpp"
-#include "detray/materials/predefined_materials.hpp"
 #include "detray/detectors/detector_metadata.hpp"
+#include "detray/materials/predefined_materials.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -37,7 +37,7 @@ using point2 = __plugin::point2<detray::scalar>;
  *
  * @tparam cylinder_id default cylinder id
  *
- * @param volume_id volume the portal should be added to
+ * @param volume_idx volume the portal should be added to
  * @param ctx geometric context
  * @param surfaces container to add new surface to
  * @param masks container to add new cylinder mask to
@@ -51,7 +51,7 @@ template <typename context_t, typename surface_container_t,
           typename mask_container_t, typename material_container_t,
           typename transform_container_t, typename volume_links>
 inline void add_cylinder_surface(
-    const dindex volume_id, context_t &ctx, surface_container_t &surfaces,
+    const dindex volume_idx, context_t &ctx, surface_container_t &surfaces,
     mask_container_t &masks, material_container_t &materials,
     transform_container_t &transforms, const scalar r, const scalar lower_z,
     const scalar upper_z, const volume_links volume_link,
@@ -84,17 +84,18 @@ inline void add_cylinder_surface(
                              masks.template size<cylinder_id>() - 1};
     material_link_type material_link{slab_id,
                                      materials.template size<slab_id>() - 1};
-    const surface_id sf_id = (volume_link != volume_id) ? surface_id::e_portal
-                                                        : surface_id::e_passive;
+    const surface_id sf_id = (volume_link != volume_idx)
+                                 ? surface_id::e_portal
+                                 : surface_id::e_passive;
     surfaces.emplace_back(transforms.size(ctx) - 1, mask_link, material_link,
-                          volume_id, dindex_invalid, sf_id);
+                          volume_idx, dindex_invalid, sf_id);
 }
 
 /** Function that adds a disc portal.
  *
  * @tparam disc_id default disc id
  *
- * @param volume_id volume the portal should be added to
+ * @param volume_idx volume the portal should be added to
  * @param ctx geometric context
  * @param surfaces container to add new surface to
  * @param masks container to add new cylinder mask to
@@ -108,7 +109,7 @@ template <typename context_t, typename surface_container_t,
           typename mask_container_t, typename material_container_t,
           typename transform_container_t, typename volume_links>
 inline void add_disc_surface(
-    const dindex volume_id, context_t &ctx, surface_container_t &surfaces,
+    const dindex volume_idx, context_t &ctx, surface_container_t &surfaces,
     mask_container_t &masks, material_container_t &materials,
     transform_container_t &transforms, const scalar inner_r,
     const scalar outer_r, const scalar z, const volume_links volume_link,
@@ -140,11 +141,11 @@ inline void add_disc_surface(
     mask_link_type mask_link{disc_id, masks.template size<disc_id>() - 1};
     material_link_type material_link{slab_id,
                                      materials.template size<slab_id>() - 1};
-    const surface_id sf_id = (volume_link != volume_id)
+    const surface_id sf_id = (volume_link != volume_idx)
                                  ? surface_id::e_portal
                                  : surface_id::e_sensitive;
     surfaces.emplace_back(transforms.size(ctx) - 1, mask_link, material_link,
-                          volume_id, dindex_invalid, sf_id);
+                          volume_idx, dindex_invalid, sf_id);
 }
 
 /** Function that adds a generic cylinder volume, using a factory for contained
@@ -188,7 +189,8 @@ void create_cyl_volume(
     const scalar upper_z = std::max(lay_neg_z, lay_pos_z);
 
     auto &cyl_volume =
-        det.new_volume({inner_r, outer_r, lower_z, upper_z, -M_PI, M_PI});
+        det.new_volume(volume_id::e_cylinder,
+                       {inner_r, outer_r, lower_z, upper_z, -M_PI, M_PI});
     cyl_volume.set_sf_finder(detector_t::sf_finders::id::e_default, 0);
 
     // Add module surfaces to volume
@@ -223,7 +225,7 @@ void create_cyl_volume(
  * @tparam rctangle_id default rectangle id
  *
  * @param ctx geometric context
- * @param volume_id volume the portal should be added to
+ * @param volume_idx volume the portal should be added to
  * @param surfaces container to add new surface to
  * @param masks container to add new cylinder mask to
  * @param transforms container to add new transform to
@@ -249,8 +251,8 @@ inline void create_barrel_modules(context_t &ctx, volume_type &vol,
     constexpr auto rectangle_id = mask_id::e_rectangle2;
     constexpr auto slab_id = material_id::e_slab;
 
-    auto volume_id = vol.index();
-    volume_link_t mask_volume_link{volume_id};
+    auto volume_idx = vol.index();
+    volume_link_t mask_volume_link{volume_idx};
 
     // Create the module centers
 
@@ -294,7 +296,7 @@ inline void create_barrel_modules(context_t &ctx, volume_type &vol,
         material_link_type material_link{slab_id,
                                          materials.template size<slab_id>()};
         const auto trf_index = transforms.size(ctx);
-        surfaces.emplace_back(trf_index, mask_link, material_link, volume_id,
+        surfaces.emplace_back(trf_index, mask_link, material_link, volume_idx,
                               dindex_invalid, surface_id::e_sensitive);
 
         // The rectangle bounds for this module
@@ -447,7 +449,7 @@ inline auto module_positions_ring(scalar z, scalar radius, scalar phi_stagger,
  * @tparam trapezoid_id default trapezoid id
  *
  * @param ctx geometric context
- * @param volume_id volume the portal should be added to
+ * @param volume_idx volume the portal should be added to
  * @param surfaces container to add new surface to
  * @param masks container to add new cylinder mask to
  * @param transforms container to add new transform to
@@ -472,8 +474,8 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
     constexpr auto trapezoid_id = mask_id::e_trapezoid2;
     constexpr auto slab_id = material_id::e_slab;
 
-    auto volume_id = vol.index();
-    volume_link_t mask_volume_link{volume_id};
+    auto volume_idx = vol.index();
+    volume_link_t mask_volume_link{volume_idx};
 
     // calculate the radii of the rings
     std::vector<scalar> radii;
@@ -547,7 +549,7 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
 
             // Surfaces with the linking into the local containers
             surfaces.emplace_back(transforms.size(ctx), mask_link,
-                                  material_link, volume_id, dindex_invalid,
+                                  material_link, volume_idx, dindex_invalid,
                                   surface_id::e_sensitive);
 
             // the module transform from the position
@@ -598,7 +600,8 @@ inline void add_beampipe(
     typename detector_t::transform_container transforms(resource);
 
     auto &beampipe =
-        det.new_volume({beampipe_vol_size.first, beampipe_vol_size.second,
+        det.new_volume(volume_id::e_cylinder,
+                       {beampipe_vol_size.first, beampipe_vol_size.second,
                         min_z, max_z, -M_PI, M_PI});
     const auto beampipe_idx = beampipe.index();
     beampipe.set_sf_finder(detector_t::sf_finders::id::e_default, 0);
@@ -694,7 +697,8 @@ inline void add_endcap_barrel_connection(
     typename detector_t::transform_container transforms(resource);
 
     auto &connector_gap =
-        det.new_volume({edc_inner_r, edc_outer_r, min_z, max_z, -M_PI, M_PI});
+        det.new_volume(volume_id::e_cylinder,
+                       {edc_inner_r, edc_outer_r, min_z, max_z, -M_PI, M_PI});
     connector_gap.set_sf_finder(detector_t::sf_finders::id::e_default, 0);
     dindex connector_gap_idx{det.volumes().back().index()};
     dindex leaving_world = dindex_invalid;


### PR DESCRIPTION
Makes the type enums of axes, surfaces and volumes accessible from headers in the definition folder. Also add an enum for the volume shape, which is used to determine how to interpret the values in the volume bounds array.
It uses the detray internal enums for e.g. the axis labels directly in the json/io payloads and adds the id for the surface type, which needs to be supplied from the outside.