### PR TITLE
Fix the Seed of Simulator

### DIFF
--- a/tests/common/include/tests/common/material_interaction.inl
+++ b/tests/common/include/tests/common/material_interaction.inl
@@ -374,21 +374,22 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
     const bound_track_parameters<transform3> bound_param(1, bound_vector,
                                                          bound_cov);
 
-    int n_samples = 100000;
+    std::size_t n_samples = 100000;
     std::vector<scalar> phi_vec;
     std::vector<scalar> theta_vec;
 
     scalar ref_phi_var(0);
     scalar ref_theta_var(0);
 
-    for (int i = 0; i < n_samples; i++) {
+    for (std::size_t i = 0; i < n_samples; i++) {
 
         propagation::print_inspector::state print_insp_state{};
         pathlimit_aborter::state aborter_state{};
         parameter_transporter<transform3>::state bound_updater{};
         interactor_t::state interactor_state{};
         interactor_state.do_energy_loss = false;
-        simulator_t::state simulator_state{};
+        // Seed = sample id
+        simulator_t::state simulator_state{i};
         parameter_resetter<transform3>::state parameter_resetter_state{};
 
         // Create actor states tuples

--- a/utils/include/detray/simulation/event_writer.hpp
+++ b/utils/include/detray/simulation/event_writer.hpp
@@ -22,7 +22,7 @@ struct event_writer : actor {
     using scalar_type = typename transform3_t::scalar_type;
 
     struct state {
-        state(std::size_t event_id, smearer_t smearer,
+        state(std::size_t event_id, smearer_t& smearer,
               const std::string directory)
             : m_particle_writer(directory +
                                 get_event_filename(event_id, "-particles.csv")),

--- a/utils/include/detray/simulation/event_writer.hpp
+++ b/utils/include/detray/simulation/event_writer.hpp
@@ -43,6 +43,8 @@ struct event_writer : actor {
         std::size_t m_hit_count = 0;
         smearer_t m_meas_smearer;
 
+        void set_seed(const std::size_t sd) { m_meas_smearer.set_seed(sd); }
+
         void write_particle(const free_track_parameters<transform3_t>& track) {
             particle_id++;
 
@@ -71,7 +73,7 @@ struct event_writer : actor {
         inline output_type operator()(
             const mask_group_t& /*mask_group*/, const index_t& /*index*/,
             const bound_track_parameters<transform3_t>& bound_params,
-            smearer_t smearer) const {
+            smearer_t& smearer) const {
 
             return smearer(mask_group_t::value_type::shape::name,
                            mask_group_t::value_type::shape::meas_dim,

--- a/utils/include/detray/simulation/measurement_smearer.hpp
+++ b/utils/include/detray/simulation/measurement_smearer.hpp
@@ -21,8 +21,11 @@ struct measurement_smearer {
     measurement_smearer(measurement_smearer<scalar_t>& smearer)
         : stddev(smearer.stddev) {}
 
-    std::array<scalar_t, 2> stddev;
+    void set_seed(const std::size_t sd){
+        generator.seed(sd);
+    }
 
+    std::array<scalar_t, 2> stddev;
     std::random_device rd{};
     std::mt19937 generator{rd()};
 

--- a/utils/include/detray/simulation/measurement_smearer.hpp
+++ b/utils/include/detray/simulation/measurement_smearer.hpp
@@ -19,11 +19,9 @@ struct measurement_smearer {
         : stddev({stddev_local0, stddev_local1}) {}
 
     measurement_smearer(measurement_smearer<scalar_t>& smearer)
-        : stddev(smearer.stddev) {}
+        : stddev(smearer.stddev), generator(smearer.generator) {}
 
-    void set_seed(const std::size_t sd){
-        generator.seed(sd);
-    }
+    void set_seed(const std::size_t sd) { generator.seed(sd); }
 
     std::array<scalar_t, 2> stddev;
     std::random_device rd{};

--- a/utils/include/detray/simulation/random_scatterer.hpp
+++ b/utils/include/detray/simulation/random_scatterer.hpp
@@ -29,6 +29,13 @@ struct random_scatterer : actor {
     struct state {
         std::random_device rd{};
         std::mt19937 generator{rd()};
+
+        /// Constructor with seed
+        ///
+        /// @param sd the seed number
+        state(const std::size_t sd = 0) { generator.seed(sd); }
+
+        void set_seed(const std::size_t sd) { generator.seed(sd); }
     };
 
     /// Observes a material interactor state @param interactor_state

--- a/utils/include/detray/simulation/simulator.hpp
+++ b/utils/include/detray/simulation/simulator.hpp
@@ -58,6 +58,8 @@ struct simulator {
           m_detector(std::make_unique<detector_t>(det)),
           m_smearer(smearer) {
         m_track_generator = track_gen;
+        m_smearer.set_seed(m_seed);
+        m_scatterer.set_seed(m_seed);
     }
 
     config& get_config() { return m_cfg; }
@@ -66,21 +68,13 @@ struct simulator {
         for (std::size_t event_id = 0; event_id < m_events; event_id++) {
             typename event_writer<transform3, smearer_t>::state writer(
                 event_id, m_smearer, m_directory);
-            writer.set_seed(m_seed);
 
             for (auto track : m_track_generator) {
 
                 writer.write_particle(track);
 
-                typename parameter_transporter<transform3>::state transporter{};
-                typename interactor_t::state interactor{};
-                typename random_scatterer<interactor_t>::state scatterer{};
-                scatterer.set_seed(m_seed);
-
-                typename parameter_resetter<transform3>::state resetter{};
-
-                auto actor_states = std::tie(transporter, interactor, scatterer,
-                                             resetter, writer);
+                auto actor_states = std::tie(m_transporter, m_interactor,
+                                             m_scatterer, m_resetter, writer);
 
                 typename propagator_type::state propagation(
                     track, m_detector->get_bfield(), *m_detector);
@@ -107,6 +101,12 @@ struct simulator {
     std::unique_ptr<detector_t> m_detector;
     track_generator_t m_track_generator;
     smearer_t m_smearer;
+
+    /// Actor states
+    typename parameter_transporter<transform3>::state m_transporter{};
+    typename interactor_t::state m_interactor{};
+    typename random_scatterer<interactor_t>::state m_scatterer{};
+    typename parameter_resetter<transform3>::state m_resetter{};
 };
 
 }  // namespace detray

--- a/utils/include/detray/simulation/simulator.hpp
+++ b/utils/include/detray/simulation/simulator.hpp
@@ -51,15 +51,12 @@ struct simulator {
 
     simulator(std::size_t events, const detector_t& det,
               track_generator_t& track_gen, smearer_t& smearer,
-              const std::size_t sd = 0, const std::string directory = "")
+              const std::string directory = "")
         : m_events(events),
-          m_seed(sd),
           m_directory(directory),
           m_detector(std::make_unique<detector_t>(det)),
           m_smearer(smearer) {
         m_track_generator = track_gen;
-        m_smearer.set_seed(m_seed);
-        m_scatterer.set_seed(m_seed);
     }
 
     config& get_config() { return m_cfg; }
@@ -69,6 +66,10 @@ struct simulator {
         for (std::size_t event_id = 0; event_id < m_events; event_id++) {
             typename event_writer<transform3, smearer_t>::state writer(
                 event_id, m_smearer, m_directory);
+
+            // Set random seed
+            m_scatterer.set_seed(event_id);
+            writer.set_seed(event_id);
 
             auto actor_states = std::tie(m_transporter, m_interactor,
                                          m_scatterer, m_resetter, writer);
@@ -97,7 +98,6 @@ struct simulator {
     private:
     config m_cfg;
     std::size_t m_events = 0;
-    std::size_t m_seed = 0;
     std::string m_directory = "";
     std::unique_ptr<detector_t> m_detector;
     track_generator_t m_track_generator;

--- a/utils/include/detray/simulation/simulator.hpp
+++ b/utils/include/detray/simulation/simulator.hpp
@@ -65,16 +65,17 @@ struct simulator {
     config& get_config() { return m_cfg; }
 
     void run() {
+
         for (std::size_t event_id = 0; event_id < m_events; event_id++) {
             typename event_writer<transform3, smearer_t>::state writer(
                 event_id, m_smearer, m_directory);
 
+            auto actor_states = std::tie(m_transporter, m_interactor,
+                                         m_scatterer, m_resetter, writer);
+
             for (auto track : m_track_generator) {
 
                 writer.write_particle(track);
-
-                auto actor_states = std::tie(m_transporter, m_interactor,
-                                             m_scatterer, m_resetter, writer);
 
                 typename propagator_type::state propagation(
                     track, m_detector->get_bfield(), *m_detector);

--- a/utils/include/detray/simulation/simulator.hpp
+++ b/utils/include/detray/simulation/simulator.hpp
@@ -51,8 +51,9 @@ struct simulator {
 
     simulator(std::size_t events, const detector_t& det,
               track_generator_t& track_gen, smearer_t& smearer,
-              const std::string directory = "")
+              const std::size_t sd = 0, const std::string directory = "")
         : m_events(events),
+          m_seed(sd),
           m_directory(directory),
           m_detector(std::make_unique<detector_t>(det)),
           m_smearer(smearer) {
@@ -65,6 +66,7 @@ struct simulator {
         for (std::size_t event_id = 0; event_id < m_events; event_id++) {
             typename event_writer<transform3, smearer_t>::state writer(
                 event_id, m_smearer, m_directory);
+            writer.set_seed(m_seed);
 
             for (auto track : m_track_generator) {
 
@@ -73,6 +75,8 @@ struct simulator {
                 typename parameter_transporter<transform3>::state transporter{};
                 typename interactor_t::state interactor{};
                 typename random_scatterer<interactor_t>::state scatterer{};
+                scatterer.set_seed(m_seed);
+
                 typename parameter_resetter<transform3>::state resetter{};
 
                 auto actor_states = std::tie(transporter, interactor, scatterer,
@@ -98,6 +102,7 @@ struct simulator {
     private:
     config m_cfg;
     std::size_t m_events = 0;
+    std::size_t m_seed = 0;
     std::string m_directory = "";
     std::unique_ptr<detector_t> m_detector;
     track_generator_t m_track_generator;


### PR DESCRIPTION
Currently, the random sequence  of simulator is not reproducible which makes it hard to debug the traccc kalman filtering.
In this PR, I made the random sequence reproducible for every run.