### PR TITLE
feat: surface factories

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -105,9 +105,11 @@ detray_add_library( detray_core core
    "include/detray/tools/associator.hpp"
    "include/detray/tools/bin_association.hpp"
    "include/detray/tools/generators.hpp"
-   "include/detray/tool/grid_builder.hpp"
-   "include/detray/tool/grid_factory.hpp"
+   "include/detray/tools/grid_builder.hpp"
+   "include/detray/tools/grid_factory.hpp"
    "include/detray/tools/local_object_finder.hpp"
+   "include/detray/tools/surface_factory.hpp"
+   "include/detray/tools/surface_factory_interface.hpp"
    "include/detray/tools/volume_builder.hpp"
    "include/detray/tools/volume_builder_interface.hpp"
    # tracks include(s)

--- a/core/include/detray/core/detail/multi_store.hpp
+++ b/core/include/detray/core/detail/multi_store.hpp
@@ -158,6 +158,22 @@ class multi_store {
             .empty();
     }
 
+    /// Removes and destructs all elements in a specific collection.
+    template <ID id>
+    DETRAY_HOST void clear(const context_type & /*ctx*/) {
+        detail::get<value_types::to_index(id)>(m_tuple_container).clear();
+    }
+
+    /// Removes and destructs all elements in the container.
+    template <std::size_t current_idx = 0>
+    DETRAY_HOST void clear_all(const context_type &ctx = {}) {
+        clear<value_types::to_id(current_idx)>(ctx);
+
+        if constexpr (current_idx < sizeof...(Ts) - 1) {
+            clear_all<current_idx + 1>(ctx);
+        }
+    }
+
     /// Reserve memory of size @param n for a collection given by @tparam id
     template <ID id>
     DETRAY_HOST void reserve(std::size_t n, const context_type & /*ctx*/) {

--- a/core/include/detray/core/detail/single_store.hpp
+++ b/core/include/detray/core/detail/single_store.hpp
@@ -156,6 +156,11 @@ class single_store {
         return m_container.at(i);
     }
 
+    /// Removes and destructs all elements in the container.
+    DETRAY_HOST void clear(const context_type & /*ctx*/) {
+        m_container.clear();
+    }
+
     /// Reserve memory of size @param n for a collection given by @tparam id
     DETRAY_HOST void reserve(std::size_t n, const context_type & /*ctx*/) {
         m_container.reserve(n);

--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -22,7 +22,10 @@
 #include "detray/masks/unmasked.hpp"
 
 // System include(s)
+#include <algorithm>
+#include <cassert>
 #include <sstream>
+#include <vector>
 
 namespace detray {
 
@@ -64,9 +67,19 @@ class mask {
     /// Default constructor
     constexpr mask() = default;
 
+    /// Constructor from single mask boundary values
     template <typename... Args>
     DETRAY_HOST_DEVICE explicit mask(const links_type& link, Args&&... args)
         : _values({{std::forward<Args>(args)...}}), _volume_link(link) {}
+
+    /// Constructor from mask boundary vector
+    DETRAY_HOST mask(const std::vector<scalar_type>& values,
+                     const links_type& link)
+        : _volume_link(link) {
+        assert(values.size() == boundaries::e_size &&
+               " Given number of boundaries does not match mask shape.");
+        std::copy(std::cbegin(values), std::cend(values), std::begin(_values));
+    }
 
     /// Assignment operator from an array, convenience function
     ///

--- a/core/include/detray/tools/surface_factory.hpp
+++ b/core/include/detray/tools/surface_factory.hpp
@@ -1,0 +1,249 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/indexing.hpp"
+#include "detray/masks/masks.hpp"
+#include "detray/tools/surface_factory_interface.hpp"
+#include "detray/utils/ranges.hpp"
+
+// System include(s)
+#include <cassert>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+namespace detray {
+
+/// @brief Generates a number of surfaces for a volume (can be portals, passives
+/// or sensitives) and fills them into the containers of a volume builder.
+///
+/// @tparam detector_t the type of detector the volume belongs to.
+/// @tparam mask_shape_t the shape of the surface.
+/// @tparam mask_id the concrete mask id that must be defined in the detector_t.
+/// @tparam sf_id eihter portal, passive or sensitive.
+template <typename detector_t, typename mask_shape_t,
+          typename detector_t::mask_link::id_type mask_id, surface_id sf_id,
+          typename volume_link_t = dindex>
+class surface_factory final
+    : public surface_factory_interface<detector_t>,
+      public std::enable_shared_from_this<surface_factory<
+          detector_t, mask_shape_t, mask_id, sf_id, volume_link_t>> {
+    public:
+    using scalar_t = typename detector_t::scalar_type;
+    // Set individual volume link for portals, but only the mothervolume index
+    // for other surfaces.
+    using volume_link_collection =
+        std::conditional_t<sf_id == surface_id::e_portal,
+                           std::vector<volume_link_t>,
+                           detray::views::single<volume_link_t>>;
+    // ensures correct returning of shared pointers without pointless
+    // construction and destructing of surface factories
+    using smart_ptr_handler = std::enable_shared_from_this<surface_factory<
+        detector_t, mask_shape_t, mask_id, sf_id, volume_link_t>>;
+
+    /// shorthad for a colleciton of surface data that can be read by a surface
+    /// factory
+    using surface_data_t = std::unique_ptr<
+        surface_data_interface<detector_t, mask_shape_t, volume_link_t>>;
+    using sf_data_collection = std::vector<surface_data_t>;
+
+    /// Empty factory.
+    DETRAY_HOST
+    surface_factory() = default;
+
+    /// @returns the current number of surfaces that will be built by this
+    /// factory
+    DETRAY_HOST
+    auto size() const -> std::size_t {
+        check();
+        return m_components.size();
+    }
+
+    /// @returns the mask boundaries currently held by the factory
+    DETRAY_HOST
+    auto components() const -> const std::vector<std::vector<scalar_t>> & {
+        return m_components;
+    }
+
+    /// @returns the transforms currently held by the factory
+    DETRAY_HOST
+    auto transforms() const
+        -> const std::vector<typename detector_t::transform3> & {
+        return m_transforms;
+    }
+
+    /// @returns the volume link(s) currently held by the factory
+    DETRAY_HOST
+    const auto &volume_links() const { return m_volume_link; }
+
+    /// Add all necessary compontents to the factory for a single surface
+    DETRAY_HOST
+    inline void add_component(surface_data_t &&sf_data) {
+
+        auto [trf, vlink, bounds] = sf_data->get_data();
+
+        assert(bounds.size() == mask_shape_t::boundaries::e_size);
+
+        if constexpr (sf_id != surface_id::e_portal) {
+            if (size() == 0) {
+                *m_volume_link = vlink;
+            } else {
+                assert(*m_volume_link == vlink);
+            }
+        } else {
+            m_volume_link.push_back(vlink);
+        }
+
+        m_transforms.push_back(trf);
+        m_components.push_back(std::move(bounds));
+    }
+
+    /// Add all necessary compontents to the factory from bundled surface
+    /// data in @param surface_data .
+    DETRAY_HOST
+    auto add_components(sf_data_collection &&surface_data)
+        -> std::shared_ptr<surface_factory<detector_t, mask_shape_t, mask_id,
+                                           sf_id, volume_link_t>> {
+        const std::size_t n_surfaces{size() + surface_data.size()};
+
+        m_transforms.reserve(n_surfaces);
+        m_components.reserve(n_surfaces);
+
+        if constexpr (sf_id == surface_id::e_portal) {
+            m_volume_link.reserve(n_surfaces);
+        }
+
+        // Get per-surface data into detector level container layout
+        for (auto &sf_data : surface_data) {
+            add_component(std::move(sf_data));
+        }
+
+        return smart_ptr_handler::shared_from_this();
+    }
+
+    /// Clear old data
+    DETRAY_HOST
+    auto clear() -> void {
+        m_components.clear();
+        m_transforms.clear();
+        // cannot clear the single-view
+        if constexpr (sf_id == surface_id::e_portal) {
+            m_volume_link.clear();
+        } else {
+            *m_volume_link = volume_link_t{};
+        }
+    }
+
+    /// Generate the surfaces and add them to given data collections.
+    ///
+    /// @param volume the volume they will be added to in the detector.
+    /// @param surfaces the resulting surface objects.
+    /// @param transforms the transforms of the surfaces.
+    /// @param masks the masks of the surfaces (all of the same shape).
+    /// @param ctx the geometry context.
+    DETRAY_HOST
+    auto operator()(const typename detector_t::volume_type &volume,
+                    typename detector_t::surface_container &surfaces,
+                    typename detector_t::transform_container &transforms,
+                    typename detector_t::mask_container &masks,
+                    typename detector_t::geometry_context ctx = {}) const
+        -> dindex_range override {
+        using surface_t = typename detector_t::surface_type;
+        using mask_link_t = typename surface_t::mask_link;
+        using material_link_t = typename surface_t::material_link;
+
+        // The material will be added in a later step
+        constexpr auto no_material = surface_t::material_id::e_none;
+        // In case the surfaces container is prefilled with other surfaces
+        std::size_t surfaces_offset = surfaces.size();
+
+        // Nothing to construct
+        if (size() == 0UL) {
+            return {surfaces_offset, surfaces_offset};
+        }
+
+        for (const auto [idx, comp] : detray::views::enumerate(m_components)) {
+
+            // Add transform
+            transforms.push_back(m_transforms[idx], ctx);
+
+            if constexpr (std::is_same_v<mask_shape_t, unmasked>) {
+                masks.template emplace_back<mask_id>(
+                    empty_context{}, m_volume_link[idx],
+                    std::numeric_limits<scalar_t>::infinity());
+            } else {
+                masks.template emplace_back<mask_id>(empty_context{}, comp,
+                                                     m_volume_link[idx]);
+            }
+
+            // Add surface with all links set (relative to the given containers)
+            mask_link_t mask_link{mask_id, masks.template size<mask_id>() - 1};
+            material_link_t material_link{no_material, dindex_invalid};
+            surfaces.emplace_back(transforms.size(ctx) - 1, mask_link,
+                                  material_link, volume.index(), dindex_invalid,
+                                  sf_id);
+        }
+
+        return {surfaces_offset, surfaces.size()};
+    }
+
+    private:
+    /// Check that the containers have the same size
+    DETRAY_HOST
+    void check() const {
+        // This should not happend (need same number and ordering of data)
+        assert(m_components.size() == m_transforms.size());
+        if constexpr (sf_id == surface_id::e_portal) {
+            assert(m_components.size() == m_volume_link.size());
+        } else {
+            assert(m_volume_link.size() == 1);
+        }
+    }
+
+    std::vector<std::vector<scalar_t>> m_components{};
+    std::vector<typename detector_t::transform3> m_transforms{};
+    volume_link_collection m_volume_link{};
+};
+
+/// @brief Bind surfaces, transforms and masks together.
+template <typename detector_t, typename mask_shape_t,
+          typename volume_link_t = dindex>
+class surface_data
+    : public surface_data_interface<detector_t, mask_shape_t, volume_link_t> {
+    public:
+    DETRAY_HOST
+    surface_data(
+        const typename detector_t::transform3 &trf, volume_link_t volume_link,
+        const std::vector<typename detector_t::scalar_type> &mask_boundaries)
+        : m_transform{trf},
+          m_volume_link{volume_link},
+          m_boundaries{mask_boundaries} {}
+
+    DETRAY_HOST
+    auto get_data() -> std::tuple<
+        typename detector_t::transform3 &, volume_link_t &,
+        std::vector<typename detector_t::scalar_type> &> override {
+        return std::tie(m_transform, m_volume_link, m_boundaries);
+    }
+
+    private:
+    /// The surface placement
+    typename detector_t::transform3 m_transform;
+    /// The index of the volume that this surface links to
+    volume_link_t m_volume_link;
+    // simple tuple of all mask types in the detector. Only one entry is filled
+    // with the mask that corresponds to this specific surface.
+    std::vector<typename detector_t::scalar_type> m_boundaries;
+};
+
+}  // namespace detray

--- a/core/include/detray/tools/surface_factory_interface.hpp
+++ b/core/include/detray/tools/surface_factory_interface.hpp
@@ -1,0 +1,54 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// System include(s)
+#include <tuple>
+
+#pragma once
+
+namespace detray {
+
+/// @brief How to generate surfaces with their corresponding masks and
+/// transforms.
+///
+/// Can be hard coded surface generation or json reader.
+template <typename detector_t>
+class surface_factory_interface {
+    public:
+    surface_factory_interface() = default;
+    virtual ~surface_factory_interface() = default;
+
+    DETRAY_HOST
+    virtual auto operator()(
+        const typename detector_t::volume_type &volume,
+        typename detector_t::surface_container &surfaces,
+        typename detector_t::transform_container &transforms,
+        typename detector_t::mask_container &masks,
+        typename detector_t::geometry_context ctx = {}) const
+        -> dindex_range = 0;
+};
+
+/// @brief Bind transform and mask data together for surface building.
+///
+/// Surface data is kept in separate detector containers and linked by indices,
+/// so during geometry building, great care has to be taken to make sure that
+/// all components of a surface get sorted and linked into the containers
+/// together and associated with the correct surface.
+template <typename detector_t, typename mask_shape_t, typename volume_link_t>
+class surface_data_interface {
+    public:
+    surface_data_interface() = default;
+    virtual ~surface_data_interface() = default;
+
+    /// Uniform interface to surface data from different sources
+    DETRAY_HOST
+    virtual auto get_data()
+        -> std::tuple<typename detector_t::transform3 &, volume_link_t &,
+                      std::vector<typename detector_t::scalar_type> &> = 0;
+};
+
+}  // namespace detray

--- a/core/include/detray/utils/ranges/single.hpp
+++ b/core/include/detray/utils/ranges/single.hpp
@@ -40,6 +40,12 @@ class single_view
     DETRAY_HOST_DEVICE constexpr explicit single_view(value_t&& value)
         : m_value{std::move(value)} {}
 
+    /// Copy constructors
+    constexpr single_view(const single_view& other) = default;
+
+    /// Move constructor for the single view
+    constexpr single_view(single_view&& other) = default;
+
     /// Construct value in place from @param args
     template <class... Args>
     DETRAY_HOST_DEVICE constexpr single_view(std::in_place_t, Args&&... args)

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -9,6 +9,7 @@
 #include "detray/core/detector.hpp"
 #include "detray/detectors/detector_metadata.hpp"
 #include "detray/materials/predefined_materials.hpp"
+#include "detray/tools/surface_factory.hpp"
 #include "detray/tools/volume_builder.hpp"
 
 // Vecmem include(s)
@@ -17,62 +18,372 @@
 // GTest include(s)
 #include <gtest/gtest.h>
 
+// System include(s)
+#include <memory>
+
+namespace {
+
 /// @note __plugin has to be defined with a preprocessor command
 using point3 = __plugin::point3<detray::scalar>;
 using vector3 = __plugin::vector3<detray::scalar>;
 using point2 = __plugin::point2<detray::scalar>;
 
-// This tests the construction of a detector class
-TEST(detector, detector_kernel) {
+/// Adds a few surfaces to the detector.
+template <typename detector_t>
+void prefill_detector(detector_t& d,
+                      typename detector_t::geometry_context ctx) {
+    using scalar_t = typename detector_t::scalar_type;
+    using mask_id = typename detector_t::masks::id;
+    using material_id = typename detector_t::materials::id;
+    using surface_t = typename detector_t::surface_type;
+    using mask_link_t = typename surface_t::mask_link;
+    using material_link_t = typename surface_t::material_link;
+
+    detray::empty_context empty_ctx{};
+    vecmem::memory_resource* host_mr = d.resource();
+    typename detector_t::transform_container trfs(*host_mr);
+    typename detector_t::surface_container surfaces{};
+    typename detector_t::mask_container masks(*host_mr);
+    typename detector_t::material_container materials(*host_mr);
+
+    /// Surface 0
+    point3 t0{0.f, 0.f, 0.f};
+    trfs.emplace_back(ctx, t0);
+    masks.template emplace_back<mask_id::e_rectangle2>(empty_ctx, 0UL, -3.f,
+                                                       3.f);
+    materials.template emplace_back<material_id::e_slab>(
+        empty_ctx, detray::gold<scalar_t>(), 3.f);
+    mask_link_t mask_link{mask_id::e_rectangle2,
+                          masks.template size<mask_id::e_rectangle2>() - 1};
+    material_link_t material_link{
+        material_id::e_slab,
+        materials.template size<material_id::e_slab>() - 1};
+    surfaces.emplace_back(trfs.size(ctx) - 1, mask_link, material_link, 0UL,
+                          detray::dindex_invalid,
+                          detray::surface_id::e_sensitive);
+    /// Surface 1
+    point3 t1{1.f, 0.f, 0.f};
+    trfs.emplace_back(ctx, t1);
+    masks.template emplace_back<mask_id::e_annulus2>(empty_ctx, 0UL, 1.f, 2.f,
+                                                     3.f, 4.f, 5.f, 6.f, 7.f);
+    materials.template emplace_back<material_id::e_slab>(
+        empty_ctx, detray::tungsten<scalar_t>(), 12.f);
+
+    mask_link = {mask_id::e_annulus2,
+                 masks.template size<mask_id::e_annulus2>() - 1};
+    material_link = {material_id::e_slab,
+                     materials.template size<material_id::e_slab>() - 1};
+    surfaces.emplace_back(trfs.size(ctx) - 1, mask_link, material_link, 0UL,
+                          detray::dindex_invalid,
+                          detray::surface_id::e_sensitive);
+
+    /// Surface 2
+    point3 t2{2.f, 0.f, 0.f};
+    trfs.emplace_back(ctx, t2);
+    masks.template emplace_back<mask_id::e_trapezoid2>(empty_ctx, 0UL, 1.f, 2.f,
+                                                       3.f);
+    materials.template emplace_back<material_id::e_rod>(
+        empty_ctx, detray::aluminium<scalar_t>(), 4.f);
+
+    mask_link = {mask_id::e_trapezoid2,
+                 masks.template size<mask_id::e_trapezoid2>() - 1};
+    material_link = {material_id::e_rod,
+                     materials.template size<material_id::e_rod>() - 1};
+    surfaces.emplace_back(trfs.size(ctx) - 1, mask_link, material_link, 0UL,
+                          detray::dindex_invalid,
+                          detray::surface_id::e_sensitive);
+
+    // Add the new data
+    d.new_volume(detray::volume_id::e_cylinder,
+                 {0.f, 10.f, -5.f, 5.f, -M_PI, M_PI});
+    d.append_surfaces(std::move(surfaces));
+    d.append_transforms(std::move(trfs));
+    d.append_masks(std::move(masks));
+    d.append_materials(std::move(materials));
+}
+
+/// Check volume links for a collection of masks in a given detector
+template <typename detector_t, typename detector_t::mask_link::id_type mask_id>
+inline void check_mask(const detector_t& d,
+                       const std::vector<detray::dindex>& vol_links) {
+    for (const auto [idx, mask] :
+         detray::views::enumerate(d.mask_store().template get<mask_id>())) {
+        EXPECT_EQ(mask.volume_link(), vol_links.at(idx))
+            << "mask no. " << idx << ": " << mask.to_string();
+    }
+}
+
+}  // anonymous namespace
+
+/// This tests the functionality of a detector as a data store manager
+TEST(detector, detector) {
 
     using namespace detray;
 
+    using detector_t =
+        detector<detector_registry::default_detector, covfie::field>;
+    using mask_id = typename detector_t::masks::id;
+    using material_id = typename detector_t::materials::id;
+    using finder_id = typename detector_t::sf_finders::id;
+
     vecmem::host_memory_resource host_mr;
+    detector_t d(host_mr);
+    auto geo_ctx = typename detector_t::geometry_context{};
+
+    EXPECT_TRUE(d.volumes().empty());
+    EXPECT_TRUE(d.surfaces().empty());
+    EXPECT_TRUE(d.transform_store().empty());
+    EXPECT_TRUE(d.mask_store().template empty<mask_id::e_rectangle2>());
+    EXPECT_TRUE(d.mask_store().template empty<mask_id::e_trapezoid2>());
+    EXPECT_TRUE(d.mask_store().template empty<mask_id::e_annulus2>());
+    EXPECT_TRUE(d.mask_store().template empty<mask_id::e_cylinder2>());
+    EXPECT_TRUE(d.mask_store().template empty<mask_id::e_portal_cylinder2>());
+    EXPECT_TRUE(d.mask_store().template empty<mask_id::e_ring2>());
+    EXPECT_TRUE(d.mask_store().template empty<mask_id::e_portal_ring2>());
+    EXPECT_TRUE(d.material_store().template empty<material_id::e_slab>());
+    EXPECT_TRUE(d.material_store().template empty<material_id::e_rod>());
+    EXPECT_TRUE(d.sf_finder_store().template empty<finder_id::e_brute_force>());
+    EXPECT_TRUE(d.sf_finder_store().template empty<finder_id::e_disc_grid>());
+    EXPECT_TRUE(
+        d.sf_finder_store().template empty<finder_id::e_cylinder_grid>());
+    EXPECT_TRUE(d.sf_finder_store().template empty<finder_id::e_default>());
+
+    // Add some geometrical data
+    prefill_detector(d, geo_ctx);
+    // TODO: add B-field check
+
+    EXPECT_EQ(d.volumes().size(), 1UL);
+    EXPECT_EQ(d.surfaces().size(), 3UL);
+    EXPECT_EQ(d.transform_store().size(), 3UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_rectangle2>(), 1UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_trapezoid2>(), 1UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_annulus2>(), 1UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_cylinder2>(), 0UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_cylinder2>(), 0UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_ring2>(), 0UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_ring2>(), 0UL);
+    EXPECT_EQ(d.material_store().template size<material_id::e_slab>(), 2UL);
+    EXPECT_EQ(d.material_store().template size<material_id::e_rod>(), 1UL);
+    EXPECT_EQ(d.sf_finder_store().template size<finder_id::e_brute_force>(),
+              0UL);
+    EXPECT_EQ(d.sf_finder_store().template size<finder_id::e_disc_grid>(), 0UL);
+    EXPECT_EQ(d.sf_finder_store().template size<finder_id::e_cylinder_grid>(),
+              0UL);
+    EXPECT_EQ(d.sf_finder_store().template size<finder_id::e_default>(), 0UL);
+}
+
+/// This tests the functionality of a surface factory
+TEST(detector, surface_factory) {
+
+    using namespace detray;
 
     using detector_t =
         detector<detector_registry::default_detector, covfie::field>;
-    using mask_ids = typename detector_t::masks::id;
-    using material_ids = typename detector_t::materials::id;
+    using transform3 = typename detector_t::transform3;
+    using mask_id = typename detector_t::masks::id;
 
-    detector_t::geometry_context ctx0{};
+    //
+    // check portal cylinder
+    //
+    using portal_cylinder_factory =
+        surface_factory<detector_t, cylinder2D<>, mask_id::e_portal_cylinder2,
+                        surface_id::e_portal>;
 
-    detector_t::transform_container trfs;
-    detector_t::surface_container surfaces = {};
-    detector_t::mask_container masks(host_mr);
-    detector_t::material_container materials(host_mr);
+    auto pt_cyl_factory = std::make_shared<portal_cylinder_factory>();
 
-    /// Surface 0
-    point3 t0{0., 0., 0.};
-    trfs.emplace_back(ctx0, t0);
-    masks.template emplace_back<mask_ids::e_rectangle2>(empty_context{}, 0UL,
-                                                        -3.f, 3.f);
-    materials.template emplace_back<material_ids::e_slab>(empty_context{},
-                                                          gold<scalar>(), 3.);
+    typename portal_cylinder_factory::sf_data_collection cyl_sf_data;
+    cyl_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, cylinder2D<>>>(
+            transform3(point3{0.f, 0.f, -1000.f}), 0UL,
+            std::vector<scalar>{10.f, -1000.f, 1500.f}));
+    cyl_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, cylinder2D<>>>(
+            transform3(point3{0.f, 0.f, 1000.f}), 2UL,
+            std::vector<scalar>{20.f, -1500.f, 1000.f}));
 
-    /// Surface 1
-    point3 t1{1., 0., 0.};
-    trfs.emplace_back(ctx0, t1);
-    masks.template emplace_back<mask_ids::e_annulus2>(
-        empty_context{}, 0UL, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f);
-    materials.template emplace_back<material_ids::e_slab>(
-        empty_context{}, tungsten<scalar>(), 12.);
+    EXPECT_EQ(pt_cyl_factory->size(), 0UL);
+    EXPECT_TRUE(pt_cyl_factory->components().empty());
+    EXPECT_TRUE(pt_cyl_factory->transforms().empty());
+    EXPECT_TRUE(pt_cyl_factory->volume_links().empty());
 
-    /// Surface 2
-    point3 t2{2., 0., 0.};
-    trfs.emplace_back(ctx0, t2);
-    masks.template emplace_back<mask_ids::e_trapezoid2>(empty_context{}, 0UL,
-                                                        1.f, 2.f, 3.f);
-    materials.template emplace_back<material_ids::e_rod>(
-        empty_context{}, aluminium<scalar>(), 4.);
+    pt_cyl_factory->add_components(std::move(cyl_sf_data));
+    // data should be safely added to the factory by now
+    cyl_sf_data.clear();
 
-    detector_t d(host_mr);
+    EXPECT_EQ(pt_cyl_factory->size(), 2UL);
+    EXPECT_EQ(pt_cyl_factory->components().size(), 2UL);
+    EXPECT_EQ(pt_cyl_factory->transforms().size(), 2UL);
+    EXPECT_EQ(pt_cyl_factory->volume_links().size(), 2UL);
+    const auto& portal_cyl_comps = pt_cyl_factory->components().front();
+    EXPECT_FLOAT_EQ(portal_cyl_comps[0], scalar{10.f});
+    EXPECT_FLOAT_EQ(portal_cyl_comps[1], scalar{-1000.f});
+    EXPECT_FLOAT_EQ(portal_cyl_comps[2], scalar{1500.f});
+    const auto& portal_cyl_vol_links = pt_cyl_factory->volume_links();
+    EXPECT_EQ(portal_cyl_vol_links[0], 0UL);
+    EXPECT_EQ(portal_cyl_vol_links[1], 2UL);
 
-    auto &v =
-        d.new_volume(volume_id::e_cylinder, {0., 10., -5., 5., -M_PI, M_PI});
-    d.add_objects_per_volume(ctx0, v, surfaces, masks, trfs, materials);
+    //
+    // check sensitive cylinder
+    //
+    using sensitive_cylinder_factory =
+        surface_factory<detector_t, cylinder2D<>, mask_id::e_cylinder2,
+                        surface_id::e_sensitive>;
+
+    auto sens_cyl_factory = std::make_shared<sensitive_cylinder_factory>();
+
+    cyl_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, cylinder2D<>>>(
+            transform3(point3{0.f, 0.f, -50.f}), 1UL,
+            std::vector<scalar>{5.f, -900.f, 900.f}));
+    cyl_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, cylinder2D<>>>(
+            transform3(point3{0.f, 0.f, 50.f}), 1UL,
+            std::vector<scalar>{5.f, -900.f, 900.f}));
+
+    EXPECT_EQ(sens_cyl_factory->size(), 0UL);
+    EXPECT_TRUE(sens_cyl_factory->components().empty());
+    EXPECT_TRUE(sens_cyl_factory->transforms().empty());
+    // The single view is never empty, only uninitialized
+    EXPECT_FALSE(sens_cyl_factory->volume_links().empty());
+
+    sens_cyl_factory->add_components(std::move(cyl_sf_data));
+    cyl_sf_data.clear();
+
+    EXPECT_EQ(sens_cyl_factory->size(), 2UL);
+    EXPECT_EQ(sens_cyl_factory->components().size(), 2UL);
+    EXPECT_EQ(sens_cyl_factory->transforms().size(), 2UL);
+    EXPECT_EQ(sens_cyl_factory->volume_links().size(), 1UL);
+    const auto& sens_cyl_comps = sens_cyl_factory->components().front();
+    EXPECT_FLOAT_EQ(sens_cyl_comps[0], scalar{5.f});
+    EXPECT_FLOAT_EQ(sens_cyl_comps[1], scalar{-900.f});
+    EXPECT_FLOAT_EQ(sens_cyl_comps[2], scalar{900.f});
+    const auto& sens_cyl_vol_links = sens_cyl_factory->volume_links();
+    EXPECT_EQ(sens_cyl_vol_links[0], 1UL);
+
+    //
+    // check passive cylinder
+    //
+    using passive_cylinder_factory =
+        surface_factory<detector_t, cylinder2D<>, mask_id::e_cylinder2,
+                        surface_id::e_passive>;
+
+    auto psv_cyl_factory = std::make_shared<passive_cylinder_factory>();
+
+    cyl_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, cylinder2D<>>>(
+            transform3(point3{0.f, 0.f, -20.f}), 1UL,
+            std::vector<scalar>{4.9f, -900.f, 900.f}));
+    cyl_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, cylinder2D<>>>(
+            transform3(point3{0.f, 0.f, 20.f}), 1UL,
+            std::vector<scalar>{4.9f, -900.f, 900.f}));
+
+    EXPECT_EQ(psv_cyl_factory->size(), 0UL);
+    EXPECT_TRUE(psv_cyl_factory->components().empty());
+    EXPECT_TRUE(psv_cyl_factory->transforms().empty());
+    // The single view is never empty, only uninitialized
+    EXPECT_FALSE(psv_cyl_factory->volume_links().empty());
+
+    psv_cyl_factory->add_components(std::move(cyl_sf_data));
+    cyl_sf_data.clear();
+
+    EXPECT_EQ(psv_cyl_factory->size(), 2UL);
+    EXPECT_EQ(psv_cyl_factory->components().size(), 2UL);
+    EXPECT_EQ(psv_cyl_factory->transforms().size(), 2UL);
+    EXPECT_EQ(psv_cyl_factory->volume_links().size(), 1UL);
+    const auto& psv_cyl_comps = psv_cyl_factory->components().front();
+    EXPECT_FLOAT_EQ(psv_cyl_comps[0], scalar{4.9f});
+    EXPECT_FLOAT_EQ(psv_cyl_comps[1], scalar{-900.f});
+    EXPECT_FLOAT_EQ(psv_cyl_comps[2], scalar{900.f});
+    const auto& psv_cyl_vol_links = psv_cyl_factory->volume_links();
+    EXPECT_EQ(psv_cyl_vol_links[0], 1UL);
+
+    //
+    // check the other mask types for this detector
+    //
+
+    // annulus
+    using annulus_factory =
+        surface_factory<detector_t, annulus2D<>, mask_id::e_annulus2,
+                        surface_id::e_sensitive>;
+
+    auto ann_factory = std::make_shared<annulus_factory>();
+
+    typename annulus_factory::sf_data_collection ann_sf_data;
+    ann_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, annulus2D<>>>(
+            transform3(point3{0.f, 0.f, 0.f}), 1UL,
+            std::vector<scalar>{300.f, 350.f, -0.1f, 0.1f, 0.5f, 0.6f, 1.4f}));
+    ann_factory->add_components(std::move(ann_sf_data));
+    ann_sf_data.clear();
+
+    const auto& ann_comps = ann_factory->components().front();
+    EXPECT_FLOAT_EQ(ann_comps[0], scalar{300.f});
+    EXPECT_FLOAT_EQ(ann_comps[1], scalar{350.f});
+    EXPECT_FLOAT_EQ(ann_comps[2], scalar{-0.1f});
+    EXPECT_FLOAT_EQ(ann_comps[3], scalar{0.1f});
+    EXPECT_FLOAT_EQ(ann_comps[4], scalar{0.5f});
+    EXPECT_FLOAT_EQ(ann_comps[5], scalar{0.6f});
+    EXPECT_FLOAT_EQ(ann_comps[6], scalar{1.4f});
+
+    // rectangles
+    using rectangle_factory =
+        surface_factory<detector_t, rectangle2D<>, mask_id::e_rectangle2,
+                        surface_id::e_sensitive>;
+
+    auto rect_factory = std::make_shared<rectangle_factory>();
+
+    typename rectangle_factory::sf_data_collection rect_sf_data;
+    rect_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, rectangle2D<>>>(
+            transform3(point3{0.f, 0.f, 0.f}), 1UL,
+            std::vector<scalar>{10.f, 8.f}));
+    rect_factory->add_components(std::move(rect_sf_data));
+    rect_sf_data.clear();
+
+    const auto& rectgl_comps = rect_factory->components().front();
+    EXPECT_FLOAT_EQ(rectgl_comps[0], scalar{10.f});
+    EXPECT_FLOAT_EQ(rectgl_comps[1], scalar{8.f});
+
+    // ring
+    using ring_factory = surface_factory<detector_t, ring2D<>, mask_id::e_ring2,
+                                         surface_id::e_passive>;
+
+    auto rng_factory = std::make_shared<ring_factory>();
+
+    typename ring_factory::sf_data_collection ring_sf_data;
+    ring_sf_data.push_back(std::make_unique<surface_data<detector_t, ring2D<>>>(
+        transform3(point3{0.f, 0.f, 0.f}), 1UL, std::vector<scalar>{0.f, 5.f}));
+    rng_factory->add_components(std::move(ring_sf_data));
+    ring_sf_data.clear();
+
+    const auto& ring_comps = rng_factory->components().front();
+    EXPECT_FLOAT_EQ(ring_comps[0], scalar{0.f});
+    EXPECT_FLOAT_EQ(ring_comps[1], scalar{5.f});
+
+    // trapezoid
+    using trapezoid_factory =
+        surface_factory<detector_t, trapezoid2D<>, mask_id::e_trapezoid2,
+                        surface_id::e_sensitive>;
+
+    auto trpz_factory = std::make_shared<trapezoid_factory>();
+
+    typename trapezoid_factory::sf_data_collection trpz_sf_data;
+    trpz_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, trapezoid2D<>>>(
+            transform3(point3{0.f, 0.f, 0.f}), 1UL,
+            std::vector<scalar>{1.f, 3.f, 2.f, 0.25f}));
+    trpz_factory->add_components(std::move(trpz_sf_data));
+    trpz_sf_data.clear();
+
+    const auto& trpz_comps = trpz_factory->components().front();
+    EXPECT_FLOAT_EQ(trpz_comps[0], scalar{1.f});
+    EXPECT_FLOAT_EQ(trpz_comps[1], scalar{3.f});
+    EXPECT_FLOAT_EQ(trpz_comps[2], scalar{2.f});
+    EXPECT_FLOAT_EQ(trpz_comps[3], scalar{0.25f});
 }
 
