### PR TITLE
feat: material builders

### DIFF
--- a/core/include/detray/tools/cuboid_portal_generator.hpp
+++ b/core/include/detray/tools/cuboid_portal_generator.hpp
@@ -65,6 +65,9 @@ class cuboid_portal_generator final
     auto size() const -> dindex override { return 6u; }
 
     DETRAY_HOST
+    void clear() override{/*Do nothing*/};
+
+    DETRAY_HOST
     void push_back(surface_data<detector_t> &&) override { /*Do nothing*/
     }
     DETRAY_HOST

--- a/core/include/detray/tools/grid_builder.hpp
+++ b/core/include/detray/tools/grid_builder.hpp
@@ -17,6 +17,12 @@
 #include "detray/tools/volume_builder.hpp"
 #include "detray/tools/volume_builder_interface.hpp"
 
+// System include(s)
+#include <array>
+#include <cassert>
+#include <memory>
+#include <vector>
+
 namespace detray {
 
 /// @brief Build a grid of a certain shape.
@@ -94,6 +100,7 @@ class grid_builder final : public volume_decorator<detector_t> {
         if (m_add_passives) {
             (*ps_factory)(volume_decorator<detector_t>::operator()(),
                           m_surfaces, m_transforms, m_masks, ctx);
+            ps_factory->clear();
         } else {
             volume_decorator<detector_t>::add_passives(std::move(ps_factory),
                                                        ctx);

--- a/core/include/detray/tools/material_builder.hpp
+++ b/core/include/detray/tools/material_builder.hpp
@@ -1,0 +1,132 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "detray/tools/material_factory.hpp"
+#include "detray/tools/volume_builder.hpp"
+#include "detray/tools/volume_builder_interface.hpp"
+
+// System include(s)
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+namespace detray {
+
+/// @brief Build a volume containing surfaces with material.
+///
+/// Decorator class to a volume builder that adds the material data to the
+/// surfaces while building the volume.
+template <typename detector_t>
+class material_builder final : public volume_decorator<detector_t> {
+
+    public:
+    using material_id = typename detector_t::materials::id;
+    using scalar_type = typename detector_t::scalar_type;
+
+    /// @param vol_builder volume builder that should be decorated with material
+    DETRAY_HOST
+    material_builder(
+        std::unique_ptr<volume_builder_interface<detector_t>> vol_builder)
+        : volume_decorator<detector_t>(std::move(vol_builder)) {}
+
+    /// Overwrite, to add material in addition to surfaces (only if surfaces are
+    /// present in the factory, otherwise only add material)
+    /// @{
+    DETRAY_HOST
+    void add_portals(
+        std::shared_ptr<surface_factory_interface<detector_t>> pt_factory,
+        typename detector_t::geometry_context ctx = {}) override {
+
+        // If the factory also holds surface data, call base volume builder
+        if (pt_factory->size() != 0u) {
+            volume_decorator<detector_t>::add_portals(pt_factory, ctx);
+        }
+
+        // Add material
+        auto mat_factory =
+            std::dynamic_pointer_cast<material_factory<detector_t>>(pt_factory);
+        if (mat_factory) {
+            (*mat_factory)(this->surfaces(), m_materials);
+        } else {
+            throw std::runtime_error("Not a material factory");
+        }
+    }
+
+    DETRAY_HOST
+    void add_sensitives(
+        std::shared_ptr<surface_factory_interface<detector_t>> sf_factory,
+        typename detector_t::geometry_context ctx = {}) override {
+        if (sf_factory->size() != 0u) {
+            volume_decorator<detector_t>::add_sensitives(sf_factory, ctx);
+        }
+
+        // Add material
+        auto mat_factory =
+            std::dynamic_pointer_cast<material_factory<detector_t>>(sf_factory);
+        if (mat_factory) {
+            (*mat_factory)(this->surfaces(), m_materials);
+        } else {
+            throw std::runtime_error("Not a material factory");
+        }
+    }
+
+    DETRAY_HOST
+    void add_passives(
+        std::shared_ptr<surface_factory_interface<detector_t>> ps_factory,
+        typename detector_t::geometry_context ctx = {}) override {
+        if (ps_factory->size() != 0u) {
+            volume_decorator<detector_t>::add_passives(ps_factory, ctx);
+        }
+
+        // Add material
+        auto mat_factory =
+            std::dynamic_pointer_cast<material_factory<detector_t>>(ps_factory);
+        if (mat_factory) {
+            (*mat_factory)(this->surfaces(), m_materials);
+        } else {
+            throw std::runtime_error("Not a material factory");
+        }
+    }
+    /// @}
+
+    /// Add the volume and the material to the detector @param det
+    DETRAY_HOST
+    auto build(detector_t &det, typename detector_t::geometry_context ctx = {})
+        -> typename detector_t::volume_type * override {
+
+        const auto &material = det.material_store();
+
+        // Update the surface material links and shift them according to the
+        // number of material slabs/rods that were in the detector previously
+        for (auto &sf : this->surfaces()) {
+            if (sf.material().id() == material_id::e_slab) {
+                sf.update_material(
+                    material.template size<material_id::e_slab>());
+            } else {
+                sf.update_material(
+                    material.template size<material_id::e_rod>());
+            }
+        }
+
+        // Add material to the detector
+        det.append_materials(std::move(m_materials));
+        m_materials.clear_all();
+
+        // Call the underlying volume builder(s) and give the volume to the
+        // next decorator
+        return volume_decorator<detector_t>::build(det, ctx);
+    }
+
+    protected:
+    // Material container for this volume
+    typename detector_t::material_container m_materials{};
+};
+
+}  // namespace detray

--- a/core/include/detray/tools/material_factory.hpp
+++ b/core/include/detray/tools/material_factory.hpp
@@ -1,0 +1,211 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/indexing.hpp"
+#include "detray/materials/material.hpp"
+#include "detray/tools/surface_factory.hpp"
+#include "detray/utils/ranges.hpp"
+
+// System include(s)
+#include <cassert>
+#include <memory>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+namespace detray {
+
+/// @brief Bind components for material together.
+template <typename scalar_t>
+class material_data {
+    public:
+    /// Construct from a predefined material
+    ///
+    /// @param mat predefined material, see
+    ///            'detray/materials/predefined_materials.hpp'
+    /// @param thickness of the material slab/rod
+    DETRAY_HOST
+    constexpr material_data(const scalar_t thickness,
+                            const material<scalar_t> &mat)
+        : m_mat{mat}, m_thickness{thickness} {}
+
+    /// Construct from all parameters:
+    ///
+    /// @param thickness of the material slab/rod
+    /// @param material_paramters0 x0 is the radiation length
+    /// @param material_paramters1 l0 is the nuclear interaction length
+    /// @param material_paramters2 ar is the relative atomic mass
+    /// @param material_paramters3 z is the nuclear charge number
+    /// @param material_paramters4 molarRho is the molar density
+    /// @param state of the material (liquid, solid etc.)
+    DETRAY_HOST
+    constexpr material_data(
+        const scalar_t thickness,
+        const std::vector<scalar_t> &material_paramters,
+        const material_state state = material_state::e_solid)
+        : m_mat{material_paramters[0], material_paramters[1],
+                material_paramters[2], material_paramters[3],
+                material_paramters[4], state},
+          m_thickness{thickness} {}
+
+    /// @returns tuple based access to the contained material data.
+    DETRAY_HOST
+    constexpr auto get_data() -> std::tuple<material<scalar_t> &, scalar_t &> {
+        return std::tie(m_mat, m_thickness);
+    }
+
+    private:
+    /// The material parametrization
+    material<scalar_t> m_mat{};
+    /// Thickness/radius of the material slab/rod
+    scalar_t m_thickness{0.f};
+};
+
+/// @brief Factory class for homogeneous material.
+///
+/// Uses a surface factory underneath the hood that handles the surface
+/// construction. The material ID from the detector determines the type of
+/// material that will be produced. The factory is filled from [a vector] of
+/// @c material_data .
+///
+/// @tparam detector_t type of detector that contains the material
+template <typename detector_t>
+class material_factory final : public factory_decorator<detector_t> {
+
+    using base_factory = factory_decorator<detector_t>;
+
+    public:
+    using material_id = typename detector_t::materials::id;
+    using scalar_type = typename detector_t::scalar_type;
+
+    /// Factory with surfaces potentially already filled.
+    DETRAY_HOST
+    material_factory(std::unique_ptr<surface_factory_interface<detector_t>>
+                         sf_factory = nullptr)
+        : base_factory(std::move(sf_factory)) {}
+
+    /// @returns the number of material that will be built by the factory
+    DETRAY_HOST
+    auto size() const -> dindex {
+
+        const dindex n_surfaces{static_cast<dindex>(m_links.size())};
+
+        // Need exactly one material per surface
+        assert(m_materials.size() == n_surfaces);
+        assert(m_thickness.size() == n_surfaces);
+
+        return n_surfaces;
+    }
+
+    /// @returns the material links to the surface (counted for this volume)
+    DETRAY_HOST
+    auto links() const -> const std::vector<material_id> & { return m_links; }
+
+    /// @returns the raw materials that are currently in the factory
+    DETRAY_HOST
+    auto materials() const -> const std::vector<material<scalar_type>> & {
+        return m_materials;
+    }
+
+    /// @returns the material thickness currently held by the factory
+    DETRAY_HOST
+    auto thickness() const -> const std::vector<scalar_type> & {
+        return m_thickness;
+    }
+
+    /// Add all necessary compontents to the factory for a single material slab
+    /// or rod (determined by the @param id)
+    DETRAY_HOST
+    void add_material(material_id id, material_data<scalar_type> &&mat_data) {
+
+        auto [mat, thickness] = mat_data.get_data();
+
+        m_links.push_back(id);
+        m_materials.push_back(mat);
+        m_thickness.push_back(thickness);
+    }
+
+    /// Add all necessary compontents to the factory for multiple material slabs
+    /// or rods (determined by the @param id)
+    DETRAY_HOST
+    void add_material(material_id id,
+                      std::vector<material_data<scalar_type>> &&mat_data_vec) {
+        // Read the material containers
+        m_links.reserve(m_links.size() + mat_data_vec.size());
+        m_materials.reserve(m_materials.size() + mat_data_vec.size());
+        m_thickness.reserve(m_thickness.size() + mat_data_vec.size());
+
+        // Add the material components
+        for (auto &mat_data : mat_data_vec) {
+            this->add_material(id, std::move(mat_data));
+        }
+    }
+
+    /// @brief Add material to the containers of a volume builder.
+    ///
+    /// This assumes that the surfaces have already been added (e.g. by this
+    /// factories underlying surface factory). The material from this factory is
+    /// added to the corresponding number of surfaces at the end of the calling
+    /// volume builder.
+    ///
+    /// @note This does not override the pure virtual function from the surface
+    /// factory interface, but presents an overload for the case when material
+    /// should be added.
+    ///
+    /// @param surfaces surface store of the volume builder that should get
+    ///                 decorated with material.
+    /// @param material material store of the volume builder that the new
+    ///                 materials get added to.
+    DETRAY_HOST
+    auto operator()(typename detector_t::surface_container_t &surfaces,
+                    typename detector_t::material_container &materials) const {
+
+        using link_t = typename detector_t::surface_type::material_link;
+
+        // Check that the surfaces were set up correctly
+        const dindex n_material{this->size()};
+        assert(surfaces.size() >= n_material);
+
+        // Range of surfaces for which to add material
+        dindex_range r{static_cast<dindex>(surfaces.size() - n_material),
+                       static_cast<dindex>(surfaces.size())};
+        std::size_t sf_idx{0u};
+        for (auto &sf : detray::ranges::subrange(surfaces, r)) {
+
+            const material<scalar_type> &mat = m_materials.at(sf_idx);
+            scalar_type t = m_thickness.at(sf_idx);
+
+            dindex n{0u};
+            if (m_links.at(sf_idx) == material_id::e_slab) {
+                n = materials.template size<material_id::e_slab>();
+                materials.template emplace_back<material_id::e_slab>({}, mat,
+                                                                     t);
+            } else {
+                n = materials.template size<material_id::e_rod>();
+                materials.template emplace_back<material_id::e_rod>({}, mat, t);
+            }
+
+            // Set the initial surface material link (will be updated when
+            // added to the detector)
+            sf.material() = link_t{m_links[sf_idx], n};
+            ++sf_idx;
+        }
+    }
+
+    protected:
+    /// Material links of surfaces (currently only type ids)
+    std::vector<material_id> m_links{};
+    /// Material thickness
+    std::vector<scalar_type> m_thickness{};
+    /// The pre-computed material to be wrapped in a slab or rod
+    std::vector<material<scalar_type>> m_materials{};
+};
+
+}  // namespace detray

--- a/core/include/detray/tools/surface_factory.hpp
+++ b/core/include/detray/tools/surface_factory.hpp
@@ -36,12 +36,14 @@ namespace detray {
 template <typename detector_t, typename mask_shape_t,
           typename detector_t::mask_link::id_type mask_id, surface_id sf_id,
           typename volume_link_t = dindex>
-class surface_factory final
+class surface_factory
     : public surface_factory_interface<detector_t>,
       public std::enable_shared_from_this<surface_factory<
           detector_t, mask_shape_t, mask_id, sf_id, volume_link_t>> {
     public:
     using scalar_t = typename detector_t::scalar_type;
+    using shape_type = mask_shape_t;
+    using detector_type = detector_t;
     // Set individual volume link for portals, but only the mothervolume index
     // for other surfaces.
     using volume_link_collection =
@@ -142,7 +144,7 @@ class surface_factory final
 
     /// Clear old data
     DETRAY_HOST
-    auto clear() -> void {
+    auto clear() -> void override {
         m_components.clear();
         m_transforms.clear();
         // cannot clear the single-view

--- a/core/include/detray/tools/volume_builder.hpp
+++ b/core/include/detray/tools/volume_builder.hpp
@@ -20,7 +20,7 @@ namespace detray {
 
 namespace detail {
 
-/// A functor to update the mask index in surface objects
+/// A functor to update the mask index in surface descriptors
 struct mask_index_update;
 
 }  // namespace detail
@@ -122,6 +122,14 @@ class volume_builder : public volume_builder_interface<detector_t> {
     }
 
     protected:
+    typename detector_t::surface_container_t& surfaces() override {
+        return m_surfaces;
+    }
+    typename detector_t::transform_container& transforms() override {
+        return m_transforms;
+    }
+    typename detector_t::mask_container& masks() override { return m_masks; }
+
     /// Add a new full set of detector components (e.g. transforms or volumes)
     /// according to given geometry_context.
     ///
@@ -183,6 +191,18 @@ struct mask_index_update {
                                        const index_t& /*index*/,
                                        surface_t& sf) const {
         sf.update_mask(static_cast<dindex>(group.size()));
+    }
+};
+
+/// TODO: Remove once the material builder is used everywhere
+/// A functor to update the material index in surface objects
+struct material_index_update {
+
+    template <typename group_t, typename index_t, typename surface_t>
+    DETRAY_HOST inline void operator()(const group_t& group,
+                                       const index_t& /*index*/,
+                                       surface_t& sf) const {
+        sf.update_material(static_cast<dindex>(group.size()));
     }
 };
 

--- a/core/include/detray/tools/volume_builder_interface.hpp
+++ b/core/include/detray/tools/volume_builder_interface.hpp
@@ -18,9 +18,15 @@ namespace detray {
 template <typename detector_t>
 class surface_factory_interface;
 
+template <typename detector_t>
+class volume_decorator;
+
 /// @brief Interface for volume builders (and volume builder decorators)
 template <typename detector_t>
 class volume_builder_interface {
+
+    // Access protected methods
+    friend class volume_decorator<detector_t>;
 
     public:
     using scalar_type = typename detector_t::scalar_type;
@@ -93,6 +99,14 @@ class volume_builder_interface {
     virtual void add_passives(
         std::shared_ptr<surface_factory_interface<detector_t>> ps_factory,
         typename detector_t::geometry_context ctx = {}) = 0;
+
+    protected:
+    /// Access to builder data
+    /// @{
+    virtual typename detector_t::surface_container_t &surfaces() = 0;
+    virtual typename detector_t::transform_container &transforms() = 0;
+    virtual typename detector_t::mask_container &masks() = 0;
+    /// @}
 };
 
 /// @brief Decorator for the volume builder.
@@ -181,22 +195,17 @@ class volume_decorator : public volume_builder_interface<detector_t> {
     /// @}
 
     protected:
+    typename detector_t::surface_container_t &surfaces() override {
+        return m_builder->surfaces();
+    }
+    typename detector_t::transform_container &transforms() override {
+        return m_builder->transforms();
+    }
+    typename detector_t::mask_container &masks() override {
+        return m_builder->masks();
+    }
+
     std::unique_ptr<volume_builder_interface<detector_t>> m_builder;
 };
-
-namespace detail {
-
-/// A functor to update the material index in surface objects
-struct material_index_update {
-
-    template <typename group_t, typename index_t, typename surface_t>
-    DETRAY_HOST inline void operator()(const group_t &group,
-                                       const index_t & /*index*/,
-                                       surface_t &sf) const {
-        sf.update_material(static_cast<dindex>(group.size()));
-    }
-};
-
-}  // namespace detail
 
 }  // namespace detray

--- a/tests/unit_tests/cpu/CMakeLists.txt
+++ b/tests/unit_tests/cpu/CMakeLists.txt
@@ -66,6 +66,7 @@ macro( detray_add_cpu_test algebra )
       "tools_helix_trajectory.cpp"
       "tools_intersection_kernel.cpp"
       "tools_line_intersection.cpp"
+      "tools_material_builder.cpp"
       "tools_matrix_helper.cpp"
       "tools_navigator.cpp"
       "tools_particle_gun.cpp"

--- a/tests/unit_tests/cpu/grid_grid_builder.cpp
+++ b/tests/unit_tests/cpu/grid_grid_builder.cpp
@@ -175,8 +175,8 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
              regular_attacher<9>>;
 
     using portal_cylinder_factory_t =
-        surface_factory<test_detector_t, cylinder2D<>, mask_id::e_cylinder2,
-                        surface_id::e_portal>;
+        surface_factory<test_detector_t, cylinder2D<>,
+                        mask_id::e_portal_cylinder2, surface_id::e_portal>;
     using rectangle_factory =
         surface_factory<test_detector_t, rectangle2D<>, mask_id::e_rectangle2,
                         surface_id::e_sensitive>;

--- a/tests/unit_tests/cpu/tools_material_builder.cpp
+++ b/tests/unit_tests/cpu/tools_material_builder.cpp
@@ -1,0 +1,225 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Detray include(s)
+#include "detray/core/detector.hpp"
+#include "detray/definitions/indexing.hpp"
+#include "detray/tools/material_builder.hpp"
+#include "detray/tools/material_factory.hpp"
+#include "detray/tools/surface_factory.hpp"
+#include "detray/tools/volume_builder.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// GTest include(s)
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <limits>
+#include <memory>
+#include <vector>
+
+using namespace detray;
+
+namespace {
+
+using point3 = __plugin::point3<scalar>;
+
+using detector_t = detector<>;
+
+constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
+
+}  // anonymous namespace
+
+/// Unittest: Test the construction of a collection of materials
+TEST(detray_tools, material_builder) {
+
+    using transform3 = typename detector_t::transform3;
+    using mask_id = typename detector_t::masks::id;
+    using material_id = typename detector_t::materials::id;
+
+    // Build rectangle surfaces with material slabs
+    using rectangle_factory =
+        surface_factory<detector_t, rectangle2D<>, mask_id::e_rectangle2,
+                        surface_id::e_sensitive>;
+    auto mat_factory = std::make_unique<material_factory<detector_t>>(
+        std::make_unique<rectangle_factory>());
+
+    vecmem::host_memory_resource host_mr;
+    detector_t d(host_mr);
+    // auto geo_ctx = typename detector_t::geometry_context{};
+
+    EXPECT_TRUE(d.material_store().template empty<material_id::e_slab>());
+    EXPECT_TRUE(d.material_store().template empty<material_id::e_rod>());
+
+    EXPECT_EQ(mat_factory->size(), 0u);
+    EXPECT_TRUE(mat_factory->materials().empty());
+    EXPECT_TRUE(mat_factory->thickness().empty());
+
+    // Add material for a few rectangle surfaces
+    mat_factory->push_back({transform3(point3{0.f, 0.f, -1.f}), 1u,
+                            std::vector<scalar>{10.f, 8.f}});
+    mat_factory->add_material(material_id::e_slab,
+                              {1.f * unit<scalar>::mm, silicon<scalar>()});
+    mat_factory->push_back({transform3(point3{0.f, 0.f, 1.f}), 1u,
+                            std::vector<scalar>{20.f, 16.f}});
+    mat_factory->add_material(material_id::e_slab,
+                              {10.f * unit<scalar>::mm, tungsten<scalar>()});
+    // Pass the parameters for 'gold'
+    mat_factory->push_back({transform3(point3{0.f, 0.f, 1.f}), 1u,
+                            std::vector<scalar>{20.f, 16.f}});
+    mat_factory->add_material(
+        material_id::e_rod,
+        {0.1f * unit<scalar>::mm,
+         std::vector<scalar>{
+             3.344f * unit<scalar>::mm, 101.6f * unit<scalar>::mm, 196.97f, 79,
+             19.32f * unit<scalar>::g / (1.f * unit<scalar>::cm3)},
+         material_state::e_solid});
+
+    EXPECT_EQ(mat_factory->size(), 3u);
+
+    // Test the mayerial data
+    EXPECT_NEAR(mat_factory->thickness()[0], 1.f * unit<scalar>::mm, tol);
+    EXPECT_NEAR(mat_factory->thickness()[1], 10.f * unit<scalar>::mm, tol);
+    EXPECT_NEAR(mat_factory->thickness()[2], 0.1f * unit<scalar>::mm, tol);
+    EXPECT_EQ(mat_factory->materials()[0], silicon<scalar>());
+    EXPECT_EQ(mat_factory->materials()[1], tungsten<scalar>());
+    EXPECT_EQ(mat_factory->materials()[2], gold<scalar>());
+}
+
+/// Integration test: material builder as volume builder decorator
+GTEST_TEST(detray_tools, decorator_material_builder) {
+
+    using transform3 = typename detector_t::transform3;
+    using mask_id = typename detector_t::masks::id;
+    using material_id = typename detector_t::materials::id;
+
+    using portal_cylinder_factory_t =
+        surface_factory<detector_t, cylinder2D<>, mask_id::e_portal_cylinder2,
+                        surface_id::e_portal>;
+    using rectangle_factory =
+        surface_factory<detector_t, rectangle2D<>, mask_id::e_rectangle2,
+                        surface_id::e_sensitive>;
+    using trapezoid_factory =
+        surface_factory<detector_t, trapezoid2D<>, mask_id::e_trapezoid2,
+                        surface_id::e_sensitive>;
+    using cylinder_factory =
+        surface_factory<detector_t, cylinder2D<>, mask_id::e_cylinder2,
+                        surface_id::e_passive>;
+
+    using mat_factory_t = material_factory<detector_t>;
+
+    vecmem::host_memory_resource host_mr;
+    detector_t d(host_mr);
+    auto geo_ctx = typename detector_t::geometry_context{};
+
+    auto vbuilder = std::make_unique<volume_builder<detector_t>>();
+    auto mat_builder = material_builder<detector_t>{std::move(vbuilder)};
+
+    EXPECT_TRUE(d.volumes().size() == 0);
+
+    // Now init the volume
+    mat_builder.init_vol(d, volume_id::e_cylinder);
+
+    const auto &vol = d.volumes().back();
+    EXPECT_TRUE(d.volumes().size() == 1u);
+    EXPECT_EQ(vol.index(), 0u);
+    EXPECT_EQ(vol.id(), volume_id::e_cylinder);
+
+    // Add some portals first
+    auto pt_cyl_factory = std::make_unique<portal_cylinder_factory_t>();
+
+    pt_cyl_factory->push_back({transform3(point3{0.f, 0.f, 0.f}), 1u,
+                               std::vector<scalar>{10.f, -1500.f, 1500.f}});
+    pt_cyl_factory->push_back({transform3(point3{0.f, 0.f, 0.f}), 2u,
+                               std::vector<scalar>{20.f, -1500.f, 1500.f}});
+
+    // Then some passive and sensitive surfaces
+    auto rect_factory = std::make_unique<rectangle_factory>();
+
+    typename rectangle_factory::sf_data_collection rect_sf_data;
+    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, -10.f}), 0u,
+                              std::vector<scalar>{10.f, 8.f});
+    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, -20.f}), 0u,
+                              std::vector<scalar>{10.f, 8.f});
+    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, -30.f}), 0u,
+                              std::vector<scalar>{10.f, 8.f});
+    rect_factory->push_back(std::move(rect_sf_data));
+
+    auto trpz_factory = std::make_unique<trapezoid_factory>();
+
+    trpz_factory->push_back({transform3(point3{0.f, 0.f, 1000.f}), 0u,
+                             std::vector<scalar>{1.f, 3.f, 2.f, 0.25f}});
+
+    auto cyl_factory = std::make_unique<cylinder_factory>();
+
+    cyl_factory->push_back({transform3(point3{0.f, 0.f, 0.f}), 0u,
+                            std::vector<scalar>{5.f, -1300.f, 1300.f}});
+
+    // Now add the material for each surface
+    auto mat_pt_cyl_factory =
+        std::make_shared<mat_factory_t>(std::move(pt_cyl_factory));
+    mat_pt_cyl_factory->add_material(
+        material_id::e_slab, {1.f * unit<scalar>::mm, silicon<scalar>()});
+    mat_pt_cyl_factory->add_material(
+        material_id::e_slab, {1.5f * unit<scalar>::mm, silicon<scalar>()});
+
+    auto mat_rect_factory =
+        std::make_shared<mat_factory_t>(std::move(rect_factory));
+    mat_rect_factory->add_material(material_id::e_slab,
+                                   {1.f * unit<scalar>::mm, silicon<scalar>()});
+    mat_rect_factory->add_material(material_id::e_slab,
+                                   {2.f * unit<scalar>::mm, silicon<scalar>()});
+    mat_rect_factory->add_material(material_id::e_slab,
+                                   {3.f * unit<scalar>::mm, silicon<scalar>()});
+
+    auto mat_trpz_factory =
+        std::make_shared<mat_factory_t>(std::move(trpz_factory));
+    mat_trpz_factory->add_material(material_id::e_slab,
+                                   {1.f * unit<scalar>::mm, silicon<scalar>()});
+
+    auto mat_cyl_factory =
+        std::make_shared<mat_factory_t>(std::move(cyl_factory));
+    mat_cyl_factory->add_material(
+        material_id::e_slab, {1.5f * unit<scalar>::mm, tungsten<scalar>()});
+
+    // Add surfaces and material to detector
+    mat_builder.add_portals(mat_pt_cyl_factory, geo_ctx);
+    mat_builder.add_sensitives(mat_rect_factory, geo_ctx);
+    mat_builder.add_sensitives(mat_trpz_factory, geo_ctx);
+    mat_builder.add_passives(mat_cyl_factory, geo_ctx);
+
+    // Add the volume to the detector
+    mat_builder.build(d);
+
+    //
+    // check results
+    //
+    EXPECT_EQ(d.surface_lookup().size(), 7u);
+    EXPECT_EQ(d.transform_store().size(), 8u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_cylinder2>(), 2u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_ring2>(), 0u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_cylinder2>(), 1u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_rectangle2>(), 3u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_trapezoid2>(), 1u);
+
+    EXPECT_EQ(d.material_store().template size<material_id::e_slab>(), 7u);
+    EXPECT_EQ(d.material_store().template size<material_id::e_rod>(), 0u);
+
+    for (auto [idx, sf_desc] : detray::views::enumerate(d.surface_lookup())) {
+        const auto &mat_link = sf_desc.material();
+        EXPECT_EQ(mat_link.id(), material_id::e_slab);
+        EXPECT_EQ(mat_link.index(), idx);
+    }
+
+    for (const auto &mat_slab :
+         d.material_store().template get<material_id::e_slab>()) {
+        EXPECT_TRUE(mat_slab.get_material() == silicon<scalar>() or
+                    mat_slab.get_material() == tungsten<scalar>());
+    }
+}

--- a/tutorials/include/detray/tutorial/square_surface_generator.hpp
+++ b/tutorials/include/detray/tutorial/square_surface_generator.hpp
@@ -47,6 +47,9 @@ class square_surface_generator final
     auto size() const -> dindex override { return m_n_squares; }
 
     DETRAY_HOST
+    void clear() override{/*Do nothing*/};
+
+    DETRAY_HOST
     void push_back(surface_data<detector_t> &&) override { /*Do nothing*/
     }
     DETRAY_HOST


### PR DESCRIPTION
This PR adds a material builder and factory for homogeneous material slabs or material rods per surface. The surface factory interface is complemented by a decorator that the material factory extends, so that the material data can be added after the surface data has already been read in. It is then handed to the material builder, which either constructs material rods or slabs (depending on the type id it is given), adds them to the detector material store and updates the surface material links accordingly.

A unit and integration test for the material factory and builder were added, too.