-// This tests the construction of a detector class
+/// This tests the initialization of a detector volume using a volume builder
 TEST(detector, volume_builder) {
 
     using namespace detray;
@@ -84,14 +395,301 @@ TEST(detector, volume_builder) {
 
     detector_t d(host_mr);
 
-    EXPECT_TRUE(d.volumes().size() == 0);
+    EXPECT_TRUE(d.volumes().size() == 0UL);
 
     volume_builder<detector_t> vbuilder{};
-    vbuilder.init_vol(d, volume_id::e_cylinder,
-                      {0., 10., -5., 5., -M_PI, M_PI});
-    const auto &vol = d.volumes().back();
+    const std::array<scalar, 6UL> bounds{0.f, 10.f, -5.f, 5.f, -M_PI, M_PI};
+    vbuilder.init_vol(d, volume_id::e_cylinder, bounds);
+    const auto& vol = d.volumes().back();
 
-    EXPECT_TRUE(d.volumes().size() == 1);
-    EXPECT_EQ(vol.index(), 0);
+    EXPECT_TRUE(d.volumes().size() == 1UL);
+    EXPECT_TRUE(vol.empty());
+    EXPECT_EQ(vol.index(), 0UL);
+    EXPECT_EQ(vol.index(), vbuilder.get_vol_index());
     EXPECT_EQ(vol.id(), volume_id::e_cylinder);
+    for (const auto [idx, b] : detray::views::enumerate(vol.bounds())) {
+        EXPECT_FLOAT_EQ(b, bounds[idx]) << "error at index: " << idx;
+    }
+}
+
+/// Integration test to build a cylinder volume with contained surfaces
+TEST(detector, detector_volume_construction) {
+
+    using namespace detray;
+
+    using detector_t =
+        detray::detector<detector_registry::default_detector, covfie::field>;
+    using transform3 = typename detector_t::transform3;
+    using geo_obj_id = typename detector_t::geo_obj_ids;
+    using mask_id = typename detector_t::masks::id;
+
+    // portal factories
+    using portal_cylinder_factory =
+        surface_factory<detector_t, cylinder2D<>, mask_id::e_portal_cylinder2,
+                        surface_id::e_portal>;
+    using portal_disc_factory =
+        surface_factory<detector_t, ring2D<>, mask_id::e_portal_ring2,
+                        surface_id::e_portal>;
+
+    // sensitive/passive surface factories
+    using annulus_factory =
+        surface_factory<detector_t, annulus2D<>, mask_id::e_annulus2,
+                        surface_id::e_sensitive>;
+    using cylinder_factory =
+        surface_factory<detector_t, cylinder2D<>, mask_id::e_cylinder2,
+                        surface_id::e_passive>;
+    using rectangle_factory =
+        surface_factory<detector_t, rectangle2D<>, mask_id::e_rectangle2,
+                        surface_id::e_sensitive>;
+    using ring_factory = surface_factory<detector_t, ring2D<>, mask_id::e_ring2,
+                                         surface_id::e_passive>;
+    using trapezoid_factory =
+        surface_factory<detector_t, trapezoid2D<>, mask_id::e_trapezoid2,
+                        surface_id::e_sensitive>;
+
+    // detector
+    vecmem::host_memory_resource host_mr;
+    detector_t d(host_mr);
+    auto geo_ctx = typename detector_t::geometry_context{};
+    // ensure there is a data offset that needs to be handled correctly
+    prefill_detector(d, geo_ctx);
+
+    // volume builder
+    volume_builder<detector_t> vbuilder{};
+    vbuilder.init_vol(d, volume_id::e_cylinder,
+                      {0.f, 500.f, -1500.f, 1500.f, -M_PI, M_PI});
+    const auto& vol = d.volumes().back();
+
+    // initial checks
+    EXPECT_EQ(d.volumes().size(), 2UL);
+    EXPECT_EQ(d.surfaces().size(), 3UL);
+    EXPECT_TRUE(vol.empty());
+    EXPECT_EQ(vol.index(), 1UL);
+    EXPECT_EQ(vol.id(), volume_id::e_cylinder);
+
+    //
+    // Fill the surface factories with data
+    //
+
+    // portal surfaces
+    auto pt_cyl_factory = std::make_shared<portal_cylinder_factory>();
+    typename portal_cylinder_factory::sf_data_collection cyl_sf_data;
+    // Creates two cylinders at radius 0mm and 10mm with an extent in z
+    // of -5mm to 5mm and linking to volumes 0 and 2, respectively.
+    cyl_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, cylinder2D<>>>(
+            transform3(point3{0.f, 0.f, 0.f}), 0UL,
+            std::vector<scalar>{10.f, -1500.f, 1500.f}));
+    cyl_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, cylinder2D<>>>(
+            transform3(point3{0.f, 0.f, 0.f}), 2UL,
+            std::vector<scalar>{20.f, -1500.f, 1500.f}));
+    pt_cyl_factory->add_components(std::move(cyl_sf_data));
+
+    auto pt_disc_factory = std::make_shared<portal_disc_factory>();
+    typename portal_disc_factory::sf_data_collection ring_sf_data;
+    // Creates two discs with a radius of 10mm, linking to volumes 3 and 4
+    ring_sf_data.push_back(std::make_unique<surface_data<detector_t, ring2D<>>>(
+        transform3(point3{0.f, 0.f, -1500.f}), 3UL,
+        std::vector<scalar>{0.f, 10.f}));
+    ring_sf_data.push_back(std::make_unique<surface_data<detector_t, ring2D<>>>(
+        transform3(point3{0.f, 0.f, 1500.f}), 4UL,
+        std::vector<scalar>{0.f, 10.f}));
+    pt_disc_factory->add_components(std::move(ring_sf_data));
+
+    // sensitive surfaces
+    auto ann_factory = std::make_shared<annulus_factory>();
+    typename annulus_factory::sf_data_collection ann_sf_data;
+    ann_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, annulus2D<>>>(
+            transform3(point3{0.f, 0.f, 1000.f}), vol.index(),
+            std::vector<scalar>{300.f, 350.f, -0.1f, 0.1f, 0.5f, 0.6f, 1.4f}));
+    ann_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, annulus2D<>>>(
+            transform3(point3{0.f, 0.f, 1000.f}), vol.index(),
+            std::vector<scalar>{350.f, 400.f, -0.1f, 0.1f, 0.5f, 0.6f, 1.4f}));
+    ann_factory->add_components(std::move(ann_sf_data));
+
+    auto rect_factory = std::make_shared<rectangle_factory>();
+    typename rectangle_factory::sf_data_collection rect_sf_data;
+    rect_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, rectangle2D<>>>(
+            transform3(point3{0.f, 0.f, -10.f}), vol.index(),
+            std::vector<scalar>{10.f, 8.f}));
+    rect_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, rectangle2D<>>>(
+            transform3(point3{0.f, 0.f, -20.f}), vol.index(),
+            std::vector<scalar>{10.f, 8.f}));
+    rect_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, rectangle2D<>>>(
+            transform3(point3{0.f, 0.f, -30.f}), vol.index(),
+            std::vector<scalar>{10.f, 8.f}));
+    rect_factory->add_components(std::move(rect_sf_data));
+
+    auto trpz_factory = std::make_shared<trapezoid_factory>();
+    typename trapezoid_factory::sf_data_collection trpz_sf_data;
+    trpz_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, trapezoid2D<>>>(
+            transform3(point3{0.f, 0.f, 1000.f}), vol.index(),
+            std::vector<scalar>{1.f, 3.f, 2.f, 0.25f}));
+    trpz_factory->add_components(std::move(trpz_sf_data));
+
+    // passive surfaces
+    auto cyl_factory = std::make_shared<cylinder_factory>();
+    cyl_sf_data.clear();
+    cyl_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, cylinder2D<>>>(
+            transform3(point3{0.f, 0.f, 0.f}), vol.index(),
+            std::vector<scalar>{5.f, -1300.f, 1300.f}));
+    cyl_factory->add_components(std::move(cyl_sf_data));
+
+    auto rng_factory = std::make_shared<ring_factory>();
+    ring_sf_data.clear();
+    ring_sf_data.push_back(std::make_unique<surface_data<detector_t, ring2D<>>>(
+        transform3(point3{0.f, 0.f, -1300.f}), vol.index(),
+        std::vector<scalar>{0.f, 5.f}));
+    ring_sf_data.push_back(std::make_unique<surface_data<detector_t, ring2D<>>>(
+        transform3(point3{0.f, 0.f, 1300.f}), vol.index(),
+        std::vector<scalar>{0.f, 5.f}));
+    rng_factory->add_components(std::move(ring_sf_data));
+
+    //
+    // Fill everything into volume
+    //
+    vbuilder.add_portals(pt_cyl_factory, geo_ctx);
+    vbuilder.add_portals(pt_disc_factory, geo_ctx);
+
+    vbuilder.add_sensitives(ann_factory, geo_ctx);
+    vbuilder.add_sensitives(rect_factory, geo_ctx);
+    vbuilder.add_sensitives(trpz_factory, geo_ctx);
+
+    vbuilder.add_passives(cyl_factory, geo_ctx);
+    vbuilder.add_passives(rng_factory, geo_ctx);
+
+    // try adding something extra later...
+    rect_factory->clear();
+    rect_sf_data.clear();
+    rect_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, rectangle2D<>>>(
+            transform3(point3{0.f, 0.f, 10.f}), vol.index(),
+            std::vector<scalar>{10.f, 8.f}));
+    rect_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, rectangle2D<>>>(
+            transform3(point3{0.f, 0.f, 20.f}), vol.index(),
+            std::vector<scalar>{10.f, 8.f}));
+    rect_factory->add_components(std::move(rect_sf_data));
+    rect_sf_data.clear();
+    rect_sf_data.push_back(
+        std::make_unique<surface_data<detector_t, rectangle2D<>>>(
+            transform3(point3{0.f, 0.f, 30.f}), vol.index(),
+            std::vector<scalar>{10.f, 8.f}));
+    rect_factory->add_components(std::move(rect_sf_data));
+
+    vbuilder.add_sensitives(rect_factory, geo_ctx);
+
+    //
+    // Adds all surfaces to the detector
+    //
+    vbuilder.build(d);
+
+    //
+    // check results
+    //
+    EXPECT_FALSE(vol.empty());
+    // default detector makes no distinction between the surface types
+    typename detector_registry::default_detector::object_link_type sf_range{};
+    sf_range[0] = {3UL, 19UL};
+    EXPECT_EQ(vol.full_range(), sf_range[geo_obj_id::e_sensitive]);
+    EXPECT_EQ(vol.template obj_link<geo_obj_id::e_portal>(),
+              sf_range[geo_obj_id::e_portal]);
+    EXPECT_EQ(vol.template obj_link<geo_obj_id::e_sensitive>(),
+              sf_range[geo_obj_id::e_sensitive]);
+    EXPECT_EQ(vol.template obj_link<geo_obj_id::e_passive>(),
+              sf_range[geo_obj_id::e_passive]);
+
+    EXPECT_EQ(d.surfaces().size(), 19UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_cylinder2>(), 3UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_ring2>(), 4UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_annulus2>(), 3UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_cylinder2>(), 3UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_rectangle2>(), 7UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_ring2>(), 4UL);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_trapezoid2>(), 2UL);
+
+    // check surface type and volume link
+    std::vector<surface_id> sf_ids{};
+    sf_ids.reserve(d.surfaces().size());
+    sf_ids.insert(sf_ids.end(), 3UL, surface_id::e_sensitive);
+    sf_ids.insert(sf_ids.end(), 4UL, surface_id::e_portal);
+    sf_ids.insert(sf_ids.end(), 6UL, surface_id::e_sensitive);
+    sf_ids.insert(sf_ids.end(), 3UL, surface_id::e_passive);
+    sf_ids.insert(sf_ids.end(), 3UL, surface_id::e_sensitive);
+    std::vector<dindex> volume_links{};
+    volume_links.insert(volume_links.end(), 3UL, 0UL);
+    volume_links.insert(volume_links.end(), 16UL, 1UL);
+    volume_links.reserve(d.surfaces().size());
+    for (const auto [idx, sf_id] : detray::views::enumerate(sf_ids)) {
+        const auto& sf = d.surface_by_index(idx);
+        EXPECT_EQ(sf.id(), sf_id) << "error at index: " << idx;
+        EXPECT_EQ(sf.volume(), volume_links.at(idx))
+            << "error at index: " << idx;
+    }
+
+    // check that the transform indices are continuous
+    for (std::size_t idx :
+         detray::views::iota(d.transform_store().size() - 1)) {
+        EXPECT_EQ(d.surface_by_index(idx).transform(), idx)
+            << "error at index: " << idx;
+    }
+
+    // check surface mask links
+    std::vector<typename detector_t::mask_link> mask_links{
+        {mask_id::e_rectangle2, 0UL},
+        {mask_id::e_annulus2, 0UL},
+        {mask_id::e_trapezoid2, 0UL},
+        {mask_id::e_portal_cylinder2, 0UL},
+        {mask_id::e_portal_cylinder2, 1UL},
+        {mask_id::e_portal_ring2, 0UL},
+        {mask_id::e_portal_ring2, 1UL},
+        {mask_id::e_annulus2, 1UL},
+        {mask_id::e_annulus2, 2UL},
+        {mask_id::e_rectangle2, 1UL},
+        {mask_id::e_rectangle2, 2UL},
+        {mask_id::e_rectangle2, 3UL},
+        {mask_id::e_trapezoid2, 1UL},
+        {mask_id::e_cylinder2, 2UL},
+        {mask_id::e_ring2, 2UL},
+        {mask_id::e_ring2, 3UL},
+        {mask_id::e_rectangle2, 4UL},
+        {mask_id::e_rectangle2, 5UL},
+        {mask_id::e_rectangle2, 6UL}};
+    for (const auto [idx, m_link] : detray::views::enumerate(mask_links)) {
+        EXPECT_EQ(d.surface_by_index(idx).mask(), m_link)
+            << "error at index: " << idx;
+    }
+
+    // check mask volume links
+    volume_links.clear();
+    volume_links = {0UL, 2UL, 1UL};
+    check_mask<detector_t, mask_id::e_portal_cylinder2>(d, volume_links);
+    check_mask<detector_t, mask_id::e_cylinder2>(d, volume_links);
+
+    volume_links.clear();
+    volume_links = {3UL, 4UL, 1UL, 1UL};
+    check_mask<detector_t, mask_id::e_portal_ring2>(d, volume_links);
+    check_mask<detector_t, mask_id::e_ring2>(d, volume_links);
+
+    volume_links.clear();
+    volume_links = {0UL, 1UL, 1UL};
+    check_mask<detector_t, mask_id::e_annulus2>(d, volume_links);
+
+    volume_links.clear();
+    volume_links.reserve(7);
+    volume_links.push_back(0UL);
+    volume_links.insert(volume_links.end(), 6UL, 1UL);
+    check_mask<detector_t, mask_id::e_rectangle2>(d, volume_links);
+
+    volume_links.clear();
+    volume_links = {0UL, 1UL};
+    check_mask<detector_t, mask_id::e_trapezoid2>(d, volume_links);
 }

--- a/utils/include/detray/detectors/detector_metadata.hpp
+++ b/utils/include/detray/detectors/detector_metadata.hpp
@@ -118,6 +118,7 @@ struct full_metadata {
     enum class material_ids {
         e_slab = 0,
         e_rod = 1,
+        e_none = 2,
     };
 
     /// How to store and link materials
@@ -208,6 +209,7 @@ struct toy_metadata {
     /// to a type!)
     enum class material_ids {
         e_slab = 0,
+        e_none = 1,
     };
 
     /// How to store and link materials
@@ -294,6 +296,7 @@ struct telescope_metadata {
     /// to a type!)
     enum class material_ids {
         e_slab = 0,
+        e_none = 1,
     };
 
     /// How to store and link materials


### PR DESCRIPTION
Adds a basic factory class that will produce surfaces with their masks, set  their links and add them to a given collection of geometry data containers. It can handle portal, sensitive and passive surfaces, but still needs a wrapper to be mapped to the detector mask types. Material needs to be added in a dedicated material volume builder in a later PR.