### PR TITLE
chore: add mathematical constants and clean up some float conversions

### DIFF
--- a/cmake/detray-compiler-options-cpp.cmake
+++ b/cmake/detray-compiler-options-cpp.cmake
@@ -34,6 +34,8 @@ if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR
    # More rigorous tests for the Debug builds.
    detray_add_flag(CMAKE_CXX_FLAGS_DEBUG "-Werror")
    detray_add_flag(CMAKE_CXX_FLAGS_DEBUG "-pedantic")
+   # No implicit single to double conversions from floating point literals
+   detray_add_flag(CMAKE_CXX_FLAGS_DEBUG "-Wconversion")
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
    # Basic flags for all build modes.

--- a/core/include/detray/coordinates/cartesian2.hpp
+++ b/core/include/detray/coordinates/cartesian2.hpp
@@ -77,7 +77,7 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
     DETRAY_HOST_DEVICE inline point3 local_to_global(
         const transform3_t &trf3, const mask_t & /*mask*/, const point2 &p,
         const vector3 & /*d*/) const {
-        return trf3.point_to_global(point3{p[0], p[1], 0.});
+        return trf3.point_to_global(point3{p[0], p[1], 0.f});
     }
 
     template <typename mask_t>
@@ -87,10 +87,10 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
                                              const vector3 & /*dir*/) const {
         vector3 ret;
         const matrix_type<3, 1> n =
-            matrix_operator().template block<3, 1>(trf3.matrix(), 0, 2);
-        ret[0] = matrix_operator().element(n, 0, 0);
-        ret[1] = matrix_operator().element(n, 1, 0);
-        ret[2] = matrix_operator().element(n, 2, 0);
+            matrix_operator().template block<3, 1>(trf3.matrix(), 0u, 2u);
+        ret[0] = matrix_operator().element(n, 0u, 0u);
+        ret[1] = matrix_operator().element(n, 1u, 0u);
+        ret[2] = matrix_operator().element(n, 2u, 0u);
         return ret;
     }
 
@@ -110,7 +110,7 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
 
         // Get d(x,y,z)/d(loc0, loc1)
         const matrix_type<3, 2> bound_pos_to_free_pos_derivative =
-            matrix_operator().template block<3, 2>(frame, 0, 0);
+            matrix_operator().template block<3, 2>(frame, 0u, 0u);
 
         matrix_operator().template set_block(bound_to_free_jacobian,
                                              bound_pos_to_free_pos_derivative,

--- a/core/include/detray/coordinates/coordinate_base.hpp
+++ b/core/include/detray/coordinates/coordinate_base.hpp
@@ -15,7 +15,7 @@
 #include "detray/tracks/detail/track_helper.hpp"
 
 // System include(s).
-#include <climits>
+#include <limits>
 
 namespace detray {
 
@@ -71,15 +71,16 @@ struct coordinate_base {
             Derived<transform3_t>().global_to_local(trf3, pos, dir);
 
         bound_vector bound_vec;
-        matrix_operator().element(bound_vec, e_bound_loc0, 0) = local[0];
-        matrix_operator().element(bound_vec, e_bound_loc1, 0) = local[1];
-        matrix_operator().element(bound_vec, e_bound_phi, 0) = getter::phi(dir);
-        matrix_operator().element(bound_vec, e_bound_theta, 0) =
+        matrix_operator().element(bound_vec, e_bound_loc0, 0u) = local[0];
+        matrix_operator().element(bound_vec, e_bound_loc1, 0u) = local[1];
+        matrix_operator().element(bound_vec, e_bound_phi, 0u) =
+            getter::phi(dir);
+        matrix_operator().element(bound_vec, e_bound_theta, 0u) =
             getter::theta(dir);
-        matrix_operator().element(bound_vec, e_bound_time, 0) =
-            matrix_operator().element(free_vec, e_free_time, 0);
-        matrix_operator().element(bound_vec, e_bound_qoverp, 0) =
-            matrix_operator().element(free_vec, e_free_qoverp, 0);
+        matrix_operator().element(bound_vec, e_bound_time, 0u) =
+            matrix_operator().element(free_vec, e_free_time, 0u);
+        matrix_operator().element(bound_vec, e_bound_qoverp, 0u) =
+            matrix_operator().element(free_vec, e_free_qoverp, 0u);
 
         return bound_vec;
     }
@@ -96,16 +97,16 @@ struct coordinate_base {
             Derived<transform3_t>().local_to_global(trf3, mask, local, dir);
 
         free_vector free_vec;
-        matrix_operator().element(free_vec, e_free_pos0, 0) = pos[0];
-        matrix_operator().element(free_vec, e_free_pos1, 0) = pos[1];
-        matrix_operator().element(free_vec, e_free_pos2, 0) = pos[2];
-        matrix_operator().element(free_vec, e_free_time, 0) =
-            matrix_operator().element(bound_vec, e_bound_time, 0);
-        matrix_operator().element(free_vec, e_free_dir0, 0) = dir[0];
-        matrix_operator().element(free_vec, e_free_dir1, 0) = dir[1];
-        matrix_operator().element(free_vec, e_free_dir2, 0) = dir[2];
-        matrix_operator().element(free_vec, e_free_qoverp, 0) =
-            matrix_operator().element(bound_vec, e_bound_qoverp, 0);
+        matrix_operator().element(free_vec, e_free_pos0, 0u) = pos[0];
+        matrix_operator().element(free_vec, e_free_pos1, 0u) = pos[1];
+        matrix_operator().element(free_vec, e_free_pos2, 0u) = pos[2];
+        matrix_operator().element(free_vec, e_free_time, 0u) =
+            matrix_operator().element(bound_vec, e_bound_time, 0u);
+        matrix_operator().element(free_vec, e_free_dir0, 0u) = dir[0];
+        matrix_operator().element(free_vec, e_free_dir1, 0u) = dir[1];
+        matrix_operator().element(free_vec, e_free_dir2, 0u) = dir[2];
+        matrix_operator().element(free_vec, e_free_qoverp, 0u) =
+            matrix_operator().element(bound_vec, e_bound_qoverp, 0u);
 
         return free_vec;
     }
@@ -120,15 +121,15 @@ struct coordinate_base {
             matrix_operator().template zero<e_free_size, e_bound_size>();
 
         // Get trigonometric values
-        const scalar_type theta =
-            matrix_operator().element(bound_vec, e_bound_theta, 0);
-        const scalar_type phi =
-            matrix_operator().element(bound_vec, e_bound_phi, 0);
+        const scalar_type theta{
+            matrix_operator().element(bound_vec, e_bound_theta, 0u)};
+        const scalar_type phi{
+            matrix_operator().element(bound_vec, e_bound_phi, 0u)};
 
-        const scalar_type cos_theta = math_ns::cos(theta);
-        const scalar_type sin_theta = math_ns::sin(theta);
-        const scalar_type cos_phi = math_ns::cos(phi);
-        const scalar_type sin_phi = math_ns::sin(phi);
+        const scalar_type cos_theta{math_ns::cos(theta)};
+        const scalar_type sin_theta{math_ns::sin(theta)};
+        const scalar_type cos_phi{math_ns::cos(phi)};
+        const scalar_type sin_phi{math_ns::sin(phi)};
 
         // Global position and direction
         const auto free_vec = bound_to_free_vector(trf3, mask, bound_vec);
@@ -141,11 +142,12 @@ struct coordinate_base {
             jac_to_global, trf3, mask, pos, dir);
 
         // Set d(bound time)/d(free time)
-        matrix_operator().element(jac_to_global, e_free_time, e_bound_time) = 1;
+        matrix_operator().element(jac_to_global, e_free_time, e_bound_time) =
+            1.f;
 
         // Set d(n_x,n_y,n_z)/d(phi, theta)
         matrix_operator().element(jac_to_global, e_free_dir0, e_bound_phi) =
-            -1 * sin_theta * sin_phi;
+            -sin_theta * sin_phi;
         matrix_operator().element(jac_to_global, e_free_dir0, e_bound_theta) =
             cos_theta * cos_phi;
         matrix_operator().element(jac_to_global, e_free_dir1, e_bound_phi) =
@@ -153,9 +155,9 @@ struct coordinate_base {
         matrix_operator().element(jac_to_global, e_free_dir1, e_bound_theta) =
             cos_theta * sin_phi;
         matrix_operator().element(jac_to_global, e_free_dir2, e_bound_theta) =
-            -1 * sin_theta;
+            -sin_theta;
         matrix_operator().element(jac_to_global, e_free_qoverp,
-                                  e_bound_qoverp) = 1;
+                                  e_bound_qoverp) = 1.f;
 
         // Set d(x,y,z)/d(phi, theta)
         Derived<transform3_t>().set_bound_angle_to_free_pos_derivative(
@@ -177,25 +179,26 @@ struct coordinate_base {
         const vector3 pos = track_helper().pos(free_vec);
         const vector3 dir = track_helper().dir(free_vec);
 
-        const scalar_type theta = getter::theta(dir);
-        const scalar_type phi = getter::phi(dir);
+        const scalar_type theta{getter::theta(dir)};
+        const scalar_type phi{getter::phi(dir)};
 
-        const scalar_type cos_theta = math_ns::cos(theta);
-        const scalar_type sin_theta = math_ns::sin(theta);
-        const scalar_type cos_phi = math_ns::cos(phi);
-        const scalar_type sin_phi = math_ns::sin(phi);
+        const scalar_type cos_theta{math_ns::cos(theta)};
+        const scalar_type sin_theta{math_ns::sin(theta)};
+        const scalar_type cos_phi{math_ns::cos(phi)};
+        const scalar_type sin_phi{math_ns::sin(phi)};
 
         // Set d(loc0, loc1)/d(x,y,z)
         Derived<transform3_t>().set_free_pos_to_bound_pos_derivative(
             jac_to_local, trf3, mask, pos, dir);
 
         // Set d(free time)/d(bound time)
-        matrix_operator().element(jac_to_local, e_bound_time, e_free_time) = 1;
+        matrix_operator().element(jac_to_local, e_bound_time, e_free_time) =
+            1.f;
 
         // Set d(phi, theta)/d(n_x, n_y, n_z)
         // @note This codes have a serious bug when theta is equal to zero...
         matrix_operator().element(jac_to_local, e_bound_phi, e_free_dir0) =
-            -1. * sin_phi / sin_theta;
+            -sin_phi / sin_theta;
         matrix_operator().element(jac_to_local, e_bound_phi, e_free_dir1) =
             cos_phi / sin_theta;
         matrix_operator().element(jac_to_local, e_bound_theta, e_free_dir0) =
@@ -203,11 +206,11 @@ struct coordinate_base {
         matrix_operator().element(jac_to_local, e_bound_theta, e_free_dir1) =
             sin_phi * cos_theta;
         matrix_operator().element(jac_to_local, e_bound_theta, e_free_dir2) =
-            -1 * sin_theta;
+            -sin_theta;
 
         // Set d(Free Qop)/d(Bound Qop)
         matrix_operator().element(jac_to_local, e_bound_qoverp, e_free_qoverp) =
-            1;
+            1.f;
 
         return jac_to_local;
     }
@@ -226,26 +229,26 @@ struct coordinate_base {
 
         // dir
         matrix_type<1, 3> t;
-        matrix_operator().element(t, 0, 0) = dir[0];
-        matrix_operator().element(t, 0, 1) = dir[1];
-        matrix_operator().element(t, 0, 2) = dir[2];
+        matrix_operator().element(t, 0u, 0u) = dir[0];
+        matrix_operator().element(t, 0u, 1u) = dir[1];
+        matrix_operator().element(t, 0u, 2u) = dir[2];
 
         // Surface normal vector (w)
         matrix_type<1, 3> w;
         const auto normal =
             Derived<transform3_t>().normal(trf3, mask, pos, dir);
-        matrix_operator().element(w, 0, 0) = normal[0];
-        matrix_operator().element(w, 0, 1) = normal[1];
-        matrix_operator().element(w, 0, 2) = normal[2];
+        matrix_operator().element(w, 0u, 0u) = normal[0];
+        matrix_operator().element(w, 0u, 1u) = normal[1];
+        matrix_operator().element(w, 0u, 2u) = normal[2];
 
         // w dot t
-        const scalar_type wt = vector::dot(normal, dir);
+        const scalar_type wt{vector::dot(normal, dir)};
 
         // transpose of t
         const matrix_type<3, 1> t_T = matrix_operator().transpose(t);
 
         // r correction term
-        const matrix_type<1, 3> r_term = -1. / wt * w;
+        const matrix_type<1, 3> r_term = -(1.f / wt) * w;
 
         // dr/dr0
         const matrix_type<3, 3> drdr0 = t_T * r_term;

--- a/core/include/detray/coordinates/cylindrical2.hpp
+++ b/core/include/detray/coordinates/cylindrical2.hpp
@@ -76,11 +76,11 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
     DETRAY_HOST_DEVICE inline point3 local_to_global(
         const transform3_t &trf, const mask_t &mask, const point2 &p,
         const vector3 & /*d*/) const {
-        const scalar_type r = mask[0];
-        const scalar_type phi = p[0] / r;
-        const scalar_type x = r * math_ns::cos(phi);
-        const scalar_type y = r * math_ns::sin(phi);
-        const scalar_type z = p[1];
+        const scalar_type r{mask[mask_t::shape::e_r]};
+        const scalar_type phi{p[0] / r};
+        const scalar_type x{r * math_ns::cos(phi)};
+        const scalar_type y{r * math_ns::sin(phi)};
+        const scalar_type z{p[1]};
 
         return trf.point_to_global(point3{x, y, z});
     }
@@ -91,9 +91,9 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
                                              const point3 &pos,
                                              const vector3 &dir) const {
         const point2 local2 = this->global_to_local(trf3, pos, dir);
-        const scalar_type r = mask[0];
-        const scalar_type phi = local2[0] / r;
-        const vector3 local_normal{math_ns::cos(phi), math_ns::sin(phi), 0};
+        const scalar_type r{mask[mask_t::shape::e_r]};
+        const scalar_type phi{local2[0] / r};
+        const vector3 local_normal{math_ns::cos(phi), math_ns::sin(phi), 0.f};
 
         // normal vector in local coordinate
         return trf3.rotation() * local_normal;
@@ -108,7 +108,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
 
         // y axis of the new frame is the z axis of cylindrical coordinate
         const auto new_yaxis =
-            matrix_operator().template block<3, 1>(trf3.matrix(), 0, 2);
+            matrix_operator().template block<3, 1>(trf3.matrix(), 0u, 2u);
 
         // z axis of the new frame is the vector normal to the cylinder surface
         const vector3 new_zaxis = normal(trf3, mask, pos, dir);
@@ -116,13 +116,13 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
         // x axis
         const vector3 new_xaxis = vector::cross(new_yaxis, new_zaxis);
 
-        matrix_operator().element(rot, 0, 0) = new_xaxis[0];
-        matrix_operator().element(rot, 1, 0) = new_xaxis[1];
-        matrix_operator().element(rot, 2, 0) = new_xaxis[2];
-        matrix_operator().template set_block<3, 1>(rot, new_yaxis, 0, 1);
-        matrix_operator().element(rot, 0, 2) = new_zaxis[0];
-        matrix_operator().element(rot, 1, 2) = new_zaxis[1];
-        matrix_operator().element(rot, 2, 2) = new_zaxis[2];
+        matrix_operator().element(rot, 0u, 0u) = new_xaxis[0];
+        matrix_operator().element(rot, 1u, 0u) = new_xaxis[1];
+        matrix_operator().element(rot, 2u, 0u) = new_xaxis[2];
+        matrix_operator().template set_block<3, 1>(rot, new_yaxis, 0u, 1u);
+        matrix_operator().element(rot, 0u, 2u) = new_zaxis[0];
+        matrix_operator().element(rot, 1u, 2u) = new_zaxis[1];
+        matrix_operator().element(rot, 2u, 2u) = new_zaxis[2];
 
         return rot;
     }
@@ -136,7 +136,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
 
         // Get d(x,y,z)/d(loc0, loc1)
         const auto bound_pos_to_free_pos_derivative =
-            matrix_operator().template block<3, 2>(frame, 0, 0);
+            matrix_operator().template block<3, 2>(frame, 0u, 0u);
 
         matrix_operator().template set_block(bound_to_free_jacobian,
                                              bound_pos_to_free_pos_derivative,
@@ -153,7 +153,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
 
         // Get d(loc0, loc1)/d(x,y,z)
         const auto free_pos_to_bound_pos_derivative =
-            matrix_operator().template block<2, 3>(frameT, 0, 0);
+            matrix_operator().template block<2, 3>(frameT, 0u, 0u);
 
         matrix_operator().template set_block(free_to_bound_jacobian,
                                              free_pos_to_bound_pos_derivative,

--- a/core/include/detray/coordinates/cylindrical3.hpp
+++ b/core/include/detray/coordinates/cylindrical3.hpp
@@ -59,8 +59,8 @@ struct cylindrical3 final : public coordinate_base<cylindrical3, transform3_t> {
     DETRAY_HOST_DEVICE inline point3 local_to_global(
         const transform3_t &trf, const mask_t & /*mask*/, const point3 &p,
         const vector3 & /*d*/) const {
-        const scalar_type x = p[0] * math_ns::cos(p[1]);
-        const scalar_type y = p[0] * math_ns::sin(p[1]);
+        const scalar_type x{p[0] * math_ns::cos(p[1])};
+        const scalar_type y{p[0] * math_ns::sin(p[1])};
 
         return trf.point_to_global(point3{x, y, p[2]});
     }

--- a/core/include/detray/coordinates/line2.hpp
+++ b/core/include/detray/coordinates/line2.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -77,8 +77,7 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         // Assign the sign depending on the position w.r.t line
         // Right: -1
         // Left: 1
-        const scalar_type sign =
-            vector::dot(r, t - p) > 0. ? scalar_type{-1.} : scalar_type{1.};
+        const scalar_type sign = vector::dot(r, t - p) > 0.f ? -1.f : 1.f;
 
         return this->operator()(local3, sign);
     }
@@ -98,7 +97,8 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         const vector3 r = vector::cross(z, d);
 
         // Local Z poisition in global cartesian coordinate
-        const point3 locZ_in_global = trf.point_to_global(point3{0., 0., p[1]});
+        const point3 locZ_in_global =
+            trf.point_to_global(point3{0.f, 0.f, p[1]});
 
         return locZ_in_global + p[0] * vector::normalize(r);
     }
@@ -112,22 +112,21 @@ struct line2 : public coordinate_base<line2, transform3_t> {
 
         // y axis of the new frame is the z axis of line coordinate
         const auto new_yaxis =
-            matrix_operator().template block<3, 1>(trf3.matrix(), 0, 2);
+            matrix_operator().template block<3, 1>(trf3.matrix(), 0u, 2u);
 
         // x axis of the new frame is (yaxis x track direction)
-        auto new_xaxis = vector::cross(new_yaxis, dir);
-        new_xaxis = vector::normalize(new_xaxis);
+        const auto new_xaxis = vector::normalize(vector::cross(new_yaxis, dir));
 
         // z axis
         const auto new_zaxis = vector::cross(new_xaxis, new_yaxis);
 
-        matrix_operator().element(rot, 0, 0) = new_xaxis[0];
-        matrix_operator().element(rot, 1, 0) = new_xaxis[1];
-        matrix_operator().element(rot, 2, 0) = new_xaxis[2];
-        matrix_operator().template set_block<3, 1>(rot, new_yaxis, 0, 1);
-        matrix_operator().element(rot, 0, 2) = new_zaxis[0];
-        matrix_operator().element(rot, 1, 2) = new_zaxis[1];
-        matrix_operator().element(rot, 2, 2) = new_zaxis[2];
+        matrix_operator().element(rot, 0u, 0u) = new_xaxis[0];
+        matrix_operator().element(rot, 1u, 0u) = new_xaxis[1];
+        matrix_operator().element(rot, 2u, 0u) = new_xaxis[2];
+        matrix_operator().template set_block<3, 1>(rot, new_yaxis, 0u, 1u);
+        matrix_operator().element(rot, 0u, 2u) = new_zaxis[0];
+        matrix_operator().element(rot, 1u, 2u) = new_zaxis[1];
+        matrix_operator().element(rot, 2u, 2u) = new_zaxis[2];
 
         return rot;
     }
@@ -141,7 +140,7 @@ struct line2 : public coordinate_base<line2, transform3_t> {
 
         // Get d(x,y,z)/d(loc0, loc1)
         const auto bound_pos_to_free_pos_derivative =
-            matrix_operator().template block<3, 2>(frame, 0, 0);
+            matrix_operator().template block<3, 2>(frame, 0u, 0u);
 
         matrix_operator().template set_block(bound_to_free_jacobian,
                                              bound_pos_to_free_pos_derivative,
@@ -158,7 +157,7 @@ struct line2 : public coordinate_base<line2, transform3_t> {
 
         // Get d(loc0, loc1)/d(x,y,z)
         const auto free_pos_to_bound_pos_derivative =
-            matrix_operator().template block<2, 3>(frameT, 0, 0);
+            matrix_operator().template block<2, 3>(frameT, 0u, 0u);
 
         matrix_operator().template set_block(free_to_bound_jacobian,
                                              free_pos_to_bound_pos_derivative,
@@ -177,16 +176,16 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         const auto frame = reference_frame(trf3, mask, pos, dir);
 
         // new x_axis
-        const auto new_xaxis = getter::vector<3>(frame, 0, 0);
+        const auto new_xaxis = getter::vector<3>(frame, 0u, 0u);
 
         // new y_axis
-        const auto new_yaxis = getter::vector<3>(frame, 0, 1);
+        const auto new_yaxis = getter::vector<3>(frame, 0u, 1u);
 
         // new z_axis
-        const auto new_zaxis = getter::vector<3>(frame, 0, 2);
+        const auto new_zaxis = getter::vector<3>(frame, 0u, 2u);
 
         // the projection of direction onto ref frame normal
-        scalar_type ipdn = 1. / vector::dot(dir, new_zaxis);
+        const scalar_type ipdn{1.f / vector::dot(dir, new_zaxis)};
 
         // d(n_x,n_y,n_z)/dPhi
         const auto dNdPhi = matrix_operator().template block<3, 1>(
@@ -202,7 +201,7 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         // build the cross product of d(D)/d(eBoundPhi) components with y axis
         auto y_cross_dNdTheta = vector::cross(new_yaxis, dNdTheta);
 
-        const scalar_type C = ipdn * local2[0];
+        const scalar_type C{ipdn * local2[0]};
         // and correct for the x axis components
         vector3 phi_to_free_pos_derivative =
             y_cross_dNdPhi - new_xaxis * vector::dot(new_xaxis, y_cross_dNdPhi);

--- a/core/include/detray/coordinates/polar2.hpp
+++ b/core/include/detray/coordinates/polar2.hpp
@@ -83,7 +83,7 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
         const scalar_type x = p[0] * math_ns::cos(p[1]);
         const scalar_type y = p[0] * math_ns::sin(p[1]);
 
-        return trf.point_to_global(point3{x, y, 0.});
+        return trf.point_to_global(point3{x, y, 0.f});
     }
 
     template <typename mask_t>
@@ -93,10 +93,10 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
                                              const vector3 & /*dir*/) const {
         vector3 ret;
         const auto n =
-            matrix_operator().template block<3, 1>(trf3.matrix(), 0, 2);
-        ret[0] = matrix_operator().element(n, 0, 0);
-        ret[1] = matrix_operator().element(n, 1, 0);
-        ret[2] = matrix_operator().element(n, 2, 0);
+            matrix_operator().template block<3, 1>(trf3.matrix(), 0u, 2u);
+        ret[0] = matrix_operator().element(n, 0u, 0u);
+        ret[1] = matrix_operator().element(n, 1u, 0u);
+        ret[2] = matrix_operator().element(n, 2u, 0u);
         return ret;
     }
 
@@ -116,21 +116,21 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
             matrix_operator().template zero<3, 2>();
 
         const point2 local2 = this->global_to_local(trf3, pos, dir);
-        const scalar_type lrad = local2[0];
-        const scalar_type lphi = local2[1];
+        const scalar_type lrad{local2[0]};
+        const scalar_type lphi{local2[1]};
 
-        const scalar_type lcos_phi = math_ns::cos(lphi);
-        const scalar_type lsin_phi = math_ns::sin(lphi);
+        const scalar_type lcos_phi{math_ns::cos(lphi)};
+        const scalar_type lsin_phi{math_ns::sin(lphi)};
 
         // reference matrix
         const auto frame = reference_frame(trf3, mask, pos, dir);
 
         // dxdu = d(x,y,z)/du
         const matrix_type<3, 1> dxdL =
-            matrix_operator().template block<3, 1>(frame, 0, 0);
+            matrix_operator().template block<3, 1>(frame, 0u, 0u);
         // dxdv = d(x,y,z)/dv
         const matrix_type<3, 1> dydL =
-            matrix_operator().template block<3, 1>(frame, 0, 1);
+            matrix_operator().template block<3, 1>(frame, 0u, 1u);
 
         const matrix_type<3, 1> col0 = dxdL * lcos_phi + dydL * lsin_phi;
         const matrix_type<3, 1> col1 =
@@ -156,11 +156,11 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
 
         const auto local = this->global_to_local(trf3, pos, dir);
 
-        const scalar_type lrad = local[0];
-        const scalar_type lphi = local[1];
+        const scalar_type lrad{local[0]};
+        const scalar_type lphi{local[1]};
 
-        const scalar_type lcos_phi = math_ns::cos(lphi);
-        const scalar_type lsin_phi = math_ns::sin(lphi);
+        const scalar_type lcos_phi{math_ns::cos(lphi)};
+        const scalar_type lsin_phi{math_ns::sin(lphi)};
 
         // reference matrix
         const auto frame = reference_frame(trf3, mask, pos, dir);
@@ -168,10 +168,10 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
 
         // dudG = du/d(x,y,z)
         const matrix_type<1, 3> dudG =
-            matrix_operator().template block<1, 3>(frameT, 0, 0);
+            matrix_operator().template block<1, 3>(frameT, 0u, 0u);
         // dvdG = dv/d(x,y,z)
         const matrix_type<1, 3> dvdG =
-            matrix_operator().template block<1, 3>(frameT, 1, 0);
+            matrix_operator().template block<1, 3>(frameT, 1u, 0u);
 
         const matrix_type<1, 3> row0 = dudG * lcos_phi + dvdG * lsin_phi;
         const matrix_type<1, 3> row1 =

--- a/core/include/detray/core/detail/tuple_container.hpp
+++ b/core/include/detray/core/detail/tuple_container.hpp
@@ -169,7 +169,7 @@ class tuple_container {
             return functor_t()(elem, std::forward<Args>(As)...);
         }
         // Check the next ID
-        if constexpr (sizeof...(remaining_idcs) >= 1) {
+        if constexpr (sizeof...(remaining_idcs) >= 1u) {
             return unroll_call<functor_t>(
                 idx, std::index_sequence<remaining_idcs...>{},
                 std::forward<Args>(As)...);

--- a/core/include/detray/definitions/indexing.hpp
+++ b/core/include/detray/definitions/indexing.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -17,7 +17,7 @@
 namespace detray {
 
 using dindex = unsigned long;
-inline dindex constexpr dindex_invalid = std::numeric_limits<dindex>::max();
+inline constexpr dindex dindex_invalid = std::numeric_limits<dindex>::max();
 using dindex_range = darray<dindex, 2>;
 using dindex_sequence = dvector<dindex>;
 
@@ -25,7 +25,7 @@ using dindex_sequence = dvector<dindex>;
 ///
 /// @tparam DIM number of indices that are held by this type
 /// @tparam index_t type of indices
-template <typename index_t = dindex, std::size_t DIM = 3>
+template <typename index_t = dindex, std::size_t DIM = 3u>
 struct dmulti_index {
     using index_type = index_t;
 

--- a/core/include/detray/definitions/track_parametrization.hpp
+++ b/core/include/detray/definitions/track_parametrization.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,24 +11,24 @@ namespace detray {
 
 /// Components of a bound track parameters vector.
 ///
-enum bound_indices : std::size_t {
+enum bound_indices : unsigned int {
     // Local position on the reference surface.
     // This is intentionally named different from the position components in
     // the other data vectors, to clarify that this is defined on a surface
     // while the others are defined in free space.
-    e_bound_loc0 = 0,
-    e_bound_loc1 = 1,
+    e_bound_loc0 = 0u,
+    e_bound_loc1 = 1u,
     // Direction angles
-    e_bound_phi = 2,
-    e_bound_theta = 3,
+    e_bound_phi = 2u,
+    e_bound_theta = 3u,
     // Global inverse-momentum-like parameter, i.e. q/p or 1/p
     // The naming is inconsistent for the case of neutral track parameters where
     // the value is interpreted as 1/p not as q/p. This is intentional to avoid
     // having multiple aliases for the same element and for lack of an
     // acceptable
     // common name.
-    e_bound_qoverp = 4,
-    e_bound_time = 5,
+    e_bound_qoverp = 4u,
+    e_bound_time = 5u,
     // Last uninitialized value contains the total number of components
     e_bound_size,
 };
@@ -39,7 +39,7 @@ enum bound_indices : std::size_t {
 /// This must be a regular `enum` and not a scoped `enum class` to allow
 /// implicit conversion to an integer. The enum value are thus visible directly
 /// in `namespace Acts` and are prefixed to avoid naming collisions.
-enum free_indices : std::size_t {
+enum free_indices : unsigned int {
     // Spatial position
     // The spatial position components must be stored as one continous block.
     e_free_pos0 = 0u,

--- a/core/include/detray/definitions/units.hpp
+++ b/core/include/detray/definitions/units.hpp
@@ -1,11 +1,13 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
+
+#include <cmath>
 
 namespace detray {
 
@@ -15,43 +17,46 @@ struct unit {
 
     /// Length, native unit mm
     /// @{
-    static constexpr scalar_t um{0.001};
-    static constexpr scalar_t mm{1.0};
-    static constexpr scalar_t cm{10.0};
-    static constexpr scalar_t m{1000.0};
+    static constexpr scalar_t um{static_cast<scalar_t>(1e-3)};
+    static constexpr scalar_t mm{static_cast<scalar_t>(1.0)};
+    static constexpr scalar_t cm{static_cast<scalar_t>(1e1)};
+    static constexpr scalar_t m{static_cast<scalar_t>(1e3)};
     /// @}
 
     /// Volume, native unit mm3
     /// @{
-    static constexpr scalar_t mm3{mm * mm * mm};
-    static constexpr scalar_t cm2{cm * cm};
-    static constexpr scalar_t cm3{cm * cm * cm};
+    /// mm³
+    static constexpr scalar_t mm3{static_cast<scalar_t>(1.0)};
+    /// cm²
+    static constexpr scalar_t cm2{static_cast<scalar_t>(1e2)};
+    /// cm³
+    static constexpr scalar_t cm3{static_cast<scalar_t>(1e3)};
     /// @}
 
     /// Time, native unit mm{[speed-of-light * time]{mm/s * s}}
     /// @{
-    static constexpr scalar_t s{299792458000.0};
-    static constexpr scalar_t fs{1e-15 * s};
-    static constexpr scalar_t ps{1e-12 * s};
-    static constexpr scalar_t ns{1e-9 * s};
-    static constexpr scalar_t us{1e-6 * s};
-    static constexpr scalar_t ms{1e-3 * s};
-    static constexpr scalar_t min{60.0 * s};
-    static constexpr scalar_t h{3600.0 * s};
+    static constexpr scalar_t s{static_cast<scalar_t>(299792458000.0)};
+    static constexpr scalar_t fs{static_cast<scalar_t>(1e-15 * 299792458000.0)};
+    static constexpr scalar_t ps{static_cast<scalar_t>(1e-12 * 299792458000.0)};
+    static constexpr scalar_t ns{static_cast<scalar_t>(1e-9 * 299792458000.0)};
+    static constexpr scalar_t us{static_cast<scalar_t>(1e-6 * 299792458000.0)};
+    static constexpr scalar_t ms{static_cast<scalar_t>(1e-3 * 299792458000.0)};
+    static constexpr scalar_t min{static_cast<scalar_t>(60.0 * 299792458000.0)};
+    static constexpr scalar_t h{static_cast<scalar_t>(3600.0 * 299792458000.0)};
     /// @}
 
     /// Energy, native unit GeV
     /// @{
-    static constexpr scalar_t eV{1e-9};
-    static constexpr scalar_t keV{1e-6};
-    static constexpr scalar_t MeV{1e-3};
-    static constexpr scalar_t GeV{1.0};
-    static constexpr scalar_t TeV{1e3};
+    static constexpr scalar_t eV{static_cast<scalar_t>(1e-9)};
+    static constexpr scalar_t keV{static_cast<scalar_t>(1e-6)};
+    static constexpr scalar_t MeV{static_cast<scalar_t>(1e-3)};
+    static constexpr scalar_t GeV{static_cast<scalar_t>(1.0)};
+    static constexpr scalar_t TeV{static_cast<scalar_t>(1e3)};
     /// @}
 
     /// Atomic mass unit u
     /// 1u == 0.93149410242 GeV/c
-    static constexpr scalar_t u{0.93149410242};
+    static constexpr scalar_t u{static_cast<scalar_t>(0.93149410242)};
 
     /// Mass
     ///     1eV/c² == 1.782662e-36kg
@@ -59,38 +64,72 @@ struct unit {
     /// ->     1kg == (1/1.782662e-27)GeV/c²
     /// ->      1g == (1/(1e3*1.782662e-27))GeV/c²
     /// @{
-    static constexpr scalar_t g{1.0 / 1.782662e-24};
-    static constexpr scalar_t kg{1.0 / 1.782662e-27};
+    static constexpr scalar_t g{static_cast<scalar_t>(1.0 / 1.782662e-24)};
+    static constexpr scalar_t kg{static_cast<scalar_t>(1.0 / 1.782662e-27)};
     /// @}
 
     /// Amount of substance, native unit mol
-    static constexpr scalar_t mol{1.0};
+    static constexpr scalar_t mol{static_cast<scalar_t>(1.0)};
 
     /// Charge, native unit e (elementary charge)
-    static constexpr scalar_t e{1.0};
+    static constexpr scalar_t e{static_cast<scalar_t>(1.0)};
 
     /// Magnetic field, native unit GeV/(e*mm)
-    static constexpr scalar_t T{
-        0.000299792458};  // equivalent to c in appropriate SI units
+    static constexpr scalar_t T{static_cast<scalar_t>(
+        0.000299792458)};  // equivalent to c in appropriate SI units
 
     // Angles, native unit radian
-    static constexpr scalar_t mrad{1e-3};
-    static constexpr scalar_t rad{1.0};
-    static constexpr scalar_t degree{0.017453292519943295};  // pi / 180
+    static constexpr scalar_t mrad{static_cast<scalar_t>(1e-3)};
+    static constexpr scalar_t rad{static_cast<scalar_t>(1.0)};
+    static constexpr scalar_t degree{
+        static_cast<scalar_t>(0.017453292519943295)};  // pi / 180
 };
 
-/// Physical constants
+/// Physical and mathematical constants
 template <typename scalar_t>
 struct constant {
 
+    /// Euler's number
+    static constexpr scalar_t e{static_cast<scalar_t>(M_E)};
+    /// Base 2 logarithm of e
+    static constexpr scalar_t log2e{static_cast<scalar_t>(M_LOG2E)};
+    /// Base 10 logarithm of e
+    static constexpr scalar_t log10e{static_cast<scalar_t>(M_LOG10E)};
+    /// Natural logarithm of 2
+    static constexpr scalar_t ln2{static_cast<scalar_t>(M_LN2)};
+    /// Natural logarithm of 10
+    static constexpr scalar_t ln10{static_cast<scalar_t>(M_LN10)};
+
+    /// π
+    static constexpr scalar_t pi{static_cast<scalar_t>(M_PI)};
+    /// π/2
+    static constexpr scalar_t pi_2{static_cast<scalar_t>(M_PI_2)};
+    /// π/4
+    static constexpr scalar_t pi_4{static_cast<scalar_t>(M_PI_4)};
+    /// 1/π
+    static constexpr scalar_t inv_pi{static_cast<scalar_t>(M_1_PI)};
+    /// 2/π
+    static constexpr scalar_t inv_2_pi{static_cast<scalar_t>(M_2_PI)};
+
+    /// √2
+    static constexpr scalar_t sqrt2{static_cast<scalar_t>(M_SQRT2)};
+    /// 1/(√2)
+    static constexpr scalar_t inv_sqrt2{static_cast<scalar_t>(M_SQRT1_2)};
+
     /// Avogadro constant
-    static constexpr scalar_t avogadro{6.02214076e23 / unit<scalar_t>::mol};
+    static constexpr scalar_t avogadro{
+        static_cast<scalar_t>(6.02214076e23 / unit<scalar_t>::mol)};
 
     /// Reduced Planck constant h/2*pi.
     ///
     /// Computed from CODATA 2018 constants to double precision.
-    static constexpr scalar_t hbar{6.582119569509066e-25 * unit<scalar_t>::GeV *
-                                   unit<scalar_t>::s};
+    static constexpr scalar_t hbar{static_cast<scalar_t>(
+        6.582119569509066e-25 * unit<scalar_t>::GeV * unit<scalar_t>::s)};
+
+    // values from RPP2018 table 33.1
+    // electron mass
+    static constexpr scalar_t m_e{
+        static_cast<scalar_t>(0.5109989461 * unit<scalar_t>::MeV)};
 };
 
 }  // namespace detray

--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,6 +11,7 @@
 #include "detray/definitions/geometry.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
 
 // System include(s)
 #include <type_traits>
@@ -239,12 +240,12 @@ class detector_volume {
     volume_id _id = volume_id::e_cylinder;
 
     /// Bounds section, default for cylinder volume
-    array_t<scalar_t, 6> _bounds = {0.,
+    array_t<scalar_t, 6> _bounds = {0.f,
                                     std::numeric_limits<scalar_t>::max(),
                                     -std::numeric_limits<scalar_t>::max(),
                                     std::numeric_limits<scalar_t>::max(),
-                                    -M_PI,
-                                    M_PI};
+                                    -constant<scalar_t>::pi,
+                                    constant<scalar_t>::pi};
 
     /// Volume index in the detector's volume container
     dindex _index = dindex_invalid;

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -38,7 +38,7 @@ struct regular {
     scalar min;
     scalar max;
 
-    static constexpr unsigned int axis_identifier = 0;
+    static constexpr unsigned int axis_identifier = 0u;
 
     /** Defualt constructor for dummy axis **/
     DETRAY_HOST_DEVICE
@@ -84,14 +84,15 @@ struct regular {
      **/
     DETRAY_HOST_DEVICE
     dindex bin(scalar v) const {
-        int ibin = static_cast<int>((v - min) / (max - min) * n_bins);
+        int ibin = static_cast<int>((v - min) / (max - min) *
+                                    static_cast<scalar>(n_bins));
         if (ibin >= 0 and ibin < static_cast<int>(n_bins)) {
             return static_cast<dindex>(ibin);
         } else {
             if (ibin < 0) {
                 return 0;
             } else {
-                return static_cast<dindex>(n_bins - 1);
+                return static_cast<dindex>(n_bins - 1u);
             }
         }
     }
@@ -107,13 +108,14 @@ struct regular {
     dindex_range range(scalar v,
                        const array_t<dindex, 2> &nhood = {0u, 0u}) const {
 
-        int ibin = static_cast<int>((v - min) / (max - min) * n_bins);
+        int ibin = static_cast<int>((v - min) / (max - min) *
+                                    static_cast<scalar>(n_bins));
         int ibinmin = ibin - static_cast<int>(nhood[0]);
         int ibinmax = ibin + static_cast<int>(nhood[1]);
-        dindex min_bin = (ibinmin >= 0) ? static_cast<dindex>(ibinmin) : 0;
+        dindex min_bin = (ibinmin >= 0) ? static_cast<dindex>(ibinmin) : 0u;
         dindex max_bin = (ibinmax < static_cast<int>(n_bins))
                              ? static_cast<dindex>(ibinmax)
-                             : static_cast<dindex>(n_bins - 1);
+                             : static_cast<dindex>(n_bins - 1u);
         return {min_bin, max_bin};
     }
 
@@ -126,11 +128,11 @@ struct regular {
      **/
     DETRAY_HOST_DEVICE
     dindex_range range(scalar v, const array_t<scalar, 2> &nhood) const {
-        int nbin =
-            static_cast<int>((v - nhood[0] - min) / (max - min) * n_bins);
-        int pbin =
-            static_cast<int>((v + nhood[1] - min) / (max - min) * n_bins);
-        dindex min_bin = (nbin >= 0) ? static_cast<dindex>(nbin) : 0;
+        int nbin = static_cast<int>((v - nhood[0] - min) / (max - min) *
+                                    static_cast<scalar>(n_bins));
+        int pbin = static_cast<int>((v + nhood[1] - min) / (max - min) *
+                                    static_cast<scalar>(n_bins));
+        dindex min_bin = (nbin >= 0) ? static_cast<dindex>(nbin) : 0u;
         dindex max_bin = (pbin < static_cast<int>(n_bins))
                              ? static_cast<dindex>(pbin)
                              : static_cast<dindex>(n_bins - 1);
@@ -152,9 +154,9 @@ struct regular {
     zone_t(scalar v, const array_t<neighbor_t, 2> &nhood) const {
         dindex_range nh_range = range(v, nhood);
         dindex_sequence sequence(static_cast<dindex_sequence::size_type>(
-                                     nh_range[1] - nh_range[0] + 1),
+                                     nh_range[1] - nh_range[0] + 1u),
                                  nh_range[0]);
-        dindex m = 0;
+        dindex m = 0u;
         std::for_each(sequence.begin(), sequence.end(),
                       [&](auto &n) { n += m++; });
         return sequence;
@@ -187,17 +189,18 @@ struct regular {
     /** @return the bin boundaries for a given @param ibin */
     DETRAY_HOST_DEVICE
     array_t<scalar, 2> borders(dindex ibin) const {
-        scalar step = (max - min) / n_bins;
-        return {min + ibin * step, min + (ibin + 1) * step};
+        scalar step = (max - min) / static_cast<scalar>(n_bins);
+        return {min + static_cast<scalar>(ibin) * step,
+                min + static_cast<scalar>(ibin + 1u) * step};
     }
 
     /** @return the values of the borders */
     DETRAY_HOST_DEVICE
     vector_t<scalar> all_borders() const {
         vector_t<scalar> borders;
-        borders.reserve(n_bins + 1);
-        scalar step = (max - min) / n_bins;
-        for (dindex ib = 0; ib < n_bins + 1; ++ib) {
+        borders.reserve(n_bins + 1u);
+        scalar step = (max - min) / static_cast<scalar>(n_bins);
+        for (dindex ib = 0u; ib < n_bins + 1u; ++ib) {
             borders.push_back(min + ib * step);
         }
         return borders;
@@ -220,7 +223,7 @@ struct circular {
     scalar min;
     scalar max;
 
-    static constexpr unsigned int axis_identifier = 1;
+    static constexpr unsigned int axis_identifier = 1u;
 
     /** Defualt constructor for dummy axis **/
     DETRAY_HOST_DEVICE
@@ -266,14 +269,15 @@ struct circular {
      **/
     DETRAY_HOST_DEVICE
     dindex bin(scalar v) const {
-        int ibin = static_cast<int>((v - min) / (max - min) * n_bins);
+        int ibin = static_cast<int>((v - min) / (max - min) *
+                                    static_cast<scalar>(n_bins));
         if (ibin >= 0 and ibin < static_cast<int>(n_bins)) {
             return static_cast<dindex>(ibin);
         } else {
             if (ibin < 0) {
-                return static_cast<dindex>(n_bins + ibin);
+                return n_bins + static_cast<dindex>(ibin);
             } else {
-                return static_cast<dindex>(ibin - n_bins);
+                return static_cast<dindex>(ibin) - n_bins;
             }
         }
     }
@@ -323,21 +327,22 @@ struct circular {
         dindex_range nh_range = range(v, nhood);
         if (nh_range[0] < nh_range[1]) {
             dindex_sequence sequence(static_cast<dindex_sequence::size_type>(
-                                         nh_range[1] - nh_range[0] + 1),
+                                         nh_range[1] - nh_range[0] + 1u),
                                      nh_range[0]);
             dindex m = 0;
             std::for_each(sequence.begin(), sequence.end(),
                           [&](auto &n) { n += m++; });
             return sequence;
         }
-        dindex vl = static_cast<dindex>(n_bins - nh_range[0] + nh_range[1] + 1);
+        dindex vl =
+            static_cast<dindex>(n_bins - nh_range[0] + nh_range[1] + 1u);
         dindex mi = 0;
         dindex mo = 0;
         dindex_sequence sequence(static_cast<dindex_sequence::size_type>(vl),
                                  nh_range[0]);
         std::for_each(sequence.begin(), sequence.end(), [&](auto &n) {
             n += mi++;
-            if (n > n_bins - 1) {
+            if (n > n_bins - 1u) {
                 n = mo++;
             }
         });
@@ -382,25 +387,26 @@ struct circular {
             return static_cast<dindex>(opt_bin);
         }
         if (opt_bin < 0) {
-            return static_cast<dindex>(n_bins + opt_bin);
+            return n_bins + static_cast<dindex>(opt_bin);
         }
-        return static_cast<dindex>(opt_bin - n_bins);
+        return static_cast<dindex>(opt_bin) - n_bins;
     }
 
     /** @return the bin boundaries for a given @param ibin */
     DETRAY_HOST_DEVICE
     array_t<scalar, 2> borders(dindex ibin) const {
         scalar step = (max - min) / n_bins;
-        return {min + ibin * step, min + (ibin + 1) * step};
+        return {min + static_cast<scalar>(ibin) * step,
+                min + static_cast<scalar>(ibin + 1u) * step};
     }
 
     /** @return the values of the borders */
     DETRAY_HOST_DEVICE
     vector_t<scalar> all_borders() const {
         vector_t<scalar> borders;
-        borders.reserve(n_bins + 1);
-        scalar step = (max - min) / n_bins;
-        for (dindex ib = 0; ib < n_bins + 1; ++ib) {
+        borders.reserve(n_bins + 1u);
+        scalar step = (max - min) / static_cast<scalar>(n_bins);
+        for (dindex ib = 0u; ib < n_bins + 1u; ++ib) {
             borders.push_back(min + ib * step);
         }
         return borders;
@@ -427,13 +433,13 @@ struct irregular {
 
     vector_t<scalar> boundaries;
 
-    static constexpr unsigned int axis_identifier = 2;
+    static constexpr unsigned int axis_identifier = 2u;
 
     /** Defualt constructor for dummy axis **/
     DETRAY_HOST_DEVICE
     irregular()
         : n_bins(detail::invalid_value<dindex>()),
-          min(0.),
+          min(0.f),
           max(static_cast<scalar>(n_bins)),
           boundaries({}) {}
 
@@ -441,14 +447,14 @@ struct irregular {
     DETRAY_HOST
     irregular(vecmem::memory_resource &resource)
         : n_bins(detail::invalid_value<dindex>()),
-          min(0.),
+          min(0.f),
           max(static_cast<scalar>(n_bins)),
           boundaries(&resource) {}
 
     /** Constructor with vecmem memory resource - rvalue **/
     DETRAY_HOST irregular(vector_t<scalar> &&bins,
                           vecmem::memory_resource &resource)
-        : n_bins(bins.size() - 1),
+        : n_bins(bins.size() - 1u),
           min(bins[0]),
           max(bins[n_bins]),
           boundaries(bins, &resource) {}
@@ -456,7 +462,7 @@ struct irregular {
     /** Constructor with vecmem memory resource - lvalue **/
     DETRAY_HOST irregular(const vector_t<scalar> &bins,
                           vecmem::memory_resource &resource)
-        : n_bins(bins.size() - 1),
+        : n_bins(bins.size() - 1u),
           min(bins[0]),
           max(bins[n_bins]),
           boundaries(bins, &resource) {}
@@ -481,7 +487,7 @@ struct irregular {
 
     /** Return the number of bins */
     DETRAY_HOST_DEVICE
-    dindex bins() const { return static_cast<dindex>(boundaries.size() - 1); }
+    dindex bins() const { return static_cast<dindex>(boundaries.size() - 1u); }
 
     /** Access function to a single bin from a value v
      *
@@ -500,7 +506,7 @@ struct irregular {
             if (ibin == 0) {
                 return static_cast<dindex>(ibin);
             } else {
-                return static_cast<dindex>(boundaries.size() - 2);
+                return static_cast<dindex>(boundaries.size() - 2u);
             }
         }
     }
@@ -517,13 +523,12 @@ struct irregular {
                        const array_t<dindex, 2> &nhood = {0u, 0u}) const {
 
         dindex ibin = bin(v);
-        int bins = static_cast<int>(boundaries.size() - 1);
-        int ibinmin = static_cast<int>(ibin - nhood[0]);
+        int bins = static_cast<int>(boundaries.size()) - 1;
+        int ibinmin = static_cast<int>(ibin) - static_cast<int>(nhood[0]);
         int ibinmax = static_cast<int>(ibin + nhood[1]);
-        dindex min_bin = (ibinmin >= 0) ? static_cast<dindex>(ibinmin) : 0;
-        dindex max_bin = (ibinmax < static_cast<int>(bins))
-                             ? static_cast<dindex>(ibinmax)
-                             : static_cast<dindex>(bins - 1);
+        dindex min_bin = (ibinmin >= 0) ? static_cast<dindex>(ibinmin) : 0u;
+        dindex max_bin = (ibinmax < bins) ? static_cast<dindex>(ibinmax)
+                                          : static_cast<dindex>(bins - 1);
         return {min_bin, max_bin};
     }
 
@@ -555,9 +560,9 @@ struct irregular {
     zone_t(scalar v, const array_t<neighbor_t, 2> nhood) const {
         dindex_range nh_range = range(v, nhood);
         dindex_sequence sequence(static_cast<dindex_sequence::size_type>(
-                                     nh_range[1] - nh_range[0] + 1),
+                                     nh_range[1] - nh_range[0] + 1u),
                                  nh_range[0]);
-        dindex m = 0;
+        dindex m = 0u;
         std::for_each(sequence.begin(), sequence.end(),
                       [&](auto &n) { n += m++; });
         return sequence;
@@ -572,7 +577,7 @@ struct irregular {
      **/
     DETRAY_HOST_DEVICE
     dindex_sequence zone(scalar v,
-                         const array_t<dindex, 2> &nhood = {0, 0}) const {
+                         const array_t<dindex, 2> &nhood = {0u, 0u}) const {
         return zone_t<dindex>(v, nhood);
     }
 
@@ -591,7 +596,7 @@ struct irregular {
     DETRAY_HOST_DEVICE
     /** @return the bin boundaries for a given @param ibin */
     array_t<scalar, 2> borders(dindex ibin) const {
-        return {boundaries[ibin], boundaries[ibin + 1]};
+        return {boundaries[ibin], boundaries[ibin + 1u]};
     }
 
     /** @return the values of the borders of all bins */
@@ -601,7 +606,7 @@ struct irregular {
     /** @return the range  */
     DETRAY_HOST_DEVICE
     array_t<scalar, 2> span() const {
-        return {boundaries[0], boundaries[boundaries.size() - 1]};
+        return {boundaries[0], boundaries[boundaries.size() - 1u]};
     }
 };
 
@@ -615,8 +620,8 @@ struct axis_data;
 
 template <typename axis_t, typename scalar_t>
 struct axis_data<axis_t, scalar_t,
-                 typename std::enable_if_t<(axis_t::axis_identifier == 0) ||
-                                           (axis_t::axis_identifier == 1)>> {
+                 typename std::enable_if_t<(axis_t::axis_identifier == 0u) ||
+                                           (axis_t::axis_identifier == 1u)>> {
 
     /// Declare that a default constructor can/should be generated
     axis_data() = default;
@@ -677,8 +682,8 @@ template <template <template <typename, std::size_t> class,
           class axis_t,
           template <typename, std::size_t> class array_t,
           template <typename...> class vector_t,
-          std::enable_if_t<axis_t<array_t, vector_t>::axis_identifier == 0 ||
-                               axis_t<array_t, vector_t>::axis_identifier == 1,
+          std::enable_if_t<axis_t<array_t, vector_t>::axis_identifier == 0u ||
+                               axis_t<array_t, vector_t>::axis_identifier == 1u,
                            bool> = true>
 inline axis_data<axis_t<array_t, vector_t>, scalar> get_data(
     axis_t<array_t, vector_t> &axis) {
@@ -696,7 +701,7 @@ template <template <template <typename, std::size_t> class,
           class axis_t,
           template <typename, std::size_t> class array_t,
           template <typename...> class vector_t,
-          std::enable_if_t<axis_t<array_t, vector_t>::axis_identifier == 2,
+          std::enable_if_t<axis_t<array_t, vector_t>::axis_identifier == 2u,
                            bool> = true>
 inline axis_data<axis_t<array_t, vector_t>, scalar> get_data(
     axis_t<array_t, vector_t> &axis) {
@@ -714,8 +719,8 @@ template <template <template <typename, std::size_t> class,
           class axis_t,
           template <typename, std::size_t> class array_t,
           template <typename...> class vector_t,
-          std::enable_if_t<axis_t<array_t, vector_t>::axis_identifier == 0 ||
-                               axis_t<array_t, vector_t>::axis_identifier == 1,
+          std::enable_if_t<axis_t<array_t, vector_t>::axis_identifier == 0u ||
+                               axis_t<array_t, vector_t>::axis_identifier == 1u,
                            bool> = true>
 inline axis_data<axis_t<array_t, vector_t>, const scalar> get_data(
     const axis_t<array_t, vector_t> &axis) {
@@ -733,7 +738,7 @@ template <template <template <typename, std::size_t> class,
           class axis_t,
           template <typename, std::size_t> class array_t,
           template <typename...> class vector_t,
-          std::enable_if_t<axis_t<array_t, vector_t>::axis_identifier == 2,
+          std::enable_if_t<axis_t<array_t, vector_t>::axis_identifier == 2u,
                            bool> = true>
 inline axis_data<axis_t<array_t, vector_t>, const scalar> get_data(
     const axis_t<array_t, vector_t> &axis) {

--- a/core/include/detray/grids/grid2.hpp
+++ b/core/include/detray/grids/grid2.hpp
@@ -41,7 +41,7 @@ template <template <template <typename...> class, template <typename...> class,
           template <typename...> class jagged_vector_t = djagged_vector,
           template <typename, std::size_t> class array_t = darray,
           template <typename...> class tuple_t = dtuple,
-          typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1>
+          typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1u>
 class grid2 {
 
     public:
@@ -262,7 +262,7 @@ class grid2 {
         // Specialization for bare value equal to store value
         if constexpr (std::is_same_v<typename populator_type::bare_value,
                                      typename populator_type::store_value>) {
-            unsigned int iz = 0;
+            unsigned int iz = 0u;
             zone = vector_t<typename populator_type::bare_value>(
                 zone0.size() * zone1.size(), {});
             for (const auto z1 : zone1) {
@@ -275,7 +275,7 @@ class grid2 {
                 }
             }
         } else {
-            zone.reserve(10);
+            zone.reserve(10u);
             for (const auto z1 : zone1) {
                 for (const auto z0 : zone0) {
                     auto sbin =

--- a/core/include/detray/grids/populator.hpp
+++ b/core/include/detray/grids/populator.hpp
@@ -36,7 +36,7 @@ namespace detray {
 template <template <typename...> class vector_t = dvector,
           template <typename...> class jagged_vector_t = djagged_vector,
           template <typename, std::size_t> class array_t = darray,
-          typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1>
+          typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1u>
 struct replace_populator {
     DETRAY_HOST_DEVICE
     replace_populator(const value_t invalid = detail::invalid_value<value_t>())
@@ -110,7 +110,7 @@ struct replace_populator {
 template <template <typename...> class vector_t = dvector,
           template <typename...> class jagged_vector_t = djagged_vector,
           template <typename, std::size_t> class array_t = darray,
-          typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1>
+          typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1u>
 struct complete_populator {
     DETRAY_HOST_DEVICE
     complete_populator(const value_t invalid = detail::invalid_value<value_t>())
@@ -204,7 +204,7 @@ struct complete_populator {
 template <template <typename...> class vector_t = dvector,
           template <typename...> class jagged_vector_t = djagged_vector,
           template <typename, std::size_t> class array_t = darray,
-          typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1>
+          typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1u>
 struct attach_populator {
     DETRAY_HOST_DEVICE
     attach_populator(const value_t invalid = detail::invalid_value<value_t>())

--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -55,15 +55,15 @@ struct cylinder_intersector {
                          bool> = true>
     DETRAY_HOST_DEVICE inline output_type operator()(
         const ray_type &ray, const mask_t &mask, const transform3_t &trf,
-        const scalar_type mask_tolerance = 0,
-        const scalar_type overstep_tolerance = 0.) const {
+        const scalar_type mask_tolerance = 0.f,
+        const scalar_type overstep_tolerance = 0.f) const {
 
         output_type ret;
 
         const scalar_type r{mask[0]};
         const auto &m = trf.matrix();
-        const vector3 sz = getter::vector<3>(m, 0, 2);
-        const vector3 sc = getter::vector<3>(m, 0, 3);
+        const vector3 sz = getter::vector<3>(m, 0u, 2u);
+        const vector3 sc = getter::vector<3>(m, 0u, 3u);
 
         const point3 &ro = ray.pos();
         const vector3 &rd = ray.dir();
@@ -71,14 +71,13 @@ struct cylinder_intersector {
         const vector3 pc_cross_sz = vector::cross(ro - sc, sz);
         const vector3 rd_cross_sz = vector::cross(rd, sz);
         const scalar_type a{vector::dot(rd_cross_sz, rd_cross_sz)};
-        const scalar_type b{scalar_type{2.} *
-                            vector::dot(rd_cross_sz, pc_cross_sz)};
+        const scalar_type b{2.f * vector::dot(rd_cross_sz, pc_cross_sz)};
         const scalar_type c{vector::dot(pc_cross_sz, pc_cross_sz) - (r * r)};
 
         quadratic_equation<scalar_type> qe = {a, b, c};
         auto qe_solution = qe();
 
-        if (std::get<0>(qe_solution) > scalar_type{0.}) {
+        if (std::get<0>(qe_solution) > 0) {
             const auto t01 = std::get<1>(qe_solution);
             const scalar_type t{(t01[0] > overstep_tolerance) ? t01[0]
                                                               : t01[1]};
@@ -97,7 +96,7 @@ struct cylinder_intersector {
                     is.p2 = mask.to_local_frame(trf, is.p3);
                     is.status = mask.is_inside(is.p2, mask_tolerance);
                 }
-                is.direction = vector::dot(is.p3, rd) > scalar_type{0.}
+                is.direction = vector::dot(is.p3, rd) > 0.f
                                    ? intersection::direction::e_along
                                    : intersection::direction::e_opposite;
                 is.link = mask.volume_link();
@@ -105,7 +104,7 @@ struct cylinder_intersector {
                 // Get incidence angle
                 const scalar_type phi{is.p2[0] / mask[mask_t::shape::e_r]};
                 const vector3 normal = {math_ns::cos(phi), math_ns::sin(phi),
-                                        0};
+                                        0.f};
                 is.cos_incidence_angle = vector::dot(rd, normal);
             }
         }

--- a/core/include/detray/intersection/detail/trajectories.hpp
+++ b/core/include/detray/intersection/detail/trajectories.hpp
@@ -14,8 +14,8 @@
 #include "detray/utils/matrix_helper.hpp"
 
 // System include(s).
-#include <climits>
 #include <cmath>
+#include <limits>
 
 namespace detray {
 
@@ -73,12 +73,12 @@ class ray {
 
     private:
     /// origin of ray
-    point3 _pos{0., 0., 0.};
+    point3 _pos{0.f, 0.f, 0.f};
     /// direction of ray
-    vector3 _dir{0., 0., 1.};
+    vector3 _dir{0.f, 0.f, 1.f};
 
     /// Overstep tolerance on a geometry surface
-    scalar_type _overstep_tolerance{-1e-4};
+    scalar_type _overstep_tolerance{-1e-4f};
 };
 
 /// @brief describes a helical trajectory in a given B-field.
@@ -148,8 +148,7 @@ class helix : public free_track_parameters<transform3_t> {
         _delta = vector::dot(_h0, _t0);
 
         // Path length scaler
-        _K =
-            -1. * free_track_parameters_type::qop() * getter::norm(*_mag_field);
+        _K = -free_track_parameters_type::qop() * getter::norm(*_mag_field);
 
         // Get longitudinal momentum parallel to B field
         scalar_type pz = vector::dot(free_track_parameters_type::mom(), _h0);
@@ -161,7 +160,7 @@ class helix : public free_track_parameters<transform3_t> {
         _R = getter::norm(pT) / getter::norm(*_mag_field);
 
         // Handle the case of pT ~ 0
-        if (getter::norm(pT) < 1e-6) {
+        if (getter::norm(pT) < 1e-6f) {
             _vz_over_vt = std::numeric_limits<scalar_type>::infinity();
         } else {
             // Get vz over vt in new coordinate
@@ -189,7 +188,7 @@ class helix : public free_track_parameters<transform3_t> {
         point3 ret = free_track_parameters_type::pos();
         ret = ret + _delta / _K * (_K * s - math_ns::sin(_K * s)) * _h0;
         ret = ret + math_ns::sin(_K * s) / _K * _t0;
-        ret = ret + _alpha / _K * (1 - math_ns::cos(_K * s)) * _n0;
+        ret = ret + _alpha / _K * (1.f - math_ns::cos(_K * s)) * _n0;
 
         return ret;
     }
@@ -203,7 +202,7 @@ class helix : public free_track_parameters<transform3_t> {
             return free_track_parameters_type::dir();
         }
 
-        vector3 ret{0, 0, 0};
+        vector3 ret{0.f, 0.f, 0.f};
 
         ret = ret + _delta * (1 - math_ns::cos(_K * s)) * _h0;
         ret = ret + math_ns::cos(_K * s) * _t0;
@@ -246,7 +245,7 @@ class helix : public free_track_parameters<transform3_t> {
                           mat_helper().column_wise_multiply(
                               matrix_operator().transpose(H0), _h0);
 
-        drdt = drdt + (math_ns::cos(_K * s) - 1) / _K *
+        drdt = drdt + (math_ns::cos(_K * s) - 1.f) / _K *
                           mat_helper().column_wise_cross(I33, _h0);
 
         matrix_operator().set_block(ret, drdt, e_free_pos0, e_free_dir0);
@@ -276,8 +275,8 @@ class helix : public free_track_parameters<transform3_t> {
         matrix_operator().set_block(ret, dtdl, e_free_dir0, e_free_qoverp);
 
         // 3x3 and 7x7 element is 1 (Maybe?)
-        matrix_operator().element(ret, e_free_time, e_free_time) = 1;
-        matrix_operator().element(ret, e_free_qoverp, e_free_qoverp) = 1;
+        matrix_operator().element(ret, e_free_time, e_free_time) = 1.f;
+        matrix_operator().element(ret, e_free_qoverp, e_free_qoverp) = 1.f;
 
         return ret;
     }

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -6,8 +6,8 @@
  */
 #pragma once
 
-#include <climits>
 #include <cmath>
+#include <limits>
 #include <sstream>
 
 #include "detray/definitions/indexing.hpp"
@@ -73,7 +73,7 @@ struct line_plane_intersection {
     surface_id sf_id = surface_id::e_sensitive;
 
     // cosine of incidence angle
-    scalar cos_incidence_angle = 1.;
+    scalar cos_incidence_angle{1.f};
 
     /** @param rhs is the right hand side intersection for comparison
      **/

--- a/core/include/detray/intersection/intersection_kernel.hpp
+++ b/core/include/detray/intersection/intersection_kernel.hpp
@@ -46,9 +46,9 @@ struct intersection_initialize {
         is_container_t &is_container, const traj_t &traj,
         const surface_t &surface,
         const transform_container_t &contextual_transforms,
-        const scalar mask_tolerance = 0.) const {
+        const scalar mask_tolerance = 0.f) const {
 
-        std::size_t count = 0;
+        std::size_t count{0u};
 
         const auto &ctf = contextual_transforms[surface.transform()];
 
@@ -70,7 +70,7 @@ struct intersection_initialize {
                 }
             }
 
-            if (count > 0) {
+            if (count > 0u) {
                 return count;
             }
         }
@@ -110,7 +110,7 @@ struct intersection_update {
         const mask_group_t &mask_group, const mask_range_t &mask_range,
         const traj_t &traj, const surface_t &surface,
         const transform_container_t &contextual_transforms,
-        const scalar mask_tolerance = 0.) const {
+        const scalar mask_tolerance = 0.f) const {
 
         const auto &ctf = contextual_transforms[surface.transform()];
 

--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -51,13 +51,13 @@ struct line_intersector {
                          bool> = true>
     DETRAY_HOST_DEVICE inline output_type operator()(
         const ray_type &ray, const mask_t &mask, const transform3_t &trf,
-        const scalar_type mask_tolerance = 0,
-        const scalar_type overstep_tolerance = 0.) const {
+        const scalar_type mask_tolerance = 0.f,
+        const scalar_type overstep_tolerance = 0.f) const {
 
         output_type ret;
 
         // line direction
-        const vector3 _z = getter::vector<3>(trf.matrix(), 0, 2);
+        const vector3 _z = getter::vector<3>(trf.matrix(), 0u, 2u);
 
         // line center
         const point3 _t = trf.translation();
@@ -71,10 +71,10 @@ struct line_intersector {
         // Projection of line to track direction
         const scalar_type zd{vector::dot(_z, _d)};
 
-        const scalar_type denom{scalar_type{1.} - (zd * zd)};
+        const scalar_type denom{1.f - (zd * zd)};
 
         // Case for wire is parallel to track
-        if (denom < scalar_type{1e-5}) {
+        if (denom < 1e-5f) {
             return ret;
         }
 
@@ -88,8 +88,7 @@ struct line_intersector {
         const scalar_type t2l_on_track{vector::dot(t2l, _d)};
 
         // path length to the point of closest approach on the track
-        const scalar_type A{scalar_type{1.} / denom *
-                            (t2l_on_track - t2l_on_line * zd)};
+        const scalar_type A{1.f / denom * (t2l_on_track - t2l_on_line * zd)};
 
         // distance to the point of closest approarch on the
         // line from line center
@@ -115,9 +114,7 @@ struct line_intersector {
             // Right: -1
             // Left: 1
             const auto r = vector::cross(_z, _d);
-            const scalar_type sign{vector::dot(r, t2l) > scalar_type{0.}
-                                       ? scalar_type{-1.}
-                                       : scalar_type{1.}};
+            const scalar_type sign{vector::dot(r, t2l) > 0.f ? -1.f : 1.f};
 
             is.p2[0] = sign * getter::perp(loc3D);
         } else {

--- a/core/include/detray/intersection/plane_intersector.hpp
+++ b/core/include/detray/intersection/plane_intersector.hpp
@@ -51,21 +51,22 @@ struct plane_intersector {
                          bool> = true>
     DETRAY_HOST_DEVICE inline output_type operator()(
         const ray_type &ray, const mask_t &mask, const transform3_t &trf,
-        const scalar_type mask_tolerance = 0,
-        const scalar_type overstep_tolerance = 0.) const {
+        const scalar_type mask_tolerance = 0.f,
+        const scalar_type overstep_tolerance = 0.f) const {
 
         output_type ret;
 
         // Retrieve the surface normal & translation (context resolved)
         const auto &sm = trf.matrix();
-        const vector3 sn = getter::vector<3>(sm, 0, 2);
-        const vector3 st = getter::vector<3>(sm, 0, 3);
+        const vector3 sn = getter::vector<3>(sm, 0u, 2u);
+        const vector3 st = getter::vector<3>(sm, 0u, 3u);
 
         // Intersection code
         const point3 &ro = ray.pos();
         const vector3 &rd = ray.dir();
         const scalar_type denom = vector::dot(rd, sn);
-        if (denom != scalar_type{0.}) {
+        // this is dangerous
+        if (denom != 0.f) {
             intersection_type &is = ret[0];
             is.path = vector::dot(sn, st - ro) / denom;
             is.p3 = ro + is.path * rd;

--- a/core/include/detray/masks/annulus2D.hpp
+++ b/core/include/detray/masks/annulus2D.hpp
@@ -47,25 +47,25 @@ namespace detray {
 /// The first two are the origin shift in x and y respectively, while
 /// bounds[6] is the average Phi angle mentioned above.
 template <template <typename> class intersector_t = plane_intersector,
-          std::size_t kMeasDim = 2>
+          unsigned int kMeasDim = 2u>
 class annulus2D {
     public:
     /// The name for this shape
     inline static const std::string name = "(stereo) annulus2D";
 
     /// The measurement dimension
-    inline static constexpr const std::size_t meas_dim = kMeasDim;
+    inline static constexpr const unsigned int meas_dim{kMeasDim};
 
     /// Names for the mask boundary values
     enum boundaries : std::size_t {
-        e_min_r = 0,
-        e_max_r = 1,
-        e_min_phi_rel = 2,
-        e_max_phi_rel = 3,
-        e_shift_x = 4,
-        e_shift_y = 5,
-        e_average_phi = 6,
-        e_size = 7,
+        e_min_r = 0u,
+        e_max_r = 1u,
+        e_min_phi_rel = 2u,
+        e_max_phi_rel = 3u,
+        e_shift_x = 4u,
+        e_shift_y = 5u,
+        e_average_phi = 6u,
+        e_size = 7u,
     };
 
     /// Local coordinate frame (both for disc and focal system ?)
@@ -95,7 +95,7 @@ class annulus2D {
     struct axes {
         static constexpr n_axis::label axis_loc0 = n_axis::label::e_r;
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_phi;
-        static constexpr std::size_t dim{2UL};
+        static constexpr std::size_t dim{2u};
 
         using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
                                  n_axis::circular<axis_loc1>>;
@@ -159,8 +159,8 @@ class annulus2D {
         // Now go to module frame to check r boundaries. Use the origin
         // shift in polar coordinates for that
         // TODO: Put shift in r-phi into the bounds?
-        const point_t shift_xy = {scalar_t{-1} * bounds[e_shift_x],
-                                  scalar_t{-1} * bounds[e_shift_y]};
+        const point_t shift_xy = {-1.f * bounds[e_shift_x],
+                                  -1.f * bounds[e_shift_y]};
         const scalar_t shift_r{getter::perp(shift_xy)};
         const scalar_t shift_phi{getter::phi(shift_xy)};
 
@@ -178,7 +178,8 @@ class annulus2D {
 
     template <typename param_t>
     DETRAY_HOST_DEVICE inline typename param_t::point2 to_measurement(
-        param_t& param, const typename param_t::point2& offset = {0, 0}) const {
+        param_t& param,
+        const typename param_t::point2& offset = {0.f, 0.f}) const {
         return param.local() + offset;
     }
 };

--- a/core/include/detray/masks/cuboid3D.hpp
+++ b/core/include/detray/masks/cuboid3D.hpp
@@ -32,13 +32,13 @@ class cuboid3D {
     inline static const std::string name = "cuboid3D";
 
     /// The measurement dimension (not allowed)
-    inline static constexpr const std::size_t meas_dim = 0;
+    inline static constexpr const unsigned int meas_dim{0u};
 
     enum boundaries : std::size_t {
-        e_half_x = 0,
-        e_half_y = 1,
-        e_half_z = 2,
-        e_size = 3,
+        e_half_x = 0u,
+        e_half_y = 1u,
+        e_half_z = 2u,
+        e_size = 3u,
     };
 
     /// Local coordinate frame for boundary checks
@@ -70,7 +70,7 @@ class cuboid3D {
         static constexpr n_axis::label axis_loc0 = n_axis::label::e_x;
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_y;
         static constexpr n_axis::label axis_loc2 = n_axis::label::e_z;
-        static constexpr std::size_t dim{3UL};
+        static constexpr std::size_t dim{3u};
 
         /// How to convert into the local axis system and back
         template <typename algebra_t>

--- a/core/include/detray/masks/cylinder2D.hpp
+++ b/core/include/detray/masks/cylinder2D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,7 +34,7 @@ namespace detray {
 /// It is defined by r and the two half lengths rel to the coordinate center.
 template <bool kRadialCheck = false,
           template <typename> class intersector_t = cylinder_intersector,
-          std::size_t kMeasDim = 2>
+          unsigned int kMeasDim = 2u>
 class cylinder2D {
     public:
     /// The name for this shape
@@ -44,13 +44,13 @@ class cylinder2D {
     static constexpr bool check_radius = kRadialCheck;
 
     /// The measurement dimension
-    inline static constexpr const std::size_t meas_dim = kMeasDim;
+    inline static constexpr const unsigned int meas_dim{kMeasDim};
 
     enum boundaries : std::size_t {
-        e_r = 0,
-        e_n_half_z = 1,
-        e_p_half_z = 2,
-        e_size = 3,
+        e_r = 0u,
+        e_n_half_z = 1u,
+        e_p_half_z = 2u,
+        e_size = 3u,
     };
 
     /// Local coordinate frame for boundary checks
@@ -85,7 +85,7 @@ class cylinder2D {
     struct axes {
         static constexpr n_axis::label axis_loc0 = n_axis::label::e_rphi;
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_cyl_z;
-        static constexpr std::size_t dim{2UL};
+        static constexpr std::size_t dim{2u};
 
         using types = std::tuple<n_axis::circular<axis_loc0>,
                                  n_axis::bounds_t<e_s, axis_loc1>>;
@@ -131,7 +131,8 @@ class cylinder2D {
 
     template <typename param_t>
     DETRAY_HOST_DEVICE inline typename param_t::point2 to_measurement(
-        param_t& param, const typename param_t::point2& offset = {0, 0}) const {
+        param_t& param,
+        const typename param_t::point2& offset = {0.f, 0.f}) const {
         return param.local() + offset;
     }
 };

--- a/core/include/detray/masks/cylinder3D.hpp
+++ b/core/include/detray/masks/cylinder3D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,13 +31,13 @@ class cylinder3D {
     inline static const std::string name = "cylinder3D";
 
     /// The measurement dimension (not allowed)
-    inline static constexpr const std::size_t meas_dim = 0;
+    inline static constexpr const unsigned int meas_dim{0u};
 
     enum boundaries : std::size_t {
-        e_r = 0,
-        e_n_half_z = 1,
-        e_p_half_z = 2,
-        e_size = 3,
+        e_r = 0u,
+        e_n_half_z = 1u,
+        e_p_half_z = 2u,
+        e_size = 3u,
     };
 
     /// Local coordinate frame for boundary checks
@@ -69,7 +69,7 @@ class cylinder3D {
         static constexpr n_axis::label axis_loc0 = n_axis::label::e_r;
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_phi;
         static constexpr n_axis::label axis_loc2 = n_axis::label::e_z;
-        static constexpr std::size_t dim{3UL};
+        static constexpr std::size_t dim{3u};
 
         using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
                                  n_axis::circular<axis_loc1>,

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -37,7 +37,7 @@ namespace detray {
 /// in z.
 template <bool kSquareCrossSect = false,
           template <typename> class intersector_t = line_intersector,
-          std::size_t kMeasDim = 1>
+          unsigned int kMeasDim = 1u>
 class line {
     public:
     /// The name for this shape
@@ -47,12 +47,12 @@ class line {
     static constexpr bool square_cross_sect = kSquareCrossSect;
 
     /// The measurement dimension
-    inline static constexpr const std::size_t meas_dim = kMeasDim;
+    inline static constexpr const unsigned int meas_dim{kMeasDim};
 
     enum boundaries : std::size_t {
-        e_cross_section = 0,
-        e_half_z = 1,
-        e_size = 2
+        e_cross_section = 0u,
+        e_half_z = 1u,
+        e_size = 2u
     };
 
     /// Local coordinate frame for boundary checks
@@ -87,7 +87,7 @@ class line {
     struct axes {
         static constexpr n_axis::label axis_loc0 = n_axis::label::e_r;
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_z;
-        static constexpr std::size_t dim{2UL};
+        static constexpr std::size_t dim{2u};
 
         using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
                                  n_axis::bounds_t<e_s, axis_loc1>>;
@@ -118,7 +118,7 @@ class line {
     /// @return true if the local point lies within the given boundaries.
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
-              typename std::enable_if_t<kDIM == 2, bool> = true>
+              typename std::enable_if_t<kDIM == 2u, bool> = true>
     DETRAY_HOST_DEVICE inline bool check_boundaries(
         const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
@@ -144,12 +144,13 @@ class line {
 
     template <typename param_t>
     DETRAY_HOST_DEVICE inline typename param_t::point2 to_measurement(
-        param_t& param, const typename param_t::point2& offset = {0, 0}) const {
+        param_t& param,
+        const typename param_t::point2& offset = {0.f, 0.f}) const {
 
         auto local = param.local();
         local[0] = std::abs(local[0]) + offset[0];
-        if (local[0] < 0.) {
-            local[0] = 0.;
+        if (local[0] < 0.f) {
+            local[0] = 0.f;
         }
         local[1] = local[1] + offset[1];
         return local;

--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -69,7 +69,8 @@ class mask {
 
     /// Constructor from single mask boundary values
     template <typename... Args>
-    DETRAY_HOST_DEVICE explicit mask(const links_type& link, Args&&... args)
+    DETRAY_HOST_DEVICE explicit constexpr mask(const links_type& link,
+                                               Args&&... args)
         : _values({{std::forward<Args>(args)...}}), _volume_link(link) {}
 
     /// Constructor from mask boundary vector
@@ -193,8 +194,8 @@ class mask {
     DETRAY_HOST_DEVICE matrix_type<2, parameter_dim> projection_matrix() const {
 
         auto ret = matrix_operator().template zero<2, parameter_dim>();
-        for (std::size_t i = 0; i < shape::meas_dim; i++) {
-            matrix_operator().element(ret, i, i) = 1.;
+        for (unsigned int i = 0u; i < shape::meas_dim; i++) {
+            matrix_operator().element(ret, i, i) = 1.f;
         }
 
         return ret;

--- a/core/include/detray/masks/rectangle2D.hpp
+++ b/core/include/detray/masks/rectangle2D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,19 +30,19 @@ namespace detray {
 ///
 /// It is defined by half length in local0 coordinates bounds[0] and bounds[1]
 template <template <typename> class intersector_t = plane_intersector,
-          std::size_t kMeasDim = 2>
+          unsigned int kMeasDim = 2u>
 class rectangle2D {
     public:
     /// The name for this shape
     inline static const std::string name = "rectangle2D";
 
     /// The measurement dimension
-    inline static constexpr const std::size_t meas_dim = kMeasDim;
+    inline static constexpr const unsigned int meas_dim{kMeasDim};
 
     enum boundaries : std::size_t {
-        e_half_x = 0,
-        e_half_y = 1,
-        e_size = 2,
+        e_half_x = 0u,
+        e_half_y = 1u,
+        e_size = 2u,
     };
 
     /// Local coordinate frame for boundary checks
@@ -71,7 +71,7 @@ class rectangle2D {
     struct axes {
         static constexpr n_axis::label axis_loc0 = n_axis::label::e_x;
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_y;
-        static constexpr std::size_t dim{2UL};
+        static constexpr std::size_t dim{2u};
 
         /// How to convert into the local axis system and back
         template <typename algebra_t>
@@ -107,7 +107,8 @@ class rectangle2D {
 
     template <typename param_t>
     DETRAY_HOST_DEVICE inline typename param_t::point2 to_measurement(
-        param_t& param, const typename param_t::point2& offset = {0, 0}) const {
+        param_t& param,
+        const typename param_t::point2& offset = {0.f, 0.f}) const {
         return param.local() + offset;
     }
 };

--- a/core/include/detray/masks/ring2D.hpp
+++ b/core/include/detray/masks/ring2D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,19 +31,19 @@ namespace detray {
 /// It is defined by the two radii bounds[0] and bounds[1],
 /// and can be checked with a tolerance in t[0] and t[1].
 template <template <typename> class intersector_t = plane_intersector,
-          std::size_t kMeasDim = 2>
+          unsigned int kMeasDim = 2u>
 class ring2D {
     public:
     /// The name for this shape
     inline static const std::string name = "ring2D";
 
     /// The measurement dimension
-    inline static constexpr const std::size_t meas_dim = kMeasDim;
+    inline static constexpr const unsigned int meas_dim{kMeasDim};
 
     enum boundaries : std::size_t {
-        e_inner_r = 0,
-        e_outer_r = 1,
-        e_size = 2,
+        e_inner_r = 0u,
+        e_outer_r = 1u,
+        e_size = 2u,
     };
 
     /// Local coordinate frame for boundary checks
@@ -72,7 +72,7 @@ class ring2D {
     struct axes {
         static constexpr n_axis::label axis_loc0 = n_axis::label::e_r;
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_phi;
-        static constexpr std::size_t dim{2UL};
+        static constexpr std::size_t dim{2u};
 
         /// How to convert into the local axis system and back
         template <typename algebra_t>
@@ -109,7 +109,8 @@ class ring2D {
 
     template <typename param_t>
     DETRAY_HOST_DEVICE inline typename param_t::point2 to_measurement(
-        param_t& param, const typename param_t::point2& offset = {0, 0}) const {
+        param_t& param,
+        const typename param_t::point2& offset = {0.f, 0.f}) const {
         return param.local() + offset;
     }
 };

--- a/core/include/detray/masks/single3D.hpp
+++ b/core/include/detray/masks/single3D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,21 +29,21 @@ namespace detray {
 /// @tparam intersector_t defines how to intersect the underlying surface
 ///         geometry
 /// @tparam kMeasDim defines the dimension of the measurement
-template <unsigned int kCheckIndex = 0,
+template <unsigned int kCheckIndex = 0u,
           template <typename> class intersector_t = plane_intersector,
-          std::size_t kMeasDim = 2>
+          unsigned int kMeasDim = 2u>
 class single3D {
     public:
     /// The name for this shape
     inline static const std::string name = "single3D";
 
     /// The measurement dimension
-    inline static constexpr const std::size_t meas_dim = kMeasDim;
+    inline static constexpr const unsigned int meas_dim{kMeasDim};
 
     enum boundaries : std::size_t {
-        e_lower = 0,
-        e_upper = 1,
-        e_size = 2,
+        e_lower = 0u,
+        e_upper = 1u,
+        e_size = 2u,
     };
 
     /// Local coordinate frame for boundary checks
@@ -71,7 +71,7 @@ class single3D {
     struct axes {
         static constexpr n_axis::label axis_loc0 =
             static_cast<n_axis::label>(kCheckIndex);
-        static constexpr std::size_t dim{1UL};
+        static constexpr std::size_t dim{1u};
 
         /// How to convert into the local axis system and back
         template <typename algebra_t>
@@ -106,7 +106,8 @@ class single3D {
 
     template <typename param_t>
     DETRAY_HOST_DEVICE inline typename param_t::point2 to_measurement(
-        param_t& param, const typename param_t::point2& offset = {0, 0}) const {
+        param_t& param,
+        const typename param_t::point2& offset = {0.f, 0.f}) const {
         return param.local() + offset;
     }
 };

--- a/core/include/detray/masks/trapezoid2D.hpp
+++ b/core/include/detray/masks/trapezoid2D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,21 +33,21 @@ namespace detray {
 /// the precomputed value of 1 / (2 * bounds[2]), which avoids
 /// excessive floating point divisions.
 template <template <typename> class intersector_t = plane_intersector,
-          std::size_t kMeasDim = 2>
+          unsigned int kMeasDim = 2u>
 class trapezoid2D {
     public:
     /// The name for this shape
     inline static const std::string name = "trapezoid2D";
 
     /// The measurement dimension
-    inline static constexpr const std::size_t meas_dim = kMeasDim;
+    inline static constexpr const unsigned int meas_dim{kMeasDim};
 
     enum boundaries : std::size_t {
-        e_half_length_0 = 0,
-        e_half_length_1 = 1,
-        e_half_length_2 = 2,
-        e_divisor = 3,  // 1 / (2 * bounds[e_half_length_2])
-        e_size = 4,
+        e_half_length_0 = 0u,
+        e_half_length_1 = 1u,
+        e_half_length_2 = 2u,
+        e_divisor = 3u,  // 1 / (2 * bounds[e_half_length_2])
+        e_size = 4u,
     };
 
     /// Local coordinate frame for boundary checks
@@ -76,7 +76,7 @@ class trapezoid2D {
     struct axes {
         static constexpr n_axis::label axis_loc0 = n_axis::label::e_x;
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_y;
-        static constexpr std::size_t dim{2UL};
+        static constexpr std::size_t dim{2u};
 
         /// How to convert into the local axis system and back
         template <typename algebra_t>
@@ -117,7 +117,8 @@ class trapezoid2D {
 
     template <typename param_t>
     DETRAY_HOST_DEVICE inline typename param_t::point2 to_measurement(
-        param_t& param, const typename param_t::point2& offset = {0, 0}) const {
+        param_t& param,
+        const typename param_t::point2& offset = {0.f, 0.f}) const {
         return param.local() + offset;
     }
 };

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -26,9 +26,9 @@ class unmasked {
     inline static const std::string name = "unmasked";
 
     /// The measurement dimension
-    inline static constexpr const std::size_t meas_dim = 2;
+    inline static constexpr const unsigned int meas_dim{2u};
 
-    enum boundaries : std::size_t { e_size = 1 };
+    enum boundaries : std::size_t { e_size = 1u };
 
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
@@ -56,7 +56,7 @@ class unmasked {
     struct axes {
         static constexpr n_axis::label axis_loc0 = n_axis::label::e_x;
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_y;
-        static constexpr std::size_t dim{2UL};
+        static constexpr std::size_t dim{2u};
 
         /// How to convert into the local axis system and back
         template <typename algebra_t>
@@ -85,7 +85,8 @@ class unmasked {
 
     template <typename param_t>
     DETRAY_HOST_DEVICE inline typename param_t::point2 to_measurement(
-        param_t& param, const typename param_t::point2& offset = {0, 0}) const {
+        param_t& param,
+        const typename param_t::point2& offset = {0.f, 0.f}) const {
         return param.local() + offset;
     }
 };

--- a/core/include/detray/materials/detail/density_effect_data.hpp
+++ b/core/include/detray/materials/detail/density_effect_data.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,23 +12,23 @@
 #include "detray/definitions/units.hpp"
 
 // System include(s)
-#include <climits>
+#include <limits>
 
 namespace detray::detail {
 
-// Ported from Geant4 and simplified
+/// @note Ported from Geant4 and simplified
 template <typename scalar_t>
 struct density_effect_data {
 
     using scalar_type = scalar_t;
 
-    density_effect_data() = default;
+    constexpr density_effect_data() = default;
 
     DETRAY_HOST_DEVICE
-    density_effect_data(const scalar_type a, const scalar_type m,
-                        const scalar_type X0, const scalar_type X1,
-                        const scalar_type I, const scalar_type nC,
-                        const scalar_type delta0)
+    constexpr density_effect_data(const scalar_type a, const scalar_type m,
+                                  const scalar_type X0, const scalar_type X1,
+                                  const scalar_type I, const scalar_type nC,
+                                  const scalar_type delta0)
         : m_a(a),
           m_m(m),
           m_X0(X0),
@@ -40,8 +40,8 @@ struct density_effect_data {
     /// Equality operator
     ///
     /// @param rhs is the right hand side to be compared to
-    DETRAY_HOST_DEVICE bool operator==(
-        const density_effect_data<scalar_t> &rhs) const {
+    DETRAY_HOST_DEVICE constexpr bool operator==(
+        const density_effect_data &rhs) const {
         return (m_a == rhs.get_A_density() && m_m == rhs.get_M_density() &&
                 m_X0 == rhs.get_X0_density() && m_X1 == rhs.get_X1_density() &&
                 m_I == rhs.get_mean_excitation_energy() &&
@@ -70,16 +70,18 @@ struct density_effect_data {
     DETRAY_HOST_DEVICE
     constexpr scalar_type get_delta0_density() const { return m_delta0; }
 
-    // Fitting parameters of Eq. 33.7 of RPP 2018
+    /// Fitting parameters of Eq. 33.7 of RPP 2018
+    /// @{
     scalar_type m_a = std::numeric_limits<scalar_type>::epsilon();
     scalar_type m_m = std::numeric_limits<scalar_type>::epsilon();
     scalar_type m_X0 = std::numeric_limits<scalar_type>::epsilon();
     scalar_type m_X1 = std::numeric_limits<scalar_type>::epsilon();
-    // Mean excitation energy in eV
+    /// @}
+    /// Mean excitation energy in eV
     scalar_type m_I = std::numeric_limits<scalar_type>::epsilon();
-    // -C
+    /// -C
     scalar_type m_nC = std::numeric_limits<scalar_type>::epsilon();
-    // Density-effect value delta(X_0)
+    /// Density-effect value delta(X_0)
     scalar_type m_delta0 = std::numeric_limits<scalar_type>::epsilon();
 };
 

--- a/core/include/detray/materials/interaction.hpp
+++ b/core/include/detray/materials/interaction.hpp
@@ -32,24 +32,24 @@ struct interaction {
 
         // return early in case of vacuum or zero thickness
         if (not mat) {
-            return scalar_type(0.);
+            return 0.f;
         }
 
-        const auto I = mat.get_material().mean_excitation_energy();
-        const auto Ne = mat.get_material().molar_electron_density();
-        const auto path_segment = mat.path_segment(is);
+        const scalar_t I{mat.get_material().mean_excitation_energy()};
+        const scalar_t Ne{mat.get_material().molar_electron_density()};
+        const scalar_t path_segment{mat.path_segment(is)};
         const relativistic_quantities rq(m, qOverP, q);
-        const auto eps = rq.compute_epsilon(Ne, path_segment);
-        const auto dhalf = rq.compute_delta_half(mat.get_material());
-        const auto u = rq.compute_mass_term(rq.Me);
-        const auto wmax = rq.compute_WMax(m);
+        const scalar_t eps{rq.compute_epsilon(Ne, path_segment)};
+        const scalar_t dhalf{rq.compute_delta_half(mat.get_material())};
+        const scalar_t u{rq.compute_mass_term(constant<scalar_t>::m_e)};
+        const scalar_t wmax{rq.compute_WMax(m)};
         // uses RPP2018 eq. 33.5 scaled from mass stopping power to linear
         // stopping power and multiplied with the material thickness to get a
         // total energy loss instead of an energy loss per length. the required
         // modification only change the prefactor which becomes identical to the
         // prefactor epsilon for the most probable value.
-        const auto running = math_ns::log(u / I) + math_ns::log(wmax / I) -
-                             2. * rq.m_beta2 - 2. * dhalf;
+        const scalar_t running{math_ns::log(u / I) + math_ns::log(wmax / I) -
+                               2.f * rq.m_beta2 - 2.f * dhalf};
         return eps * running;
     }
 
@@ -61,20 +61,19 @@ struct interaction {
 
         // return early in case of vacuum or zero thickness
         if (not mat) {
-            return scalar_type(0.);
+            return 0.f;
         }
 
-        const auto I = mat.get_material().mean_excitation_energy();
-        const auto Ne = mat.get_material().molar_electron_density();
-        const auto path_segment = mat.path_segment(is);
+        const scalar_t I{mat.get_material().mean_excitation_energy()};
+        const scalar_t Ne{mat.get_material().molar_electron_density()};
+        const scalar_t path_segment{mat.path_segment(is)};
         const relativistic_quantities rq(m, qOverP, q);
-        const auto eps = rq.compute_epsilon(Ne, path_segment);
-        const auto dhalf = rq.compute_delta_half(mat.get_material());
-        const auto t = rq.compute_mass_term(rq.Me);
+        const scalar_t eps{rq.compute_epsilon(Ne, path_segment)};
+        const scalar_t dhalf{rq.compute_delta_half(mat.get_material())};
+        const scalar_t t{rq.compute_mass_term(constant<scalar_t>::m_e)};
         // uses RPP2018 eq. 33.11
-        const auto running = math_ns::log(t / I) + math_ns::log(eps / I) +
-                             scalar_type(0.2) - rq.m_beta2 -
-                             scalar_type(2.) * dhalf;
+        const scalar_t running{math_ns::log(t / I) + math_ns::log(eps / I) +
+                               0.2f - rq.m_beta2 - 2.f * dhalf};
         return eps * running;
     }
 
@@ -88,7 +87,7 @@ struct interaction {
         const relativistic_quantities rq(m, qOverP, q);
 
         // the Landau-Vavilov fwhm is 4*eps (see RPP2018 fig. 33.7)
-        return scalar_type(4.) * rq.compute_epsilon(Ne, path_segment);
+        return 4.f * rq.compute_epsilon(Ne, path_segment);
     }
 
     template <typename material_t>
@@ -99,19 +98,19 @@ struct interaction {
 
         // return early in case of vacuum or zero thickness
         if (not mat) {
-            return scalar_type(0.);
+            return 0.f;
         }
         /*
         const auto Ne = mat.get_material().molar_electron_density();
         const auto path_segment = mat.path_segment(is);
         const relativistic_quantities rq(m, qOverP, q);
         // the Landau-Vavilov fwhm is 4*eps (see RPP2018 fig. 33.7)
-        const auto fwhm = 4 * rq.compute_epsilon(Ne, path_segment);
+        const auto fwhm = 4.f * rq.compute_epsilon(Ne, path_segment);
         */
         const relativistic_quantities rq(m, qOverP, q);
-        const auto fwhm =
-            compute_energy_loss_landau_fwhm(is, mat, pdg, m, qOverP, q);
-        const auto sigmaE = convert_landau_fwhm_to_gaussian_sigma(fwhm);
+        const scalar_t fwhm{
+            compute_energy_loss_landau_fwhm(is, mat, pdg, m, qOverP, q)};
+        const scalar_t sigmaE{convert_landau_fwhm_to_gaussian_sigma(fwhm)};
         //  var(q/p) = (d(q/p)/dE)² * var(E)
         // d(q/p)/dE = d/dE (q/sqrt(E²-m²))
         //           = q * -(1/2) * 1/p³ * 2E
@@ -120,7 +119,7 @@ struct interaction {
         //           q²
         //           = (1/p)^4 * (q/beta)² * var(E)
         // do not need to care about the sign since it is only used squared
-        const auto pInv = qOverP / q;
+        const scalar_t pInv{qOverP / q};
 
         return std::sqrt(rq.m_q2OverBeta2) * pInv * pInv * sigmaE;
     }
@@ -132,17 +131,17 @@ struct interaction {
         const scalar_type q) const {
         // return early in case of vacuum or zero thickness
         if (not mat) {
-            return scalar_type(0.);
+            return 0.f;
         }
 
         // relative radiation length
-        const scalar_type xOverX0 = mat.path_segment_in_X0(is);
+        const scalar_type xOverX0{mat.path_segment_in_X0(is)};
         // 1/p = q/(pq) = (q/p)/q
-        const scalar_type momentumInv = std::abs(qOverP / q);
+        const scalar_type momentumInv{std::abs(qOverP / q)};
         // q²/beta²; a smart compiler should be able to remove the unused
         // computations
         const relativistic_quantities rq(m, qOverP, q);
-        const scalar_type q2OverBeta2 = rq.m_q2OverBeta2;
+        const scalar_type q2OverBeta2{rq.m_q2OverBeta2};
 
         // if electron or positron
         if ((pdg == pdg_particle::eElectron) or
@@ -163,11 +162,11 @@ struct interaction {
     theta0Highland(const scalar_type xOverX0, const scalar_type momentumInv,
                    const scalar_type q2OverBeta2) const {
         // RPP2018 eq. 33.15 (treats beta and q² consistenly)
-        const scalar_type t = std::sqrt(xOverX0 * q2OverBeta2);
+        const scalar_type t{std::sqrt(xOverX0 * q2OverBeta2)};
         // log((x/X0) * (q²/beta²)) = log((sqrt(x/X0) * (q/beta))²)
         //                          = 2 * log(sqrt(x/X0) * (q/beta))
-        return 13.6 * unit<scalar_type>::MeV * momentumInv * t *
-               (1.0 + 0.038 * 2. * math_ns::log(t));
+        return 13.6f * unit<scalar_type>::MeV * momentumInv * t *
+               (1.0f + 0.038f * 2.f * math_ns::log(t));
     }
 
     /// Multiple scattering theta0 for electrons.
@@ -175,9 +174,9 @@ struct interaction {
     theta0RossiGreisen(const scalar_type xOverX0, const scalar_type momentumInv,
                        const scalar_type q2OverBeta2) const {
         // TODO add source paper/ resource
-        const scalar_type t = std::sqrt(xOverX0 * q2OverBeta2);
-        return 17.5 * unit<scalar_type>::MeV * momentumInv * t *
-               (1.0 + 0.125 * math_ns::log10(10.0 * xOverX0));
+        const scalar_type t{std::sqrt(xOverX0 * q2OverBeta2)};
+        return 17.5f * unit<scalar_type>::MeV * momentumInv * t *
+               (1.0f + 0.125f * math_ns::log10(10.0f * xOverX0));
     }
 
     /// Convert Landau full-width-half-maximum to an equivalent Gaussian sigma,
@@ -190,7 +189,8 @@ struct interaction {
     /// @todo: Add a unit test for this function
     DETRAY_HOST_DEVICE scalar_type
     convert_landau_fwhm_to_gaussian_sigma(const scalar_type fwhm) const {
-        return fwhm / (2 * std::sqrt(2 * math_ns::log(2.0)));
+        return 0.5f * constant<scalar_type>::inv_sqrt2 * fwhm /
+               std::sqrt(constant<scalar_type>::ln2);
     }
 };
 

--- a/core/include/detray/materials/material.hpp
+++ b/core/include/detray/materials/material.hpp
@@ -14,12 +14,12 @@
 #include "detray/materials/detail/density_effect_data.hpp"
 
 // System include(s)
-#include <climits>
+#include <limits>
 #include <ratio>
 
 namespace detray {
 
-// Material State
+/// Material State
 enum class material_state { e_solid = 0, e_liquid = 1, e_gas = 2 };
 
 template <typename scalar_t, typename R = std::ratio<1, 1>>
@@ -27,15 +27,16 @@ struct material {
     using ratio = R;
     using scalar_type = scalar_t;
 
-    material() = default;
+    constexpr material() = default;
 
     DETRAY_HOST_DEVICE
-    material(const scalar_type x0, const scalar_type l0, const scalar_type ar,
-             const scalar_type z, const scalar_type mass_rho,
-             const material_state state, const scalar_type d_a,
-             const scalar_type d_m, const scalar_type d_X0,
-             const scalar_type d_X1, const scalar_type d_I,
-             const scalar_type d_nC, const scalar_type d_delta0)
+    constexpr material(const scalar_type x0, const scalar_type l0,
+                       const scalar_type ar, const scalar_type z,
+                       const scalar_type mass_rho, const material_state state,
+                       const scalar_type d_a, const scalar_type d_m,
+                       const scalar_type d_X0, const scalar_type d_X1,
+                       const scalar_type d_I, const scalar_type d_nC,
+                       const scalar_type d_delta0)
         : m_x0(x0),
           m_l0(l0),
           m_ar(ar),
@@ -47,52 +48,52 @@ struct material {
         m_molar_rho = mass_to_molar_density(ar, mass_rho);
     }
 
-    /** Equality operator
-     *
-     * @param rhs is the right hand side to be compared to
-     */
-    DETRAY_HOST_DEVICE bool operator==(const material<scalar_t> &rhs) const {
+    /// Equality operator
+    ///
+    /// @param rhs is the right hand side to be compared to
+    DETRAY_HOST_DEVICE
+    constexpr bool operator==(const material<scalar_t>& rhs) const {
         return (m_x0 == rhs.X0() && m_l0 == rhs.L0() && m_ar == rhs.Ar() &&
                 m_z == rhs.Z());
     }
 
-    /// Return the radition length. Infinity in case of vacuum.
+    /// @returns the radition length. Infinity in case of vacuum.
     DETRAY_HOST_DEVICE
     constexpr scalar_type X0() const { return m_x0; }
-    /// Return the nuclear interaction length. Infinity in case of vacuum.
+    /// @returns the nuclear interaction length. Infinity in case of vacuum.
     DETRAY_HOST_DEVICE
     constexpr scalar_type L0() const { return m_l0; }
-    /// Return the relative atomic mass.
+    /// @returns the relative atomic mass.
     DETRAY_HOST_DEVICE
     constexpr scalar_type Ar() const { return m_ar; }
-    /// Return the nuclear charge number.
+    /// @returns the nuclear charge number.
     DETRAY_HOST_DEVICE
     constexpr scalar_type Z() const { return m_z; }
-    /// Return the mass density.
+    /// @returns the mass density.
     DETRAY_HOST_DEVICE
     constexpr scalar_type mass_density() const { return m_mass_rho; }
-    /// Return the molar density.
+    /// @returns the molar density.
     DETRAY_HOST_DEVICE
     constexpr scalar_type molar_density() const { return m_molar_rho; }
-    /// Return the molar electron density.
+    /// @returns the molar electron density.
     DETRAY_HOST_DEVICE
     constexpr scalar_type molar_electron_density() const {
         return m_z * m_molar_rho;
     }
-    /// Return the density effect data
+    /// @returns the density effect data
     DETRAY_HOST_DEVICE
     constexpr detail::density_effect_data<scalar_type> density_effect_data()
         const {
         return m_density;
     }
 
-    /// Return the (Approximated) mean excitation energy
+    /// @returns the (Approximated) mean excitation energy
     DETRAY_HOST_DEVICE
     scalar_type mean_excitation_energy() const {
         // use approximative computation as defined in ATL-SOFT-PUB-2008-003
         if (m_density == detail::density_effect_data<scalar_type>{}) {
-            return scalar_type(16 * unit<scalar_type>::eV) *
-                   math_ns::pow(m_z, scalar_type(0.9));
+            return 16.f * unit<scalar_type>::eV *
+                   math_ns::pow(m_z, static_cast<scalar_type>(0.9));
         } else {
             return m_density.get_mean_excitation_energy();
         }
@@ -100,30 +101,36 @@ struct material {
 
     DETRAY_HOST_DEVICE
     constexpr scalar_type fraction() const {
-        return ratio::num / static_cast<scalar_type>(ratio::den);
+        if constexpr (ratio::num == 0) {
+            return 0.f;
+        } else if constexpr (ratio::den == 0) {
+            return std::numeric_limits<scalar_type>::infinity();
+        } else {
+            return static_cast<scalar_type>(ratio::num) /
+                   static_cast<scalar_type>(ratio::den);
+        }
     }
 
     protected:
     DETRAY_HOST_DEVICE
-    scalar_type mass_to_molar_density(scalar_type ar, scalar_type mass_rho) {
-        if (mass_rho == 0) {
-            return 0;
+    constexpr scalar_type mass_to_molar_density(double ar, double mass_rho) {
+        if (mass_rho == 0.) {
+            return 0.f;
         }
 
-        double atomic_mass = static_cast<double>(ar) * unit<scalar_type>::u;
+        const double molar_mass{ar * unit<double>::u *
+                                constant<double>::avogadro};
 
-        return static_cast<scalar_type>(
-            static_cast<double>(mass_rho) /
-            (atomic_mass * constant<scalar_type>::avogadro));
+        return static_cast<scalar_type>(mass_rho / molar_mass);
     }
 
     // Material properties
     scalar_type m_x0 = std::numeric_limits<scalar_type>::infinity();
     scalar_type m_l0 = std::numeric_limits<scalar_type>::infinity();
-    scalar_type m_ar = 0;
-    scalar_type m_z = 0;
-    scalar_type m_mass_rho = 0;
-    scalar_type m_molar_rho = 0;
+    scalar_type m_ar = 0.f;
+    scalar_type m_z = 0.f;
+    scalar_type m_mass_rho = 0.f;
+    scalar_type m_molar_rho = 0.f;
     material_state m_state = material_state::e_solid;
     detail::density_effect_data<scalar_type> m_density = {};
 };
@@ -137,7 +144,7 @@ struct material {
         using base_type = material<scalar_t, R>;                             \
         using base_type::base_type;                                          \
         DETRAY_HOST_DEVICE                                                   \
-        MATERIAL_NAME()                                                      \
+        constexpr MATERIAL_NAME()                                            \
             : base_type(X0, L0, Ar, Z, Rho, State, Density0, Density1,       \
                         Density2, Density3, Density4, Density5, Density6) {} \
     }

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,9 +21,9 @@ struct material_rod {
     using scalar_type = scalar_t;
     using material_type = material<scalar_t>;
 
-    material_rod() = default;
+    constexpr material_rod() = default;
 
-    material_rod(const material_type& material, scalar_type radius)
+    constexpr material_rod(const material_type& material, scalar_type radius)
         : m_material(material),
           m_radius(radius),
           m_radius_in_X0(radius / material.X0()),
@@ -33,12 +33,13 @@ struct material_rod {
     ///
     /// @param rhs is the right hand side to be compared to
     DETRAY_HOST_DEVICE
-    bool operator==(const material_rod<scalar_t>& rhs) const {
+    constexpr bool operator==(const material_rod<scalar_t>& rhs) const {
         return (m_material == rhs.get_material() && m_radius == rhs.radius());
     }
 
     /// Boolean operator
-    DETRAY_HOST_DEVICE constexpr operator bool() const {
+    DETRAY_HOST_DEVICE
+    constexpr operator bool() const {
         if (m_radius <= std::numeric_limits<scalar>::epsilon() ||
             m_material == vacuum<scalar_type>() || m_material.Z() == 0 ||
             m_material.mass_density() == 0) {
@@ -60,15 +61,14 @@ struct material_rod {
     scalar_type path_segment(const line_plane_intersection& is) const {
         // Assume that is.p2[0] is radial distance of line intersector
         if (is.p2[0] > m_radius) {
-            return 0;
+            return 0.f;
         }
 
-        auto const sin_incidence_angle = std::sqrt(
-            scalar_type(1.) - is.cos_incidence_angle * is.cos_incidence_angle);
+        const scalar_type sin_incidence_angle_2{
+            1.f - is.cos_incidence_angle * is.cos_incidence_angle};
 
-        return scalar_type(2.) *
-               std::sqrt(m_radius * m_radius - is.p2[0] * is.p2[0]) /
-               sin_incidence_angle;
+        return 2.f * std::sqrt((m_radius * m_radius - is.p2[0] * is.p2[0]) /
+                               sin_incidence_angle_2);
     }
     /// Return the path segment in X0
     scalar_type path_segment_in_X0(const line_plane_intersection& is) const {

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,7 +14,7 @@
 #include "detray/materials/predefined_materials.hpp"
 
 // System include(s)
-#include <climits>
+#include <limits>
 
 namespace detray {
 
@@ -24,12 +24,13 @@ struct material_slab {
     using scalar_type = scalar_t;
     using material_type = material<scalar_t>;
 
-    material_slab() = default;
+    constexpr material_slab() = default;
 
     /// Constructor
     /// @param material is the elemental or mixture material
     /// @param thickness is the thickness of the slab
-    material_slab(const material_type& material, scalar_type thickness)
+    constexpr material_slab(const material_type& material,
+                            scalar_type thickness)
         : m_material(material),
           m_thickness(thickness),
           m_thickness_in_X0(thickness / material.X0()),
@@ -38,17 +39,18 @@ struct material_slab {
     /// Equality operator
     ///
     /// @param rhs is the right hand side to be compared to
-    DETRAY_HOST_DEVICE bool operator==(
-        const material_slab<scalar_t>& rhs) const {
+    DETRAY_HOST_DEVICE
+    constexpr bool operator==(const material_slab& rhs) const {
         return (m_material == rhs.get_material() &&
                 m_thickness == rhs.thickness());
     }
 
     /// Boolean operator
-    DETRAY_HOST_DEVICE constexpr operator bool() const {
+    DETRAY_HOST_DEVICE
+    constexpr explicit operator bool() const {
         if (m_thickness <= std::numeric_limits<scalar_type>::epsilon() ||
-            m_material == vacuum<scalar_type>() || m_material.Z() == 0 ||
-            m_material.mass_density() == 0) {
+            m_material == vacuum<scalar_type>() || m_material.Z() == 0.f ||
+            m_material.mass_density() == 0.f) {
             return false;
         }
         return true;
@@ -68,17 +70,20 @@ struct material_slab {
     constexpr scalar_type thickness_in_L0() const { return m_thickness_in_L0; }
     /// Return the path segment
     DETRAY_HOST_DEVICE
-    scalar_type path_segment(const line_plane_intersection& is) const {
+    constexpr scalar_type path_segment(
+        const line_plane_intersection& is) const {
         return m_thickness / is.cos_incidence_angle;
     }
     /// Return the path segment in X0
     DETRAY_HOST_DEVICE
-    scalar_type path_segment_in_X0(const line_plane_intersection& is) const {
+    constexpr scalar_type path_segment_in_X0(
+        const line_plane_intersection& is) const {
         return m_thickness_in_X0 / is.cos_incidence_angle;
     }
     /// Return the path segment in L0
     DETRAY_HOST_DEVICE
-    scalar_type path_segment_in_L0(const line_plane_intersection& is) const {
+    constexpr scalar_type path_segment_in_L0(
+        const line_plane_intersection& is) const {
         return m_thickness_in_L0 / is.cos_incidence_angle;
     }
 

--- a/core/include/detray/materials/mixture.hpp
+++ b/core/include/detray/materials/mixture.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,8 +16,8 @@
 
 namespace detray {
 
-// Compile-time material mixture type. The summation of ratios should be eqaul
-// to one
+/// Compile-time material mixture type. The summation of ratios should be equal
+/// to one
 template <typename scalar_t, typename... material_types>
 struct mixture
     : public material<scalar_t, typename ratio_sum<
@@ -25,18 +25,14 @@ struct mixture
     public:
     using ratio = typename ratio_sum<typename material_types::ratio...>::ratio;
 
-    using scalar_type = scalar_t;
-    using base_type = material<scalar_type, ratio>;
-    using base_type::base_type;
-
     static_assert(is_ratio_one_v<ratio>,
                   "Sumation of ratios should be equal to 1");
 
-    // Constructor
-    mixture() {
+    /// Constructor
+    constexpr mixture() {
         // Compute effective relative atomic mass
         // Zeff = Ar0 * ratio0 + Ar1 * ratio1 + ...
-        auto sum_Ar = [](material_types... M) -> decltype(auto) {
+        auto sum_Ar = [](material_types... M) constexpr->decltype(auto) {
             return ((M.Ar() * M.fraction()) + ...);
         };
 
@@ -44,14 +40,14 @@ struct mixture
 
         // Compute effective atomic number
         // Zeff = Z0 * ratio0 + Z1 * ratio1 + ...
-        auto sum_Z = [](material_types... M) -> decltype(auto) {
+        auto sum_Z = [](material_types... M) constexpr->decltype(auto) {
             return ((M.Z() * M.fraction()) + ...);
         };
 
         this->m_z = std::apply(sum_Z, std::tuple<material_types...>());
 
         // Get averaged mass density
-        auto sum_rho = [](material_types... M) -> decltype(auto) {
+        auto sum_rho = [](material_types... M) constexpr->decltype(auto) {
             return ((M.mass_density() * M.fraction()) + ...);
         };
 
@@ -64,20 +60,22 @@ struct mixture
         // where:
         // W_i is mass density of i_th component
         // W_avg is the averaged mass density
-        auto sum_rho_over_X0 = [](material_types... M) -> decltype(auto) {
+        auto sum_rho_over_X0 =
+            [](material_types... M) constexpr->decltype(auto) {
             return ((M.fraction() / M.X0()) + ...);
         };
         this->m_x0 =
-            1. / std::apply(sum_rho_over_X0, std::tuple<material_types...>());
+            1.f / std::apply(sum_rho_over_X0, std::tuple<material_types...>());
 
         // Compute effective nuclear radiation length
         // Follow the same equation of effective X0
-        auto sum_rho_over_L0 = [](material_types... M) -> decltype(auto) {
+        auto sum_rho_over_L0 =
+            [](material_types... M) constexpr->decltype(auto) {
             return ((M.fraction() / M.L0()) + ...);
         };
 
         this->m_l0 =
-            1. / std::apply(sum_rho_over_L0, std::tuple<material_types...>());
+            1.f / std::apply(sum_rho_over_L0, std::tuple<material_types...>());
 
         // Compute molar density
         this->m_molar_rho =

--- a/core/include/detray/materials/predefined_materials.hpp
+++ b/core/include/detray/materials/predefined_materials.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,7 +13,7 @@
 #include "detray/materials/material.hpp"
 
 // System include(s)
-#include <climits>
+#include <limits>
 
 namespace detray {
 
@@ -29,97 +29,111 @@ namespace detray {
 
 // Vacuum
 DETRAY_DECLARE_MATERIAL(vacuum, std::numeric_limits<scalar>::infinity(),
-                        std::numeric_limits<scalar>::infinity(), 0, 0, 0,
-                        material_state::e_gas, 0, 0, 0, 0, 0, 0, 0);
+                        std::numeric_limits<scalar>::infinity(), 0.f, 0.f, 0.f,
+                        material_state::e_gas, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f,
+                        0.f);
 
 // H₂ (1): Hydrogen Gas
-DETRAY_DECLARE_MATERIAL(hydrogen_gas, 7.526E6 * unit<scalar>::mm,
-                        6.209E6 * unit<scalar>::mm, 1.008 * 2, 1 * 2,
-                        8.376E-5 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_gas, 0.1409, 5.7273, 1.8639, 3.2718,
-                        19.2, 9.5834, 0.00);
+DETRAY_DECLARE_MATERIAL(hydrogen_gas, 7.526E3f * unit<scalar>::m,
+                        6.209E3f * unit<scalar>::m, 2.016f, 2.f,
+                        static_cast<scalar>(8.376E-5 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_gas, 0.1409f, 5.7273f, 1.8639f,
+                        3.2718f, 19.2f, 9.5834f, 0.f);
 
 // H₂ (1): Hydrogen Liquid
-DETRAY_DECLARE_MATERIAL(hydrogen_liquid, 8904 * unit<scalar>::mm,
-                        7346 * unit<scalar>::mm, 1.008 * 2, 1 * 2,
-                        0.07080 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_liquid, 0.1348, 5.6249, 0.4400,
-                        1.8856, 21.8, 3.0977, 0.00);
+DETRAY_DECLARE_MATERIAL(hydrogen_liquid, 8.904f * unit<scalar>::m,
+                        7.346f * unit<scalar>::m, 2.016f, 2.f,
+                        static_cast<scalar>(0.07080f * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_liquid, 0.1348f, 5.6249f, 0.4400f,
+                        1.8856f, 21.8f, 3.0977f, 0.f);
 
 // He (2): Helium Gas
-DETRAY_DECLARE_MATERIAL(helium_gas, 5.671E6 * unit<scalar>::mm,
-                        4.269E6 * unit<scalar>::mm, 4.003, 2,
-                        1.663E-4 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_gas, 0.1344, 5.8347, 2.2017, 3.6122,
-                        41.8, 11.1393, 0.00);
+DETRAY_DECLARE_MATERIAL(helium_gas, 5.671E3f * unit<scalar>::m,
+                        4.269E3f * unit<scalar>::m, 4.003f, 2.f,
+                        static_cast<scalar>(1.663E-4 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_gas, 0.1344f, 5.8347f, 2.2017f,
+                        3.6122f, 41.8f, 11.1393f, 0.f);
 
 // Be (4)
-DETRAY_DECLARE_MATERIAL(beryllium, 352.8 * unit<scalar>::mm,
-                        421.0 * unit<scalar>::mm, 9.012, 4.0,
-                        1.848 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_solid, 0.8039, 2.4339, 0.0592, 1.6922,
-                        63.7, 2.7847, 0.14);
+DETRAY_DECLARE_MATERIAL(beryllium, 352.8f * unit<scalar>::mm,
+                        421.0f * unit<scalar>::mm, 9.012f, 4.f,
+                        static_cast<scalar>(1.848 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_solid, 0.8039f, 2.4339f, 0.0592f,
+                        1.6922f, 63.7f, 2.7847f, 0.14f);
 
 // C (6): Carbon (amorphous)
-DETRAY_DECLARE_MATERIAL(carbon_gas, 213.5 * unit<scalar>::mm,
-                        429.0 * unit<scalar>::mm, 12.01, 6,
-                        2.0 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_gas, 0, 0, 0, 0, 0, 0, 0);
+DETRAY_DECLARE_MATERIAL(
+    carbon_gas, 213.5f * unit<scalar>::mm, 429.0f * unit<scalar>::mm, 12.01f,
+    6.f, static_cast<scalar>(2.0 * unit<double>::g / unit<double>::cm3),
+    material_state::e_gas, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
 
 // N₂ (7): Nitrogen Gas
-DETRAY_DECLARE_MATERIAL(nitrogen_gas, 3.260E+05 * unit<scalar>::mm,
-                        7.696E+05 * unit<scalar>::mm, 14.007 * 2, 7 * 2,
-                        1.165E-03 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_gas, 0.1535, 3.2125, 1.7378, 4.1323,
-                        82.0, 10.5400, 0.00);
+DETRAY_DECLARE_MATERIAL(nitrogen_gas, 3.260E+02f * unit<scalar>::m,
+                        7.696E+02f * unit<scalar>::m, 28.014f, 14.f,
+                        static_cast<scalar>(1.165E-03 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_gas, 0.1535f, 3.2125f, 1.7378f,
+                        4.1323f, 82.0f, 10.5400f, 0.f);
 
 // O₂ (8): Oxygen Gas
-DETRAY_DECLARE_MATERIAL(oxygen_gas, 2.571E+05 * unit<scalar>::mm,
-                        6.772E+05 * unit<scalar>::mm, 15.999 * 2, 8 * 2,
-                        1.332E-3 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_gas, 0.1178, 3.2913, 1.7541, 4.3213,
-                        95.0, 10.7004, 0.00);
+DETRAY_DECLARE_MATERIAL(oxygen_gas, 2.571E+02f * unit<scalar>::m,
+                        6.772E+02f * unit<scalar>::m, 31.998f, 16.f,
+                        static_cast<scalar>(1.332E-3 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_gas, 0.1178f, 3.2913f, 1.7541f,
+                        4.3213f, 95.0f, 10.7004f, 0.f);
 
 // O₂ (8): Oxygen liquid
-DETRAY_DECLARE_MATERIAL(oxygen_liquid, 300.1 * unit<scalar>::mm,
-                        790.3 * unit<scalar>::mm, 15.999 * 2, 8 * 2,
-                        1.141 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_liquid, 0, 0, 0, 0, 0, 0, 0);
+DETRAY_DECLARE_MATERIAL(oxygen_liquid, 300.1f * unit<scalar>::mm,
+                        790.3f * unit<scalar>::mm, 31.998f, 16.f,
+                        static_cast<scalar>(1.141 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_liquid, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f,
+                        0.f);
 
 // Al (13)
-DETRAY_DECLARE_MATERIAL(aluminium, 88.97 * unit<scalar>::mm,
-                        397.0 * unit<scalar>::mm, 26.98, 13,
-                        2.699 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_solid, 0.0802, 3.6345, 0.1708, 3.0127,
-                        166.0, 4.2395, 0.12);
+DETRAY_DECLARE_MATERIAL(aluminium, 88.97f * unit<scalar>::mm,
+                        397.0f * unit<scalar>::mm, 26.98f, 13.f,
+                        static_cast<scalar>(2.699 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_solid, 0.0802f, 3.6345f, 0.1708f,
+                        3.0127f, 166.f, 4.2395f, 0.12f);
 
 // Si (14)
-DETRAY_DECLARE_MATERIAL(silicon, 93.7 * unit<scalar>::mm,
-                        465.2 * unit<scalar>::mm, 28.0855, 14.,
-                        2.329 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_solid, 0.1492, 3.2546, 0.2015, 2.8716,
-                        173.0, 4.4355, 0.14);
+DETRAY_DECLARE_MATERIAL(silicon, 93.7f * unit<scalar>::mm,
+                        465.2f * unit<scalar>::mm, 28.0855f, 14.f,
+                        static_cast<scalar>(2.329 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_solid, 0.1492f, 3.2546f, 0.2015f,
+                        2.8716f, 173.0f, 4.4355f, 0.14f);
 
 // Ar (18): Argon gas
-DETRAY_DECLARE_MATERIAL(argon_gas, 1.176E+05 * unit<scalar>::mm,
-                        7.204E+05 * unit<scalar>::mm, 39.948, 18.,
-                        1.662E-03 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_gas, 0.1971, 2.9618, 1.7635, 4.4855,
-                        188.0, 11.9480, 0.00);
+DETRAY_DECLARE_MATERIAL(argon_gas, 1.176E+02f * unit<scalar>::m,
+                        7.204E+02f * unit<scalar>::m, 39.948f, 18.f,
+                        static_cast<scalar>(1.662E-03 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_gas, 0.1971f, 2.9618f, 1.7635f,
+                        4.4855f, 188.f, 11.9480f, 0.f);
 
 // W (74)
-DETRAY_DECLARE_MATERIAL(tungsten, 3.504 * unit<scalar>::mm,
-                        99.46 * unit<scalar>::mm, 183.84, 74,
-                        19.3 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_solid, 0.1551, 2.8447, 0.2167, 3.4960,
-                        727.0, 5.4059, 0.14);
+DETRAY_DECLARE_MATERIAL(tungsten, 3.504f * unit<scalar>::mm,
+                        99.46f * unit<scalar>::mm, 183.84f, 74.f,
+                        static_cast<scalar>(19.3 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_solid, 0.1551f, 2.8447f, 0.2167f,
+                        3.4960f, 727.0f, 5.4059f, 0.14f);
 
 // Au (79)
-DETRAY_DECLARE_MATERIAL(gold, 3.344 * unit<scalar>::mm,
-                        101.6 * unit<scalar>::mm, 196.97, 79,
-                        19.32 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_solid, 0.0976, 3.1101, 0.2021, 3.6979,
-                        790.0, 5.5747, 0.14);
+DETRAY_DECLARE_MATERIAL(gold, 3.344f * unit<scalar>::mm,
+                        101.6f * unit<scalar>::mm, 196.97f, 79.f,
+                        static_cast<scalar>(19.32 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_solid, 0.0976f, 3.1101f, 0.2021f,
+                        3.6979f, 790.f, 5.5747f, 0.14f);
 
 /**
  * Elements Declaration for ACTS Generic detector
@@ -127,18 +141,20 @@ DETRAY_DECLARE_MATERIAL(gold, 3.344 * unit<scalar>::mm,
  */
 
 // Be (4)
-DETRAY_DECLARE_MATERIAL(beryllium_tml, 352.8 * unit<scalar>::mm,
-                        407.0 * unit<scalar>::mm, 9.012, 4.0,
-                        1.848 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_solid, 0.8039, 2.4339, 0.0592, 1.6922,
-                        63.7, 2.7847, 0.14);
+DETRAY_DECLARE_MATERIAL(beryllium_tml, 352.8f * unit<scalar>::mm,
+                        407.f * unit<scalar>::mm, 9.012f, 4.f,
+                        static_cast<scalar>(1.848 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_solid, 0.8039f, 2.4339f, 0.0592f,
+                        1.6922f, 63.7f, 2.7847f, 0.14f);
 
 // Si (14)
-DETRAY_DECLARE_MATERIAL(silicon_tml, 95.7 * unit<scalar>::mm,
-                        465.2 * unit<scalar>::mm, 28.03, 14.,
-                        2.32 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_solid, 0.1492, 3.2546, 0.2015, 2.8716,
-                        173.0, 4.4355, 0.14);
+DETRAY_DECLARE_MATERIAL(silicon_tml, 95.7f * unit<scalar>::mm,
+                        465.2f * unit<scalar>::mm, 28.03f, 14.f,
+                        static_cast<scalar>(2.32 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_solid, 0.1492f, 3.2546f, 0.2015f,
+                        2.8716f, 173.f, 4.4355f, 0.14f);
 
 /**
  * Mixtures or Compounds
@@ -148,10 +164,12 @@ DETRAY_DECLARE_MATERIAL(silicon_tml, 95.7 * unit<scalar>::mm,
 // @note:
 // https://pdg.lbl.gov/2020/AtomicNuclearProperties/HTML/air_dry_1_atm.html
 // @note: Ar from Wikipedia (https://en.wikipedia.org/wiki/Molar_mass)
-DETRAY_DECLARE_MATERIAL(air, 3.039E+05 * unit<scalar>::mm,
-                        7.477E+05 * unit<scalar>::mm, 28.97, 14.46,
-                        1.205E-03 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_gas, 0, 0, 0, 0, 0, 0, 0);
+DETRAY_DECLARE_MATERIAL(air, 3.039E+02f * unit<scalar>::m,
+                        7.477E+02f * unit<scalar>::m, 28.97f, 14.46f,
+                        static_cast<scalar>(1.205E-03 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_gas, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f,
+                        0.f);
 
 // (CH3)2CHCH3 Gas
 // @note: (X0, L0, mass_rho) from https://pdg.lbl.gov/2005/reviews/atomicrpp.pdf
@@ -159,18 +177,20 @@ DETRAY_DECLARE_MATERIAL(air, 3.039E+05 * unit<scalar>::mm,
 // @note: Z was caculated by simply summing the number of atoms. Surprisingly
 // it seems the right value because Z/A is 0.58496, which is the same with <Z/A>
 // in the pdg refernce
-DETRAY_DECLARE_MATERIAL(isobutane, 169300 * unit<scalar>::mm,
-                        288.3 * unit<scalar>::mm, 58.124, 34.,
-                        2.67 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_gas, 0, 0, 0, 0, 0, 0, 0);
+DETRAY_DECLARE_MATERIAL(
+    isobutane, 1693E+02f * unit<scalar>::mm, 288.3f * unit<scalar>::mm, 58.124f,
+    34.f, static_cast<scalar>(2.67 * unit<double>::g / unit<double>::cm3),
+    material_state::e_gas, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
 
 // C3H8 Gas
 // @note: (X0, L0, mass_rho) from
 // https://pdg.lbl.gov/2020/AtomicNuclearProperties/HTML/propane.html
 // @note: Ar from Wikipedia (https://en.wikipedia.org/wiki/Propane)
-DETRAY_DECLARE_MATERIAL(propane, 2.429E+05 * unit<scalar>::mm,
-                        4.106E+05 * unit<scalar>::mm, 44.097, 26,
-                        1.868E-03 * unit<scalar>::g / (1 * unit<scalar>::cm3),
-                        material_state::e_gas, 0, 0, 0, 0, 0, 0, 0);
+DETRAY_DECLARE_MATERIAL(propane, 2.429E+02f * unit<scalar>::m,
+                        4.106E+02f * unit<scalar>::m, 44.097f, 26.f,
+                        static_cast<scalar>(1.868E-03 * unit<double>::g /
+                                            unit<double>::cm3),
+                        material_state::e_gas, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f,
+                        0.f);
 
 }  // namespace detray

--- a/core/include/detray/propagator/constrained_step.hpp
+++ b/core/include/detray/propagator/constrained_step.hpp
@@ -32,11 +32,11 @@ enum direction : int {
 /// from aborter  - this would be a target condition
 /// from user     - this is user given for what reason ever
 enum constraint : std::size_t {
-    e_accuracy = 0,
-    e_actor = 1,
-    e_aborter = 2,
-    e_user = 3,
-    e_all = 4
+    e_accuracy = 0u,
+    e_actor = 1u,
+    e_aborter = 2u,
+    e_user = 3u,
+    e_all = 4u
 };
 
 }  // namespace step

--- a/core/include/detray/propagator/navigator.hpp
+++ b/core/include/detray/propagator/navigator.hpp
@@ -446,7 +446,7 @@ class navigator {
         navigation::direction _direction = navigation::direction::e_forward;
 
         /// The on object tolerance - permille
-        scalar _on_object_tolerance = 1e-3;
+        scalar _on_object_tolerance{1e-3f};
 
         /// The navigation trust level determines how this states cache is to
         /// be updated in the current navigation call
@@ -454,7 +454,7 @@ class navigator {
             navigation::trust_level::e_no_trust;
 
         /// Index in the detector volume container of current navigation volume
-        dindex _volume_index = 0;
+        dindex _volume_index{0u};
     };
 
     /// Helper method to initialize a volume.
@@ -802,7 +802,7 @@ create_candidates_buffer(
     vecmem::memory_resource &device_resource,
     vecmem::memory_resource *host_access_resource = nullptr) {
     return vecmem::data::jagged_vector_buffer<line_plane_intersection>(
-        std::vector<std::size_t>(n_tracks, 0),
+        std::vector<std::size_t>(n_tracks, 0u),
         std::vector<std::size_t>(n_tracks, det.get_n_max_objects_per_volume()),
         device_resource, host_access_resource);
 }

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -62,13 +62,13 @@ class rk_stepper final
             const magnetic_field_t& mag_field, const detector_t& det)
             : base_type::state(bound_params, det), _magnetic_field(mag_field) {}
         /// error tolerance
-        scalar _tolerance = 1e-4;
+        scalar _tolerance{1e-4f};
 
         /// step size cutoff value
-        scalar _step_size_cutoff = 1e-4;
+        scalar _step_size_cutoff{1e-4f};
 
         /// maximum trial number of RK stepping
-        size_t _max_rk_step_trials = 10000;
+        std::size_t _max_rk_step_trials{10000u};
 
         /// stepping data required for RKN4
         struct {
@@ -101,10 +101,9 @@ class rk_stepper final
                                   const scalar h, const vector3& k_prev);
     };
 
-    /** Take a step, using an adaptive Runge-Kutta algorithm.
-     *
-     * @return returning the heartbeat, indicating if the stepping is alive
-     */
+    /// Take a step, using an adaptive Runge-Kutta algorithm.
+    ///
+    /// @return returning the heartbeat, indicating if the stepping is alive
     template <typename propagation_state_t>
     DETRAY_HOST_DEVICE bool step(propagation_state_t& propagation);
 };

--- a/core/include/detray/surface_finders/grid/detail/populator_impl.hpp
+++ b/core/include/detray/surface_finders/grid/detail/populator_impl.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -157,7 +157,7 @@ class ranged_bin
     }
 
     protected:
-    std::size_t n_elements{0};
+    std::size_t n_elements{0u};
 };
 
 /// A complete populator that adds elements to a bin content which contains an
@@ -169,7 +169,7 @@ class ranged_bin
 ///
 /// @note the entry type must be default constructible, since its default
 /// entry may be interpreted as the empty element in which to put the new entry.
-template <std::size_t kDIM = 1, bool kSORT = false,
+template <std::size_t kDIM = 1u, bool kSORT = false,
           template <typename, std::size_t> class array_t = darray>
 struct completer {
 
@@ -203,7 +203,7 @@ struct completer {
     template <typename bin_storage_t>
     DETRAY_HOST_DEVICE decltype(auto) view(const bin_storage_t &storage,
                                            const dindex gbin) const {
-        return storage[gbin].view(dindex_range{0, storage[gbin].n_entries()});
+        return storage[gbin].view(dindex_range{0u, storage[gbin].n_entries()});
     }
 
     template <typename bin_storage_t>
@@ -223,7 +223,8 @@ struct completer {
 
         // The first entry always exists
         stored[0] = entry;
-        std::size_t n_elem = entry == detail::invalid_value<entry_t>() ? 0 : 1;
+        std::size_t n_elem =
+            entry == detail::invalid_value<entry_t>() ? 0u : 1u;
 
         return {{stored}, n_elem};
     }
@@ -238,7 +239,7 @@ struct completer {
 /// @note the number of entries are assumed to be the same in every bin.
 /// @note the entry type must be default constructible, since its default
 /// entry may be interpreted as the empty element in which to put the new entry.
-template <std::size_t kDIM = 1, bool kSORT = false,
+template <std::size_t kDIM = 1u, bool kSORT = false,
           template <typename, std::size_t> class array_t = darray>
 struct regular_attacher {
 
@@ -269,7 +270,7 @@ struct regular_attacher {
     template <typename bin_storage_t>
     DETRAY_HOST_DEVICE auto view(const bin_storage_t &storage,
                                  const dindex gbin) const {
-        return storage[gbin].view(dindex_range{0, storage[gbin].n_entries()});
+        return storage[gbin].view(dindex_range{0u, storage[gbin].n_entries()});
     }
 
     template <typename bin_storage_t>
@@ -289,7 +290,8 @@ struct regular_attacher {
 
         // The first element always exists
         stored[0] = entry;
-        std::size_t n_elem = entry == detail::invalid_value<entry_t>() ? 0 : 1;
+        std::size_t n_elem =
+            entry == detail::invalid_value<entry_t>() ? 0u : 1u;
 
         return {{stored}, n_elem};
     }

--- a/core/include/detray/surface_finders/grid/grid.hpp
+++ b/core/include/detray/surface_finders/grid/grid.hpp
@@ -65,6 +65,7 @@ class grid {
     /// Backend storage type for the grid
     using bin_storage_type =
         typename container_types::template vector_type<bin_type>;
+
     /// Vecmem based grid view type
     using view_type =
         dmulti_view<dvector_view<bin_type>, typename axes_type::view_type>;
@@ -96,13 +97,13 @@ class grid {
     /// Create grid from container pointers - non-owning (both grid and axes)
     DETRAY_HOST_DEVICE
     grid(bin_storage_type *bin_data_ptr, axes_type &axes,
-         const dindex offset = 0)
+         const dindex offset = 0u)
         : m_data(bin_data_ptr, offset), m_axes(axes) {}
 
     /// Create grid from container pointers - non-owning (both grid and axes)
     DETRAY_HOST_DEVICE
     grid(bin_storage_type *bin_data_ptr, axes_type &&axes,
-         const dindex offset = 0)
+         const dindex offset = 0u)
         : m_data(bin_data_ptr, offset), m_axes(axes) {}
 
     /// Device-side construction from a vecmem based view type
@@ -143,8 +144,8 @@ class grid {
     /// @returns the total number of bins in the grid
     DETRAY_HOST_DEVICE inline constexpr auto nbins() const -> std::size_t {
         const auto n_bins_per_axis = m_axes.nbins();
-        std::size_t n_bins{1};
-        for (std::size_t i{0}; i < Dim; ++i) {
+        std::size_t n_bins{1u};
+        for (std::size_t i{0u}; i < Dim; ++i) {
             n_bins *= n_bins_per_axis[i];
         }
         return n_bins;

--- a/core/include/detray/tools/associator.hpp
+++ b/core/include/detray/tools/associator.hpp
@@ -1,13 +1,13 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-#include <climits>
+#include <limits>
 #include <vector>
 
 namespace detray {
@@ -28,11 +28,11 @@ struct center_of_gravity_rectangle {
     bool operator()(const std::vector<point2_t> &bin_contour,
                     const std::vector<point2_t> &surface_contour) {
         // Check if centre of gravity is inside bin
-        point2_t cgs = {0., 0.};
+        point2_t cgs = {0.f, 0.f};
         for (const auto &svtx : surface_contour) {
             cgs = cgs + svtx;
         }
-        cgs = 1. / surface_contour.size() * cgs;
+        cgs = 1.f / static_cast<scalar>(surface_contour.size()) * cgs;
         scalar min_l0 = std::numeric_limits<scalar>::max();
         scalar max_l0 = -std::numeric_limits<scalar>::max();
         scalar min_l1 = std::numeric_limits<scalar>::max();
@@ -67,17 +67,17 @@ struct center_of_gravity_generic {
     bool operator()(const std::vector<point2_t> &bin_contour,
                     const std::vector<point2_t> &surface_contour) {
         // Check if centre of gravity is inside bin
-        point2_t cgs = {0., 0.};
+        point2_t cgs = {0.f, 0.f};
         for (const auto &svtx : surface_contour) {
             cgs = cgs + svtx;
         }
-        cgs = 1. / surface_contour.size() * cgs;
+        cgs = 1.f / static_cast<scalar>(surface_contour.size()) * cgs;
 
-        size_t i, j = 0;
-        size_t num_points = bin_contour.size();
+        std::size_t i, j = 0u;
+        std::size_t num_points = bin_contour.size();
 
         bool inside = false;
-        for (i = 0, j = num_points - 1; i < num_points; j = i++) {
+        for (i = 0u, j = num_points - 1u; i < num_points; j = i++) {
             const auto &pi = bin_contour[i];
             const auto &pj = bin_contour[j];
             if ((((pi[1] <= cgs[1]) and (cgs[1] < pj[1])) or
@@ -110,14 +110,14 @@ struct edges_intersect_generic {
             scalar d = (pj[0] - pi[0]) * (pl[1] - pk[1]) -
                        (pj[1] - pi[1]) * (pl[0] - pk[0]);
 
-            if (d != 0.) {
+            if (d != 0.f) {
                 double r = ((pi[1] - pk[1]) * (pl[0] - pk[0]) -
                             (pi[0] - pk[0]) * (pl[1] - pk[1])) /
                            d;
                 double s = ((pi[1] - pk[1]) * (pj[0] - pi[0]) -
                             (pi[0] - pk[0]) * (pj[1] - pi[1])) /
                            d;
-                if (r >= 0. and r <= 1. and s >= 0. and s <= 1.) {
+                if (r >= 0.f and r <= 1.f and s >= 0.f and s <= 1.f) {
                     return true;
                 }
             }
@@ -125,15 +125,15 @@ struct edges_intersect_generic {
         };
 
         // Loop over bin_contour
-        for (size_t j = 1; j <= bin_contour.size(); ++j) {
-            size_t i = j - 1;
-            size_t jc = (j == bin_contour.size()) ? 0 : j;
+        for (std::size_t j = 1u; j <= bin_contour.size(); ++j) {
+            std::size_t i = j - 1u;
+            std::size_t jc = (j == bin_contour.size()) ? 0u : j;
             const auto &pi = bin_contour[i];
             const auto &pj = bin_contour[jc];
             // Loop over surface_contour
-            for (size_t k = 1; k <= surface_contour.size(); ++k) {
-                size_t l = k - 1;
-                size_t kc = (k == surface_contour.size()) ? 0 : k;
+            for (std::size_t k = 1u; k <= surface_contour.size(); ++k) {
+                std::size_t l = k - 1u;
+                std::size_t kc = (k == surface_contour.size()) ? 0u : k;
                 const auto &pl = surface_contour[l];
                 const auto &pk = surface_contour[kc];
                 if (intersect(pi, pj, pk, pl)) {

--- a/core/include/detray/tools/bin_association.hpp
+++ b/core/include/detray/tools/bin_association.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/units.hpp"
 #include "detray/tools/associator.hpp"
 #include "detray/tools/generators.hpp"
 #include "detray/utils/ranges.hpp"
@@ -206,12 +207,16 @@ static inline void bin_association(const context_t & /*context*/,
                             }
                             // Check for phi wrapping
                             std::vector<std::vector<point2_t>> surface_contours;
-                            if (phi_max - phi_min > M_PI and
+                            if (phi_max - phi_min > constant<scalar>::pi and
                                 phi_max * phi_min < 0.) {
-                                s_c_neg.push_back({z_max_neg, -M_PI});
-                                s_c_neg.push_back({z_min_neg, -M_PI});
-                                s_c_pos.push_back({z_max_pos, M_PI});
-                                s_c_pos.push_back({z_min_pos, M_PI});
+                                s_c_neg.push_back(
+                                    {z_max_neg, -constant<scalar>::pi});
+                                s_c_neg.push_back(
+                                    {z_min_neg, -constant<scalar>::pi});
+                                s_c_pos.push_back(
+                                    {z_max_pos, constant<scalar>::pi});
+                                s_c_pos.push_back(
+                                    {z_min_pos, constant<scalar>::pi});
                                 surface_contours = {s_c_neg, s_c_pos};
                             } else {
                                 surface_contours = {surface_contour};

--- a/core/include/detray/tools/bin_fillers.hpp
+++ b/core/include/detray/tools/bin_fillers.hpp
@@ -132,7 +132,7 @@ struct bin_associator {
         -> void {
         // Fill the surfaces into the grid by matching their contour onto the
         // grid bins
-        bin_association(ctx, surfaces, transforms, masks, grid, {0.1, 0.1},
+        bin_association(ctx, surfaces, transforms, masks, grid, {0.1f, 0.1f},
                         false);
     }
 };

--- a/core/include/detray/tools/generators.hpp
+++ b/core/include/detray/tools/generators.hpp
@@ -23,11 +23,11 @@ namespace detray {
  */
 template <typename scalar_t>
 static inline dvector<scalar_t> phi_values(scalar_t start_phi, scalar_t end_phi,
-                                           unsigned int lseg) {
+                                           dindex lseg) {
     dvector<scalar_t> values;
-    values.reserve(lseg + 1);
-    scalar_t step_phi = (end_phi - start_phi) / lseg;
-    for (unsigned int istep = 0; istep <= lseg; ++istep) {
+    values.reserve(lseg + 1u);
+    scalar_t step_phi = (end_phi - start_phi) / static_cast<scalar_t>(lseg);
+    for (unsigned int istep = 0u; istep <= lseg; ++istep) {
         values.push_back(start_phi + istep * step_phi);
     }
     return values;
@@ -45,8 +45,7 @@ static inline dvector<scalar_t> phi_values(scalar_t start_phi, scalar_t end_phi,
 template <typename point2_t, typename point3_t, typename links_t,
           typename transform3_t>
 dvector<point3_t> vertices(
-    const mask<annulus2D<>, links_t, transform3_t> &annulus_mask,
-    unsigned int lseg) {
+    const mask<annulus2D<>, links_t, transform3_t> &annulus_mask, dindex lseg) {
     using scalar_t = typename transform3_t::scalar_type;
 
     const auto &m_values = annulus_mask.values();
@@ -75,21 +74,21 @@ dvector<point3_t> vertices(
         //
         scalar_t m = std::tan(phi);
         point2_t dir = {math_ns::cos(phi), std::sin(phi)};
-        scalar_t x1 =
-            (O_x + O_y * m -
-             std::sqrt(-std::pow(O_x, 2) * std::pow(m, 2) + 2 * O_x * O_y * m -
-                       std::pow(O_y, 2) + std::pow(m, 2) * std::pow(r, 2) +
-                       std::pow(r, 2))) /
-            (std::pow(m, 2) + 1);
-        scalar_t x2 =
-            (O_x + O_y * m +
-             std::sqrt(-std::pow(O_x, 2) * std::pow(m, 2) + 2 * O_x * O_y * m -
-                       std::pow(O_y, 2) + std::pow(m, 2) * std::pow(r, 2) +
-                       std::pow(r, 2))) /
-            (std::pow(m, 2) + 1);
+        scalar_t x1 = (O_x + O_y * m -
+                       std::sqrt(-std::pow(O_x, 2.f) * std::pow(m, 2.f) +
+                                 2.f * O_x * O_y * m - std::pow(O_y, 2.f) +
+                                 std::pow(m, 2.f) * std::pow(r, 2.f) +
+                                 std::pow(r, 2.f))) /
+                      (std::pow(m, 2.f) + 1.f);
+        scalar_t x2 = (O_x + O_y * m +
+                       std::sqrt(-std::pow(O_x, 2.f) * std::pow(m, 2.f) +
+                                 2.f * O_x * O_y * m - std::pow(O_y, 2.f) +
+                                 std::pow(m, 2.f) * std::pow(r, 2.f) +
+                                 std::pow(r, 2.f))) /
+                      (std::pow(m, 2.f) + 1.f);
 
         point2_t v1 = {x1, m * x1};
-        if (vector::dot(v1, dir) > 0)
+        if (vector::dot(v1, dir) > 0.f)
             return v1;
         return {x2, m * x2};
     };
@@ -110,13 +109,13 @@ dvector<point3_t> vertices(
     for (auto iphi : inner_phi) {
         annulus_vertices.push_back(
             point3_t{min_r * math_ns::cos(iphi) + origin_x,
-                     min_r * std::sin(iphi) + origin_y, 0.});
+                     min_r * std::sin(iphi) + origin_y, 0.f});
     }
 
     for (auto ophi : outer_phi) {
         annulus_vertices.push_back(
             point3_t{max_r * math_ns::cos(ophi) + origin_x,
-                     max_r * std::sin(ophi) + origin_y, 0.});
+                     max_r * std::sin(ophi) + origin_y, 0.f});
     }
 
     return annulus_vertices;
@@ -158,13 +157,13 @@ dvector<point3_t> vertices(
     unsigned int /*ignored*/) {
     const auto &m_values = rectangle_mask.values();
     // left hand lower corner
-    point3_t lh_lc = {-m_values[0], -m_values[1], 0.};
+    point3_t lh_lc = {-m_values[0], -m_values[1], 0.f};
     // right hand lower corner
-    point3_t rh_lc = {m_values[0], -m_values[1], 0.};
+    point3_t rh_lc = {m_values[0], -m_values[1], 0.f};
     // right hand upper corner
-    point3_t rh_uc = {m_values[0], m_values[1], 0.};
+    point3_t rh_uc = {m_values[0], m_values[1], 0.f};
     // left hand upper corner
-    point3_t lh_uc = {-m_values[0], m_values[1], 0.};
+    point3_t lh_uc = {-m_values[0], m_values[1], 0.f};
     return {lh_lc, rh_lc, rh_uc, lh_uc};
     // Return the confining vertices
 }
@@ -203,13 +202,13 @@ dvector<point3_t> vertices(
 
     const auto &m_values = trapezoid_mask.values();
     // left hand lower corner
-    point3_t lh_lc = {-m_values[0], -m_values[2], 0.};
+    point3_t lh_lc = {-m_values[0], -m_values[2], 0.f};
     // right hand lower corner
-    point3_t rh_lc = {m_values[0], -m_values[2], 0.};
+    point3_t rh_lc = {m_values[0], -m_values[2], 0.f};
     // right hand upper corner
-    point3_t rh_uc = {m_values[1], m_values[2], 0.};
+    point3_t rh_uc = {m_values[1], m_values[2], 0.f};
     // left hand upper corner
-    point3_t lh_uc = {-m_values[1], m_values[2], 0.};
+    point3_t lh_uc = {-m_values[1], m_values[2], 0.f};
     // Return the confining vertices
     return {lh_lc, rh_lc, rh_uc, lh_uc};
 }
@@ -254,10 +253,10 @@ struct vertexer {
 template <typename scalar_t, typename point2_t>
 std::vector<point2_t> r_phi_polygon(scalar_t rmin, scalar_t rmax,
                                     scalar_t phimin, scalar_t phimax,
-                                    unsigned int nsegments = 1) {
+                                    unsigned int nsegments = 1u) {
 
     std::vector<point2_t> r_phi_poly;
-    r_phi_poly.reserve(2 * nsegments + 2);
+    r_phi_poly.reserve(2u * nsegments + 2u);
 
     scalar_t cos_min_phi = math_ns::cos(phimin);
     scalar_t sin_min_phi = std::sin(phimin);

--- a/core/include/detray/tools/grid_builder.hpp
+++ b/core/include/detray/tools/grid_builder.hpp
@@ -99,7 +99,7 @@ class grid_builder final : public volume_decorator<detector_t> {
         // detector and update their links
         const auto trf_offset{det.transform_store().size(ctx)};
         // TODO: make the grid directly iterable
-        for (std::size_t gbin{0}; gbin < m_grid.nbins(); ++gbin) {
+        for (std::size_t gbin{0u}; gbin < m_grid.nbins(); ++gbin) {
             for (auto &sf : m_grid.at(gbin)) {
                 det.mask_store().template call<detail::mask_index_update>(
                     sf.mask(), sf);

--- a/core/include/detray/tools/grid_factory.hpp
+++ b/core/include/detray/tools/grid_factory.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/surface_finders/grid/axis.hpp"
 #include "detray/surface_finders/grid/grid.hpp"
@@ -189,8 +190,8 @@ class grid_factory {
         auto b_values = grid_bounds.values();
 
         return new_grid<cylinder2D<>>(
-            {-static_cast<scalar_type>(M_PI) * b_values[boundary::e_r],
-             static_cast<scalar_type>(M_PI) * b_values[boundary::e_r],
+            {-constant<scalar_type>::pi * b_values[boundary::e_r],
+             constant<scalar_type>::pi * b_values[boundary::e_r],
              b_values[boundary::e_n_half_z], b_values[boundary::e_p_half_z]},
             {n_bins[e_rphi_axis], n_bins[e_z_axis]},
             {bin_edges[e_rphi_axis], bin_edges[e_z_axis]},
@@ -222,8 +223,8 @@ class grid_factory {
         auto b_values = grid_bounds.values();
 
         return new_grid<cylinder3D>(
-            {0.f, b_values[boundary::e_r], -static_cast<scalar_type>(M_PI),
-             static_cast<scalar_type>(M_PI), -b_values[boundary::e_n_half_z],
+            {0.f, b_values[boundary::e_r], -constant<scalar_type>::pi,
+             constant<scalar_type>::pi, -b_values[boundary::e_n_half_z],
              b_values[boundary::e_p_half_z]},
             {n_bins[e_r_axis], n_bins[e_phi_axis], n_bins[e_z_axis]},
             {bin_edges[e_r_axis], bin_edges[e_phi_axis], bin_edges[e_z_axis]},
@@ -254,7 +255,7 @@ class grid_factory {
 
         return new_grid<ring2D<>>(
             {b_values[boundary::e_inner_r], b_values[boundary::e_outer_r],
-             -static_cast<scalar_type>(M_PI), static_cast<scalar_type>(M_PI)},
+             -constant<scalar_type>::pi, constant<scalar_type>::pi},
             {n_bins[e_r_axis], n_bins[e_phi_axis]},
             {bin_edges[e_r_axis], bin_edges[e_phi_axis]},
             std::tuple<r_bounds, phi_bounds>{},
@@ -388,8 +389,8 @@ class grid_factory {
                           std::tuple_element_t<I, binnings>,
                           n_axis::regular<host_container_types, scalar_type>>) {
             axes_data.push_back({bin_edges.size(), n_bins.at(I)});
-            bin_edges.push_back(spans.at(I * 2));
-            bin_edges.push_back(spans.at(I * 2 + 1));
+            bin_edges.push_back(spans.at(I * 2u));
+            bin_edges.push_back(spans.at(I * 2u + 1u));
         } else {
             const auto &bin_edges_loc = ax_bin_edges.at(I);
             axes_data.push_back({bin_edges.size(),
@@ -428,19 +429,19 @@ auto grid_factory<value_t, serializer_t, populator_impl_t,
     // Loop over the first dimension
     const auto &ax0 = gr.template get_axis<0>();
     std::cout << "{";
-    for (std::size_t i{0}; i < ax0.nbins(); ++i) {
+    for (std::size_t i{0u}; i < ax0.nbins(); ++i) {
 
         // Loop over the second dimension
-        if constexpr (grid_t::Dim > 1) {
+        if constexpr (grid_t::Dim > 1u) {
             const auto &ax1 = gr.template get_axis<1>();
             std::cout << "{";
-            for (std::size_t j{0}; j < ax1.nbins(); ++j) {
+            for (std::size_t j{0u}; j < ax1.nbins(); ++j) {
 
                 // Loop over the third dimension
                 if constexpr (grid_t::Dim > 2) {
                     const auto &ax2 = gr.template get_axis<2>();
                     std::cout << "{";
-                    for (std::size_t k{0}; k < ax2.nbins(); ++k) {
+                    for (std::size_t k{0u}; k < ax2.nbins(); ++k) {
 
                         // Print the bin content - three dimensions
                         std::cout << "( ";

--- a/core/include/detray/tracks/bound_track_parameters.hpp
+++ b/core/include/detray/tracks/bound_track_parameters.hpp
@@ -1,6 +1,6 @@
 /** Algebra plugins library, part of the ACTS project
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -50,7 +50,7 @@ struct bound_track_parameters {
               matrix_operator().template zero<e_bound_size, e_bound_size>()) {}
 
     DETRAY_HOST_DEVICE
-    bound_track_parameters(const std::size_t sf_idx, const vector_type& vec,
+    bound_track_parameters(const dindex sf_idx, const vector_type& vec,
                            const covariance_type& cov)
         : m_surface_link(sf_idx), m_vector(vec), m_covariance(cov) {}
 
@@ -62,17 +62,17 @@ struct bound_track_parameters {
             return false;
         }
 
-        for (std::size_t i = 0; i < e_bound_size; i++) {
-            const auto lhs_val = matrix_operator().element(m_vector, i, 0);
-            const auto rhs_val = matrix_operator().element(rhs.vector(), i, 0);
+        for (unsigned int i = 0u; i < e_bound_size; i++) {
+            const auto lhs_val = matrix_operator().element(m_vector, i, 0u);
+            const auto rhs_val = matrix_operator().element(rhs.vector(), i, 0u);
 
             if (std::abs(lhs_val - rhs_val) >
                 std::numeric_limits<scalar_type>::epsilon()) {
                 return false;
             }
         }
-        for (std::size_t i = 0; i < e_bound_size; i++) {
-            for (std::size_t j = 0; j < e_bound_size; j++) {
+        for (unsigned int i = 0u; i < e_bound_size; i++) {
+            for (unsigned int j = 0u; j < e_bound_size; j++) {
                 const auto lhs_val =
                     matrix_operator().element(m_covariance, i, j);
                 const auto rhs_val =
@@ -88,10 +88,10 @@ struct bound_track_parameters {
     }
 
     DETRAY_HOST_DEVICE
-    const std::size_t& surface_link() const { return m_surface_link; }
+    const dindex& surface_link() const { return m_surface_link; }
 
     DETRAY_HOST_DEVICE
-    void set_surface_link(std::size_t link) { m_surface_link = link; }
+    void set_surface_link(dindex link) { m_surface_link = link; }
 
     DETRAY_HOST_DEVICE
     vector_type& vector() { return m_vector; }
@@ -116,12 +116,12 @@ struct bound_track_parameters {
 
     DETRAY_HOST_DEVICE
     scalar_type phi() const {
-        return matrix_operator().element(m_vector, e_bound_phi, 0);
+        return matrix_operator().element(m_vector, e_bound_phi, 0u);
     }
 
     DETRAY_HOST_DEVICE
     scalar_type theta() const {
-        return matrix_operator().element(m_vector, e_bound_theta, 0);
+        return matrix_operator().element(m_vector, e_bound_theta, 0u);
     }
 
     DETRAY_HOST_DEVICE
@@ -129,26 +129,27 @@ struct bound_track_parameters {
 
     DETRAY_HOST_DEVICE
     scalar_type time() const {
-        return matrix_operator().element(m_vector, e_bound_time, 0);
+        return matrix_operator().element(m_vector, e_bound_time, 0u);
     }
 
     DETRAY_HOST_DEVICE
     scalar_type charge() const {
-        if (matrix_operator().element(m_vector, e_bound_qoverp, 0) < 0) {
-            return -1.;
+        if (std::signbit(
+                matrix_operator().element(m_vector, e_bound_qoverp, 0u))) {
+            return -1.f;
         } else {
-            return 1.;
+            return 1.f;
         }
     }
 
     DETRAY_HOST_DEVICE
     scalar_type qop() const {
-        return matrix_operator().element(m_vector, e_bound_qoverp, 0);
+        return matrix_operator().element(m_vector, e_bound_qoverp, 0u);
     }
 
     DETRAY_HOST_DEVICE
     void set_qop(const scalar qop) {
-        matrix_operator().element(m_vector, e_bound_qoverp, 0) = qop;
+        matrix_operator().element(m_vector, e_bound_qoverp, 0u) = qop;
     }
 
     DETRAY_HOST_DEVICE

--- a/core/include/detray/tracks/detail/track_helper.hpp
+++ b/core/include/detray/tracks/detail/track_helper.hpp
@@ -46,44 +46,45 @@ struct track_helper {
 
     DETRAY_HOST_DEVICE
     inline point3 pos(const free_vector& free_vec) const {
-        return {matrix_operator().element(free_vec, e_free_pos0, 0),
-                matrix_operator().element(free_vec, e_free_pos1, 0),
-                matrix_operator().element(free_vec, e_free_pos2, 0)};
+        return {matrix_operator().element(free_vec, e_free_pos0, 0u),
+                matrix_operator().element(free_vec, e_free_pos1, 0u),
+                matrix_operator().element(free_vec, e_free_pos2, 0u)};
     }
 
     DETRAY_HOST_DEVICE
     inline void set_pos(free_vector& free_vec, const point3& pos) {
-        matrix_operator().element(free_vec, e_free_pos0, 0) = pos[0];
-        matrix_operator().element(free_vec, e_free_pos1, 0) = pos[1];
-        matrix_operator().element(free_vec, e_free_pos2, 0) = pos[2];
+        matrix_operator().element(free_vec, e_free_pos0, 0u) = pos[0];
+        matrix_operator().element(free_vec, e_free_pos1, 0u) = pos[1];
+        matrix_operator().element(free_vec, e_free_pos2, 0u) = pos[2];
     }
 
     DETRAY_HOST_DEVICE
     inline vector3 dir(const free_vector& free_vec) const {
-        return {matrix_operator().element(free_vec, e_free_dir0, 0),
-                matrix_operator().element(free_vec, e_free_dir1, 0),
-                matrix_operator().element(free_vec, e_free_dir2, 0)};
+        return {matrix_operator().element(free_vec, e_free_dir0, 0u),
+                matrix_operator().element(free_vec, e_free_dir1, 0u),
+                matrix_operator().element(free_vec, e_free_dir2, 0u)};
     }
 
     DETRAY_HOST_DEVICE
     inline void set_dir(free_vector& free_vec, const vector3& dir) {
-        matrix_operator().element(free_vec, e_free_dir0, 0) = dir[0];
-        matrix_operator().element(free_vec, e_free_dir1, 0) = dir[1];
-        matrix_operator().element(free_vec, e_free_dir2, 0) = dir[2];
+        matrix_operator().element(free_vec, e_free_dir0, 0u) = dir[0];
+        matrix_operator().element(free_vec, e_free_dir1, 0u) = dir[1];
+        matrix_operator().element(free_vec, e_free_dir2, 0u) = dir[2];
     }
 
     DETRAY_HOST_DEVICE
     inline point2 local(const bound_vector& bound_vec) const {
-        return {matrix_operator().element(bound_vec, e_bound_loc0, 0),
-                matrix_operator().element(bound_vec, e_bound_loc1, 0)};
+        return {matrix_operator().element(bound_vec, e_bound_loc0, 0u),
+                matrix_operator().element(bound_vec, e_bound_loc1, 0u)};
     }
 
     DETRAY_HOST_DEVICE
     inline vector3 dir(const bound_vector& bound_vec) const {
-        const auto& phi = matrix_operator().element(bound_vec, e_bound_phi, 0);
-        const auto& theta =
-            matrix_operator().element(bound_vec, e_bound_theta, 0);
-        const auto sinTheta = math_ns::sin(theta);
+        const scalar_type phi{
+            matrix_operator().element(bound_vec, e_bound_phi, 0u)};
+        const scalar_type theta{
+            matrix_operator().element(bound_vec, e_bound_theta, 0u)};
+        const scalar_type sinTheta{math_ns::sin(theta)};
 
         return {math_ns::cos(phi) * sinTheta, math_ns::sin(phi) * sinTheta,
                 math_ns::cos(theta)};

--- a/core/include/detray/utils/axis_rotation.hpp
+++ b/core/include/detray/utils/axis_rotation.hpp
@@ -28,14 +28,14 @@ struct axis_rotation {
 
     DETRAY_HOST_DEVICE
     axis_rotation(const vector3& axis, const scalar_type theta) {
-        scalar_type cos_theta = math_ns::cos(theta);
+        scalar_type cos_theta{math_ns::cos(theta)};
 
         matrix_type<3, 3> I = matrix_operator().template identity<3, 3>();
         matrix_type<3, 3> axis_cross = mat_helper().cross_matrix(axis);
         matrix_type<3, 3> axis_outer = mat_helper().outer_product(axis, axis);
 
         R = cos_theta * I + std::sin(theta) * axis_cross +
-            (1 - cos_theta) * axis_outer;
+            (1.f - cos_theta) * axis_outer;
     }
 
     template <typename vector3_t>

--- a/core/include/detray/utils/quadratic_equation.hpp
+++ b/core/include/detray/utils/quadratic_equation.hpp
@@ -21,23 +21,24 @@ template <typename scalar_t,
           template <typename, std::size_t> class array_t = darray,
           template <typename...> class tuple_t = dtuple>
 struct quadratic_equation {
-    array_t<scalar_t, 3> _params = {0., 0., 0.};
+    array_t<scalar_t, 3> _params = {0.f, 0.f, 0.f};
 
     /** Solve the quadratic equation
      **/
     DETRAY_HOST_DEVICE
     tuple_t<int, array_t<scalar_t, 2>> operator()() const {
         scalar_t discriminant =
-            _params[1] * _params[1] - 4 * _params[0] * _params[2];
-        if (discriminant < 0.) {
+            _params[1] * _params[1] - 4.f * _params[0] * _params[2];
+        if (discriminant < 0.f) {
             return {0,
                     {std::numeric_limits<scalar_t>::infinity(),
                      std::numeric_limits<scalar_t>::infinity()}};
         } else {
-            int solutions = (discriminant == 0.) ? 1 : 2;
-            double q = -0.5 * (_params[1] + (_params[1] > 0
-                                                 ? std::sqrt(discriminant)
-                                                 : -std::sqrt(discriminant)));
+            int solutions = (discriminant == 0.f) ? 1 : 2;
+            scalar_t q =
+                -0.5f *
+                (_params[1] + (_params[1] > 0.f ? std::sqrt(discriminant)
+                                                : -std::sqrt(discriminant)));
             scalar_t first = q / _params[0];
             scalar_t second = _params[2] / q;
             array_t<scalar_t, 2> poles =

--- a/core/include/detray/utils/ranges/iota.hpp
+++ b/core/include/detray/utils/ranges/iota.hpp
@@ -34,7 +34,7 @@ class iota_view : public detray::ranges::view_interface<iota_view<incr_t>> {
     /// @brief Nested iterator to generate a range of values on demand.
     struct iterator {
 
-        using difference_type = incr_t;
+        using difference_type = std::ptrdiff_t;
         using value_type = incr_t;
         using pointer = incr_t *;
         using reference = incr_t &;

--- a/core/include/detray/utils/ranges/join.hpp
+++ b/core/include/detray/utils/ranges/join.hpp
@@ -176,7 +176,7 @@ struct join_iterator {
     DETRAY_HOST_DEVICE
     constexpr join_iterator(const iterator_coll_t &begins,
                             const iterator_coll_t &ends)
-        : m_begins(&begins), m_ends(&ends), m_iter{(*m_begins)[0]}, m_idx{0} {}
+        : m_begins(&begins), m_ends(&ends), m_iter{(*m_begins)[0]}, m_idx{0u} {}
 
     /// Fully parametrized construction
     DETRAY_HOST_DEVICE
@@ -202,9 +202,9 @@ struct join_iterator {
     DETRAY_HOST_DEVICE constexpr auto operator++() -> join_iterator & {
         ++m_iter;
         // Switch to next range in the collection
-        constexpr std::size_t max_idx =
-            sizeof(iterator_coll_t) / sizeof(iterator_t) - 1;
-        if (m_iter == (*m_ends)[m_idx] and m_idx < max_idx) {
+        constexpr std::size_t max_idx{
+            sizeof(iterator_coll_t) / sizeof(iterator_t) - 1u};
+        if ((m_iter == (*m_ends)[m_idx]) and (m_idx < max_idx)) {
             ++m_idx;
             m_iter = (*m_begins)[m_idx];
         }
@@ -216,15 +216,15 @@ struct join_iterator {
               std::enable_if_t<detray::ranges::bidirectional_iterator_v<I>,
                                bool> = true>
     DETRAY_HOST_DEVICE constexpr auto operator--() -> join_iterator & {
-        if (m_iter != (*m_begins)[m_idx] and m_idx > 0) {
+        if (m_iter != (*m_begins)[m_idx] and m_idx > 0u) {
             // Normal case
             --m_idx;
             --m_iter;
-        } else if (m_idx > 0) {
+        } else if (m_idx > 0u) {
             // Iterator has reached last valid position in this range during the
             // previous decrement. Now go to the end of the previous range
             --m_idx;
-            m_iter = (*m_ends)[m_idx] - difference_type{1};
+            m_iter = (*m_ends)[m_idx] - 1;
         }
         return *this;
     }
@@ -246,7 +246,7 @@ struct join_iterator {
         join_iterator<iterator_coll_t> tmp(*this);
         // walk through join to catch the switch between intermediate ranges
         difference_type i{j};
-        if (i >= difference_type{0}) {
+        if (i >= 0) {
             while (i--) {
                 ++tmp;
             };
@@ -279,7 +279,7 @@ struct join_iterator {
         if (m_idx < other.m_idx) {
             // Negative distance
             difference_type diff{m_iter - (*m_ends)[m_idx]};
-            for (std::size_t i{m_idx + 1}; i < other.m_idx; ++i) {
+            for (std::size_t i{m_idx + 1u}; i < other.m_idx; ++i) {
                 diff += (*m_begins)[i] - (*m_ends)[i];
             }
             diff += (*other.m_begins)[m_idx] - other.m_iter;
@@ -287,7 +287,7 @@ struct join_iterator {
         } else {
             // Positive distance
             difference_type diff{m_iter - (*m_begins)[m_idx]};
-            for (std::size_t i{m_idx - 1}; i > other.m_idx; --i) {
+            for (std::size_t i{m_idx - 1u}; i > other.m_idx; --i) {
                 diff += (*m_ends)[i] - (*m_begins)[i];
             }
             diff += (*other.m_ends)[other.m_idx] - other.m_iter;
@@ -329,10 +329,9 @@ struct join_iterator {
     template <typename I = iterator_t,
               std::enable_if_t<detray::ranges::random_access_iterator_v<I>,
                                bool> = true>
-    DETRAY_HOST_DEVICE constexpr auto operator[](const dindex i) const
+    DETRAY_HOST_DEVICE constexpr auto operator[](const difference_type i) const
         -> const value_type & {
-        difference_type offset{static_cast<difference_type>(i) -
-                               (m_iter - (*m_begins)[0])};
+        difference_type offset{i - (m_iter - (*m_begins)[0])};
         return *(*this + offset);
     }
 
@@ -340,10 +339,9 @@ struct join_iterator {
     template <typename I = iterator_t,
               std::enable_if_t<detray::ranges::random_access_iterator_v<I>,
                                bool> = true>
-    DETRAY_HOST_DEVICE constexpr auto operator[](const dindex i)
+    DETRAY_HOST_DEVICE constexpr auto operator[](const difference_type i)
         -> value_type & {
-        difference_type offset{static_cast<difference_type>(i) -
-                               (m_iter - (*m_begins)[0])};
+        difference_type offset{i - (m_iter - (*m_begins)[0])};
         return *(*this + offset);
     }
 

--- a/core/include/detray/utils/ranges/ranges.hpp
+++ b/core/include/detray/utils/ranges/ranges.hpp
@@ -14,6 +14,7 @@
 
 // System include(s)
 #include <cassert>
+#include <memory>
 #include <type_traits>
 
 namespace detray::ranges {
@@ -242,7 +243,7 @@ class view_interface : public base_view {
     /// @note requires contiguous range (not yet modelled)
     DETRAY_HOST_DEVICE
     constexpr auto data() const {
-        return empty() ? nullptr : &(*(_impl_ptr->begin()));
+        return empty() ? nullptr : std::addressof(*(_impl_ptr->begin()));
     }
 
     /// @note requires contiguous range (not yet modelled)
@@ -261,7 +262,7 @@ class view_interface : public base_view {
     /// @note requires forward range
     template <typename R = view_impl_t,
               std::enable_if_t<detray::ranges::forward_range_v<R>, bool> = true>
-    DETRAY_HOST_DEVICE constexpr auto front() const {
+    DETRAY_HOST_DEVICE constexpr decltype(auto) front() const {
         const auto bg = _impl_ptr->begin();
         assert(not empty());
         return *bg;
@@ -270,7 +271,7 @@ class view_interface : public base_view {
     /// @note requires forward range
     template <typename R = view_impl_t,
               std::enable_if_t<detray::ranges::forward_range_v<R>, bool> = true>
-    DETRAY_HOST_DEVICE constexpr auto front() {
+    DETRAY_HOST_DEVICE constexpr decltype(auto) front() {
         const auto bg = _impl_ptr->begin();
         assert(not empty());
         return *bg;
@@ -296,21 +297,26 @@ class view_interface : public base_view {
         return *(--sentinel);
     }
 
+    /// Subscript operator that takes detray @c dindex
+    ///
     /// @note requires random access range
     template <
         typename R = view_impl_t,
         std::enable_if_t<detray::ranges::random_access_range_v<R>, bool> = true>
     DETRAY_HOST_DEVICE constexpr decltype(auto) operator[](
         const dindex i) const {
-        return (_impl_ptr->begin())[i];
+        return (_impl_ptr->begin())
+            [static_cast<detray::ranges::range_difference_t<R>>(i)];
     }
-
+    /// Subscript operator that takes detray @c dindex
+    ///
     /// @note requires random access range
     template <
         typename R = view_impl_t,
         std::enable_if_t<detray::ranges::random_access_range_v<R>, bool> = true>
     DETRAY_HOST_DEVICE constexpr decltype(auto) operator[](const dindex i) {
-        return (_impl_ptr->begin())[i];
+        return (_impl_ptr->begin())
+            [static_cast<detray::ranges::range_difference_t<R>>(i)];
     }
 
     private:

--- a/core/include/detray/utils/ranges/subrange.hpp
+++ b/core/include/detray/utils/ranges/subrange.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -54,11 +54,15 @@ class subrange : public detray::ranges::view_interface<subrange<range_t>> {
     /// Construct from a @param range and starting position @param pos. Used
     /// as an overload when only a single position is needed.
     template <
-        typename deduced_range_t,
-        std::enable_if_t<detray::ranges::range_v<deduced_range_t>, bool> = true>
-    DETRAY_HOST_DEVICE constexpr subrange(deduced_range_t &&range,
-                                          difference_t pos)
-        : m_begin{detray::ranges::next(detray::ranges::begin(range), pos)},
+        typename deduced_range_t, typename index_t,
+        std::enable_if_t<detray::ranges::range_v<deduced_range_t>, bool> = true,
+        std::enable_if_t<
+            std::is_convertible_v<
+                index_t, detray::ranges::range_difference_t<deduced_range_t>>,
+            bool> = true>
+    DETRAY_HOST_DEVICE constexpr subrange(deduced_range_t &&range, index_t pos)
+        : m_begin{detray::ranges::next(detray::ranges::begin(range),
+                                       static_cast<difference_t>(pos))},
           m_end{detray::ranges::next(m_begin)} {}
 
     /// Construct from a @param range and an index range provided by a volume
@@ -79,10 +83,12 @@ class subrange : public detray::ranges::view_interface<subrange<range_t>> {
             true>
     DETRAY_HOST_DEVICE constexpr subrange(deduced_range_t &&range,
                                           index_range_t &&pos)
-        : m_begin{detray::ranges::next(detray::ranges::begin(range),
-                                       detray::detail::get<0>(pos))},
-          m_end{detray::ranges::next(detray::ranges::begin(range),
-                                     detray::detail::get<1>(pos))} {}
+        : m_begin{detray::ranges::next(
+              detray::ranges::begin(range),
+              static_cast<difference_t>(detray::detail::get<0>(pos)))},
+          m_end{detray::ranges::next(
+              detray::ranges::begin(range),
+              static_cast<difference_t>(detray::detail::get<1>(pos)))} {}
 
     /// Copy assignment operator
     DETRAY_HOST_DEVICE
@@ -122,11 +128,13 @@ template <
 DETRAY_HOST_DEVICE subrange(deduced_range_t &&range)->subrange<deduced_range_t>;
 
 template <
-    typename deduced_range_t,
-    std::enable_if_t<detray::ranges::range_v<deduced_range_t>, bool> = true>
-DETRAY_HOST_DEVICE subrange(
-    deduced_range_t &&range,
-    typename detray::ranges::range_difference_t<deduced_range_t> pos)
+    typename deduced_range_t, typename index_t,
+    std::enable_if_t<detray::ranges::range_v<deduced_range_t>, bool> = true,
+    std::enable_if_t<
+        std::is_convertible_v<
+            index_t, detray::ranges::range_difference_t<deduced_range_t>>,
+        bool> = true>
+DETRAY_HOST_DEVICE subrange(deduced_range_t &&range, index_t pos)
     ->subrange<deduced_range_t>;
 
 template <

--- a/core/include/detray/utils/ratio.hpp
+++ b/core/include/detray/utils/ratio.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,7 +12,8 @@
 
 namespace detray {
 
-// Helper struct to sum over variadic std::ratio
+/// Helper struct to sum over variadic std::ratio
+/// @{
 template <typename... ratios>
 struct ratio_sum_helper;
 
@@ -28,21 +29,21 @@ struct ratio_sum_helper<ratio1, ratio2, ratios...> {
 
     using next_helper = ratio_sum_helper<first_two_sum, ratios...>;
 
-    static constexpr bool is_done = (sizeof...(ratios) == 0);
-
     // recursive summation of first two std::ratio
-    using ratio = typename std::conditional_t<is_done, first_two_sum,
-                                              typename next_helper::ratio>;
+    using ratio =
+        typename std::conditional_t<sizeof...(ratios) == 0, first_two_sum,
+                                    typename next_helper::ratio>;
 };
+/// @}
 
-// Struct to sum over variadic std::ratio
+/// Struct to sum over variadic std::ratio
 template <typename... ratios>
 struct ratio_sum {
     using helper = ratio_sum_helper<ratios...>;
     using ratio = typename helper::ratio;
 };
 
-// Helper trait to check if the ratio is one
+/// Helper trait to check if the ratio is one
 template <typename R>
 struct is_ratio_one {
     static constexpr bool value = (R::num == R::den);

--- a/core/include/detray/utils/statistics.hpp
+++ b/core/include/detray/utils/statistics.hpp
@@ -24,7 +24,7 @@ inline auto mean(const range_t& r) noexcept(false) {
     using value_t = detray::ranges::range_value_t<range_t>;
 
     value_t sum = std::accumulate(r.begin(), r.end(), value_t{});
-    value_t mean = sum * (1.0f / r.size());
+    value_t mean = sum * (1.0f / static_cast<value_t>(r.size()));
 
     return mean;
 }
@@ -41,7 +41,7 @@ inline auto variance(const range_t& r) noexcept(false) {
                    [mean](value_t x) { return x - mean; });
     value_t sq_sum =
         std::inner_product(diff.begin(), diff.end(), diff.begin(), value_t{});
-    value_t variance = sq_sum * (1.0f / r.size());
+    value_t variance = sq_sum * (1.0f / static_cast<value_t>(r.size()));
 
     return variance;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 # Set the common C++ flags.
 include( detray-compiler-options-cpp )
+include_directories( SYSTEM $<TARGET_PROPERTY:dfelibs::dfelibs,INTERFACE_INCLUDE_DIRECTORIES> )
 
 # Include all of the code-holding sub-directories.
 add_subdirectory( common )

--- a/tests/benchmarks/core/benchmark_grids.cpp
+++ b/tests/benchmarks/core/benchmark_grids.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,18 +30,18 @@ darray<dindex, 2> zone22 = {2u, 2u};
 // TrackML detector has 25 x 60 cells int he detector grid
 using grid2r =
     grid2<replace_populator, axis::regular, axis::regular, serializer2>;
-grid2r::axis_p0_type xaxisr{25, 0., 25., host_mr};
-grid2r::axis_p1_type yaxisr{60, 0., 60., host_mr};
+grid2r::axis_p0_type xaxisr{25u, 0.f, 25.f, host_mr};
+grid2r::axis_p1_type yaxisr{60u, 0.f, 60.f, host_mr};
 
 grid2r g2r(std::move(xaxisr), std::move(yaxisr), host_mr);
 
 // This runs a reference test with a regular grid structure
 static void BM_REGULAR_GRID_BIN(benchmark::State &state) {
     for (auto _ : state) {
-        for (unsigned int itest = 0; itest < 1000000; ++itest) {
+        for (unsigned int itest = 0u; itest < 1000000u; ++itest) {
             test::point2<detray::scalar> p = {
-                static_cast<scalar>((rand() % 50) * 0.5),
-                static_cast<scalar>((rand() % 120) * 0.5)};
+                static_cast<scalar>((rand() % 50)) * 0.5f,
+                static_cast<scalar>((rand() % 120)) * 0.5f};
             g2r.bin(p);
         }
     }
@@ -49,10 +49,10 @@ static void BM_REGULAR_GRID_BIN(benchmark::State &state) {
 
 static void BM_REGULAR_GRID_ZONE(benchmark::State &state) {
     for (auto _ : state) {
-        for (unsigned int itest = 0; itest < 1000000; ++itest) {
+        for (unsigned int itest = 0u; itest < 1000000u; ++itest) {
             test::point2<detray::scalar> p = {
-                static_cast<scalar>((rand() % 50) * 0.5),
-                static_cast<scalar>((rand() % 120) * 0.5)};
+                static_cast<scalar>((rand() % 50)) * 0.5f,
+                static_cast<scalar>((rand() % 120)) * 0.5f};
             g2r.zone(p, {zone22, zone22});
         }
     }
@@ -61,12 +61,12 @@ static void BM_REGULAR_GRID_ZONE(benchmark::State &state) {
 auto construct_irregular_grid() {
     // Fill a 25 x 60 grid with an "irregular" axis
     dvector<scalar> xboundaries = {};
-    xboundaries.reserve(25);
+    xboundaries.reserve(25u);
     dvector<scalar> yboundaries = {};
-    yboundaries.reserve(60);
+    yboundaries.reserve(60u);
 
-    for (unsigned int i = 0; i < 61; ++i) {
-        if (i < 26) {
+    for (unsigned int i = 0u; i < 61u; ++i) {
+        if (i < 26u) {
             xboundaries.push_back(i);
         }
         yboundaries.push_back(i);
@@ -86,10 +86,10 @@ auto g2irr = construct_irregular_grid();
 // This runs a reference test with a irregular grid structure
 static void BM_IRREGULAR_GRID_BIN(benchmark::State &state) {
     for (auto _ : state) {
-        for (unsigned int itest = 0; itest < 1000000; ++itest) {
+        for (unsigned int itest = 0u; itest < 1000000u; ++itest) {
             test::point2<detray::scalar> p = {
-                static_cast<scalar>((rand() % 50) * 0.5),
-                static_cast<scalar>((rand() % 120) * 0.5)};
+                static_cast<scalar>((rand() % 50)) * 0.5f,
+                static_cast<scalar>((rand() % 120)) * 0.5f};
             g2irr.bin(p);
         }
     }
@@ -97,10 +97,10 @@ static void BM_IRREGULAR_GRID_BIN(benchmark::State &state) {
 
 static void BM_IRREGULAR_GRID_ZONE(benchmark::State &state) {
     for (auto _ : state) {
-        for (unsigned int itest = 0; itest < 1000000; ++itest) {
+        for (unsigned int itest = 0u; itest < 1000000u; ++itest) {
             test::point2<detray::scalar> p = {
-                static_cast<scalar>((rand() % 50) * 0.5),
-                static_cast<scalar>((rand() % 120) * 0.5)};
+                static_cast<scalar>((rand() % 50)) * 0.5f,
+                static_cast<scalar>((rand() % 120)) * 0.5f};
             g2irr.zone(p, {zone22, zone22});
         }
     }

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -25,14 +25,14 @@ vecmem::cuda::device_memory_resource dev_mr;
 vecmem::binary_page_memory_resource bp_mng_mr(mng_mr);
 
 // detector configuration
-constexpr std::size_t n_brl_layers = 4;
-constexpr std::size_t n_edc_layers = 7;
+constexpr std::size_t n_brl_layers{4u};
+constexpr std::size_t n_edc_layers{7u};
 
 void fill_tracks(vecmem::vector<free_track_parameters<transform3>> &tracks,
                  const std::size_t theta_steps, const std::size_t phi_steps) {
     // Set origin position of tracks
-    const point3 ori{0., 0., 0.};
-    const scalar mom_mag = 10. * unit<scalar>::GeV;
+    const point3 ori{0.f, 0.f, 0.f};
+    const scalar mom_mag{10.f * unit<scalar>::GeV};
 
     // Iterate through uniformly distributed momentum directions
     for (auto traj : uniform_track_generator<free_track_parameters<transform3>>(
@@ -66,7 +66,8 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
 
         // Get tracks
         vecmem::vector<free_track_parameters<transform3>> tracks(&host_mr);
-        fill_tracks(tracks, state.range(0), state.range(0));
+        fill_tracks(tracks, static_cast<std::size_t>(state.range(0)),
+                    static_cast<std::size_t>(state.range(0)));
 
         state.ResumeTiming();
 
@@ -106,7 +107,8 @@ static void BM_PROPAGATOR_CUDA(benchmark::State &state) {
 
         // Get tracks
         vecmem::vector<free_track_parameters<transform3>> tracks(&bp_mng_mr);
-        fill_tracks(tracks, state.range(0), state.range(0));
+        fill_tracks(tracks, static_cast<std::size_t>(state.range(0)),
+                    static_cast<std::size_t>(state.range(0)));
 
         state.ResumeTiming();
 

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
@@ -56,7 +56,7 @@ void propagator_benchmark(
     vecmem::data::jagged_vector_view<intersection_t>& candidates_data) {
 
     constexpr int thread_dim = 2 * WARP_SIZE;
-    int block_dim = tracks_data.size() / thread_dim + 1;
+    int block_dim = static_cast<int>(tracks_data.size()) / thread_dim + 1;
 
     // run the test kernel
     propagator_benchmark_kernel<<<block_dim, thread_dim>>>(

--- a/tests/common/include/tests/common/axis_rotation.inl
+++ b/tests/common/include/tests/common/axis_rotation.inl
@@ -1,11 +1,12 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 // Project include(s).
+#include "detray/definitions/units.hpp"
 #include "detray/utils/axis_rotation.hpp"
 
 // GTest include(s).
@@ -19,28 +20,28 @@ using size_type = typename matrix_operator::size_ty;
 template <size_type ROWS, size_type COLS>
 using matrix_type = typename matrix_operator::template matrix_type<ROWS, COLS>;
 
-const scalar isclose = 1e-5;
+constexpr scalar isclose{1e-5f};
 
 TEST(utils, axis_rotation) {
 
-    const vector3 axis{0, 0, 1};
+    const vector3 axis{0.f, 0.f, 1.f};
 
-    const vector3 v1{1, 0, 0};
+    const vector3 v1{1.f, 0.f, 0.f};
 
-    const auto u1 = axis_rotation<transform3>(axis, M_PI_2)(v1);
+    const auto u1 = axis_rotation<transform3>(axis, constant<scalar>::pi_2)(v1);
 
-    EXPECT_NEAR(u1[0], 0, isclose);
-    EXPECT_NEAR(u1[1], 1, isclose);
-    EXPECT_NEAR(u1[2], 0, isclose);
+    EXPECT_NEAR(u1[0], 0.f, isclose);
+    EXPECT_NEAR(u1[1], 1.f, isclose);
+    EXPECT_NEAR(u1[2], 0.f, isclose);
 
     matrix_type<3, 1> v2;
-    matrix_operator().element(v2, 0, 0) = 1. / M_SQRT2;
-    matrix_operator().element(v2, 1, 0) = 1. / M_SQRT2;
-    matrix_operator().element(v2, 2, 0) = 0;
+    matrix_operator().element(v2, 0, 0) = constant<scalar>::inv_sqrt2;
+    matrix_operator().element(v2, 1, 0) = constant<scalar>::inv_sqrt2;
+    matrix_operator().element(v2, 2, 0) = 0.f;
 
-    const auto u2 = axis_rotation<transform3>(axis, M_PI_4)(v2);
+    const auto u2 = axis_rotation<transform3>(axis, constant<scalar>::pi_4)(v2);
 
-    EXPECT_NEAR(matrix_operator().element(u2, 0, 0), 0, isclose);
-    EXPECT_NEAR(matrix_operator().element(u2, 1, 0), 1, isclose);
-    EXPECT_NEAR(matrix_operator().element(u2, 2, 0), 0, isclose);
+    EXPECT_NEAR(matrix_operator().element(u2, 0, 0), 0.f, isclose);
+    EXPECT_NEAR(matrix_operator().element(u2, 1, 0), 1.f, isclose);
+    EXPECT_NEAR(matrix_operator().element(u2, 2, 0), 0.f, isclose);
 }

--- a/tests/common/include/tests/common/benchmark_find_volume.inl
+++ b/tests/common/include/tests/common/benchmark_find_volume.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -27,18 +27,18 @@ using vector3 = __plugin::vector3<detray::scalar>;
 }  // namespace
 
 #ifdef DETRAY_BENCHMARKS_REP
-unsigned int gbench_repetitions = DETRAY_BENCHMARKS_REP;
+int gbench_repetitions = DETRAY_BENCHMARKS_REP;
 #else
-unsigned int gbench_repetitions = 0;
+int gbench_repetitions = 0;
 #endif
 
 // Detector configuration
-constexpr std::size_t n_brl_layers{4};
-constexpr std::size_t n_edc_layers{7};
+constexpr unsigned int n_brl_layers{4u};
+constexpr unsigned int n_edc_layers{7u};
 vecmem::host_memory_resource host_mr;
 auto d = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
 
-const unsigned int itest = 10000;
+const unsigned int itest = 10000u;
 
 // Benchmarks the cost of searching a volume by position
 static void BM_FIND_VOLUMES(benchmark::State &state) {
@@ -54,13 +54,14 @@ static void BM_FIND_VOLUMES(benchmark::State &state) {
     scalar step0{(range0[1] - range0[0]) / itest};
     scalar step1{(range1[1] - range1[0]) / itest};
 
-    std::size_t successful{0};
-    std::size_t unsuccessful{0};
+    std::size_t successful{0u};
+    std::size_t unsuccessful{0u};
 
     for (auto _ : state) {
-        for (unsigned int i1 = 0; i1 < itest; ++i1) {
-            for (unsigned int i0 = 0; i0 < itest; ++i0) {
-                vector3 rz{i0 * step0, 0., i1 * step1};
+        for (unsigned int i1 = 0u; i1 < itest; ++i1) {
+            for (unsigned int i0 = 0u; i0 < itest; ++i0) {
+                vector3 rz{static_cast<scalar>(i0) * step0, 0.f,
+                           static_cast<scalar>(i1) * step1};
                 const auto &v = d.volume_by_pos(rz);
 
                 benchmark::DoNotOptimize(successful);

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -29,18 +29,18 @@
 using namespace detray;
 
 #ifdef DETRAY_BENCHMARKS_REP
-unsigned int gbench_repetitions = DETRAY_BENCHMARKS_REP;
+int gbench_repetitions = DETRAY_BENCHMARKS_REP;
 #else
-unsigned int gbench_repetitions = 0;
+int gbench_repetitions = 0;
 #endif
 
-unsigned int theta_steps = 100;
-unsigned int phi_steps = 100;
+unsigned int theta_steps{100u};
+unsigned int phi_steps{100u};
 bool stream_file = false;
 
 // Detector configuration
-constexpr std::size_t n_brl_layers{4};
-constexpr std::size_t n_edc_layers{7};
+constexpr std::size_t n_brl_layers{4u};
+constexpr std::size_t n_edc_layers{7u};
 vecmem::host_memory_resource host_mr;
 auto d = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
 
@@ -61,13 +61,13 @@ static void BM_INTERSECT_ALL(benchmark::State &state) {
     {
         hit_out.open("tml_hits.csv");
     }*/
-    unsigned int hits = 0;
-    unsigned int missed = 0;
+    unsigned int hits{0u};
+    unsigned int missed{0u};
 
-    // point3 ori = {0., 0., 0.};
+    // point3 ori = {0.f, 0.f, 0.f};
 
     for (auto _ : state) {
-        point3<detray::scalar> pos{0., 0., 0.};
+        point3<detray::scalar> pos{0.f, 0.f, 0.f};
 
         // Iterate through uniformly distributed momentum directions
         for (const auto track :

--- a/tests/common/include/tests/common/benchmark_masks.inl
+++ b/tests/common/include/tests/common/benchmark_masks.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,17 +18,18 @@ using namespace detray;
 using namespace __plugin;
 
 #ifdef DETRAY_BENCHMARKS_REP
-unsigned int gbench_repetitions = DETRAY_BENCHMARKS_REP;
+int gbench_repetitions = DETRAY_BENCHMARKS_REP;
 #else
-unsigned int gbench_repetitions = 0;
+int gbench_repetitions = 0;
 #endif
 
-unsigned int steps_x3 = 1000;
-unsigned int steps_y3 = 1000;
-unsigned int steps_z3 = 1000;
+constexpr unsigned int steps_x3{1000u};
+constexpr unsigned int steps_y3{1000u};
+constexpr unsigned int steps_z3{1000u};
 
-unsigned int steps_x2 = sqrt(steps_x3 * steps_y3 * steps_z3);
-unsigned int steps_y2 = steps_x2;
+const unsigned int steps_x2 =
+    static_cast<unsigned int>(std::sqrt(steps_x3 * steps_y3 * steps_z3));
+const unsigned int steps_y2 = steps_x2;
 
 bool screen_output = false;
 
@@ -42,26 +43,26 @@ namespace {
 static void BM_RECTANGLE_2D_MASK(benchmark::State &state) {
     using point_t = typename mask<rectangle2D<>>::loc_point_t;
 
-    mask<rectangle2D<>, dindex, transform_t> r{0UL, 3.f, 4.f};
+    constexpr mask<rectangle2D<>, dindex, transform_t> r(0u, 3.f, 4.f);
 
-    scalar world = 10.;
-    scalar area = 4 * r[0] * r[1];
-    scalar rest = world * world - area;
+    constexpr scalar world{10.f};
+    constexpr scalar area{4.f * r[0] * r[1]};
+    constexpr scalar rest{world * world - area};
 
-    scalar sx = world / steps_x3;
-    scalar sy = world / steps_y3;
-    scalar sz = world / steps_z3;
+    constexpr scalar sx{world / steps_x3};
+    constexpr scalar sy{world / steps_y3};
+    constexpr scalar sz{world / steps_z3};
 
-    unsigned long inside = 0;
-    unsigned long outside = 0;
+    unsigned long inside = 0u;
+    unsigned long outside = 0u;
 
     for (auto _ : state) {
-        for (unsigned int ix = 0; ix < steps_x3; ++ix) {
-            scalar x = -0.5 * world + ix * sx;
-            for (unsigned int iy = 0; iy < steps_y3; ++iy) {
-                scalar y = -0.5 * world + iy * sy;
-                for (unsigned int iz = 0; iz < steps_z3; ++iz) {
-                    scalar z = -0.5 * world + iz * sz;
+        for (unsigned int ix = 0u; ix < steps_x3; ++ix) {
+            scalar x{-0.5f * world + static_cast<scalar>(ix) * sx};
+            for (unsigned int iy = 0u; iy < steps_y3; ++iy) {
+                scalar y{-0.5f * world + static_cast<scalar>(iy) * sy};
+                for (unsigned int iz = 0u; iz < steps_z3; ++iz) {
+                    scalar z{-0.5f * world + static_cast<scalar>(iz) * sz};
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
@@ -88,26 +89,26 @@ static void BM_RECTANGLE_2D_MASK(benchmark::State &state) {
 static void BM_TRAPEZOID_2D_MASK(benchmark::State &state) {
     using point_t = typename mask<trapezoid2D<>>::loc_point_t;
 
-    mask<trapezoid2D<>> t{0UL, 2.f, 3.f, 4.f};
+    constexpr mask<trapezoid2D<>> t{0u, 2.f, 3.f, 4.f};
 
-    scalar world = 10.;
-    scalar area = 2 * (t[0] + t[1]) * t[2];
-    scalar rest = world * world - area;
+    constexpr scalar world{10.f};
+    constexpr scalar area{2.f * (t[0] + t[1]) * t[2]};
+    constexpr scalar rest{world * world - area};
 
-    scalar sx = world / steps_x3;
-    scalar sy = world / steps_y3;
-    scalar sz = world / steps_z3;
+    constexpr scalar sx{world / steps_x3};
+    constexpr scalar sy{world / steps_y3};
+    constexpr scalar sz{world / steps_z3};
 
-    unsigned long inside = 0;
-    unsigned long outside = 0;
+    unsigned long inside = 0u;
+    unsigned long outside = 0u;
 
     for (auto _ : state) {
-        for (unsigned int ix = 0; ix < steps_x3; ++ix) {
-            scalar x = -0.5 * world + ix * sx;
-            for (unsigned int iy = 0; iy < steps_y3; ++iy) {
-                scalar y = -0.5 * world + iy * sy;
-                for (unsigned int iz = 0; iz < steps_z3; ++iz) {
-                    scalar z = -0.5 * world + iz * sz;
+        for (unsigned int ix = 0u; ix < steps_x3; ++ix) {
+            scalar x{-0.5f * world + static_cast<scalar>(ix) * sx};
+            for (unsigned int iy = 0u; iy < steps_y3; ++iy) {
+                scalar y{-0.5f * world + static_cast<scalar>(iy) * sy};
+                for (unsigned int iz = 0u; iz < steps_z3; ++iz) {
+                    scalar z{-0.5f * world + static_cast<scalar>(iz) * sz};
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
@@ -134,26 +135,26 @@ static void BM_TRAPEZOID_2D_MASK(benchmark::State &state) {
 static void BM_RING_2D_MASK(benchmark::State &state) {
     using point_t = typename mask<ring2D<>>::loc_point_t;
 
-    mask<ring2D<>> r{0UL, 0.f, 5.f};
+    constexpr mask<ring2D<>> r{0u, 0.f, 5.f};
 
-    scalar world = 10.;
-    scalar area = r[1] * r[1] * M_PI;
-    scalar rest = world * world - area;
+    constexpr scalar world{10.f};
+    constexpr scalar area{r[1] * r[1] * constant<scalar>::pi};
+    constexpr scalar rest{world * world - area};
 
-    scalar sx = world / steps_x3;
-    scalar sy = world / steps_y3;
-    scalar sz = world / steps_z3;
+    constexpr scalar sx{world / steps_x3};
+    constexpr scalar sy{world / steps_y3};
+    constexpr scalar sz{world / steps_z3};
 
-    unsigned long inside = 0;
-    unsigned long outside = 0;
+    unsigned long inside = 0u;
+    unsigned long outside = 0u;
 
     for (auto _ : state) {
-        for (unsigned int ix = 0; ix < steps_x3; ++ix) {
-            scalar x = -0.5 * world + ix * sx;
-            for (unsigned int iy = 0; iy < steps_y3; ++iy) {
-                scalar y = -0.5 * world + iy * sy;
-                for (unsigned int iz = 0; iz < steps_z3; ++iz) {
-                    scalar z = -0.5 * world + iz * sz;
+        for (unsigned int ix = 0u; ix < steps_x3; ++ix) {
+            scalar x{-0.5f * world + static_cast<scalar>(ix) * sx};
+            for (unsigned int iy = 0u; iy < steps_y3; ++iy) {
+                scalar y{-0.5f * world + static_cast<scalar>(iy) * sy};
+                for (unsigned int iz = 0u; iz < steps_z3; ++iz) {
+                    scalar z{-0.5f * world + static_cast<scalar>(iz) * sz};
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
@@ -179,26 +180,26 @@ static void BM_RING_2D_MASK(benchmark::State &state) {
 static void BM_DISC_2D_MASK(benchmark::State &state) {
     using point_t = typename mask<ring2D<>>::loc_point_t;
 
-    mask<ring2D<>> r{0UL, 2.f, 5.f};
+    constexpr mask<ring2D<>> r{0u, 2.f, 5.f};
 
-    scalar world = 10.;
-    scalar area = (r[1] * r[1] - r[0] * r[0]) * M_PI;
-    scalar rest = world * world - area;
+    constexpr scalar world{10.f};
+    constexpr scalar area{(r[1] * r[1] - r[0] * r[0]) * constant<scalar>::pi};
+    constexpr scalar rest{world * world - area};
 
-    scalar sx = world / steps_x3;
-    scalar sy = world / steps_y3;
-    scalar sz = world / steps_z3;
+    constexpr scalar sx{world / steps_x3};
+    constexpr scalar sy{world / steps_y3};
+    constexpr scalar sz{world / steps_z3};
 
-    unsigned long inside = 0;
-    unsigned long outside = 0;
+    unsigned long inside = 0u;
+    unsigned long outside = 0u;
 
     for (auto _ : state) {
-        for (unsigned int ix = 0; ix < steps_x3; ++ix) {
-            scalar x = -0.5 * world + ix * sx;
-            for (unsigned int iy = 0; iy < steps_y3; ++iy) {
-                scalar y = -0.5 * world + iy * sy;
-                for (unsigned int iz = 0; iz < steps_z3; ++iz) {
-                    scalar z = -0.5 * world + iz * sz;
+        for (unsigned int ix = 0u; ix < steps_x3; ++ix) {
+            scalar x{-0.5f * world + static_cast<scalar>(ix) * sx};
+            for (unsigned int iy = 0u; iy < steps_y3; ++iy) {
+                scalar y{-0.5f * world + static_cast<scalar>(iy) * sy};
+                for (unsigned int iz = 0u; iz < steps_z3; ++iz) {
+                    scalar z{-0.5f * world + static_cast<scalar>(iz) * sz};
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
@@ -224,29 +225,29 @@ static void BM_DISC_2D_MASK(benchmark::State &state) {
 static void BM_CYLINDER_2D_MASK(benchmark::State &state) {
     using point_t = typename mask<cylinder2D<>>::loc_point_t;
 
-    mask<cylinder2D<>> c{0UL, 3.f, 5.f, 0.f};
+    constexpr mask<cylinder2D<>> c{0u, 3.f, 5.f, 0.f};
 
-    scalar world = 10.;
+    constexpr scalar world{10.f};
 
-    scalar sx = world / steps_x3;
-    scalar sy = world / steps_y3;
-    scalar sz = world / steps_z3;
+    constexpr scalar sx{world / steps_x3};
+    constexpr scalar sy{world / steps_y3};
+    constexpr scalar sz{world / steps_z3};
 
-    unsigned long inside = 0;
-    unsigned long outside = 0;
+    unsigned long inside = 0u;
+    unsigned long outside = 0u;
 
     for (auto _ : state) {
-        for (unsigned int ix = 0; ix < steps_x3; ++ix) {
-            scalar x = -0.5 * world + ix * sx;
-            for (unsigned int iy = 0; iy < steps_y3; ++iy) {
-                scalar y = -0.5 * world + iy * sy;
-                for (unsigned int iz = 0; iz < steps_z3; ++iz) {
-                    scalar z = -0.5 * world + iz * sz;
+        for (unsigned int ix = 0u; ix < steps_x3; ++ix) {
+            scalar x{-0.5f * world + static_cast<scalar>(ix) * sx};
+            for (unsigned int iy = 0u; iy < steps_y3; ++iy) {
+                scalar y{-0.5f * world + static_cast<scalar>(iy) * sy};
+                for (unsigned int iz = 0u; iz < steps_z3; ++iz) {
+                    scalar z{-0.5f * world + static_cast<scalar>(iz) * sz};
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     point_t loc_p{c.to_local_frame(trf, {x, y, z})};
-                    if (c.is_inside(loc_p, 0.1) ==
+                    if (c.is_inside(loc_p, 0.1f) ==
                         intersection::status::e_inside) {
                         ++inside;
                     } else {
@@ -268,24 +269,25 @@ static void BM_CYLINDER_2D_MASK(benchmark::State &state) {
 static void BM_ANNULUS_2D_MASK(benchmark::State &state) {
     using point_t = typename mask<annulus2D<>>::loc_point_t;
 
-    mask<annulus2D<>> ann{0UL, 2.5f, 5.f, -0.64299f, 4.13173f, 1.f, 0.5f, 0.f};
+    constexpr mask<annulus2D<>> ann{0u,       2.5f, 5.f,  -0.64299f,
+                                    4.13173f, 1.f,  0.5f, 0.f};
 
-    scalar world = 10.;
+    constexpr scalar world{10.f};
 
-    scalar sx = world / steps_x3;
-    scalar sy = world / steps_y3;
-    scalar sz = world / steps_z3;
+    constexpr scalar sx{world / steps_x3};
+    constexpr scalar sy{world / steps_y3};
+    constexpr scalar sz{world / steps_z3};
 
-    unsigned long inside = 0;
-    unsigned long outside = 0;
+    unsigned long inside = 0u;
+    unsigned long outside = 0u;
 
     for (auto _ : state) {
-        for (unsigned int ix = 0; ix < steps_x3; ++ix) {
-            scalar x = -0.5 * world + ix * sx;
-            for (unsigned int iy = 0; iy < steps_y3; ++iy) {
-                scalar y = -0.5 * world + iy * sy;
-                for (unsigned int iz = 0; iz < steps_z3; ++iz) {
-                    scalar z = -0.5 * world + iz * sz;
+        for (unsigned int ix = 0u; ix < steps_x3; ++ix) {
+            scalar x{-0.5f * world + static_cast<scalar>(ix) * sx};
+            for (unsigned int iy = 0u; iy < steps_y3; ++iy) {
+                scalar y{-0.5f * world + static_cast<scalar>(iy) * sy};
+                for (unsigned int iz = 0u; iz < steps_z3; ++iz) {
+                    scalar z{-0.5f * world + static_cast<scalar>(iz) * sz};
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);

--- a/tests/common/include/tests/common/check_geometry_navigation.inl
+++ b/tests/common/include/tests/common/check_geometry_navigation.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -43,8 +43,8 @@ using free_track_parameters_type = free_track_parameters<transform3_type>;
 TEST(ALGEBRA_PLUGIN, straight_line_navigation) {
 
     // Detector configuration
-    constexpr std::size_t n_brl_layers{4};
-    constexpr std::size_t n_edc_layers{7};
+    constexpr std::size_t n_brl_layers{4u};
+    constexpr std::size_t n_edc_layers{7u};
     vecmem::host_memory_resource host_mr;
     auto det = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
 
@@ -57,10 +57,10 @@ TEST(ALGEBRA_PLUGIN, straight_line_navigation) {
     // Propagator
     propagator_t prop(stepper_t{}, navigator_t{});
 
-    constexpr std::size_t theta_steps{50};
-    constexpr std::size_t phi_steps{50};
+    constexpr std::size_t theta_steps{50u};
+    constexpr std::size_t phi_steps{50u};
 
-    const point3 ori{0., 0., 0.};
+    const point3 ori{0.f, 0.f, 0.f};
     // det.volume_by_pos(ori).index();
 
     // Iterate through uniformly distributed momentum directions
@@ -73,7 +73,7 @@ TEST(ALGEBRA_PLUGIN, straight_line_navigation) {
 
         // Now follow that ray with a track and check, if we find the same
         // volumes and distances along the way
-        free_track_parameters_type track(ray.pos(), 0, ray.dir(), -1);
+        free_track_parameters_type track(ray.pos(), 0.f, ray.dir(), -1.f);
         propagator_t::state propagation(track, det);
 
         // Retrieve navigation information
@@ -87,7 +87,7 @@ TEST(ALGEBRA_PLUGIN, straight_line_navigation) {
         EXPECT_EQ(obj_tracer.object_trace.size(), intersection_trace.size());
 
         std::stringstream debug_stream;
-        for (std::size_t intr_idx = 0; intr_idx < intersection_trace.size();
+        for (std::size_t intr_idx = 0u; intr_idx < intersection_trace.size();
              ++intr_idx) {
             debug_stream << "-------Intersection trace\n"
                          << "ray gun: "
@@ -98,13 +98,13 @@ TEST(ALGEBRA_PLUGIN, straight_line_navigation) {
         }
 
         // Check every single recorded intersection
-        for (std::size_t i = 0; i < obj_tracer.object_trace.size(); ++i) {
+        for (std::size_t i = 0u; i < obj_tracer.object_trace.size(); ++i) {
             if (obj_tracer[i].index != intersection_trace[i].second.index) {
                 // Intersection record at portal bound might be flipped
                 // (the portals overlap completely)
                 if (obj_tracer[i].index ==
-                        intersection_trace[i + 1].second.index and
-                    obj_tracer[i + 1].index ==
+                        intersection_trace[i + 1u].second.index and
+                    obj_tracer[i + 1u].index ==
                         intersection_trace[i].second.index) {
                     // Have already checked the next record
                     ++i;
@@ -123,16 +123,16 @@ TEST(ALGEBRA_PLUGIN, helix_navigation) {
     using namespace navigation;
 
     // Detector configuration
-    constexpr std::size_t n_brl_layers{4};
-    constexpr std::size_t n_edc_layers{7};
+    constexpr std::size_t n_brl_layers{4u};
+    constexpr std::size_t n_edc_layers{7u};
     vecmem::host_memory_resource host_mr;
 
     using b_field_t = decltype(
         create_toy_geometry(std::declval<vecmem::host_memory_resource &>(),
                             n_brl_layers, n_edc_layers))::bfield_type;
 
-    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
-                    2. * unit<scalar>::T};
+    const vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                    2.f * unit<scalar>::T};
 
     auto det = create_toy_geometry(
         host_mr,
@@ -148,15 +148,15 @@ TEST(ALGEBRA_PLUGIN, helix_navigation) {
     // Propagator
     propagator_t prop(stepper_t{}, navigator_t{});
 
-    constexpr std::size_t theta_steps{10};
-    constexpr std::size_t phi_steps{10};
+    constexpr std::size_t theta_steps{10u};
+    constexpr std::size_t phi_steps{10u};
 
     // det.volume_by_pos(ori).index();
-    const point3 ori{0., 0., 0.};
-    const scalar p_mag{10. * unit<scalar>::GeV};
+    const point3 ori{0.f, 0.f, 0.f};
+    const scalar p_mag{10.f * unit<scalar>::GeV};
 
     // Overstepping
-    constexpr scalar overstep_tol{-7. * unit<scalar>::um};
+    constexpr scalar overstep_tol{-7.f * unit<scalar>::um};
 
     // Iterate through uniformly distributed momentum directions
     for (auto track : uniform_track_generator<free_track_parameters_type>(
@@ -183,7 +183,7 @@ TEST(ALGEBRA_PLUGIN, helix_navigation) {
         ASSERT_TRUE(prop.propagate(propagation)) << debug_printer.to_string();
 
         std::stringstream debug_stream;
-        for (std::size_t intr_idx = 0; intr_idx < intersection_trace.size();
+        for (std::size_t intr_idx = 0u; intr_idx < intersection_trace.size();
              ++intr_idx) {
             debug_stream << "-------Intersection trace\n"
                          << "helix gun: "
@@ -198,13 +198,13 @@ TEST(ALGEBRA_PLUGIN, helix_navigation) {
             << debug_printer.to_string() << debug_stream.str();
 
         // Check every single recorded intersection
-        for (std::size_t i = 0; i < obj_tracer.object_trace.size(); ++i) {
+        for (std::size_t i = 0u; i < obj_tracer.object_trace.size(); ++i) {
             if (obj_tracer[i].index != intersection_trace[i].second.index) {
                 // Intersection record at portal bound might be flipped
                 // (the portals overlap completely)
                 if (obj_tracer[i].index ==
-                        intersection_trace[i + 1].second.index and
-                    obj_tracer[i + 1].index ==
+                        intersection_trace[i + 1u].second.index and
+                    obj_tracer[i + 1u].index ==
                         intersection_trace[i].second.index) {
                     // Have already checked the next record
                     ++i;

--- a/tests/common/include/tests/common/coordinate_cartesian2.inl
+++ b/tests/common/include/tests/common/coordinate_cartesian2.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -22,22 +22,22 @@ using size_type = typename matrix_operator::size_ty;
 template <size_type ROWS, size_type COLS>
 using matrix_type = typename matrix_operator::template matrix_type<ROWS, COLS>;
 
-const scalar isclose = 1e-5;
+const scalar isclose{1e-5f};
 
 // This test cartesian2 coordinate
 TEST(coordinate, cartesian2) {
 
     // Preparation work
-    const vector3 z = {0., 0., 1.};
-    const vector3 x = {1., 0., 0.};
-    const point3 t = {2., 3., 4.};
+    const vector3 z = {0.f, 0.f, 1.f};
+    const vector3 x = {1.f, 0.f, 0.f};
+    const point3 t = {2.f, 3.f, 4.f};
     const transform3 trf(t, z, x);
     const cartesian2<transform3> c2;
-    const point3 global1 = {4., 7., 4.};
-    const vector3 mom = {1., 2., 3.};
+    const point3 global1 = {4.f, 7.f, 4.f};
+    const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
-    const scalar time = 0.1;
-    const scalar charge = -1.;
+    const scalar time{0.1f};
+    const scalar charge{-1.f};
     struct dummy_mask {
     } mask;
 
@@ -45,8 +45,8 @@ TEST(coordinate, cartesian2) {
     const point2 local = c2.global_to_local(trf, global1, d);
 
     // Check if the local position is correct
-    ASSERT_NEAR(local[0], 2., isclose);
-    ASSERT_NEAR(local[1], 4., isclose);
+    ASSERT_NEAR(local[0], 2.f, isclose);
+    ASSERT_NEAR(local[1], 4.f, isclose);
 
     // Local to global transformation
     const point3 global2 = c2.local_to_global(trf, mask, local, d);
@@ -67,37 +67,37 @@ TEST(coordinate, cartesian2) {
     const matrix_operator m;
 
     // Check if the bound vector is correct
-    ASSERT_NEAR(m.element(bound_vec, 0, 0), 2., isclose);
-    ASSERT_NEAR(m.element(bound_vec, 1, 0), 4., isclose);
-    ASSERT_NEAR(m.element(bound_vec, 2, 0), 1.1071487,
+    ASSERT_NEAR(m.element(bound_vec, 0u, 0u), 2.f, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 1u, 0u), 4.f, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 2u, 0u), 1.1071487f,
                 isclose);  // atan(2)
-    ASSERT_NEAR(m.element(bound_vec, 3, 0), 0.64052231,
+    ASSERT_NEAR(m.element(bound_vec, 3u, 0u), 0.64052231f,
                 isclose);  // atan(sqrt(5)/3)
-    ASSERT_NEAR(m.element(bound_vec, 4, 0), -1 / 3.7416574, isclose);
-    ASSERT_NEAR(m.element(bound_vec, 5, 0), 0.1, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 4u, 0u), -1. / 3.7416574f, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 5u, 0u), 0.1f, isclose);
 
     // Check if the same free vector is obtained
-    for (int i = 0; i < 8; i++) {
-        ASSERT_NEAR(m.element(free_vec1, i, 0), m.element(free_vec2, i, 0),
+    for (unsigned int i = 0u; i < 8u; i++) {
+        ASSERT_NEAR(m.element(free_vec1, i, 0u), m.element(free_vec2, i, 0u),
                     isclose);
     }
 
     // Normal vector
     const vector3 n =
         c2.normal(trf, mask, free_params.pos(), free_params.dir());
-    ASSERT_EQ(n, vector3({0., 0., 1.}));
+    ASSERT_EQ(n, vector3({0.f, 0.f, 1.f}));
 
     // Test Jacobian transformation
     const matrix_type<6, 6> J =
         c2.free_to_bound_jacobian(trf, mask, free_vec1) *
         c2.bound_to_free_jacobian(trf, mask, bound_vec);
 
-    for (std::size_t i = 0; i < 6; i++) {
-        for (std::size_t j = 0; j < 6; j++) {
+    for (unsigned int i = 0u; i < 6u; i++) {
+        for (unsigned int j = 0u; j < 6u; j++) {
             if (i == j) {
-                EXPECT_NEAR(m.element(J, i, j), 1., isclose);
+                EXPECT_NEAR(m.element(J, i, j), 1.f, isclose);
             } else {
-                EXPECT_NEAR(m.element(J, i, j), 0., isclose);
+                EXPECT_NEAR(m.element(J, i, j), 0.f, isclose);
             }
         }
     }

--- a/tests/common/include/tests/common/coordinate_cartesian3.inl
+++ b/tests/common/include/tests/common/coordinate_cartesian3.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,19 +19,19 @@ using vector3 = __plugin::vector3<scalar>;
 using transform3 = __plugin::transform3<detray::scalar>;
 using matrix_operator = typename transform3::matrix_actor;
 
-const scalar isclose = 1e-5;
+const scalar isclose{1e-5f};
 
 // This test cartesian3 coordinate
 TEST(coordinate, cartesian3) {
 
     // Preparation work
-    const vector3 z = {0., 0., 1.};
-    const vector3 x = {1., 0., 0.};
-    const point3 t = {2., 3., 4.};
+    const vector3 z = {0.f, 0.f, 1.f};
+    const vector3 x = {1.f, 0.f, 0.f};
+    const point3 t = {2.f, 3.f, 4.f};
     const transform3 trf(t, z, x);
     const cartesian3<transform3> c3;
-    const point3 global1 = {4., 7., 5.};
-    const vector3 mom = {1., 2., 3.};
+    const point3 global1 = {4.f, 7.f, 5.f};
+    const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
     struct dummy_mask {
     } mask;
@@ -40,9 +40,9 @@ TEST(coordinate, cartesian3) {
     const point3 local = c3.global_to_local(trf, global1, d);
 
     // Check if the local position is correct
-    ASSERT_NEAR(local[0], 2., isclose);
-    ASSERT_NEAR(local[1], 4., isclose);
-    ASSERT_NEAR(local[2], 1., isclose);
+    ASSERT_NEAR(local[0], 2.f, isclose);
+    ASSERT_NEAR(local[1], 4.f, isclose);
+    ASSERT_NEAR(local[2], 1.f, isclose);
 
     // Local to global transformation
     const point3 global2 = c3.local_to_global(trf, mask, local, d);

--- a/tests/common/include/tests/common/coordinate_cylindrical2.inl
+++ b/tests/common/include/tests/common/coordinate_cylindrical2.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,9 +14,10 @@
 #include <gtest/gtest.h>
 
 // System include(s).
-#include <climits>
+#include <limits>
 
 using namespace detray;
+
 using point2 = __plugin::point2<scalar>;
 using point3 = __plugin::point3<scalar>;
 using vector3 = __plugin::vector3<scalar>;
@@ -26,34 +27,34 @@ using size_type = typename matrix_operator::size_ty;
 template <size_type ROWS, size_type COLS>
 using matrix_type = typename matrix_operator::template matrix_type<ROWS, COLS>;
 
-const scalar isclose = 1e-5;
+constexpr scalar isclose{1e-5f};
 
 // This test cylindrical2 coordinate
 TEST(coordinate, cylindrical2) {
 
     // Preparation work
-    const vector3 z = {0., 0., 1.};
-    const vector3 x = {1., 0., 0.};
-    const point3 t = {2., 3., 4.};
+    const vector3 z = {0.f, 0.f, 1.f};
+    const vector3 x = {1.f, 0.f, 0.f};
+    const point3 t = {2.f, 3.f, 4.f};
     const transform3 trf(t, z, x);
     const cylindrical2<transform3> c2;
     // Global position on surface
-    const point3 global1 = {scalar{3.4142136}, scalar{4.4142136}, scalar{9.}};
-    const vector3 mom = {1., 2., 3.};
+    const point3 global1 = {3.4142136f, 4.4142136f, 9.f};
+    const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
-    const scalar time = 0.1;
-    const scalar charge = -1.;
+    const scalar time{0.1f};
+    const scalar charge{-1.f};
 
-    const scalar r = 2.;
-    const scalar hz = std::numeric_limits<scalar>::infinity();
-    mask<cylinder2D<>> mask{0UL, r, -hz, hz};
+    const scalar r{2.f};
+    const scalar hz{std::numeric_limits<scalar>::infinity()};
+    mask<cylinder2D<>> mask{0u, r, -hz, hz};
 
     // Global to local transformation
     const point2 local = c2.global_to_local(trf, global1, d);
 
     // Check if the local position is correct
-    ASSERT_NEAR(local[0], r * scalar{M_PI_4}, isclose);
-    ASSERT_NEAR(local[1], 5., isclose);
+    ASSERT_NEAR(local[0], r * constant<scalar>::pi_4, isclose);
+    ASSERT_NEAR(local[1], 5.f, isclose);
 
     // Local to global transformation
     const point3 global2 = c2.local_to_global(trf, mask, local, d);
@@ -74,39 +75,40 @@ TEST(coordinate, cylindrical2) {
     const matrix_operator m;
 
     // Check if the bound vector is correct
-    ASSERT_NEAR(m.element(bound_vec, 0, 0), r * scalar{M_PI_4}, isclose);
-    ASSERT_NEAR(m.element(bound_vec, 1, 0), 5, isclose);
-    ASSERT_NEAR(m.element(bound_vec, 2, 0), 1.1071487,
+    ASSERT_NEAR(m.element(bound_vec, 0u, 0u), r * constant<scalar>::pi_4,
+                isclose);
+    ASSERT_NEAR(m.element(bound_vec, 1u, 0u), 5.f, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 2u, 0u), 1.1071487f,
                 isclose);  // atan(2)
-    ASSERT_NEAR(m.element(bound_vec, 3, 0), 0.64052231,
+    ASSERT_NEAR(m.element(bound_vec, 3u, 0u), 0.64052231f,
                 isclose);  // atan(sqrt(5)/3)
-    ASSERT_NEAR(m.element(bound_vec, 4, 0), -1 / 3.7416574, isclose);
-    ASSERT_NEAR(m.element(bound_vec, 5, 0), 0.1, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 4u, 0u), -1.f / 3.7416574f, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 5u, 0u), 0.1f, isclose);
 
     // Check if the same free vector is obtained
-    for (int i = 0; i < 8; i++) {
-        ASSERT_NEAR(m.element(free_vec1, i, 0), m.element(free_vec2, i, 0),
+    for (unsigned int i = 0u; i < 8u; i++) {
+        ASSERT_NEAR(m.element(free_vec1, i, 0u), m.element(free_vec2, i, 0u),
                     isclose);
     }
 
     // Normal vector
     const vector3 n =
         c2.normal(trf, mask, free_params.pos(), free_params.dir());
-    ASSERT_NEAR(n[0], 1. / std::sqrt(2), isclose);
-    ASSERT_NEAR(n[1], 1. / std::sqrt(2), isclose);
-    ASSERT_NEAR(n[2], 0., isclose);
+    ASSERT_NEAR(n[0], constant<scalar>::inv_sqrt2, isclose);
+    ASSERT_NEAR(n[1], constant<scalar>::inv_sqrt2, isclose);
+    ASSERT_NEAR(n[2], 0.f, isclose);
 
     // Test Jacobian transformation
     const matrix_type<6, 6> J =
         c2.free_to_bound_jacobian(trf, mask, free_vec1) *
         c2.bound_to_free_jacobian(trf, mask, bound_vec);
 
-    for (std::size_t i = 0; i < 6; i++) {
-        for (std::size_t j = 0; j < 6; j++) {
+    for (unsigned int i = 0u; i < 6u; i++) {
+        for (unsigned int j = 0u; j < 6u; j++) {
             if (i == j) {
-                EXPECT_NEAR(m.element(J, i, j), 1., isclose);
+                EXPECT_NEAR(m.element(J, i, j), 1.f, isclose);
             } else {
-                EXPECT_NEAR(m.element(J, i, j), 0., isclose);
+                EXPECT_NEAR(m.element(J, i, j), 0.f, isclose);
             }
         }
     }

--- a/tests/common/include/tests/common/coordinate_cylindrical3.inl
+++ b/tests/common/include/tests/common/coordinate_cylindrical3.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,25 +13,26 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
+
 using point2 = __plugin::point2<scalar>;
 using point3 = __plugin::point3<scalar>;
 using vector3 = __plugin::vector3<scalar>;
 using transform3 = __plugin::transform3<detray::scalar>;
 using matrix_operator = typename transform3::matrix_actor;
 
-const scalar isclose = 1e-5;
+constexpr scalar isclose{1e-5f};
 
 // This test cylindrical3 coordinate
 TEST(coordinate, cylindrical3) {
 
     // Preparation work
-    const vector3 z = {0., 0., 1.};
-    const vector3 x = {1., 0., 0.};
-    const point3 t = {2., 3., 4.};
+    const vector3 z = {0.f, 0.f, 1.f};
+    const vector3 x = {1.f, 0.f, 0.f};
+    const point3 t = {2.f, 3.f, 4.f};
     const transform3 trf(t, z, x);
     const cylindrical3<transform3> c3;
-    const point3 global1 = {scalar{3.4142136}, scalar{4.4142136}, scalar{9.}};
-    const vector3 mom = {1., 2., 3.};
+    const point3 global1 = {3.4142136f, 4.4142136f, 9.f};
+    const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
     struct dummy_mask {
     } mask;
@@ -40,9 +41,9 @@ TEST(coordinate, cylindrical3) {
     const point3 local = c3.global_to_local(trf, global1, d);
 
     // Check if the local position is correct
-    ASSERT_NEAR(local[0], 2, isclose);
-    ASSERT_NEAR(local[1], M_PI_4, isclose);
-    ASSERT_NEAR(local[2], 5., isclose);
+    ASSERT_NEAR(local[0], 2.f, isclose);
+    ASSERT_NEAR(local[1], constant<scalar>::pi_4, isclose);
+    ASSERT_NEAR(local[2], 5.f, isclose);
 
     // Local to global transformation
     const point3 global2 = c3.local_to_global(trf, mask, local, d);

--- a/tests/common/include/tests/common/coordinate_line2.inl
+++ b/tests/common/include/tests/common/coordinate_line2.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
+
 using point2 = __plugin::point2<scalar>;
 using point3 = __plugin::point3<scalar>;
 using vector3 = __plugin::vector3<scalar>;
@@ -22,23 +23,23 @@ using size_type = typename matrix_operator::size_ty;
 template <size_type ROWS, size_type COLS>
 using matrix_type = typename matrix_operator::template matrix_type<ROWS, COLS>;
 
-const scalar isclose = 1e-5;
+constexpr scalar isclose{1e-5f};
 
 TEST(coordinate, line2_case1) {
 
     // Preparation work
-    vector3 z = {1., 1., 1.};
+    vector3 z = {1.f, 1.f, 1.f};
     z = vector::normalize(z);
-    vector3 x = {1., 0., -1.};
+    vector3 x = {1.f, 0.f, -1.f};
     x = vector::normalize(x);
-    const point3 t = {0., 0., 0.};
+    const point3 t = {0.f, 0.f, 0.f};
     const transform3 trf(t, z, x);
     const line2<transform3> l2;
-    const point3 global1 = {1, 1.5, 0.5};
-    const vector3 mom = {0., 1., 1.};
+    const point3 global1 = {1.f, 1.5f, 0.5f};
+    const vector3 mom = {0.f, 1.f, 1.f};
     const vector3 d = vector::normalize(mom);
-    const scalar time = 0.1;
-    const scalar charge = -1.;
+    const scalar time{0.1f};
+    const scalar charge{-1.f};
     struct dummy_mask {
     } mask;
 
@@ -46,8 +47,8 @@ TEST(coordinate, line2_case1) {
     const point2 local = l2.global_to_local(trf, global1, d);
 
     // Check if the local position is correct
-    ASSERT_NEAR(local[0], -1. / sqrt(2), isclose);
-    ASSERT_NEAR(local[1], sqrt(3), isclose);
+    ASSERT_NEAR(local[0], -constant<scalar>::inv_sqrt2, isclose);
+    ASSERT_NEAR(local[1], std::sqrt(3.f), isclose);
 
     // Local to global transformation
     const point3 global2 = l2.local_to_global(trf, mask, local, d);
@@ -68,16 +69,18 @@ TEST(coordinate, line2_case1) {
     const matrix_operator m;
 
     // Check if the bound vector is correct
-    ASSERT_NEAR(m.element(bound_vec, 0, 0), -1. / sqrt(2), isclose);
-    ASSERT_NEAR(m.element(bound_vec, 1, 0), sqrt(3), isclose);
-    ASSERT_NEAR(m.element(bound_vec, 2, 0), M_PI_2, isclose);
-    ASSERT_NEAR(m.element(bound_vec, 3, 0), M_PI_4, isclose);
-    ASSERT_NEAR(m.element(bound_vec, 4, 0), -1. / sqrt(2), isclose);
-    ASSERT_NEAR(m.element(bound_vec, 5, 0), 0.1, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 0u, 0u), -constant<scalar>::inv_sqrt2,
+                isclose);
+    ASSERT_NEAR(m.element(bound_vec, 1u, 0u), std::sqrt(3.f), isclose);
+    ASSERT_NEAR(m.element(bound_vec, 2u, 0u), constant<scalar>::pi_2, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 3u, 0u), constant<scalar>::pi_4, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 4u, 0u), -constant<scalar>::inv_sqrt2,
+                isclose);
+    ASSERT_NEAR(m.element(bound_vec, 5u, 0u), 0.1f, isclose);
 
     // Check if the same free vector is obtained
-    for (int i = 0; i < 8; i++) {
-        ASSERT_NEAR(m.element(free_vec1, i, 0), m.element(free_vec2, i, 0),
+    for (unsigned int i = 0u; i < 8u; i++) {
+        ASSERT_NEAR(m.element(free_vec1, i, 0u), m.element(free_vec2, i, 0u),
                     isclose);
     }
 
@@ -86,12 +89,12 @@ TEST(coordinate, line2_case1) {
         l2.free_to_bound_jacobian(trf, mask, free_vec1) *
         l2.bound_to_free_jacobian(trf, mask, bound_vec);
 
-    for (std::size_t i = 0; i < 6; i++) {
-        for (std::size_t j = 0; j < 6; j++) {
+    for (unsigned int i = 0u; i < 6u; i++) {
+        for (unsigned int j = 0u; j < 6u; j++) {
             if (i == j) {
-                EXPECT_NEAR(m.element(J, i, j), 1., isclose);
+                EXPECT_NEAR(m.element(J, i, j), 1.f, isclose);
             } else {
-                EXPECT_NEAR(m.element(J, i, j), 0., isclose);
+                EXPECT_NEAR(m.element(J, i, j), 0.f, isclose);
             }
         }
     }
@@ -100,18 +103,18 @@ TEST(coordinate, line2_case1) {
 TEST(coordinate, line2_case2) {
 
     // Preparation work
-    vector3 z = {1., 2., 3.};
+    vector3 z = {1.f, 2.f, 3.f};
     z = vector::normalize(z);
-    vector3 x = {2., -4., 2.};
+    vector3 x = {2.f, -4.f, 2.f};
     x = vector::normalize(x);
-    const point3 t = {0., 0., 0.};
+    const point3 t = {0.f, 0.f, 0.f};
     const transform3 trf(t, z, x);
     const line2<transform3> l2;
-    const point2 local1 = {1, 2};
-    const vector3 mom = {1., 6., -2.};
+    const point2 local1 = {1.f, 2.f};
+    const vector3 mom = {1.f, 6.f, -2.f};
     const vector3 d = vector::normalize(mom);
-    const scalar time = 0.1;
-    const scalar charge = -1.;
+    const scalar time{0.1f};
+    const scalar charge{-1.f};
     struct dummy_mask {
     } mask;
 
@@ -137,12 +140,12 @@ TEST(coordinate, line2_case2) {
 
     const matrix_operator m;
 
-    for (std::size_t i = 0; i < 6; i++) {
-        for (std::size_t j = 0; j < 6; j++) {
+    for (unsigned int i = 0u; i < 6u; i++) {
+        for (unsigned int j = 0u; j < 6u; j++) {
             if (i == j) {
-                EXPECT_NEAR(m.element(J, i, j), 1., isclose);
+                EXPECT_NEAR(m.element(J, i, j), 1.f, isclose);
             } else {
-                EXPECT_NEAR(m.element(J, i, j), 0., isclose);
+                EXPECT_NEAR(m.element(J, i, j), 0.f, isclose);
             }
         }
     }

--- a/tests/common/include/tests/common/coordinate_polar2.inl
+++ b/tests/common/include/tests/common/coordinate_polar2.inl
@@ -22,22 +22,22 @@ using size_type = typename matrix_operator::size_ty;
 template <size_type ROWS, size_type COLS>
 using matrix_type = typename matrix_operator::template matrix_type<ROWS, COLS>;
 
-const scalar isclose = 1e-5;
+const scalar isclose{1e-5f};
 
 // This test polar2 coordinate
 TEST(coordinate, polar2) {
 
     // Preparation work
-    const vector3 z = {0., 0., 1.};
-    const vector3 x = {1., 0., 0.};
-    const point3 t = {2., 3., 4.};
+    const vector3 z = {0.f, 0.f, 1.f};
+    const vector3 x = {1.f, 0.f, 0.f};
+    const point3 t = {2.f, 3.f, 4.f};
     const transform3 trf(t, z, x);
     const polar2<transform3> p2;
-    const point3 global1 = {4., 7., 4.};
-    const vector3 mom = {1., 2., 3.};
+    const point3 global1 = {4.f, 7.f, 4.f};
+    const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
-    const scalar time = 0.1;
-    const scalar charge = -1.;
+    const scalar time{0.1f};
+    const scalar charge{-1.};
     struct dummy_mask {
     } mask;
 
@@ -45,8 +45,8 @@ TEST(coordinate, polar2) {
     const point2 local = p2.global_to_local(trf, global1, d);
 
     // Check if the local position is correct
-    ASSERT_NEAR(local[0], std::sqrt(20.), isclose);
-    ASSERT_NEAR(local[1], atan2(4., 2.), isclose);
+    ASSERT_NEAR(local[0], std::sqrt(20.f), isclose);
+    ASSERT_NEAR(local[1], std::atan2(4.f, 2.f), isclose);
 
     // Local to global transformation
     const point3 global2 = p2.local_to_global(trf, mask, local, d);
@@ -67,38 +67,38 @@ TEST(coordinate, polar2) {
     const matrix_operator m;
 
     // Check if the bound vector is correct
-    ASSERT_NEAR(m.element(bound_vec, 0, 0), std::sqrt(20.), isclose);
-    ASSERT_NEAR(m.element(bound_vec, 1, 0), atan2(4., 2.), isclose);
-    ASSERT_NEAR(m.element(bound_vec, 2, 0), 1.1071487,
+    ASSERT_NEAR(m.element(bound_vec, 0u, 0u), std::sqrt(20.f), isclose);
+    ASSERT_NEAR(m.element(bound_vec, 1u, 0u), std::atan2(4.f, 2.f), isclose);
+    ASSERT_NEAR(m.element(bound_vec, 2u, 0u), 1.1071487f,
                 isclose);  // atan(2)
-    ASSERT_NEAR(m.element(bound_vec, 3, 0), 0.64052231,
+    ASSERT_NEAR(m.element(bound_vec, 3u, 0u), 0.64052231f,
                 isclose);  // atan(sqrt(5)/3)
-    ASSERT_NEAR(m.element(bound_vec, 4, 0), -1 / 3.7416574, isclose);
-    ASSERT_NEAR(m.element(bound_vec, 5, 0), 0.1, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 4u, 0u), -1.f / 3.7416574f, isclose);
+    ASSERT_NEAR(m.element(bound_vec, 5u, 0u), 0.1f, isclose);
 
     // Check if the same free vector is obtained
-    for (int i = 0; i < 8; i++) {
-        ASSERT_NEAR(m.element(free_vec1, i, 0), m.element(free_vec2, i, 0),
+    for (unsigned int i = 0u; i < 8u; i++) {
+        ASSERT_NEAR(m.element(free_vec1, i, 0u), m.element(free_vec2, i, 0u),
                     isclose);
     }
 
     // Normal vector
     const vector3 n =
         p2.normal(trf, mask, free_params.pos(), free_params.dir());
-    ASSERT_EQ(n, vector3({0., 0., 1.}));
+    ASSERT_EQ(n, vector3({0.f, 0.f, 1.f}));
 
     // Test Jacobian transformation
     const matrix_type<6, 6> J =
         p2.free_to_bound_jacobian(trf, mask, free_vec1) *
         p2.bound_to_free_jacobian(trf, mask, bound_vec);
 
-    for (std::size_t i = 0; i < 6; i++) {
-        for (std::size_t j = 0; j < 6; j++) {
+    for (unsigned int i = 0u; i < 6u; i++) {
+        for (unsigned int j = 0u; j < 6u; j++) {
 
             if (i == j) {
-                EXPECT_NEAR(m.element(J, i, j), 1., isclose);
+                EXPECT_NEAR(m.element(J, i, j), 1.f, isclose);
             } else {
-                EXPECT_NEAR(m.element(J, i, j), 0., isclose);
+                EXPECT_NEAR(m.element(J, i, j), 0.f, isclose);
             }
         }
     }

--- a/tests/common/include/tests/common/core_container.inl
+++ b/tests/common/include/tests/common/core_container.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,11 +23,15 @@
 
 using namespace detray;
 
+constexpr float tol_single{1e-7f};
+constexpr double tol_double{1e-31f};
+
 struct test_func {
     using output_type = std::size_t;
 
     template <typename container_t>
-    output_type operator()(const container_t& coll, const int /*index*/) {
+    output_type operator()(const container_t& coll,
+                           const unsigned int /*index*/) {
         return coll.size();
     }
 };
@@ -69,8 +73,8 @@ TEST(container, tuple_container) {
     device_tuple_t dev_container(view);
 
     // Base container function check
-    EXPECT_EQ(container.size(), 3);
-    EXPECT_EQ(dev_container.size(), 3);
+    EXPECT_EQ(container.size(), 3u);
+    EXPECT_EQ(dev_container.size(), 3u);
 
     EXPECT_TRUE(container.get<0>().empty());
     EXPECT_TRUE(container.get<1>().empty());
@@ -88,30 +92,30 @@ TEST(container, vector_multi_type_store) {
         vector_store(resource);
 
     // Base container function check
-    EXPECT_EQ(vector_store.n_collections(), 3);
+    EXPECT_EQ(vector_store.n_collections(), 3u);
     EXPECT_EQ(vector_store.empty<0>(), true);
     EXPECT_EQ(vector_store.empty<1>(), true);
     EXPECT_EQ(vector_store.empty<2>(), true);
-    EXPECT_EQ(vector_store.size<0>(), 0UL);
-    EXPECT_EQ(vector_store.size<1>(), 0UL);
-    EXPECT_EQ(vector_store.size<2>(), 0UL);
+    EXPECT_EQ(vector_store.size<0>(), 0u);
+    EXPECT_EQ(vector_store.size<1>(), 0u);
+    EXPECT_EQ(vector_store.size<2>(), 0u);
 
     // Add elements to the container
-    vector_store.push_back<0>(1UL);
-    vector_store.emplace_back<0>(empty_context{}, 2UL);
+    vector_store.push_back<0>(1u);
+    vector_store.emplace_back<0>(empty_context{}, 2u);
     vector_store.push_back<1>(3.1f);
     vector_store.emplace_back<1>(empty_context{}, 4.5f);
     vector_store.push_back<2>(5.5);
-    vector_store.emplace_back<2>(empty_context{}, 6.);
+    vector_store.emplace_back<2>(empty_context{}, 6.f);
 
     EXPECT_EQ(vector_store.empty<0>(), false);
     EXPECT_EQ(vector_store.empty<1>(), false);
     EXPECT_EQ(vector_store.empty<2>(), false);
-    EXPECT_EQ(vector_store.size<0>(), 2UL);
-    EXPECT_EQ(vector_store.size<1>(), 2UL);
-    EXPECT_EQ(vector_store.size<2>(), 2UL);
+    EXPECT_EQ(vector_store.size<0>(), 2u);
+    EXPECT_EQ(vector_store.size<1>(), 2u);
+    EXPECT_EQ(vector_store.size<2>(), 2u);
 
-    vecmem::vector<std::size_t> int_vec{3UL, 4UL, 5UL};
+    vecmem::vector<std::size_t> int_vec{3u, 4u, 5u};
     vector_store.insert(int_vec);
 
     vecmem::vector<float> float_vec{12.1f};
@@ -120,28 +124,28 @@ TEST(container, vector_multi_type_store) {
     vector_store.insert(vecmem::vector<double>{10.5, 7.6});
 
     // int collectiont
-    EXPECT_EQ(vector_store.size<0>(), 5UL);
-    EXPECT_EQ(vector_store.get<0>()[0], 1UL);
-    EXPECT_EQ(vector_store.get<0>()[1], 2UL);
-    EXPECT_EQ(vector_store.get<0>()[2], 3UL);
-    EXPECT_EQ(vector_store.get<0>()[3], 4UL);
-    EXPECT_EQ(vector_store.get<0>()[4], 5UL);
+    EXPECT_EQ(vector_store.size<0>(), 5u);
+    EXPECT_EQ(vector_store.get<0>()[0], 1u);
+    EXPECT_EQ(vector_store.get<0>()[1], 2u);
+    EXPECT_EQ(vector_store.get<0>()[2], 3u);
+    EXPECT_EQ(vector_store.get<0>()[3], 4u);
+    EXPECT_EQ(vector_store.get<0>()[4], 5u);
 
     // float collectiont
-    EXPECT_EQ(vector_store.size<1>(), 3UL);
-    EXPECT_FLOAT_EQ(vector_store.get<1>()[0], 3.1f);
-    EXPECT_FLOAT_EQ(vector_store.get<1>()[1], 4.5f);
-    EXPECT_FLOAT_EQ(vector_store.get<1>()[2], 12.1f);
+    EXPECT_EQ(vector_store.size<1>(), 3u);
+    EXPECT_NEAR(vector_store.get<1>()[0], 3.1f, tol_single);
+    EXPECT_NEAR(vector_store.get<1>()[1], 4.5f, tol_single);
+    EXPECT_NEAR(vector_store.get<1>()[2], 12.1f, tol_single);
 
     // double collectiont
-    EXPECT_EQ(vector_store.size<2>(), 4UL);
-    EXPECT_FLOAT_EQ(vector_store.get<2>()[0], 5.5);
-    EXPECT_FLOAT_EQ(vector_store.get<2>()[1], 6.);
-    EXPECT_FLOAT_EQ(vector_store.get<2>()[2], 10.5);
-    EXPECT_FLOAT_EQ(vector_store.get<2>()[3], 7.6);
+    EXPECT_EQ(vector_store.size<2>(), 4u);
+    EXPECT_NEAR(vector_store.get<2>()[0], 5.5, tol_double);
+    EXPECT_NEAR(vector_store.get<2>()[1], 6., tol_double);
+    EXPECT_NEAR(vector_store.get<2>()[2], 10.5, tol_double);
+    EXPECT_NEAR(vector_store.get<2>()[3], 7.6, tol_double);
 
     // call functor
-    EXPECT_EQ(vector_store.call<test_func>(std::make_pair(0, 0)), 5UL);
-    EXPECT_EQ(vector_store.call<test_func>(std::make_pair(1, 0)), 3UL);
-    EXPECT_EQ(vector_store.call<test_func>(std::make_pair(2, 0)), 4UL);
+    EXPECT_EQ(vector_store.call<test_func>(std::make_pair(0u, 0u)), 5u);
+    EXPECT_EQ(vector_store.call<test_func>(std::make_pair(1u, 0u)), 3u);
+    EXPECT_EQ(vector_store.call<test_func>(std::make_pair(2u, 0u)), 4u);
 }

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -28,6 +28,8 @@ using point3 = __plugin::point3<detray::scalar>;
 using vector3 = __plugin::vector3<detray::scalar>;
 using point2 = __plugin::point2<detray::scalar>;
 
+constexpr detray::scalar tol{1e-7f};
+
 /// Adds a few surfaces to the detector.
 template <typename detector_t>
 void prefill_detector(detector_t& d,
@@ -49,7 +51,7 @@ void prefill_detector(detector_t& d,
     /// Surface 0
     point3 t0{0.f, 0.f, 0.f};
     trfs.emplace_back(ctx, t0);
-    masks.template emplace_back<mask_id::e_rectangle2>(empty_ctx, 0UL, -3.f,
+    masks.template emplace_back<mask_id::e_rectangle2>(empty_ctx, 0u, -3.f,
                                                        3.f);
     materials.template emplace_back<material_id::e_slab>(
         empty_ctx, detray::gold<scalar_t>(), 3.f);
@@ -58,13 +60,13 @@ void prefill_detector(detector_t& d,
     material_link_t material_link{
         material_id::e_slab,
         materials.template size<material_id::e_slab>() - 1};
-    surfaces.emplace_back(trfs.size(ctx) - 1, mask_link, material_link, 0UL,
+    surfaces.emplace_back(trfs.size(ctx) - 1, mask_link, material_link, 0u,
                           detray::dindex_invalid,
                           detray::surface_id::e_sensitive);
     /// Surface 1
     point3 t1{1.f, 0.f, 0.f};
     trfs.emplace_back(ctx, t1);
-    masks.template emplace_back<mask_id::e_annulus2>(empty_ctx, 0UL, 1.f, 2.f,
+    masks.template emplace_back<mask_id::e_annulus2>(empty_ctx, 0u, 1.f, 2.f,
                                                      3.f, 4.f, 5.f, 6.f, 7.f);
     materials.template emplace_back<material_id::e_slab>(
         empty_ctx, detray::tungsten<scalar_t>(), 12.f);
@@ -73,14 +75,14 @@ void prefill_detector(detector_t& d,
                  masks.template size<mask_id::e_annulus2>() - 1};
     material_link = {material_id::e_slab,
                      materials.template size<material_id::e_slab>() - 1};
-    surfaces.emplace_back(trfs.size(ctx) - 1, mask_link, material_link, 0UL,
+    surfaces.emplace_back(trfs.size(ctx) - 1, mask_link, material_link, 0u,
                           detray::dindex_invalid,
                           detray::surface_id::e_sensitive);
 
     /// Surface 2
     point3 t2{2.f, 0.f, 0.f};
     trfs.emplace_back(ctx, t2);
-    masks.template emplace_back<mask_id::e_trapezoid2>(empty_ctx, 0UL, 1.f, 2.f,
+    masks.template emplace_back<mask_id::e_trapezoid2>(empty_ctx, 0u, 1.f, 2.f,
                                                        3.f);
     materials.template emplace_back<material_id::e_rod>(
         empty_ctx, detray::aluminium<scalar_t>(), 4.f);
@@ -89,13 +91,14 @@ void prefill_detector(detector_t& d,
                  masks.template size<mask_id::e_trapezoid2>() - 1};
     material_link = {material_id::e_rod,
                      materials.template size<material_id::e_rod>() - 1};
-    surfaces.emplace_back(trfs.size(ctx) - 1, mask_link, material_link, 0UL,
+    surfaces.emplace_back(trfs.size(ctx) - 1, mask_link, material_link, 0u,
                           detray::dindex_invalid,
                           detray::surface_id::e_sensitive);
 
     // Add the new data
     d.new_volume(detray::volume_id::e_cylinder,
-                 {0.f, 10.f, -5.f, 5.f, -M_PI, M_PI});
+                 {0.f, 10.f, -5.f, 5.f, -detray::constant<scalar_t>::pi,
+                  detray::constant<scalar_t>::pi});
     d.append_surfaces(std::move(surfaces));
     d.append_transforms(std::move(trfs));
     d.append_masks(std::move(masks));
@@ -152,24 +155,24 @@ TEST(detector, detector) {
     prefill_detector(d, geo_ctx);
     // TODO: add B-field check
 
-    EXPECT_EQ(d.volumes().size(), 1UL);
-    EXPECT_EQ(d.surfaces().size(), 3UL);
-    EXPECT_EQ(d.transform_store().size(), 3UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_rectangle2>(), 1UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_trapezoid2>(), 1UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_annulus2>(), 1UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_cylinder2>(), 0UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_cylinder2>(), 0UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_ring2>(), 0UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_ring2>(), 0UL);
-    EXPECT_EQ(d.material_store().template size<material_id::e_slab>(), 2UL);
-    EXPECT_EQ(d.material_store().template size<material_id::e_rod>(), 1UL);
+    EXPECT_EQ(d.volumes().size(), 1u);
+    EXPECT_EQ(d.surfaces().size(), 3u);
+    EXPECT_EQ(d.transform_store().size(), 3u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_rectangle2>(), 1u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_trapezoid2>(), 1u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_annulus2>(), 1u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_cylinder2>(), 0u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_cylinder2>(), 0u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_ring2>(), 0u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_ring2>(), 0u);
+    EXPECT_EQ(d.material_store().template size<material_id::e_slab>(), 2u);
+    EXPECT_EQ(d.material_store().template size<material_id::e_rod>(), 1u);
     EXPECT_EQ(d.sf_finder_store().template size<finder_id::e_brute_force>(),
-              0UL);
-    EXPECT_EQ(d.sf_finder_store().template size<finder_id::e_disc_grid>(), 0UL);
+              0u);
+    EXPECT_EQ(d.sf_finder_store().template size<finder_id::e_disc_grid>(), 0u);
     EXPECT_EQ(d.sf_finder_store().template size<finder_id::e_cylinder_grid>(),
-              0UL);
-    EXPECT_EQ(d.sf_finder_store().template size<finder_id::e_default>(), 0UL);
+              0u);
+    EXPECT_EQ(d.sf_finder_store().template size<finder_id::e_default>(), 0u);
 }
 
 /// This tests the functionality of a surface factory
@@ -194,14 +197,14 @@ TEST(detector, surface_factory) {
     typename portal_cylinder_factory::sf_data_collection cyl_sf_data;
     cyl_sf_data.push_back(
         std::make_unique<surface_data<detector_t, cylinder2D<>>>(
-            transform3(point3{0.f, 0.f, -1000.f}), 0UL,
+            transform3(point3{0.f, 0.f, -1000.f}), 0u,
             std::vector<scalar>{10.f, -1000.f, 1500.f}));
     cyl_sf_data.push_back(
         std::make_unique<surface_data<detector_t, cylinder2D<>>>(
-            transform3(point3{0.f, 0.f, 1000.f}), 2UL,
+            transform3(point3{0.f, 0.f, 1000.f}), 2u,
             std::vector<scalar>{20.f, -1500.f, 1000.f}));
 
-    EXPECT_EQ(pt_cyl_factory->size(), 0UL);
+    EXPECT_EQ(pt_cyl_factory->size(), 0u);
     EXPECT_TRUE(pt_cyl_factory->components().empty());
     EXPECT_TRUE(pt_cyl_factory->transforms().empty());
     EXPECT_TRUE(pt_cyl_factory->volume_links().empty());
@@ -210,17 +213,17 @@ TEST(detector, surface_factory) {
     // data should be safely added to the factory by now
     cyl_sf_data.clear();
 
-    EXPECT_EQ(pt_cyl_factory->size(), 2UL);
-    EXPECT_EQ(pt_cyl_factory->components().size(), 2UL);
-    EXPECT_EQ(pt_cyl_factory->transforms().size(), 2UL);
-    EXPECT_EQ(pt_cyl_factory->volume_links().size(), 2UL);
+    EXPECT_EQ(pt_cyl_factory->size(), 2u);
+    EXPECT_EQ(pt_cyl_factory->components().size(), 2u);
+    EXPECT_EQ(pt_cyl_factory->transforms().size(), 2u);
+    EXPECT_EQ(pt_cyl_factory->volume_links().size(), 2u);
     const auto& portal_cyl_comps = pt_cyl_factory->components().front();
-    EXPECT_FLOAT_EQ(portal_cyl_comps[0], scalar{10.f});
-    EXPECT_FLOAT_EQ(portal_cyl_comps[1], scalar{-1000.f});
-    EXPECT_FLOAT_EQ(portal_cyl_comps[2], scalar{1500.f});
+    EXPECT_NEAR(portal_cyl_comps[0], 10.f, tol);
+    EXPECT_NEAR(portal_cyl_comps[1], -1000.f, tol);
+    EXPECT_NEAR(portal_cyl_comps[2], 1500.f, tol);
     const auto& portal_cyl_vol_links = pt_cyl_factory->volume_links();
-    EXPECT_EQ(portal_cyl_vol_links[0], 0UL);
-    EXPECT_EQ(portal_cyl_vol_links[1], 2UL);
+    EXPECT_EQ(portal_cyl_vol_links[0], 0u);
+    EXPECT_EQ(portal_cyl_vol_links[1], 2u);
 
     //
     // check sensitive cylinder
@@ -233,14 +236,14 @@ TEST(detector, surface_factory) {
 
     cyl_sf_data.push_back(
         std::make_unique<surface_data<detector_t, cylinder2D<>>>(
-            transform3(point3{0.f, 0.f, -50.f}), 1UL,
+            transform3(point3{0.f, 0.f, -50.f}), 1u,
             std::vector<scalar>{5.f, -900.f, 900.f}));
     cyl_sf_data.push_back(
         std::make_unique<surface_data<detector_t, cylinder2D<>>>(
-            transform3(point3{0.f, 0.f, 50.f}), 1UL,
+            transform3(point3{0.f, 0.f, 50.f}), 1u,
             std::vector<scalar>{5.f, -900.f, 900.f}));
 
-    EXPECT_EQ(sens_cyl_factory->size(), 0UL);
+    EXPECT_EQ(sens_cyl_factory->size(), 0u);
     EXPECT_TRUE(sens_cyl_factory->components().empty());
     EXPECT_TRUE(sens_cyl_factory->transforms().empty());
     // The single view is never empty, only uninitialized
@@ -249,16 +252,16 @@ TEST(detector, surface_factory) {
     sens_cyl_factory->add_components(std::move(cyl_sf_data));
     cyl_sf_data.clear();
 
-    EXPECT_EQ(sens_cyl_factory->size(), 2UL);
-    EXPECT_EQ(sens_cyl_factory->components().size(), 2UL);
-    EXPECT_EQ(sens_cyl_factory->transforms().size(), 2UL);
-    EXPECT_EQ(sens_cyl_factory->volume_links().size(), 1UL);
+    EXPECT_EQ(sens_cyl_factory->size(), 2u);
+    EXPECT_EQ(sens_cyl_factory->components().size(), 2u);
+    EXPECT_EQ(sens_cyl_factory->transforms().size(), 2u);
+    EXPECT_EQ(sens_cyl_factory->volume_links().size(), 1u);
     const auto& sens_cyl_comps = sens_cyl_factory->components().front();
-    EXPECT_FLOAT_EQ(sens_cyl_comps[0], scalar{5.f});
-    EXPECT_FLOAT_EQ(sens_cyl_comps[1], scalar{-900.f});
-    EXPECT_FLOAT_EQ(sens_cyl_comps[2], scalar{900.f});
+    EXPECT_NEAR(sens_cyl_comps[0], 5.f, tol);
+    EXPECT_NEAR(sens_cyl_comps[1], -900.f, tol);
+    EXPECT_NEAR(sens_cyl_comps[2], 900.f, tol);
     const auto& sens_cyl_vol_links = sens_cyl_factory->volume_links();
-    EXPECT_EQ(sens_cyl_vol_links[0], 1UL);
+    EXPECT_EQ(sens_cyl_vol_links[0], 1u);
 
     //
     // check passive cylinder
@@ -271,14 +274,14 @@ TEST(detector, surface_factory) {
 
     cyl_sf_data.push_back(
         std::make_unique<surface_data<detector_t, cylinder2D<>>>(
-            transform3(point3{0.f, 0.f, -20.f}), 1UL,
+            transform3(point3{0.f, 0.f, -20.f}), 1u,
             std::vector<scalar>{4.9f, -900.f, 900.f}));
     cyl_sf_data.push_back(
         std::make_unique<surface_data<detector_t, cylinder2D<>>>(
-            transform3(point3{0.f, 0.f, 20.f}), 1UL,
+            transform3(point3{0.f, 0.f, 20.f}), 1u,
             std::vector<scalar>{4.9f, -900.f, 900.f}));
 
-    EXPECT_EQ(psv_cyl_factory->size(), 0UL);
+    EXPECT_EQ(psv_cyl_factory->size(), 0u);
     EXPECT_TRUE(psv_cyl_factory->components().empty());
     EXPECT_TRUE(psv_cyl_factory->transforms().empty());
     // The single view is never empty, only uninitialized
@@ -287,16 +290,16 @@ TEST(detector, surface_factory) {
     psv_cyl_factory->add_components(std::move(cyl_sf_data));
     cyl_sf_data.clear();
 
-    EXPECT_EQ(psv_cyl_factory->size(), 2UL);
-    EXPECT_EQ(psv_cyl_factory->components().size(), 2UL);
-    EXPECT_EQ(psv_cyl_factory->transforms().size(), 2UL);
-    EXPECT_EQ(psv_cyl_factory->volume_links().size(), 1UL);
+    EXPECT_EQ(psv_cyl_factory->size(), 2u);
+    EXPECT_EQ(psv_cyl_factory->components().size(), 2u);
+    EXPECT_EQ(psv_cyl_factory->transforms().size(), 2u);
+    EXPECT_EQ(psv_cyl_factory->volume_links().size(), 1u);
     const auto& psv_cyl_comps = psv_cyl_factory->components().front();
-    EXPECT_FLOAT_EQ(psv_cyl_comps[0], scalar{4.9f});
-    EXPECT_FLOAT_EQ(psv_cyl_comps[1], scalar{-900.f});
-    EXPECT_FLOAT_EQ(psv_cyl_comps[2], scalar{900.f});
+    EXPECT_NEAR(psv_cyl_comps[0], 4.9f, tol);
+    EXPECT_NEAR(psv_cyl_comps[1], -900.f, tol);
+    EXPECT_NEAR(psv_cyl_comps[2], 900.f, tol);
     const auto& psv_cyl_vol_links = psv_cyl_factory->volume_links();
-    EXPECT_EQ(psv_cyl_vol_links[0], 1UL);
+    EXPECT_EQ(psv_cyl_vol_links[0], 1u);
 
     //
     // check the other mask types for this detector
@@ -312,19 +315,19 @@ TEST(detector, surface_factory) {
     typename annulus_factory::sf_data_collection ann_sf_data;
     ann_sf_data.push_back(
         std::make_unique<surface_data<detector_t, annulus2D<>>>(
-            transform3(point3{0.f, 0.f, 0.f}), 1UL,
+            transform3(point3{0.f, 0.f, 0.f}), 1u,
             std::vector<scalar>{300.f, 350.f, -0.1f, 0.1f, 0.5f, 0.6f, 1.4f}));
     ann_factory->add_components(std::move(ann_sf_data));
     ann_sf_data.clear();
 
     const auto& ann_comps = ann_factory->components().front();
-    EXPECT_FLOAT_EQ(ann_comps[0], scalar{300.f});
-    EXPECT_FLOAT_EQ(ann_comps[1], scalar{350.f});
-    EXPECT_FLOAT_EQ(ann_comps[2], scalar{-0.1f});
-    EXPECT_FLOAT_EQ(ann_comps[3], scalar{0.1f});
-    EXPECT_FLOAT_EQ(ann_comps[4], scalar{0.5f});
-    EXPECT_FLOAT_EQ(ann_comps[5], scalar{0.6f});
-    EXPECT_FLOAT_EQ(ann_comps[6], scalar{1.4f});
+    EXPECT_NEAR(ann_comps[0], 300.f, tol);
+    EXPECT_NEAR(ann_comps[1], 350.f, tol);
+    EXPECT_NEAR(ann_comps[2], -0.1f, tol);
+    EXPECT_NEAR(ann_comps[3], 0.1f, tol);
+    EXPECT_NEAR(ann_comps[4], 0.5f, tol);
+    EXPECT_NEAR(ann_comps[5], 0.6f, tol);
+    EXPECT_NEAR(ann_comps[6], 1.4f, tol);
 
     // rectangles
     using rectangle_factory =
@@ -336,14 +339,14 @@ TEST(detector, surface_factory) {
     typename rectangle_factory::sf_data_collection rect_sf_data;
     rect_sf_data.push_back(
         std::make_unique<surface_data<detector_t, rectangle2D<>>>(
-            transform3(point3{0.f, 0.f, 0.f}), 1UL,
+            transform3(point3{0.f, 0.f, 0.f}), 1u,
             std::vector<scalar>{10.f, 8.f}));
     rect_factory->add_components(std::move(rect_sf_data));
     rect_sf_data.clear();
 
     const auto& rectgl_comps = rect_factory->components().front();
-    EXPECT_FLOAT_EQ(rectgl_comps[0], scalar{10.f});
-    EXPECT_FLOAT_EQ(rectgl_comps[1], scalar{8.f});
+    EXPECT_NEAR(rectgl_comps[0], 10.f, tol);
+    EXPECT_NEAR(rectgl_comps[1], 8.f, tol);
 
     // ring
     using ring_factory = surface_factory<detector_t, ring2D<>, mask_id::e_ring2,
@@ -353,13 +356,13 @@ TEST(detector, surface_factory) {
 
     typename ring_factory::sf_data_collection ring_sf_data;
     ring_sf_data.push_back(std::make_unique<surface_data<detector_t, ring2D<>>>(
-        transform3(point3{0.f, 0.f, 0.f}), 1UL, std::vector<scalar>{0.f, 5.f}));
+        transform3(point3{0.f, 0.f, 0.f}), 1u, std::vector<scalar>{0.f, 5.f}));
     rng_factory->add_components(std::move(ring_sf_data));
     ring_sf_data.clear();
 
     const auto& ring_comps = rng_factory->components().front();
-    EXPECT_FLOAT_EQ(ring_comps[0], scalar{0.f});
-    EXPECT_FLOAT_EQ(ring_comps[1], scalar{5.f});
+    EXPECT_NEAR(ring_comps[0], 0.f, tol);
+    EXPECT_NEAR(ring_comps[1], 5.f, tol);
 
     // trapezoid
     using trapezoid_factory =
@@ -371,16 +374,16 @@ TEST(detector, surface_factory) {
     typename trapezoid_factory::sf_data_collection trpz_sf_data;
     trpz_sf_data.push_back(
         std::make_unique<surface_data<detector_t, trapezoid2D<>>>(
-            transform3(point3{0.f, 0.f, 0.f}), 1UL,
+            transform3(point3{0.f, 0.f, 0.f}), 1u,
             std::vector<scalar>{1.f, 3.f, 2.f, 0.25f}));
     trpz_factory->add_components(std::move(trpz_sf_data));
     trpz_sf_data.clear();
 
     const auto& trpz_comps = trpz_factory->components().front();
-    EXPECT_FLOAT_EQ(trpz_comps[0], scalar{1.f});
-    EXPECT_FLOAT_EQ(trpz_comps[1], scalar{3.f});
-    EXPECT_FLOAT_EQ(trpz_comps[2], scalar{2.f});
-    EXPECT_FLOAT_EQ(trpz_comps[3], scalar{0.25f});
+    EXPECT_NEAR(trpz_comps[0], 1.f, tol);
+    EXPECT_NEAR(trpz_comps[1], 3.f, tol);
+    EXPECT_NEAR(trpz_comps[2], 2.f, tol);
+    EXPECT_NEAR(trpz_comps[3], 0.25f, tol);
 }
 
 /// This tests the initialization of a detector volume using a volume builder
@@ -395,20 +398,21 @@ TEST(detector, volume_builder) {
 
     detector_t d(host_mr);
 
-    EXPECT_TRUE(d.volumes().size() == 0UL);
+    EXPECT_TRUE(d.volumes().size() == 0u);
 
     volume_builder<detector_t> vbuilder{};
-    const std::array<scalar, 6UL> bounds{0.f, 10.f, -5.f, 5.f, -M_PI, M_PI};
+    const std::array<scalar, 6> bounds{
+        0.f, 10.f, -5.f, 5.f, -constant<scalar>::pi, constant<scalar>::pi};
     vbuilder.init_vol(d, volume_id::e_cylinder, bounds);
     const auto& vol = d.volumes().back();
 
-    EXPECT_TRUE(d.volumes().size() == 1UL);
+    EXPECT_TRUE(d.volumes().size() == 1u);
     EXPECT_TRUE(vol.empty());
-    EXPECT_EQ(vol.index(), 0UL);
+    EXPECT_EQ(vol.index(), 0u);
     EXPECT_EQ(vol.index(), vbuilder.get_vol_index());
     EXPECT_EQ(vol.id(), volume_id::e_cylinder);
     for (const auto [idx, b] : detray::views::enumerate(vol.bounds())) {
-        EXPECT_FLOAT_EQ(b, bounds[idx]) << "error at index: " << idx;
+        EXPECT_NEAR(b, bounds[idx], tol) << "error at index: " << idx;
     }
 }
 
@@ -457,14 +461,15 @@ TEST(detector, detector_volume_construction) {
     // volume builder
     volume_builder<detector_t> vbuilder{};
     vbuilder.init_vol(d, volume_id::e_cylinder,
-                      {0.f, 500.f, -1500.f, 1500.f, -M_PI, M_PI});
+                      {0.f, 500.f, -1500.f, 1500.f, -constant<scalar>::pi,
+                       constant<scalar>::pi});
     const auto& vol = d.volumes().back();
 
     // initial checks
-    EXPECT_EQ(d.volumes().size(), 2UL);
-    EXPECT_EQ(d.surfaces().size(), 3UL);
+    EXPECT_EQ(d.volumes().size(), 2u);
+    EXPECT_EQ(d.surfaces().size(), 3u);
     EXPECT_TRUE(vol.empty());
-    EXPECT_EQ(vol.index(), 1UL);
+    EXPECT_EQ(vol.index(), 1u);
     EXPECT_EQ(vol.id(), volume_id::e_cylinder);
 
     //
@@ -478,11 +483,11 @@ TEST(detector, detector_volume_construction) {
     // of -5mm to 5mm and linking to volumes 0 and 2, respectively.
     cyl_sf_data.push_back(
         std::make_unique<surface_data<detector_t, cylinder2D<>>>(
-            transform3(point3{0.f, 0.f, 0.f}), 0UL,
+            transform3(point3{0.f, 0.f, 0.f}), 0u,
             std::vector<scalar>{10.f, -1500.f, 1500.f}));
     cyl_sf_data.push_back(
         std::make_unique<surface_data<detector_t, cylinder2D<>>>(
-            transform3(point3{0.f, 0.f, 0.f}), 2UL,
+            transform3(point3{0.f, 0.f, 0.f}), 2u,
             std::vector<scalar>{20.f, -1500.f, 1500.f}));
     pt_cyl_factory->add_components(std::move(cyl_sf_data));
 
@@ -490,10 +495,10 @@ TEST(detector, detector_volume_construction) {
     typename portal_disc_factory::sf_data_collection ring_sf_data;
     // Creates two discs with a radius of 10mm, linking to volumes 3 and 4
     ring_sf_data.push_back(std::make_unique<surface_data<detector_t, ring2D<>>>(
-        transform3(point3{0.f, 0.f, -1500.f}), 3UL,
+        transform3(point3{0.f, 0.f, -1500.f}), 3u,
         std::vector<scalar>{0.f, 10.f}));
     ring_sf_data.push_back(std::make_unique<surface_data<detector_t, ring2D<>>>(
-        transform3(point3{0.f, 0.f, 1500.f}), 4UL,
+        transform3(point3{0.f, 0.f, 1500.f}), 4u,
         std::vector<scalar>{0.f, 10.f}));
     pt_disc_factory->add_components(std::move(ring_sf_data));
 
@@ -598,7 +603,7 @@ TEST(detector, detector_volume_construction) {
     EXPECT_FALSE(vol.empty());
     // default detector makes no distinction between the surface types
     typename detector_registry::default_detector::object_link_type sf_range{};
-    sf_range[0] = {3UL, 19UL};
+    sf_range[0] = {3u, 19u};
     EXPECT_EQ(vol.full_range(), sf_range[geo_obj_id::e_sensitive]);
     EXPECT_EQ(vol.template obj_link<geo_obj_id::e_portal>(),
               sf_range[geo_obj_id::e_portal]);
@@ -607,26 +612,26 @@ TEST(detector, detector_volume_construction) {
     EXPECT_EQ(vol.template obj_link<geo_obj_id::e_passive>(),
               sf_range[geo_obj_id::e_passive]);
 
-    EXPECT_EQ(d.surfaces().size(), 19UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_cylinder2>(), 3UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_ring2>(), 4UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_annulus2>(), 3UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_cylinder2>(), 3UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_rectangle2>(), 7UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_ring2>(), 4UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_trapezoid2>(), 2UL);
+    EXPECT_EQ(d.surfaces().size(), 19u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_cylinder2>(), 3u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_ring2>(), 4u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_annulus2>(), 3u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_cylinder2>(), 3u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_rectangle2>(), 7u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_ring2>(), 4u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_trapezoid2>(), 2u);
 
     // check surface type and volume link
     std::vector<surface_id> sf_ids{};
     sf_ids.reserve(d.surfaces().size());
-    sf_ids.insert(sf_ids.end(), 3UL, surface_id::e_sensitive);
-    sf_ids.insert(sf_ids.end(), 4UL, surface_id::e_portal);
-    sf_ids.insert(sf_ids.end(), 6UL, surface_id::e_sensitive);
-    sf_ids.insert(sf_ids.end(), 3UL, surface_id::e_passive);
-    sf_ids.insert(sf_ids.end(), 3UL, surface_id::e_sensitive);
+    sf_ids.insert(sf_ids.end(), 3u, surface_id::e_sensitive);
+    sf_ids.insert(sf_ids.end(), 4u, surface_id::e_portal);
+    sf_ids.insert(sf_ids.end(), 6u, surface_id::e_sensitive);
+    sf_ids.insert(sf_ids.end(), 3u, surface_id::e_passive);
+    sf_ids.insert(sf_ids.end(), 3u, surface_id::e_sensitive);
     std::vector<dindex> volume_links{};
-    volume_links.insert(volume_links.end(), 3UL, 0UL);
-    volume_links.insert(volume_links.end(), 16UL, 1UL);
+    volume_links.insert(volume_links.end(), 3u, 0u);
+    volume_links.insert(volume_links.end(), 16u, 1u);
     volume_links.reserve(d.surfaces().size());
     for (const auto [idx, sf_id] : detray::views::enumerate(sf_ids)) {
         const auto& sf = d.surface_by_index(idx);
@@ -644,25 +649,25 @@ TEST(detector, detector_volume_construction) {
 
     // check surface mask links
     std::vector<typename detector_t::mask_link> mask_links{
-        {mask_id::e_rectangle2, 0UL},
-        {mask_id::e_annulus2, 0UL},
-        {mask_id::e_trapezoid2, 0UL},
-        {mask_id::e_portal_cylinder2, 0UL},
-        {mask_id::e_portal_cylinder2, 1UL},
-        {mask_id::e_portal_ring2, 0UL},
-        {mask_id::e_portal_ring2, 1UL},
-        {mask_id::e_annulus2, 1UL},
-        {mask_id::e_annulus2, 2UL},
-        {mask_id::e_rectangle2, 1UL},
-        {mask_id::e_rectangle2, 2UL},
-        {mask_id::e_rectangle2, 3UL},
-        {mask_id::e_trapezoid2, 1UL},
-        {mask_id::e_cylinder2, 2UL},
-        {mask_id::e_ring2, 2UL},
-        {mask_id::e_ring2, 3UL},
-        {mask_id::e_rectangle2, 4UL},
-        {mask_id::e_rectangle2, 5UL},
-        {mask_id::e_rectangle2, 6UL}};
+        {mask_id::e_rectangle2, 0u},
+        {mask_id::e_annulus2, 0u},
+        {mask_id::e_trapezoid2, 0u},
+        {mask_id::e_portal_cylinder2, 0u},
+        {mask_id::e_portal_cylinder2, 1u},
+        {mask_id::e_portal_ring2, 0u},
+        {mask_id::e_portal_ring2, 1u},
+        {mask_id::e_annulus2, 1u},
+        {mask_id::e_annulus2, 2u},
+        {mask_id::e_rectangle2, 1u},
+        {mask_id::e_rectangle2, 2u},
+        {mask_id::e_rectangle2, 3u},
+        {mask_id::e_trapezoid2, 1u},
+        {mask_id::e_cylinder2, 2u},
+        {mask_id::e_ring2, 2u},
+        {mask_id::e_ring2, 3u},
+        {mask_id::e_rectangle2, 4u},
+        {mask_id::e_rectangle2, 5u},
+        {mask_id::e_rectangle2, 6u}};
     for (const auto [idx, m_link] : detray::views::enumerate(mask_links)) {
         EXPECT_EQ(d.surface_by_index(idx).mask(), m_link)
             << "error at index: " << idx;
@@ -670,26 +675,26 @@ TEST(detector, detector_volume_construction) {
 
     // check mask volume links
     volume_links.clear();
-    volume_links = {0UL, 2UL, 1UL};
+    volume_links = {0u, 2u, 1u};
     check_mask<detector_t, mask_id::e_portal_cylinder2>(d, volume_links);
     check_mask<detector_t, mask_id::e_cylinder2>(d, volume_links);
 
     volume_links.clear();
-    volume_links = {3UL, 4UL, 1UL, 1UL};
+    volume_links = {3u, 4u, 1u, 1u};
     check_mask<detector_t, mask_id::e_portal_ring2>(d, volume_links);
     check_mask<detector_t, mask_id::e_ring2>(d, volume_links);
 
     volume_links.clear();
-    volume_links = {0UL, 1UL, 1UL};
+    volume_links = {0u, 1u, 1u};
     check_mask<detector_t, mask_id::e_annulus2>(d, volume_links);
 
     volume_links.clear();
-    volume_links.reserve(7);
-    volume_links.push_back(0UL);
-    volume_links.insert(volume_links.end(), 6UL, 1UL);
+    volume_links.reserve(7u);
+    volume_links.push_back(0u);
+    volume_links.insert(volume_links.end(), 6u, 1u);
     check_mask<detector_t, mask_id::e_rectangle2>(d, volume_links);
 
     volume_links.clear();
-    volume_links = {0UL, 1UL};
+    volume_links = {0u, 1u};
     check_mask<detector_t, mask_id::e_trapezoid2>(d, volume_links);
 }

--- a/tests/common/include/tests/common/core_mask_store.inl
+++ b/tests/common/include/tests/common/core_mask_store.inl
@@ -55,7 +55,7 @@ TEST(ALGEBRA_PLUGIN, static_mask_store) {
     ASSERT_TRUE(store.empty<mask_ids::e_single3>());
     ASSERT_TRUE(store.empty<mask_ids::e_trapezoid2>());
 
-    store.emplace_back<mask_ids::e_cylinder3>(empty_context{}, 0UL, 1.f, 0.5f,
+    store.emplace_back<mask_ids::e_cylinder3>(empty_context{}, 0u, 1.f, 0.5f,
                                               2.0f);
 
     ASSERT_TRUE(store.empty<mask_ids::e_annulus2>());
@@ -65,15 +65,13 @@ TEST(ALGEBRA_PLUGIN, static_mask_store) {
     ASSERT_TRUE(store.empty<mask_ids::e_single3>());
     ASSERT_TRUE(store.empty<mask_ids::e_trapezoid2>());
 
-    store.emplace_back<mask_ids::e_cylinder3>(empty_context{}, 0UL, 1.f, 1.5f,
+    store.emplace_back<mask_ids::e_cylinder3>(empty_context{}, 0u, 1.f, 1.5f,
                                               2.0f);
-    store.emplace_back<mask_ids::e_trapezoid2>(empty_context{}, 0UL, 0.5f, 1.5f,
+    store.emplace_back<mask_ids::e_trapezoid2>(empty_context{}, 0u, 0.5f, 1.5f,
                                                4.0f);
-    store.emplace_back<mask_ids::e_rectangle2>(empty_context{}, 0UL, 1.0f,
-                                               2.0f);
-    store.emplace_back<mask_ids::e_rectangle2>(empty_context{}, 0UL, 2.0f,
-                                               1.0f);
-    store.emplace_back<mask_ids::e_rectangle2>(empty_context{}, 0UL, 10.0f,
+    store.emplace_back<mask_ids::e_rectangle2>(empty_context{}, 0u, 1.0f, 2.0f);
+    store.emplace_back<mask_ids::e_rectangle2>(empty_context{}, 0u, 2.0f, 1.0f);
+    store.emplace_back<mask_ids::e_rectangle2>(empty_context{}, 0u, 10.0f,
                                                100.0f);
 
     ASSERT_TRUE(store.empty<mask_ids::e_annulus2>());
@@ -83,12 +81,12 @@ TEST(ALGEBRA_PLUGIN, static_mask_store) {
     ASSERT_TRUE(store.empty<mask_ids::e_single3>());
     ASSERT_EQ(store.size<mask_ids::e_trapezoid2>(), 1);
 
-    store.emplace_back<mask_ids::e_annulus2>(empty_context{}, 0UL, 1.f, 2.f,
-                                             3.f, 4.f, 5.f, 6.f, 7.f);
-    store.emplace_back<mask_ids::e_ring2>(empty_context{}, 0UL, 10.f, 100.f);
-    store.emplace_back<mask_ids::e_ring2>(empty_context{}, 0UL, 10.f, 100.f);
-    store.emplace_back<mask_ids::e_ring2>(empty_context{}, 0UL, 10.f, 100.f);
-    store.emplace_back<mask_ids::e_ring2>(empty_context{}, 0UL, 10.f, 100.f);
+    store.emplace_back<mask_ids::e_annulus2>(empty_context{}, 0u, 1.f, 2.f, 3.f,
+                                             4.f, 5.f, 6.f, 7.f);
+    store.emplace_back<mask_ids::e_ring2>(empty_context{}, 0u, 10.f, 100.f);
+    store.emplace_back<mask_ids::e_ring2>(empty_context{}, 0u, 10.f, 100.f);
+    store.emplace_back<mask_ids::e_ring2>(empty_context{}, 0u, 10.f, 100.f);
+    store.emplace_back<mask_ids::e_ring2>(empty_context{}, 0u, 10.f, 100.f);
 
     const auto &annulus_masks = store.get<mask_ids::e_annulus2>();
     const auto &cylinder_masks = store.get<mask_ids::e_cylinder3>();

--- a/tests/common/include/tests/common/geometry_volume.inl
+++ b/tests/common/include/tests/common/geometry_volume.inl
@@ -1,12 +1,13 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #include <gtest/gtest.h>
 
+#include "detray/definitions/units.hpp"
 #include "detray/geometry/detector_volume.hpp"
 
 /// @note __plugin has to be defined with a preprocessor command
@@ -40,27 +41,28 @@ TEST(ALGEBRA_PLUGIN, detector_volume) {
         detector_volume<geo_objects, object_link_t, sf_finder_link_t>;
 
     // Check construction, setters and getters
-    darray<scalar, 6> bounds = {0., 10., -5., 5., -M_PI, M_PI};
+    darray<scalar, 6> bounds = {
+        0.f, 10.f, -5.f, 5.f, -constant<scalar>::pi, constant<scalar>::pi};
     volume_t v1(volume_id::e_cylinder, bounds);
-    v1.set_index(12345);
-    v1.set_sf_finder({sf_finder_ids::e_default, 12});
+    v1.set_index(12345u);
+    v1.set_sf_finder({sf_finder_ids::e_default, 12u});
 
     ASSERT_TRUE(v1.empty());
     ASSERT_TRUE(v1.id() == volume_id::e_cylinder);
-    ASSERT_TRUE(v1.index() == 12345);
+    ASSERT_TRUE(v1.index() == 12345u);
     ASSERT_TRUE(v1.bounds() == bounds);
     ASSERT_TRUE(v1.sf_finder_type() == sf_finder_ids::e_default);
-    ASSERT_TRUE(v1.sf_finder_index() == 12);
+    ASSERT_TRUE(v1.sf_finder_index() == 12u);
 
     // Check surface and portal ranges
-    dindex_range surface_range{2, 8};
-    dindex_range surface_range_update{8, 10};
-    dindex_range full_surface_range{2, 10};
-    dindex_range portal_range{10, 24};
-    dindex_range full_range{2, 24};
+    dindex_range surface_range{2u, 8u};
+    dindex_range surface_range_update{8u, 10u};
+    dindex_range full_surface_range{2u, 10u};
+    dindex_range portal_range{10u, 24u};
+    dindex_range full_range{2u, 24u};
 
     typename volume_t::sf_finder_link_type sf_finder_link{
-        sf_finder_ids::e_default, 12};
+        sf_finder_ids::e_default, 12u};
     v1.update_obj_link<geo_objects::e_sensitive>(surface_range);
     ASSERT_EQ(v1.obj_link<geo_objects::e_sensitive>(), surface_range);
     v1.update_obj_link<geo_objects::e_sensitive>(surface_range_update);
@@ -70,15 +72,15 @@ TEST(ALGEBRA_PLUGIN, detector_volume) {
     ASSERT_EQ(v1.full_range(), full_range);
 
     ASSERT_FALSE(v1.empty());
-    ASSERT_EQ(v1.template n_objects<geo_objects::e_all>(), 22);
-    ASSERT_EQ(v1.template n_objects<geo_objects::e_sensitive>(), 8);
-    ASSERT_EQ(v1.template n_objects<geo_objects::e_portal>(), 14);
+    ASSERT_EQ(v1.template n_objects<geo_objects::e_all>(), 22u);
+    ASSERT_EQ(v1.template n_objects<geo_objects::e_sensitive>(), 8u);
+    ASSERT_EQ(v1.template n_objects<geo_objects::e_portal>(), 14u);
     ASSERT_EQ(v1.sf_finder_link(), sf_finder_link);
 
     // Check copy constructor
     const auto v2 = volume_t(v1);
     ASSERT_FALSE(v1.empty());
-    ASSERT_EQ(v2.index(), 12345);
+    ASSERT_EQ(v2.index(), 12345u);
     ASSERT_EQ(v2.id(), volume_id::e_cylinder);
     ASSERT_EQ(v2.bounds(), bounds);
     ASSERT_EQ(v2.sf_finder_link(), sf_finder_link);

--- a/tests/common/include/tests/common/geometry_volume_graph.inl
+++ b/tests/common/include/tests/common/geometry_volume_graph.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -22,8 +22,10 @@ TEST(ALGEBRA_PLUGIN, volume_graph) {
     using namespace __plugin;
 
     vecmem::host_memory_resource host_mr;
-    dindex n_brl_layers = 4;
-    dindex n_edc_layers = 1;
+
+    unsigned int n_brl_layers{4u};
+    unsigned int n_edc_layers{1u};
+
     auto det = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
     using detector_t = decltype(det);
 

--- a/tests/common/include/tests/common/grid_axis.inl
+++ b/tests/common/include/tests/common/grid_axis.inl
@@ -1,13 +1,13 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #include <gtest/gtest.h>
 
-#include <climits>
+#include <limits>
 
 // detray test
 #include <vecmem/containers/device_vector.hpp>
@@ -35,20 +35,21 @@ using cartesian_3D =
                single_axis<closed<label::e_z>, regular<containers, scalar>>>;
 
 // Floating point comparison
-constexpr scalar tol{1e-5};
+constexpr scalar tol{1e-5f};
 
 }  // anonymous namespace
 
 TEST(grid, open_regular_axis) {
 
     // Lower bin edges: min and max bin edge for the regular axis
-    vecmem::vector<scalar> bin_edges = {-10, -5, -3, 7, 7, 14, 20};
+    vecmem::vector<scalar> bin_edges = {-10.f, -5.f, -3.f, 7.f,
+                                        7.f,   14.f, 20.f};
     // Regular axis: first entry is the offset in the bin edges vector (2), the
     // second entry is the number of bins (10): Lower and upper bin edges of
     // the max and min bin are -3 and 7 => stepsize is (7 - (-3)) / 10 = 1
     // ... -3, -2, -1,  0,  1,  2,  3,  4,  5,  6,  7 ...
     //  [0]  [1] [2] [3] [4] [5] [6] [7] [8] [9] [10] [11]
-    dindex_range edge_range = {2, 10};
+    const dindex_range edge_range = {2u, 10u};
 
     // An open regular x-axis
     single_axis<open<label::e_x>, regular<>> or_axis{&edge_range, &bin_edges};
@@ -59,65 +60,65 @@ TEST(grid, open_regular_axis) {
     EXPECT_EQ(or_axis.binning(), n_axis::binning::e_regular);
 
     // N bins
-    EXPECT_EQ(or_axis.nbins(), 10UL + 2UL);
-    EXPECT_NEAR(or_axis.span()[0], scalar{-3}, tol);
-    EXPECT_NEAR(or_axis.span()[1], scalar{7}, tol);
+    EXPECT_EQ(or_axis.nbins(), 10u + 2u);
+    EXPECT_NEAR(or_axis.span()[0], -3.f, tol);
+    EXPECT_NEAR(or_axis.span()[1], 7.f, tol);
     // Axis bin access
     // Axis is open: Every value smaller than -3 is mapped into bin 0:
     // which is (inf, -3)
-    EXPECT_EQ(or_axis.bin(-4.), 0u);
-    EXPECT_EQ(or_axis.bin(2.5), 6u);
+    EXPECT_EQ(or_axis.bin(-4.f), 0u);
+    EXPECT_EQ(or_axis.bin(2.5f), 6u);
     // Axis is open: Every value greater than 7 is mapped into bin 11:
     // which is (7, inf)
-    EXPECT_EQ(or_axis.bin(8.), 11u);
+    EXPECT_EQ(or_axis.bin(8.f), 11u);
 
     // Axis range access - binned (symmetric & asymmetric)
-    darray<dindex, 2> nhood00i = {0u, 0u};
-    darray<dindex, 2> nhood01i = {0u, 1u};
-    darray<dindex, 2> nhood11i = {1u, 1u};
-    darray<dindex, 2> nhood44i = {4u, 4u};
-    darray<dindex, 2> nhood55i = {5u, 5u};
+    const darray<dindex, 2> nhood00i = {0u, 0u};
+    const darray<dindex, 2> nhood01i = {0u, 1u};
+    const darray<dindex, 2> nhood11i = {1u, 1u};
+    const darray<dindex, 2> nhood44i = {4u, 4u};
+    const darray<dindex, 2> nhood55i = {5u, 5u};
 
     dindex_range expected_range = {6u, 6u};
-    EXPECT_EQ(or_axis.range(2.5, nhood00i), expected_range);
+    EXPECT_EQ(or_axis.range(2.5f, nhood00i), expected_range);
     expected_range = {6u, 7u};
-    EXPECT_EQ(or_axis.range(2.5, nhood01i), expected_range);
+    EXPECT_EQ(or_axis.range(2.5f, nhood01i), expected_range);
     expected_range = {5u, 7u};
-    EXPECT_EQ(or_axis.range(2.5, nhood11i), expected_range);
+    EXPECT_EQ(or_axis.range(2.5f, nhood11i), expected_range);
     expected_range = {2u, 10u};
-    EXPECT_EQ(or_axis.range(2.5, nhood44i), expected_range);
+    EXPECT_EQ(or_axis.range(2.5f, nhood44i), expected_range);
     expected_range = {1u, 11u};
-    EXPECT_EQ(or_axis.range(2.5, nhood55i), expected_range);
+    EXPECT_EQ(or_axis.range(2.5f, nhood55i), expected_range);
     expected_range = {1u, 9u};
-    EXPECT_EQ(or_axis.range(1.5, nhood44i), expected_range);
+    EXPECT_EQ(or_axis.range(1.5f, nhood44i), expected_range);
     expected_range = {4u, 11u};
-    EXPECT_EQ(or_axis.range(5.5, nhood55i), expected_range);
+    EXPECT_EQ(or_axis.range(5.5f, nhood55i), expected_range);
 
     // Axis range access - scalar (symmteric & asymmetric)
-    darray<scalar, 2> nhood00s = {0., 0.};
-    darray<scalar, 2> epsilon = {0.01, 0.01};
-    darray<scalar, 2> nhood11s = {1., 1.};
-    darray<scalar, 2> nhoodAlls = {10., 10.};
+    const darray<scalar, 2> nhood00s = {0.f, 0.f};
+    const darray<scalar, 2> nhood_tol = {0.01f, 0.01f};
+    const darray<scalar, 2> nhood11s = {1.f, 1.f};
+    const darray<scalar, 2> nhoodAlls = {10.f, 10.f};
 
     expected_range = {6u, 6u};
-    EXPECT_EQ(or_axis.range(2.5, nhood00s), expected_range);
-    EXPECT_EQ(or_axis.range(2.5, epsilon), expected_range);
+    EXPECT_EQ(or_axis.range(2.5f, nhood00s), expected_range);
+    EXPECT_EQ(or_axis.range(2.5f, nhood_tol), expected_range);
     expected_range = {5u, 7u};
-    EXPECT_EQ(or_axis.range(2.5, nhood11s), expected_range);
+    EXPECT_EQ(or_axis.range(2.5f, nhood11s), expected_range);
     expected_range = {0u, 11u};
-    EXPECT_EQ(or_axis.range(2.5, nhoodAlls), expected_range);
+    EXPECT_EQ(or_axis.range(2.5f, nhoodAlls), expected_range);
 }
 
 TEST(grid, closed_regular_axis) {
 
     // Lower bin edges: min and max bin edge for the regular axis
-    vecmem::vector<scalar> bin_edges = {-10, -3, -3, 7, 7, 14};
+    vecmem::vector<scalar> bin_edges = {-10.f, -3.f, -3.f, 7.f, 7.f, 14.f};
     // Regular axis: first entry is the offset in the bin edges vector (2), the
     // second entry is the number of bins (10): Lower and upper bin edges of
     // the max and min bin are -3 and 7 => stepsize is (7 - (-3)) / 10 = 1
     // -3, -2, -1,  0,  1,  2,  3,  4,  5,  6,  7
     //   [0] [1] [2] [3] [4] [5] [6] [7] [8] [9]
-    dindex_range edge_range = {2, 10};
+    const dindex_range edge_range = {2u, 10u};
 
     // A closed regular r-axis
     single_axis<closed<label::e_r>, regular<>> cr_axis{&edge_range, &bin_edges};
@@ -129,71 +130,66 @@ TEST(grid, closed_regular_axis) {
 
     // N bins
     EXPECT_EQ(cr_axis.nbins(), 10u);
-    EXPECT_NEAR(cr_axis.span()[0], scalar{-3}, tol);
-    EXPECT_NEAR(cr_axis.span()[1], scalar{7}, tol);
+    EXPECT_NEAR(cr_axis.span()[0], -3.f, tol);
+    EXPECT_NEAR(cr_axis.span()[1], 7.f, tol);
     // Axis bin access
     // Axis is closed: Every value smaller than -3 is mapped into bin 0:
     // which is [-3, -2)
-    EXPECT_EQ(cr_axis.bin(-4.), 0u);
-    EXPECT_EQ(cr_axis.bin(2.5), 5u);
+    EXPECT_EQ(cr_axis.bin(-4.f), 0u);
+    EXPECT_EQ(cr_axis.bin(2.5f), 5u);
     // Axis is closed: Every value greater than 7 is mapped into bin 9:
     // which is (6, 7]
-    EXPECT_EQ(cr_axis.bin(8.), 9u);
+    EXPECT_EQ(cr_axis.bin(8.f), 9u);
 
     // Axis range access - binned (symmetric & asymmetric)
-    darray<dindex, 2> nhood00i = {0u, 0u};
-    darray<dindex, 2> nhood01i = {0u, 1u};
-    darray<dindex, 2> nhood11i = {1u, 1u};
-    darray<dindex, 2> nhood44i = {4u, 4u};
-    darray<dindex, 2> nhood55i = {5u, 5u};
+    const darray<dindex, 2> nhood00i = {0u, 0u};
+    const darray<dindex, 2> nhood01i = {0u, 1u};
+    const darray<dindex, 2> nhood11i = {1u, 1u};
+    const darray<dindex, 2> nhood44i = {4u, 4u};
+    const darray<dindex, 2> nhood55i = {5u, 5u};
 
     dindex_range expected_range = {5u, 5u};
-    EXPECT_EQ(cr_axis.range(2.5, nhood00i), expected_range);
+    EXPECT_EQ(cr_axis.range(2.5f, nhood00i), expected_range);
     expected_range = {5u, 6u};
-    EXPECT_EQ(cr_axis.range(2.5, nhood01i), expected_range);
+    EXPECT_EQ(cr_axis.range(2.5f, nhood01i), expected_range);
     expected_range = {4u, 6u};
-    EXPECT_EQ(cr_axis.range(2.5, nhood11i), expected_range);
+    EXPECT_EQ(cr_axis.range(2.5f, nhood11i), expected_range);
     expected_range = {1u, 9u};
-    EXPECT_EQ(cr_axis.range(2.5, nhood44i), expected_range);
+    EXPECT_EQ(cr_axis.range(2.5f, nhood44i), expected_range);
     expected_range = {0u, 9u};
-    EXPECT_EQ(cr_axis.range(2.5, nhood55i), expected_range);
+    EXPECT_EQ(cr_axis.range(2.5f, nhood55i), expected_range);
     expected_range = {0u, 8u};
-    EXPECT_EQ(cr_axis.range(1.5, nhood44i), expected_range);
+    EXPECT_EQ(cr_axis.range(1.5f, nhood44i), expected_range);
     expected_range = {3u, 9u};
-    EXPECT_EQ(cr_axis.range(5.5, nhood55i), expected_range);
+    EXPECT_EQ(cr_axis.range(5.5f, nhood55i), expected_range);
 
     // Axis range access - scalar (symmteric & asymmetric)
-    darray<scalar, 2> nhood00s = {0., 0.};
-    darray<scalar, 2> epsilon = {0.01, 0.01};
-    darray<scalar, 2> nhood11s = {1., 1.};
-    darray<scalar, 2> nhoodAlls = {10., 10.};
+    const darray<scalar, 2> nhood00s = {0.f, 0.f};
+    const darray<scalar, 2> nhood_tol = {0.01f, 0.01f};
+    const darray<scalar, 2> nhood11s = {1.f, 1.f};
+    const darray<scalar, 2> nhoodAlls = {10.f, 10.f};
 
     expected_range = {5u, 5u};
-    EXPECT_EQ(cr_axis.range(2.5, nhood00s), expected_range);
-    EXPECT_EQ(cr_axis.range(2.5, epsilon), expected_range);
+    EXPECT_EQ(cr_axis.range(2.5f, nhood00s), expected_range);
+    EXPECT_EQ(cr_axis.range(2.5f, nhood_tol), expected_range);
     expected_range = {4u, 6u};
-    EXPECT_EQ(cr_axis.range(2.5, nhood11s), expected_range);
+    EXPECT_EQ(cr_axis.range(2.5f, nhood11s), expected_range);
     expected_range = {0u, 9u};
-    EXPECT_EQ(cr_axis.range(2.5, nhoodAlls), expected_range);
+    EXPECT_EQ(cr_axis.range(2.5f, nhoodAlls), expected_range);
 }
 
 TEST(grid, circular_regular_axis) {
 
-    scalar epsilon = 10 * std::numeric_limits<scalar>::epsilon();
-
     // Let's say 36 modules, but with 4 directly at 0, pi/2, pi, -pi2
-    scalar pi{M_PI};
-    scalar pi2{M_PI_2};
-
-    scalar half_module{scalar{2} * pi2 / scalar{72}};
-    scalar phi_min{-pi + half_module};
-    scalar phi_max{pi - half_module};
+    const scalar half_module{constant<scalar>::pi / 72.f};
+    const scalar phi_min{-constant<scalar>::pi + half_module};
+    const scalar phi_max{constant<scalar>::pi - half_module};
 
     // Lower bin edges: min and max bin edge for the regular axis
-    vecmem::vector<scalar> bin_edges = {-10, phi_min, phi_max, 56};
+    vecmem::vector<scalar> bin_edges = {-10.f, phi_min, phi_max, 56.f};
     // Regular axis: first entry is the offset in the bin edges vector (1), the
     // second entry is the number of bins (36)
-    dindex_range edge_range = {1, 36};
+    const dindex_range edge_range = {1u, 36u};
 
     // A closed regular x-axis
     single_axis<circular<>, regular<>> cr_axis(&edge_range, &bin_edges);
@@ -207,9 +203,9 @@ TEST(grid, circular_regular_axis) {
     EXPECT_EQ(cr_axis.nbins(), 36u);
     // Axis bin access
     // overflow
-    EXPECT_EQ(cr_axis.bin(phi_max + epsilon), 0u);
+    EXPECT_EQ(cr_axis.bin(phi_max + tol), 0u);
     // underflow
-    EXPECT_EQ(cr_axis.bin(phi_min - epsilon), 35u);
+    EXPECT_EQ(cr_axis.bin(phi_min - tol), 35u);
     // middle of the axis
     EXPECT_EQ(cr_axis.bin(0), 18u);
 
@@ -222,41 +218,48 @@ TEST(grid, circular_regular_axis) {
     EXPECT_EQ(circ_bounds.wrap(40, 36u), 4u);
 
     // Axis range access - binned (symmetric & asymmetric)
-    darray<dindex, 2> nhood00i = {0u, 0u};
-    darray<dindex, 2> nhood01i = {0u, 1u};
-    darray<dindex, 2> nhood11i = {1u, 1u};
-    darray<dindex, 2> nhood22i = {2u, 2u};
+    const darray<dindex, 2> nhood00i = {0u, 0u};
+    const darray<dindex, 2> nhood01i = {0u, 1u};
+    const darray<dindex, 2> nhood11i = {1u, 1u};
+    const darray<dindex, 2> nhood22i = {2u, 2u};
 
     dindex_range expected_range = {0u, 0u};
-    EXPECT_EQ(cr_axis.range(pi + epsilon, nhood00i), expected_range);
+    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood00i),
+              expected_range);
     expected_range = {0u, 1u};
-    EXPECT_EQ(cr_axis.range(pi + epsilon, nhood01i), expected_range);
+    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood01i),
+              expected_range);
     expected_range = {35u, 1u};
-    EXPECT_EQ(cr_axis.range(pi + epsilon, nhood11i), expected_range);
+    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood11i),
+              expected_range);
     expected_range = {34u, 2u};
-    EXPECT_EQ(cr_axis.range(pi + epsilon, nhood22i), expected_range);
+    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood22i),
+              expected_range);
 
     // Axis range access - scalar (symmetric & asymmteric)
-    darray<scalar, 2> nhood00s = {0., 0.};
-    darray<scalar, 2> nhoodEpsilon = {scalar{0.5} * epsilon,
-                                      scalar{0.5} * epsilon};
-    scalar bin_step{cr_axis.bin_width()};
-    darray<scalar, 2> nhood22s = {2 * bin_step, 2 * bin_step};
+    const darray<scalar, 2> nhood00s = {0.f, 0.f};
+    const darray<scalar, 2> nhood_tol = {0.5f * tol, 0.5f * tol};
+    const scalar bin_step{cr_axis.bin_width()};
+    const darray<scalar, 2> nhood22s = {2.f * bin_step, 2.f * bin_step};
 
     expected_range = {0u, 0u};
-    EXPECT_EQ(cr_axis.range(pi + epsilon, nhood00s), expected_range);
-    EXPECT_EQ(cr_axis.range(pi + epsilon, nhoodEpsilon), expected_range);
+    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood00s),
+              expected_range);
+    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood_tol),
+              expected_range);
     expected_range = {34u, 2u};
-    EXPECT_EQ(cr_axis.range(pi + epsilon, nhood22s), expected_range);
+    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood22s),
+              expected_range);
 }
 
 TEST(grid, closed_irregular_axis) {
 
     // Lower bin edges: all lower bin edges for irregular binning, plus the
     // final upper bin edge
-    vecmem::vector<scalar> bin_edges = {-100, -3, 1, 2, 4, 8, 12, 15, 18};
+    vecmem::vector<scalar> bin_edges = {-100.f, -3.f, 1.f,  2.f, 4.f,
+                                        8.f,    12.f, 15.f, 18.f};
     // Index range for the bin edges [-3, 15]
-    dindex_range edge_range = {1, 7};
+    dindex_range edge_range = {1u, 7u};
 
     // A closed irregular z-axis
     single_axis<closed<label::e_z>, irregular<>> cir_axis(&edge_range,
@@ -274,40 +277,40 @@ TEST(grid, closed_irregular_axis) {
     // Bin tests
     EXPECT_EQ(cir_axis.bin(-2), 0u);
     EXPECT_EQ(cir_axis.bin(10), 4u);
-    EXPECT_EQ(cir_axis.bin(5.8), 3u);
+    EXPECT_EQ(cir_axis.bin(5.8f), 3u);
     // Underflow test
     EXPECT_EQ(cir_axis.bin(-4), 0u);
     // Overflow test
     EXPECT_EQ(cir_axis.bin(17), 5u);
 
     // Axis range access - binned  (symmetric & asymmetric)
-    darray<dindex, 2> nhood00i = {0u, 0u};
-    darray<dindex, 2> nhood01i = {0u, 1u};
-    darray<dindex, 2> nhood11i = {1u, 1u};
-    darray<dindex, 2> nhood22i = {2u, 2u};
+    const darray<dindex, 2> nhood00i = {0u, 0u};
+    const darray<dindex, 2> nhood01i = {0u, 1u};
+    const darray<dindex, 2> nhood11i = {1u, 1u};
+    const darray<dindex, 2> nhood22i = {2u, 2u};
 
     dindex_range expected_range = {2u, 2u};
-    EXPECT_EQ(cir_axis.range(3., nhood00i), expected_range);
+    EXPECT_EQ(cir_axis.range(3.f, nhood00i), expected_range);
     expected_range = {1u, 3u};
-    EXPECT_EQ(cir_axis.range(3., nhood11i), expected_range);
+    EXPECT_EQ(cir_axis.range(3.f, nhood11i), expected_range);
     expected_range = {2u, 3u};
-    EXPECT_EQ(cir_axis.range(3., nhood01i), expected_range);
+    EXPECT_EQ(cir_axis.range(3.f, nhood01i), expected_range);
     expected_range = {0u, 1u};
-    EXPECT_EQ(cir_axis.range(0., nhood11i), expected_range);
+    EXPECT_EQ(cir_axis.range(0.f, nhood11i), expected_range);
     expected_range = {2u, 5u};
-    EXPECT_EQ(cir_axis.range(10., nhood22i), expected_range);
+    EXPECT_EQ(cir_axis.range(10.f, nhood22i), expected_range);
 
     // Axis range access - scalar
-    darray<scalar, 2> nhood00s = {0., 0.};
-    darray<scalar, 2> nhood10s = {1.5, 0.2};
-    darray<scalar, 2> nhood11s = {4., 5.5};
+    const darray<scalar, 2> nhood00s = {0.f, 0.f};
+    const darray<scalar, 2> nhood10s = {1.5f, 0.2f};
+    const darray<scalar, 2> nhood11s = {4.f, 5.5f};
 
     expected_range = {2u, 2u};
-    EXPECT_EQ(cir_axis.range(3., nhood00s), expected_range);
+    EXPECT_EQ(cir_axis.range(3.f, nhood00s), expected_range);
     expected_range = {1u, 2u};
-    EXPECT_EQ(cir_axis.range(3., nhood10s), expected_range);
+    EXPECT_EQ(cir_axis.range(3.f, nhood10s), expected_range);
     expected_range = {0u, 4u};
-    EXPECT_EQ(cir_axis.range(3., nhood11s), expected_range);
+    EXPECT_EQ(cir_axis.range(3.f, nhood11s), expected_range);
 }
 
 TEST(grid, multi_axis) {
@@ -317,7 +320,7 @@ TEST(grid, multi_axis) {
     bool constexpr is_not_owning = false;
 
     // Lower bin edges for all axes
-    vecmem::vector<scalar> bin_edges = {-10., 10., -20., 20., 0., 100.};
+    vecmem::vector<scalar> bin_edges = {-10.f, 10.f, -20.f, 20.f, 0.f, 100.f};
     // Offsets into edges container and #bins for all axes
     vecmem::vector<dindex_range> edge_ranges = {
         {0u, 20u}, {2u, 40u}, {4u, 50u}};
@@ -340,22 +343,22 @@ TEST(grid, multi_axis) {
     EXPECT_EQ(ax.nbins(), 40u);
 
     // Test bin search
-    point3 p3{0., 0., 0.};  // origin
+    point3 p3{0.f, 0.f, 0.f};  // origin
     dmulti_index<dindex, 3> expected_bins{10u, 20u, 0u};
     EXPECT_EQ(axes.bins(p3), expected_bins);
-    p3 = {-5.5, -3.2, 24.1};
+    p3 = {-5.5f, -3.2f, 24.1f};
     expected_bins = {4u, 16u, 12u};
     EXPECT_EQ(axes.bins(p3), expected_bins);
-    p3 = {-1., 21., 12.};
+    p3 = {-1.f, 21.f, 12.f};
     expected_bins = {9u, 39u, 6u};
     EXPECT_EQ(axes.bins(p3), expected_bins);
 
     // Test bin range search
-    p3 = {1., 1., 10.};
+    p3 = {1.f, 1.f, 10.f};
     // Axis range access - binned  (symmetric & asymmetric)
-    darray<dindex, 2> nhood00i = {0u, 0u};
-    darray<dindex, 2> nhood01i = {0u, 1u};
-    darray<dindex, 2> nhood22i = {2u, 2u};
+    const darray<dindex, 2> nhood00i = {0u, 0u};
+    const darray<dindex, 2> nhood01i = {0u, 1u};
+    const darray<dindex, 2> nhood22i = {2u, 2u};
 
     dmulti_index<dindex_range, 3> expected_ranges{};
     expected_ranges[0] = {11u, 11u};
@@ -372,9 +375,9 @@ TEST(grid, multi_axis) {
     EXPECT_EQ(axes.bin_ranges(p3, nhood22i), expected_ranges);
 
     // Axis range access - scalar
-    darray<scalar, 2> nhood00s = {0., 0.};
-    darray<scalar, 2> nhood10s = {1.5, 0.2};
-    darray<scalar, 2> nhood11s = {4., 5.5};
+    const darray<scalar, 2> nhood00s = {0.f, 0.f};
+    const darray<scalar, 2> nhood10s = {1.5f, 0.2f};
+    const darray<scalar, 2> nhood11s = {4.f, 5.5f};
 
     expected_ranges[0] = {11u, 11u};
     expected_ranges[1] = {21u, 21u};

--- a/tests/common/include/tests/common/grid_grid_builder.inl
+++ b/tests/common/include/tests/common/grid_grid_builder.inl
@@ -50,8 +50,8 @@ TEST(grid, grid_factory) {
     const scalar minR{0.f};
     const scalar maxR{10.f};
     const scalar minPhi{0.f};
-    const scalar maxPhi{M_PI};
-    mask<annulus2D<>> ann2{0UL, minR, maxR, minPhi, maxPhi, 0.f, 0.f, 0.f};
+    const scalar maxPhi{constant<scalar>::pi};
+    mask<annulus2D<>> ann2{0u, minR, maxR, minPhi, maxPhi, 0.f, 0.f, 0.f};
 
     // Grid with correctly initialized axes, but empty bin content
     auto ann_gr = gr_factory.new_grid(ann2, {5, 10});
@@ -61,7 +61,7 @@ TEST(grid, grid_factory) {
     EXPECT_EQ(ann_axis_r.label(), label::e_r);
     EXPECT_EQ(ann_axis_r.bounds(), bounds::e_closed);
     EXPECT_EQ(ann_axis_r.binning(), binning::e_regular);
-    EXPECT_EQ(ann_axis_r.nbins(), 5UL);
+    EXPECT_EQ(ann_axis_r.nbins(), 5u);
     EXPECT_NEAR(ann_axis_r.span()[0], 0.f,
                 std::numeric_limits<scalar>::epsilon());
     EXPECT_NEAR(ann_axis_r.span()[1], 10.f,
@@ -71,9 +71,9 @@ TEST(grid, grid_factory) {
     point3 p = {0.5f, 2.f, 0.f};
     vector3 d{};
     auto loc_p = ann_gr.global_to_local(Identity, p, d);
-    ann_gr.populate(loc_p, 3UL);
+    ann_gr.populate(loc_p, 3u);
 
-    EXPECT_FLOAT_EQ(ann_gr.search(loc_p)[0], 3UL);
+    EXPECT_EQ(ann_gr.search(loc_p)[0], 3u);
 
     // gr_builder.to_string(ann_gr);
 
@@ -84,8 +84,8 @@ TEST(grid, grid_factory) {
 
     auto cyl_gr = gr_factory.template new_grid<cylinder2D<>>(
         {bin_edges_z.front(), bin_edges_z.back(), 0.f,
-         2.f * static_cast<scalar>(M_PI)},
-        {bin_edges_z.size() - 1, 10UL}, {bin_edges_phi, bin_edges_z},
+         2.f * constant<scalar>::pi},
+        {bin_edges_z.size() - 1, 10u}, {bin_edges_phi, bin_edges_z},
         std::tuple<circular<label::e_rphi>, closed<label::e_cyl_z>>{},
         std::tuple<regular<>, irregular<>>{});
 
@@ -94,7 +94,7 @@ TEST(grid, grid_factory) {
     EXPECT_EQ(cyl_axis_z.label(), label::e_cyl_z);
     EXPECT_EQ(cyl_axis_z.bounds(), bounds::e_closed);
     EXPECT_EQ(cyl_axis_z.binning(), binning::e_irregular);
-    EXPECT_EQ(cyl_axis_z.nbins(), 7UL);
+    EXPECT_EQ(cyl_axis_z.nbins(), 7u);
     EXPECT_NEAR(cyl_axis_z.span()[0], -10.f,
                 std::numeric_limits<scalar>::epsilon());
     EXPECT_NEAR(cyl_axis_z.span()[1], 9.f,
@@ -102,29 +102,29 @@ TEST(grid, grid_factory) {
 
     // Test fill a bin to see, if bin content was correctly initialized
     loc_p = cyl_gr.global_to_local(Identity, p, d);
-    cyl_gr.populate(loc_p, 33UL);
+    cyl_gr.populate(loc_p, 33u);
 
-    EXPECT_FLOAT_EQ(cyl_gr.search(loc_p)[0], 33UL);
+    EXPECT_EQ(cyl_gr.search(loc_p)[0], 33u);
 
     // Build the same cylinder grid from a mask
     const scalar r{5.f};
     const scalar n_half_z{-10.f};
     const scalar p_half_z{9.f};
-    mask<cylinder2D<>> cyl2{0UL, r, n_half_z, p_half_z};
+    mask<cylinder2D<>> cyl2{0u, r, n_half_z, p_half_z};
 
     auto cyl_gr2 = gr_factory.template new_grid<circular<label::e_rphi>,
                                                 closed<label::e_cyl_z>,
                                                 regular<>, irregular<>>(
-        cyl2, {bin_edges_z.size() - 1, 10UL}, {bin_edges_phi, bin_edges_z});
+        cyl2, {bin_edges_z.size() - 1, 10u}, {bin_edges_phi, bin_edges_z});
 
     // Get grid collection with the correct allocator
     auto grid_coll = gr_factory.new_collection<decltype(cyl_gr)>();
-    EXPECT_TRUE(grid_coll.size() == 0UL);
+    EXPECT_TRUE(grid_coll.size() == 0u);
     grid_coll.push_back(cyl_gr);
     grid_coll.push_back(cyl_gr2);
-    EXPECT_TRUE(grid_coll.size() == 2UL);
+    EXPECT_TRUE(grid_coll.size() == 2u);
 
-    EXPECT_FLOAT_EQ(grid_coll[0].search(loc_p)[0], 33UL);
+    EXPECT_EQ(grid_coll[0].search(loc_p)[0], 33u);
     // gr_factory.to_string(grid_coll[0]);
 }
 
@@ -141,8 +141,8 @@ TEST(grid, grid_builder) {
                                  detray::detail::bin_associator>{};
 
     // The cylinder portals are at the end of the surface range by construction
-    const auto cyl_mask = mask<cylinder2D<>>{0UL, 10.f, -500.f, 500.f};
-    std::size_t n_phi_bins{5UL}, n_z_bins{4UL};
+    const auto cyl_mask = mask<cylinder2D<>>{0u, 10.f, -500.f, 500.f};
+    std::size_t n_phi_bins{5u}, n_z_bins{4u};
 
     // Build empty grid
     gbuilder.init_grid(cyl_mask, {n_phi_bins, n_z_bins});
@@ -152,7 +152,7 @@ TEST(grid, grid_builder) {
     EXPECT_EQ(cyl_axis_z.label(), label::e_cyl_z);
     EXPECT_EQ(cyl_axis_z.bounds(), bounds::e_closed);
     EXPECT_EQ(cyl_axis_z.binning(), binning::e_regular);
-    EXPECT_EQ(cyl_axis_z.nbins(), 4UL);
+    EXPECT_EQ(cyl_axis_z.nbins(), 4u);
     EXPECT_NEAR(cyl_axis_z.span()[0], -500.f,
                 std::numeric_limits<scalar>::epsilon());
     EXPECT_NEAR(cyl_axis_z.span()[1], 500.f,
@@ -196,8 +196,8 @@ TEST(grid, decorator_grid_builder) {
     // gbuilder.set_add_passives();
 
     // The cylinder portals are at the end of the surface range by construction
-    const auto cyl_mask = mask<cylinder2D<>>{0UL, 10.f, -500.f, 500.f};
-    std::size_t n_phi_bins{5UL}, n_z_bins{4UL};
+    const auto cyl_mask = mask<cylinder2D<>>{0u, 10.f, -500.f, 500.f};
+    std::size_t n_phi_bins{5u}, n_z_bins{4u};
 
     // Build empty grid
     gbuilder.init_grid(cyl_mask, {n_phi_bins, n_z_bins});
@@ -205,12 +205,13 @@ TEST(grid, decorator_grid_builder) {
     EXPECT_TRUE(d.volumes().size() == 0);
 
     // Now init the volume
-    gbuilder.init_vol(d, volume_id::e_cylinder,
-                      {0., 10., -5., 5., -M_PI, M_PI});
+    gbuilder.init_vol(
+        d, volume_id::e_cylinder,
+        {0.f, 10.f, -5.f, 5.f, -constant<scalar>::pi, constant<scalar>::pi});
 
     const auto& vol = d.volumes().back();
-    EXPECT_TRUE(d.volumes().size() == 1);
-    EXPECT_EQ(vol.index(), 0);
+    EXPECT_TRUE(d.volumes().size() == 1u);
+    EXPECT_EQ(vol.index(), 0u);
     EXPECT_EQ(vol.id(), volume_id::e_cylinder);
 
     // Add some portals first
@@ -219,11 +220,11 @@ TEST(grid, decorator_grid_builder) {
     typename portal_cylinder_factory_t::sf_data_collection cyl_sf_data;
     cyl_sf_data.push_back(
         std::make_unique<surface_data<test_detector_t, cylinder2D<>>>(
-            transform3(point3{0.f, 0.f, 0.f}), 0UL,
+            transform3(point3{0.f, 0.f, 0.f}), 0u,
             std::vector<scalar>{10.f, -1500.f, 1500.f}));
     cyl_sf_data.push_back(
         std::make_unique<surface_data<test_detector_t, cylinder2D<>>>(
-            transform3(point3{0.f, 0.f, 0.f}), 2UL,
+            transform3(point3{0.f, 0.f, 0.f}), 2u,
             std::vector<scalar>{20.f, -1500.f, 1500.f}));
     pt_cyl_factory->add_components(std::move(cyl_sf_data));
 
@@ -271,7 +272,7 @@ TEST(grid, decorator_grid_builder) {
 
     const auto& cyl_axis_z = gbuilder().template get_axis<label::e_cyl_z>();
     EXPECT_EQ(cyl_axis_z.label(), label::e_cyl_z);
-    EXPECT_EQ(cyl_axis_z.nbins(), 4UL);
+    EXPECT_EQ(cyl_axis_z.nbins(), 4u);
 
     gbuilder.build(d);
 
@@ -281,7 +282,7 @@ TEST(grid, decorator_grid_builder) {
     EXPECT_FALSE(vol.empty());
     // only the portals are referenced through the volume
     typename detector_registry::toy_detector::object_link_type sf_range{};
-    sf_range[0] = {0UL, 3UL};
+    sf_range[0] = {0u, 3u};
     // toy detector makes no distinction between the surface types
     EXPECT_EQ(vol.full_range(), sf_range[geo_obj_id::e_sensitive]);
     EXPECT_EQ(vol.template obj_link<geo_obj_id::e_portal>(),
@@ -292,12 +293,12 @@ TEST(grid, decorator_grid_builder) {
               sf_range[geo_obj_id::e_passive]);
 
     // Only the portals should be in the detector's surface container now
-    EXPECT_EQ(d.surfaces().size(), 3UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_cylinder2>(), 3UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_ring2>(), 0UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_cylinder2>(), 3UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_rectangle2>(), 3UL);
-    EXPECT_EQ(d.mask_store().template size<mask_id::e_trapezoid2>(), 1UL);
+    EXPECT_EQ(d.surfaces().size(), 3u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_cylinder2>(), 3u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_ring2>(), 0u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_cylinder2>(), 3u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_rectangle2>(), 3u);
+    EXPECT_EQ(d.mask_store().template size<mask_id::e_trapezoid2>(), 1u);
 
     // check the portals in the detector
     for (const auto& sf : d.surfaces()) {
@@ -314,7 +315,7 @@ TEST(grid, decorator_grid_builder) {
     for (std::size_t gbin{0}; gbin < cyl_grid.nbins(); ++gbin) {
         for (auto& sf : cyl_grid.at(gbin)) {
             EXPECT_TRUE(sf.is_sensitive());
-            EXPECT_EQ(sf.volume(), 0UL);
+            EXPECT_EQ(sf.volume(), 0u);
             EXPECT_EQ(sf.transform(), trf_idx++);
         }
     }

--- a/tests/common/include/tests/common/grid_grid_collection.inl
+++ b/tests/common/include/tests/common/grid_grid_collection.inl
@@ -70,11 +70,11 @@ TEST(grid, grid_collection) {
 
     // Bin test entries
     grid_t::bin_storage_type bin_data{};
-    bin_data.resize(197UL);
+    bin_data.resize(197u);
     std::generate_n(
-        bin_data.begin(), 197UL,
+        bin_data.begin(), 197u,
         bin_content_sequence<populator<grid_t::populator_impl>, dindex>());
-    dvector<dindex> grid_offsets = {0UL, 48UL, 72UL};
+    dvector<dindex> grid_offsets = {0u, 48u, 72u};
 
     // Data-owning grid collection
     auto grid_coll =
@@ -84,10 +84,10 @@ TEST(grid, grid_collection) {
     // Tests
 
     // Basics
-    EXPECT_EQ(grid_coll.size(), 3UL);
-    EXPECT_EQ(grid_coll.bin_storage().size(), 197UL);
-    EXPECT_EQ(grid_coll.axes_storage().size(), 9UL);
-    EXPECT_EQ(grid_coll.bin_edges_storage().size(), 18UL);
+    EXPECT_EQ(grid_coll.size(), 3u);
+    EXPECT_EQ(grid_coll.bin_storage().size(), 197u);
+    EXPECT_EQ(grid_coll.axes_storage().size(), 9u);
+    EXPECT_EQ(grid_coll.bin_edges_storage().size(), 18u);
 
     // Get a grid instance
     auto single_grid = grid_coll[1];
@@ -97,20 +97,20 @@ TEST(grid, grid_collection) {
 
     EXPECT_EQ(single_grid.Dim, 3);
     auto r_axis = single_grid.get_axis<label::e_r>();
-    EXPECT_EQ(r_axis.nbins(), 1UL);
+    EXPECT_EQ(r_axis.nbins(), 1u);
     using z_axis_t = single_axis<closed<label::e_z>, regular<>>;
     auto z_axis = single_grid.get_axis<z_axis_t>();
-    EXPECT_EQ(z_axis.nbins(), 8UL);
+    EXPECT_EQ(z_axis.nbins(), 8u);
 
     // The generator starts countaing at one instead of zero
-    EXPECT_EQ(single_grid.at(0u, 0u, 0u)[0u], 49UL);
+    EXPECT_EQ(single_grid.at(0u, 0u, 0u)[0u], 49u);
     EXPECT_EQ(single_grid.at(0u, 0u, 0u)[1u], inf);
     EXPECT_EQ(single_grid.at(0u, 0u, 0u)[2u], inf);
 
     auto bin_view = grid_coll[2].at(101u);
-    grid_coll[2].populate(101UL, 42UL);
-    EXPECT_EQ(bin_view[0u], 102UL + 72UL);
-    EXPECT_EQ(bin_view[1u], 42UL);
+    grid_coll[2].populate(101u, 42u);
+    EXPECT_EQ(bin_view[0u], 102u + 72u);
+    EXPECT_EQ(bin_view[1u], 42u);
     EXPECT_EQ(bin_view[2u], inf);
 
     auto grid_coll_view = get_data(grid_coll);

--- a/tests/common/include/tests/common/grid_populator.inl
+++ b/tests/common/include/tests/common/grid_populator.inl
@@ -58,21 +58,21 @@ TEST(grid, replace_populator) {
     std::generate_n(bin_data.begin(), 50, increment<populator_t, dindex>());
 
     // Check test setup
-    EXPECT_EQ(bin_data[2].content(), 3UL);
-    EXPECT_EQ(replace_populator.view(bin_data, 2)[0], 3UL);
-    EXPECT_EQ(bin_data[42].content(), 43UL);
-    EXPECT_EQ(replace_populator.view(bin_data, 42)[0], 43UL);
+    EXPECT_EQ(bin_data[2].content(), 3u);
+    EXPECT_EQ(replace_populator.view(bin_data, 2)[0], 3u);
+    EXPECT_EQ(bin_data[42].content(), 43u);
+    EXPECT_EQ(replace_populator.view(bin_data, 42)[0], 43u);
 
     // Replace some bin entries
     dindex entry{15};
 
     replace_populator(bin_data, 2, entry);
-    EXPECT_EQ(bin_data[2].content(), 15UL);
-    EXPECT_EQ(replace_populator.view(bin_data, 2)[0], 15UL);
+    EXPECT_EQ(bin_data[2].content(), 15u);
+    EXPECT_EQ(replace_populator.view(bin_data, 2)[0], 15u);
 
     replace_populator(bin_data, 2, entry);
-    EXPECT_EQ(bin_data[2].content(), 15UL);
-    EXPECT_EQ(replace_populator.view(bin_data, 2)[0], 15UL);
+    EXPECT_EQ(bin_data[2].content(), 15u);
+    EXPECT_EQ(replace_populator.view(bin_data, 2)[0], 15u);
 }
 
 /// Complete populator
@@ -88,23 +88,23 @@ TEST(grid, complete_populator) {
     std::generate_n(bin_data.begin(), 50, increment<populator_t, dindex>());
 
     // Check test setup
-    populator_t::template bin_type<dindex>::content_type stored = {3UL, inf,
-                                                                   inf, inf};
+    populator_t::template bin_type<dindex>::content_type stored = {3u, inf, inf,
+                                                                   inf};
     EXPECT_EQ(bin_data[2].content(), stored);
     test_content(complete_populator, bin_data, 2, stored);
-    stored = {43UL, inf, inf, inf};
+    stored = {43u, inf, inf, inf};
     EXPECT_EQ(bin_data[42].content(), stored);
     test_content(complete_populator, bin_data, 42, stored);
 
     // Fill up some bin entries
     dindex entry{15};
 
-    stored = {3UL, 15UL, 15UL, 15UL};
+    stored = {3u, 15u, 15u, 15u};
     complete_populator(bin_data, 2, entry);
     EXPECT_EQ(bin_data[2].content(), stored);
     test_content(complete_populator, bin_data, 2, stored);
 
-    stored = {43UL, 15UL, 15UL, 15UL};
+    stored = {43u, 15u, 15u, 15u};
     complete_populator(bin_data, 42, entry);
     EXPECT_EQ(bin_data[42].content(), stored);
     test_content(complete_populator, bin_data, 42, stored);
@@ -112,12 +112,12 @@ TEST(grid, complete_populator) {
     // Do sorting, 4 dims, dindex entries in backend storage, std::array
     populator<completer<4, true>> sort_complete_populator;
 
-    stored = {2UL, 15UL, 15UL, 15UL};
+    stored = {2u, 15u, 15u, 15u};
     sort_complete_populator(bin_data, 1, entry);
     EXPECT_EQ(bin_data[1].content(), stored);
     test_content(sort_complete_populator, bin_data, 1, stored);
 
-    stored = {15UL, 15UL, 15UL, 42UL};
+    stored = {15u, 15u, 15u, 42u};
     sort_complete_populator(bin_data, 41, entry);
     EXPECT_EQ(bin_data[41].content(), stored);
     test_content(sort_complete_populator, bin_data, 41, stored);
@@ -136,24 +136,24 @@ TEST(grid, regular_attach_populator) {
     std::generate_n(bin_data.begin(), 50, increment<populator_t, dindex>());
 
     // Check test setup
-    populator_t::template bin_type<dindex>::content_type stored = {3UL, inf,
-                                                                   inf, inf};
+    populator_t::template bin_type<dindex>::content_type stored = {3u, inf, inf,
+                                                                   inf};
     EXPECT_EQ(bin_data[2].content(), stored);
     test_content(reg_attach_populator, bin_data, 2, stored);
-    stored = {43UL, inf, inf, inf};
+    stored = {43u, inf, inf, inf};
     EXPECT_EQ(bin_data[42].content(), stored);
     test_content(reg_attach_populator, bin_data, 42, stored);
 
     // Attach some bin entries
     dindex entry1{15}, entry2{8};
 
-    stored = {3UL, 15UL, 8UL, inf};
+    stored = {3u, 15u, 8u, inf};
     reg_attach_populator(bin_data, 2, entry1);
     reg_attach_populator(bin_data, 2, entry2);
     EXPECT_EQ(bin_data[2].content(), stored);
     test_content(reg_attach_populator, bin_data, 2, stored);
 
-    stored = {43UL, 15UL, 8UL, 16UL};
+    stored = {43u, 15u, 8u, 16u};
     reg_attach_populator(bin_data, 42, entry1);
     reg_attach_populator(bin_data, 42, entry2);
     reg_attach_populator(bin_data, 42, entry1 + 1);
@@ -163,14 +163,14 @@ TEST(grid, regular_attach_populator) {
     // Do sorting, 4 dims, dindex entries in backend storage, std::array
     populator<regular_attacher<4, true>> sort_reg_attach_populator;
 
-    stored = {2UL, 8UL, 9UL, 15UL};
+    stored = {2u, 8u, 9u, 15u};
     sort_reg_attach_populator(bin_data, 1, entry1);
     sort_reg_attach_populator(bin_data, 1, entry2);
     sort_reg_attach_populator(bin_data, 1, entry2 + 1);
     EXPECT_EQ(bin_data[1].content(), stored);
     test_content(sort_reg_attach_populator, bin_data, 1, stored);
 
-    stored = {8UL, 15UL, 42UL, inf};
+    stored = {8u, 15u, 42u, inf};
     sort_reg_attach_populator(bin_data, 41, entry1);
     sort_reg_attach_populator(bin_data, 41, entry2);
     EXPECT_EQ(bin_data[41].content(), stored);

--- a/tests/common/include/tests/common/grid_serializer.inl
+++ b/tests/common/include/tests/common/grid_serializer.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,7 +39,7 @@ using cylinder_axes = multi_axis<
     single_axis<closed<label::e_z>, regular<host_container_types, scalar>>>;
 
 // Floating point comparison
-constexpr scalar tol{1e-5};
+constexpr scalar tol{1e-5f};
 
 }  // anonymous namespace
 

--- a/tests/common/include/tests/common/line_stepper.inl
+++ b/tests/common/include/tests/common/line_stepper.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,7 +29,7 @@ using namespace detray;
 using matrix_operator = standard_matrix_operator<scalar>;
 using transform3 = __plugin::transform3<detray::scalar>;
 
-constexpr scalar epsilon = 1e-6;
+constexpr scalar tol{1e-6f};
 
 TEST(line_stepper, covariance_transport) {
 
@@ -39,8 +39,8 @@ TEST(line_stepper, covariance_transport) {
     constexpr bool unbounded = true;
 
     // Create telescope detector with a single plane
-    detail::ray<transform3> traj{{0, 0, 0}, 0, {1, 0, 0}, -1};
-    std::vector<scalar> positions = {0., 10., 20., 30., 40., 50., 60.};
+    detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
+    std::vector<scalar> positions = {0.f, 10.f, 20.f, 30.f, 40.f, 50.f, 60.f};
 
     const auto det =
         create_telescope_detector<unbounded>(host_mr, positions, traj);
@@ -54,20 +54,20 @@ TEST(line_stepper, covariance_transport) {
 
     // Bound vector
     typename bound_track_parameters<transform3>::vector_type bound_vector;
-    getter::element(bound_vector, e_bound_loc0, 0) = 0.;
-    getter::element(bound_vector, e_bound_loc1, 0) = 0.;
-    getter::element(bound_vector, e_bound_phi, 0) = 0.;
-    getter::element(bound_vector, e_bound_theta, 0) = M_PI / 4.;
-    getter::element(bound_vector, e_bound_qoverp, 0) = -1. / 10.;
-    getter::element(bound_vector, e_bound_time, 0) = 0.;
+    getter::element(bound_vector, e_bound_loc0, 0u) = 0.f;
+    getter::element(bound_vector, e_bound_loc1, 0u) = 0.f;
+    getter::element(bound_vector, e_bound_phi, 0u) = 0.f;
+    getter::element(bound_vector, e_bound_theta, 0u) = constant<scalar>::pi_4;
+    getter::element(bound_vector, e_bound_qoverp, 0u) = -1.f / 10.f;
+    getter::element(bound_vector, e_bound_time, 0u) = 0.f;
 
     // Bound covariance
     typename bound_track_parameters<transform3>::covariance_type bound_cov =
         matrix_operator().template identity<e_bound_size, e_bound_size>();
 
     // Note: Set angle error as ZERO, to constrain the loc0 and loc1 divergence
-    getter::element(bound_cov, e_bound_phi, e_bound_phi) = 0.;
-    getter::element(bound_cov, e_bound_theta, e_bound_theta) = 0.;
+    getter::element(bound_cov, e_bound_phi, e_bound_phi) = 0.f;
+    getter::element(bound_cov, e_bound_theta, e_bound_theta) = 0.f;
 
     // Bound track parameter
     const bound_track_parameters<transform3> bound_param0(0, bound_vector,
@@ -90,26 +90,26 @@ TEST(line_stepper, covariance_transport) {
     // const auto bound_vec1 = bound_param1.vector();
 
     // Check if the track reaches the final surface
-    EXPECT_EQ(bound_param0.surface_link(), 0);
-    EXPECT_EQ(bound_param1.surface_link(), 5);
+    EXPECT_EQ(bound_param0.surface_link(), 0u);
+    EXPECT_EQ(bound_param1.surface_link(), 5u);
 
     const auto bound_cov0 = bound_param0.covariance();
     const auto bound_cov1 = bound_param1.covariance();
 
     // Check covaraince
-    for (std::size_t i = 0; i < e_bound_size; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < e_bound_size; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             EXPECT_NEAR(matrix_operator().element(bound_cov0, i, j),
-                        matrix_operator().element(bound_cov1, i, j), epsilon);
+                        matrix_operator().element(bound_cov1, i, j), tol);
         }
     }
 
     // Check covaraince
-    for (std::size_t i = 0; i < e_bound_size; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < e_bound_size; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
 
             EXPECT_NEAR(matrix_operator().element(bound_cov0, i, j),
-                        matrix_operator().element(bound_cov1, i, j), epsilon);
+                        matrix_operator().element(bound_cov1, i, j), tol);
         }
     }
 }

--- a/tests/common/include/tests/common/masks_annulus2D.inl
+++ b/tests/common/include/tests/common/masks_annulus2D.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,22 +13,24 @@
 using namespace detray;
 using namespace __plugin;
 
+constexpr scalar tol{1e-7f};
+
 /// This tests the basic functionality of a stereo annulus
 TEST(mask, annulus2D) {
     using point_t = typename mask<annulus2D<>>::loc_point_t;
 
-    constexpr scalar minR{7.2 * unit<scalar>::mm};
-    constexpr scalar maxR{12.0 * unit<scalar>::mm};
-    constexpr scalar minPhi{0.74195};
-    constexpr scalar maxPhi{1.33970};
-    point_t offset = {-2., 2.};
+    constexpr scalar minR{7.2f * unit<scalar>::mm};
+    constexpr scalar maxR{12.0f * unit<scalar>::mm};
+    constexpr scalar minPhi{0.74195f};
+    constexpr scalar maxPhi{1.33970f};
+    point_t offset = {-2.f, 2.f};
 
     // points in cartesian module frame
-    point_t p2_in = {7., 7.};
-    point_t p2_out1 = {5., 5.};
-    point_t p2_out2 = {10., 3.};
-    point_t p2_out3 = {10., 10.};
-    point_t p2_out4 = {4., 10.};
+    point_t p2_in = {7.f, 7.f};
+    point_t p2_out1 = {5.f, 5.f};
+    point_t p2_out2 = {10.f, 3.f};
+    point_t p2_out3 = {10.f, 10.f};
+    point_t p2_out4 = {4.f, 10.f};
 
     auto toStripFrame = [&](const point_t& xy) -> point_t {
         auto shifted = xy + offset;
@@ -37,16 +39,16 @@ TEST(mask, annulus2D) {
         return point_t{r, phi};
     };
 
-    mask<annulus2D<>> ann2{0UL,    minR,      maxR,      minPhi,
+    mask<annulus2D<>> ann2{0u,     minR,      maxR,      minPhi,
                            maxPhi, offset[0], offset[1], 0.f};
 
-    ASSERT_FLOAT_EQ(ann2[annulus2D<>::e_min_r], scalar{7.2});
-    ASSERT_FLOAT_EQ(ann2[annulus2D<>::e_max_r], scalar{12.0});
-    ASSERT_FLOAT_EQ(ann2[annulus2D<>::e_min_phi_rel], scalar{0.74195});
-    ASSERT_FLOAT_EQ(ann2[annulus2D<>::e_max_phi_rel], scalar{1.33970});
-    ASSERT_FLOAT_EQ(ann2[annulus2D<>::e_shift_x], scalar{-2.0});
-    ASSERT_FLOAT_EQ(ann2[annulus2D<>::e_shift_y], scalar{2.0});
-    ASSERT_FLOAT_EQ(ann2[annulus2D<>::e_average_phi], scalar{0.});
+    ASSERT_NEAR(ann2[annulus2D<>::e_min_r], 7.2f, tol);
+    ASSERT_NEAR(ann2[annulus2D<>::e_max_r], 12.0f, tol);
+    ASSERT_NEAR(ann2[annulus2D<>::e_min_phi_rel], 0.74195f, tol);
+    ASSERT_NEAR(ann2[annulus2D<>::e_max_phi_rel], 1.33970f, tol);
+    ASSERT_NEAR(ann2[annulus2D<>::e_shift_x], -2.0f, tol);
+    ASSERT_NEAR(ann2[annulus2D<>::e_shift_y], 2.0f, tol);
+    ASSERT_NEAR(ann2[annulus2D<>::e_average_phi], 0.f, tol);
 
     ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_in)) ==
                 intersection::status::e_inside);
@@ -59,19 +61,19 @@ TEST(mask, annulus2D) {
     ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out4)) ==
                 intersection::status::e_outside);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out1), 1.3) ==
+    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out1), 1.3f) ==
                 intersection::status::e_inside);
-    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out4), 0.07) ==
+    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out4), 0.07f) ==
                 intersection::status::e_inside);
 
     // Check projection matrix
     const auto proj = ann2.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j && i < decltype(ann2)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }

--- a/tests/common/include/tests/common/masks_cylinder.inl
+++ b/tests/common/include/tests/common/masks_cylinder.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,41 +13,43 @@
 using namespace detray;
 using namespace __plugin;
 
-constexpr scalar r{3. * unit<scalar>::mm};
-constexpr scalar hz{4. * unit<scalar>::mm};
+constexpr scalar tol{1e-7f};
+
+constexpr scalar r{3.f * unit<scalar>::mm};
+constexpr scalar hz{4.f * unit<scalar>::mm};
 
 /// This tests the basic functionality of a 3D cylinder
 TEST(mask, cylinder3D) {
     using point_t = typename mask<cylinder3D>::loc_point_t;
 
-    point_t p3_in = {r, 0., -1.};
-    point_t p3_edge = {0., r, hz};
-    point_t p3_out = {static_cast<scalar>(r / std::sqrt(2.)),
-                      static_cast<scalar>(r / std::sqrt(2.)), 4.5};
-    point_t p3_off = {1., 1., -9.};
+    point_t p3_in = {r, 0.f, -1.f};
+    point_t p3_edge = {0.f, r, hz};
+    point_t p3_out = {r * constant<scalar>::inv_sqrt2,
+                      r * constant<scalar>::inv_sqrt2, 4.5f};
+    point_t p3_off = {1.f, 1.f, -9.f};
 
     // Test radius to be on surface, too
-    mask<cylinder3D> c{0UL, r, -hz, hz};
+    mask<cylinder3D> c{0u, r, -hz, hz};
 
-    ASSERT_FLOAT_EQ(c[cylinder3D::e_r], r);
-    ASSERT_FLOAT_EQ(c[cylinder3D::e_n_half_z], -hz);
-    ASSERT_FLOAT_EQ(c[cylinder3D::e_p_half_z], hz);
+    ASSERT_NEAR(c[cylinder3D::e_r], r, tol);
+    ASSERT_NEAR(c[cylinder3D::e_n_half_z], -hz, tol);
+    ASSERT_NEAR(c[cylinder3D::e_p_half_z], hz, tol);
 
     ASSERT_TRUE(c.is_inside(p3_in) == intersection::status::e_inside);
     ASSERT_TRUE(c.is_inside(p3_edge) == intersection::status::e_inside);
     ASSERT_TRUE(c.is_inside(p3_out) == intersection::status::e_outside);
     ASSERT_TRUE(c.is_inside(p3_off) == intersection::status::e_outside);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(c.is_inside(p3_out, 0.6) == intersection::status::e_inside);
+    ASSERT_TRUE(c.is_inside(p3_out, 0.6f) == intersection::status::e_inside);
 
     // Check projection matrix
     const auto proj = c.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j && i < decltype(c)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }
@@ -57,31 +59,31 @@ TEST(mask, cylinder3D) {
 TEST(mask, cylinder2D) {
     using point_t = typename mask<cylinder2D<>>::loc_point_t;
 
-    point_t p2_in = {r, -1.};
+    point_t p2_in = {r, -1.f};
     point_t p2_edge = {r, hz};
-    point_t p2_out = {3.5, 4.5};
+    point_t p2_out = {3.5f, 4.5f};
 
     // Test radius to be on surface, too
-    mask<cylinder2D<>> c{0UL, r, -hz, hz};
+    mask<cylinder2D<>> c{0u, r, -hz, hz};
 
-    ASSERT_FLOAT_EQ(c[cylinder2D<>::e_r], r);
-    ASSERT_FLOAT_EQ(c[cylinder2D<>::e_n_half_z], -hz);
-    ASSERT_FLOAT_EQ(c[cylinder2D<>::e_p_half_z], hz);
+    ASSERT_NEAR(c[cylinder2D<>::e_r], r, tol);
+    ASSERT_NEAR(c[cylinder2D<>::e_n_half_z], -hz, tol);
+    ASSERT_NEAR(c[cylinder2D<>::e_p_half_z], hz, tol);
 
     ASSERT_TRUE(c.is_inside(p2_in) == intersection::status::e_inside);
     ASSERT_TRUE(c.is_inside(p2_edge) == intersection::status::e_inside);
     ASSERT_TRUE(c.is_inside(p2_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(c.is_inside(p2_out, 0.6) == intersection::status::e_inside);
+    ASSERT_TRUE(c.is_inside(p2_out, 0.6f) == intersection::status::e_inside);
 
     // Check projection matrix
     const auto proj = c.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j && i < decltype(c)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }

--- a/tests/common/include/tests/common/masks_line.inl
+++ b/tests/common/include/tests/common/masks_line.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,9 +15,11 @@ using namespace __plugin;
 
 namespace {
 
+constexpr scalar tol{1e-7f};
+
 // 50 mm wire with 1 mm radial cell size
-constexpr scalar cell_size{1. * unit<scalar>::mm};
-constexpr scalar hz{50. * unit<scalar>::mm};
+constexpr scalar cell_size{1.f * unit<scalar>::mm};
+constexpr scalar hz{50.f * unit<scalar>::mm};
 
 }  // anonymous namespace
 
@@ -25,15 +27,15 @@ constexpr scalar hz{50. * unit<scalar>::mm};
 TEST(mask, line_radial_cross_sect) {
     using point_t = typename mask<line<>>::loc_point_t;
 
-    const point_t ln_in{0.09, 0.5};
-    const point_t ln_edge{1., 50.};
-    const point_t ln_out1{1.2, 0};
-    const point_t ln_out2{0.09, -51.};
+    const point_t ln_in{0.09f, 0.5f};
+    const point_t ln_edge{1.f, 50.f};
+    const point_t ln_out1{1.2f, 0.f};
+    const point_t ln_out2{0.09f, -51.f};
 
-    const mask<line<>> ln{0UL, cell_size, hz};
+    const mask<line<>> ln{0u, cell_size, hz};
 
-    ASSERT_FLOAT_EQ(ln[line<>::e_cross_section], scalar{1. * unit<scalar>::mm});
-    ASSERT_FLOAT_EQ(ln[line<>::e_half_z], scalar{50. * unit<scalar>::mm});
+    ASSERT_NEAR(ln[line<>::e_cross_section], 1.f * unit<scalar>::mm, tol);
+    ASSERT_NEAR(ln[line<>::e_half_z], 50.f * unit<scalar>::mm, tol);
 
     ASSERT_TRUE(ln.is_inside(ln_in) == intersection::status::e_inside);
     ASSERT_TRUE(ln.is_inside(ln_edge) == intersection::status::e_inside);
@@ -42,12 +44,12 @@ TEST(mask, line_radial_cross_sect) {
 
     // Check projection matrix
     const auto proj = ln.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j && i < decltype(ln)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }
@@ -57,30 +59,30 @@ TEST(mask, line_radial_cross_sect) {
 TEST(mask, line_square_cross_sect) {
     using point_t = typename mask<line<true>>::loc_point_t;
 
-    const point_t ln_in{0.9, 0.9, 0};
-    const point_t ln_edge{1., 1., 0.};
-    const point_t ln_out{1.1, 0., 0};
+    const point_t ln_in{0.9f, 0.9f, 0.f};
+    const point_t ln_edge{1.f, 1.f, 0.f};
+    const point_t ln_out{1.1f, 0.f, 0.f};
 
     // 50 mm wire with 1 mm square cell sizes
-    const mask<line<true>> ln{0UL, cell_size, hz};
+    const mask<line<true>> ln{0u, cell_size, hz};
 
-    ASSERT_FLOAT_EQ(ln[line<>::e_cross_section], scalar{1. * unit<scalar>::mm});
-    ASSERT_FLOAT_EQ(ln[line<>::e_half_z], scalar{50. * unit<scalar>::mm});
+    ASSERT_NEAR(ln[line<>::e_cross_section], 1.f * unit<scalar>::mm, tol);
+    ASSERT_NEAR(ln[line<>::e_half_z], 50.f * unit<scalar>::mm, tol);
 
     ASSERT_TRUE(ln.is_inside(ln_in) == intersection::status::e_inside);
-    ASSERT_TRUE(ln.is_inside(ln_edge, 1e-5) == intersection::status::e_inside);
-    ASSERT_TRUE(ln.is_inside(ln_edge, -1e-5) ==
+    ASSERT_TRUE(ln.is_inside(ln_edge, 1e-5f) == intersection::status::e_inside);
+    ASSERT_TRUE(ln.is_inside(ln_edge, -1e-5f) ==
                 intersection::status::e_outside);
     ASSERT_TRUE(ln.is_inside(ln_out) == intersection::status::e_outside);
 
     // Check projection matrix
     const auto proj = ln.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j && i < decltype(ln)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }

--- a/tests/common/include/tests/common/masks_rectangle2D.inl
+++ b/tests/common/include/tests/common/masks_rectangle2D.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,37 +13,39 @@
 using namespace detray;
 using namespace __plugin;
 
-constexpr scalar hx{1. * unit<scalar>::mm};
-constexpr scalar hy{9.3 * unit<scalar>::mm};
-constexpr scalar hz{0.5 * unit<scalar>::mm};
+constexpr scalar tol{1e-7f};
+
+constexpr scalar hx{1.f * unit<scalar>::mm};
+constexpr scalar hy{9.3f * unit<scalar>::mm};
+constexpr scalar hz{0.5f * unit<scalar>::mm};
 
 /// This tests the basic functionality of a rectangle
 TEST(mask, rectangle2D) {
     using point_t = typename mask<rectangle2D<>>::loc_point_t;
 
-    point_t p2_in = {0.5, -9.};
-    point_t p2_edge = {1., 9.3};
-    point_t p2_out = {1.5, -9.};
+    point_t p2_in = {0.5f, -9.f};
+    point_t p2_edge = {1.f, 9.3f};
+    point_t p2_out = {1.5f, -9.f};
 
-    mask<rectangle2D<>> r2{0UL, hx, hy};
+    mask<rectangle2D<>> r2{0u, hx, hy};
 
-    ASSERT_FLOAT_EQ(r2[rectangle2D<>::e_half_x], hx);
-    ASSERT_FLOAT_EQ(r2[rectangle2D<>::e_half_y], hy);
+    ASSERT_NEAR(r2[rectangle2D<>::e_half_x], hx, tol);
+    ASSERT_NEAR(r2[rectangle2D<>::e_half_y], hy, tol);
 
     ASSERT_TRUE(r2.is_inside(p2_in) == intersection::status::e_inside);
     ASSERT_TRUE(r2.is_inside(p2_edge) == intersection::status::e_inside);
     ASSERT_TRUE(r2.is_inside(p2_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(r2.is_inside(p2_out, 1.) == intersection::status::e_inside);
+    ASSERT_TRUE(r2.is_inside(p2_out, 1.f) == intersection::status::e_inside);
 
     // Check projection matrix
     const auto proj = r2.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j && i < decltype(r2)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }
@@ -53,19 +55,19 @@ TEST(mask, rectangle2D) {
 TEST(mask, cuboid3D) {
     using point_t = typename mask<cuboid3D>::loc_point_t;
 
-    point_t p2_in = {0.5, 8.0, -0.4};
-    point_t p2_edge = {1., 9.3, 0.5};
-    point_t p2_out = {1.5, -9., 0.55};
+    point_t p2_in = {0.5f, 8.0f, -0.4f};
+    point_t p2_edge = {1.f, 9.3f, 0.5f};
+    point_t p2_out = {1.5f, -9.f, 0.55f};
 
-    mask<cuboid3D> c3{0UL, hx, hy, hz};
+    mask<cuboid3D> c3{0u, hx, hy, hz};
 
-    ASSERT_FLOAT_EQ(c3[cuboid3D::e_half_x], hx);
-    ASSERT_FLOAT_EQ(c3[cuboid3D::e_half_y], hy);
-    ASSERT_FLOAT_EQ(c3[cuboid3D::e_half_z], hz);
+    ASSERT_NEAR(c3[cuboid3D::e_half_x], hx, tol);
+    ASSERT_NEAR(c3[cuboid3D::e_half_y], hy, tol);
+    ASSERT_NEAR(c3[cuboid3D::e_half_z], hz, tol);
 
     ASSERT_TRUE(c3.is_inside(p2_in) == intersection::status::e_inside);
     ASSERT_TRUE(c3.is_inside(p2_edge) == intersection::status::e_inside);
     ASSERT_TRUE(c3.is_inside(p2_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(c3.is_inside(p2_out, 1.) == intersection::status::e_inside);
+    ASSERT_TRUE(c3.is_inside(p2_out, 1.f) == intersection::status::e_inside);
 }

--- a/tests/common/include/tests/common/masks_ring2D.inl
+++ b/tests/common/include/tests/common/masks_ring2D.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,36 +12,39 @@
 
 using namespace detray;
 
+constexpr scalar tol{1e-7f};
+
 /// This tests the basic functionality of a ring
 TEST(mask, ring2D) {
     using point_t = typename mask<ring2D<>>::loc_point_t;
 
-    point_t p2_pl_in = {0.5, -2.};
-    point_t p2_pl_edge = {0., 3.5};
-    point_t p2_pl_out = {3.6, 5.};
+    point_t p2_pl_in = {0.5f, -2.f};
+    point_t p2_pl_edge = {0.f, 3.5f};
+    point_t p2_pl_out = {3.6f, 5.f};
 
-    constexpr scalar inner_r{0. * unit<scalar>::mm};
-    constexpr scalar outer_r{3.5 * unit<scalar>::mm};
+    constexpr scalar inner_r{0.f * unit<scalar>::mm};
+    constexpr scalar outer_r{3.5f * unit<scalar>::mm};
 
-    mask<ring2D<>> r2{0UL, inner_r, outer_r};
+    mask<ring2D<>> r2{0u, inner_r, outer_r};
 
-    ASSERT_FLOAT_EQ(r2[ring2D<>::e_inner_r], static_cast<scalar>(0.));
-    ASSERT_FLOAT_EQ(r2[ring2D<>::e_outer_r], static_cast<scalar>(3.5));
+    ASSERT_NEAR(r2[ring2D<>::e_inner_r], 0.f, tol);
+    ASSERT_NEAR(r2[ring2D<>::e_outer_r], 3.5f, tol);
 
     ASSERT_TRUE(r2.is_inside(p2_pl_in) == intersection::status::e_inside);
     ASSERT_TRUE(r2.is_inside(p2_pl_edge) == intersection::status::e_inside);
     ASSERT_TRUE(r2.is_inside(p2_pl_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(r2.is_inside(p2_pl_out, 1.2) == intersection::status::e_inside);
+    ASSERT_TRUE(r2.is_inside(p2_pl_out, 1.2f) ==
+                intersection::status::e_inside);
 
     // Check projection matrix
     const auto proj = r2.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j && i < decltype(r2)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }

--- a/tests/common/include/tests/common/masks_single3D.inl
+++ b/tests/common/include/tests/common/masks_single3D.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,55 +13,57 @@
 using namespace detray;
 using namespace __plugin;
 
+constexpr scalar tol{1e-7f};
+
 /// This tests the basic functionality of a single value mask (index 0)
 TEST(mask, single3_0) {
     using point_t = typename mask<single3D<>>::loc_point_t;
 
-    point_t p3_in = {0.5, -9., 0.};
-    point_t p3_edge = {1., 9.3, 2.};
-    point_t p3_out = {1.5, -9.8, 8.};
+    point_t p3_in = {0.5f, -9.f, 0.f};
+    point_t p3_edge = {1.f, 9.3f, 2.f};
+    point_t p3_out = {1.5f, -9.8f, 8.f};
 
-    constexpr scalar h0{1. * unit<scalar>::mm};
-    mask<single3D<>> m1_0{0UL, -h0, h0};
+    constexpr scalar h0{1.f * unit<scalar>::mm};
+    mask<single3D<>> m1_0{0u, -h0, h0};
 
-    ASSERT_FLOAT_EQ(m1_0[single3D<>::e_lower], -h0);
-    ASSERT_FLOAT_EQ(m1_0[single3D<>::e_upper], h0);
+    ASSERT_NEAR(m1_0[single3D<>::e_lower], -h0, tol);
+    ASSERT_NEAR(m1_0[single3D<>::e_upper], h0, tol);
 
     ASSERT_TRUE(m1_0.is_inside(p3_in) == intersection::status::e_inside);
     ASSERT_TRUE(m1_0.is_inside(p3_edge) == intersection::status::e_inside);
     ASSERT_TRUE(m1_0.is_inside(p3_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance - take t0 not t1
-    ASSERT_TRUE(m1_0.is_inside(p3_out, 0.6) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_0.is_inside(p3_out, 0.6f) == intersection::status::e_inside);
 }
 
 /// This tests the basic functionality of a single value mask (index 1)
 TEST(mask, single3_1) {
     using point_t = typename mask<single3D<1>>::loc_point_t;
 
-    point_t p3_in = {0.5, -9., 0.};
-    point_t p3_edge = {1., 9.3, 2.};
-    point_t p3_out = {1.5, -9.8, 8.};
+    point_t p3_in = {0.5f, -9.f, 0.f};
+    point_t p3_edge = {1.f, 9.3f, 2.f};
+    point_t p3_out = {1.5f, -9.8f, 8.f};
 
-    constexpr scalar h1{9.3 * unit<scalar>::mm};
-    mask<single3D<1>> m1_1{0UL, -h1, h1};
+    constexpr scalar h1{9.3f * unit<scalar>::mm};
+    mask<single3D<1>> m1_1{0u, -h1, h1};
 
-    ASSERT_FLOAT_EQ(m1_1[single3D<>::e_lower], -h1);
-    ASSERT_FLOAT_EQ(m1_1[single3D<>::e_upper], h1);
+    ASSERT_NEAR(m1_1[single3D<>::e_lower], -h1, tol);
+    ASSERT_NEAR(m1_1[single3D<>::e_upper], h1, tol);
 
     ASSERT_TRUE(m1_1.is_inside(p3_in) == intersection::status::e_inside);
     ASSERT_TRUE(m1_1.is_inside(p3_edge) == intersection::status::e_inside);
     ASSERT_TRUE(m1_1.is_inside(p3_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance - take t1 not t1
-    ASSERT_TRUE(m1_1.is_inside(p3_out, 0.6) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_1.is_inside(p3_out, 0.6f) == intersection::status::e_inside);
 
     // Check projection matrix
     const auto proj = m1_1.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j && i < decltype(m1_1)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }
@@ -71,30 +73,30 @@ TEST(mask, single3_1) {
 TEST(mask, single3_2) {
     using point_t = typename mask<single3D<2>>::loc_point_t;
 
-    point_t p3_in = {0.5, -9., 0.};
-    point_t p3_edge = {1., 9.3, 2.};
-    point_t p3_out = {1.5, -9.8, 8.};
+    point_t p3_in = {0.5f, -9.f, 0.f};
+    point_t p3_edge = {1.f, 9.3f, 2.f};
+    point_t p3_out = {1.5f, -9.8f, 8.f};
 
-    constexpr scalar h2{2. * unit<scalar>::mm};
-    mask<single3D<2>> m1_2{0UL, -h2, h2};
+    constexpr scalar h2{2.f * unit<scalar>::mm};
+    mask<single3D<2>> m1_2{0u, -h2, h2};
 
-    ASSERT_FLOAT_EQ(m1_2[single3D<>::e_lower], -h2);
-    ASSERT_FLOAT_EQ(m1_2[single3D<>::e_upper], h2);
+    ASSERT_NEAR(m1_2[single3D<>::e_lower], -h2, tol);
+    ASSERT_NEAR(m1_2[single3D<>::e_upper], h2, tol);
 
     ASSERT_TRUE(m1_2.is_inside(p3_in) == intersection::status::e_inside);
     ASSERT_TRUE(m1_2.is_inside(p3_edge) == intersection::status::e_inside);
     ASSERT_TRUE(m1_2.is_inside(p3_out) == intersection::status::e_outside);
     // Move outside point inside using a tolerance - take t1 not t1
-    ASSERT_TRUE(m1_2.is_inside(p3_out, 6.1) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_2.is_inside(p3_out, 6.1f) == intersection::status::e_inside);
 
     // Check projection matrix
     const auto proj = m1_2.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j && i < decltype(m1_2)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }

--- a/tests/common/include/tests/common/masks_trapezoid2D.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2D.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,25 +13,27 @@
 using namespace detray;
 using namespace __plugin;
 
+constexpr scalar tol{1e-7f};
+
 /// This tests the basic functionality of a trapezoid
 TEST(mask, trapezoid2D) {
     using point_t = typename mask<trapezoid2D<>>::loc_point_t;
 
-    point_t p2_in = {1., -0.5};
-    point_t p2_edge = {2.5, 1.};
-    point_t p2_out = {3., 1.5};
+    point_t p2_in = {1.f, -0.5f};
+    point_t p2_edge = {2.5f, 1.f};
+    point_t p2_out = {3.f, 1.5f};
 
-    constexpr scalar hx_miny{1. * unit<scalar>::mm};
-    constexpr scalar hx_maxy{3. * unit<scalar>::mm};
-    constexpr scalar hy{2. * unit<scalar>::mm};
-    constexpr scalar divisor{1. / (2. * hy)};
+    constexpr scalar hx_miny{1.f * unit<scalar>::mm};
+    constexpr scalar hx_maxy{3.f * unit<scalar>::mm};
+    constexpr scalar hy{2.f * unit<scalar>::mm};
+    constexpr scalar divisor{1.f / (2.f * hy)};
 
-    mask<trapezoid2D<>> t2{0UL, hx_miny, hx_maxy, hy, divisor};
+    mask<trapezoid2D<>> t2{0u, hx_miny, hx_maxy, hy, divisor};
 
-    ASSERT_EQ(t2[trapezoid2D<>::e_half_length_0], hx_miny);
-    ASSERT_EQ(t2[trapezoid2D<>::e_half_length_1], hx_maxy);
-    ASSERT_EQ(t2[trapezoid2D<>::e_half_length_2], hy);
-    ASSERT_EQ(t2[trapezoid2D<>::e_divisor], divisor);
+    ASSERT_NEAR(t2[trapezoid2D<>::e_half_length_0], hx_miny, tol);
+    ASSERT_NEAR(t2[trapezoid2D<>::e_half_length_1], hx_maxy, tol);
+    ASSERT_NEAR(t2[trapezoid2D<>::e_half_length_2], hy, tol);
+    ASSERT_NEAR(t2[trapezoid2D<>::e_divisor], divisor, tol);
 
     ASSERT_TRUE(t2.is_inside(p2_in) == intersection::status::e_inside);
     ASSERT_TRUE(t2.is_inside(p2_edge) == intersection::status::e_inside);
@@ -41,12 +43,12 @@ TEST(mask, trapezoid2D) {
 
     // Check projection matrix
     const auto proj = t2.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j && i < decltype(t2)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }

--- a/tests/common/include/tests/common/masks_unmasked.inl
+++ b/tests/common/include/tests/common/masks_unmasked.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,22 +11,24 @@
 
 using namespace detray;
 
+constexpr scalar tol{1e-7f};
+
 /// This tests the basic functionality of an unmasked plane
 TEST(mask, unmasked) {
-    typename mask<unmasked>::loc_point_t p2 = {0.5, -9.};
+    typename mask<unmasked>::loc_point_t p2 = {0.5f, -9.f};
 
     mask<unmasked> u{};
 
-    ASSERT_TRUE(u.is_inside(p2, 0) == intersection::status::e_inside);
+    ASSERT_TRUE(u.is_inside(p2, 0.f) == intersection::status::e_inside);
 
     // Check projection matrix
     const auto proj = u.projection_matrix<e_bound_size>();
-    for (std::size_t i = 0; i < 2; i++) {
-        for (std::size_t j = 0; j < e_bound_size; j++) {
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j) {
-                ASSERT_EQ(getter::element(proj, i, j), 1);
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0);
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
             }
         }
     }

--- a/tests/common/include/tests/common/material_interaction.inl
+++ b/tests/common/include/tests/common/material_interaction.inl
@@ -53,106 +53,106 @@ TEST_P(EnergyLossBetheValidation, bethe_energy_loss) {
     line_plane_intersection is;
 
     // H2 liquid with a unit thickness
-    material_slab<scalar> slab(std::get<0>(GetParam()), 1 * unit<scalar>::cm);
+    material_slab<scalar> slab(std::get<0>(GetParam()), 1.f * unit<scalar>::cm);
 
     // muon
-    const int pdg = pdg_particle::eMuon;
+    constexpr int pdg = pdg_particle::eMuon;
 
     // mass
-    const scalar m = 105.7 * unit<scalar>::MeV;
+    constexpr scalar m{105.7f * unit<scalar>::MeV};
 
     // qOverP
-    const scalar qOverP = -1. / std::get<1>(GetParam());
+    const scalar qOverP{-1.f / std::get<1>(GetParam())};
 
     // Bethe Stopping power in MeV * cm^2 / g
-    const scalar dEdx =
-        I.compute_energy_loss_bethe(is, slab, pdg, m, qOverP, -1.) /
+    const scalar dEdx{
+        I.compute_energy_loss_bethe(is, slab, pdg, m, qOverP, -1.f) /
         slab.path_segment(is) / slab.get_material().mass_density() /
-        (unit<scalar>::MeV * unit<scalar>::cm2 / unit<scalar>::g);
+        (unit<scalar>::MeV * unit<scalar>::cm2 / unit<scalar>::g)};
 
     // Check if difference is within 5% error
-    EXPECT_TRUE(std::abs(std::get<2>(GetParam()) - dEdx) / dEdx < 0.05);
+    EXPECT_TRUE(std::abs(std::get<2>(GetParam()) - dEdx) / dEdx < 0.05f);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_0p1GeV_H2Liquid, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(hydrogen_liquid<scalar>(),
-                                      0.1003 * unit<scalar>::GeV, 6.539)));
+                                      0.1003f * unit<scalar>::GeV, 6.539f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_1GeV_H2Liquid, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(hydrogen_liquid<scalar>(),
-                                      1.101 * unit<scalar>::GeV, 4.182)));
+                                      1.101f * unit<scalar>::GeV, 4.182f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_10GeV_H2Liquid, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(hydrogen_liquid<scalar>(),
-                                      10.11 * unit<scalar>::GeV, 4.777)));
+                                      10.11f * unit<scalar>::GeV, 4.777f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_H2Liquid, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(hydrogen_liquid<scalar>(),
-                                      100.1 * unit<scalar>::GeV, 5.305)));
+                                      100.1f * unit<scalar>::GeV, 5.305f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_0p1GeV_HeGas, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(helium_gas<scalar>(),
-                                      0.1003 * unit<scalar>::GeV, 3.082)));
+                                      0.1003f * unit<scalar>::GeV, 3.082f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_1GeV_HeGas, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(helium_gas<scalar>(),
-                                      1.101 * unit<scalar>::GeV, 2.133)));
+                                      1.101f * unit<scalar>::GeV, 2.133f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_10GeV_HeGas, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(helium_gas<scalar>(),
-                                      10.11 * unit<scalar>::GeV, 2.768)));
+                                      10.11f * unit<scalar>::GeV, 2.768f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_HeGas, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(helium_gas<scalar>(),
-                                      100.1 * unit<scalar>::GeV, 3.188)));
+                                      100.1f * unit<scalar>::GeV, 3.188f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_0p1GeV_Al, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(aluminium<scalar>(),
-                                      0.1003 * unit<scalar>::GeV, 2.533)));
+                                      0.1003f * unit<scalar>::GeV, 2.533f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_1GeV_Al, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(aluminium<scalar>(),
-                                      1.101 * unit<scalar>::GeV, 1.744)));
+                                      1.101f * unit<scalar>::GeV, 1.744f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_10GeV_Al, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(aluminium<scalar>(),
-                                      10.11 * unit<scalar>::GeV, 2.097)));
+                                      10.11f * unit<scalar>::GeV, 2.097f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_Al, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(aluminium<scalar>(),
-                                      100.1 * unit<scalar>::GeV, 2.360)));
+                                      100.1f * unit<scalar>::GeV, 2.360f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_0p1GeV_Si, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
-                                      0.1003 * unit<scalar>::GeV, 2.608)));
+                                      0.1003f * unit<scalar>::GeV, 2.608f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_1GeV_Si, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
-                                      1.101 * unit<scalar>::GeV, 1.803)));
+                                      1.101f * unit<scalar>::GeV, 1.803f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_10GeV_Si, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
-                                      10.11 * unit<scalar>::GeV, 2.177)));
+                                      10.11f * unit<scalar>::GeV, 2.177f)));
 
 INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_Si, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
-                                      100.1 * unit<scalar>::GeV, 2.451)));
+                                      100.1f * unit<scalar>::GeV, 2.451f)));
 
 // Test class for MUON energy loss with Landau function
 // Input tuple: < material / energy / expected energy loss  / expected fwhm  >
@@ -170,39 +170,39 @@ TEST_P(EnergyLossLandauValidation, landau_energy_loss) {
 
     // H2 liquid with a unit thickness
     material_slab<scalar> slab(std::get<0>(GetParam()),
-                               0.17 * unit<scalar>::cm);
+                               0.17f * unit<scalar>::cm);
 
     // muon
-    const int pdg = pdg_particle::eMuon;
+    constexpr int pdg{pdg_particle::eMuon};
 
     // mass
-    const scalar m = 105.7 * unit<scalar>::MeV;
+    constexpr scalar m{105.7f * unit<scalar>::MeV};
 
     // qOverP
-    const scalar qOverP = -1. / std::get<1>(GetParam());
+    const scalar qOverP{-1.f / std::get<1>(GetParam())};
 
     // Landau Energy loss in MeV
-    const scalar dE =
-        I.compute_energy_loss_landau(is, slab, pdg, m, qOverP, -1) /
-        (unit<scalar>::MeV);
+    const scalar dE{
+        I.compute_energy_loss_landau(is, slab, pdg, m, qOverP, -1.f) /
+        unit<scalar>::MeV};
 
     // Check if difference is within 5% error
-    EXPECT_TRUE(std::abs(std::get<2>(GetParam()) - dE) / dE < 0.05);
+    EXPECT_TRUE(std::abs(std::get<2>(GetParam()) - dE) / dE < 0.05f);
 
     // Landau Energy loss Fluctuation
-    const scalar fwhm =
-        I.compute_energy_loss_landau_fwhm(is, slab, pdg, m, qOverP, -1) /
-        (unit<scalar>::MeV);
+    const scalar fwhm{
+        I.compute_energy_loss_landau_fwhm(is, slab, pdg, m, qOverP, -1.f) /
+        unit<scalar>::MeV};
 
     // Check if difference is within 10% error
-    EXPECT_TRUE(std::abs(std::get<3>(GetParam()) - fwhm) / fwhm < 0.1);
+    EXPECT_TRUE(std::abs(std::get<3>(GetParam()) - fwhm) / fwhm < 0.1f);
 }
 
 // Expected output from Fig 33.7 in RPP2018
-INSTANTIATE_TEST_SUITE_P(
-    Landau_10GeV_Silicon, EnergyLossLandauValidation,
-    ::testing::Values(std::make_tuple(silicon<scalar>(),
-                                      10. * unit<scalar>::GeV, 0.525, 0.13)));
+INSTANTIATE_TEST_SUITE_P(Landau_10GeV_Silicon, EnergyLossLandauValidation,
+                         ::testing::Values(std::make_tuple(
+                             silicon<scalar>(), 10.f * unit<scalar>::GeV,
+                             0.525f, 0.13f)));
 
 // Material interaction test with telescope Geometry
 TEST(material_interaction, telescope_geometry_energy_loss) {
@@ -210,16 +210,16 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
     vecmem::host_memory_resource host_mr;
 
     // Build from given module positions
-    detail::ray<transform3> traj{{0, 0, 0}, 0, {1, 0, 0}, -1};
-    std::vector<scalar> positions = {0.,   50., 100., 150., 200., 250.,
-                                     300., 350, 400,  450., 500.};
+    detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
+    std::vector<scalar> positions = {0.f,   50.f,  100.f, 150.f, 200.f, 250.f,
+                                     300.f, 350.f, 400.f, 450.f, 500.f};
 
     const auto mat = silicon_tml<scalar>();
-    const scalar thickness = 0.17 * unit<scalar>::cm;
+    constexpr scalar thickness{0.17f * unit<scalar>::cm};
 
     const auto det = create_telescope_detector(
-        host_mr, positions, traj, 20. * unit<scalar>::mm,
-        20. * unit<scalar>::mm, mat, thickness);
+        host_mr, positions, traj, 20.f * unit<scalar>::mm,
+        20.f * unit<scalar>::mm, mat, thickness);
 
     using navigator_t = navigator<decltype(det)>;
     using constraints_t = constrained_step<>;
@@ -235,21 +235,21 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
     // Propagator is built from the stepper and navigator
     propagator_t p({}, {});
 
-    const scalar q = -1.;
-    const scalar iniP = 10 * unit<scalar>::GeV;
+    constexpr scalar q{-1.f};
+    constexpr scalar iniP{10.f * unit<scalar>::GeV};
 
     typename bound_track_parameters<transform3>::vector_type bound_vector;
-    getter::element(bound_vector, e_bound_loc0, 0) = 0.;
-    getter::element(bound_vector, e_bound_loc1, 0) = 0.;
-    getter::element(bound_vector, e_bound_phi, 0) = 0.;
-    getter::element(bound_vector, e_bound_theta, 0) = M_PI / 2.;
+    getter::element(bound_vector, e_bound_loc0, 0) = 0.f;
+    getter::element(bound_vector, e_bound_loc1, 0) = 0.f;
+    getter::element(bound_vector, e_bound_phi, 0) = 0.f;
+    getter::element(bound_vector, e_bound_theta, 0) = constant<scalar>::pi_2;
     getter::element(bound_vector, e_bound_qoverp, 0) = q / iniP;
-    getter::element(bound_vector, e_bound_time, 0) = 0.;
+    getter::element(bound_vector, e_bound_time, 0) = 0.f;
     typename bound_track_parameters<transform3>::covariance_type bound_cov =
         matrix_operator().template zero<e_bound_size, e_bound_size>();
 
     // bound track parameter at first physical plane
-    const bound_track_parameters<transform3> bound_param(1, bound_vector,
+    const bound_track_parameters<transform3> bound_param(1u, bound_vector,
                                                          bound_cov);
 
     propagation::print_inspector::state print_insp_state{};
@@ -269,25 +269,25 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
         << print_insp_state.to_string() << std::endl;
 
     // muon
-    const int pdg = interactor_state.pdg;
+    const int pdg{interactor_state.pdg};
 
     // mass
-    const scalar mass = interactor_state.mass;
+    const scalar mass{interactor_state.mass};
 
     // new momentum
-    const scalar newP = state._stepping._bound_params.charge() /
-                        state._stepping._bound_params.qop();
+    const scalar newP{state._stepping._bound_params.charge() /
+                      state._stepping._bound_params.qop()};
 
     // new energy
-    const scalar newE = std::hypot(newP, mass);
+    const scalar newE{std::hypot(newP, mass)};
 
     // Initial energy
-    const scalar iniE = std::hypot(iniP, mass);
+    const scalar iniE{std::hypot(iniP, mass)};
 
     // New qop variance
-    const scalar new_var_qop =
+    const scalar new_var_qop{
         matrix_operator().element(state._stepping._bound_params.covariance(),
-                                  e_bound_qoverp, e_bound_qoverp);
+                                  e_bound_qoverp, e_bound_qoverp)};
 
     // Interaction object
     interaction<scalar> I;
@@ -305,20 +305,21 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
     // the assumption is not very bad
 
     // -2 is required because the first and last surface is a portal
-    const scalar dE =
+    const scalar dE{
         I.compute_energy_loss_bethe(is, slab, pdg, mass, q / iniP, q) *
-        (positions.size() - 2);
+        static_cast<scalar>(positions.size() - 2u)};
 
     // Check if the new energy after propagation is enough close to the
     // expected value
-    EXPECT_NEAR(newE, iniE - dE, 1e-5);
+    EXPECT_NEAR(newE, iniE - dE, 1e-5f);
 
-    const scalar sigma_qop = I.compute_energy_loss_landau_sigma_QOverP(
-        is, slab, pdg, mass, q / iniP, q);
+    const scalar sigma_qop{I.compute_energy_loss_landau_sigma_QOverP(
+        is, slab, pdg, mass, q / iniP, q)};
 
-    const scalar dvar_qop = sigma_qop * sigma_qop * (positions.size() - 1);
+    const scalar dvar_qop{sigma_qop * sigma_qop *
+                          static_cast<scalar>(positions.size() - 1u)};
 
-    EXPECT_NEAR(new_var_qop, dvar_qop, 1e-10);
+    EXPECT_NEAR(new_var_qop, dvar_qop, 1e-10f);
 
     // @todo: Validate the backward direction case as well?
 }
@@ -328,18 +329,18 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
     vecmem::host_memory_resource host_mr;
 
     // Build from given module positions
-    detail::ray<transform3> traj{{0, 0, 0}, 0, {1, 0, 0}, -1};
-    std::vector<scalar> positions = {0., 1000. * unit<scalar>::cm,
-                                     2000. * unit<scalar>::cm};
+    detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
+    std::vector<scalar> positions = {0.f, 1000.f * unit<scalar>::cm,
+                                     2000.f * unit<scalar>::cm};
 
     const auto mat = silicon_tml<scalar>();
-    const scalar thickness = 500 * unit<scalar>::cm;
+    constexpr scalar thickness{500.f * unit<scalar>::cm};
     // Use unbounded surfaces
     constexpr bool unbounded = true;
 
     const auto det = create_telescope_detector<unbounded>(
-        host_mr, positions, traj, 2000. * unit<scalar>::mm,
-        2000. * unit<scalar>::mm, mat, thickness);
+        host_mr, positions, traj, 2000.f * unit<scalar>::mm,
+        2000.f * unit<scalar>::mm, mat, thickness);
 
     using navigator_t = navigator<decltype(det)>;
     using constraints_t = constrained_step<>;
@@ -357,16 +358,16 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
     // Propagator is built from the stepper and navigator
     propagator_t p({}, {});
 
-    const scalar q = -1.;
-    const scalar iniP = 10 * unit<scalar>::GeV;
+    constexpr scalar q{-1.f};
+    constexpr scalar iniP{10.f * unit<scalar>::GeV};
 
     typename bound_track_parameters<transform3>::vector_type bound_vector;
-    getter::element(bound_vector, e_bound_loc0, 0) = 0.;
-    getter::element(bound_vector, e_bound_loc1, 0) = 0.;
-    getter::element(bound_vector, e_bound_phi, 0) = 0;
-    getter::element(bound_vector, e_bound_theta, 0) = M_PI_2;
+    getter::element(bound_vector, e_bound_loc0, 0) = 0.f;
+    getter::element(bound_vector, e_bound_loc1, 0) = 0.f;
+    getter::element(bound_vector, e_bound_phi, 0) = 0.f;
+    getter::element(bound_vector, e_bound_theta, 0) = constant<scalar>::pi_2;
     getter::element(bound_vector, e_bound_qoverp, 0) = q / iniP;
-    getter::element(bound_vector, e_bound_time, 0) = 0.;
+    getter::element(bound_vector, e_bound_time, 0) = 0.f;
     typename bound_track_parameters<transform3>::covariance_type bound_cov =
         matrix_operator().template zero<e_bound_size, e_bound_size>();
 
@@ -374,14 +375,14 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
     const bound_track_parameters<transform3> bound_param(1, bound_vector,
                                                          bound_cov);
 
-    std::size_t n_samples = 100000;
+    std::size_t n_samples{100000u};
     std::vector<scalar> phi_vec;
     std::vector<scalar> theta_vec;
 
-    scalar ref_phi_var(0);
-    scalar ref_theta_var(0);
+    scalar ref_phi_var{0.f};
+    scalar ref_theta_var{0.f};
 
-    for (unsigned int i = 0; i < n_samples; i++) {
+    for (std::size_t i = 0u; i < n_samples; i++) {
 
         propagation::print_inspector::state print_insp_state{};
         pathlimit_aborter::state aborter_state{};
@@ -399,7 +400,7 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
 
         propagator_t::state state(bound_param, det);
 
-        state._stepping().set_overstep_tolerance(-1000. * unit<scalar>::um);
+        state._stepping().set_overstep_tolerance(-1000.f * unit<scalar>::um);
 
         // Propagate the entire detector
         ASSERT_TRUE(p.propagate(state, actor_states))
@@ -407,7 +408,7 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
 
         const auto& final_params = state._stepping._bound_params;
 
-        if (i == 0) {
+        if (i == 0u) {
             const auto& covariance = final_params.covariance();
             ref_phi_var =
                 matrix_operator().element(covariance, e_bound_phi, e_bound_phi);
@@ -419,12 +420,12 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
         theta_vec.push_back(final_params.theta());
     }
 
-    scalar phi_var = statistics::variance(phi_vec);
-    scalar theta_var = statistics::variance(theta_vec);
+    scalar phi_var{statistics::variance(phi_vec)};
+    scalar theta_var{statistics::variance(theta_vec)};
 
-    EXPECT_NEAR((phi_var - ref_phi_var) / ref_phi_var, 0, 0.05);
-    EXPECT_NEAR((theta_var - ref_theta_var) / ref_theta_var, 0, 0.05);
+    EXPECT_NEAR((phi_var - ref_phi_var) / ref_phi_var, 0.f, 0.05f);
+    EXPECT_NEAR((theta_var - ref_theta_var) / ref_theta_var, 0.f, 0.05f);
 
     // To make sure that the varainces are not zero
-    EXPECT_TRUE(ref_phi_var > 1e-4 && ref_theta_var > 1e-4);
+    EXPECT_TRUE(ref_phi_var > 1e-4f && ref_theta_var > 1e-4f);
 }

--- a/tests/common/include/tests/common/materials.inl
+++ b/tests/common/include/tests/common/materials.inl
@@ -25,98 +25,100 @@ using point3 = __plugin::point3<scalar>;
 using transform3 = __plugin::transform3<detray::scalar>;
 using vector3 = __plugin::vector3<scalar>;
 
+constexpr scalar tol{1e-7f};
+constexpr scalar epsilon{std::numeric_limits<scalar>::epsilon()};
+
 // This tests the density effect data correction
 TEST(density_effect_data, density_effect_data) {
     // Check the default constructor of density effect data
-    detail::density_effect_data<scalar> D{};
+    constexpr detail::density_effect_data<scalar> D{};
 
-    EXPECT_FLOAT_EQ(D.get_A_density(), std::numeric_limits<scalar>::epsilon());
-    EXPECT_FLOAT_EQ(D.get_M_density(), std::numeric_limits<scalar>::epsilon());
-    EXPECT_FLOAT_EQ(D.get_X0_density(), std::numeric_limits<scalar>::epsilon());
-    EXPECT_FLOAT_EQ(D.get_X1_density(), std::numeric_limits<scalar>::epsilon());
-    EXPECT_FLOAT_EQ(D.get_mean_excitation_energy(),
-                    std::numeric_limits<scalar>::epsilon());
-    EXPECT_FLOAT_EQ(D.get_C_density(), std::numeric_limits<scalar>::epsilon());
-    EXPECT_FLOAT_EQ(D.get_delta0_density(),
-                    std::numeric_limits<scalar>::epsilon());
+    EXPECT_EQ(D.get_A_density(), epsilon);
+    EXPECT_EQ(D.get_M_density(), epsilon);
+    EXPECT_EQ(D.get_X0_density(), epsilon);
+    EXPECT_EQ(D.get_X1_density(), epsilon);
+    EXPECT_EQ(D.get_mean_excitation_energy(), epsilon);
+    EXPECT_EQ(D.get_C_density(), epsilon);
+    EXPECT_EQ(D.get_delta0_density(), epsilon);
 }
 
 // This tests the material functionalities
 TEST(materials, material) {
     // vacuum
-    EXPECT_FLOAT_EQ(vacuum<scalar>().X0(),
-                    std::numeric_limits<scalar>::infinity());
-    EXPECT_FLOAT_EQ(vacuum<scalar>().L0(),
-                    std::numeric_limits<scalar>::infinity());
-    EXPECT_FLOAT_EQ(vacuum<scalar>().Ar(), 0);
-    EXPECT_FLOAT_EQ(vacuum<scalar>().Z(), 0);
-    EXPECT_FLOAT_EQ(vacuum<scalar>().molar_density(), 0);
-    EXPECT_FLOAT_EQ(vacuum<scalar>().molar_electron_density(), 0);
+    constexpr vacuum<scalar> vac;
+    EXPECT_TRUE(std::isinf(vac.X0()));
+    EXPECT_TRUE(std::isinf(vac.L0()));
+    EXPECT_EQ(vac.Ar(), scalar{0});
+    EXPECT_EQ(vac.Z(), scalar{0});
+    EXPECT_EQ(vac.molar_density(), scalar{0});
+    EXPECT_EQ(vac.molar_electron_density(), scalar{0});
 
     // beryllium
-    EXPECT_FLOAT_EQ(beryllium_tml<scalar>().X0(), 352.8 * unit<scalar>::mm);
-    EXPECT_FLOAT_EQ(beryllium_tml<scalar>().L0(), 407.0 * unit<scalar>::mm);
-    EXPECT_FLOAT_EQ(beryllium_tml<scalar>().Ar(), 9.012);
-    EXPECT_FLOAT_EQ(beryllium_tml<scalar>().Z(), 4.0);
+    constexpr beryllium_tml<scalar> beryll;
+    EXPECT_NEAR(beryll.X0(), static_cast<scalar>(352.8 * unit<double>::mm),
+                1e-4);
+    EXPECT_NEAR(beryll.L0(), static_cast<scalar>(407.0 * unit<double>::mm),
+                tol);
+    EXPECT_NEAR(beryll.Ar(), 9.012f, tol);
+    EXPECT_NEAR(beryll.Z(), 4.0f, tol);
 
     // @note molar density is obtained by the following equation:
     // molar_density = mass_density [GeV/c²] / molar_mass [GeV/c²] * mol / cm³
-    EXPECT_FLOAT_EQ(beryllium_tml<scalar>().molar_density(),
-                    1.848 / beryllium_tml<scalar>().Ar() * unit<scalar>::mol /
-                        unit<scalar>::cm3);
+    EXPECT_NEAR(beryll.molar_density(),
+                static_cast<scalar>(1.848 / beryllium_tml<double>().Ar() *
+                                    unit<double>::mol / unit<double>::cm3),
+                tol);
 
     // silicon
-    EXPECT_FLOAT_EQ(silicon_tml<scalar>().X0(), 95.7 * unit<scalar>::mm);
-    EXPECT_FLOAT_EQ(silicon_tml<scalar>().L0(), 465.2 * unit<scalar>::mm);
-    EXPECT_FLOAT_EQ(silicon_tml<scalar>().Ar(), 28.03);
-    EXPECT_FLOAT_EQ(silicon_tml<scalar>().Z(), 14.);
-    EXPECT_FLOAT_EQ(silicon_tml<scalar>().molar_density(),
-                    2.32 / silicon_tml<scalar>().Ar() * unit<scalar>::mol /
-                        unit<scalar>::cm3);
+    constexpr silicon_tml<scalar> silicon;
+    EXPECT_NEAR(silicon.X0(), static_cast<scalar>(95.7 * unit<double>::mm),
+                1e-5);
+    EXPECT_NEAR(silicon.L0(), static_cast<scalar>(465.2 * unit<double>::mm),
+                1e-4);
+    EXPECT_NEAR(silicon.Ar(), 28.03f, tol);
+    EXPECT_NEAR(silicon.Z(), 14.f, tol);
+    EXPECT_NEAR(silicon.molar_density(),
+                static_cast<scalar>(2.32 / silicon_tml<double>().Ar() *
+                                    unit<double>::mol / unit<double>::cm3),
+                tol);
 }
 
 TEST(materials, mixture) {
 
     // Check if material property doesn't change after mixing with other
     // material of 0 ratio
-    using mat1 = oxygen_gas<scalar>;
-    using mat2 = mixture<scalar, oxygen_gas<scalar>,
-                         aluminium<scalar, std::ratio<0, 1>>>;
+    constexpr oxygen_gas<scalar> pure_oxygen;
+    constexpr mixture<scalar, oxygen_gas<scalar>,
+                      aluminium<scalar, std::ratio<0, 1>>>
+        oxygen_mix;
 
-    EXPECT_FLOAT_EQ(mat1().X0(), mat2().X0());
-    EXPECT_FLOAT_EQ(mat1().L0(), mat2().L0());
-    EXPECT_FLOAT_EQ(mat1().Ar(), mat2().Ar());
-    EXPECT_FLOAT_EQ(mat1().Z(), mat2().Z());
-    EXPECT_FLOAT_EQ(mat1().mass_density(), mat2().mass_density());
-    EXPECT_FLOAT_EQ(mat1().molar_density(), mat2().molar_density());
+    EXPECT_NEAR(pure_oxygen.X0(), oxygen_mix.X0(), 0.02f);
+    EXPECT_NEAR(pure_oxygen.L0(), oxygen_mix.L0(), tol);
+    EXPECT_NEAR(pure_oxygen.Ar(), oxygen_mix.Ar(), tol);
+    EXPECT_NEAR(pure_oxygen.Z(), oxygen_mix.Z(), tol);
+    EXPECT_NEAR(pure_oxygen.mass_density(), oxygen_mix.mass_density(), tol);
+    EXPECT_NEAR(pure_oxygen.molar_density(), oxygen_mix.molar_density(), tol);
 
     // Air mixture check
-    mixture<scalar, carbon_gas<scalar, std::ratio<0, 100>>,
-            nitrogen_gas<scalar, std::ratio<76, 100>>,
-            oxygen_gas<scalar, std::ratio<23, 100>>,
-            argon_gas<scalar, std::ratio<1, 100>>>
+    constexpr mixture<scalar, carbon_gas<scalar, std::ratio<0, 100>>,
+                      nitrogen_gas<scalar, std::ratio<76, 100>>,
+                      oxygen_gas<scalar, std::ratio<23, 100>>,
+                      argon_gas<scalar, std::ratio<1, 100>>>
         air_mix;
+    constexpr air<scalar> pure_air;
 
-    EXPECT_TRUE(std::abs(air_mix.X0() - air<scalar>().X0()) /
-                    air<scalar>().X0() <
-                0.01);
-    EXPECT_TRUE(std::abs(air_mix.L0() - air<scalar>().L0()) /
-                    air<scalar>().L0() <
-                0.01);
-    EXPECT_TRUE(std::abs(air_mix.Ar() - air<scalar>().Ar()) /
-                    air<scalar>().Ar() <
-                0.01);
-    EXPECT_TRUE(std::abs(air_mix.Z() - air<scalar>().Z()) / air<scalar>().Z() <
-                0.01);
-    EXPECT_TRUE(
-        std::abs(air_mix.mass_density() - air<scalar>().mass_density()) /
-            air<scalar>().mass_density() <
-        0.01);
+    EXPECT_TRUE(std::abs(air_mix.X0() - pure_air.X0()) / pure_air.X0() < 0.01f);
+    EXPECT_TRUE(std::abs(air_mix.L0() - pure_air.L0()) / pure_air.L0() < 0.01f);
+    EXPECT_TRUE(std::abs(air_mix.Ar() - pure_air.Ar()) / pure_air.Ar() < 0.01f);
+    EXPECT_TRUE(std::abs(air_mix.Z() - pure_air.Z()) / pure_air.Z() < 0.01f);
+    EXPECT_TRUE(std::abs(air_mix.mass_density() - pure_air.mass_density()) /
+                    pure_air.mass_density() <
+                0.01f);
 
     // Vector check
-    material_slab<scalar> slab1(air_mix, 5.5);
-    material_slab<scalar> slab2(air<scalar>(), 2.3);
-    material_slab<scalar> slab3(oxygen_gas<scalar>(), 2);
+    material_slab<scalar> slab1(air_mix, 5.5f);
+    material_slab<scalar> slab2(pure_air, 2.3f);
+    material_slab<scalar> slab3(oxygen_gas<scalar>(), 2.f);
 
     std::vector<material_slab<scalar>> slab_vec;
 
@@ -124,60 +126,59 @@ TEST(materials, mixture) {
     slab_vec.push_back(slab2);
     slab_vec.push_back(slab3);
 
-    EXPECT_FLOAT_EQ(slab_vec[0].thickness_in_X0(),
-                    slab1.thickness() / slab1.get_material().X0());
-    EXPECT_FLOAT_EQ(slab_vec[1].thickness_in_X0(),
-                    slab2.thickness() / slab2.get_material().X0());
-    EXPECT_FLOAT_EQ(slab_vec[2].thickness_in_X0(),
-                    slab3.thickness() / slab3.get_material().X0());
+    EXPECT_NEAR(slab_vec[0].thickness_in_X0(),
+                slab1.thickness() / slab1.get_material().X0(), tol);
+    EXPECT_NEAR(slab_vec[1].thickness_in_X0(),
+                slab2.thickness() / slab2.get_material().X0(), tol);
+    EXPECT_NEAR(slab_vec[2].thickness_in_X0(),
+                slab3.thickness() / slab3.get_material().X0(), tol);
 }
 
 // This tests the material slab functionalities
 TEST(materials, material_slab) {
 
-    material_slab<scalar> slab(oxygen_gas<scalar>(),
-                               scalar(2) * scalar(unit<scalar>::mm));
+    constexpr material_slab<scalar> slab(oxygen_gas<scalar>(),
+                                         2.f * unit<scalar>::mm);
 
     line_plane_intersection is;
-    is.cos_incidence_angle = scalar(0.3);
+    is.cos_incidence_angle = 0.3f;
 
-    EXPECT_FLOAT_EQ(slab.path_segment(is),
-                    scalar(2) * scalar(unit<scalar>::mm) / scalar(0.3));
-    EXPECT_FLOAT_EQ(slab.path_segment_in_X0(is),
-                    slab.path_segment(is) / slab.get_material().X0());
-    EXPECT_FLOAT_EQ(slab.path_segment_in_L0(is),
-                    slab.path_segment(is) / slab.get_material().L0());
+    EXPECT_NEAR(slab.path_segment(is), 2.f * unit<scalar>::mm / 0.3f, tol);
+    EXPECT_NEAR(slab.path_segment_in_X0(is),
+                slab.path_segment(is) / slab.get_material().X0(), tol);
+    EXPECT_NEAR(slab.path_segment_in_L0(is),
+                slab.path_segment(is) / slab.get_material().L0(), tol);
 }
 
 // This tests the material rod functionalities
 TEST(materials, material_rod) {
 
     // Rod with 1 mm radius
-    material_rod<scalar> rod(oxygen_gas<scalar>(),
-                             scalar(1.) * scalar(unit<scalar>::mm));
+    constexpr material_rod<scalar> rod(oxygen_gas<scalar>(),
+                                       1.f * unit<scalar>::mm);
 
     // tf3 with Identity rotation and no translation
-    const vector3 x{1, 0, 0};
-    const vector3 z{0, 0, 1};
-    const vector3 t{0, 0, 0};
+    const vector3 x{1.f, 0.f, 0.f};
+    const vector3 z{0.f, 0.f, 1.f};
+    const vector3 t{0.f, 0.f, 0.f};
     const transform3 tf{t, vector::normalize(z), vector::normalize(x)};
 
     // Create a track
-    const point3 pos{-1. / 6., -10., 0};
-    const vector3 dir{0, 1., 3.};
-    const free_track_parameters<transform3> trk(pos, 0, dir, -1);
+    const point3 pos{-1.f / 6.f, -10.f, 0.f};
+    const vector3 dir{0.f, 1.f, 3.f};
+    const free_track_parameters<transform3> trk(pos, 0.f, dir, -1.f);
 
     // Infinite wire with 1 mm radial cell size
-    const mask<line<>> ln{0UL, static_cast<scalar>(1. * unit<scalar>::mm),
+    const mask<line<>> ln{0u, 1.f * unit<scalar>::mm,
                           std::numeric_limits<scalar>::infinity()};
 
     line_plane_intersection is =
         line_intersector<transform3>()(detail::ray<transform3>(trk), ln, tf)[0];
 
-    EXPECT_NEAR(rod.path_segment(is),
-                scalar(2.) * std::sqrt(1. - 1. / 36) * std::sqrt(10), 1e-5);
-    EXPECT_FLOAT_EQ(rod.path_segment_in_X0(is),
-                    rod.path_segment(is) / rod.get_material().X0());
-    EXPECT_FLOAT_EQ(rod.path_segment_in_L0(is),
-                    rod.path_segment(is) / rod.get_material().L0());
+    EXPECT_NEAR(rod.path_segment(is), 2.f * std::sqrt(10.f - 10.f / 36.f),
+                1e-5f);
+    EXPECT_NEAR(rod.path_segment_in_X0(is),
+                rod.path_segment(is) / rod.get_material().X0(), tol);
+    EXPECT_NEAR(rod.path_segment_in_L0(is),
+                rod.path_segment(is) / rod.get_material().L0(), tol);
 }

--- a/tests/common/include/tests/common/test_base/propagator_test.hpp
+++ b/tests/common/include/tests/common/test_base/propagator_test.hpp
@@ -63,18 +63,18 @@ using free_track_parameters_type = free_track_parameters<transform3>;
 using free_matrix = typename free_track_parameters_type::covariance_type;
 
 // Detector configuration
-static constexpr std::size_t n_brl_layers{4};
-static constexpr std::size_t n_edc_layers{3};
+constexpr std::size_t n_brl_layers{4u};
+constexpr std::size_t n_edc_layers{3u};
 
 // Geomery navigation configurations
-static constexpr unsigned int theta_steps{10};
-static constexpr unsigned int phi_steps{10};
+constexpr unsigned int theta_steps{10u};
+constexpr unsigned int phi_steps{10u};
 
-static constexpr scalar rk_tolerance{1e-4};
-static constexpr scalar overstep_tolerance{-3 * unit<scalar>::um};
-static constexpr scalar constrainted_step_size{2. * unit<scalar>::mm};
-static constexpr scalar is_close{1e-4};
-static constexpr scalar path_limit{2 * unit<scalar>::m};
+constexpr scalar rk_tolerance{1e-4f};
+constexpr scalar overstep_tolerance{-3.f * unit<scalar>::um};
+constexpr scalar constrainted_step_size{2.f * unit<scalar>::mm};
+constexpr scalar is_close{1e-4f};
+constexpr scalar path_limit{2.f * unit<scalar>::m};
 
 template <template <typename...> class vector_t>
 struct track_inspector : actor {

--- a/tests/common/include/tests/common/test_core.inl
+++ b/tests/common/include/tests/common/test_core.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -27,31 +27,31 @@ using point3 = __plugin::point3<scalar>;
 
 /// Define mask types
 enum mask_ids : unsigned int {
-    e_unmasked = 0,
+    e_unmasked = 0u,
 };
 
 /// Define material types
 enum material_ids : unsigned int {
-    e_slab = 0,
+    e_slab = 0u,
 };
 
 using mask_link_t = dtyped_index<mask_ids, dindex>;
 using material_link_t = dtyped_index<material_ids, dindex>;
 
-constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
+constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
 
 // This tests the construction of a surface_base object
 TEST(ALGEBRA_PLUGIN, surface) {
     // Preparatioon work, create a transform
-    vector3 z = vector::normalize(vector3{3., 2., 1.});
-    vector3 x = vector::normalize(vector3{2., -3., 0.});
-    point3 t{2., 3., 4.};
+    vector3 z = vector::normalize(vector3{3.f, 2.f, 1.f});
+    vector3 x = vector::normalize(vector3{2.f, -3.f, 0.f});
+    point3 t{2.f, 3.f, 4.f};
     transform3 trf(t, z, x);
 
-    mask_link_t mask_id{mask_ids::e_unmasked, 0};
-    material_link_t material_id{material_ids::e_slab, 0};
+    mask_link_t mask_id{mask_ids::e_unmasked, 0u};
+    material_link_t material_id{material_ids::e_slab, 0u};
     surface<mask_link_t, material_link_t, transform3> s(
-        std::move(trf), mask_id, material_id, -1, false,
+        std::move(trf), mask_id, material_id, dindex_invalid, false,
         surface_id::e_sensitive);
 }
 
@@ -60,10 +60,10 @@ TEST(ALGEBRA_PLUGIN, intersection) {
 
     using intersection_t = line_plane_intersection;
 
-    intersection_t i0 = {2., point3{0.3, 0.5, 0.7}, point2{0.2, 0.4},
+    intersection_t i0 = {2.f, point3{0.3f, 0.5f, 0.7f}, point2{0.2f, 0.4f},
                          intersection::status::e_hit};
 
-    intersection_t i1 = {1.7, point3{0.2, 0.3, 0.}, point2{0.2, 0.4},
+    intersection_t i1 = {1.7f, point3{0.2f, 0.3f, 0.f}, point2{0.2f, 0.4f},
                          intersection::status::e_inside};
 
     intersection_t invalid;
@@ -72,7 +72,7 @@ TEST(ALGEBRA_PLUGIN, intersection) {
     dvector<intersection_t> intersections = {invalid, i0, i1};
     std::sort(intersections.begin(), intersections.end());
 
-    ASSERT_NEAR(intersections[0].path, 1.7, epsilon);
-    ASSERT_NEAR(intersections[1].path, 2, epsilon);
+    ASSERT_NEAR(intersections[0].path, 1.7f, tol);
+    ASSERT_NEAR(intersections[1].path, 2.f, tol);
     ASSERT_TRUE(std::isinf(intersections[2].path));
 }

--- a/tests/common/include/tests/common/test_telescope_detector.inl
+++ b/tests/common/include/tests/common/test_telescope_detector.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -59,13 +59,13 @@ TEST(ALGEBRA_PLUGIN, telescope_detector) {
     using inspector_t = navigation::print_inspector;
 
     // Test tolerance
-    constexpr scalar tol = 1e-4;
+    constexpr scalar tol{1e-4f};
 
     vecmem::host_memory_resource host_mr;
 
     // B-fields
-    vector3 B_z{0., 0., 1. * unit<scalar>::T};
-    vector3 B_x{1. * unit<scalar>::T, 0., 0.};
+    vector3 B_z{0.f, 0.f, 1.f * unit<scalar>::T};
+    vector3 B_x{1.f * unit<scalar>::T, 0.f, 0.f};
     b_field_t b_field_z{
         b_field_t::backend_t::configuration_t{B_z[0], B_z[1], B_z[2]}};
     b_field_t b_field_x{
@@ -80,21 +80,21 @@ TEST(ALGEBRA_PLUGIN, telescope_detector) {
     //
 
     // Build from given module positions
-    std::vector<scalar> positions = {0.,   50., 100., 150., 200., 250.,
-                                     300., 350, 400,  450., 500.};
+    std::vector<scalar> positions = {0.f,   50.f,  100.f, 150.f, 200.f, 250.f,
+                                     300.f, 350.f, 400.f, 450.f, 500.f};
     // Build telescope detector with unbounded planes
     const auto z_tel_det1 =
         create_telescope_detector<rectangular>(host_mr, positions);
 
     // Build the same telescope detector with rectangular planes and given
     // length/number of surfaces
-    dindex n_surfaces = 11;
-    scalar tel_length = 500. * unit<scalar>::mm;
+    const std::size_t n_surfaces{11u};
+    const scalar tel_length{500.f * unit<scalar>::mm};
     const auto z_tel_det2 =
         create_telescope_detector<rectangular>(host_mr, n_surfaces, tel_length);
 
     // Compare
-    for (std::size_t i = 0; i < z_tel_det1.surfaces().size(); ++i) {
+    for (std::size_t i = 0u; i < z_tel_det1.surfaces().size(); ++i) {
         EXPECT_TRUE(z_tel_det1.surface_by_index(i) ==
                     z_tel_det2.surface_by_index(i));
     }
@@ -104,7 +104,8 @@ TEST(ALGEBRA_PLUGIN, telescope_detector) {
     //
 
     // Same telescope, but in x direction and created from custom stepper
-    detail::ray<transform3> x_track({0, 0, 0}, 0, {1, 0, 0}, -1);
+    detail::ray<transform3> x_track({0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f},
+                                    -1.f);
 
     const auto x_tel_det = create_telescope_detector<rectangular>(
         host_mr, n_surfaces, tel_length, x_track);
@@ -114,12 +115,12 @@ TEST(ALGEBRA_PLUGIN, telescope_detector) {
     //
 
     // Telescope navigation should be symmetric in x and z
-    vector3 pos = {0., 0., 0.};
-    vector3 mom = {0., 0., 1.};
-    free_track_parameters<transform3> test_track_z1(pos, 0, mom, -1);
-    free_track_parameters<transform3> test_track_z2(pos, 0, mom, -1);
-    mom = {1., 0., 0.};
-    free_track_parameters<transform3> test_track_x(pos, 0, mom, -1);
+    vector3 pos = {0.f, 0.f, 0.f};
+    vector3 mom = {0.f, 0.f, 1.f};
+    free_track_parameters<transform3> test_track_z1(pos, 0.f, mom, -1.f);
+    free_track_parameters<transform3> test_track_z2(pos, 0.f, mom, -1.f);
+    mom = {1.f, 0.f, 0.f};
+    free_track_parameters<transform3> test_track_x(pos, 0.f, mom, -1.f);
 
     // navigators
     navigator<decltype(z_tel_det1), inspector_t> navigator_z1;
@@ -171,18 +172,18 @@ TEST(ALGEBRA_PLUGIN, telescope_detector) {
         EXPECT_NEAR(
             std::fabs(stepping_z1._path_length - stepping_z2._path_length) /
                 stepping_z1._path_length,
-            0., tol);
+            0.f, tol);
         EXPECT_NEAR(
             std::fabs(stepping_z1._path_length - stepping_x._path_length) /
                 stepping_x._path_length,
-            0., tol);
+            0.f, tol);
         // The track positions in z should match exactly
         EXPECT_NEAR(getter::norm(stepping_z1().pos() - stepping_z2().pos()) /
                         getter::norm(stepping_z1().pos()),
-                    0., tol);
+                    0.f, tol);
         EXPECT_NEAR(getter::norm(stepping_z1().dir() - stepping_z2().dir()) /
                         getter::norm(stepping_z1().dir()),
-                    0., tol);
+                    0.f, tol);
     }
 
     // check that all propagation flows exited successfully
@@ -196,11 +197,11 @@ TEST(ALGEBRA_PLUGIN, telescope_detector) {
     //
     // Build a telescope along a bent track
     //
-    pos = {0., 0., 0.};
-    mom = {0., 1., 0.};
+    pos = {0.f, 0.f, 0.f};
+    mom = {0.f, 1.f, 0.f};
 
-    auto pilot_track = free_track_parameters<transform3>(pos, 0, mom, -1);
-    pilot_track.set_overstep_tolerance(-10 * unit<scalar>::um);
+    auto pilot_track = free_track_parameters<transform3>(pos, 0.f, mom, -1.f);
+    pilot_track.set_overstep_tolerance(-10.f * unit<scalar>::um);
 
     detail::helix<transform3> helix_bz(pilot_track, &B_z);
 

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -86,8 +86,8 @@ struct surface_grid_tester {
 TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     vecmem::host_memory_resource host_mr;
-    std::size_t n_brl_layers = 4;
-    std::size_t n_edc_layers = 3;
+    constexpr std::size_t n_brl_layers{4u};
+    constexpr std::size_t n_edc_layers{3u};
 
     const auto toy_det =
         create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
@@ -112,28 +112,28 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Materials
     auto portal_mat =
-        material_slab<scalar>(vacuum<scalar>(), 0. * unit<scalar>::mm);
+        material_slab<scalar>(vacuum<scalar>(), 0.f * unit<scalar>::mm);
     auto beampipe_mat =
-        material_slab<scalar>(beryllium_tml<scalar>(), 0.8 * unit<scalar>::mm);
+        material_slab<scalar>(beryllium_tml<scalar>(), 0.8f * unit<scalar>::mm);
     auto pixel_mat =
-        material_slab<scalar>(silicon_tml<scalar>(), 0.15 * unit<scalar>::mm);
+        material_slab<scalar>(silicon_tml<scalar>(), 0.15f * unit<scalar>::mm);
 
     /** Link to outer world (leaving detector) */
     const dindex leaving_world = dindex_invalid;
 
     // Check number of geomtery objects
-    EXPECT_EQ(volumes.size(), 20);
-    EXPECT_EQ(surfaces.size(), 3244);
+    EXPECT_EQ(volumes.size(), 20u);
+    EXPECT_EQ(surfaces.size(), 3244u);
     /*EXPECT_EQ(sf_finders.template size<sf_finder_ids::e_brute_force>(), 1);
     EXPECT_EQ(sf_finders.template size<sf_finder_ids::e_cylinder_grid>(),
               n_brl_layers);
     EXPECT_EQ(sf_finders.template size<sf_finder_ids::e_disc_grid>(), 14);*/
-    EXPECT_EQ(transforms.size(ctx), 3244);
-    EXPECT_EQ(masks.template size<mask_ids::e_rectangle2>(), 2492);
-    EXPECT_EQ(masks.template size<mask_ids::e_trapezoid2>(), 648);
-    EXPECT_EQ(masks.template size<mask_ids::e_portal_cylinder2>(), 52);
-    EXPECT_EQ(masks.template size<mask_ids::e_portal_ring2>(), 52);
-    EXPECT_EQ(materials.template size<material_ids::e_slab>(), 3244);
+    EXPECT_EQ(transforms.size(ctx), 3244u);
+    EXPECT_EQ(masks.template size<mask_ids::e_rectangle2>(), 2492u);
+    EXPECT_EQ(masks.template size<mask_ids::e_trapezoid2>(), 648u);
+    EXPECT_EQ(masks.template size<mask_ids::e_portal_cylinder2>(), 52u);
+    EXPECT_EQ(masks.template size<mask_ids::e_portal_ring2>(), 52u);
+    EXPECT_EQ(materials.template size<material_ids::e_slab>(), 3244u);
 
     /** Test the links of a volume.
      *
@@ -249,37 +249,41 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     auto vol_itr = volumes.begin();
-    darray<scalar, 6> bounds = {0., 27., -825., 825., -M_PI, M_PI};
-    darray<dindex, 2> range = {0, 16};
-    sf_finder_link_t sf_finder_link{sf_finder_ids::e_brute_force, 0};
+    darray<scalar, 6> bounds = {
+        0.f, 27.f, -825.f, 825.f, -constant<scalar>::pi, constant<scalar>::pi};
+    darray<dindex, 2> range = {0u, 16u};
+    sf_finder_link_t sf_finder_link{sf_finder_ids::e_brute_force, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 0, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 0u, bounds, range, sf_finder_link);
 
     // Check links of beampipe itself
-    range = {0, 1};
+    range = {0u, 1u};
     test_module_links(vol_itr->index(), surfaces.begin(), range, range[0],
-                      {mask_ids::e_cylinder2, 0}, {material_ids::e_slab, 0},
+                      {mask_ids::e_cylinder2, 0u}, {material_ids::e_slab, 0u},
                       beampipe_mat, {vol_itr->index()});
 
     // Check links of portals
     // cylinder portals
-    range = {1, 8};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 1},
-                      {material_ids::e_slab, 1}, portal_mat,
-                      {1, 2, 3, 4, 5, 6, 7});
-    range = {8, 14};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 8},
-                      {material_ids::e_slab, 8}, portal_mat,
-                      {14, 15, 16, 17, 18, 19});
+    range = {1u, 8u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 1u},
+                      {material_ids::e_slab, 1u}, portal_mat,
+                      {1u, 2u, 3u, 4u, 5u, 6u, 7u});
+    range = {8u, 14u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 8u},
+                      {material_ids::e_slab, 8u}, portal_mat,
+                      {14u, 15u, 16u, 17u, 18u, 19u});
 
     // disc portals
-    range = {14, 16};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 0},
-                      {material_ids::e_slab, 14}, portal_mat,
+    range = {14u, 16u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 0u},
+                      {material_ids::e_slab, 14u}, portal_mat,
                       {leaving_world, leaving_world});
 
     //
@@ -288,18 +292,24 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., -825., -815., -M_PI, M_PI};
-    range = {16, 128};
-    sf_finder_link = {sf_finder_ids::e_disc_grid, 0};
+    bounds = {27.f,
+              180.f,
+              -825.f,
+              -815.f,
+              -constant<scalar>::pi,
+              constant<scalar>::pi};
+    range = {16u, 128u};
+    sf_finder_link = {sf_finder_ids::e_disc_grid, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 1, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 1u, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
-    range = {16, 124};
-    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_trapezoid2, 0},
-                      {material_ids::e_slab, 16}, pixel_mat,
+    range = {16u, 124u};
+    test_module_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_trapezoid2, 0u},
+                      {material_ids::e_slab, 16u}, pixel_mat,
                       {vol_itr->index()});
 
     // Check link of surfaces in surface finder
@@ -307,17 +317,19 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check links of portals
     // cylinder portals
-    range = {124, 126};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 14},
-                      {material_ids::e_slab, 124}, portal_mat,
-                      {0, leaving_world});
+    range = {124u, 126u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 14u},
+                      {material_ids::e_slab, 124u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {126, 128};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 2},
-                      {material_ids::e_slab, 126}, portal_mat,
-                      {leaving_world, 2});
+    range = {126u, 128u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 2u},
+                      {material_ids::e_slab, 126u}, portal_mat,
+                      {leaving_world, 2u});
 
     //
     // gap
@@ -325,25 +337,32 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., -815., -705., -M_PI, M_PI};
-    range = {128, 132};
-    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+    bounds = {27.f,
+              180.f,
+              -815.f,
+              -705.f,
+              -constant<scalar>::pi,
+              constant<scalar>::pi};
+    range = {128u, 132u};
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 2, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 2u, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
-    range = {128, 130};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 16},
-                      {material_ids::e_slab, 128}, portal_mat,
-                      {0, leaving_world});
+    range = {128u, 130u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 16u},
+                      {material_ids::e_slab, 128u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {130, 132};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 4},
-                      {material_ids::e_slab, 130}, portal_mat, {1, 3});
+    range = {130u, 132u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 4u},
+                      {material_ids::e_slab, 130u}, portal_mat, {1u, 3u});
 
     //
     // neg endcap (layer 2)
@@ -351,18 +370,24 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., -705., -695., -M_PI, M_PI};
-    range = {132, 244};
-    sf_finder_link = {sf_finder_ids::e_disc_grid, 1};
+    bounds = {27.f,
+              180.f,
+              -705.f,
+              -695.f,
+              -constant<scalar>::pi,
+              constant<scalar>::pi};
+    range = {132u, 244u};
+    sf_finder_link = {sf_finder_ids::e_disc_grid, 1u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 3, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 3u, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
-    range = {132, 240};
-    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_trapezoid2, 108},
-                      {material_ids::e_slab, 132}, pixel_mat,
+    range = {132u, 240u};
+    test_module_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_trapezoid2, 108u},
+                      {material_ids::e_slab, 132u}, pixel_mat,
                       {vol_itr->index()});
 
     // Check link of surfaces in surface finder
@@ -370,16 +395,18 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check links of portals
     // cylinder portals
-    range = {240, 242};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 18},
-                      {material_ids::e_slab, 240}, portal_mat,
-                      {0, leaving_world});
+    range = {240u, 242u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 18u},
+                      {material_ids::e_slab, 240u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {242, 244};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 6},
-                      {material_ids::e_slab, 242}, portal_mat, {2, 4});
+    range = {242u, 244u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 6u},
+                      {material_ids::e_slab, 242u}, portal_mat, {2u, 4u});
 
     //
     // gap
@@ -387,25 +414,32 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., -695., -605., -M_PI, M_PI};
-    range = {244, 248};
-    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+    bounds = {27.f,
+              180.f,
+              -695.f,
+              -605.f,
+              -constant<scalar>::pi,
+              constant<scalar>::pi};
+    range = {244u, 248u};
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 4, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 4u, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
-    range = {244, 246};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 20},
-                      {material_ids::e_slab, 244}, portal_mat,
-                      {0, leaving_world});
+    range = {244u, 246u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 20u},
+                      {material_ids::e_slab, 244u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {246, 248};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 8},
-                      {material_ids::e_slab, 246}, portal_mat, {3, 5});
+    range = {246u, 248u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 8u},
+                      {material_ids::e_slab, 246u}, portal_mat, {3u, 5u});
 
     //
     // neg endcap (layer 1)
@@ -413,18 +447,24 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., -605., -595., -M_PI, M_PI};
-    range = {248, 360};
-    sf_finder_link = {sf_finder_ids::e_disc_grid, 2};
+    bounds = {27.f,
+              180.f,
+              -605.f,
+              -595.f,
+              -constant<scalar>::pi,
+              constant<scalar>::pi};
+    range = {248u, 360u};
+    sf_finder_link = {sf_finder_ids::e_disc_grid, 2u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 5, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 5u, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
-    range = {248, 356};
-    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_trapezoid2, 216},
-                      {material_ids::e_slab, 248}, pixel_mat,
+    range = {248u, 356u};
+    test_module_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_trapezoid2, 216u},
+                      {material_ids::e_slab, 248u}, pixel_mat,
                       {vol_itr->index()});
 
     // Check link of surfaces in surface finder
@@ -432,16 +472,18 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check links of portals
     // cylinder portals
-    range = {356, 358};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 22},
-                      {material_ids::e_slab, 356}, portal_mat,
-                      {0, leaving_world});
+    range = {356u, 358u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 22u},
+                      {material_ids::e_slab, 356u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {358, 360};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 10},
-                      {material_ids::e_slab, 358}, portal_mat, {4, 6});
+    range = {358u, 360u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 10u},
+                      {material_ids::e_slab, 358u}, portal_mat, {4u, 6u});
 
     //
     // gap
@@ -449,26 +491,33 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., -595., -500., -M_PI, M_PI};
-    range = {360, 370};
-    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+    bounds = {27.f,
+              180.f,
+              -595.f,
+              -500.f,
+              -constant<scalar>::pi,
+              constant<scalar>::pi};
+    range = {360u, 370u};
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 6, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 6u, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
-    range = {360, 362};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 24},
-                      {material_ids::e_slab, 360}, portal_mat,
-                      {0, leaving_world});
+    range = {360u, 362u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 24u},
+                      {material_ids::e_slab, 360u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {362, 370};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 12},
-                      {material_ids::e_slab, 362}, portal_mat,
-                      {5, 7, 8, 9, 10, 11, 12, 13});
+    range = {362u, 370u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 12u},
+                      {material_ids::e_slab, 362u}, portal_mat,
+                      {5u, 7u, 8u, 9u, 10u, 11u, 12u, 13u});
 
     //
     // barrel
@@ -480,18 +529,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 38., -500., 500, -M_PI, M_PI};
-    range = {370, 598};
-    sf_finder_link = {sf_finder_ids::e_cylinder_grid, 0};
+    bounds = {
+        27.f, 38.f, -500.f, 500.f, -constant<scalar>::pi, constant<scalar>::pi};
+    range = {370u, 598u};
+    sf_finder_link = {sf_finder_ids::e_cylinder_grid, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 7, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 7u, bounds, range, sf_finder_link);
 
     // Check links of modules
-    range = {370, 594};
-    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_rectangle2, 0},
-                      {material_ids::e_slab, 370}, pixel_mat,
+    range = {370u, 594u};
+    test_module_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_rectangle2, 0u},
+                      {material_ids::e_slab, 370u}, pixel_mat,
                       {vol_itr->index()});
 
     // Check link of surfaces in surface finder
@@ -499,16 +550,18 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check links of portals
     // cylinder portals
-    range = {594, 596};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 26},
-                      {material_ids::e_slab, 594}, portal_mat, {0, 8});
+    range = {594u, 596u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 26u},
+                      {material_ids::e_slab, 594u}, portal_mat, {0u, 8u});
 
     // disc portals
-    range = {596, 598};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 20},
-                      {material_ids::e_slab, 596}, portal_mat, {6, 14});
+    range = {596u, 598u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 20u},
+                      {material_ids::e_slab, 596u}, portal_mat, {6u, 14u});
 
     //
     // gap
@@ -516,24 +569,27 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {38., 64., -500., 500, -M_PI, M_PI};
-    range = {598, 602};
-    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+    bounds = {
+        38.f, 64.f, -500.f, 500.f, -constant<scalar>::pi, constant<scalar>::pi};
+    range = {598u, 602u};
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 8, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 8u, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
-    range = {598, 600};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 28},
-                      {material_ids::e_slab, 598}, portal_mat, {7, 9});
+    range = {598u, 600u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 28u},
+                      {material_ids::e_slab, 598u}, portal_mat, {7u, 9u});
     // disc portals
-    range = {600, 602};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 22},
-                      {material_ids::e_slab, 600}, portal_mat, {6, 14});
+    range = {600u, 602u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 22u},
+                      {material_ids::e_slab, 600u}, portal_mat, {6u, 14u});
 
     //
     // second layer
@@ -541,18 +597,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {64., 80., -500., 500, -M_PI, M_PI};
-    range = {602, 1054};
-    sf_finder_link = {sf_finder_ids::e_cylinder_grid, 1};
+    bounds = {
+        64.f, 80.f, -500.f, 500.f, -constant<scalar>::pi, constant<scalar>::pi};
+    range = {602u, 1054u};
+    sf_finder_link = {sf_finder_ids::e_cylinder_grid, 1u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 9, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 9u, bounds, range, sf_finder_link);
 
     // Check links of modules
-    range = {602, 1050};
-    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_rectangle2, 224},
-                      {material_ids::e_slab, 602}, pixel_mat,
+    range = {602u, 1050u};
+    test_module_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_rectangle2, 224u},
+                      {material_ids::e_slab, 602u}, pixel_mat,
                       {vol_itr->index()});
 
     // Check link of surfaces in surface finder
@@ -560,16 +618,18 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check links of portals
     // cylinder portals
-    range = {1050, 1052};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 30},
-                      {material_ids::e_slab, 1050}, portal_mat, {8, 10});
+    range = {1050u, 1052u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 30u},
+                      {material_ids::e_slab, 1050u}, portal_mat, {8u, 10u});
 
     // disc portals
-    range = {1052, 1054};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 24},
-                      {material_ids::e_slab, 1052}, portal_mat, {6, 14});
+    range = {1052u, 1054u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 24u},
+                      {material_ids::e_slab, 1052u}, portal_mat, {6u, 14u});
 
     //
     // gap
@@ -577,24 +637,31 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {80., 108., -500., 500, -M_PI, M_PI};
-    range = {1054, 1058};
-    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+    bounds = {80.f,
+              108.f,
+              -500.f,
+              500.f,
+              -constant<scalar>::pi,
+              constant<scalar>::pi};
+    range = {1054u, 1058u};
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 10, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 10u, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
-    range = {1054, 1056};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 32},
-                      {material_ids::e_slab, 1054}, portal_mat, {9, 11});
+    range = {1054u, 1056u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 32u},
+                      {material_ids::e_slab, 1054u}, portal_mat, {9u, 11u});
     // disc portals
-    range = {1056, 1058};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 26},
-                      {material_ids::e_slab, 1056}, portal_mat, {6, 14});
+    range = {1056u, 1058u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 26u},
+                      {material_ids::e_slab, 1056u}, portal_mat, {6u, 14u});
 
     //
     // third layer
@@ -602,18 +669,24 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {108., 124., -500., 500, -M_PI, M_PI};
-    range = {1058, 1790};
-    sf_finder_link = {sf_finder_ids::e_cylinder_grid, 2};
+    bounds = {108.f,
+              124.f,
+              -500.f,
+              500.f,
+              -constant<scalar>::pi,
+              constant<scalar>::pi};
+    range = {1058u, 1790u};
+    sf_finder_link = {sf_finder_ids::e_cylinder_grid, 2u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 11, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 11u, bounds, range, sf_finder_link);
 
     // Check links of modules
-    range = {1058, 1786};
-    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_rectangle2, 672},
-                      {material_ids::e_slab, 1058}, pixel_mat,
+    range = {1058u, 1786u};
+    test_module_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_rectangle2, 672u},
+                      {material_ids::e_slab, 1058u}, pixel_mat,
                       {vol_itr->index()});
 
     // Check link of surfaces in surface finder
@@ -621,16 +694,18 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check links of portals
     // cylinder portals
-    range = {1786, 1788};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 34},
-                      {material_ids::e_slab, 1786}, portal_mat, {10, 12});
+    range = {1786u, 1788u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 34u},
+                      {material_ids::e_slab, 1786u}, portal_mat, {10u, 12u});
 
     // disc portals
-    range = {1788, 1790};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 28},
-                      {material_ids::e_slab, 1788}, portal_mat, {6, 14});
+    range = {1788u, 1790u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 28u},
+                      {material_ids::e_slab, 1788u}, portal_mat, {6u, 14u});
 
     //
     // gap
@@ -638,24 +713,31 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {124., 164., -500., 500, -M_PI, M_PI};
-    range = {1790, 1794};
-    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+    bounds = {124.f,
+              164.f,
+              -500.f,
+              500.f,
+              -constant<scalar>::pi,
+              constant<scalar>::pi};
+    range = {1790u, 1794u};
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 12, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 12u, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
-    range = {1790, 1792};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 36},
-                      {material_ids::e_slab, 1790}, portal_mat, {11, 13});
+    range = {1790u, 1792u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 36u},
+                      {material_ids::e_slab, 1790u}, portal_mat, {11u, 13u});
     // disc portals
-    range = {1792, 1794};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 30},
-                      {material_ids::e_slab, 1792}, portal_mat, {6, 14});
+    range = {1792u, 1794u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 30u},
+                      {material_ids::e_slab, 1792u}, portal_mat, {6u, 14u});
 
     //
     // fourth layer
@@ -663,18 +745,24 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {164., 180., -500., 500, -M_PI, M_PI};
-    range = {1794, 2890};
-    sf_finder_link = {sf_finder_ids::e_cylinder_grid, 3};
+    bounds = {164.f,
+              180.f,
+              -500.f,
+              500.f,
+              -constant<scalar>::pi,
+              constant<scalar>::pi};
+    range = {1794u, 2890u};
+    sf_finder_link = {sf_finder_ids::e_cylinder_grid, 3u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 13, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 13u, bounds, range, sf_finder_link);
 
     // Check links of modules
-    range = {1794, 2886};
-    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_rectangle2, 1400},
-                      {material_ids::e_slab, 1794}, pixel_mat,
+    range = {1794u, 2886u};
+    test_module_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_rectangle2, 1400u},
+                      {material_ids::e_slab, 1794u}, pixel_mat,
                       {vol_itr->index()});
 
     // Check link of surfaces in surface finder
@@ -682,17 +770,19 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check links of portals
     // cylinder portals
-    range = {2886, 2888};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 38},
-                      {material_ids::e_slab, 2886}, portal_mat,
-                      {12, leaving_world});
+    range = {2886u, 2888u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 38u},
+                      {material_ids::e_slab, 2886u}, portal_mat,
+                      {12u, leaving_world});
 
     // disc portals
-    range = {2888, 2890};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 32},
-                      {material_ids::e_slab, 2888}, portal_mat, {6, 14});
+    range = {2888u, 2890u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 32u},
+                      {material_ids::e_slab, 2888u}, portal_mat, {6u, 14u});
 
     //
     // positive endcap
@@ -704,26 +794,29 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., 500., 595., -M_PI, M_PI};
-    range = {2890, 2900};
-    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+    bounds = {
+        27.f, 180.f, 500.f, 595.f, -constant<scalar>::pi, constant<scalar>::pi};
+    range = {2890u, 2900u};
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 14, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 14u, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
-    range = {2890, 2892};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 40},
-                      {material_ids::e_slab, 2890}, portal_mat,
-                      {0, leaving_world});
+    range = {2890u, 2892u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 40u},
+                      {material_ids::e_slab, 2890u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {2892, 2900};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 34},
-                      {material_ids::e_slab, 2892}, portal_mat,
-                      {15, 7, 8, 9, 10, 11, 12, 13});
+    range = {2892u, 2900u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 34u},
+                      {material_ids::e_slab, 2892u}, portal_mat,
+                      {15u, 7u, 8u, 9u, 10u, 11u, 12u, 13u});
 
     //
     // pos endcap (layer 1)
@@ -731,18 +824,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., 595., 605., -M_PI, M_PI};
-    range = {2900, 3012};
-    sf_finder_link = {sf_finder_ids::e_disc_grid, 3};
+    bounds = {
+        27.f, 180.f, 595.f, 605.f, -constant<scalar>::pi, constant<scalar>::pi};
+    range = {2900u, 3012u};
+    sf_finder_link = {sf_finder_ids::e_disc_grid, 3u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 15, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 15u, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
-    range = {2900, 3008};
-    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_trapezoid2, 324},
-                      {material_ids::e_slab, 2900}, pixel_mat,
+    range = {2900u, 3008u};
+    test_module_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_trapezoid2, 324u},
+                      {material_ids::e_slab, 2900u}, pixel_mat,
                       {vol_itr->index()});
 
     // Check link of surfaces in surface finder
@@ -750,16 +845,18 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check links of portals
     // cylinder portals
-    range = {3008, 3010};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 42},
-                      {material_ids::e_slab, 3008}, portal_mat,
-                      {0, leaving_world});
+    range = {3008u, 3010u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 42u},
+                      {material_ids::e_slab, 3008u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {3010, 3012};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 42},
-                      {material_ids::e_slab, 3010}, portal_mat, {14, 16});
+    range = {3010u, 3012u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 42u},
+                      {material_ids::e_slab, 3010u}, portal_mat, {14u, 16u});
 
     //
     // gap
@@ -767,25 +864,28 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., 605., 695., -M_PI, M_PI};
-    range = {3012, 3016};
-    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+    bounds = {
+        27.f, 180.f, 605.f, 695.f, -constant<scalar>::pi, constant<scalar>::pi};
+    range = {3012u, 3016u};
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 16, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 16u, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
-    range = {3012, 3014};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 44},
-                      {material_ids::e_slab, 3012}, portal_mat,
-                      {0, leaving_world});
+    range = {3012u, 3014u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 44u},
+                      {material_ids::e_slab, 3012u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {3014, 3016};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 44},
-                      {material_ids::e_slab, 3014}, portal_mat, {15, 17});
+    range = {3014u, 3016u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 44u},
+                      {material_ids::e_slab, 3014u}, portal_mat, {15u, 17u});
 
     //
     // pos endcap (layer 2)
@@ -793,18 +893,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., 695., 705., -M_PI, M_PI};
-    range = {3016, 3128};
-    sf_finder_link = {sf_finder_ids::e_disc_grid, 4};
+    bounds = {
+        27.f, 180.f, 695.f, 705.f, -constant<scalar>::pi, constant<scalar>::pi};
+    range = {3016u, 3128u};
+    sf_finder_link = {sf_finder_ids::e_disc_grid, 4u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 17, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 17u, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
-    range = {3016, 3124};
-    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_trapezoid2, 432},
-                      {material_ids::e_slab, 3016}, pixel_mat,
+    range = {3016u, 3124u};
+    test_module_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_trapezoid2, 432u},
+                      {material_ids::e_slab, 3016u}, pixel_mat,
                       {vol_itr->index()});
 
     // Check link of surfaces in surface finder
@@ -812,16 +914,18 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check links of portals
     // cylinder portals
-    range = {3124, 3126};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 46},
-                      {material_ids::e_slab, 3124}, portal_mat,
-                      {0, leaving_world});
+    range = {3124u, 3126u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 46u},
+                      {material_ids::e_slab, 3124u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {3126, 3128};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 46},
-                      {material_ids::e_slab, 3126}, portal_mat, {16, 18});
+    range = {3126u, 3128u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 46u},
+                      {material_ids::e_slab, 3126u}, portal_mat, {16u, 18u});
 
     //
     // gap
@@ -829,25 +933,28 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., 705., 815., -M_PI, M_PI};
-    range = {3128, 3132};
-    sf_finder_link = {sf_finder_ids::e_brute_force, 0};
+    bounds = {
+        27.f, 180.f, 705.f, 815.f, -constant<scalar>::pi, constant<scalar>::pi};
+    range = {3128u, 3132u};
+    sf_finder_link = {sf_finder_ids::e_brute_force, 0u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 18, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 18u, bounds, range, sf_finder_link);
 
     // Check links of portals
     // cylinder portals
-    range = {3128, 3130};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 48},
-                      {material_ids::e_slab, 3128}, portal_mat,
-                      {0, leaving_world});
+    range = {3128u, 3130u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 48u},
+                      {material_ids::e_slab, 3128u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {3130, 3132};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 48},
-                      {material_ids::e_slab, 3130}, portal_mat, {17, 19});
+    range = {3130u, 3132u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 48u},
+                      {material_ids::e_slab, 3130u}, portal_mat, {17u, 19u});
 
     //
     // pos endcap (layer 3)
@@ -855,18 +962,20 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check volume
     ++vol_itr;
-    bounds = {27., 180., 815., 825., -M_PI, M_PI};
-    range = {3132, 3244};
-    sf_finder_link = {sf_finder_ids::e_disc_grid, 5};
+    bounds = {
+        27.f, 180.f, 815.f, 825.f, -constant<scalar>::pi, constant<scalar>::pi};
+    range = {3132u, 3244u};
+    sf_finder_link = {sf_finder_ids::e_disc_grid, 5u};
 
     // Test the links in the volumes
-    test_volume_links(vol_itr, 19, bounds, range, sf_finder_link);
+    test_volume_links(vol_itr, 19u, bounds, range, sf_finder_link);
 
     // Check the trapezoid modules
-    range = {3132, 3240};
-    test_module_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_trapezoid2, 540},
-                      {material_ids::e_slab, 3132}, pixel_mat,
+    range = {3132u, 3240u};
+    test_module_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_trapezoid2, 540u},
+                      {material_ids::e_slab, 3132u}, pixel_mat,
                       {vol_itr->index()});
 
     // Check link of surfaces in surface finder
@@ -874,15 +983,17 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
 
     // Check links of portals
     // cylinder portals
-    range = {3240, 3242};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_cylinder2, 50},
-                      {material_ids::e_slab, 3240}, portal_mat,
-                      {0, leaving_world});
+    range = {3240u, 3242u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_cylinder2, 50u},
+                      {material_ids::e_slab, 3240u}, portal_mat,
+                      {0u, leaving_world});
     // disc portals
-    range = {3242, 3244};
-    test_portal_links(vol_itr->index(), surfaces.begin() + range[0], range,
-                      range[0], {mask_ids::e_portal_ring2, 50},
-                      {material_ids::e_slab, 3242}, portal_mat,
-                      {18, leaving_world});
+    range = {3242u, 3244u};
+    test_portal_links(vol_itr->index(),
+                      surfaces.begin() + static_cast<std::ptrdiff_t>(range[0]),
+                      range, range[0], {mask_ids::e_portal_ring2, 50u},
+                      {material_ids::e_slab, 3242u}, portal_mat,
+                      {18u, leaving_world});
 }

--- a/tests/common/include/tests/common/tools/hash_tree.hpp
+++ b/tests/common/include/tests/common/tools/hash_tree.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -56,7 +56,10 @@ class hash_tree {
     struct hashed_node {
 
         hashed_node(hash_t hash)
-            : _key(hash), _parent(-1), _left_child(-1), _right_child(-1) {}
+            : _key(hash),
+              _parent(std::numeric_limits<dindex>::infinity()),
+              _left_child(std::numeric_limits<dindex>::infinity()),
+              _right_child(std::numeric_limits<dindex>::infinity()) {}
 
         hash_t _key;
         dindex _parent, _left_child, _right_child;
@@ -112,14 +115,14 @@ class hash_tree {
             _tree.emplace_back(_hash(data));
         }
         // Need an even number of leaves to build the tree correctly
-        if (input_data.size() % 2 != 0) {
+        if (input_data.size() % 2u != 0u) {
             _tree.emplace_back(_hash(0));
         }
         // Size of the tree is already known (all iterators stay valid in
         // recursion)
         // we might need to add one dummy node per level
         auto n_levels = static_cast<std::size_t>(std::log(input_data.size()));
-        _tree.reserve(2 * _tree.size() + n_levels);
+        _tree.reserve(2u * _tree.size() + n_levels);
         // Build next level
         build(_tree.begin(), _tree.size());
     }
@@ -131,30 +134,32 @@ class hash_tree {
     template <typename iterator_t>
     void build(iterator_t &&first_child, std::size_t n_prev_level) {
         // base case
-        if (n_prev_level <= 1) {
+        if (n_prev_level <= 1u) {
             return;
         }
 
-        auto last_child = first_child + n_prev_level;
+        auto last_child =
+            first_child + static_cast<std::ptrdiff_t>(n_prev_level);
 
         // Run over previous tree level to build the next level
         for (auto current_child = first_child; current_child != last_child;
-             current_child += 2) {
+             current_child += 2u) {
             auto parent_digest =
-                _hash(current_child->key(), (current_child + 1)->key());
+                _hash(current_child->key(), (current_child + 1u)->key());
             hashed_node parent = _tree.emplace_back(parent_digest);
 
             // Parent node index is at the back of the tree
-            current_child->set_parent(_tree.size() - 1);
-            (current_child + 1)->set_parent(_tree.size() - 1);
+            current_child->set_parent(_tree.size() - 1u);
+            (current_child + 1)->set_parent(_tree.size() - 1u);
 
             // Set the indices as distances in the contiguous container
-            dindex left_child_idx = std::distance(current_child, _tree.begin());
-            parent.set_children(left_child_idx, left_child_idx + 1);
+            auto left_child_idx = std::distance(current_child, _tree.begin());
+            parent.set_children(static_cast<dindex>(left_child_idx),
+                                static_cast<dindex>(left_child_idx) + 1u);
         }
-        auto n_level = static_cast<std::size_t>(0.5 * n_prev_level);
+        std::size_t n_level = n_prev_level / 2u;
         // Need dummy leaf node for next level?
-        if (n_level % 2 != 0 and n_level > 1) {
+        if (n_level % 2u != 0u and n_level > 1u) {
             _tree.emplace_back(0);
             n_level++;
         }

--- a/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
@@ -52,21 +52,21 @@ struct helix_cylinder_intersector {
     template <typename mask_t>
     DETRAY_HOST_DEVICE inline output_type operator()(
         const helix_type &h, const mask_t &mask, const transform3_t &trf,
-        const scalar_type mask_tolerance = 0) const {
+        const scalar_type mask_tolerance = 0.f) const {
 
         output_type ret;
 
         // Guard against inifinite loops
-        constexpr std::size_t max_n_tries{100};
+        constexpr std::size_t max_n_tries{100u};
         // Tolerance for convergence
-        constexpr scalar_type tol{1e-3};
+        constexpr scalar_type tol{1e-3f};
 
         // Get the surface placement
         const auto &sm = trf.matrix();
         // Cylinder z axis
-        const vector3 sz = getter::vector<3>(sm, 0, 2);
+        const vector3 sz = getter::vector<3>(sm, 0u, 2u);
         // Cylinder centre
-        const point3 sc = getter::vector<3>(sm, 0, 3);
+        const point3 sc = getter::vector<3>(sm, 0u, 3u);
 
         // Starting point on the helix for the Newton iteration
         // The mask is a cylinder -> it provides its radius as the first value
@@ -74,20 +74,19 @@ struct helix_cylinder_intersector {
         // Helix path length parameter
         scalar_type s{r * getter::perp(h.dir(tol))};
         // Path length in the previous iteration step
-        scalar_type s_prev{s - scalar{0.1}};
+        scalar_type s_prev{s - 0.1f};
 
         // f(s) = ((h.pos(s) - sc) x sz)^2 - r^2 == 0
         // Run the iteration on s
-        std::size_t n_tries{0};
+        std::size_t n_tries{0u};
         while (std::abs(s - s_prev) > tol and n_tries < max_n_tries) {
 
             // f'(s) = 2 * ( (h.pos(s) - sc) x sz) * (h.dir(s) x sz) )
             const vector3 crp = vector::cross(h.pos(s) - sc, sz);
             const scalar_type denom{
-                scalar_type{2.} *
-                vector::dot(crp, vector::cross(h.dir(s), sz))};
+                2.f * vector::dot(crp, vector::cross(h.dir(s), sz))};
             // No intersection can be found if dividing by zero
-            if (denom == scalar_type{0.}) {
+            if (denom == 0.f) {
                 return ret;
             }
             // x_n+1 = x_n - f(s) / f'(s)
@@ -114,7 +113,7 @@ struct helix_cylinder_intersector {
         const scalar_type radial_pos{getter::perp(trf.point_to_local(is.p3))};
         const bool r_check =
             std::abs(r - radial_pos) <
-            mask_tolerance + 5 * std::numeric_limits<scalar_type>::epsilon();
+            mask_tolerance + 5.f * std::numeric_limits<scalar_type>::epsilon();
         if (not r_check) {
             is.status = intersection::status::e_outside;
         }

--- a/tests/common/include/tests/common/tools/intersectors/helix_intersection_kernel.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_intersection_kernel.hpp
@@ -43,7 +43,7 @@ struct helix_intersection_update {
         const mask_group_t &mask_group, const mask_range_t &mask_range,
         const traj_t &traj, const surface_t &surface,
         const transform_container_t &contextual_transforms,
-        const scalar mask_tolerance = 0.) const {
+        const scalar mask_tolerance = 0.f) const {
 
         using transform3_type = typename traj_t::transform3_type;
         using helix_plane_intersector_type =

--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -50,34 +50,34 @@ struct helix_plane_intersector {
     template <typename mask_t>
     DETRAY_HOST_DEVICE inline output_type operator()(
         const helix_type &h, const mask_t &mask, const transform3_t &trf,
-        const scalar mask_tolerance = 0) const {
+        const scalar mask_tolerance = 0.f) const {
 
         output_type ret;
 
         // Guard against inifinite loops
-        constexpr std::size_t max_n_tries{100};
+        constexpr std::size_t max_n_tries{100u};
         // Tolerance for convergence
-        constexpr scalar tol{1e-3};
+        constexpr scalar tol{1e-3f};
 
         // Get the surface info
         const auto &sm = trf.matrix();
         // Surface normal
-        const vector3 sn = getter::vector<3>(sm, 0, 2);
+        const vector3 sn = getter::vector<3>(sm, 0u, 2u);
         // Surface translation
-        const point3 st = getter::vector<3>(sm, 0, 3);
+        const point3 st = getter::vector<3>(sm, 0u, 3u);
 
         // Starting point on the helix for the Newton iteration
-        scalar s{getter::norm(sn) - scalar{0.1}};
-        scalar s_prev{s - scalar{0.1}};
+        scalar s{getter::norm(sn) - 0.1f};
+        scalar s_prev{s - 0.1f};
 
         // f(s) = sn * (h.pos(s) - st) == 0
         // Run the iteration on s
-        std::size_t n_tries{0};
+        std::size_t n_tries{0u};
         while (std::abs(s - s_prev) > tol and n_tries < max_n_tries) {
             // f'(s) = sn * h.dir(s)
             const scalar denom{vector::dot(sn, h.dir(s))};
             // No intersection can be found if dividing by zero
-            if (denom == 0.) {
+            if (denom == 0.f) {
                 return ret;
             }
             // x_n+1 = x_n - f(s) / f'(s)
@@ -99,7 +99,7 @@ struct helix_plane_intersector {
         is.p2 = mask.to_local_frame(trf, is.p3, h.dir(s));
 
         is.status = mask.is_inside(is.p2, mask_tolerance);
-        is.direction = vector::dot(st, h.dir(s)) > scalar{0.}
+        is.direction = vector::dot(st, h.dir(s)) > 0.f
                            ? intersection::direction::e_along
                            : intersection::direction::e_opposite;
         is.link = mask.volume_link();

--- a/tests/common/include/tests/common/tools/particle_gun.hpp
+++ b/tests/common/include/tests/common/tools/particle_gun.hpp
@@ -58,7 +58,7 @@ struct particle_gun {
                 intersection_type sfi;
                 if constexpr (std::is_same_v<trajectory_t, helix_type>) {
                     sfi = mask_store.template call<helix_intersection_update>(
-                        sf.mask(), traj, sf, tf_store, 1e-4);
+                        sf.mask(), traj, sf, tf_store, 1e-4f);
                 } else {
                     sfi = mask_store.template call<intersection_update>(
                         sf.mask(), traj, sf, tf_store);

--- a/tests/common/include/tests/common/tools/ray_scan_utils.hpp
+++ b/tests/common/include/tests/common/tools/ray_scan_utils.hpp
@@ -53,10 +53,11 @@ inline bool check_connectivity(
     // If the intersection trace comes from the ray gun/trace intersections
     // function it should be sorted, which is the stronger constraint
     using records_iterator_t = decltype(trace.begin());
-    std::function<records_iterator_t(dindex)> get_connected_record;
+    using index_t = typename records_iterator_t::difference_type;
+    std::function<records_iterator_t(index_t)> get_connected_record;
     if constexpr (check_sorted_trace) {
         // Get the next record
-        get_connected_record = [&](dindex next) -> records_iterator_t {
+        get_connected_record = [&](index_t next) -> records_iterator_t {
             auto rec = trace.begin() + next;
             if ((std::get<1>(rec->first) == on_volume) or
                 (std::get<1>(rec->second) == on_volume)) {
@@ -66,7 +67,7 @@ inline bool check_connectivity(
         };
     } else {
         // Search for the existence of a fitting record
-        get_connected_record = [&](dindex /*next*/) -> records_iterator_t {
+        get_connected_record = [&](index_t /*next*/) -> records_iterator_t {
             return find_if(
                 trace.begin(), trace.end(),
                 [&](const std::pair<entry_type, entry_type> &rec) -> bool {
@@ -77,7 +78,7 @@ inline bool check_connectivity(
     }
 
     // Init chain search
-    dindex i = 0;
+    index_t i{0};
     auto record = get_connected_record(i);
 
     // Check first volume index, which has no partner otherwise

--- a/tests/common/include/tests/common/tools/test_surfaces.hpp
+++ b/tests/common/include/tests/common/tools/test_surfaces.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -28,11 +28,11 @@ using namespace vector;
 
 // TODO: Remove Cyclic dependendy with benchmark_intersec_surfaces.inl types
 enum plane_mask_ids : unsigned int {
-    e_plane_rectangle2 = 0,
+    e_plane_rectangle2 = 0u,
 };
 
 enum plane_material_ids : unsigned int {
-    e_plane_slab = 0,
+    e_plane_slab = 0u,
 };
 
 using transform3 = __plugin::transform3<detray::scalar>;
@@ -44,13 +44,12 @@ using plane_material_link_t = dtyped_index<plane_material_ids, dindex>;
 
 using binned_neighborhood = darray<darray<dindex, 2>, 2>;
 
-/** This method creates a number (distances.size()) planes along a direction
- */
+/// This method creates a number (distances.size()) planes along a direction
 dvector<surface<plane_mask_link_t, plane_material_link_t, transform3>>
 planes_along_direction(dvector<scalar> distances, vector3 direction) {
     // Rotation matrix
     vector3 z = direction;
-    vector3 x = normalize(vector3{0, -z[2], z[1]});
+    vector3 x = normalize(vector3{0.f, -z[2], z[1]});
 
     dvector<surface<plane_mask_link_t, plane_material_link_t, transform3>>
         return_surfaces;
@@ -60,9 +59,9 @@ planes_along_direction(dvector<scalar> distances, vector3 direction) {
         transform3 trf(t, z, x);
         plane_mask_link_t mask_link{plane_mask_ids::e_plane_rectangle2, idx};
         plane_material_link_t material_link{plane_material_ids::e_plane_slab,
-                                            0};
+                                            0u};
         return_surfaces.emplace_back(std::move(trf), std::move(mask_link),
-                                     std::move(material_link), 0, false,
+                                     std::move(material_link), 0u, false,
                                      surface_id::e_sensitive);
     }
     return return_surfaces;
@@ -73,37 +72,37 @@ using disc_point2 = __plugin::point2<detray::scalar>;
 using endcap_surface_finder = std::function<dvector<dindex>(
     const disc_point2 &, const binned_neighborhood &)>;
 
-/** This method creates a barrel description of surfaces
- *
- * @param inner_r The inner radius of the endcap disc
- * @param outer_r The outer radius of the endcap disc
- * @param pos_z The nominal z position of the endcap disc
- * @param stagger_z The possible staggering in z
- * @param n_phi The number of modules in phi
- * @param overlap_phi The overlap in phi coverage (approximated)
- * @param volume_inner_r the volume inner radius for the local finder
- * @param volume_outer_r the volume outer radius for the local finder
- * @param volumer_min_z the volume minimum z
- * @param volume_max_z the volume maximumz
- * @param transform_offset The offset for the transform grid
- *
- * @returns a tuple for rectangle descriptions and transforms
- */
+/// This method creates an endcap description of surfaces
+///
+/// @param inner_r The inner radius of the endcap disc
+/// @param outer_r The outer radius of the endcap disc
+/// @param pos_z The nominal z position of the endcap disc
+/// @param stagger_z The possible staggering in z
+/// @param n_phi The number of modules in phi
+/// @param overlap_phi The overlap in phi coverage (approximated)
+/// @param volume_inner_r the volume inner radius for the local finder
+/// @param volume_outer_r the volume outer radius for the local finder
+/// @param volumer_min_z the volume minimum z
+/// @param volume_max_z the volume maximumz
+/// @param transform_offset The offset for the transform grid
+///
+/// @returns a tuple for rectangle descriptions and transforms
 dtuple<darray<scalar, 3>, dvector<transform3>, dvector<endcap_surface_finder>>
 create_endcap_components(scalar inner_r, scalar outer_r, scalar pos_z,
                          scalar stagger_z, unsigned int n_phi,
                          scalar overlap_phi, scalar volume_inner_r,
                          scalar volume_outer_r, scalar volume_min_z,
                          scalar volume_max_z,
-                         unsigned int transform_offset = 0) {
-    scalar module_inner_lx = 2. * inner_r * M_PI * (1. + overlap_phi) / (n_phi);
-    scalar module_outer_lx = 2. * outer_r * M_PI * (1. + overlap_phi) / (n_phi);
-    scalar module_hy = 0.5 * (outer_r - inner_r);
+                         unsigned int transform_offset = 0u) {
+    scalar module_inner_lx{2.f * inner_r * constant<scalar>::pi *
+                           (1.f + overlap_phi) / static_cast<scalar>(n_phi)};
+    scalar module_outer_lx{2.f * outer_r * constant<scalar>::pi *
+                           (1.f + overlap_phi) / static_cast<scalar>(n_phi)};
+    scalar module_hy{0.5f * (outer_r - inner_r)};
 
-    darray<scalar, 3> trapezoid_values = {
-        static_cast<scalar>(0.5 * module_inner_lx),
-        static_cast<scalar>(0.5 * module_outer_lx), module_hy};
-    scalar step_phi = 2 * M_PI / n_phi;
+    darray<scalar, 3> trapezoid_values = {0.5f * module_inner_lx,
+                                          0.5f * module_outer_lx, module_hy};
+    scalar step_phi{2.f * constant<scalar>::pi / static_cast<scalar>(n_phi)};
     dvector<transform3> transforms;
 
     // Prepare the local finders
@@ -117,24 +116,24 @@ create_endcap_components(scalar inner_r, scalar outer_r, scalar pos_z,
                             decltype(serializer)>;
 
     typename cylinder_grid::axis_p0_type rphi_axis_inner = {
-        n_phi, static_cast<scalar>(-volume_inner_r * (M_PI + 0.5 * step_phi)),
-        static_cast<scalar>(volume_inner_r * (M_PI - 0.5 * step_phi)), host_mr};
-    typename cylinder_grid::axis_p1_type z_axis_inner = {1, volume_min_z,
+        n_phi, -volume_inner_r * (constant<scalar>::pi + 0.5f * step_phi),
+        volume_inner_r * (constant<scalar>::pi - 0.5f * step_phi), host_mr};
+    typename cylinder_grid::axis_p1_type z_axis_inner = {1u, volume_min_z,
                                                          volume_max_z, host_mr};
     typename cylinder_grid::axis_p0_type rphi_axis_outer = {
-        n_phi, static_cast<scalar>(-volume_outer_r * (M_PI + 0.5 * step_phi)),
-        static_cast<scalar>(volume_outer_r * (M_PI - 0.5 * step_phi)), host_mr};
+        n_phi, -volume_outer_r * (constant<scalar>::pi + 0.5f * step_phi),
+        volume_outer_r * (constant<scalar>::pi - 0.5f * step_phi), host_mr};
 
-    typename disc_grid::axis_p0_type r_axis_ecn = {1, volume_inner_r,
+    typename disc_grid::axis_p0_type r_axis_ecn = {1u, volume_inner_r,
                                                    volume_outer_r, host_mr};
     typename disc_grid::axis_p1_type phi_axis_ecn = {
-        n_phi, static_cast<scalar>(-M_PI - 0.5 * step_phi),
-        static_cast<scalar>(M_PI - 0.5 * step_phi), host_mr};
-    typename disc_grid::axis_p0_type r_axis_ecp = {1, volume_inner_r,
+        n_phi, -constant<scalar>::pi - 0.5f * step_phi,
+        constant<scalar>::pi - 0.5f * step_phi, host_mr};
+    typename disc_grid::axis_p0_type r_axis_ecp = {1u, volume_inner_r,
                                                    volume_outer_r, host_mr};
     typename disc_grid::axis_p1_type phi_axis_ecp = {
-        n_phi, static_cast<scalar>(-M_PI - 0.5 * step_phi),
-        static_cast<scalar>(M_PI - 0.5 * step_phi), host_mr};
+        n_phi, -constant<scalar>::pi - 0.5f * step_phi,
+        constant<scalar>::pi - 0.5f * step_phi, host_mr};
 
     cylinder_grid ec_grid_inner(std::move(rphi_axis_inner),
                                 std::move(z_axis_inner), host_mr);
@@ -145,10 +144,11 @@ create_endcap_components(scalar inner_r, scalar outer_r, scalar pos_z,
     disc_grid ec_grid_p(std::move(r_axis_ecp), std::move(phi_axis_ecp),
                         host_mr);
 
-    scalar r = 0.5 * (inner_r + outer_r);
+    scalar r{0.5f * (inner_r + outer_r)};
 
-    for (unsigned int iphi = 0; iphi < n_phi; ++iphi) {
-        scalar phi = -M_PI + iphi * step_phi;
+    for (unsigned int iphi = 0u; iphi < n_phi; ++iphi) {
+        scalar phi{-constant<scalar>::pi +
+                   static_cast<scalar>(iphi) * step_phi};
 
         // Populate the grids
         ec_grid_inner.populate(cylinder_point2{volume_inner_r * phi, pos_z},
@@ -160,12 +160,12 @@ create_endcap_components(scalar inner_r, scalar outer_r, scalar pos_z,
         ec_grid_p.populate(disc_point2{r, phi},
                            transforms.size() + transform_offset);
 
-        scalar z_addon = (iphi % 2) ? -stagger_z : stagger_z;
+        scalar z_addon = (iphi % 2u) ? -stagger_z : stagger_z;
         scalar cos_phi = std::cos(phi);
         scalar sin_phi = std::sin(phi);
         point3 p = {r * cos_phi, r * sin_phi, pos_z + z_addon};
-        vector3 z = {0., 0., 1.};
-        vector3 x = {sin_phi, -cos_phi, 0.};
+        vector3 z = {0.f, 0.f, 1.f};
+        vector3 x = {sin_phi, -cos_phi, 0.f};
         transforms.push_back(transform3(p, z, x));
     }
 
@@ -182,43 +182,44 @@ create_endcap_components(scalar inner_r, scalar outer_r, scalar pos_z,
 using barrel_surface_finder = std::function<dvector<dindex>(
     const cylinder_point2 &, const binned_neighborhood &)>;
 
-/** This method creates a barrel description of surfaces
- *
- * @param r The radius of the barrel cylinder
- * @param stagger_r The (optional) staggering in r
- * @param n_phi The number of modules in phi
- * @param tilt_phi The tilt of the modules in phi
- * @param overlap_rphi The overlap in rphi coverage (approximated)
- * @param length_z The length of the (sensitive) barrel in z
- * @param overlap_z The (optional) staggering in z
- * @param volume_inner_r The volume inner r
- * @param volume_outer_r The volume outer r
- * @param volume_length_z The volume half length
- * @param transform_offset The offset for the transform grid
- *
- * @returns a tuple for rectangle descriptions, transforms, object finders
- */
+/// This method creates a barrel description of surfaces
+///
+/// @param r The radius of the barrel cylinder
+/// @param stagger_r The (optional) staggering in r
+/// @param n_phi The number of modules in phi
+/// @param tilt_phi The tilt of the modules in phi
+/// @param overlap_rphi The overlap in rphi coverage (approximated)
+/// @param length_z The length of the (sensitive) barrel in z
+/// @param overlap_z The (optional) staggering in z
+/// @param volume_inner_r The volume inner r
+/// @param volume_outer_r The volume outer r
+/// @param volume_length_z The volume half length
+/// @param transform_offset The offset for the transform grid
+///
+/// @returns a tuple for rectangle descriptions, transforms, object finders
 dtuple<darray<scalar, 2>, dvector<transform3>, dvector<barrel_surface_finder>>
 create_barrel_components(scalar r, scalar stagger_r, unsigned int n_phi,
                          scalar tilt_phi, scalar overlap_rphi, scalar length_z,
                          scalar overlap_z, unsigned int n_z,
                          scalar volume_inner_r, scalar volume_outer_r,
                          scalar /*volume_half_z*/,
-                         unsigned int transform_offset = 0) {
+                         unsigned int transform_offset = 0u) {
     // Estimate module dimensions
-    scalar module_lx = 2 * r * M_PI * (1 + overlap_rphi) / n_phi;
-    scalar module_ly = (length_z + (n_z - 1) * overlap_z) / n_z;
-    darray<scalar, 2> rectangle_bounds = {static_cast<scalar>(0.5 * module_lx),
-                                          static_cast<scalar>(0.5 * module_ly)};
+    scalar module_lx{2.f * r * constant<scalar>::pi * (1.f + overlap_rphi) /
+                     static_cast<scalar>(n_phi)};
+    scalar module_ly{(length_z + static_cast<scalar>(n_z - 1u) * overlap_z) /
+                     static_cast<scalar>(n_z)};
+    darray<scalar, 2> rectangle_bounds = {0.5f * module_lx, 0.5f * module_ly};
 
     // Prepare the local finders
     serializer2 serializer;
 
     // The detector transforms
     dvector<transform3> transforms;
-    scalar step_phi = 2 * M_PI / n_phi;
-    scalar step_z = module_ly - overlap_z;
-    scalar start_z = -0.5 * (n_z - 1) * (module_ly - overlap_z);
+    scalar step_phi{2.f * constant<scalar>::pi / static_cast<scalar>(n_phi)};
+    scalar step_z{module_ly - overlap_z};
+    scalar start_z{-0.5f * static_cast<scalar>(n_z - 1u) *
+                   (module_ly - overlap_z)};
 
     // Declare the inner, outer, ecn, ecp object finder
     using cylinder_grid = grid2<replace_populator, axis::circular,
@@ -227,27 +228,24 @@ create_barrel_components(scalar r, scalar stagger_r, unsigned int n_phi,
                             decltype(serializer)>;
 
     typename cylinder_grid::axis_p0_type rphi_axis_inner = {
-        n_phi, static_cast<scalar>(-volume_inner_r * (M_PI + 0.5 * step_phi)),
-        static_cast<scalar>(volume_inner_r * (M_PI - 0.5 * step_phi)), host_mr};
+        n_phi, -volume_inner_r * (constant<scalar>::pi + 0.5f * step_phi),
+        volume_inner_r * (constant<scalar>::pi - 0.5f * step_phi), host_mr};
     typename cylinder_grid::axis_p1_type z_axis_inner = {
-        n_z, static_cast<scalar>(-0.5 * length_z),
-        static_cast<scalar>(0.5 * length_z), host_mr};
+        n_z, -0.5f * length_z, 0.5f * length_z, host_mr};
     typename cylinder_grid::axis_p0_type rphi_axis_outer = {
-        n_phi, static_cast<scalar>(-volume_outer_r * (M_PI + 0.5 * step_phi)),
-        static_cast<scalar>(volume_outer_r * (M_PI - 0.5 * step_phi)), host_mr};
-    // axis::regular<> z_axis_outer = {n_z, static_cast<scalar>(-0.5 *
-    // length_z),
-    //                                static_cast<scalar>(0.5 * length_z)};
+        n_phi, -volume_outer_r * (constant<scalar>::pi + 0.5f * step_phi),
+        volume_outer_r * (constant<scalar>::pi - 0.5f * step_phi), host_mr};
+    // axis::regular<> z_axis_outer = {n_z, -0.5f * length_z, 0.5f * length_z};
     typename disc_grid::axis_p0_type r_axis_ecn = {1, volume_inner_r,
                                                    volume_outer_r, host_mr};
     typename disc_grid::axis_p1_type phi_axis_ecn = {
-        n_phi, static_cast<scalar>(-M_PI - 0.5 * step_phi),
-        static_cast<scalar>(M_PI - 0.5 * step_phi), host_mr};
+        n_phi, -constant<scalar>::pi - 0.5f * step_phi,
+        constant<scalar>::pi - 0.5f * step_phi, host_mr};
     typename disc_grid::axis_p0_type r_axis_ecp = {1, volume_inner_r,
                                                    volume_outer_r, host_mr};
     typename disc_grid::axis_p1_type phi_axis_ecp = {
-        n_phi, static_cast<scalar>(-M_PI - 0.5 * step_phi),
-        static_cast<scalar>(M_PI - 0.5 * step_phi), host_mr};
+        n_phi, -constant<scalar>::pi - 0.5f * step_phi,
+        constant<scalar>::pi - 0.5f * step_phi, host_mr};
 
     cylinder_grid barrel_grid_inner(std::move(rphi_axis_inner),
                                     std::move(z_axis_inner), host_mr);
@@ -258,10 +256,11 @@ create_barrel_components(scalar r, scalar stagger_r, unsigned int n_phi,
     disc_grid barrel_grid_p(std::move(r_axis_ecp), std::move(phi_axis_ecp),
                             host_mr);
 
-    for (unsigned int iz = 0; iz < n_z; ++iz) {
-        scalar pos_z = start_z + iz * step_z;
-        for (unsigned int iphi = 0; iphi < n_phi; ++iphi) {
-            scalar phi = -M_PI + iphi * step_phi;
+    for (unsigned int iz = 0u; iz < n_z; ++iz) {
+        scalar pos_z = start_z + static_cast<scalar>(iz) * step_z;
+        for (unsigned int iphi = 0u; iphi < n_phi; ++iphi) {
+            scalar phi{-constant<scalar>::pi +
+                       static_cast<scalar>(iphi) * step_phi};
             // Populate the grids
             barrel_grid_inner.populate(
                 cylinder_point2{volume_inner_r * phi, pos_z},
@@ -269,21 +268,21 @@ create_barrel_components(scalar r, scalar stagger_r, unsigned int n_phi,
             barrel_grid_outer.populate(
                 cylinder_point2{volume_outer_r * phi, pos_z},
                 transforms.size() + transform_offset);
-            if (iz == 0) {
+            if (iz == 0u) {
                 barrel_grid_n.populate(disc_point2{r, phi},
                                        transforms.size() + transform_offset);
             }
-            if (iz == n_z - 1) {
+            if (iz == n_z - 1u) {
                 barrel_grid_p.populate(disc_point2{r, phi},
                                        transforms.size() + transform_offset);
             }
             // Finally create the transform
-            scalar r_addon = (iz % 2) ? -stagger_r : stagger_r;
+            scalar r_addon = (iz % 2u) ? -stagger_r : stagger_r;
             point3 p = {(r + r_addon) * std::cos(phi),
                         (r + r_addon) * std::sin(phi), pos_z};
             vector3 z = {std::cos(phi + tilt_phi), std::sin(phi + tilt_phi),
-                         0.};
-            vector3 x = {z[1], -z[0], 0.};
+                         0.f};
+            vector3 x = {z[1], -z[0], 0.f};
             transforms.push_back(transform3(p, z, x));
         }
     }

--- a/tests/common/include/tests/common/tools_actor_chain.inl
+++ b/tests/common/include/tests/common/tools_actor_chain.inl
@@ -61,14 +61,16 @@ struct example_actor : detray::actor {
     template <typename propagator_state_t>
     void operator()(state &example_state,
                     const propagator_state_t & /*p_state*/) const {
-        example_state.buffer.push_back(example_state.buffer.size());
+        example_state.buffer.push_back(
+            static_cast<float>(example_state.buffer.size()));
     }
 
     /// Observing actor implementation: Counts vector elements (division)
     template <typename propagator_state_t>
     void operator()(state &example_state, const state &subject_state,
                     const propagator_state_t & /*p_state*/) const {
-        example_state.buffer.push_back(subject_state.buffer.size() / 10.);
+        example_state.buffer.push_back(
+            static_cast<float>(subject_state.buffer.size()) * 0.1f);
     }
 
     /// Observing actor implementation to printer: do nothing

--- a/tests/common/include/tests/common/tools_cylinder_intersection.inl
+++ b/tests/common/include/tests/common/tools_cylinder_intersection.inl
@@ -33,67 +33,67 @@ using scalar_type = typename transform3_type::scalar_type;
 using ray_type = detray::detail::ray<transform3_type>;
 using helix_type = detray::detail::helix<transform3_type>;
 
-constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
+constexpr scalar tol = std::numeric_limits<scalar>::epsilon();
 constexpr scalar not_defined = std::numeric_limits<scalar>::infinity();
-constexpr scalar isclose = 1e-5;
+constexpr scalar isclose{1e-5f};
 
-const scalar r{4.};
-const scalar hz{10.};
+const scalar r{4.f};
+const scalar hz{10.f};
 
 }  // anonymous namespace
 
 // This defines the local frame test suite
 TEST(ALGEBRA_PLUGIN, translated_cylinder) {
     // Create a translated cylinder and test untersection
-    const transform3_type shifted(vector3{3., 2., 10.});
+    const transform3_type shifted(vector3{3.f, 2.f, 10.f});
     cylinder_intersector<transform3_type> ci;
 
     // Test ray
-    const point3 ori = {3., 2., 5.};
-    const point3 dir = {1., 0., 0.};
-    const ray_type ray(ori, 0., dir, 0.);
+    const point3 ori = {3.f, 2.f, 5.f};
+    const point3 dir = {1.f, 0.f, 0.f};
+    const ray_type ray(ori, 0.f, dir, 0.f);
 
     // Check intersection
     mask<cylinder2D<>, unsigned int, transform3_type> cylinder_bound{0u, r, -hz,
                                                                      hz};
     const auto hit_bound = ci(ray, cylinder_bound, shifted)[0];
     ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
-    ASSERT_NEAR(hit_bound.p3[0], 7., epsilon);
-    ASSERT_NEAR(hit_bound.p3[1], 2., epsilon);
-    ASSERT_NEAR(hit_bound.p3[2], 5., epsilon);
+    ASSERT_NEAR(hit_bound.p3[0], 7.f, tol);
+    ASSERT_NEAR(hit_bound.p3[1], 2.f, tol);
+    ASSERT_NEAR(hit_bound.p3[2], 5.f, tol);
     ASSERT_TRUE(hit_bound.p2[0] != not_defined &&
                 hit_bound.p2[1] != not_defined);
-    ASSERT_NEAR(hit_bound.p2[0], 0., isclose);
-    ASSERT_NEAR(hit_bound.p2[1], -5., isclose);
-    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1., isclose);
+    ASSERT_NEAR(hit_bound.p2[0], 0.f, isclose);
+    ASSERT_NEAR(hit_bound.p2[1], -5.f, isclose);
+    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1.f, isclose);
 }
 
 // This defines the local frame test suite
 TEST(ALGEBRA_PLUGIN, cylinder_incidence_angle) {
-    const transform3_type tf(vector3{0., 0., 0.});
+    const transform3_type tf(vector3{0.f, 0.f, 0.f});
     cylinder_intersector<transform3_type> ci;
 
     // Test ray
-    const point3 ori = {0., 1., 0.};
-    const point3 dir = {1., 0., 0.};
-    const ray_type ray(ori, 0., dir, 0.);
+    const point3 ori = {0.f, 1.f, 0.f};
+    const point3 dir = {1.f, 0.f, 0.f};
+    const ray_type ray(ori, 0.f, dir, 0.f);
 
     // Check intersection
     mask<cylinder2D<>, unsigned int, transform3_type> cylinder_bound{0u, r, -hz,
                                                                      hz};
     const auto hit_bound = ci(ray, cylinder_bound, tf)[0];
-    ASSERT_NEAR(hit_bound.cos_incidence_angle, std::sqrt(15) / 4., isclose);
+    ASSERT_NEAR(hit_bound.cos_incidence_angle, 0.25f * std::sqrt(15), isclose);
 }
 
 // This defines the local frame test suite
 TEST(ALGEBRA_PLUGIN, concentric_cylinders) {
     // Test ray
-    const point3 ori = {1., 0.5, 1.};
-    const point3 dir = vector::normalize(vector3{1., 1., 1.});
-    const ray_type ray(ori, 0., dir, 0.);
+    const point3 ori = {1.f, 0.5f, 1.f};
+    const point3 dir = vector::normalize(vector3{1.f, 1.f, 1.f});
+    const ray_type ray(ori, 0.f, dir, 0.f);
 
     // Create a concentric cylinder and test intersection
-    const transform3_type identity(vector3{0., 0., 0.});
+    const transform3_type identity(vector3{0.f, 0.f, 0.f});
     mask<cylinder2D<>, unsigned int, transform3_type> cylinder{0u, r, -hz, hz};
     mask<cylinder2D<false, concentric_cylinder_intersector>, unsigned int,
          transform3_type>
@@ -103,7 +103,7 @@ TEST(ALGEBRA_PLUGIN, concentric_cylinders) {
 
     // Check intersection
     const auto hit_cylinrical = ci(ray, cylinder, identity)[0];
-    const auto hit_cocylindrical = cci(ray, cylinder, identity)[0];
+    const auto hit_cocylindrical = cci(ray, conc_cylinder, identity)[0];
 
     ASSERT_TRUE(hit_cylinrical.status == intersection::status::e_inside);
     ASSERT_TRUE(hit_cocylindrical.status == intersection::status::e_inside);
@@ -128,15 +128,15 @@ TEST(ALGEBRA_PLUGIN, concentric_cylinders) {
 // This defines the local frame test suite
 TEST(ALGEBRA_PLUGIN, helix_cylinder_intersector) {
     // Create a translated cylinder and test untersection
-    const transform3_type shifted(vector3{3., 2., 10.});
+    const transform3_type shifted(vector3{3.f, 2.f, 10.f});
     helix_cylinder_intersector<transform3_type> hi;
 
     // Test helix
-    const point3 pos{3., 2., 5.};
-    const vector3 mom{1., 0., 0.};
-    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
-                    epsilon * unit<scalar>::T};
-    const helix_type h({pos, 0, mom, -1}, &B);
+    const point3 pos{3.f, 2.f, 5.f};
+    const vector3 mom{1.f, 0.f, 0.f};
+    const vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                    tol * unit<scalar>::T};
+    const helix_type h({pos, 0.f, mom, -1.f}, &B);
 
     // Check intersection
     mask<cylinder2D<false, helix_cylinder_intersector>, unsigned int,
@@ -144,11 +144,11 @@ TEST(ALGEBRA_PLUGIN, helix_cylinder_intersector) {
         cylinder_bound{0u, r, -hz, hz};
     const auto hit_bound = hi(h, cylinder_bound, shifted)[0];
     ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
-    ASSERT_NEAR(hit_bound.p3[0], 7., epsilon);
-    ASSERT_NEAR(hit_bound.p3[1], 2., epsilon);
-    ASSERT_NEAR(hit_bound.p3[2], 5., epsilon);
+    ASSERT_NEAR(hit_bound.p3[0], 7.f, tol);
+    ASSERT_NEAR(hit_bound.p3[1], 2.f, tol);
+    ASSERT_NEAR(hit_bound.p3[2], 5.f, tol);
     ASSERT_TRUE(hit_bound.p2[0] != not_defined &&
                 hit_bound.p2[1] != not_defined);
-    ASSERT_NEAR(hit_bound.p2[0], 0., isclose);
-    ASSERT_NEAR(hit_bound.p2[1], -5., isclose);
+    ASSERT_NEAR(hit_bound.p2[0], 0.f, isclose);
+    ASSERT_NEAR(hit_bound.p2[1], -5.f, isclose);
 }

--- a/tests/common/include/tests/common/tools_intersection_kernel.inl
+++ b/tests/common/include/tests/common/tools_intersection_kernel.inl
@@ -29,13 +29,13 @@ using point3 = __plugin::point3<scalar>;
 using transform3_type = __plugin::transform3<scalar>;
 
 enum mask_ids : unsigned int {
-    e_rectangle2 = 0,
-    e_trapezoid2 = 1,
-    e_annulus2 = 2,
+    e_rectangle2 = 0u,
+    e_trapezoid2 = 1u,
+    e_annulus2 = 2u,
 };
 
 enum material_ids : unsigned int {
-    e_slab = 0,
+    e_slab = 0u,
 };
 
 /// Surface components:
@@ -59,7 +59,7 @@ using transform_link_t = dindex;
 using surface_t = surface<mask_link_t, material_link_t, transform_link_t>;
 using surface_container_t = dvector<surface_t>;
 
-constexpr const float epsilon = 1e-3;
+constexpr const scalar tol{1e-3f};
 
 // TODO: How about merging ray and helix tests into one to remove the code
 // repetition?
@@ -72,36 +72,36 @@ TEST(tools, intersection_kernel_ray) {
     typename transform_container_t::context_type static_context{};
     transform_container_t transform_store;
     // Transforms of the rectangle, trapezoid and annulus
-    transform_store.emplace_back(static_context, point3{0., 0., 10.});
-    transform_store.emplace_back(static_context, point3{0., 0., 20.});
-    transform_store.emplace_back(static_context, point3{0., -20., 30.});
+    transform_store.emplace_back(static_context, point3{0.f, 0.f, 10.f});
+    transform_store.emplace_back(static_context, point3{0.f, 0.f, 20.f});
+    transform_store.emplace_back(static_context, point3{0.f, -20.f, 30.f});
     // The masks & their store
     mask_container_t mask_store(host_mr);
-    mask_store.template emplace_back<e_rectangle2>(empty_context{}, 0UL, 10.f,
+    mask_store.template emplace_back<e_rectangle2>(empty_context{}, 0u, 10.f,
                                                    10.f);
-    mask_store.template emplace_back<e_trapezoid2>(empty_context{}, 0UL, 10.f,
+    mask_store.template emplace_back<e_trapezoid2>(empty_context{}, 0u, 10.f,
                                                    20.f, 30.f);
     mask_store.template emplace_back<e_annulus2>(
-        empty_context{}, 0UL, 15.f, 55.f, 0.75f, 1.95f, 2.f, -2.f, 0.f);
+        empty_context{}, 0u, 15.f, 55.f, 0.75f, 1.95f, 2.f, -2.f, 0.f);
 
     // The surfaces and their store
-    const surface_t rectangle_surface(0u, {e_rectangle2, 0}, {e_slab, 0}, 0, 0,
-                                      surface_id::e_sensitive);
-    const surface_t trapezoid_surface(1u, {e_trapezoid2, 0}, {e_slab, 1}, 0, 1,
-                                      surface_id::e_sensitive);
-    const surface_t annulus_surface(2u, {e_annulus2, 0}, {e_slab, 2}, 0, 2,
+    const surface_t rectangle_surface(0u, {e_rectangle2, 0u}, {e_slab, 0u}, 0u,
+                                      0u, surface_id::e_sensitive);
+    const surface_t trapezoid_surface(1u, {e_trapezoid2, 0u}, {e_slab, 1u}, 0u,
+                                      1u, surface_id::e_sensitive);
+    const surface_t annulus_surface(2u, {e_annulus2, 0u}, {e_slab, 2u}, 0u, 2u,
                                     surface_id::e_sensitive);
     surface_container_t surfaces = {rectangle_surface, trapezoid_surface,
                                     annulus_surface};
 
-    const point3 pos{0., 0., 0.};
-    const vector3 mom{0.01, 0.01, 10.};
-    const free_track_parameters<transform3_type> track(pos, 0, mom, -1);
+    const point3 pos{0.f, 0.f, 0.f};
+    const vector3 mom{0.01f, 0.01f, 10.f};
+    const free_track_parameters<transform3_type> track(pos, 0.f, mom, -1.f);
 
     // Validation data
-    const point3 expected_rectangle{0.01, 0.01, 10.};
-    const point3 expected_trapezoid{0.02, 0.02, 20.};
-    const point3 expected_annulus{0.03, 0.03, 30.};
+    const point3 expected_rectangle{0.01f, 0.01f, 10.f};
+    const point3 expected_trapezoid{0.02f, 0.02f, 20.f};
+    const point3 expected_annulus{0.03f, 0.03f, 30.f};
 
     const std::vector<point3> expected_points = {
         expected_rectangle, expected_trapezoid, expected_annulus};
@@ -124,15 +124,15 @@ TEST(tools, intersection_kernel_ray) {
 
         sfi_update.push_back(sfi);
 
-        ASSERT_NEAR(sfi.p3[0], expected_points[sf_idx][0], 1e-7);
-        ASSERT_NEAR(sfi.p3[1], expected_points[sf_idx][1], 1e-7);
-        ASSERT_NEAR(sfi.p3[2], expected_points[sf_idx][2], 1e-7);
+        ASSERT_NEAR(sfi.p3[0], expected_points[sf_idx][0], 1e-7f);
+        ASSERT_NEAR(sfi.p3[1], expected_points[sf_idx][1], 1e-7f);
+        ASSERT_NEAR(sfi.p3[2], expected_points[sf_idx][2], 1e-7f);
     }
 
     // Compare
-    ASSERT_EQ(sfi_init.size(), 3);
-    ASSERT_EQ(sfi_update.size(), 3);
-    for (int i = 0; i < 3; i++) {
+    ASSERT_EQ(sfi_init.size(), 3u);
+    ASSERT_EQ(sfi_update.size(), 3u);
+    for (unsigned int i = 0u; i < 3u; i++) {
         ASSERT_EQ(sfi_init[i].p3, sfi_update[i].p3);
         ASSERT_EQ(sfi_init[i].p2, sfi_update[i].p2);
         ASSERT_EQ(sfi_init[i].path, sfi_update[i].path);
@@ -148,37 +148,37 @@ TEST(tools, intersection_kernel_helix) {
     typename transform_container_t::context_type static_context{};
     transform_container_t transform_store;
     // Transforms of the rectangle, trapezoid and annulus
-    transform_store.emplace_back(static_context, point3{0., 0., 10.});
-    transform_store.emplace_back(static_context, point3{0., 0., 20.});
-    transform_store.emplace_back(static_context, point3{0., -20., 30.});
+    transform_store.emplace_back(static_context, point3{0.f, 0.f, 10.f});
+    transform_store.emplace_back(static_context, point3{0.f, 0.f, 20.f});
+    transform_store.emplace_back(static_context, point3{0.f, -20.f, 30.f});
     // The masks & their store
     mask_container_t mask_store(host_mr);
-    mask_store.template emplace_back<e_rectangle2>(empty_context{}, 0UL, 10.f,
+    mask_store.template emplace_back<e_rectangle2>(empty_context{}, 0u, 10.f,
                                                    10.f);
-    mask_store.template emplace_back<e_trapezoid2>(empty_context{}, 0UL, 10.f,
+    mask_store.template emplace_back<e_trapezoid2>(empty_context{}, 0u, 10.f,
                                                    20.f, 30.f);
     mask_store.template emplace_back<e_annulus2>(
-        empty_context{}, 0UL, 15.f, 55.f, 0.75f, 1.95f, 2.f, -2.f, 0.f);
+        empty_context{}, 0u, 15.f, 55.f, 0.75f, 1.95f, 2.f, -2.f, 0.f);
 
     // The surfaces and their store
-    const surface_t rectangle_surface(0u, {e_rectangle2, 0}, {e_slab, 0}, 0, 0,
-                                      surface_id::e_sensitive);
-    const surface_t trapezoid_surface(1u, {e_trapezoid2, 0}, {e_slab, 1}, 0, 1,
-                                      surface_id::e_sensitive);
-    const surface_t annulus_surface(2u, {e_annulus2, 0}, {e_slab, 2}, 0, 2,
+    const surface_t rectangle_surface(0u, {e_rectangle2, 0u}, {e_slab, 0u}, 0u,
+                                      0u, surface_id::e_sensitive);
+    const surface_t trapezoid_surface(1u, {e_trapezoid2, 0u}, {e_slab, 1u}, 0u,
+                                      1u, surface_id::e_sensitive);
+    const surface_t annulus_surface(2u, {e_annulus2, 0u}, {e_slab, 2u}, 0u, 2u,
                                     surface_id::e_sensitive);
     surface_container_t surfaces = {rectangle_surface, trapezoid_surface,
                                     annulus_surface};
-    const point3 pos{0., 0., 0.};
-    const vector3 mom{0.01, 0.01, 10.};
-    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
-                    epsilon * unit<scalar>::T};
-    const detail::helix<transform3_type> h({pos, 0, mom, -1}, &B);
+    const point3 pos{0.f, 0.f, 0.f};
+    const vector3 mom{0.01f, 0.01f, 10.f};
+    const vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                    tol * unit<scalar>::T};
+    const detail::helix<transform3_type> h({pos, 0.f, mom, -1.f}, &B);
 
     // Validation data
-    const point3 expected_rectangle{0.01, 0.01, 10.};
-    const point3 expected_trapezoid{0.02, 0.02, 20.};
-    const point3 expected_annulus{0.03, 0.03, 30.};
+    const point3 expected_rectangle{0.01f, 0.01f, 10.f};
+    const point3 expected_trapezoid{0.02f, 0.02f, 20.f};
+    const point3 expected_annulus{0.03f, 0.03f, 30.f};
     const std::vector<point3> expected_points = {
         expected_rectangle, expected_trapezoid, expected_annulus};
 
@@ -187,8 +187,8 @@ TEST(tools, intersection_kernel_helix) {
         const auto sfi_helix = mask_store.call<helix_intersection_update>(
             surface.mask(), h, surface, transform_store);
 
-        ASSERT_NEAR(sfi_helix.p3[0], expected_points[sf_idx][0], 1e-7);
-        ASSERT_NEAR(sfi_helix.p3[1], expected_points[sf_idx][1], 1e-7);
-        ASSERT_NEAR(sfi_helix.p3[2], expected_points[sf_idx][2], 1e-7);
+        ASSERT_NEAR(sfi_helix.p3[0], expected_points[sf_idx][0], 1e-7f);
+        ASSERT_NEAR(sfi_helix.p3[1], expected_points[sf_idx][1], 1e-7f);
+        ASSERT_NEAR(sfi_helix.p3[2], expected_points[sf_idx][2], 1e-7f);
     }
 }

--- a/tests/common/include/tests/common/tools_line_intersection.inl
+++ b/tests/common/include/tests/common/tools_line_intersection.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,156 +30,161 @@ using point3 = __plugin::point3<scalar>;
 using point2 = __plugin::point2<scalar>;
 using line_intersector_type = line_intersector<transform3>;
 
-constexpr scalar tolerance = 1e-5;
+constexpr scalar tol{1e-5f};
 
 // Test simplest case
 TEST(tools, line_intersector_case1) {
 
     // tf3 with Identity rotation and no translation
-    const vector3 x{1, 0, 0};
-    const vector3 y{0, 1, 0};
-    const vector3 z{0, 0, 1};
-    const vector3 t{0, 0, 0};
-
-    const transform3 tf{t, x, y, z};
+    const transform3 tf{};
 
     // Create a track
     std::vector<free_track_parameters<transform3>> trks;
-    trks.emplace_back(point3{1, -1, 0}, 0, vector3{0, 1, 0}, -1);
-    trks.emplace_back(point3{-1, -1, 0}, 0, vector3{0, 1, 0}, -1);
-    trks.emplace_back(point3{1, -1, 2}, 0, vector3{0, 1, -1}, -1);
+    trks.emplace_back(point3{1.f, -1.f, 0.f}, 0.f, vector3{0.f, 1.f, 0.f},
+                      -1.f);
+    trks.emplace_back(point3{-1.f, -1.f, 0.f}, 0.f, vector3{0.f, 1.f, 0.f},
+                      -1.f);
+    trks.emplace_back(point3{1.f, -1.f, 2.f}, 0.f, vector3{0.f, 1.f, -1.f},
+                      -1.f);
 
     // Infinite wire with 10 mm radial cell size
-    const mask<line<>> ln{0UL, 10.f, std::numeric_limits<scalar>::infinity()};
+    const mask<line<>> ln{0u, 10.f, std::numeric_limits<scalar>::infinity()};
 
     // Test intersect
-    std::vector<line_intersector_type::intersection_type> is(3);
+    std::vector<line_intersector_type::intersection_type> is(3u);
     is[0] = line_intersector_type()(detail::ray(trks[0]), ln, tf)[0];
     is[1] = line_intersector_type()(detail::ray(trks[1]), ln, tf)[0];
     is[2] = line_intersector_type()(detail::ray(trks[2]), ln, tf)[0];
 
     EXPECT_EQ(is[0].status, intersection::status::e_inside);
-    EXPECT_EQ(is[0].path, 1);
-    EXPECT_EQ(is[0].p3, point3({1, 0, 0}));
-    EXPECT_EQ(is[0].p2, point2({-1, 0}));  // right
-    EXPECT_NEAR(is[0].cos_incidence_angle, 0, tolerance);
+    EXPECT_EQ(is[0].path, 1.f);
+    EXPECT_EQ(is[0].p3, point3({1.f, 0.f, 0.f}));
+    EXPECT_EQ(is[0].p2, point2({-1.f, 0.f}));  // right
+    EXPECT_NEAR(is[0].cos_incidence_angle, 0.f, tol);
 
     EXPECT_EQ(is[1].status, intersection::status::e_inside);
-    EXPECT_EQ(is[1].path, 1);
-    EXPECT_EQ(is[1].p3, point3({-1, 0, 0}));
-    EXPECT_EQ(is[1].p2, point2({1, 0}));  // left
-    EXPECT_NEAR(is[1].cos_incidence_angle, 0, tolerance);
+    EXPECT_EQ(is[1].path, 1.f);
+    EXPECT_EQ(is[1].p3, point3({-1.f, 0.f, 0.f}));
+    EXPECT_EQ(is[1].p2, point2({1.f, 0.f}));  // left
+    EXPECT_NEAR(is[1].cos_incidence_angle, 0.f, tol);
 
     EXPECT_EQ(is[2].status, intersection::status::e_inside);
-    EXPECT_NEAR(is[2].path, std::sqrt(2), tolerance);
-    EXPECT_NEAR(is[2].p3[0], 1., tolerance);
-    EXPECT_NEAR(is[2].p3[1], 0., tolerance);
-    EXPECT_NEAR(is[2].p3[2], 1., tolerance);
-    EXPECT_NEAR(is[2].p2[0], -1., tolerance);  // right
-    EXPECT_NEAR(is[2].p2[1], 1., tolerance);
-    EXPECT_NEAR(is[2].cos_incidence_angle, 1. / std::sqrt(2), tolerance);
+    EXPECT_NEAR(is[2].path, constant<scalar>::sqrt2, tol);
+    EXPECT_NEAR(is[2].p3[0], 1.f, tol);
+    EXPECT_NEAR(is[2].p3[1], 0.f, tol);
+    EXPECT_NEAR(is[2].p3[2], 1.f, tol);
+    EXPECT_NEAR(is[2].p2[0], -1.f, tol);  // right
+    EXPECT_NEAR(is[2].p2[1], 1.f, tol);
+    EXPECT_NEAR(is[2].cos_incidence_angle, constant<scalar>::inv_sqrt2, tol);
 }
 
 // Test inclined wire
 TEST(tools, line_intersector_case2) {
     // tf3 with skewed axis
-    const vector3 x{1, 0, -1};
-    const vector3 z{1, 0, 1};
-    const vector3 t{1, 1, 1};
+    const vector3 x{1.f, 0.f, -1.f};
+    const vector3 z{1.f, 0.f, 1.f};
+    const vector3 t{1.f, 1.f, 1.f};
     const transform3 tf{t, vector::normalize(z), vector::normalize(x)};
 
     // Create a track
-    const point3 pos{1, -1, 0};
-    const vector3 dir{0, 1, 0};
-    const free_track_parameters<transform3> trk(pos, 0, dir, -1);
+    const point3 pos{1.f, -1.f, 0.f};
+    const vector3 dir{0.f, 1.f, 0.f};
+    const free_track_parameters<transform3> trk(pos, 0.f, dir, -1.f);
 
     // Infinite wire with 10 mm
     // radial cell size
-    const mask<line<>> ln{0UL, 10.f, std::numeric_limits<scalar>::infinity()};
+    const mask<line<>> ln{0u, 10.f, std::numeric_limits<scalar>::infinity()};
 
     // Test intersect
     const line_intersector_type::intersection_type is =
         line_intersector_type()(detail::ray<transform3>(trk), ln, tf)[0];
 
     EXPECT_EQ(is.status, intersection::status::e_inside);
-    EXPECT_NEAR(is.path, 2., tolerance);
-    EXPECT_NEAR(is.p3[0], 1., tolerance);
-    EXPECT_NEAR(is.p3[1], 1., tolerance);
-    EXPECT_NEAR(is.p3[2], 0., tolerance);
-    EXPECT_NEAR(is.p2[0], -1. / std::sqrt(2), tolerance);  // right
-    EXPECT_NEAR(is.p2[1], -1. / std::sqrt(2), tolerance);
+    EXPECT_NEAR(is.path, 2.f, tol);
+    EXPECT_NEAR(is.p3[0], 1.f, tol);
+    EXPECT_NEAR(is.p3[1], 1.f, tol);
+    EXPECT_NEAR(is.p3[2], 0.f, tol);
+    EXPECT_NEAR(is.p2[0], -constant<scalar>::inv_sqrt2, tol);  // right
+    EXPECT_NEAR(is.p2[1], -constant<scalar>::inv_sqrt2, tol);
 }
 
 TEST(tools, line_intersector_square_scope) {
 
     // tf3 with Identity rotation and no translation
-    const vector3 x{1, 0, 0};
-    const vector3 y{0, 1, 0};
-    const vector3 z{0, 0, 1};
-    const vector3 t{0, 0, 0};
-
-    const transform3 tf{t, x, y, z};
+    const transform3 tf{};
 
     /// Create a track
     std::vector<free_track_parameters<transform3>> trks;
-    trks.emplace_back(point3{2, 0, 0}, 0, vector3{-1, 1, 0}, -1);
-    trks.emplace_back(point3{1.9, 0, 0}, 0, vector3{-1, 1, 0}, -1);
-    trks.emplace_back(point3{2.1, 0, 0}, 0, vector3{-1, 1, 0}, -1);
+    trks.emplace_back(point3{2.f, 0.f, 0.f}, 0.f, vector3{-1.f, 1.f, 0.f},
+                      -1.f);
+    trks.emplace_back(point3{1.9f, 0.f, 0.f}, 0.f, vector3{-1.f, 1.f, 0.f},
+                      -1.f);
+    trks.emplace_back(point3{2.1f, 0.f, 0.f}, 0.f, vector3{-1.f, 1.f, 0.f},
+                      -1.f);
 
-    trks.emplace_back(point3{-2, 0, 0}, 0, vector3{1, 1, 0}, -1);
-    trks.emplace_back(point3{-1.9, 0, 0}, 0, vector3{1, 1, 0}, -1);
-    trks.emplace_back(point3{-2.1, 0, 0}, 0, vector3{1, 1, 0}, -1);
+    trks.emplace_back(point3{-2.f, 0.f, 0.f}, 0.f, vector3{1.f, 1.f, 0.f},
+                      -1.f);
+    trks.emplace_back(point3{-1.9f, 0.f, 0.f}, 0.f, vector3{1.f, 1.f, 0.f},
+                      -1.f);
+    trks.emplace_back(point3{-2.1f, 0.f, 0.f}, 0.f, vector3{1.f, 1.f, 0.f},
+                      -1.f);
 
-    trks.emplace_back(point3{0, -2, 0}, 0, vector3{-1, 1, 0}, -1);
-    trks.emplace_back(point3{0, -1.9, 0}, 0, vector3{-1, 1, 0}, -1);
-    trks.emplace_back(point3{0, -2.1, 0}, 0, vector3{-1, 1, 0}, -1);
+    trks.emplace_back(point3{0.f, -2.f, 0.f}, 0.f, vector3{-1.f, 1.f, 0.f},
+                      -1.f);
+    trks.emplace_back(point3{0.f, -1.9f, 0.f}, 0.f, vector3{-1.f, 1.f, 0.f},
+                      -1.f);
+    trks.emplace_back(point3{0.f, -2.1f, 0.f}, 0.f, vector3{-1.f, 1.f, 0.f},
+                      -1.f);
 
-    trks.emplace_back(point3{0, -2, 0}, 0, vector3{1, 1, 0}, -1);
-    trks.emplace_back(point3{0, -1.9, 0}, 0, vector3{1, 1, 0}, -1);
-    trks.emplace_back(point3{0, -2.1, 0}, 0, vector3{1, 1, 0}, -1);
+    trks.emplace_back(point3{0.f, -2.f, 0.f}, 0.f, vector3{1.f, 1.f, 0.f},
+                      -1.f);
+    trks.emplace_back(point3{0.f, -1.9f, 0.f}, 0.f, vector3{1.f, 1.f, 0.f},
+                      -1.f);
+    trks.emplace_back(point3{0.f, -2.1f, 0.f}, 0.f, vector3{1.f, 1.f, 0.f},
+                      -1.f);
 
     // Infinite wire with 1 mm square cell size
     mask<line<true, line_intersector>, dindex, transform3> ln{
-        0UL, 1.f, std::numeric_limits<scalar>::infinity()};
+        0u, 1.f, std::numeric_limits<scalar>::infinity()};
 
     // Test intersect
     std::vector<line_plane_intersection> is;
     for (const auto& trk : trks) {
         is.push_back(line_intersector_type()(detail::ray<transform3>(trk), ln,
-                                             tf, 1e-5)[0]);
+                                             tf, 1e-5f)[0]);
     }
 
     EXPECT_EQ(is[0].status, intersection::status::e_inside);
-    EXPECT_NEAR(is[0].path, std::sqrt(2), tolerance);
-    EXPECT_NEAR(is[0].p3[0], 1, tolerance);
-    EXPECT_NEAR(is[0].p3[1], 1, tolerance);
-    EXPECT_NEAR(is[0].p3[2], 0, tolerance);
-    EXPECT_NEAR(is[0].p2[0], -1 * std::sqrt(2), tolerance);
-    EXPECT_NEAR(is[0].p2[1], 0, tolerance);
+    EXPECT_NEAR(is[0].path, constant<scalar>::sqrt2, tol);
+    EXPECT_NEAR(is[0].p3[0], 1.f, tol);
+    EXPECT_NEAR(is[0].p3[1], 1.f, tol);
+    EXPECT_NEAR(is[0].p3[2], 0.f, tol);
+    EXPECT_NEAR(is[0].p2[0], -constant<scalar>::sqrt2, tol);
+    EXPECT_NEAR(is[0].p2[1], 0.f, tol);
 
     EXPECT_EQ(is[1].status, intersection::status::e_inside);
-    EXPECT_TRUE(is[1].p2[0] < 0);
+    EXPECT_TRUE(std::signbit(is[1].p2[0]));
     EXPECT_EQ(is[2].status, intersection::status::e_outside);
-    EXPECT_TRUE(is[2].p2[0] < 0);
+    EXPECT_TRUE(std::signbit(is[2].p2[0]));
 
     EXPECT_EQ(is[3].status, intersection::status::e_inside);
-    EXPECT_TRUE(is[3].p2[0] > 0);
+    EXPECT_FALSE(std::signbit(is[3].p2[0]));
     EXPECT_EQ(is[4].status, intersection::status::e_inside);
-    EXPECT_TRUE(is[4].p2[0] > 0);
+    EXPECT_FALSE(std::signbit(is[4].p2[0]));
     EXPECT_EQ(is[5].status, intersection::status::e_outside);
-    EXPECT_TRUE(is[5].p2[0] > 0);
+    EXPECT_FALSE(std::signbit(is[5].p2[0]));
 
     EXPECT_EQ(is[6].status, intersection::status::e_inside);
-    EXPECT_TRUE(is[6].p2[0] > 0);
+    EXPECT_FALSE(std::signbit(is[6].p2[0]));
     EXPECT_EQ(is[7].status, intersection::status::e_inside);
-    EXPECT_TRUE(is[7].p2[0] > 0);
+    EXPECT_FALSE(std::signbit(is[7].p2[0]));
     EXPECT_EQ(is[8].status, intersection::status::e_outside);
-    EXPECT_TRUE(is[8].p2[0] > 0);
+    EXPECT_FALSE(std::signbit(is[8].p2[0]));
 
     EXPECT_EQ(is[9].status, intersection::status::e_inside);
-    EXPECT_TRUE(is[9].p2[0] < 0);
+    EXPECT_TRUE(std::signbit(is[9].p2[0]));
     EXPECT_EQ(is[10].status, intersection::status::e_inside);
-    EXPECT_TRUE(is[10].p2[0] < 0);
+    EXPECT_TRUE(std::signbit(is[10].p2[0]));
     EXPECT_EQ(is[11].status, intersection::status::e_outside);
-    EXPECT_TRUE(is[11].p2[0] < 0);
+    EXPECT_TRUE(std::signbit(is[11].p2[0]));
 }

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -113,10 +113,10 @@ TEST(ALGEBRA_PLUGIN, navigator) {
     vecmem::host_memory_resource host_mr;
 
     /// Tolerance for tests
-    constexpr double tol = 0.01;
+    constexpr double tol{0.01};
 
-    std::size_t n_brl_layers = 4;
-    std::size_t n_edc_layers = 3;
+    unsigned int n_brl_layers{4u};
+    unsigned int n_edc_layers{3u};
     auto toy_det = create_toy_geometry(host_mr, n_brl_layers, n_edc_layers);
     using detector_t = decltype(toy_det);
     using inspector_t = navigation::print_inspector;
@@ -125,9 +125,9 @@ TEST(ALGEBRA_PLUGIN, navigator) {
     using stepper_t = line_stepper<transform3, constraint_t>;
 
     // test track
-    point3 pos{0., 0., 0.};
-    vector3 mom{1., 1., 0.};
-    free_track_parameters<transform3> traj(pos, 0, mom, -1);
+    point3 pos{0.f, 0.f, 0.f};
+    vector3 mom{1.f, 1.f, 0.f};
+    free_track_parameters<transform3> traj(pos, 0.f, mom, -1.f);
 
     stepper_t stepper;
     navigator_t nav;
@@ -157,13 +157,13 @@ TEST(ALGEBRA_PLUGIN, navigator) {
     // The status is towards beampipe
     // Two candidates: beampipe and portal
     // First candidate is the beampipe
-    check_towards_surface<navigator_t>(navigation, 0, 2, 0);
+    check_towards_surface<navigator_t>(navigation, 0u, 2u, 0u);
     // Distance to beampipe surface
-    ASSERT_NEAR(navigation(), 19., tol);
+    ASSERT_NEAR(navigation(), 19.f, tol);
 
     // Let's make half the step towards the beampipe
     stepping.template set_constraint<step::constraint::e_user>(navigation() *
-                                                               0.5);
+                                                               0.5f);
     stepper.step(propagation);
     // Navigation policy might reduce trust level to fair trust
     navigation.set_fair_trust();
@@ -175,19 +175,19 @@ TEST(ALGEBRA_PLUGIN, navigator) {
     // Trust level is restored
     ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
     // The status remains: towards surface
-    check_towards_surface<navigator_t>(navigation, 0, 2, 0);
+    check_towards_surface<navigator_t>(navigation, 0u, 2u, 0u);
     // Distance to beampipe is now halved
-    ASSERT_NEAR(navigation(), 9.5, tol);
+    ASSERT_NEAR(navigation(), 9.5f, tol);
 
     // Let's immediately update, nothing should change, as there is full trust
     ASSERT_TRUE(nav.update(propagation));
-    check_towards_surface<navigator_t>(navigation, 0, 2, 0);
-    ASSERT_NEAR(navigation(), 9.5, tol);
+    check_towards_surface<navigator_t>(navigation, 0u, 2u, 0u);
+    ASSERT_NEAR(navigation(), 9.5f, tol);
 
     // Now step onto the beampipe (idx 0)
-    check_step(nav, stepper, propagation, 0, 2, 0, 7);
+    check_step(nav, stepper, propagation, 0u, 2u, 0u, 7u);
     // New target: Distance to the beampipe volume cylinder portal
-    ASSERT_NEAR(navigation(), 8, tol);
+    ASSERT_NEAR(navigation(), 8.f, tol);
 
     // Step onto portal 7 in volume 0
     stepper.step(propagation);
@@ -201,25 +201,25 @@ TEST(ALGEBRA_PLUGIN, navigator) {
     //
 
     // Last volume before we leave world
-    dindex last_vol_id = 13;
+    dindex last_vol_id = 13u;
 
     // maps volume id to the sequence of surfaces that the navigator encounters
     std::map<dindex, std::vector<dindex>> sf_sequences;
 
     // layer 1
-    sf_sequences[7] = {594, 491, 475, 492, 476, 595};
+    sf_sequences[7] = {594u, 491u, 475u, 492u, 476u, 595u};
     // gap 1
-    sf_sequences[8] = {598, 599};
+    sf_sequences[8] = {598u, 599u};
     // layer 2
-    sf_sequences[9] = {1050, 845, 813, 846, 814, 1051};
+    sf_sequences[9] = {1050u, 845u, 813u, 846u, 814u, 1051u};
     // gap 2
-    sf_sequences[10] = {1054, 1055};
+    sf_sequences[10] = {1054u, 1055u};
     // layer 3
-    sf_sequences[11] = {1786, 1454, 1402, 1787};
+    sf_sequences[11] = {1786u, 1454u, 1402u, 1787u};
     // gap 3
-    sf_sequences[12] = {1790, 1791};
+    sf_sequences[12] = {1790u, 1791u};
     // layer 4
-    sf_sequences[last_vol_id] = {2886, 2388, 2310, 2887};
+    sf_sequences[last_vol_id] = {2886u, 2388u, 2310u, 2887u};
 
     // Every iteration steps through one barrel layer
     for (const auto &[vol_id, sf_seq] : sf_sequences) {
@@ -234,9 +234,9 @@ TEST(ALGEBRA_PLUGIN, navigator) {
                                       sf_seq[0], sf_seq[1]);
 
         // Step through the module surfaces
-        for (std::size_t sf = 1; sf < sf_seq.size() - 1; ++sf) {
+        for (std::size_t sf = 1u; sf < sf_seq.size() - 1u; ++sf) {
             check_step(nav, stepper, propagation, vol_id, n_candidates,
-                       sf_seq[sf], sf_seq[sf + 1]);
+                       sf_seq[sf], sf_seq[sf + 1u]);
         }
 
         // Step onto the portal in volume

--- a/tests/common/include/tests/common/tools_particle_gun.inl
+++ b/tests/common/include/tests/common/tools_particle_gun.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -24,7 +24,7 @@ using namespace detray;
 
 using transform3_type = __plugin::transform3<scalar>;
 
-constexpr const scalar epsilon = 1e-3;
+constexpr const scalar tol{1e-3f};
 
 /// Brute force test: Intersect toy geometry and compare between ray and helix
 /// without B-field
@@ -34,9 +34,9 @@ TEST(tools, particle_gun) {
     vecmem::host_memory_resource host_mr;
     auto toy_det = create_toy_geometry(host_mr);
 
-    unsigned int theta_steps = 50;
-    unsigned int phi_steps = 50;
-    const point3 ori{0., 0., 0.};
+    unsigned int theta_steps{50u};
+    unsigned int phi_steps{50u};
+    const point3 ori{0.f, 0.f, 0.f};
 
     // Record ray tracing
     std::vector<std::vector<std::pair<dindex, particle_gun::intersection_type>>>
@@ -54,10 +54,10 @@ TEST(tools, particle_gun) {
     }
 
     // Simulate straight line track
-    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
-                    epsilon * unit<scalar>::T};
+    const vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                    tol * unit<scalar>::T};
     // Iterate through uniformly distributed momentum directions with helix
-    std::size_t n_tracks{0};
+    std::size_t n_tracks{0u};
     for (const auto track :
          uniform_track_generator<free_track_parameters<transform3_type>>(
              theta_steps, phi_steps, ori)) {
@@ -72,13 +72,13 @@ TEST(tools, particle_gun) {
         EXPECT_EQ(expected[n_tracks].size(), intersection_trace.size());
 
         // Check every single recorded intersection
-        for (std::size_t i = 0; i < intersection_trace.size(); ++i) {
+        for (std::size_t i = 0u; i < intersection_trace.size(); ++i) {
             if (expected[n_tracks][i].first != intersection_trace[i].first) {
                 // Intersection record at portal bound might be flipped
                 // (the portals overlap completely)
                 if (expected[n_tracks][i].first ==
-                        intersection_trace[i + 1].first and
-                    expected[n_tracks][i + 1].first ==
+                        intersection_trace[i + 1u].first and
+                    expected[n_tracks][i + 1u].first ==
                         intersection_trace[i].first) {
                     // Have already checked the next record
                     ++i;

--- a/tests/common/include/tests/common/tools_planar_intersection.inl
+++ b/tests/common/include/tests/common/tools_planar_intersection.inl
@@ -1,20 +1,23 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
-#include <climits>
-#include <cmath>
-
+// Project include(s)
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/intersection/intersection.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/masks/masks.hpp"
 #include "tests/common/tools/intersectors/helix_plane_intersector.hpp"
+
+// GTest include
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <cmath>
+#include <limits>
 
 /// @note __plugin has to be defined with a preprocessor command
 using namespace detray;
@@ -24,19 +27,19 @@ using vector3 = __plugin::vector3<scalar>;
 using point3 = __plugin::point3<scalar>;
 using transform3 = __plugin::transform3<detray::scalar>;
 
-constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
-constexpr scalar not_defined = std::numeric_limits<scalar>::infinity();
-constexpr scalar isclose = 1e-5;
+constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
+constexpr scalar not_defined{std::numeric_limits<scalar>::infinity()};
+constexpr scalar isclose{1e-5f};
 
 // This defines the local frame test suite
 TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
     // Create a shifted plane
-    const transform3 shifted(vector3{3., 2., 10.});
+    const transform3 shifted(vector3{3.f, 2.f, 10.f});
 
     // Test ray
-    const point3 pos{2., 1., 0.};
-    const vector3 mom{0., 0., 1.};
-    const detail::ray<transform3> r(pos, 0., mom, 0.);
+    const point3 pos{2.f, 1.f, 0.f};
+    const vector3 mom{0.f, 0.f, 1.f};
+    const detail::ray<transform3> r(pos, 0.f, mom, 0.f);
 
     // The same test but bound to local frame
     plane_intersector<transform3> pi;
@@ -45,75 +48,75 @@ TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
 
     ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
     // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound.p3[0], 2., epsilon);
-    ASSERT_NEAR(hit_bound.p3[1], 1., epsilon);
-    ASSERT_NEAR(hit_bound.p3[2], 10., epsilon);
+    ASSERT_NEAR(hit_bound.p3[0], 2.f, tol);
+    ASSERT_NEAR(hit_bound.p3[1], 1.f, tol);
+    ASSERT_NEAR(hit_bound.p3[2], 10.f, tol);
     // Local intersection information
-    ASSERT_NEAR(hit_bound.p2[0], -1., epsilon);
-    ASSERT_NEAR(hit_bound.p2[1], -1., epsilon);
+    ASSERT_NEAR(hit_bound.p2[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound.p2[1], -1.f, tol);
     // Incidence angle
-    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1., epsilon);
+    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1.f, tol);
 
     // The same test but bound to local frame & masked - inside
-    mask<rectangle2D<>> rect_for_inside{0UL, 3.f, 3.f};
+    mask<rectangle2D<>> rect_for_inside{0u, 3.f, 3.f};
     const auto hit_bound_inside = pi(r, rect_for_inside, shifted)[0];
     ASSERT_TRUE(hit_bound_inside.status == intersection::status::e_inside);
     // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound_inside.p3[0], 2., epsilon);
-    ASSERT_NEAR(hit_bound_inside.p3[1], 1., epsilon);
-    ASSERT_NEAR(hit_bound_inside.p3[2], 10., epsilon);
+    ASSERT_NEAR(hit_bound_inside.p3[0], 2.f, tol);
+    ASSERT_NEAR(hit_bound_inside.p3[1], 1.f, tol);
+    ASSERT_NEAR(hit_bound_inside.p3[2], 10.f, tol);
     // Local intersection infoimation - unchanged
-    ASSERT_NEAR(hit_bound_inside.p2[0], -1., epsilon);
-    ASSERT_NEAR(hit_bound_inside.p2[1], -1., epsilon);
+    ASSERT_NEAR(hit_bound_inside.p2[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound_inside.p2[1], -1.f, tol);
 
     // The same test but bound to local frame & masked - outside
-    mask<rectangle2D<>> rect_for_outside{0UL, 0.5f, 3.5f};
+    mask<rectangle2D<>> rect_for_outside{0u, 0.5f, 3.5f};
     const auto hit_bound_outside = pi(r, rect_for_outside, shifted)[0];
     ASSERT_TRUE(hit_bound_outside.status == intersection::status::e_outside);
     // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound_outside.p3[0], 2., epsilon);
-    ASSERT_NEAR(hit_bound_outside.p3[1], 1., epsilon);
-    ASSERT_NEAR(hit_bound_outside.p3[2], 10., epsilon);
+    ASSERT_NEAR(hit_bound_outside.p3[0], 2.f, tol);
+    ASSERT_NEAR(hit_bound_outside.p3[1], 1.f, tol);
+    ASSERT_NEAR(hit_bound_outside.p3[2], 10.f, tol);
     // Local intersection infoimation - unchanged
-    ASSERT_NEAR(hit_bound_outside.p2[0], -1., epsilon);
-    ASSERT_NEAR(hit_bound_outside.p2[1], -1., epsilon);
+    ASSERT_NEAR(hit_bound_outside.p2[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound_outside.p2[1], -1.f, tol);
 }
 
 // This defines the local frame test suite
 TEST(ALGEBRA_PLUGIN, plane_incidence_angle) {
     // tf3 with rotated axis
-    const vector3 x{1, 0, -1};
-    const vector3 z{1, 0, 1};
-    const vector3 t{0, 0, 0};
+    const vector3 x{1.f, 0.f, -1.f};
+    const vector3 z{1.f, 0.f, 1.f};
+    const vector3 t{0.f, 0.f, 0.f};
 
     const transform3 rotated{t, vector::normalize(z), vector::normalize(x)};
 
     plane_intersector<transform3> pi;
 
     // Test ray
-    const point3 pos{-1., 0., 0.};
-    const vector3 mom{1., 0., 0.};
-    const detail::ray<transform3> r(pos, 0., mom, 0.);
+    const point3 pos{-1.f, 0.f, 0.f};
+    const vector3 mom{1.f, 0.f, 0.f};
+    const detail::ray<transform3> r(pos, 0.f, mom, 0.f);
 
     // The same test but bound to local frame & masked - inside
-    mask<rectangle2D<>> rect{0UL, 3.f, 3.f};
+    mask<rectangle2D<>> rect{0u, 3.f, 3.f};
 
     const line_plane_intersection is = pi(r, rect, rotated)[0];
 
-    ASSERT_NEAR(is.cos_incidence_angle, std::cos(M_PI / 4), epsilon);
+    ASSERT_NEAR(is.cos_incidence_angle, std::cos(constant<scalar>::pi_4), tol);
 }
 
 // This defines the local frame test suite
 TEST(ALGEBRA_PLUGIN, translated_plane_helix) {
     // Create a shifted plane
-    const transform3 shifted(vector3{3., 2., 10.});
+    const transform3 shifted(vector3{3.f, 2.f, 10.f});
 
     // Test helix
-    const point3 pos{2., 1., 0.};
-    const vector3 mom{0., 0., 1.};
-    const vector3 B{0. * unit<scalar>::T, 0. * unit<scalar>::T,
-                    epsilon * unit<scalar>::T};
-    const detail::helix<transform3> h({pos, 0, mom, -1}, &B);
+    const point3 pos{2.f, 1.f, 0.f};
+    const vector3 mom{0.f, 0.f, 1.f};
+    const vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                    tol * unit<scalar>::T};
+    const detail::helix<transform3> h({pos, 0.f, mom, -1.f}, &B);
 
     // The same test but bound to local frame
     helix_plane_intersector<transform3> pi;
@@ -122,36 +125,36 @@ TEST(ALGEBRA_PLUGIN, translated_plane_helix) {
 
     ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
     // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound.p3[0], 2., epsilon);
-    ASSERT_NEAR(hit_bound.p3[1], 1., epsilon);
-    ASSERT_NEAR(hit_bound.p3[2], 10., epsilon);
+    ASSERT_NEAR(hit_bound.p3[0], 2.f, tol);
+    ASSERT_NEAR(hit_bound.p3[1], 1.f, tol);
+    ASSERT_NEAR(hit_bound.p3[2], 10.f, tol);
     // Local intersection information
-    ASSERT_NEAR(hit_bound.p2[0], -1., epsilon);
-    ASSERT_NEAR(hit_bound.p2[1], -1., epsilon);
+    ASSERT_NEAR(hit_bound.p2[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound.p2[1], -1.f, tol);
     // Incidence angle
-    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1., epsilon);
+    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1.f, tol);
 
     // The same test but bound to local frame & masked - inside
-    mask<rectangle2D<>> rect_for_inside{0UL, 3.f, 3.f};
+    mask<rectangle2D<>> rect_for_inside{0u, 3.f, 3.f};
     const auto hit_bound_inside = pi(h, rect_for_inside, shifted)[0];
     ASSERT_TRUE(hit_bound_inside.status == intersection::status::e_inside);
     // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound_inside.p3[0], 2., epsilon);
-    ASSERT_NEAR(hit_bound_inside.p3[1], 1., epsilon);
-    ASSERT_NEAR(hit_bound_inside.p3[2], 10., epsilon);
+    ASSERT_NEAR(hit_bound_inside.p3[0], 2.f, tol);
+    ASSERT_NEAR(hit_bound_inside.p3[1], 1.f, tol);
+    ASSERT_NEAR(hit_bound_inside.p3[2], 10.f, tol);
     // Local intersection infoimation - unchanged
-    ASSERT_NEAR(hit_bound_inside.p2[0], -1., epsilon);
-    ASSERT_NEAR(hit_bound_inside.p2[1], -1., epsilon);
+    ASSERT_NEAR(hit_bound_inside.p2[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound_inside.p2[1], -1.f, tol);
 
     // The same test but bound to local frame & masked - outside
-    mask<rectangle2D<>> rect_for_outside{0UL, 0.5f, 3.5f};
+    mask<rectangle2D<>> rect_for_outside{0u, 0.5f, 3.5f};
     const auto hit_bound_outside = pi(h, rect_for_outside, shifted)[0];
     ASSERT_TRUE(hit_bound_outside.status == intersection::status::e_outside);
     // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound_outside.p3[0], 2., epsilon);
-    ASSERT_NEAR(hit_bound_outside.p3[1], 1., epsilon);
-    ASSERT_NEAR(hit_bound_outside.p3[2], 10., epsilon);
+    ASSERT_NEAR(hit_bound_outside.p3[0], 2.f, tol);
+    ASSERT_NEAR(hit_bound_outside.p3[1], 1.f, tol);
+    ASSERT_NEAR(hit_bound_outside.p3[2], 10.f, tol);
     // Local intersection infoimation - unchanged
-    ASSERT_NEAR(hit_bound_outside.p2[0], -1., epsilon);
-    ASSERT_NEAR(hit_bound_outside.p2[1], -1., epsilon);
+    ASSERT_NEAR(hit_bound_outside.p2[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound_outside.p2[1], -1.f, tol);
 }

--- a/tests/common/include/tests/common/tools_track.inl
+++ b/tests/common/include/tests/common/tools_track.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,29 +31,31 @@ enum material_ids : unsigned int {
 using mask_link_t = dtyped_index<mask_ids, dindex>;
 using material_link_t = dtyped_index<material_ids, dindex>;
 
+constexpr scalar tol{1e-5f};
+
 TEST(tools, bound_track_parameters) {
 
     // surface container
     std::vector<surface<mask_link_t, material_link_t>> surfaces;
-    surfaces.emplace_back(0, mask_link_t{e_rectangle2, 0},
-                          material_link_t{e_slab, 0}, 0, 0,
+    surfaces.emplace_back(0u, mask_link_t{e_rectangle2, 0u},
+                          material_link_t{e_slab, 0u}, 0u, 0u,
                           surface_id::e_sensitive);
-    surfaces.emplace_back(1, mask_link_t{e_rectangle2, 0},
-                          material_link_t{e_slab, 0}, 0, 0,
+    surfaces.emplace_back(1u, mask_link_t{e_rectangle2, 0u},
+                          material_link_t{e_slab, 0u}, 0u, 0u,
                           surface_id::e_sensitive);
 
     /// Declare track parameters
 
     // first track
-    dindex sf_idx1 = 0;
+    dindex sf_idx1 = 0u;
     typename bound_track_parameters<transform3>::vector_type bound_vec1 =
         matrix_operator().template zero<e_bound_size, 1>();
-    getter::element(bound_vec1, e_bound_loc0, 0) = 1.;
-    getter::element(bound_vec1, e_bound_loc1, 0) = 2.;
-    getter::element(bound_vec1, e_bound_phi, 0) = 0.1;
-    getter::element(bound_vec1, e_bound_theta, 0) = 0.2;
-    getter::element(bound_vec1, e_bound_qoverp, 0) = -0.01;
-    getter::element(bound_vec1, e_bound_time, 0) = 0.1;
+    getter::element(bound_vec1, e_bound_loc0, 0u) = 1.f;
+    getter::element(bound_vec1, e_bound_loc1, 0u) = 2.f;
+    getter::element(bound_vec1, e_bound_phi, 0u) = 0.1f;
+    getter::element(bound_vec1, e_bound_theta, 0u) = 0.2f;
+    getter::element(bound_vec1, e_bound_qoverp, 0u) = -0.01f;
+    getter::element(bound_vec1, e_bound_time, 0u) = 0.1f;
 
     typename bound_track_parameters<transform3>::covariance_type bound_cov1 =
         matrix_operator().template zero<e_bound_size, e_bound_size>();
@@ -62,15 +64,15 @@ TEST(tools, bound_track_parameters) {
                                                     bound_cov1);
 
     // second track
-    dindex sf_idx2 = 1;
+    dindex sf_idx2 = 1u;
     typename bound_track_parameters<transform3>::vector_type bound_vec2 =
         matrix_operator().template zero<e_bound_size, 1>();
-    getter::element(bound_vec2, e_bound_loc0, 0) = 4.;
-    getter::element(bound_vec2, e_bound_loc1, 0) = 20.;
-    getter::element(bound_vec2, e_bound_phi, 0) = 0.8;
-    getter::element(bound_vec2, e_bound_theta, 0) = 1.4;
-    getter::element(bound_vec2, e_bound_qoverp, 0) = 1.;
-    getter::element(bound_vec2, e_bound_time, 0) = 0.;
+    getter::element(bound_vec2, e_bound_loc0, 0u) = 4.f;
+    getter::element(bound_vec2, e_bound_loc1, 0u) = 20.f;
+    getter::element(bound_vec2, e_bound_phi, 0u) = 0.8f;
+    getter::element(bound_vec2, e_bound_theta, 0u) = 1.4f;
+    getter::element(bound_vec2, e_bound_qoverp, 0u) = 1.f;
+    getter::element(bound_vec2, e_bound_time, 0u) = 0.f;
 
     typename bound_track_parameters<transform3>::covariance_type bound_cov2 =
         matrix_operator().template zero<e_bound_size, e_bound_size>();
@@ -83,50 +85,54 @@ TEST(tools, bound_track_parameters) {
     /// Check the elements
 
     // first track
-    EXPECT_FLOAT_EQ(bound_param1.local()[0],
-                    getter::element(bound_vec1, e_bound_loc0, 0));
-    EXPECT_FLOAT_EQ(bound_param1.local()[1],
-                    getter::element(bound_vec1, e_bound_loc1, 0));
-    EXPECT_FLOAT_EQ(bound_param1.phi(),
-                    getter::element(bound_vec1, e_bound_phi, 0));
-    EXPECT_FLOAT_EQ(bound_param1.theta(),
-                    getter::element(bound_vec1, e_bound_theta, 0));
-    EXPECT_FLOAT_EQ(bound_param1.qop(),
-                    getter::element(bound_vec1, e_bound_qoverp, 0));
-    EXPECT_FLOAT_EQ(bound_param1.charge(), -1);
-    EXPECT_FLOAT_EQ(bound_param1.time(),
-                    getter::element(bound_vec1, e_bound_time, 0));
-    EXPECT_FLOAT_EQ(bound_param1.mom()[0], bound_param1.p() *
-                                               std::sin(bound_param1.theta()) *
-                                               std::cos(bound_param1.phi()));
-    EXPECT_FLOAT_EQ(bound_param1.mom()[1], bound_param1.p() *
-                                               std::sin(bound_param1.theta()) *
-                                               std::sin(bound_param1.phi()));
-    EXPECT_FLOAT_EQ(bound_param1.mom()[2],
-                    bound_param1.p() * std::cos(bound_param1.theta()));
+    EXPECT_NEAR(bound_param1.local()[0],
+                getter::element(bound_vec1, e_bound_loc0, 0u), tol);
+    EXPECT_NEAR(bound_param1.local()[1],
+                getter::element(bound_vec1, e_bound_loc1, 0u), tol);
+    EXPECT_NEAR(bound_param1.phi(),
+                getter::element(bound_vec1, e_bound_phi, 0u), tol);
+    EXPECT_NEAR(bound_param1.theta(),
+                getter::element(bound_vec1, e_bound_theta, 0u), tol);
+    EXPECT_NEAR(bound_param1.qop(),
+                getter::element(bound_vec1, e_bound_qoverp, 0u), tol);
+    EXPECT_NEAR(bound_param1.charge(), -1.f, tol);
+    EXPECT_NEAR(bound_param1.time(),
+                getter::element(bound_vec1, e_bound_time, 0u), tol);
+    EXPECT_NEAR(bound_param1.mom()[0],
+                bound_param1.p() * std::sin(bound_param1.theta()) *
+                    std::cos(bound_param1.phi()),
+                tol);
+    EXPECT_NEAR(bound_param1.mom()[1],
+                bound_param1.p() * std::sin(bound_param1.theta()) *
+                    std::sin(bound_param1.phi()),
+                tol);
+    EXPECT_NEAR(bound_param1.mom()[2],
+                bound_param1.p() * std::cos(bound_param1.theta()), tol);
 
     // second track
-    EXPECT_FLOAT_EQ(bound_param2.local()[0],
-                    getter::element(bound_vec2, e_bound_loc0, 0));
-    EXPECT_FLOAT_EQ(bound_param2.local()[1],
-                    getter::element(bound_vec2, e_bound_loc1, 0));
-    EXPECT_FLOAT_EQ(bound_param2.phi(),
-                    getter::element(bound_vec2, e_bound_phi, 0));
-    EXPECT_FLOAT_EQ(bound_param2.theta(),
-                    getter::element(bound_vec2, e_bound_theta, 0));
-    EXPECT_FLOAT_EQ(bound_param2.qop(),
-                    getter::element(bound_vec2, e_bound_qoverp, 0));
-    EXPECT_FLOAT_EQ(bound_param2.charge(), 1.);
-    EXPECT_FLOAT_EQ(bound_param2.time(),
-                    getter::element(bound_vec2, e_bound_time, 0));
-    EXPECT_FLOAT_EQ(bound_param2.mom()[0], bound_param2.p() *
-                                               std::sin(bound_param2.theta()) *
-                                               std::cos(bound_param2.phi()));
-    EXPECT_FLOAT_EQ(bound_param2.mom()[1], bound_param2.p() *
-                                               std::sin(bound_param2.theta()) *
-                                               std::sin(bound_param2.phi()));
-    EXPECT_FLOAT_EQ(bound_param2.mom()[2],
-                    bound_param2.p() * std::cos(bound_param2.theta()));
+    EXPECT_NEAR(bound_param2.local()[0],
+                getter::element(bound_vec2, e_bound_loc0, 0u), tol);
+    EXPECT_NEAR(bound_param2.local()[1],
+                getter::element(bound_vec2, e_bound_loc1, 0u), tol);
+    EXPECT_NEAR(bound_param2.phi(),
+                getter::element(bound_vec2, e_bound_phi, 0u), tol);
+    EXPECT_NEAR(bound_param2.theta(),
+                getter::element(bound_vec2, e_bound_theta, 0u), tol);
+    EXPECT_NEAR(bound_param2.qop(),
+                getter::element(bound_vec2, e_bound_qoverp, 0u), tol);
+    EXPECT_NEAR(bound_param2.charge(), 1.f, tol);
+    EXPECT_NEAR(bound_param2.time(),
+                getter::element(bound_vec2, e_bound_time, 0u), tol);
+    EXPECT_NEAR(bound_param2.mom()[0],
+                bound_param2.p() * std::sin(bound_param2.theta()) *
+                    std::cos(bound_param2.phi()),
+                tol);
+    EXPECT_NEAR(bound_param2.mom()[1],
+                bound_param2.p() * std::sin(bound_param2.theta()) *
+                    std::sin(bound_param2.phi()),
+                tol);
+    EXPECT_NEAR(bound_param2.mom()[2],
+                bound_param2.p() * std::cos(bound_param2.theta()), tol);
 
     EXPECT_TRUE(!(bound_param2 == bound_param1));
     EXPECT_TRUE(bound_param2 == bound_param3);
@@ -134,72 +140,72 @@ TEST(tools, bound_track_parameters) {
 
 TEST(tools, free_track_parameters) {
 
-    point3 pos = {4., 10., 2.};
-    scalar time = 0.1;
-    vector3 mom = {10., 20., 30.};
-    scalar charge = -1.;
+    point3 pos = {4.f, 10.f, 2.f};
+    scalar time = 0.1f;
+    vector3 mom = {10.f, 20.f, 30.f};
+    scalar charge = -1.f;
 
     typename free_track_parameters<transform3>::vector_type free_vec =
         matrix_operator().template zero<e_free_size, 1>();
-    getter::element(free_vec, e_free_pos0, 0) = pos[0];
-    getter::element(free_vec, e_free_pos1, 0) = pos[1];
-    getter::element(free_vec, e_free_pos2, 0) = pos[2];
-    getter::element(free_vec, e_free_time, 0) = time;
-    getter::element(free_vec, e_free_dir0, 0) = mom[0] / getter::norm(mom);
-    getter::element(free_vec, e_free_dir1, 0) = mom[1] / getter::norm(mom);
-    getter::element(free_vec, e_free_dir2, 0) = mom[2] / getter::norm(mom);
-    getter::element(free_vec, e_free_qoverp, 0) = charge / getter::norm(mom);
+    getter::element(free_vec, e_free_pos0, 0u) = pos[0];
+    getter::element(free_vec, e_free_pos1, 0u) = pos[1];
+    getter::element(free_vec, e_free_pos2, 0u) = pos[2];
+    getter::element(free_vec, e_free_time, 0u) = time;
+    getter::element(free_vec, e_free_dir0, 0u) = mom[0] / getter::norm(mom);
+    getter::element(free_vec, e_free_dir1, 0u) = mom[1] / getter::norm(mom);
+    getter::element(free_vec, e_free_dir2, 0u) = mom[2] / getter::norm(mom);
+    getter::element(free_vec, e_free_qoverp, 0u) = charge / getter::norm(mom);
 
     typename free_track_parameters<transform3>::covariance_type free_cov =
         matrix_operator().template zero<e_free_size, e_free_size>();
 
     // first constructor
     free_track_parameters<transform3> free_param1(free_vec, free_cov);
-    EXPECT_FLOAT_EQ(free_param1.pos()[0],
-                    getter::element(free_vec, e_free_pos0, 0));
-    EXPECT_FLOAT_EQ(free_param1.pos()[1],
-                    getter::element(free_vec, e_free_pos1, 0));
-    EXPECT_FLOAT_EQ(free_param1.pos()[2],
-                    getter::element(free_vec, e_free_pos2, 0));
-    EXPECT_FLOAT_EQ(free_param1.dir()[0],
-                    getter::element(free_vec, e_free_dir0, 0));
-    EXPECT_FLOAT_EQ(free_param1.dir()[1],
-                    getter::element(free_vec, e_free_dir1, 0));
-    EXPECT_FLOAT_EQ(free_param1.dir()[2],
-                    getter::element(free_vec, e_free_dir2, 0));
-    EXPECT_FLOAT_EQ(getter::norm(free_param1.mom()), getter::norm(mom));
-    EXPECT_FLOAT_EQ(free_param1.time(),
-                    getter::element(free_vec, e_free_time, 0));
-    EXPECT_FLOAT_EQ(free_param1.qop(),
-                    getter::element(free_vec, e_free_qoverp, 0));
-    EXPECT_FLOAT_EQ(free_param1.pT(),
-                    std::sqrt(std::pow(mom[0], 2) + std::pow(mom[1], 2)));
-    EXPECT_FLOAT_EQ(free_param1.mom()[0],
-                    free_param1.p() * free_param1.dir()[0]);
-    EXPECT_FLOAT_EQ(free_param1.mom()[1],
-                    free_param1.p() * free_param1.dir()[1]);
-    EXPECT_FLOAT_EQ(free_param1.mom()[2],
-                    free_param1.p() * free_param1.dir()[2]);
+    EXPECT_NEAR(free_param1.pos()[0],
+                getter::element(free_vec, e_free_pos0, 0u), tol);
+    EXPECT_NEAR(free_param1.pos()[1],
+                getter::element(free_vec, e_free_pos1, 0u), tol);
+    EXPECT_NEAR(free_param1.pos()[2],
+                getter::element(free_vec, e_free_pos2, 0u), tol);
+    EXPECT_NEAR(free_param1.dir()[0],
+                getter::element(free_vec, e_free_dir0, 0u), tol);
+    EXPECT_NEAR(free_param1.dir()[1],
+                getter::element(free_vec, e_free_dir1, 0u), tol);
+    EXPECT_NEAR(free_param1.dir()[2],
+                getter::element(free_vec, e_free_dir2, 0u), tol);
+    EXPECT_NEAR(getter::norm(free_param1.mom()), getter::norm(mom), tol);
+    EXPECT_NEAR(free_param1.time(), getter::element(free_vec, e_free_time, 0u),
+                tol);
+    EXPECT_NEAR(free_param1.qop(), getter::element(free_vec, e_free_qoverp, 0u),
+                tol);
+    EXPECT_NEAR(free_param1.pT(),
+                std::sqrt(std::pow(mom[0], 2.f) + std::pow(mom[1], 2.f)), tol);
+    EXPECT_NEAR(free_param1.mom()[0], free_param1.p() * free_param1.dir()[0],
+                tol);
+    EXPECT_NEAR(free_param1.mom()[1], free_param1.p() * free_param1.dir()[1],
+                tol);
+    EXPECT_NEAR(free_param1.mom()[2], free_param1.p() * free_param1.dir()[2],
+                tol);
 
     // second constructor
     free_track_parameters<transform3> free_param2(pos, time, mom, charge);
-    EXPECT_FLOAT_EQ(free_param2.pos()[0], pos[0]);
-    EXPECT_FLOAT_EQ(free_param2.pos()[1], pos[1]);
-    EXPECT_FLOAT_EQ(free_param2.pos()[2], pos[2]);
-    EXPECT_FLOAT_EQ(free_param2.dir()[0], mom[0] / getter::norm(mom));
-    EXPECT_FLOAT_EQ(free_param2.dir()[1], mom[1] / getter::norm(mom));
-    EXPECT_FLOAT_EQ(free_param2.dir()[2], mom[2] / getter::norm(mom));
-    EXPECT_FLOAT_EQ(getter::norm(free_param2.mom()), getter::norm(mom));
-    EXPECT_FLOAT_EQ(free_param2.time(), time);
-    EXPECT_FLOAT_EQ(free_param2.qop(), charge / getter::norm(mom));
-    EXPECT_FLOAT_EQ(free_param2.pT(),
-                    std::sqrt(std::pow(mom[0], 2) + std::pow(mom[1], 2)));
-    EXPECT_FLOAT_EQ(free_param2.mom()[0],
-                    free_param2.p() * free_param2.dir()[0]);
-    EXPECT_FLOAT_EQ(free_param2.mom()[1],
-                    free_param2.p() * free_param2.dir()[1]);
-    EXPECT_FLOAT_EQ(free_param2.mom()[2],
-                    free_param2.p() * free_param2.dir()[2]);
+    EXPECT_NEAR(free_param2.pos()[0], pos[0], tol);
+    EXPECT_NEAR(free_param2.pos()[1], pos[1], tol);
+    EXPECT_NEAR(free_param2.pos()[2], pos[2], tol);
+    EXPECT_NEAR(free_param2.dir()[0], mom[0] / getter::norm(mom), tol);
+    EXPECT_NEAR(free_param2.dir()[1], mom[1] / getter::norm(mom), tol);
+    EXPECT_NEAR(free_param2.dir()[2], mom[2] / getter::norm(mom), tol);
+    EXPECT_NEAR(getter::norm(free_param2.mom()), getter::norm(mom), tol);
+    EXPECT_NEAR(free_param2.time(), time, tol);
+    EXPECT_NEAR(free_param2.qop(), charge / getter::norm(mom), tol);
+    EXPECT_NEAR(free_param2.pT(),
+                std::sqrt(std::pow(mom[0], 2.f) + std::pow(mom[1], 2.f)), tol);
+    EXPECT_NEAR(free_param2.mom()[0], free_param2.p() * free_param2.dir()[0],
+                tol);
+    EXPECT_NEAR(free_param2.mom()[1], free_param2.p() * free_param2.dir()[1],
+                tol);
+    EXPECT_NEAR(free_param2.mom()[2], free_param2.p() * free_param2.dir()[2],
+                tol);
 
     EXPECT_TRUE(free_param2 == free_param1);
 }

--- a/tests/simulation/run_simulation.cpp
+++ b/tests/simulation/run_simulation.cpp
@@ -25,7 +25,7 @@ int main() {
     vecmem::host_memory_resource host_mr;
 
     // Create B field
-    const vector3 B{0, 0, 2 * unit<scalar>::T};
+    const vector3 B{0.f, 0.f, 2.f * unit<scalar>::T};
 
     // Create geometry
     using b_field_t = decltype(create_toy_geometry(host_mr))::bfield_type;
@@ -34,18 +34,18 @@ int main() {
         b_field_t(b_field_t::backend_t::configuration_t{B[0], B[1], B[2]}));
 
     // Create track generator
-    constexpr unsigned int theta_steps{4};
-    constexpr unsigned int phi_steps{4};
-    const vector3 ori{0, 0, 0};
-    const scalar mom = 1 * unit<scalar>::GeV;
+    constexpr std::size_t theta_steps{4u};
+    constexpr std::size_t phi_steps{4u};
+    const vector3 ori{0.f, 0.f, 0.f};
+    const scalar mom{1.f * unit<scalar>::GeV};
     auto generator = uniform_track_generator<free_track_parameters<transform3>>(
         theta_steps, phi_steps, ori, mom);
 
     // Create smearer
-    measurement_smearer<scalar> smearer(100 * unit<scalar>::um,
-                                        100 * unit<scalar>::um);
+    measurement_smearer<scalar> smearer(100.f * unit<scalar>::um,
+                                        100.f * unit<scalar>::um);
 
-    unsigned int n_events = 2;
+    std::size_t n_events = 2u;
     auto sim = simulator(n_events, detector, std::move(generator), smearer);
 
     sim.run();

--- a/tests/unit_tests/core/grids_axis.cpp
+++ b/tests/unit_tests/core/grids_axis.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,6 +16,7 @@
 
 // detray core
 #include "detray/definitions/indexing.hpp"
+#include "detray/definitions/units.hpp"
 #include "detray/grids/axis.hpp"
 
 using namespace detray;
@@ -23,13 +24,13 @@ using namespace detray;
 TEST(grids, regular_closed_axis) {
     vecmem::host_memory_resource resource;
 
-    axis::regular<> ten_bins{10, -3., 7., resource};
+    axis::regular<> ten_bins{10u, -3.f, 7.f, resource};
     // N bins
     EXPECT_EQ(ten_bins.bins(), 10u);
     // Axis bin access
-    EXPECT_EQ(ten_bins.bin(-4.), 0u);
-    EXPECT_EQ(ten_bins.bin(2.5), 5u);
-    EXPECT_EQ(ten_bins.bin(8.), 9u);
+    EXPECT_EQ(ten_bins.bin(-4.f), 0u);
+    EXPECT_EQ(ten_bins.bin(2.5f), 5u);
+    EXPECT_EQ(ten_bins.bin(8.f), 9u);
 
     // Axis range access - binned (symmetric & asymmetric)
     darray<dindex, 2> zone00 = {0u, 0u};
@@ -39,73 +40,73 @@ TEST(grids, regular_closed_axis) {
     darray<dindex, 2> zone55 = {5u, 5u};
 
     dindex_range expected_range = {5u, 5u};
-    EXPECT_EQ(ten_bins.range(2.5, zone00), expected_range);
+    EXPECT_EQ(ten_bins.range(2.5f, zone00), expected_range);
     expected_range = {4u, 6u};
-    EXPECT_EQ(ten_bins.range(2.5, zone11), expected_range);
+    EXPECT_EQ(ten_bins.range(2.5f, zone11), expected_range);
     expected_range = {5u, 6u};
-    EXPECT_EQ(ten_bins.range(2.5, zone01), expected_range);
+    EXPECT_EQ(ten_bins.range(2.5f, zone01), expected_range);
     expected_range = {0u, 8u};
-    EXPECT_EQ(ten_bins.range(1.5, zone44), expected_range);
+    EXPECT_EQ(ten_bins.range(1.5f, zone44), expected_range);
     expected_range = {3u, 9u};
-    EXPECT_EQ(ten_bins.range(5.5, zone55), expected_range);
+    EXPECT_EQ(ten_bins.range(5.5f, zone55), expected_range);
 
     // Axis sequence access - binned (symmetric & asymmetric)
     dindex_sequence expected_zone = {5u};
-    EXPECT_EQ(ten_bins.zone(2.5, zone00), expected_zone);
+    EXPECT_EQ(ten_bins.zone(2.5f, zone00), expected_zone);
     expected_zone = {5u, 6u};
-    EXPECT_EQ(ten_bins.zone(2.5, zone01), expected_zone);
+    EXPECT_EQ(ten_bins.zone(2.5f, zone01), expected_zone);
     expected_zone = {4u, 5u, 6u};
-    EXPECT_EQ(ten_bins.zone(2.5, zone11), expected_zone);
+    EXPECT_EQ(ten_bins.zone(2.5f, zone11), expected_zone);
     expected_zone = {0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u};
-    EXPECT_EQ(ten_bins.zone(1.5, zone44), expected_zone);
+    EXPECT_EQ(ten_bins.zone(1.5f, zone44), expected_zone);
 
     // Axis range access - scalar (symmteric & asymmetric)
-    darray<scalar, 2> szone00 = {0., 0.};
-    darray<scalar, 2> sepsilon = {0.01, 0.01};
-    darray<scalar, 2> szone11 = {1., 1.};
-    darray<scalar, 2> szoneAll = {10., 10.};
+    darray<scalar, 2> szone00 = {0.f, 0.f};
+    darray<scalar, 2> sepsilon = {0.01f, 0.01f};
+    darray<scalar, 2> szone11 = {1.f, 1.f};
+    darray<scalar, 2> szoneAll = {10.f, 10.f};
 
     expected_range = {5u, 5u};
-    EXPECT_EQ(ten_bins.range(2.5, szone00), expected_range);
-    EXPECT_EQ(ten_bins.range(2.5, sepsilon), expected_range);
+    EXPECT_EQ(ten_bins.range(2.5f, szone00), expected_range);
+    EXPECT_EQ(ten_bins.range(2.5f, sepsilon), expected_range);
     expected_range = {4u, 6u};
-    EXPECT_EQ(ten_bins.range(2.5, szone11), expected_range);
+    EXPECT_EQ(ten_bins.range(2.5f, szone11), expected_range);
     expected_range = {0u, 9u};
-    EXPECT_EQ(ten_bins.range(2.5, szoneAll), expected_range);
+    EXPECT_EQ(ten_bins.range(2.5f, szoneAll), expected_range);
 
     // Axis sequence acces - scalar (symmteric & asymmetric)
     expected_zone = {5u};
-    EXPECT_EQ(ten_bins.zone(2.5, szone00), expected_zone);
-    EXPECT_EQ(ten_bins.zone(2.5, sepsilon), expected_zone);
+    EXPECT_EQ(ten_bins.zone(2.5f, szone00), expected_zone);
+    EXPECT_EQ(ten_bins.zone(2.5f, sepsilon), expected_zone);
     expected_zone = {4u, 5u, 6u};
-    EXPECT_EQ(ten_bins.zone(2.5, szone11), expected_zone);
+    EXPECT_EQ(ten_bins.zone(2.5f, szone11), expected_zone);
     expected_zone = {0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u, 9u};
-    EXPECT_EQ(ten_bins.zone(2.5, szoneAll), expected_zone);
+    EXPECT_EQ(ten_bins.zone(2.5f, szoneAll), expected_zone);
 }
 
 TEST(grids, regular_circular_axis) {
     vecmem::host_memory_resource resource;
 
-    scalar epsilon = 10 * std::numeric_limits<scalar>::epsilon();
+    constexpr scalar epsilon{10.f * std::numeric_limits<scalar>::epsilon()};
 
     // Let's say 36 modules, but with 4 directly at 0, pi/2, pi, -pi2
-    scalar half_module = 2 * M_PI_2 / 72;
-    scalar phi_min = -M_PI + half_module;
-    scalar phi_max = M_PI - half_module;
-    axis::circular<> full_pi = {36, phi_min, phi_max, resource};
+    scalar half_module{constant<scalar>::pi / 72.f};
+    scalar phi_min = -constant<scalar>::pi + half_module;
+    scalar phi_max = constant<scalar>::pi - half_module;
+    axis::circular<> full_pi = {36u, phi_min, phi_max, resource};
     // N bins
     EXPECT_EQ(full_pi.bins(), 36u);
     // Axis bin access
-    EXPECT_EQ(full_pi.bin(M_PI - epsilon), 0u);
-    EXPECT_EQ(full_pi.bin(M_PI + epsilon), 0u);
-    EXPECT_EQ(full_pi.bin(0), 18u);
+    EXPECT_EQ(full_pi.bin(constant<scalar>::pi - epsilon), 0u);
+    EXPECT_EQ(full_pi.bin(constant<scalar>::pi + epsilon), 0u);
+    EXPECT_EQ(full_pi.bin(0u), 18u);
     // Remap test
     EXPECT_EQ(full_pi.remap(4, -1), 3u);
     EXPECT_EQ(full_pi.remap(4, 1), 5u);
-    EXPECT_EQ(full_pi.remap(0, -1), 35);
-    EXPECT_EQ(full_pi.remap(0, -2), 34);
-    EXPECT_EQ(full_pi.remap(-1, -1), 34);
-    EXPECT_EQ(full_pi.remap(35, 1), 0);
+    EXPECT_EQ(full_pi.remap(0, -1), 35u);
+    EXPECT_EQ(full_pi.remap(0, -2), 34u);
+    EXPECT_EQ(full_pi.remap(1, -1), 0u);
+    EXPECT_EQ(full_pi.remap(35, 1), 0u);
 
     // Axis range access - binned (symmetric & asymmetric)
     darray<dindex, 2> zone00 = {0u, 0u};
@@ -114,40 +115,49 @@ TEST(grids, regular_circular_axis) {
     darray<dindex, 2> zone22 = {2u, 2u};
 
     dindex_range expected_range = {0u, 0u};
-    EXPECT_EQ(full_pi.range(M_PI + epsilon, zone00), expected_range);
+    EXPECT_EQ(full_pi.range(constant<scalar>::pi + epsilon, zone00),
+              expected_range);
     expected_range = {0u, 1u};
-    EXPECT_EQ(full_pi.range(M_PI + epsilon, zone01), expected_range);
+    EXPECT_EQ(full_pi.range(constant<scalar>::pi + epsilon, zone01),
+              expected_range);
     expected_range = {35u, 1u};
-    EXPECT_EQ(full_pi.range(M_PI + epsilon, zone11), expected_range);
+    EXPECT_EQ(full_pi.range(constant<scalar>::pi + epsilon, zone11),
+              expected_range);
     expected_range = {34u, 2u};
-    EXPECT_EQ(full_pi.range(M_PI + epsilon, zone22), expected_range);
+    EXPECT_EQ(full_pi.range(constant<scalar>::pi + epsilon, zone22),
+              expected_range);
 
     // Zone test - binned
     dindex_sequence expected_zone = {34u, 35u, 0u, 1u, 2u};
-    EXPECT_EQ(full_pi.zone(M_PI + epsilon, zone22), expected_zone);
+    EXPECT_EQ(full_pi.zone(constant<scalar>::pi + epsilon, zone22),
+              expected_zone);
 
     // Axis range access - scalar (symmetric & asymmteric)
-    darray<scalar, 2> szone00 = {0., 0.};
-    darray<scalar, 2> szoneEpsilon = {scalar{0.5} * epsilon,
-                                      scalar{0.5} * epsilon};
-    scalar bin_step = (full_pi.max - full_pi.min) / full_pi.bins();
-    darray<scalar, 2> szone22 = {2 * bin_step, 2 * bin_step};
+    darray<scalar, 2> szone00 = {0.f, 0.f};
+    darray<scalar, 2> szoneEpsilon = {0.5f * epsilon, 0.5f * epsilon};
+    scalar bin_step =
+        (full_pi.max - full_pi.min) / static_cast<scalar>(full_pi.bins());
+    darray<scalar, 2> szone22 = {2.f * bin_step, 2.f * bin_step};
 
     expected_range = {0u, 0u};
-    EXPECT_EQ(full_pi.range(M_PI + epsilon, szone00), expected_range);
-    EXPECT_EQ(full_pi.range(M_PI + epsilon, szoneEpsilon), expected_range);
+    EXPECT_EQ(full_pi.range(constant<scalar>::pi + epsilon, szone00),
+              expected_range);
+    EXPECT_EQ(full_pi.range(constant<scalar>::pi + epsilon, szoneEpsilon),
+              expected_range);
 
     expected_range = {34u, 2u};
-    EXPECT_EQ(full_pi.range(M_PI + epsilon, szone22), expected_range);
+    EXPECT_EQ(full_pi.range(constant<scalar>::pi + epsilon, szone22),
+              expected_range);
 
     expected_zone = {34u, 35u, 0u, 1u, 2u};
-    EXPECT_EQ(full_pi.zone(M_PI + epsilon, szone22), expected_zone);
+    EXPECT_EQ(full_pi.zone(constant<scalar>::pi + epsilon, szone22),
+              expected_zone);
 }
 
 TEST(grids, irregular_closed_axis) {
     vecmem::host_memory_resource resource;
 
-    axis::irregular<> nonreg({-3., 1., 2, 4., 8., 12.}, resource);
+    axis::irregular<> nonreg({-3.f, 1.f, 2.f, 4.f, 8.f, 12.f}, resource);
 
     // Axis bin access
     //
@@ -168,40 +178,40 @@ TEST(grids, irregular_closed_axis) {
     darray<dindex, 2> zone22 = {2u, 2u};
 
     dindex_range expected_range = {1u, 3u};
-    EXPECT_EQ(nonreg.range(3., zone11), expected_range);
+    EXPECT_EQ(nonreg.range(3.f, zone11), expected_range);
 
     expected_range = {2u, 3u};
-    EXPECT_EQ(nonreg.range(3., zone01), expected_range);
+    EXPECT_EQ(nonreg.range(3.f, zone01), expected_range);
 
     dindex_range expected_range_truncated_low = {0u, 1u};
-    EXPECT_EQ(nonreg.range(0., zone11), expected_range_truncated_low);
+    EXPECT_EQ(nonreg.range(0.f, zone11), expected_range_truncated_low);
 
     dindex_range expected_range_truncated_high = {2u, 4u};
-    EXPECT_EQ(nonreg.range(10., zone22), expected_range_truncated_high);
+    EXPECT_EQ(nonreg.range(10.f, zone22), expected_range_truncated_high);
 
     // Axis sequence access - binned
     dindex_sequence expected_zone = {1u, 2u, 3u};
-    EXPECT_EQ(nonreg.zone(3., zone11), expected_zone);
+    EXPECT_EQ(nonreg.zone(3.f, zone11), expected_zone);
 
     dindex_sequence expected_zone_truncated_low = {0u, 1u};
-    EXPECT_EQ(nonreg.zone(0., zone11), expected_zone_truncated_low);
+    EXPECT_EQ(nonreg.zone(0.f, zone11), expected_zone_truncated_low);
 
     dindex_sequence expected_zone_truncated_high = {2u, 3u, 4u};
-    EXPECT_EQ(nonreg.zone(10., zone22), expected_zone_truncated_high);
+    EXPECT_EQ(nonreg.zone(10.f, zone22), expected_zone_truncated_high);
 
     // Axis range access - scalar
-    darray<scalar, 2> szone00 = {0., 0.};
-    darray<scalar, 2> szone10 = {1.5, 0.2};
+    darray<scalar, 2> szone00 = {0.f, 0.f};
+    darray<scalar, 2> szone10 = {1.5f, 0.2f};
     expected_range = {2u, 2u};
-    EXPECT_EQ(nonreg.range(3., szone00), expected_range);
+    EXPECT_EQ(nonreg.range(3.f, szone00), expected_range);
 
     expected_range = {1u, 2u};
-    EXPECT_EQ(nonreg.range(3., szone10), expected_range);
+    EXPECT_EQ(nonreg.range(3.f, szone10), expected_range);
 
     // Axis sequence access - scalar
     expected_zone = {2u};
-    EXPECT_EQ(nonreg.zone(3., szone00), expected_zone);
+    EXPECT_EQ(nonreg.zone(3.f, szone00), expected_zone);
 
     expected_zone = {1u, 2u};
-    EXPECT_EQ(nonreg.zone(3., szone10), expected_zone);
+    EXPECT_EQ(nonreg.zone(3.f, szone10), expected_zone);
 }

--- a/tests/unit_tests/core/grids_grid2.cpp
+++ b/tests/unit_tests/core/grids_grid2.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,33 +30,33 @@ TEST(grids, grid2_replace_populator) {
 
     using grid2r = grid2<replace_populator, axis::regular, axis::regular,
                          decltype(serializer)>;
-    typename grid2r::axis_p0_type xaxis{10, -5., 5., host_mr};
-    typename grid2r::axis_p1_type yaxis{10, -5., 5., host_mr};
+    typename grid2r::axis_p0_type xaxis{10u, -5.f, 5.f, host_mr};
+    typename grid2r::axis_p1_type yaxis{10u, -5.f, 5.f, host_mr};
 
     grid2r g2(std::move(xaxis), std::move(yaxis), host_mr);
 
     // Test the initialization
-    test::point2<detray::scalar> p = {-4.5, -4.5};
-    for (unsigned int ib0 = 0; ib0 < 10; ++ib0) {
-        for (unsigned int ib1 = 0; ib1 < 10; ++ib1) {
-            p = {static_cast<scalar>(-4.5 + ib0),
-                 static_cast<scalar>(-4.5 + ib1)};
+    test::point2<detray::scalar> p = {-4.5f, -4.5f};
+    for (unsigned int ib0 = 0u; ib0 < 10u; ++ib0) {
+        for (unsigned int ib1 = 0u; ib1 < 10u; ++ib1) {
+            p = {-4.5f + static_cast<scalar>(ib0),
+                 -4.5f + static_cast<scalar>(ib1)};
             EXPECT_EQ(g2.bin(p), std::numeric_limits<dindex>::max());
         }
     }
 
-    p = {-4.5, -4.5};
+    p = {-4.5f, -4.5f};
     // Fill and read
     g2.populate(p, 3u);
     EXPECT_EQ(g2.bin(p), 3u);
 
     // Fill and read two times, fill first 0-99, then 100-199
-    for (unsigned int il = 0; il < 2; ++il) {
-        unsigned int counter = il * 100;
-        for (unsigned int ib0 = 0; ib0 < 10; ++ib0) {
-            for (unsigned int ib1 = 0; ib1 < 10; ++ib1) {
-                p = {static_cast<scalar>(-4.5 + ib0),
-                     static_cast<scalar>(-4.5 + ib1)};
+    for (unsigned int il = 0u; il < 2u; ++il) {
+        unsigned int counter = il * 100u;
+        for (unsigned int ib0 = 0u; ib0 < 10u; ++ib0) {
+            for (unsigned int ib1 = 0; ib1 < 10u; ++ib1) {
+                p = {-4.5f + static_cast<scalar>(ib0),
+                     -4.5f + static_cast<scalar>(ib1)};
                 g2.populate(p, counter);
                 EXPECT_EQ(g2.bin(p), counter++);
             }
@@ -64,13 +64,13 @@ TEST(grids, grid2_replace_populator) {
     }
 
     // A zone test w/o neighbour hood
-    p = {-4.5, -4.5};
+    p = {-4.5f, -4.5f};
     auto test = g2.zone(p);
     dvector<dindex> expect = {100u};
     EXPECT_EQ(test, expect);
 
     // A zone test with neighbour hood
-    p = {0.5, 0.5};
+    p = {0.5f, 0.5f};
 
     darray<dindex, 2> zone11 = {1u, 1u};
     darray<dindex, 2> zone22 = {2u, 2u};
@@ -83,21 +83,21 @@ TEST(grids, grid2_replace_populator) {
     using grid2cc = grid2<replace_populator, axis::circular, axis::regular,
                           decltype(serializer)>;
 
-    typename grid2cc::axis_p0_type circular{4, -2., 2., host_mr};
-    typename grid2cc::axis_p1_type closed{5, 0., 5., host_mr};
+    typename grid2cc::axis_p0_type circular{4u, -2.f, 2.f, host_mr};
+    typename grid2cc::axis_p1_type closed{5u, 0.f, 5.f, host_mr};
 
     grid2cc g2cc(std::move(circular), std::move(closed), host_mr);
-    unsigned int counter = 0;
-    for (unsigned icl = 0; icl < 5; ++icl) {
-        for (unsigned ici = 0; ici < 4; ++ici) {
-            p = {static_cast<scalar>(-1.5 + ici),
-                 static_cast<scalar>(0.5 + icl)};
+    unsigned int counter = 0u;
+    for (unsigned icl = 0u; icl < 5u; ++icl) {
+        for (unsigned ici = 0u; ici < 4u; ++ici) {
+            p = {-1.5f + static_cast<scalar>(ici),
+                 0.5f + static_cast<scalar>(icl)};
             g2cc.populate(p, counter++);
         }
     }
 
     // A zone test for circular testing
-    p = {1.5, 2.5};
+    p = {1.5f, 2.5f};
     test = g2cc.zone(p, {zone11, zone11}, true);
     expect = {4u, 6u, 7u, 8u, 10u, 11u, 12u, 14u, 15u};
     EXPECT_EQ(test, expect);
@@ -112,25 +112,25 @@ TEST(grids, grid2_complete_populator) {
                          decltype(serializer), dvector, djagged_vector, darray,
                          dtuple, dindex, false, 3>;
 
-    typename grid2r::axis_p0_type xaxis{2, -1., 1., host_mr};
-    typename grid2r::axis_p1_type yaxis{2, -1., 1., host_mr};
+    typename grid2r::axis_p0_type xaxis{2u, -1.f, 1.f, host_mr};
+    typename grid2r::axis_p1_type yaxis{2u, -1.f, 1.f, host_mr};
 
     grid2r g2(std::move(xaxis), std::move(yaxis), host_mr);
 
     // Test the initialization
-    test::point2<detray::scalar> p = {-0.5, -0.5};
+    test::point2<detray::scalar> p = {-0.5f, -0.5f};
     grid2r::populator_type::store_value invalid = {
         dindex_invalid, dindex_invalid, dindex_invalid};
-    for (unsigned int ib0 = 0; ib0 < 2; ++ib0) {
-        for (unsigned int ib1 = 0; ib1 < 2; ++ib1) {
-            p = {static_cast<scalar>(-0.5 + ib0),
-                 static_cast<scalar>(-0.5 + ib1)};
+    for (unsigned int ib0 = 0u; ib0 < 2u; ++ib0) {
+        for (unsigned int ib1 = 0u; ib1 < 2u; ++ib1) {
+            p = {-0.5f + static_cast<scalar>(ib0),
+                 -0.5f + static_cast<scalar>(ib1)};
             EXPECT_EQ(g2.bin(p), invalid);
         }
     }
 
     // Fill and read
-    p = {-0.5, -0.5};
+    p = {-0.5f, -0.5f};
     g2.populate(p, 4u);
 
     grid2r::populator_type::store_value expected = {4u, dindex_invalid,
@@ -166,10 +166,10 @@ TEST(grids, grid2_complete_populator) {
     EXPECT_EQ(zone_test, zone_expected);
 
     // Fill some other bins
-    p = {0.5, -0.5};
+    p = {0.5f, -0.5f};
     g2.populate(p, 16u);
 
-    p = {0.5, 0.5};
+    p = {0.5f, 0.5f};
     g2.populate(p, 17u);
     g2.populate(p, 18u);
 
@@ -185,23 +185,23 @@ TEST(grids, grid2_attach_populator) {
 
     using grid2r = grid2<attach_populator, axis::regular, axis::regular,
                          decltype(serializer)>;
-    typename grid2r::axis_p0_type xaxis{2, -1., 1., host_mr};
-    typename grid2r::axis_p1_type yaxis{2, -1., 1., host_mr};
+    typename grid2r::axis_p0_type xaxis{2u, -1.f, 1.f, host_mr};
+    typename grid2r::axis_p1_type yaxis{2u, -1.f, 1.f, host_mr};
 
     grid2r g2(std::move(xaxis), std::move(yaxis), host_mr);
 
     // Test the initialization
-    test::point2<detray::scalar> p = {-0.5, -0.5};
+    test::point2<detray::scalar> p = {-0.5f, -0.5f};
     grid2r::populator_type::store_value invalid = {};
-    for (unsigned int ib0 = 0; ib0 < 2; ++ib0) {
-        for (unsigned int ib1 = 0; ib1 < 2; ++ib1) {
-            p = {static_cast<scalar>(-0.5 + ib0),
-                 static_cast<scalar>(-0.5 + ib1)};
+    for (unsigned int ib0 = 0u; ib0 < 2u; ++ib0) {
+        for (unsigned int ib1 = 0u; ib1 < 2u; ++ib1) {
+            p = {-0.5f + static_cast<scalar>(ib0),
+                 -0.5f + static_cast<scalar>(ib1)};
             EXPECT_EQ(g2.bin(p), invalid);
         }
     }
 
-    p = {-0.5, -0.5};
+    p = {-0.5f, -0.5f};
     g2.populate(p, 4u);
 
     grid2r::populator_type::store_value expected = {4u};
@@ -212,13 +212,13 @@ TEST(grids, grid2_attach_populator) {
     dvector<dindex> zone_expected = {4u};
     EXPECT_EQ(zone_test, zone_expected);
 
-    p = {-0.5, 0.5};
+    p = {-0.5f, 0.5f};
     g2.populate(p, 9u);
 
-    p = {0.5, -0.5};
+    p = {0.5f, -0.5f};
     g2.populate(p, 1u);
 
-    p = {0.5, 0.5};
+    p = {0.5f, 0.5f};
     g2.populate(p, 7u);
 
     expected = {7u};
@@ -240,13 +240,13 @@ TEST(grids, grid2_shift) {
     using grid2r = grid2<replace_populator, axis::regular, axis::regular,
                          decltype(serializer)>;
 
-    typename grid2r::axis_p0_type xaxis{10, -5., 5., host_mr};
-    typename grid2r::axis_p1_type yaxis{10, -5., 5., host_mr};
+    typename grid2r::axis_p0_type xaxis{10u, -5.f, 5.f, host_mr};
+    typename grid2r::axis_p1_type yaxis{10u, -5.f, 5.f, host_mr};
 
     grid2r g2(std::move(xaxis), std::move(yaxis), host_mr, 0);
 
     // Test the initialization
-    test::point2<detray::scalar> p = {-4.5, -4.5};
+    test::point2<detray::scalar> p = {-4.5f, -4.5f};
     EXPECT_EQ(g2.bin(p), 0u);
 
     g2.shift(8u);
@@ -263,13 +263,13 @@ TEST(grids, grid2_irregular_replace) {
                           decltype(serializer)>;
 
     typename grid2ir::axis_p0_type xaxis{
-        {-3, -2., 1, 0.5, 0.7, 0.71, 4., 1000.}, host_mr};
-    typename grid2ir::axis_p1_type yaxis{{0.1, 0.8, 0.9, 10., 12., 15.},
+        {-3.f, -2.f, 1.f, 0.5f, 0.7f, 0.71f, 4.f, 1000.f}, host_mr};
+    typename grid2ir::axis_p1_type yaxis{{0.1f, 0.8f, 0.9f, 10.f, 12.f, 15.f},
                                          host_mr};
 
     grid2ir g2(std::move(xaxis), std::move(yaxis), host_mr);
 
-    test::point2<detray::scalar> p = {-0.5, 0.5};
+    test::point2<detray::scalar> p = {-0.5f, 0.5f};
     g2.populate(p, 4u);
     EXPECT_EQ(g2.bin(p), 4u);
 }

--- a/tests/unit_tests/core/grids_populator.cpp
+++ b/tests/unit_tests/core/grids_populator.cpp
@@ -1,13 +1,13 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #include <gtest/gtest.h>
 
-#include <climits>
+#include <limits>
 
 // detray test
 #include "tests/common/test_defs.hpp"
@@ -20,18 +20,18 @@ using namespace detray;
 
 TEST(grids, replace_populator) {
     replace_populator<> replacer;
-    dindex stored = 3;
-    replacer(stored, 2);
+    dindex stored = 3u;
+    replacer(stored, 2u);
     EXPECT_EQ(stored, 2u);
 
-    replacer(stored, 42);
+    replacer(stored, 42u);
     EXPECT_EQ(stored, 42u);
 }
 
 TEST(grids, complete_populator) {
 
     using cpopulator4 =
-        complete_populator<dvector, djagged_vector, darray, dindex, false, 4>;
+        complete_populator<dvector, djagged_vector, darray, dindex, false, 4u>;
     cpopulator4 completer;
 
     cpopulator4::store_value stored = {completer.m_invalid, completer.m_invalid,
@@ -40,39 +40,39 @@ TEST(grids, complete_populator) {
 
     cpopulator4::store_value test = stored;
     test[0] = 9u;
-    completer(stored, 9);
+    completer(stored, 9u);
     EXPECT_EQ(stored, test);
 
     test[1] = 3u;
-    completer(stored, 3);
+    completer(stored, 3u);
     EXPECT_EQ(stored, test);
 
     using sort_cpopulator4 =
-        complete_populator<dvector, djagged_vector, darray, dindex, true, 4>;
+        complete_populator<dvector, djagged_vector, darray, dindex, true, 4u>;
     sort_cpopulator4 sort_completer;
 
-    test = {0, 3, 9, 1000};
-    sort_completer(stored, 1000);
-    sort_completer(stored, 0);
+    test = {0u, 3u, 9u, 1000u};
+    sort_completer(stored, 1000u);
+    sort_completer(stored, 0u);
     EXPECT_EQ(stored, test);
 }
 
 TEST(grids, attach_populator) {
     // Attch populator without sorting
     attach_populator<> attacher;
-    attach_populator<>::store_value stored = {3};
-    attacher(stored, 2);
+    attach_populator<>::store_value stored = {3u};
+    attacher(stored, 2u);
     attach_populator<>::store_value test = {3u, 2u};
     EXPECT_EQ(stored, test);
 
-    attacher(stored, 42);
+    attacher(stored, 42u);
     test = {3u, 2u, 42u};
     EXPECT_EQ(stored, test);
 
     // Attach populator with sorting
     attach_populator<dvector, djagged_vector, darray, dindex, true>
         sort_attacher;
-    sort_attacher(stored, 11);
+    sort_attacher(stored, 11u);
     test = {2u, 3u, 11u, 42u};
     EXPECT_EQ(stored, test);
 }

--- a/tests/unit_tests/core/grids_serializer.cpp
+++ b/tests/unit_tests/core/grids_serializer.cpp
@@ -1,13 +1,13 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #include <gtest/gtest.h>
 
-#include <climits>
+#include <limits>
 
 // detray test
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -24,8 +24,8 @@ using namespace detray;
 TEST(grids, serialize_deserialize) {
     vecmem::host_memory_resource resource;
 
-    axis::regular<> r6{6, -3., 7., resource};
-    axis::circular<> c12{12, -3., 3., resource};
+    axis::regular<> r6{6u, -3.f, 7.f, resource};
+    axis::circular<> c12{12u, -3.f, 3.f, resource};
 
     serializer2 ser2;
 

--- a/tests/unit_tests/core/thrust_tuple.cpp
+++ b/tests/unit_tests/core/thrust_tuple.cpp
@@ -16,7 +16,7 @@ namespace {
 struct TestStruct {
 
     int m_int = 0;
-    float m_float = 0.;
+    float m_float = 0.f;
     double m_double = 0.;
 
 };  // struct TestStruct
@@ -27,15 +27,15 @@ TEST(thrust_tuple, constructor) {
 
     auto t1 = thrust::make_tuple(12, 2.f, 3.);
     (void)t1;
-    auto t2 = thrust::make_tuple(3.14f, TestStruct{3, 4., 5.});
+    auto t2 = thrust::make_tuple(3.14f, TestStruct{3, 4.f, 5.});
     (void)t2;
 }
 
 TEST(thrust_tuple, access) {
 
-    auto t1 = thrust::make_tuple(3.14f, TestStruct{3, 4., 5.});
-    EXPECT_NEAR(thrust::get<0>(t1), 3.14f, 0.01f);
+    auto t1 = thrust::make_tuple(3.14f, TestStruct{3, 4.f, 5.});
+    EXPECT_FLOAT_EQ(thrust::get<0>(t1), 3.14f);
     EXPECT_EQ(thrust::get<1>(t1).m_int, 3);
-    EXPECT_NEAR(thrust::get<1>(t1).m_float, 4.f, 0.01f);
-    EXPECT_NEAR(thrust::get<1>(t1).m_double, 5., 0.01);
+    EXPECT_FLOAT_EQ(thrust::get<1>(t1).m_float, 4.f);
+    EXPECT_DOUBLE_EQ(thrust::get<1>(t1).m_double, 5.);
 }

--- a/tests/unit_tests/core/tools_hash_tree.cpp
+++ b/tests/unit_tests/core/tools_hash_tree.cpp
@@ -18,20 +18,21 @@ template <typename hasher_t, typename digest_collection_t>
 void test_hash(std::size_t first_child, std::size_t n_prev_level,
                digest_collection_t &digests) {
     // base case
-    if (n_prev_level <= 1) {
+    if (n_prev_level <= 1u) {
         return;
     }
 
     auto last_child = first_child + n_prev_level;
 
     // Run over previous tree level to build the next level
-    for (std::size_t i = first_child; i < last_child; i += 2) {
-        auto digest = hasher_t{}(digests[i], digests[i + 1]);
+    for (std::size_t i = first_child; i < last_child; i += 2u) {
+        auto digest = hasher_t{}(digests[i], digests[i + 1u]);
         digests.push_back(digest);
     }
-    std::size_t n_level = static_cast<std::size_t>(0.5 * n_prev_level);
+    std::size_t n_level =
+        static_cast<std::size_t>(0.5f * static_cast<float>(n_prev_level));
     // Need dummy leaf node for next level?
-    if (n_level % 2 != 0 and n_level > 1) {
+    if (n_level % 2u != 0u and n_level > 1u) {
         digests.push_back(0);
         n_level++;
     }
@@ -45,7 +46,7 @@ void test_hash(std::size_t first_child, std::size_t n_prev_level,
 TEST(ALGEBRA_PLUGIN, hash_tree) {
     using namespace detray;
 
-    dvector<dindex> test_matrix = {1, 1, 1, 1, 1, 1};
+    dvector<dindex> test_matrix = {1u, 1u, 1u, 1u, 1u, 1u};
 
     auto ht = hash_tree(test_matrix);
     using hash_tree_t = decltype(ht);
@@ -64,7 +65,7 @@ TEST(ALGEBRA_PLUGIN, hash_tree) {
 
     const auto tree_data = ht.tree();
     EXPECT_EQ(digests.size(), tree_data.size());
-    for (std::size_t n_idx = 0; n_idx < tree_data.size(); ++n_idx) {
+    for (std::size_t n_idx = 0u; n_idx < tree_data.size(); ++n_idx) {
         EXPECT_EQ(digests[n_idx], tree_data[n_idx].key());
     }
 }

--- a/tests/unit_tests/core/tuple_helpers.cpp
+++ b/tests/unit_tests/core/tuple_helpers.cpp
@@ -24,8 +24,8 @@ TEST(tuple_helpers, tuple_helpers) {
 
     const auto s_tuple_size = detail::tuple_size<decltype(s_tuple)>::value;
 
-    EXPECT_EQ(s_tuple_size, 3);
-    EXPECT_FLOAT_EQ(detail::get<0>(s_tuple), 1.0);
+    EXPECT_EQ(s_tuple_size, 3u);
+    EXPECT_DOUBLE_EQ(detail::get<0>(s_tuple), 1.0);
     EXPECT_EQ(detail::get<1>(s_tuple), 2);
     EXPECT_EQ(detail::get<2>(s_tuple), "std::tuple");
 
@@ -34,8 +34,8 @@ TEST(tuple_helpers, tuple_helpers) {
 
     const auto t_tuple_size = detail::tuple_size<decltype(t_tuple)>::value;
 
-    EXPECT_EQ(t_tuple_size, 3);
-    EXPECT_FLOAT_EQ(detail::get<0>(t_tuple), 1.0);
+    EXPECT_EQ(t_tuple_size, 3u);
+    EXPECT_DOUBLE_EQ(detail::get<0>(t_tuple), 1.0);
     EXPECT_EQ(detail::get<1>(t_tuple), 2);
     EXPECT_EQ(detail::get<2>(t_tuple), "thrust::tuple");
 }

--- a/tests/unit_tests/core/utils_local_object_finder.cpp
+++ b/tests/unit_tests/core/utils_local_object_finder.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,13 +29,13 @@ TEST(utils, local_object_finder) {
 
     serializer2 serializer;
 
-    test::point2<detray::scalar> p2 = {-4.5, -4.5};
+    test::point2<detray::scalar> p2 = {-4.5f, -4.5f};
 
     using grid2r = grid2<replace_populator, axis::regular, axis::regular,
                          decltype(serializer)>;
 
-    typename grid2r::axis_p0_type xaxis{10, -5., 5., host_mr};
-    typename grid2r::axis_p1_type yaxis{10, -5., 5., host_mr};
+    typename grid2r::axis_p0_type xaxis{10u, -5.f, 5.f, host_mr};
+    typename grid2r::axis_p1_type yaxis{10u, -5.f, 5.f, host_mr};
 
     grid2r g2(std::move(xaxis), std::move(yaxis), host_mr);
 

--- a/tests/unit_tests/core/utils_quadratic_equation.cpp
+++ b/tests/unit_tests/core/utils_quadratic_equation.cpp
@@ -17,10 +17,10 @@ using namespace detray;
 
 // This tests the convenience quadratic equation struct
 TEST(utils, quad_equation) {
-    quadratic_equation<scalar> qe = {{2., 5., -3.}};
+    quadratic_equation<scalar> qe = {{2.f, 5.f, -3.f}};
     auto solution = qe();
 
     ASSERT_EQ(std::get<0>(solution), 2);
-    ASSERT_NEAR(std::get<1>(solution)[0], -3., 1e-5);
-    ASSERT_NEAR(std::get<1>(solution)[1], 0.5, 1e-5);
+    ASSERT_NEAR(std::get<1>(solution)[0], -3.f, 1e-7f);
+    ASSERT_NEAR(std::get<1>(solution)[1], 0.5f, 1e-7f);
 }

--- a/tests/unit_tests/core/utils_ranges.cpp
+++ b/tests/unit_tests/core/utils_ranges.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -118,7 +118,7 @@ TEST(utils, ranges_empty) {
     static_assert(std::is_destructible_v<typename decltype(ev)::iterator_t>);
 
     // Test inherited member functions
-    ASSERT_EQ(ev.size(), 0UL);
+    ASSERT_EQ(ev.size(), 0u);
 
     for (const auto i : ev) {
         ASSERT_TRUE(i != i);
@@ -128,7 +128,7 @@ TEST(utils, ranges_empty) {
 // Unittest for the generation of a single element sequence
 TEST(utils, ranges_single) {
 
-    const dindex value{251UL};
+    const dindex value{251u};
 
     auto sngl = detray::views::single(value);
 
@@ -147,20 +147,20 @@ TEST(utils, ranges_single) {
 
     // Test inherited member functions
     ASSERT_EQ(sngl[0], value);
-    ASSERT_EQ(sngl.size(), 1UL);
-    ASSERT_EQ(sngl.front(), 251UL);
-    ASSERT_EQ(sngl.back(), 251UL);
+    ASSERT_EQ(sngl.size(), 1u);
+    ASSERT_EQ(sngl.front(), 251u);
+    ASSERT_EQ(sngl.back(), 251u);
 
     for (auto i : sngl) {
-        ASSERT_EQ(251, i);
+        ASSERT_EQ(251u, i);
     }
 }
 
 // Unittest for the generation of a single element sequence
 TEST(utils, ranges_iota_single) {
 
-    dindex check = 0;
-    dindex single = 7;
+    dindex check{0u};
+    dindex single{7u};
 
     auto seq = detray::views::iota(single);
 
@@ -179,7 +179,7 @@ TEST(utils, ranges_iota_single) {
     static_assert(std::is_destructible_v<typename decltype(seq)::iterator_t>);
 
     // Test inherited member functions
-    ASSERT_EQ(seq.size(), 1UL);
+    ASSERT_EQ(seq.size(), 1u);
 
     for (auto& i : seq) {
         check += i;
@@ -190,7 +190,7 @@ TEST(utils, ranges_iota_single) {
 // Unittest for the generation of a sequence in an interval
 TEST(utils, ranges_iota_interval) {
 
-    darray<dindex, 2> interval = {2, 7};
+    darray<dindex, 2> interval = {2u, 7u};
 
     auto seq = detray::views::iota(interval);
 
@@ -209,9 +209,9 @@ TEST(utils, ranges_iota_interval) {
     static_assert(std::is_destructible_v<typename decltype(seq)::iterator_t>);
 
     // Test inherited member functions
-    ASSERT_EQ(seq.size(), 5UL);
+    ASSERT_EQ(seq.size(), 5u);
 
-    std::vector<dindex> reference = {2, 3, 4, 5, 6};
+    std::vector<dindex> reference = {2u, 3u, 4u, 5u, 6u};
     std::vector<dindex> check = {};
     for (auto& i : seq) {
         check.push_back(i);
@@ -224,10 +224,10 @@ TEST(utils, ranges_iota_interval) {
 TEST(utils, ranges_enumerate) {
 
     struct uint_holder {
-        unsigned int ui = 0;
+        unsigned int ui{0u};
     };
 
-    dvector<uint_holder> seq = {{0}, {1}, {2}, {3}, {4}, {5}};
+    dvector<uint_holder> seq = {{0u}, {1u}, {2u}, {3u}, {4u}, {5u}};
 
     auto enumerator = detray::views::enumerate(seq);
 
@@ -247,9 +247,9 @@ TEST(utils, ranges_enumerate) {
 
     // Test inherited member functions
     const auto [i, v] = enumerator[2];
-    ASSERT_EQ(i, 2UL);
-    ASSERT_EQ(v.ui, 2UL);
-    ASSERT_EQ(enumerator.size(), 6UL);
+    ASSERT_EQ(i, 2u);
+    ASSERT_EQ(v.ui, 2u);
+    ASSERT_EQ(enumerator.size(), 6u);
     const auto [i_front, v_front] = enumerator.front();
     ASSERT_EQ(i_front, 0u);
     ASSERT_EQ(v_front.ui, 0u);
@@ -267,14 +267,15 @@ TEST(utils, ranges_enumerate) {
 TEST(utils, ranges_pick) {
 
     // The indices of the iota elements to be picked
-    std::vector<dindex> indices = {2, 3, 7, 8};
+    std::vector<dindex> indices = {2u, 3u, 7u, 8u};
     std::vector<dindex> check = {};
 
     struct uint_holder {
-        unsigned int ui = 0;
+        unsigned int ui{0u};
     };
 
-    dvector<uint_holder> seq = {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}};
+    dvector<uint_holder> seq = {{0u}, {1u}, {2u}, {3u}, {4u},
+                                {5u}, {6u}, {7u}, {8u}};
 
     auto selected = detray::views::pick(seq, indices);
 
@@ -294,15 +295,15 @@ TEST(utils, ranges_pick) {
 
     // Test inherited member functions
     const auto [i, v] = selected[2];
-    ASSERT_EQ(i, 7UL);
-    ASSERT_EQ(v.ui, 7UL);
-    ASSERT_EQ(selected.size(), 4UL);
+    ASSERT_EQ(i, 7u);
+    ASSERT_EQ(v.ui, 7u);
+    ASSERT_EQ(selected.size(), 4u);
     const auto [i_front, v_front] = selected.front();
-    ASSERT_EQ(i_front, 2UL);
-    ASSERT_EQ(v_front.ui, 2UL);
+    ASSERT_EQ(i_front, 2u);
+    ASSERT_EQ(v_front.ui, 2u);
     const auto [i_back, v_back] = selected.back();
-    ASSERT_EQ(i_back, 8UL);
-    ASSERT_EQ(v_back.ui, 8UL);
+    ASSERT_EQ(i_back, 8u);
+    ASSERT_EQ(v_back.ui, 8u);
 
     for (auto [j, w] : selected) {
         ASSERT_TRUE(j == w.ui);
@@ -315,10 +316,10 @@ TEST(utils, ranges_pick) {
 // Unittest for the joining of multiple ranges
 TEST(utils, ranges_join) {
 
-    dvector<dindex> interval_1 = {2, 3, 4};
-    dvector<dindex> interval_2 = {7, 8, 9};
+    dvector<dindex> interval_1 = {2u, 3u, 4u};
+    dvector<dindex> interval_2 = {7u, 8u, 9u};
 
-    std::vector<dindex> reference = {2, 3, 4, 7, 8, 9};
+    std::vector<dindex> reference = {2u, 3u, 4u, 7u, 8u, 9u};
     std::vector<dindex> check = {};
 
     auto joined = detray::views::join(interval_1, interval_2);
@@ -338,11 +339,11 @@ TEST(utils, ranges_join) {
         std::is_destructible_v<typename decltype(joined)::iterator_t>);
 
     // Test inherited member functions
-    ASSERT_EQ(joined[1], 3UL);
-    ASSERT_EQ(joined[4], 8UL);
-    ASSERT_EQ(joined.size(), 6UL);
-    ASSERT_EQ(joined.front(), 2UL);
-    ASSERT_EQ(joined.back(), 9UL);
+    ASSERT_EQ(joined[1], 3u);
+    ASSERT_EQ(joined[4], 8u);
+    ASSERT_EQ(joined.size(), 6u);
+    ASSERT_EQ(joined.front(), 2u);
+    ASSERT_EQ(joined.back(), 9u);
 
     for (const auto j : joined) {
         check.push_back(j);
@@ -354,8 +355,8 @@ TEST(utils, ranges_join) {
 // Unittest for the subrange implementation
 TEST(utils, ranges_subrange) {
 
-    std::size_t begin = 1;
-    std::size_t end = 4;
+    std::size_t begin{1u};
+    std::size_t end{4u};
     std::array<std::size_t, 2> interval{begin, end};
 
     dvector<int> seq = {0, 1, 2, 3, 4, 5};
@@ -374,22 +375,22 @@ TEST(utils, ranges_subrange) {
     static_assert(std::is_copy_assignable_v<typename decltype(sr)::iterator_t>);
     static_assert(std::is_destructible_v<typename decltype(sr)::iterator_t>);
 
-    ASSERT_EQ(sr[1], seq[begin + 1]);
-    ASSERT_EQ(sr.size(), 3UL);
-    ASSERT_EQ(sr.front(), 1UL);
-    ASSERT_EQ(sr.back(), 3UL);
+    ASSERT_EQ(sr[1], seq[begin + 1u]);
+    ASSERT_EQ(sr.size(), 3u);
+    ASSERT_EQ(sr.front(), 1u);
+    ASSERT_EQ(sr.back(), 3u);
 
     // non-const iteration
-    std::size_t i = 1;
+    std::size_t i{1u};
     for (const auto& v : sr) {
-        ASSERT_NE(v, 0);
-        ASSERT_NE(v, 4);
+        ASSERT_NE(v, 0u);
+        ASSERT_NE(v, 4u);
         ASSERT_EQ(v, seq[i++]);
     }
 
     // const iteration
     const dvector<int> seq_c(seq);
-    i = 1;
+    i = 1u;
     for (const auto& v : detray::ranges::subrange(seq_c, interval)) {
         ASSERT_EQ(v, seq[i++]);
     }
@@ -402,8 +403,8 @@ TEST(utils, ranges_subrange) {
 // Integration test for enumeration of a subrange
 TEST(utils, ranges_subrange_iota) {
 
-    std::array<std::size_t, 2> seq{1, 10};
-    std::array<std::size_t, 2> interval{3, 7};
+    std::array<std::size_t, 2> seq{1u, 10u};
+    std::array<std::size_t, 2> interval{3u, 7u};
 
     auto iota_sr = detray::ranges::subrange(detray::views::iota(seq), interval);
 
@@ -411,7 +412,7 @@ TEST(utils, ranges_subrange_iota) {
     static_assert(detray::ranges::input_range_v<decltype(iota_sr)>);
     static_assert(not detray::ranges::forward_range_v<decltype(iota_sr)>);
 
-    std::size_t i{4};
+    std::size_t i{4u};
     for (const auto v : iota_sr) {
         ASSERT_EQ(i++, v);
     }
@@ -421,13 +422,13 @@ TEST(utils, ranges_subrange_iota) {
 TEST(utils, ranges_enumerated_subrange) {
 
     struct uint_holder {
-        unsigned int ui = 0;
+        unsigned int ui{0u};
     };
 
-    dvector<uint_holder> seq = {{0}, {1}, {2}, {3}, {4}, {5}};
+    dvector<uint_holder> seq = {{0u}, {1u}, {2u}, {3u}, {4u}, {5u}};
 
-    std::size_t begin = 1;
-    std::size_t end = 4;
+    std::size_t begin{1u};
+    std::size_t end{4u};
     std::array<std::size_t, 2> interval{begin, end};
 
     auto enum_sr =
@@ -437,25 +438,26 @@ TEST(utils, ranges_enumerated_subrange) {
     static_assert(detray::ranges::random_access_range_v<decltype(enum_sr)>);
 
     for (const auto [i, v] : enum_sr) {
-        ASSERT_EQ(i, v.ui - 1);
+        ASSERT_EQ(i, v.ui - 1u);
     }
 }
 
 // Integration test for the picking of indexed elements from another range
 TEST(utils, ranges_pick_joined_sequence) {
 
-    darray<dindex, 2> interval_1 = {2, 4};
-    darray<dindex, 2> interval_2 = {7, 9};
+    darray<dindex, 2> interval_1 = {2u, 4u};
+    darray<dindex, 2> interval_2 = {7u, 9u};
 
     // The indices of the iota elements to be picked
-    std::vector<dindex> reference = {2, 3, 7, 8};
+    std::vector<dindex> reference = {2u, 3u, 7u, 8u};
     std::vector<dindex> check = {};
 
     struct uint_holder {
-        unsigned int ui = 0;
+        unsigned int ui{0u};
     };
 
-    dvector<uint_holder> seq = {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}};
+    dvector<uint_holder> seq = {{0u}, {1u}, {2u}, {3u}, {4u},
+                                {5u}, {6u}, {7u}, {8u}};
 
     auto indices = detray::views::join(detray::views::iota(interval_1),
                                        detray::views::iota(interval_2));
@@ -469,15 +471,15 @@ TEST(utils, ranges_pick_joined_sequence) {
 
     // Test inherited member functions
     const auto [i, v] = selected[2];
-    ASSERT_EQ(i, 7UL);
-    ASSERT_EQ(v.ui, 7UL);
-    ASSERT_EQ(selected.size(), 4UL);
+    ASSERT_EQ(i, 7u);
+    ASSERT_EQ(v.ui, 7u);
+    ASSERT_EQ(selected.size(), 4u);
     const auto [i_front, v_front] = selected.front();
-    ASSERT_EQ(i_front, 2UL);
-    ASSERT_EQ(v_front.ui, 2UL);
+    ASSERT_EQ(i_front, 2u);
+    ASSERT_EQ(v_front.ui, 2u);
     const auto [i_back, v_back] = selected.back();
-    ASSERT_EQ(i_back, 8UL);
-    ASSERT_EQ(v_back.ui, 8UL);
+    ASSERT_EQ(i_back, 8u);
+    ASSERT_EQ(v_back.ui, 8u);
 
     for (auto [j, w] : selected) {
         ASSERT_TRUE(j == w.ui);

--- a/tests/unit_tests/covfie/constant_field.cpp
+++ b/tests/unit_tests/covfie/constant_field.cpp
@@ -23,7 +23,7 @@ TEST(Covfie, ConstantField1D) {
     field_t f(field_t::backend_t::configuration_t{2.f});
     field_t::view_t v(f);
 
-    for (float x = -100.f; x <= 100.f; x += 1.) {
+    for (float x = -100.f; x <= 100.f; x += 1.f) {
         EXPECT_EQ(v.at(x)[0], 2.f);
     }
 }
@@ -36,8 +36,8 @@ TEST(Covfie, ConstantField2D) {
     field_t f(field_t::backend_t::configuration_t{2.f, 5.f});
     field_t::view_t v(f);
 
-    for (float x = -100.f; x <= 100.f; x += 1.) {
-        for (float y = -100.f; y <= 100.f; y += 1.) {
+    for (float x = -100.f; x <= 100.f; x += 1.f) {
+        for (float y = -100.f; y <= 100.f; y += 1.f) {
             EXPECT_EQ(v.at(x, y)[0], 2.f);
             EXPECT_EQ(v.at(x, y)[1], 5.f);
         }
@@ -52,9 +52,9 @@ TEST(Covfie, ConstantField3D) {
     field_t f(field_t::backend_t::configuration_t{2.f, 5.f, -4.f});
     field_t::view_t v(f);
 
-    for (float x = -10.f; x <= 10.f; x += 1.) {
-        for (float y = -10.f; y <= 10.f; y += 1.) {
-            for (float z = -10.f; z <= 10.f; z += 1.) {
+    for (float x = -10.f; x <= 10.f; x += 1.f) {
+        for (float y = -10.f; y <= 10.f; y += 1.f) {
+            for (float z = -10.f; z <= 10.f; z += 1.f) {
                 EXPECT_EQ(v.at(x, y, z)[0], 2.f);
                 EXPECT_EQ(v.at(x, y, z)[1], 5.f);
                 EXPECT_EQ(v.at(x, y, z)[2], -4.f);

--- a/tests/unit_tests/device/cuda/container_cuda.cpp
+++ b/tests/unit_tests/device/cuda/container_cuda.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,7 +39,7 @@ TEST(container_cuda, multi_type_store) {
     store.emplace_back<1>(empty_context{}, 3.1f);
     store.emplace_back<1>(empty_context{}, 4.5f);
     store.emplace_back<2>(empty_context{}, 5.5);
-    store.emplace_back<2>(empty_context{}, 6.);
+    store.emplace_back<2>(empty_context{}, 6.0);
 
     vecmem::vector<std::size_t> int_vec{3UL, 4UL, 5UL};
     store.insert(int_vec);
@@ -50,14 +50,14 @@ TEST(container_cuda, multi_type_store) {
     store.insert(vecmem::vector<double>{10.5, 7.6});
 
     // CPU sum check
-    double cpu_sum = 0;
+    double cpu_sum = 0.;
     cpu_sum =
         std::accumulate(store.get<0>().begin(), store.get<0>().end(), cpu_sum);
     cpu_sum =
         std::accumulate(store.get<1>().begin(), store.get<1>().end(), cpu_sum);
     cpu_sum =
         std::accumulate(store.get<2>().begin(), store.get<2>().end(), cpu_sum);
-    EXPECT_FLOAT_EQ(cpu_sum, 69.9);
+    EXPECT_NEAR(cpu_sum, 69.9, 1e-6);
 
     // CUDA sum check
     typename host_store_type::view_type store_data = get_data(store);
@@ -68,5 +68,5 @@ TEST(container_cuda, multi_type_store) {
 
     get_sum(store_data, sum_data);
 
-    EXPECT_FLOAT_EQ(cpu_sum, cuda_sum[0]);
+    EXPECT_NEAR(cpu_sum, cuda_sum[0], 1e-6);
 }

--- a/tests/unit_tests/device/cuda/detector_cuda.cpp
+++ b/tests/unit_tests/device/cuda/detector_cuda.cpp
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 
 // System include(s)
-#include <climits>
+#include <limits>
 
 using namespace detray;
 
@@ -66,30 +66,30 @@ TEST(detector_cuda, detector) {
                   rectangles_data, discs_data, cylinders_data);
 
     // check if the same volume objects are copied
-    for (unsigned int i = 0; i < volumes_host.size(); i++) {
+    for (unsigned int i = 0u; i < volumes_host.size(); i++) {
         EXPECT_EQ(volumes_host[i] == volumes_device[i], true);
     }
 
     // check if the same surface objects are copied
-    for (unsigned int i = 0; i < surfaces_host.size(); i++) {
+    for (unsigned int i = 0u; i < surfaces_host.size(); i++) {
         EXPECT_EQ(surfaces_host[i] == surfaces_device[i], true);
     }
 
     // check if the same transform objects are copied
-    for (unsigned int i = 0; i < transforms_host.size(ctx0); i++) {
+    for (unsigned int i = 0u; i < transforms_host.size(ctx0); i++) {
         EXPECT_EQ(transforms_host.at(i, ctx0) == transforms_device[i], true);
     }
 
     // check if the same masks are copied
-    for (unsigned int i = 0; i < rectangles_host.size(); i++) {
+    for (unsigned int i = 0u; i < rectangles_host.size(); i++) {
         EXPECT_EQ(rectangles_host[i] == rectangles_device[i], true);
     }
 
-    for (unsigned int i = 0; i < discs_host.size(); i++) {
+    for (unsigned int i = 0u; i < discs_host.size(); i++) {
         EXPECT_EQ(discs_host[i] == discs_device[i], true);
     }
 
-    for (unsigned int i = 0; i < cylinders_host.size(); i++) {
+    for (unsigned int i = 0u; i < cylinders_host.size(); i++) {
         EXPECT_EQ(cylinders_host[i] == cylinders_device[i], true);
     }
 }
@@ -114,7 +114,7 @@ TEST(detector_cuda, enumerate) {
     // Create and fill the vector of surfaces
     vecmem::jagged_vector<surface_t> surfaces_host(volumes.size(), &mng_mr);
 
-    for (unsigned int i = 0; i < volumes.size(); i++) {
+    for (unsigned int i = 0u; i < volumes.size(); i++) {
         for (const auto [obj_idx, obj] : detray::views::enumerate(
                  detector.surfaces(), detector.volume_by_index(i))) {
             surfaces_host[i].push_back(obj);
@@ -126,7 +126,7 @@ TEST(detector_cuda, enumerate) {
     for (auto& surfs : surfaces_host) {
         capacities.push_back(surfs.size());
     }
-    std::vector<std::size_t> sizes(surfaces_host.size(), 0);
+    std::vector<std::size_t> sizes(surfaces_host.size(), 0u);
 
     vecmem::data::jagged_vector_buffer<surface_t> surfaces_buffer(
         sizes, capacities, mng_mr);
@@ -145,7 +145,7 @@ TEST(detector_cuda, enumerate) {
     copy(surfaces_buffer, surfaces_device);
 
     // Compare the surfaces_host and surfaces_device
-    for (unsigned int i = 0; i < surfaces_host.size(); i++) {
+    for (unsigned int i = 0u; i < surfaces_host.size(); i++) {
         EXPECT_EQ(surfaces_host[i], surfaces_device[i]);
     }
 }

--- a/tests/unit_tests/device/cuda/detector_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/detector_cuda_kernel.cu
@@ -32,19 +32,19 @@ __global__ void detector_test_kernel(
     vecmem::device_vector<cylinder_t> cylinders_device(cylinders_data);
 
     // copy objects - volume
-    for (unsigned int i = 0; i < det_device.volumes().size(); i++) {
+    for (unsigned int i = 0u; i < det_device.volumes().size(); i++) {
         volumes_device[i] = det_device.volume_by_index(i);
     }
 
     // copy objects - surfaces
-    for (unsigned int i = 0; i < det_device.surfaces().size(); i++) {
+    for (unsigned int i = 0u; i < det_device.surfaces().size(); i++) {
         surfaces_device[i] = det_device.surfaces()[i];
     }
 
     // copy objects - transforms
     auto& trfs = det_device.transform_store();
     auto ctx = typename detector_host_t::geometry_context{};
-    for (unsigned int i = 0; i < trfs.size(ctx); i++) {
+    for (unsigned int i = 0u; i < trfs.size(ctx); i++) {
         transforms_device[i] = trfs.at(i, ctx);
     }
 
@@ -52,28 +52,28 @@ __global__ void detector_test_kernel(
     auto& masks = det_device.mask_store();
     auto& rectangles =
         masks.template get<detector_host_t::masks::id::e_rectangle2>();
-    for (unsigned int i = 0; i < rectangles.size(); i++) {
+    for (unsigned int i = 0u; i < rectangles.size(); i++) {
         rectangles_device[i] = rectangles[i];
     }
 
     auto& discs =
         masks.template get<detector_host_t::masks::id::e_portal_ring2>();
-    for (unsigned int i = 0; i < discs.size(); i++) {
+    for (unsigned int i = 0u; i < discs.size(); i++) {
         discs_device[i] = discs[i];
     }
 
     auto& cylinders =
         masks.template get<detector_host_t::masks::id::e_portal_cylinder2>();
-    for (unsigned int i = 0; i < cylinders.size(); i++) {
+    for (unsigned int i = 0u; i < cylinders.size(); i++) {
         cylinders_device[i] = cylinders[i];
     }
 
     // print output test for surface finder
     /*auto& sf_finder_device = det_device.sf_finders_store();
-    for (unsigned int i_s = 0; i_s < sf_finder_device.size(); i_s++) {
+    for (unsigned int i_s = 0u; i_s < sf_finder_device.size(); i_s++) {
         auto& grid = sf_finder_device[i_s];
-        for (unsigned int i = 0; i < grid.axis_p0().bins(); i++) {
-            for (unsigned int j = 0; j < grid.axis_p1().bins(); j++) {
+        for (unsigned int i = 0u; i < grid.axis_p0().bins(); i++) {
+            for (unsigned int j = 0u; j < grid.axis_p1().bins(); j++) {
                 const auto& bin = grid.bin(i, j);
                 for (auto& id : bin) {
                     // printf("%d \n", id);
@@ -92,8 +92,8 @@ void detector_test(typename detector_host_t::detector_view_type det_data,
                    vecmem::data::vector_view<disc_t> discs_data,
                    vecmem::data::vector_view<cylinder_t> cylinders_data) {
 
-    constexpr int block_dim = 1;
-    constexpr int thread_dim = 1;
+    constexpr int block_dim = 1u;
+    constexpr int thread_dim = 1u;
 
     // run the test kernel
     detector_test_kernel<<<block_dim, thread_dim>>>(
@@ -140,7 +140,7 @@ void enumerate_test(typename detector_host_t::detector_view_type det_data,
 
     constexpr int thread_dim = WARP_SIZE * 2;
 
-    int block_dim = surfaces_data.size() / thread_dim + 1;
+    int block_dim = static_cast<int>(surfaces_data.size()) / thread_dim + 1;
 
     // run the test kernel
     enumerate_test_kernel<<<block_dim, thread_dim>>>(det_data, surfaces_data);

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
@@ -1,11 +1,12 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 // Detray include(s).
+#include "detray/definitions/units.hpp"
 #include "grids_grid2_cuda_kernel.hpp"
 
 // VecMem include(s).
@@ -16,8 +17,7 @@
 #include <gtest/gtest.h>
 
 // System include(s).
-#include <climits>
-#include <iostream>
+#include <limits>
 
 using namespace detray;
 
@@ -26,19 +26,21 @@ TEST(grids_cuda, grid2_replace_populator) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // axis
-    axis::regular<> xaxis{4, -1., 3., mng_mr};
-    axis::regular<> yaxis{6, 0., 6., mng_mr};
+    axis::regular<> xaxis{4u, -1.f, 3.f, mng_mr};
+    axis::regular<> yaxis{6u, 0.f, 6.f, mng_mr};
 
-    auto x_interval = (xaxis.max - xaxis.min) / xaxis.n_bins;
-    auto y_interval = (yaxis.max - yaxis.min) / yaxis.n_bins;
+    auto x_interval =
+        (xaxis.max - xaxis.min) / static_cast<detray::scalar>(xaxis.n_bins);
+    auto y_interval =
+        (yaxis.max - yaxis.min) / static_cast<detray::scalar>(yaxis.n_bins);
 
     // declare host grid
     host_grid2_replace g2(std::move(xaxis), std::move(yaxis), mng_mr,
-                          test::point3<detray::scalar>{0, 0, 0});
+                          test::point3<detray::scalar>{0.f, 0.f, 0.f});
 
     // pre-check
-    for (unsigned int i_x = 0; i_x < xaxis.bins(); i_x++) {
-        for (unsigned int i_y = 0; i_y < yaxis.bins(); i_y++) {
+    for (std::size_t i_x = 0u; i_x < xaxis.bins(); i_x++) {
+        for (std::size_t i_y = 0u; i_y < yaxis.bins(); i_y++) {
 
             const auto& data = g2.bin(i_x, i_y);
 
@@ -53,14 +55,14 @@ TEST(grids_cuda, grid2_replace_populator) {
     grid_replace_test(g2_data);
 
     // post-check
-    for (unsigned int i_x = 0; i_x < xaxis.bins(); i_x++) {
-        for (unsigned int i_y = 0; i_y < yaxis.bins(); i_y++) {
-            auto bin_id = i_x + i_y * xaxis.bins();
+    for (std::size_t i_x = 0u; i_x < xaxis.bins(); i_x++) {
+        for (std::size_t i_y = 0u; i_y < yaxis.bins(); i_y++) {
+            auto bin_id = static_cast<detray::scalar>(i_x + i_y * xaxis.bins());
             const auto& data = g2.bin(i_x, i_y);
 
             test::point3<detray::scalar> tp({xaxis.min + bin_id * x_interval,
                                              yaxis.min + bin_id * y_interval,
-                                             0.5});
+                                             0.5f});
 
             EXPECT_EQ(data, tp);
         }
@@ -72,18 +74,19 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // axis
-    axis::circular<> caxis{4, -2., 2., mng_mr};
-    axis::irregular<> iaxis{{1, 3, 9, 27, 81}, mng_mr};
+    axis::circular<> caxis{4u, -2.f, 2.f, mng_mr};
+    axis::irregular<> iaxis{{1.f, 3.f, 9.f, 27.f, 81.f}, mng_mr};
 
-    auto x_interval = (caxis.max - caxis.min) / caxis.n_bins;
+    auto x_interval =
+        (caxis.max - caxis.min) / static_cast<detray::scalar>(caxis.n_bins);
 
     // declare host grid
     host_grid2_replace_ci g2(std::move(caxis), std::move(iaxis), mng_mr,
-                             test::point3<detray::scalar>{0, 0, 0});
+                             test::point3<detray::scalar>{0.f, 0.f, 0.f});
 
     // pre-check
-    for (unsigned int i_x = 0; i_x < caxis.bins(); i_x++) {
-        for (unsigned int i_y = 0; i_y < iaxis.bins(); i_y++) {
+    for (std::size_t i_x = 0u; i_x < caxis.bins(); i_x++) {
+        for (std::size_t i_y = 0u; i_y < iaxis.bins(); i_y++) {
 
             const auto& data = g2.bin(i_x, i_y);
 
@@ -98,16 +101,16 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     grid_replace_ci_test(g2_data);
 
     // post-check
-    for (unsigned int i_x = 0; i_x < caxis.bins(); i_x++) {
-        for (unsigned int i_y = 0; i_y < iaxis.bins(); i_y++) {
+    for (std::size_t i_x = 0u; i_x < caxis.bins(); i_x++) {
+        for (std::size_t i_y = 0u; i_y < iaxis.bins(); i_y++) {
             auto y_interval = iaxis.boundaries[i_y + 1] - iaxis.boundaries[i_y];
-            auto bin_id = i_x + i_y * caxis.bins();
+            auto bin_id = static_cast<detray::scalar>(i_x + i_y * caxis.bins());
 
             const auto& data = g2.bin(i_x, i_y);
 
             test::point3<detray::scalar> tp({caxis.min + bin_id * x_interval,
                                              iaxis.min + bin_id * y_interval,
-                                             0.5});
+                                             0.5f});
 
             EXPECT_EQ(data, tp);
         }
@@ -119,16 +122,16 @@ TEST(grids_cuda, grid2_complete_populator) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // axis
-    axis::regular<> xaxis{7, -1., 6., mng_mr};
-    axis::regular<> yaxis{3, 0., 3., mng_mr};
+    axis::regular<> xaxis{7u, -1.f, 6.f, mng_mr};
+    axis::regular<> yaxis{3u, 0.f, 3.f, mng_mr};
 
     // declare grid
     host_grid2_complete g2(std::move(xaxis), std::move(yaxis), mng_mr,
-                           test::point3<detray::scalar>{0, 0, 0});
+                           test::point3<detray::scalar>{0.f, 0.f, 0.f});
 
     // pre-check
-    for (unsigned int i_x = 0; i_x < xaxis.bins(); i_x++) {
-        for (unsigned int i_y = 0; i_y < yaxis.bins(); i_y++) {
+    for (std::size_t i_x = 0u; i_x < xaxis.bins(); i_x++) {
+        for (std::size_t i_y = 0u; i_y < yaxis.bins(); i_y++) {
 
             const auto& data = g2.bin(i_x, i_y);
 
@@ -144,24 +147,27 @@ TEST(grids_cuda, grid2_complete_populator) {
     // fill the grid
     grid_complete_test(g2_data);
 
-    auto x_interval = (xaxis.max - xaxis.min) / xaxis.n_bins;
-    auto y_interval = (yaxis.max - yaxis.min) / yaxis.n_bins;
+    auto x_interval =
+        (xaxis.max - xaxis.min) / static_cast<detray::scalar>(xaxis.n_bins);
+    auto y_interval =
+        (yaxis.max - yaxis.min) / static_cast<detray::scalar>(yaxis.n_bins);
 
     // post-check
-    for (unsigned int i_y = 0; i_y < yaxis.bins(); i_y++) {
-        for (unsigned int i_x = 0; i_x < xaxis.bins(); i_x++) {
+    for (std::size_t i_y = 0u; i_y < yaxis.bins(); i_y++) {
+        for (std::size_t i_x = 0u; i_x < xaxis.bins(); i_x++) {
 
             const auto& data = g2.bin(i_x, i_y);
 
-            for (size_t i_p = 0; i_p < data.size(); i_p++) {
+            for (std::size_t i_p = 0u; i_p < data.size(); i_p++) {
                 auto& pt = data[i_p];
 
                 auto bin_id = i_x + i_y * xaxis.bins();
-                auto gid = i_p + bin_id * data.size();
+                auto gid =
+                    static_cast<detray::scalar>(i_p + bin_id * data.size());
 
                 test::point3<detray::scalar> tp({xaxis.min + gid * x_interval,
                                                  yaxis.min + gid * y_interval,
-                                                 0.5});
+                                                 0.5f});
                 EXPECT_EQ(pt, tp);
             }
         }
@@ -173,26 +179,29 @@ TEST(grids_cuda, grid2_attach_populator) {
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;
 
-    axis::circular<> xaxis{65, -M_PI, M_PI, mng_mr};
-    axis::regular<> yaxis{2, 0., 6., mng_mr};
+    axis::circular<> xaxis{65u, -detray::constant<scalar>::pi,
+                           detray::constant<scalar>::pi, mng_mr};
+    axis::regular<> yaxis{2u, 0.f, 6.f, mng_mr};
 
-    auto x_interval = (xaxis.max - xaxis.min) / xaxis.n_bins;
-    auto y_interval = (yaxis.max - yaxis.min) / yaxis.n_bins;
+    auto x_interval =
+        (xaxis.max - xaxis.min) / static_cast<detray::scalar>(xaxis.n_bins);
+    auto y_interval =
+        (yaxis.max - yaxis.min) / static_cast<detray::scalar>(yaxis.n_bins);
 
     host_grid2_attach g2(xaxis, yaxis, mng_mr,
-                         test::point3<detray::scalar>{0, 0, 0});
+                         test::point3<detray::scalar>{0.f, 0.f, 0.f});
 
-    for (unsigned int i_y = 0; i_y < yaxis.bins(); i_y++) {
-        for (unsigned int i_x = 0; i_x < xaxis.bins(); i_x++) {
+    for (std::size_t i_y = 0u; i_y < yaxis.bins(); i_y++) {
+        for (std::size_t i_x = 0u; i_x < xaxis.bins(); i_x++) {
 
-            for (int i_p = 0; i_p < 100; i_p++) {
+            for (std::size_t i_p = 0; i_p < 100; i_p++) {
 
                 auto bin_id = i_x + i_y * xaxis.bins();
-                auto gid = i_p + bin_id * 100;
+                auto gid = static_cast<detray::scalar>(i_p + bin_id * 100u);
 
                 test::point3<detray::scalar> tp({xaxis.min + gid * x_interval,
                                                  yaxis.min + gid * y_interval,
-                                                 0.5});
+                                                 0.5f});
                 g2.populate(i_x, i_y, std::move(tp));
             }
         }
@@ -213,8 +222,8 @@ TEST(grids_cuda, grid2_buffer_attach_populator) {
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;
 
-    axis::circular<> xaxis{2, -1., 3., mng_mr};
-    axis::regular<> yaxis{2, 0., 6., mng_mr};
+    axis::circular<> xaxis{2u, -1.f, 3.f, mng_mr};
+    axis::regular<> yaxis{2u, 0.f, 6.f, mng_mr};
 
     grid2_buffer<host_grid2_attach> g2_buffer(xaxis, yaxis, {2, 5, 8, 10},
                                               {100, 200, 300, 400}, mng_mr);
@@ -224,27 +233,27 @@ TEST(grids_cuda, grid2_buffer_attach_populator) {
     // Non-zero starting size not working yet so initial argument for sizes is
     // ignored (acts-projects/vecmem#95)
     const auto& ptr = g2_buffer._buffer.host_ptr();
-    EXPECT_EQ(ptr[0].size(), 0);
-    EXPECT_EQ(ptr[1].size(), 0);
-    EXPECT_EQ(ptr[2].size(), 0);
-    EXPECT_EQ(ptr[3].size(), 0);
-    EXPECT_EQ(ptr[0].capacity(), 100);
-    EXPECT_EQ(ptr[1].capacity(), 200);
-    EXPECT_EQ(ptr[2].capacity(), 300);
-    EXPECT_EQ(ptr[3].capacity(), 400);
+    EXPECT_EQ(ptr[0].size(), 0u);
+    EXPECT_EQ(ptr[1].size(), 0u);
+    EXPECT_EQ(ptr[2].size(), 0u);
+    EXPECT_EQ(ptr[3].size(), 0u);
+    EXPECT_EQ(ptr[0].capacity(), 100u);
+    EXPECT_EQ(ptr[1].capacity(), 200u);
+    EXPECT_EQ(ptr[2].capacity(), 300u);
+    EXPECT_EQ(ptr[3].capacity(), 400u);
 
     // fill each bin with 100 points
     grid_attach_fill_test(g2_buffer);
 
     host_grid2_attach g2(xaxis, yaxis, mng_mr,
-                         test::point3<detray::scalar>{0, 0, 0});
+                         test::point3<detray::scalar>{0.f, 0.f, 0.f});
     copy(g2_buffer._buffer, g2.data());
 
     // Check if each bin has 100 points
-    EXPECT_EQ(g2.data()[0].size(), 100);
-    EXPECT_EQ(g2.data()[1].size(), 100);
-    EXPECT_EQ(g2.data()[2].size(), 100);
-    EXPECT_EQ(g2.data()[3].size(), 100);
+    EXPECT_EQ(g2.data()[0].size(), 100u);
+    EXPECT_EQ(g2.data()[1].size(), 100u);
+    EXPECT_EQ(g2.data()[2].size(), 100u);
+    EXPECT_EQ(g2.data()[3].size(), 100u);
 
     // Check that we can give a non-const buffer to a function expecting
     // a const view.
@@ -259,8 +268,8 @@ TEST(grids_cuda, grid2_buffer_attach_populator2) {
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;
 
-    axis::circular<> xaxis{2, -1., 3., mng_mr};
-    axis::regular<> yaxis{2, 0., 6., mng_mr};
+    axis::circular<> xaxis{2u, -1.f, 3.f, mng_mr};
+    axis::regular<> yaxis{2u, 0.f, 6.f, mng_mr};
 
     grid2_buffer<host_grid2_attach> g2_buffer(xaxis, yaxis, {1, 2, 3, 4},
                                               mng_mr);
@@ -268,38 +277,38 @@ TEST(grids_cuda, grid2_buffer_attach_populator2) {
 
     // Check if the initialization works well
     const auto& ptr = g2_buffer._buffer.host_ptr();
-    EXPECT_EQ(ptr[0].size(), 1);
-    EXPECT_EQ(ptr[1].size(), 2);
-    EXPECT_EQ(ptr[2].size(), 3);
-    EXPECT_EQ(ptr[3].size(), 4);
-    EXPECT_EQ(ptr[0].capacity(), 1);
-    EXPECT_EQ(ptr[1].capacity(), 2);
-    EXPECT_EQ(ptr[2].capacity(), 3);
-    EXPECT_EQ(ptr[3].capacity(), 4);
+    EXPECT_EQ(ptr[0].size(), 1u);
+    EXPECT_EQ(ptr[1].size(), 2u);
+    EXPECT_EQ(ptr[2].size(), 3u);
+    EXPECT_EQ(ptr[3].size(), 4u);
+    EXPECT_EQ(ptr[0].capacity(), 1u);
+    EXPECT_EQ(ptr[1].capacity(), 2u);
+    EXPECT_EQ(ptr[2].capacity(), 3u);
+    EXPECT_EQ(ptr[3].capacity(), 4u);
 
     // Assign values to the vector elements
     grid_attach_assign_test(g2_buffer);
 
     host_grid2_attach g2(xaxis, yaxis, mng_mr,
-                         test::point3<detray::scalar>{0, 0, 0});
+                         test::point3<detray::scalar>{0.f, 0.f, 0.f});
     copy(g2_buffer._buffer, g2.data());
 
     // Check the outputs
-    auto bin0 = g2.bin(0);
-    EXPECT_EQ(bin0[0], test::point3<detray::scalar>({0., 1., 2.}));
+    auto bin0 = g2.bin(0u);
+    EXPECT_EQ(bin0[0], test::point3<detray::scalar>({0.f, 1.f, 2.f}));
 
-    auto bin1 = g2.bin(1);
-    EXPECT_EQ(bin1[0], test::point3<detray::scalar>({0., 1., 2.}));
-    EXPECT_EQ(bin1[1], test::point3<detray::scalar>({1., 2., 3.}));
+    auto bin1 = g2.bin(1u);
+    EXPECT_EQ(bin1[0], test::point3<detray::scalar>({0.f, 1.f, 2.f}));
+    EXPECT_EQ(bin1[1], test::point3<detray::scalar>({1.f, 2.f, 3.f}));
 
-    auto bin2 = g2.bin(2);
-    EXPECT_EQ(bin2[0], test::point3<detray::scalar>({0., 1., 2.}));
-    EXPECT_EQ(bin2[1], test::point3<detray::scalar>({1., 2., 3.}));
-    EXPECT_EQ(bin2[2], test::point3<detray::scalar>({2., 3., 4.}));
+    auto bin2 = g2.bin(2u);
+    EXPECT_EQ(bin2[0], test::point3<detray::scalar>({0.f, 1.f, 2.f}));
+    EXPECT_EQ(bin2[1], test::point3<detray::scalar>({1.f, 2.f, 3.f}));
+    EXPECT_EQ(bin2[2], test::point3<detray::scalar>({2.f, 3.f, 4.f}));
 
-    auto bin3 = g2.bin(3);
-    EXPECT_EQ(bin3[0], test::point3<detray::scalar>({0., 1., 2.}));
-    EXPECT_EQ(bin3[1], test::point3<detray::scalar>({1., 2., 3.}));
-    EXPECT_EQ(bin3[2], test::point3<detray::scalar>({2., 3., 4.}));
-    EXPECT_EQ(bin3[3], test::point3<detray::scalar>({3., 4., 5.}));
+    auto bin3 = g2.bin(3u);
+    EXPECT_EQ(bin3[0], test::point3<detray::scalar>({0.f, 1.f, 2.f}));
+    EXPECT_EQ(bin3[1], test::point3<detray::scalar>({1.f, 2.f, 3.f}));
+    EXPECT_EQ(bin3[2], test::point3<detray::scalar>({2.f, 3.f, 4.f}));
+    EXPECT_EQ(bin3[3], test::point3<detray::scalar>({3.f, 4.f, 5.f}));
 }

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda_kernel.cu
@@ -30,7 +30,7 @@ __global__ void grid_replace_test_kernel(
 
     auto gid = threadIdx.x + threadIdx.y * blockDim.x;
     auto pt = test::point3<detray::scalar>{axis0.min + gid * x_interval,
-                                           axis1.min + gid * y_interval, 0.5};
+                                           axis1.min + gid * y_interval, 0.5f};
 
     // replace the bin elements
     g2_device.populate(threadIdx.x, threadIdx.y, std::move(pt));
@@ -68,7 +68,7 @@ __global__ void grid_replace_ci_test_kernel(
 
     auto gid = threadIdx.x + threadIdx.y * blockDim.x;
     auto pt = test::point3<detray::scalar>{axis0.min + gid * x_interval,
-                                           axis1.min + gid * y_interval, 0.5};
+                                           axis1.min + gid * y_interval, 0.5f};
 
     // replace the bin elements
     g2_device.populate(threadIdx.x, threadIdx.y, std::move(pt));
@@ -100,8 +100,8 @@ __global__ void grid_complete_kernel(
     grid2_view<host_grid2_complete> grid_view) {
 
     // Let's try building the grid object
-    device_grid2_complete g2_device(grid_view,
-                                    test::point3<detray::scalar>{0, 0, 0});
+    device_grid2_complete g2_device(
+        grid_view, test::point3<detray::scalar>{0.f, 0.f, 0.f});
 
     const auto& axis0 = g2_device.axis_p0();
     const auto& axis1 = g2_device.axis_p1();
@@ -114,7 +114,7 @@ __global__ void grid_complete_kernel(
     for (int i_p = 0; i_p < n_points; i_p++) {
         auto gid = i_p + bin_id * n_points;
         auto pt = test::point3<detray::scalar>{
-            axis0.min + gid * x_interval, axis1.min + gid * y_interval, 0.5};
+            axis0.min + gid * x_interval, axis1.min + gid * y_interval, 0.5f};
         // printf("%f %f %f \n", pt[0], pt[1], pt[2]);
         g2_device.populate(threadIdx.x, threadIdx.y, std::move(pt));
     }
@@ -147,7 +147,7 @@ __global__ void grid_attach_read_test_kernel(
 
     // Let's try building the grid object
     const const_device_grid2_attach g2_device(
-        grid_view, test::point3<detray::scalar>{0, 0, 0});
+        grid_view, test::point3<detray::scalar>{0.f, 0.f, 0.f});
 
     auto data = g2_device.bin(threadIdx.x, threadIdx.y);
 
@@ -229,10 +229,10 @@ __global__ void grid_attach_assign_test_kernel(
 
     auto pts = g2_device.bin(threadIdx.x, threadIdx.y);
 
-    for (std::size_t i = 0; i < pts.size(); i++) {
+    for (std::size_t i = 0u; i < pts.size(); i++) {
         pts[i] = {static_cast<detray::scalar>(i),
-                  static_cast<detray::scalar>(i + 1),
-                  static_cast<detray::scalar>(i + 2)};
+                  static_cast<detray::scalar>(i + 1u),
+                  static_cast<detray::scalar>(i + 2u)};
     }
 }
 

--- a/tests/unit_tests/device/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda.cpp
@@ -28,13 +28,13 @@ TEST(mask_store_cuda, mask_store) {
     ASSERT_TRUE(store.template empty<e_single3>());
     ASSERT_TRUE(store.template empty<e_trapezoid2>());
 
-    store.template emplace_back<e_rectangle2>(empty_context{}, 0UL, 1.0f, 2.0f);
-    store.template emplace_back<e_trapezoid2>(empty_context{}, 0UL, 0.5f, 1.5f,
+    store.template emplace_back<e_rectangle2>(empty_context{}, 0u, 1.0f, 2.0f);
+    store.template emplace_back<e_trapezoid2>(empty_context{}, 0u, 0.5f, 1.5f,
                                               4.0f);
-    store.template emplace_back<e_ring2>(empty_context{}, 0UL, 1.0f, 10.0f);
-    store.template emplace_back<e_cylinder2>(empty_context{}, 0UL, 1.f, 0.5f,
+    store.template emplace_back<e_ring2>(empty_context{}, 0u, 1.0f, 10.0f);
+    store.template emplace_back<e_cylinder2>(empty_context{}, 0u, 1.f, 0.5f,
                                              2.0f);
-    store.template emplace_back<e_annulus2>(empty_context{}, 0UL, 1.f, 2.f, 3.f,
+    store.template emplace_back<e_annulus2>(empty_context{}, 0u, 1.f, 2.f, 3.f,
                                             4.f, 5.f, 6.f, 7.f);
 
     ASSERT_FALSE(store.empty<e_annulus2>());
@@ -47,9 +47,9 @@ TEST(mask_store_cuda, mask_store) {
     /** Generate random points for test **/
     vecmem::vector<point2> input_point2(n_points, &mng_mr);
 
-    for (int i = 0; i < n_points; i++) {
-        point2 rand_point2 = {static_cast<scalar>(rand() % 100 / 10.),
-                              static_cast<scalar>(rand() % 100 / 10.)};
+    for (unsigned int i = 0u; i < n_points; i++) {
+        point2 rand_point2 = {static_cast<scalar>(rand() % 100) / 10.f,
+                              static_cast<scalar>(rand() % 100) / 10.f};
         input_point2[i] = rand_point2;
     }
 
@@ -64,7 +64,7 @@ TEST(mask_store_cuda, mask_store) {
     const auto& annulus_mask = store.get<e_annulus2>()[0];
 
     /** get host results from is_inside function **/
-    for (int i = 0; i < n_points; i++) {
+    for (unsigned int i = 0u; i < n_points; i++) {
         output_host[0].push_back(rectangle_mask.is_inside(input_point2[i]));
         output_host[1].push_back(trapezoid_mask.is_inside(input_point2[i]));
         output_host[2].push_back(ring_mask.is_inside(input_point2[i]));
@@ -93,7 +93,7 @@ TEST(mask_store_cuda, mask_store) {
     copy(output_buffer, output_device);
 
     /** Compare the values **/
-    for (int i = 0; i < n_points; i++) {
+    for (unsigned int i = 0u; i < n_points; i++) {
         ASSERT_EQ(output_host[0][i], output_device[0][i]);
         ASSERT_EQ(output_host[0][i], output_device[0][i]);
         ASSERT_EQ(output_host[2][i], output_device[2][i]);

--- a/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
@@ -50,12 +50,12 @@ using trapezoid = mask<trapezoid2D<>>;
 /** Enumerate different mask types for convenience
  **/
 enum mask_ids : unsigned int {
-    e_rectangle2 = 0,
-    e_trapezoid2 = 1,
-    e_ring2 = 2,
-    e_cylinder2 = 3,
-    e_single3 = 4,
-    e_annulus2 = 5,
+    e_rectangle2 = 0u,
+    e_trapezoid2 = 1u,
+    e_ring2 = 2u,
+    e_cylinder2 = 3u,
+    e_single3 = 4u,
+    e_annulus2 = 5u,
 };
 
 using host_store_type =

--- a/tests/unit_tests/device/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda.cpp
@@ -34,13 +34,14 @@ TEST(navigator_cuda, navigator) {
     vecmem::vector<free_track_parameters<transform3>> tracks_device(&mng_mr);
 
     // Set origin position of tracks
-    const point3 ori{0., 0., 0.};
-    const scalar p_mag{10. * unit<scalar>::GeV};
+    const point3 ori{0.f, 0.f, 0.f};
+    const scalar p_mag{10.f * unit<scalar>::GeV};
 
     // Iterate through uniformly distributed momentum directions
     for (auto track :
          uniform_track_generator<free_track_parameters<transform3>>(
-             theta_steps, phi_steps, ori, p_mag, {0.01, M_PI}, {-M_PI, M_PI})) {
+             theta_steps, phi_steps, ori, p_mag, {0.01f, constant<scalar>::pi},
+             {-constant<scalar>::pi, constant<scalar>::pi})) {
         track.set_overstep_tolerance(overstep_tolerance);
 
         tracks_host.push_back(track);
@@ -55,7 +56,7 @@ TEST(navigator_cuda, navigator) {
     vecmem::jagged_vector<point3> position_records_host(theta_steps * phi_steps,
                                                         &mng_mr);
 
-    for (unsigned int i = 0; i < theta_steps * phi_steps; i++) {
+    for (unsigned int i = 0u; i < theta_steps * phi_steps; i++) {
 
         auto& track = tracks_host[i];
         stepper_t stepper;
@@ -93,7 +94,7 @@ TEST(navigator_cuda, navigator) {
     std::vector<size_t> sizes;
     std::vector<size_t> capacities;
 
-    for (unsigned int i = 0; i < theta_steps * phi_steps; i++) {
+    for (unsigned int i = 0u; i < theta_steps * phi_steps; i++) {
         sizes.push_back(0);
         capacities.push_back(volume_records_host[i].size());
     }
@@ -125,12 +126,12 @@ TEST(navigator_cuda, navigator) {
     copy(volume_records_buffer, volume_records_device);
     copy(position_records_buffer, position_records_device);
 
-    for (unsigned int i = 0; i < volume_records_host.size(); i++) {
+    for (unsigned int i = 0u; i < volume_records_host.size(); i++) {
 
         EXPECT_EQ(volume_records_host[i].size(),
                   volume_records_device[i].size());
 
-        for (unsigned int j = 0; j < volume_records_host[i].size(); j++) {
+        for (unsigned int j = 0u; j < volume_records_host[i].size(); j++) {
 
             EXPECT_EQ(volume_records_host[i][j], volume_records_device[i][j]);
 

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
@@ -41,15 +41,15 @@ using navigator_device_t = navigator<detector_device_t>;
 using stepper_t = line_stepper<transform3>;
 
 // detector configuration
-constexpr std::size_t n_brl_layers = 4;
-constexpr std::size_t n_edc_layers = 3;
+constexpr std::size_t n_brl_layers{4u};
+constexpr std::size_t n_edc_layers{3u};
 
 // geomery navigation configurations
-constexpr unsigned int theta_steps = 100;
-constexpr unsigned int phi_steps = 100;
+constexpr unsigned int theta_steps{100u};
+constexpr unsigned int phi_steps{100u};
 
-constexpr scalar pos_diff_tolerance = 1e-3;
-constexpr scalar overstep_tolerance = -1e-4;
+constexpr scalar pos_diff_tolerance{1e-3f};
+constexpr scalar overstep_tolerance{-1e-4f};
 
 // dummy propagator state
 template <typename navigation_t>

--- a/tests/unit_tests/device/cuda/propagator_cuda.cpp
+++ b/tests/unit_tests/device/cuda/propagator_cuda.cpp
@@ -40,13 +40,14 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
     vecmem::vector<free_track_parameters<transform3>> tracks_device(&mng_mr);
 
     // Set origin position of tracks
-    const point3 ori{0., 0., 0.};
-    const scalar p_mag{10. * unit<scalar>::GeV};
+    const point3 ori{0.f, 0.f, 0.f};
+    const scalar p_mag{10.f * unit<scalar>::GeV};
 
     // Iterate through uniformly distributed momentum directions
     for (auto track :
          uniform_track_generator<free_track_parameters<transform3>>(
-             theta_steps, phi_steps, ori, p_mag, {0.01, M_PI}, {-M_PI, M_PI})) {
+             theta_steps, phi_steps, ori, p_mag, {0.01f, constant<scalar>::pi},
+             {-constant<scalar>::pi, constant<scalar>::pi})) {
         track.set_overstep_tolerance(overstep_tolerance);
 
         // Put it into vector of trajectories

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
@@ -24,9 +24,9 @@ namespace {
 /// Test single entry bin content element by element
 template <typename content_t>
 void test_content(const content_t& bin_content, const content_t& expected) {
-    dindex i = 0;
+    unsigned int i{0u};
     for (const auto& elem : bin_content) {
-        ASSERT_FLOAT_EQ(elem, expected[i++]);
+        ASSERT_NEAR(elem, expected[i++], tol);
     }
 }
 
@@ -37,12 +37,12 @@ void test_entry_collection(const content_t& bin_content,
 
     // Running indices for the points in the collection and the elements of a
     // single point3
-    dindex i = 0, j = 0;
+    unsigned int i = 0u, j = 0u;
     for (const auto& entry : bin_content) {
         const auto& expt_entry = expected[i++];
-        j = 0;
+        j = 0u;
         for (const auto& elem : entry) {
-            ASSERT_FLOAT_EQ(elem, expt_entry[j++]);
+            ASSERT_NEAR(elem, expt_entry[j++], tol);
         }
     }
 }
@@ -72,17 +72,18 @@ TEST(grids_cuda, grid3_replace_populator) {
     typename axes_t::edges_storage_type bin_edges(&mng_mr);
 
     axis_data.reserve(3);
-    axis_data.insert(axis_data.begin(), {dindex_range{0, 3}, dindex_range{2, 6},
-                                         dindex_range{4, 10}});
+    axis_data.insert(
+        axis_data.begin(),
+        {dindex_range{0u, 3u}, dindex_range{2u, 6u}, dindex_range{4u, 10u}});
     bin_edges.reserve(6);
-    bin_edges.insert(bin_edges.begin(), {-1., 4., 0., 6., -5., 5.});
+    bin_edges.insert(bin_edges.begin(), {-1.f, 4.f, 0.f, 6.f, -5.f, 5.f});
 
     axes_t axes(std::move(axis_data), std::move(bin_edges));
 
     // build host grid
     host_grid3_replace::bin_storage_type bin_data(&mng_mr);
     bin_data.resize(
-        3 * 6 * 10,
+        3u * 6u * 10u,
         populator<host_grid3_replace::populator_impl>::init<point3>());
 
     host_grid3_replace g3(std::move(bin_data), std::move(axes));
@@ -92,9 +93,9 @@ TEST(grids_cuda, grid3_replace_populator) {
     const auto& axis_z = g3.template get_axis<n_axis::label::e_z>();
 
     // pre-check
-    for (std::size_t i_x = 0; i_x < axis_x.nbins(); i_x++) {
-        for (std::size_t i_y = 0; i_y < axis_y.nbins(); i_y++) {
-            for (std::size_t i_z = 0; i_z < axis_z.nbins(); i_z++) {
+    for (std::size_t i_x = 0u; i_x < axis_x.nbins(); i_x++) {
+        for (std::size_t i_y = 0u; i_y < axis_y.nbins(); i_y++) {
+            for (std::size_t i_z = 0u; i_z < axis_z.nbins(); i_z++) {
                 const auto& bin = g3.at({i_x, i_y, i_z});
                 auto invalid_bin = populator<
                     host_grid3_replace::populator_impl>::init<point3>();
@@ -106,17 +107,19 @@ TEST(grids_cuda, grid3_replace_populator) {
     grid_replace_test(get_data(g3), axis_x.nbins(), axis_y.nbins(),
                       axis_z.nbins());
     // post-check
-    for (std::size_t i_x = 0; i_x < axis_x.nbins(); i_x++) {
-        for (std::size_t i_y = 0; i_y < axis_y.nbins(); i_y++) {
-            for (std::size_t i_z = 0; i_z < axis_z.nbins(); i_z++) {
-                dindex gbin_idx = g3.serializer()(
+    for (std::size_t i_x = 0u; i_x < axis_x.nbins(); i_x++) {
+        for (std::size_t i_y = 0u; i_y < axis_y.nbins(); i_y++) {
+            for (std::size_t i_z = 0u; i_z < axis_z.nbins(); i_z++) {
+                const dindex gbin_idx = g3.serializer()(
                     g3.axes(), detray::n_axis::multi_bin<3>{i_x, i_y, i_z});
 
                 const auto& bin = g3.at(gbin_idx);
 
-                const point3 tp{axis_x.min() + gbin_idx * axis_x.bin_width(),
-                                axis_y.min() + gbin_idx * axis_y.bin_width(),
-                                axis_z.min() + gbin_idx * axis_z.bin_width()};
+                const detray::scalar gbin_idx_f{
+                    static_cast<detray::scalar>(gbin_idx)};
+                const point3 tp{axis_x.min() + gbin_idx_f * axis_x.bin_width(),
+                                axis_y.min() + gbin_idx_f * axis_y.bin_width(),
+                                axis_z.min() + gbin_idx_f * axis_z.bin_width()};
 
                 test_content(bin[0], tp);
             }
@@ -134,17 +137,18 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     typename axes_t::boundary_storage_type axis_data(&mng_mr);
     typename axes_t::edges_storage_type bin_edges(&mng_mr);
 
-    axis_data.reserve(2);
-    axis_data.insert(axis_data.end(), {dindex_range{0, 4}, dindex_range{5, 2}});
-    bin_edges.reserve(7);
-    bin_edges.insert(bin_edges.end(), {1., 3., 9., 27., 81., -2., 4.});
+    axis_data.reserve(2u);
+    axis_data.insert(axis_data.end(),
+                     {dindex_range{0u, 4u}, dindex_range{5u, 2u}});
+    bin_edges.reserve(7u);
+    bin_edges.insert(bin_edges.end(), {1.f, 3.f, 9.f, 27.f, 81.f, -2.f, 4.f});
 
     axes_t axes(std::move(axis_data), std::move(bin_edges));
 
     // build host grid
     host_grid2_replace_ci::bin_storage_type bin_data(&mng_mr);
     bin_data.resize(
-        2 * 4,
+        2u * 4u,
         populator<host_grid2_replace_ci::populator_impl>::init<point3>());
 
     host_grid2_replace_ci g2(std::move(bin_data), std::move(axes));
@@ -153,8 +157,8 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     const auto& axis_phi = g2.template get_axis<n_axis::label::e_phi>();
 
     // pre-check
-    for (std::size_t i_r = 0; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0; i_phi < axis_phi.nbins(); i_phi++) {
+    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
             const auto& bin = g2.at({i_r, i_phi});
             auto invalid_bin = populator<
                 host_grid2_replace_ci::populator_impl>::init<point3>();
@@ -167,15 +171,17 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     grid_replace_ci_test(get_data(g2), axis_r.nbins(), axis_phi.nbins());
 
     // post-check
-    for (std::size_t i_r = 0; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0; i_phi < axis_phi.nbins(); i_phi++) {
-            dindex gbin_idx = g2.serializer()(
+    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
+            const dindex gbin_idx = g2.serializer()(
                 g2.axes(), detray::n_axis::multi_bin<2>{i_r, i_phi});
             const auto& bin = g2.at(gbin_idx);
 
-            const point3 tp{axis_r.min() + gbin_idx * axis_r.bin_width(i_r),
-                            axis_phi.min() + gbin_idx * axis_phi.bin_width(),
-                            0.5};
+            const detray::scalar gbin_idx_f{
+                static_cast<detray::scalar>(gbin_idx)};
+            const point3 tp{axis_r.min() + gbin_idx_f * axis_r.bin_width(i_r),
+                            axis_phi.min() + gbin_idx_f * axis_phi.bin_width(),
+                            0.5f};
 
             test_content(bin[0], tp);
         }
@@ -192,20 +198,20 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     typename axes_t::boundary_storage_type axis_data(&mng_mr);
     typename axes_t::edges_storage_type bin_edges(&mng_mr);
 
-    axis_data.reserve(2);
+    axis_data.reserve(2u);
     axis_data.insert(axis_data.begin(),
-                      {dindex_range{0, 3}, dindex_range{2, 7}});
+                      {dindex_range{0u, 3u}, dindex_range{2u, 7u}});
     bin_edges.reserve(4);
-    bin_edges.insert(bin_edges.begin(), {0., 3., -1, 6.});
+    bin_edges.insert(bin_edges.begin(), {0.f, 3.f, -1.f, 6.f});
 
     axes_t axes(std::move(axis_data), std::move(bin_edges));
 
     // build host grid
-    const point3 first_tp{3., 3., 3.};
+    const point3 first_tp{3.f, 3.f, 3.f};
 
     host_grid2_complete::bin_storage_type bin_data(&mng_mr);
     bin_data.resize(
-        3 * 7,
+        3u * 7u,
 populator<host_grid2_complete::populator_impl>::init<point3>(first_tp));
 
     host_grid2_complete g2(std::move(bin_data), std::move(axes));
@@ -217,8 +223,8 @@ populator<host_grid2_complete::populator_impl>::init<point3>(first_tp));
     auto width_phi = axis_phi.bin_width();
 
     // pre-check
-    for (std::size_t i_r = 0; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0; i_phi < axis_phi.nbins(); i_phi++) {
+    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
             auto bin = g2.at({i_r, i_phi});
             auto invalid_bin =
                 populator<host_grid2_complete::populator_impl>::init<point3>(first_tp);
@@ -231,15 +237,16 @@ populator<host_grid2_complete::populator_impl>::init<point3>(first_tp));
     grid_complete_test(get_data(g2), axis_r.nbins(), axis_phi.nbins());
 
     // post-check
-    for (std::size_t i_r = 0; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0; i_phi < axis_phi.nbins(); i_phi++) {
-            dindex gbin_idx = g2.serializer()(
+    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
+            const dindex gbin_idx = g2.serializer()(
                 g2.axes(), detray::n_axis::multi_bin<2>{i_r, i_phi});
             const auto& bin = g2.at(gbin_idx);
 
             // Other point with which the bin has been completed
-            const point3 tp{axis_r.min() + gbin_idx * width_r,
-                            axis_phi.min() + gbin_idx * width_phi, 0.5};
+            const detray::scalar
+gbin_idx_f{static_cast<detray::scalar>(gbin_idx)}; const point3 tp{axis_r.min()
++ gbin_idx_f * width_r, axis_phi.min() + gbin_idx_f * width_phi, 0.5};
 
             // Go through all points and compare
             int pt_idx{0};
@@ -268,18 +275,19 @@ TEST(grids_cuda, grid2_attach_populator) {
 
     axis_data.reserve(2);
     axis_data.insert(axis_data.begin(),
-                      {dindex_range{0, 2}, dindex_range{2, 65}});
+                      {dindex_range{0u, 2u}, dindex_range{2u, 65u}});
     bin_edges.reserve(4);
-    bin_edges.insert(bin_edges.begin(), {0., 6., -M_PI, M_PI});
+    bin_edges.insert(bin_edges.begin(), {0.f, 6.f, -constant<scalar>::pi,
+constant<scalar>::pi});
 
     axes_t axes(std::move(axis_data), std::move(bin_edges));
 
     // build host grid
-    const point3 first_tp{3., 3., 3.};
-    const point3 invalid_tp{0., 0., 0.};
+    const point3 first_tp{3.f, 3.f, 3.f};
+    const point3 invalid_tp{0.f, 0.f, 0.f};
 
     host_grid2_attach::bin_storage_type bin_data(&mng_mr);
-    bin_data.resize(2 * 65,
+    bin_data.resize(2u * 65u,
                     populator<host_grid2_attach::populator_impl>::init<point3>(first_tp));
 
     host_grid2_attach g2(std::move(bin_data), std::move(axes));
@@ -291,8 +299,8 @@ TEST(grids_cuda, grid2_attach_populator) {
     auto width_phi = axis_phi.bin_width();
 
     // pre-check
-    for (std::size_t i_r = 0; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0; i_phi < axis_phi.nbins(); i_phi++) {
+    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
             auto bin = g2.at({i_r, i_phi});
             auto invalid_bin =
                 populator<host_grid2_complete::populator_impl>::init<point3>(first_tp);
@@ -305,15 +313,16 @@ TEST(grids_cuda, grid2_attach_populator) {
     grid_attach_test(get_data(g2), axis_r.nbins(), axis_phi.nbins());
 
     // post-check
-    for (std::size_t i_r = 0; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0; i_phi < axis_phi.nbins(); i_phi++) {
-            dindex gbin_idx = g2.serializer()(
+    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
+            const dindex gbin_idx = g2.serializer()(
                 g2.axes(), detray::n_axis::multi_bin<2>{i_r, i_phi});
             const auto& bin = g2.at(gbin_idx);
 
             // Other point with which the bin has been completed
-            const point3 tp{axis_r.min() + gbin_idx * width_r,
-                            axis_phi.min() + gbin_idx * width_phi, 0.5};
+            const detray::scalar
+gbin_idx_f{static_cast<detray::scalar>(gbin_idx)}; const point3 tp{axis_r.min()
++ gbin_idx_f * width_r, axis_phi.min() + gbin_idx_f * width_phi, 0.5};
 
             // Go through all points and compare
             int pt_idx{0};
@@ -349,11 +358,11 @@ TEST(grids_cuda, cylindrical3D_collection) {
     typename grid_collection_t::edges_storage_type bin_edges(&mng_mr);
 
     // Offsets for the grids into the bin storage
-    grid_offsets.reserve(3);
-    grid_offsets.insert(grid_offsets.begin(), {0UL, 48UL, 72UL});
+    grid_offsets.reserve(3u);
+    grid_offsets.insert(grid_offsets.begin(), {0u, 48u, 72u});
 
     // Offsets into edges container and #bins for all axes
-    edge_ranges.reserve(9);
+    edge_ranges.reserve(9u);
     edge_ranges.insert(
         edge_ranges.begin(),
         {dindex_range{0u, 2u}, dindex_range{2u, 4u}, dindex_range{4u, 6u},
@@ -361,19 +370,19 @@ TEST(grids_cuda, cylindrical3D_collection) {
          dindex_range{12u, 5u}, dindex_range{14u, 5u}, dindex_range{16u, 5u}});
 
     // Bin edges for all axes (two boundaries for regular binned axes)
-    bin_edges.reserve(18);
+    bin_edges.reserve(18u);
     bin_edges.insert(bin_edges.begin(),
-                     {-10, 10., -20., 20., 0., 120., -5., 5., -15., 15., 0.,
-                      50., -15, 15., -35., 35., 0., 550.});
+                     {-10.f, 10.f, -20.f, 20.f, 0.f, 120.f, -5.f, 5.f, -15.f,
+                      15.f, 0.f, 50.f, -15.f, 15.f, -35.f, 35.f, 0.f, 550.f});
 
     // Bin test entries
-    bin_data.resize(197UL);
+    bin_data.resize(197u);
     std::generate_n(
-        bin_data.begin(), 197UL,
+        bin_data.begin(), 197u,
         bin_content_sequence<populator<n_own_host_grid2_attach::populator_impl>,
                              dindex>());
 
-    vecmem::vector<std::size_t> n_bins(9, &mng_mr);
+    vecmem::vector<std::size_t> n_bins(9u, &mng_mr);
     vecmem::vector<std::array<dindex, 3>> result_bins(bin_data.size(), &mng_mr);
 
     grid_collection_t grid_coll(std::move(grid_offsets), std::move(bin_data),
@@ -390,17 +399,17 @@ TEST(grids_cuda, cylindrical3D_collection) {
                          axis_r.nbins(), axis_phi.nbins(), axis_z.nbins());
 
     // Compare results
-    EXPECT_EQ(4UL, n_bins[0]);
-    EXPECT_EQ(4UL, n_bins[1]);
-    EXPECT_EQ(8UL, n_bins[2]);
-    EXPECT_EQ(3UL, n_bins[3]);
-    EXPECT_EQ(3UL, n_bins[4]);
-    EXPECT_EQ(10UL, n_bins[5]);
-    EXPECT_EQ(7UL, n_bins[6]);
-    EXPECT_EQ(5UL, n_bins[7]);
-    EXPECT_EQ(7UL, n_bins[8]);
+    EXPECT_EQ(4u, n_bins[0]);
+    EXPECT_EQ(4u, n_bins[1]);
+    EXPECT_EQ(8u, n_bins[2]);
+    EXPECT_EQ(3u, n_bins[3]);
+    EXPECT_EQ(3u, n_bins[4]);
+    EXPECT_EQ(10u, n_bins[5]);
+    EXPECT_EQ(7u, n_bins[6]);
+    EXPECT_EQ(5u, n_bins[7]);
+    EXPECT_EQ(7u, n_bins[8]);
 
-    for (std::size_t i{0}; i < bin_data.size(); ++i) {
+    for (std::size_t i{0u}; i < bin_data.size(); ++i) {
         EXPECT_EQ(bin_data[i].content(), result_bins[i]);
     }
 }

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.cu
@@ -68,7 +68,7 @@ __global__ void grid_replace_ci_test_kernel(
     auto gid = threadIdx.x + threadIdx.y * blockDim.x;
 
     point3 tp{axis_r.min() + gid * axis_r.bin_width(threadIdx.x),
-              axis_phi.min() + gid * axis_phi.bin_width(), 0.5};
+              axis_phi.min() + gid * axis_phi.bin_width(), 0.5f};
 
     // replace the bin elements
     g2_device.populate({threadIdx.x, threadIdx.y}, std::move(tp));
@@ -104,7 +104,7 @@ __global__ void grid_complete_kernel(host_grid2_complete::view_type grid_view) {
 
     auto gid = threadIdx.x + threadIdx.y * blockDim.x;
     auto tp = point3{axis_r.min() + gid * axis_r.bin_width(),
-                     axis_phi.min() + gid * axis_phi.bin_width(), 0.5};
+                     axis_phi.min() + gid * axis_phi.bin_width(), 0.5f};
 
     g2_device.populate({threadIdx.x, threadIdx.y}, std::move(tp));
 }
@@ -143,7 +143,7 @@ __global__ void grid_attach_kernel(host_grid2_attach::view_type grid_view) {
 
     auto gid = threadIdx.x + threadIdx.y * blockDim.x;
     auto tp = point3{axis_r.min() + gid * width_r,
-                     axis_phi.min() + gid * width_phi, 0.5};
+                     axis_phi.min() + gid * width_phi, 0.5f};
 
     g2_device.populate({threadIdx.x, threadIdx.y}, std::move(tp));
 }

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.hpp
@@ -39,7 +39,8 @@ namespace detray {
 
 using namespace n_axis;
 
-static constexpr std::size_t n_points = 3;
+static constexpr scalar tol{1e-7f};
+static constexpr std::size_t n_points{3u};
 static constexpr bool is_owning = true;
 
 // Coordinate system definitions (all data-owning)

--- a/tests/unit_tests/device/cuda/transform_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/transform_store_cuda.cpp
@@ -31,30 +31,30 @@ TEST(transform_store_cuda, transform_store) {
 
     ASSERT_EQ(static_store.size(ctx0), 0u);
 
-    point3 t0{1., 2., 3.};
-    point3 z0{4., 2., 3.};
-    point3 x0{1., 0, 3.};
+    point3 t0{1.f, 2.f, 3.f};
+    point3 z0{4.f, 2.f, 3.f};
+    point3 x0{1.f, 0.f, 3.f};
     transform3 tf0{t0, z0, x0};
     static_store.push_back(tf0, ctx0);
     ASSERT_EQ(static_store.size(ctx0), 1u);
 
-    point3 t1{1., 1., 2.};
-    point3 z1{1., 0, 0};
-    point3 x1{0, 0, 2.};
+    point3 t1{1.f, 1.f, 2.f};
+    point3 z1{1.f, 0.f, 0.f};
+    point3 x1{0.f, 0.f, 2.f};
     transform3 tf1{t1, z1, x1};
     static_store.push_back(tf1, ctx1);
     ASSERT_EQ(static_store.size(ctx1), 2u);
 
-    point3 t2{2., 2., 5.};
-    point3 z2{0., 0., 0.};
-    point3 x2{1., 2., 3.};
+    point3 t2{2.f, 2.f, 5.f};
+    point3 z2{0.f, 0.f, 0.f};
+    point3 x2{1.f, 2.f, 3.f};
     transform3 tf2{t2, z2, x2};
     static_store.push_back(std::move(tf2), ctx0);
     ASSERT_EQ(static_store.size(ctx0), 3u);
 
-    point3 t3{2., 0., 5.};
-    point3 z3{1., 2., 3.};
-    point3 x3{0., 0., 0.};
+    point3 t3{2.f, 0.f, 5.f};
+    point3 z3{1.f, 2.f, 3.f};
+    point3 x3{0.f, 0.f, 0.f};
     transform3 tf3{t3, z3, x3};
     static_store.emplace_back(ctx0, std::move(t3));
     ASSERT_EQ(static_store.size(ctx0), 4u);
@@ -67,17 +67,17 @@ TEST(transform_store_cuda, transform_store) {
 
     // Fill input vector
     vecmem::vector<point3> input(&mng_mr);
-    for (unsigned int i = 0; i < n_transforms; i++) {
-        input.push_back({static_cast<scalar>(i), static_cast<scalar>(i + 1),
-                         static_cast<scalar>(i + 2)});
+    for (unsigned int i = 0u; i < n_transforms; i++) {
+        input.push_back({static_cast<scalar>(i), static_cast<scalar>(i + 1u),
+                         static_cast<scalar>(i + 2u)});
     }
 
     // Get transformed vector from host side
     std::vector<point3> output_host;
 
     auto range = detray::ranges::subrange(static_store.get(ctx0),
-                                          dindex_range{0, n_transforms});
-    int count = 0;
+                                          dindex_range{0u, n_transforms});
+    std::size_t count{0u};
     for (const auto& tf : range) {
         auto output = tf.point_to_global(input[count]);
         output_host.push_back(output);
@@ -94,7 +94,7 @@ TEST(transform_store_cuda, transform_store) {
                    static_store.size());
 
     // Compare the values
-    for (unsigned int i = 0; i < n_transforms; i++) {
+    for (unsigned int i = 0u; i < n_transforms; i++) {
         ASSERT_EQ(output_host[i], output_device[i]);
     }
 }

--- a/tests/unit_tests/device/cuda/transform_store_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/transform_store_cuda_kernel.cu
@@ -23,7 +23,7 @@ __global__ void transform_test_kernel(
     vecmem::device_vector<point3<detray::scalar>> output(output_data);
 
     auto range = detray::ranges::subrange(store.get(ctx0),
-                                          dindex_range{0, store.size(ctx0)});
+                                          dindex_range{0u, store.size(ctx0)});
     output[threadIdx.x] =
         range[threadIdx.x].point_to_global(input[threadIdx.x]);
 }

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda.cpp
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda.cpp
@@ -17,7 +17,7 @@ using namespace detray;
 // This tests the single value view
 TEST(utils_ranges_cuda, single) {
 
-    dindex value{251UL};
+    dindex value{251u};
     dindex check{std::numeric_limits<dindex>::max()};
 
     // Run the test code
@@ -37,16 +37,16 @@ TEST(utils_ranges_cuda, iota) {
     vecmem::cuda::managed_memory_resource managed_resource;
 
     // Input reference vector for test
-    vecmem::vector<dindex> reference({2, 3, 4, 5, 6});
+    vecmem::vector<dindex> reference({2u, 3u, 4u, 5u, 6u});
 
     // Const range for enumeration test
-    const darray<dindex, 2> range = {2, 7};
+    const darray<dindex, 2> range = {2u, 7u};
 
     // Output vector buffer for enumeration test
     vecmem::data::vector_buffer<dindex> check_buffer(
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(range[1] -
                                                                     range[0]),
-        0, managed_resource);
+        0u, managed_resource);
     copy.setup(check_buffer);
 
     // Run test function
@@ -70,7 +70,7 @@ TEST(utils_ranges_cuda, enumerate) {
     vecmem::cuda::managed_memory_resource managed_resource;
 
     // Input vector sequence for test
-    vecmem::vector<uint_holder> seq({{0}, {1}, {2}, {3}, {4}, {5}},
+    vecmem::vector<uint_holder> seq({{0u}, {1u}, {2u}, {3u}, {4u}, {5u}},
                                     &managed_resource);
 
     // Get vector_data object
@@ -79,12 +79,12 @@ TEST(utils_ranges_cuda, enumerate) {
     // Output vector buffer for enumeration test
     vecmem::data::vector_buffer<dindex> idx_buffer(
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(seq.size()),
-        0, managed_resource);
+        0u, managed_resource);
     copy.setup(idx_buffer);
 
     vecmem::data::vector_buffer<dindex> value_buffer(
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(seq.size()),
-        0, managed_resource);
+        0u, managed_resource);
     copy.setup(value_buffer);
 
     // Run test function
@@ -98,7 +98,7 @@ TEST(utils_ranges_cuda, enumerate) {
     copy(value_buffer, value_vec);
 
     // Check the result
-    for (std::size_t i = 0; i < idx_vec.size(); i++) {
+    for (std::size_t i = 0u; i < idx_vec.size(); i++) {
         ASSERT_EQ(idx_vec[i], value_vec[i]);
     }
 }
@@ -113,10 +113,10 @@ TEST(utils_ranges_cuda, pick) {
     vecmem::cuda::managed_memory_resource managed_resource;
 
     // Input vector sequence for test
-    vecmem::vector<uint_holder> seq({{0}, {1}, {2}, {3}, {4}, {5}},
+    vecmem::vector<uint_holder> seq({{0u}, {1u}, {2u}, {3u}, {4u}, {5u}},
                                     &managed_resource);
     // Input index sequence for test
-    vecmem::vector<dindex> idx({0, 2, 4, 5}, &managed_resource);
+    vecmem::vector<dindex> idx({0u, 2u, 4u, 5u}, &managed_resource);
 
     // Get vector_data object
     auto seq_data = vecmem::get_data(seq);
@@ -125,12 +125,12 @@ TEST(utils_ranges_cuda, pick) {
     // Output vector buffer for enumeration test
     vecmem::data::vector_buffer<dindex> idx_buffer(
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(seq.size()),
-        0, managed_resource);
+        0u, managed_resource);
     copy.setup(idx_buffer);
 
     vecmem::data::vector_buffer<dindex> value_buffer(
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(seq.size()),
-        0, managed_resource);
+        0u, managed_resource);
     copy.setup(value_buffer);
 
     // Run test function
@@ -144,7 +144,7 @@ TEST(utils_ranges_cuda, pick) {
     copy(value_buffer, value_vec);
 
     // Check the result
-    for (std::size_t i = 0; i < idx_vec.size(); i++) {
+    for (std::size_t i = 0u; i < idx_vec.size(); i++) {
         ASSERT_EQ(idx[i], idx_vec[i]);
         ASSERT_EQ(seq[idx_vec[i]].ui, value_vec[i]);
     }
@@ -160,9 +160,9 @@ TEST(utils_ranges_cuda, join) {
     vecmem::cuda::managed_memory_resource managed_resource;
 
     // Input vector sequence for test
-    vecmem::vector<uint_holder> seq_1({{0}, {1}, {2}, {3}, {4}, {5}},
+    vecmem::vector<uint_holder> seq_1({{0u}, {1u}, {2u}, {3u}, {4u}, {5u}},
                                       &managed_resource);
-    vecmem::vector<uint_holder> seq_2({{2}, {0}, {9}, {4}, {15}},
+    vecmem::vector<uint_holder> seq_2({{2u}, {0u}, {9u}, {4u}, {15u}},
                                       &managed_resource);
     // Get vector_data object
     auto seq_data_1 = vecmem::get_data(seq_1);
@@ -172,7 +172,7 @@ TEST(utils_ranges_cuda, join) {
     vecmem::data::vector_buffer<dindex> value_buffer(
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(
             seq_1.size() + seq_2.size()),
-        0, managed_resource);
+        0u, managed_resource);
     copy.setup(value_buffer);
 
     // Run test function
@@ -183,11 +183,11 @@ TEST(utils_ranges_cuda, join) {
     copy(value_buffer, value_vec);
 
     // First sequence
-    for (std::size_t i = 0; i < seq_1.size(); i++) {
+    for (std::size_t i = 0u; i < seq_1.size(); i++) {
         ASSERT_EQ(seq_1[i].ui, value_vec[i]);
     }
     // Second sequence
-    for (std::size_t i = 0; i < seq_1.size(); i++) {
+    for (std::size_t i = 0u; i < seq_1.size(); i++) {
         ASSERT_EQ(seq_2[i].ui, value_vec[i + seq_1.size()]);
     }
 }
@@ -207,13 +207,13 @@ TEST(utils_ranges_cuda, subrange) {
     auto seq_data = vecmem::get_data(seq);
 
     // Begin and end index for iteration
-    const std::size_t begin = 1;
-    const std::size_t end = 4;
+    const std::size_t begin{1u};
+    const std::size_t end{4u};
 
     // Output vector buffer for iteration test
     vecmem::data::vector_buffer<int> check_buffer(
         static_cast<vecmem::data::vector_buffer<int>::size_type>(end - begin),
-        0, managed_resource);
+        0u, managed_resource);
     copy.setup(check_buffer);
 
     // Run test function

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.cu
@@ -24,7 +24,7 @@ __global__ void single_kernel(const dindex value, dindex* result) {
 void test_single(const dindex value, dindex& check) {
     dindex* result{nullptr};
     cudaMallocManaged(&result, sizeof(dindex));
-    *result = 0;
+    *result = 0u;
 
     // run the kernel
     single_kernel<<<1, 1>>>(value, result);

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.hpp
@@ -21,7 +21,7 @@ namespace detray {
 
 /// Test type
 struct uint_holder {
-    dindex ui = 0;
+    dindex ui = 0u;
 };
 
 /// Test @c detray::views::single

--- a/tests/unit_tests/io/io_json_payload.cpp
+++ b/tests/unit_tests/io/io_json_payload.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,13 +9,14 @@
 
 #include "detray/definitions/geometry.hpp"
 #include "detray/definitions/grid_axis.hpp"
+#include "detray/definitions/units.hpp"
 #include "detray/io/json_io.hpp"
 
 TEST(io, json_algebra_payload) {
 
     detray::transform_payload p;
-    p.tr = {100., 200., 300.};
-    p.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
+    p.tr = {100.f, 200.f, 300.f};
+    p.rot = {1.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f};
 
     nlohmann::json j;
     j["transform"] = p;
@@ -32,8 +33,9 @@ TEST(io, json_axis_payload) {
     ea.binning = detray::n_axis::binning::e_regular;
     ea.bounds = detray::n_axis::bounds::e_circular;
     ea.label = detray::n_axis::label::e_phi;
-    ea.edges = {-M_PI, M_PI};
-    ea.bins = 10u;
+    ea.edges = {-detray::constant<detray::real_io>::pi,
+                detray::constant<detray::real_io>::pi};
+    ea.bins = 10UL;
 
     nlohmann::json je;
     je["axis"] = ea;
@@ -50,8 +52,8 @@ TEST(io, json_axis_payload) {
     va.binning = detray::n_axis::binning::e_irregular;
     va.bounds = detray::n_axis::bounds::e_closed;
     va.label = detray::n_axis::label::e_r;
-    va.edges = {0, 1, 4, 5, 8, 10};
-    va.bins = va.edges.size() - 1;
+    va.edges = {0.f, 1.f, 4.f, 5.f, 8.f, 10.f};
+    va.bins = va.edges.size() - 1UL;
 
     nlohmann::json jv;
     jv["axis"] = va;
@@ -67,17 +69,19 @@ TEST(io, json_axis_payload) {
 
 TEST(io, json_grid_payload) {
 
-    std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
-                                                      {1, 2}, {2, 1}, {2, 2}};
+    std::vector<std::vector<unsigned int>> entries = {
+        {0u, 1u}, {0u, 2u}, {1u, 1u}, {1u, 2u}, {2u, 1u}, {2u, 2u}};
 
-    detray::axis_payload a0{detray::n_axis::binning::e_regular,
-                            detray::n_axis::bounds::e_circular,
-                            detray::n_axis::label::e_phi,
-                            std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
+    detray::axis_payload a0{
+        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_circular,
+        detray::n_axis::label::e_phi,
+        std::vector<detray::real_io>{-detray::constant<detray::real_io>::pi,
+                                     detray::constant<detray::real_io>::pi},
+        3u};
 
     detray::axis_payload a1{
         detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_closed,
-        detray::n_axis::label::e_r, std::vector<detray::real_io>{0, 2u}, 2u};
+        detray::n_axis::label::e_r, std::vector<detray::real_io>{0.f, 2.f}, 2u};
 
     detray::grid_payload g;
     g.axes = {a0, a1};
@@ -107,17 +111,19 @@ TEST(io, single_object_payload) {
 TEST(io, grid_objects_payload) {
     detray::grid_objects_payload go;
 
-    std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
-                                                      {1, 2}, {2, 1}, {2, 2}};
+    std::vector<std::vector<unsigned int>> entries = {
+        {0u, 1u}, {0u, 2u}, {1u, 1u}, {1u, 2u}, {2u, 1u}, {2u, 2u}};
 
-    detray::axis_payload a0{detray::n_axis::binning::e_regular,
-                            detray::n_axis::bounds::e_circular,
-                            detray::n_axis::label::e_phi,
-                            std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
+    detray::axis_payload a0{
+        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_circular,
+        detray::n_axis::label::e_phi,
+        std::vector<detray::real_io>{-detray::constant<detray::real_io>::pi,
+                                     detray::constant<detray::real_io>::pi},
+        3u};
 
     detray::axis_payload a1{
         detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_closed,
-        detray::n_axis::label::e_r, std::vector<detray::real_io>{0, 2u}, 2u};
+        detray::n_axis::label::e_r, std::vector<detray::real_io>{0.f, 2.f}, 2u};
 
     detray::grid_payload g;
     g.axes = {a0, a1};
@@ -133,8 +139,8 @@ TEST(io, grid_objects_payload) {
     EXPECT_EQ(go.grid.entries, pgo.grid.entries);
 
     detray::transform_payload p;
-    p.tr = {100., 200., 300.};
-    p.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
+    p.tr = {100.f, 200.f, 300.f};
+    p.rot = {1.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f};
 
     detray::grid_objects_payload got;
     got.transform = p;
@@ -152,17 +158,19 @@ TEST(io, grid_objects_payload) {
 
 TEST(io, json_links_payload) {
 
-    std::vector<std::vector<unsigned int>> entries = {{0, 1}, {0, 2}, {1, 1},
-                                                      {1, 2}, {2, 1}, {2, 2}};
+    std::vector<std::vector<unsigned int>> entries = {
+        {0u, 1u}, {0u, 2u}, {1u, 1u}, {1u, 2u}, {2u, 1u}, {2u, 2u}};
 
-    detray::axis_payload a0{detray::n_axis::binning::e_regular,
-                            detray::n_axis::bounds::e_circular,
-                            detray::n_axis::label::e_phi,
-                            std::vector<detray::real_io>{-M_PI, M_PI}, 3u};
+    detray::axis_payload a0{
+        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_circular,
+        detray::n_axis::label::e_phi,
+        std::vector<detray::real_io>{-detray::constant<detray::real_io>::pi,
+                                     detray::constant<detray::real_io>::pi},
+        3u};
 
     detray::axis_payload a1{
         detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_closed,
-        detray::n_axis::label::e_r, std::vector<detray::real_io>{0, 2u}, 2u};
+        detray::n_axis::label::e_r, std::vector<detray::real_io>{0.f, 2.f}, 2u};
 
     detray::grid_payload g;
     g.axes = {a0, a1};
@@ -194,7 +202,7 @@ TEST(io, json_mask_payload) {
 
     detray::mask_payload m;
     m.shape = detray::mask_payload::mask_shape::cylinder3;
-    m.boundaries = {10., 100.};
+    m.boundaries = {10.f, 100.f};
 
     nlohmann::json j;
     j["mask"] = m;
@@ -208,7 +216,7 @@ TEST(io, json_mask_payload) {
 TEST(io, json_material_slab_payload) {
 
     detray::material_slab_payload m;
-    m.slab = {1., 2., 3., 4., 5.};
+    m.slab = {1.f, 2.f, 3.f, 4.f, 5.f};
 
     nlohmann::json j;
     j["material"] = m;
@@ -223,15 +231,15 @@ TEST(io, json_surface_payload) {
     detray::surface_payload s;
 
     detray::transform_payload t;
-    t.tr = {100., 200., 300.};
-    t.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
+    t.tr = {100.f, 200.f, 300.f};
+    t.rot = {1.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f};
 
     detray::mask_payload m;
     m.shape = detray::mask_payload::mask_shape::trapezoid2;
-    m.boundaries = {10., 20., 34., 1.4};
+    m.boundaries = {10.f, 20.f, 34.f, 1.4f};
 
     detray::material_slab_payload mat;
-    mat.slab = {1., 2., 3., 4., 5.};
+    mat.slab = {1.f, 2.f, 3.f, 4.f, 5.f};
 
     s.transform = t;
     s.mask = m;
@@ -259,15 +267,15 @@ TEST(io, json_portal_payload) {
     detray::surface_payload s;
 
     detray::transform_payload t;
-    t.tr = {100., 200., 300.};
-    t.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
+    t.tr = {100.f, 200.f, 300.f};
+    t.rot = {1.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f};
 
     detray::mask_payload m;
     m.shape = detray::mask_payload::mask_shape::trapezoid2;
-    m.boundaries = {10., 20., 34., 1.4};
+    m.boundaries = {10.f, 20.f, 34.f, 1.4f};
 
     detray::material_slab_payload mat;
-    mat.slab = {1., 2., 3., 4., 5.};
+    mat.slab = {1.f, 2.f, 3.f, 4.f, 5.f};
 
     s.transform = t;
     s.mask = m;
@@ -299,7 +307,7 @@ TEST(io, json_volume_bounds_payload) {
 
     detray::volume_bounds_payload vb;
     vb.type = detray::volume_id::e_cylinder;
-    vb.values = {0., 100., 120.};
+    vb.values = {0.f, 100.f, 120.f};
 
     nlohmann::json j;
     j["volume_bounds"] = vb;
@@ -313,12 +321,12 @@ TEST(io, json_volume_bounds_payload) {
 TEST(io, json_volume_payload) {
 
     detray::transform_payload t;
-    t.tr = {100., 200., 300.};
-    t.rot = {1., 0., 0., 0., 1., 0., 0., 0., 1};
+    t.tr = {100.f, 200.f, 300.f};
+    t.rot = {1.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f};
 
     detray::volume_bounds_payload vb;
     vb.type = detray::volume_id::e_cylinder;
-    vb.values = {0., 100., 120.};
+    vb.values = {0.f, 100.f, 120.f};
 
     detray::single_object_payload so;
     so.link = 0u;
@@ -330,10 +338,10 @@ TEST(io, json_volume_payload) {
 
     detray::mask_payload m;
     m.shape = detray::mask_payload::mask_shape::trapezoid2;
-    m.boundaries = {10., 20., 34., 1.4};
+    m.boundaries = {10.f, 20.f, 34.f, 1.4f};
 
     detray::material_slab_payload mat;
-    mat.slab = {1., 2., 3., 4., 5.};
+    mat.slab = {1.f, 2.f, 3.f, 4.f, 5.f};
 
     s.transform = t;
     s.mask = m;

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -150,16 +150,16 @@ inline void create_telescope(context_t &ctx, const trajectory_t &traj,
         vector3 m_local_z = algebra::vector::normalize(m_placement._dir);
 
         // Project onto the weakest direction component of the normal vector
-        vector3 e_i{0., 0., 0.};
+        vector3 e_i{0.f, 0.f, 0.f};
         scalar min = std::numeric_limits<scalar>::infinity();
-        dindex i = dindex_invalid;
-        for (unsigned int k = 0; k < 3; ++k) {
+        unsigned int i{std::numeric_limits<uint>::max()};
+        for (unsigned int k = 0u; k < 3u; ++k) {
             if (m_local_z[k] < min) {
                 min = m_local_z[k];
                 i = k;
             }
         }
-        e_i[i] = 1.;
+        e_i[i] = 1.f;
         vector3 proj = algebra::vector::dot(m_local_z, e_i) * m_local_z;
         // Local x axis is the normal to local y,z
         vector3 m_local_x = algebra::vector::normalize(e_i - proj);
@@ -199,11 +199,12 @@ auto create_telescope_detector(
     vecmem::memory_resource &resource,
     covfie::field<detector_registry::telescope_detector::bfield_backend_t>
         &&bfield,
-    std::vector<scalar> pos, trajectory_t traj = {{0, 0, 0}, 0, {0, 0, 1}, -1},
-    scalar half_x = 20. * unit<scalar>::mm,
-    scalar half_y = 20. * unit<scalar>::mm,
+    std::vector<scalar> pos,
+    trajectory_t traj = {{0.f, 0.f, 0.f}, 0.f, {0.f, 0.f, 1.f}, -1.f},
+    scalar half_x = 20.f * unit<scalar>::mm,
+    scalar half_y = 20.f * unit<scalar>::mm,
     const material<scalar> mat = silicon_tml<scalar>(),
-    const scalar thickness = 80 * unit<scalar>::um) {
+    const scalar thickness = 80.f * unit<scalar>::um) {
 
     // detector type
     using detector_t = detector<telescope_types, covfie::field, container_t>;
@@ -224,8 +225,10 @@ auto create_telescope_detector(
     plane_config pl_config{half_x, half_y, pos, mat, thickness};
 
     // volume boundaries are not needed. Same goes for portals
-    det.new_volume(volume_id::e_cylinder, {0., 0., 0., 0., -M_PI, M_PI});
-    typename detector_t::volume_type &vol = det.volume_by_index(0);
+    det.new_volume(
+        volume_id::e_cylinder,
+        {0.f, 0.f, 0.f, 0.f, -constant<scalar>::pi, constant<scalar>::pi});
+    typename detector_t::volume_type &vol = det.volume_by_index(0u);
 
     // Add module surfaces to volume
     typename detector_t::surface_container surfaces(&resource);
@@ -258,15 +261,15 @@ auto create_telescope_detector(
     vecmem::memory_resource &resource,
     covfie::field<detector_registry::telescope_detector::bfield_backend_t>
         &&bfield,
-    dindex n_surfaces = 10, scalar tel_length = 500. * unit<scalar>::mm,
-    trajectory_t traj = {{0, 0, 0}, 0, {0, 0, 1}, -1},
-    scalar half_x = 20. * unit<scalar>::mm,
-    scalar half_y = 20. * unit<scalar>::mm) {
+    std::size_t n_surfaces = 10u, scalar tel_length = 500.f * unit<scalar>::mm,
+    trajectory_t traj = {{0.f, 0.f, 0.f}, 0.f, {0.f, 0.f, 1.f}, -1.f},
+    scalar half_x = 20.f * unit<scalar>::mm,
+    scalar half_y = 20.f * unit<scalar>::mm) {
     // Generate equidistant positions
     std::vector<scalar> positions = {};
-    scalar pos = 0.;
-    scalar dist = tel_length / (n_surfaces - 1);
-    for (std::size_t i = 0; i < n_surfaces; ++i) {
+    scalar pos{0.f};
+    scalar dist{tel_length / static_cast<scalar>(n_surfaces - 1u)};
+    for (std::size_t i = 0u; i < n_surfaces; ++i) {
         positions.push_back(pos);
         pos += dist;
     }
@@ -283,11 +286,11 @@ template <bool unbounded_planes = true,
           typename container_t = host_container_types>
 auto create_telescope_detector(
     vecmem::memory_resource &resource, std::vector<scalar> pos,
-    trajectory_t traj = {{0, 0, 0}, 0, {0, 0, 1}, -1},
-    scalar half_x = 20. * unit<scalar>::mm,
-    scalar half_y = 20. * unit<scalar>::mm,
+    trajectory_t traj = {{0.f, 0.f, 0.f}, 0.f, {0.f, 0.f, 1.f}, -1.f},
+    scalar half_x = 20.f * unit<scalar>::mm,
+    scalar half_y = 20.f * unit<scalar>::mm,
     const material<scalar> mat = silicon_tml<scalar>(),
-    const scalar thickness = 80 * unit<scalar>::um) {
+    const scalar thickness = 80.f * unit<scalar>::um) {
 
     // Build the geometry
     return create_telescope_detector<unbounded_planes, trajectory_t,
@@ -303,11 +306,11 @@ template <bool unbounded_planes = true,
           typename trajectory_t = detail::ray<__plugin::transform3<scalar>>,
           typename container_t = host_container_types>
 auto create_telescope_detector(
-    vecmem::memory_resource &resource, dindex n_surfaces = 10,
-    scalar tel_length = 500. * unit<scalar>::mm,
-    trajectory_t traj = {{0, 0, 0}, 0, {0, 0, 1}, -1},
-    scalar half_x = 20. * unit<scalar>::mm,
-    scalar half_y = 20. * unit<scalar>::mm) {
+    vecmem::memory_resource &resource, std::size_t n_surfaces = 10u,
+    scalar tel_length = 500.f * unit<scalar>::mm,
+    trajectory_t traj = {{0.f, 0.f, 0.f}, 0.f, {0.f, 0.f, 1.f}, -1.f},
+    scalar half_x = 20.f * unit<scalar>::mm,
+    scalar half_y = 20.f * unit<scalar>::mm) {
 
     // Build the geometry
     return create_telescope_detector<unbounded_planes, trajectory_t,

--- a/utils/include/detray/detectors/create_toy_geometry.hpp
+++ b/utils/include/detray/detectors/create_toy_geometry.hpp
@@ -22,7 +22,7 @@
 #include <covfie/core/field.hpp>
 
 // System include(s)
-#include <climits>
+#include <limits>
 #include <stdexcept>
 #include <type_traits>
 
@@ -70,7 +70,7 @@ inline void add_cylinder_surface(
     const scalar max_z{std::max(lower_z, upper_z)};
 
     // translation
-    point3 tsl{0., 0., 0};
+    point3 tsl{0.f, 0.f, 0.f};
 
     // add transform and masks
     transforms.emplace_back(ctx, tsl);
@@ -82,13 +82,13 @@ inline void add_cylinder_surface(
 
     // add surface
     mask_link_type mask_link{cylinder_id,
-                             masks.template size<cylinder_id>() - 1};
+                             masks.template size<cylinder_id>() - 1u};
     material_link_type material_link{slab_id,
-                                     materials.template size<slab_id>() - 1};
+                                     materials.template size<slab_id>() - 1u};
     const surface_id sf_id = (volume_link != volume_idx)
                                  ? surface_id::e_portal
                                  : surface_id::e_passive;
-    surfaces.emplace_back(transforms.size(ctx) - 1, mask_link, material_link,
+    surfaces.emplace_back(transforms.size(ctx) - 1u, mask_link, material_link,
                           volume_idx, dindex_invalid, sf_id);
 }
 
@@ -128,7 +128,7 @@ inline void add_disc_surface(
     const scalar max_r{std::max(inner_r, outer_r)};
 
     // translation
-    point3 tsl{0., 0., z};
+    point3 tsl{0.f, 0.f, z};
 
     // add transform and mask
     transforms.emplace_back(ctx, tsl);
@@ -139,13 +139,13 @@ inline void add_disc_surface(
     materials.template emplace_back<slab_id>(empty_context{}, mat, thickness);
 
     // add surface
-    mask_link_type mask_link{disc_id, masks.template size<disc_id>() - 1};
+    mask_link_type mask_link{disc_id, masks.template size<disc_id>() - 1u};
     material_link_type material_link{slab_id,
-                                     materials.template size<slab_id>() - 1};
+                                     materials.template size<slab_id>() - 1u};
     const surface_id sf_id = (volume_link != volume_idx)
                                  ? surface_id::e_portal
                                  : surface_id::e_sensitive;
-    surfaces.emplace_back(transforms.size(ctx) - 1, mask_link, material_link,
+    surfaces.emplace_back(transforms.size(ctx) - 1u, mask_link, material_link,
                           volume_idx, dindex_invalid, sf_id);
 }
 
@@ -165,7 +165,6 @@ inline void add_disc_surface(
  * @param volume_links volume links for the portals of the volume
  * @param module_factory functor that adds module surfaces to volume
  */
-
 template <
     typename detector_t, typename factory_t,
     std::enable_if_t<
@@ -184,15 +183,15 @@ void create_cyl_volume(
         &volume_links,
     factory_t &module_factory) {
     // volume bounds
-    const scalar inner_r = std::min(lay_inner_r, lay_outer_r);
-    const scalar outer_r = std::max(lay_inner_r, lay_outer_r);
-    const scalar lower_z = std::min(lay_neg_z, lay_pos_z);
-    const scalar upper_z = std::max(lay_neg_z, lay_pos_z);
+    const scalar inner_r{std::min(lay_inner_r, lay_outer_r)};
+    const scalar outer_r{std::max(lay_inner_r, lay_outer_r)};
+    const scalar lower_z{std::min(lay_neg_z, lay_pos_z)};
+    const scalar upper_z{std::max(lay_neg_z, lay_pos_z)};
 
-    auto &cyl_volume =
-        det.new_volume(volume_id::e_cylinder,
-                       {inner_r, outer_r, lower_z, upper_z, -M_PI, M_PI});
-    cyl_volume.set_sf_finder(detector_t::sf_finders::id::e_default, 0);
+    auto &cyl_volume = det.new_volume(
+        volume_id::e_cylinder, {inner_r, outer_r, lower_z, upper_z,
+                                -constant<scalar>::pi, constant<scalar>::pi});
+    cyl_volume.set_sf_finder(detector_t::sf_finders::id::e_default, 0u);
 
     // Add module surfaces to volume
     typename detector_t::surface_container surfaces(&resource);
@@ -206,16 +205,16 @@ void create_cyl_volume(
     // negative and positive, inner and outer portal surface
     add_cylinder_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
                          transforms, inner_r, lower_z, upper_z, volume_links[0],
-                         vacuum<scalar>(), 0. * unit<scalar>::mm);
+                         vacuum<scalar>(), 0.f * unit<scalar>::mm);
     add_cylinder_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
                          transforms, outer_r, lower_z, upper_z, volume_links[1],
-                         vacuum<scalar>(), 0. * unit<scalar>::mm);
+                         vacuum<scalar>(), 0.f * unit<scalar>::mm);
     add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
                      transforms, inner_r, outer_r, lower_z, volume_links[2],
-                     vacuum<scalar>(), 0. * unit<scalar>::mm);
+                     vacuum<scalar>(), 0.f * unit<scalar>::mm);
     add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
                      transforms, inner_r, outer_r, upper_z, volume_links[3],
-                     vacuum<scalar>(), 0. * unit<scalar>::mm);
+                     vacuum<scalar>(), 0.f * unit<scalar>::mm);
 
     det.add_objects_per_volume(ctx, cyl_volume, surfaces, masks, transforms,
                                materials);
@@ -265,24 +264,25 @@ inline void create_barrel_modules(context_t &ctx, volume_type &vol,
     m_centers.reserve(n_phi_bins * n_z_bins);
 
     // prep work
-    scalar pi{static_cast<scalar>(M_PI)};
-    scalar phi_step{scalar{2} * pi / (n_phi_bins)};
-    scalar min_phi{-pi + scalar{0.5} * phi_step};
+    scalar phi_step{2.f * constant<scalar>::pi /
+                    static_cast<scalar>(n_phi_bins)};
+    scalar min_phi{-constant<scalar>::pi + 0.5f * phi_step};
 
-    scalar z_start{scalar{-0.5} * (n_z_bins - 1) *
-                   (scalar{2} * cfg.m_half_y - cfg.m_long_overlap)};
-    scalar z_step{(std::abs(z_start) - z_start) / (n_z_bins - 1)};
+    scalar z_start{-0.5f * static_cast<scalar>(n_z_bins - 1u) *
+                   (2.f * cfg.m_half_y - cfg.m_long_overlap)};
+    scalar z_step{(std::abs(z_start) - z_start) /
+                  static_cast<scalar>(n_z_bins - 1)};
 
     // loop over the z bins
-    for (size_t z_bin = 0; z_bin < size_t(n_z_bins); ++z_bin) {
+    for (std::size_t z_bin = 0u; z_bin < n_z_bins; ++z_bin) {
         // prepare z and r
-        scalar m_z{z_start + z_bin * z_step};
-        scalar m_r{(z_bin % 2) != 0u
-                       ? cfg.layer_r - scalar{0.5} * cfg.m_radial_stagger
-                       : cfg.layer_r + scalar{0.5} * cfg.m_radial_stagger};
-        for (size_t phiBin = 0; phiBin < size_t(n_phi_bins); ++phiBin) {
+        scalar m_z{z_start + static_cast<scalar>(z_bin) * z_step};
+        scalar m_r{(z_bin % 2u) != 0u
+                       ? cfg.layer_r - 0.5f * cfg.m_radial_stagger
+                       : cfg.layer_r + 0.5f * cfg.m_radial_stagger};
+        for (std::size_t phiBin = 0u; phiBin < n_phi_bins; ++phiBin) {
             // calculate the current phi value
-            scalar m_phi{min_phi + phiBin * phi_step};
+            scalar m_phi{min_phi + static_cast<scalar>(phiBin) * phi_step};
             m_centers.push_back(
                 point3{m_r * math_ns::cos(m_phi), m_r * std::sin(m_phi), m_z});
         }
@@ -311,10 +311,10 @@ inline void create_barrel_modules(context_t &ctx, volume_type &vol,
         scalar m_phi{algebra::getter::phi(m_center)};
         // Local z axis is the normal vector
         vector3 m_local_z{math_ns::cos(m_phi + cfg.m_tilt_phi),
-                          std::sin(m_phi + cfg.m_tilt_phi), 0.};
+                          std::sin(m_phi + cfg.m_tilt_phi), 0.f};
         // Local x axis the normal to local y,z
         vector3 m_local_x{-std::sin(m_phi + cfg.m_tilt_phi),
-                          math_ns::cos(m_phi + cfg.m_tilt_phi), 0.};
+                          math_ns::cos(m_phi + cfg.m_tilt_phi), 0.f};
 
         // Create the module transform
         transforms.emplace_back(ctx, m_center, m_local_z, m_local_x);
@@ -344,7 +344,7 @@ inline void add_cylinder_grid(const typename detector_t::geometry_context &ctx,
     // The cylinder portals are at the end of the surface range by construction
     const auto portal_link = vol.template obj_link<geo_obj_ids::e_portal>();
     const auto portal_mask_idx =
-        det.surfaces()[portal_link[1] - 3].mask().index();
+        det.surfaces()[portal_link[1] - 3u].mask().index();
     const auto &cyl_mask =
         det.mask_store().template get<cyl_id>().at(portal_mask_idx);
 
@@ -359,7 +359,7 @@ inline void add_cylinder_grid(const typename detector_t::geometry_context &ctx,
 
     det.sf_finder_store().template push_back<grid_id>(gbuilder());
     vol.set_sf_finder(grid_id,
-                      det.sf_finder_store().template size<grid_id>() - 1);
+                      det.sf_finder_store().template size<grid_id>() - 1u);
 }
 
 /** Helper function that creates a surface grid of trapezoidal endcap modules.
@@ -386,7 +386,7 @@ inline void add_disc_grid(const typename detector_t::geometry_context &ctx,
 
     // The cylinder portals are at the end of the surface range by construction
     auto portal_link = vol.template obj_link<geo_obj_ids::e_portal>();
-    auto portal_mask_idx = det.surfaces()[portal_link[1] - 1].mask().index();
+    auto portal_mask_idx = det.surfaces()[portal_link[1] - 1u].mask().index();
     const auto &disc_mask =
         det.mask_store().template get<disc_id>().at(portal_mask_idx);
 
@@ -397,7 +397,7 @@ inline void add_disc_grid(const typename detector_t::geometry_context &ctx,
 
     det.sf_finder_store().template push_back<grid_id>(gbuilder());
     vol.set_sf_finder(grid_id,
-                      det.sf_finder_store().template size<grid_id>() - 1);
+                      det.sf_finder_store().template size<grid_id>() - 1u);
 }
 
 /** Helper method for positioning of modules in an endcap ring
@@ -412,35 +412,34 @@ inline void add_disc_grid(const typename detector_t::geometry_context &ctx,
  */
 inline auto module_positions_ring(scalar z, scalar radius, scalar phi_stagger,
                                   scalar phi_sub_stagger,
-                                  std::size_t n_phi_bins) {
+                                  unsigned int n_phi_bins) {
     // create and fill the positions
     std::vector<vector3> r_positions;
     r_positions.reserve(n_phi_bins);
 
     // prep work
-    scalar pi{static_cast<scalar>(M_PI)};
-    scalar phi_step{scalar{2} * pi / (n_phi_bins)};
-    scalar min_phi{-pi + scalar{0.5} * phi_step};
+    scalar phi_step{2.f * constant<scalar>::pi /
+                    static_cast<scalar>(n_phi_bins)};
+    scalar min_phi{-constant<scalar>::pi + 0.5f * phi_step};
 
-    for (size_t iphi = 0; iphi < size_t(n_phi_bins); ++iphi) {
+    for (std::size_t iphi = 0; iphi < std::size_t(n_phi_bins); ++iphi) {
         // if we have a phi sub stagger presents
-        scalar rzs = 0.;
+        scalar rzs{0.f};
         // phi stagger affects 0 vs 1, 2 vs 3 ... etc
         // -> only works if it is a %4
         // phi sub stagger affects 2 vs 4, 1 vs 3 etc.
-        if (phi_sub_stagger != 0. && !(n_phi_bins % 4)) {
+        if (phi_sub_stagger != 0.f && !(n_phi_bins % 4u)) {
             // switch sides
-            if (!(iphi % 4)) {
+            if (!(iphi % 4u)) {
                 rzs = phi_sub_stagger;
-            } else if (!((iphi + 1) % 4)) {
+            } else if (!((iphi + 1u) % 4u)) {
                 rzs = -phi_sub_stagger;
             }
         }
         // the module phi
-        scalar phi{min_phi + iphi * phi_step};
+        scalar phi{min_phi + static_cast<scalar>(iphi) * phi_step};
         // main z position depending on phi bin
-        scalar rz{iphi % 2 ? z - scalar{0.5} * phi_stagger
-                           : z + scalar{0.5} * phi_stagger};
+        scalar rz{iphi % 2u ? z - 0.5f * phi_stagger : z + 0.5f * phi_stagger};
         r_positions.push_back(vector3{radius * math_ns::cos(phi),
                                       radius * std::sin(phi), rz + rzs});
     }
@@ -488,21 +487,22 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
     scalar delta_r{cfg.outer_r - cfg.inner_r};
 
     // Only one ring
-    if (cfg.disc_binning.size() == 1) {
-        radii.push_back(scalar{0.5} * (cfg.inner_r + cfg.outer_r));
+    if (cfg.disc_binning.size() == 1u) {
+        radii.push_back(0.5f * (cfg.inner_r + cfg.outer_r));
         // radial_boarders = {inner_r, outer_r};
     } else {
         // sum up the total length of the modules along r
-        scalar tot_length{0};
+        scalar tot_length{0.f};
         for (auto &m_hlength : cfg.m_half_y) {
-            tot_length += 2 * m_hlength + 0.5;
+            tot_length += 2.f * m_hlength + 0.5f;
         }
         // now calculate the overlap (equal pay)
-        scalar r_overlap{(tot_length - delta_r) / (cfg.m_half_y.size() - 1)};
+        scalar r_overlap{(tot_length - delta_r) /
+                         static_cast<scalar>(cfg.m_half_y.size() - 1u)};
         // and now fill the radii and gaps
         scalar prev_r{cfg.inner_r};
-        scalar prev_hl{0};
-        scalar prev_ol{0};
+        scalar prev_hl{0.f};
+        scalar prev_ol{0.f};
         // remember the radial boarders
         // radial_boarders.push_back(inner_r);
         for (auto &m_hlength : cfg.m_half_y) {
@@ -512,23 +512,22 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
             prev_ol = r_overlap;
             prev_hl = m_hlength;
             // and register the radial boarder
-            // radial_boarders.push_back(prev_r + scalar{2} * prev_hl -
-            // scalar{0.5} * prev_ol);
+            // radial_boarders.push_back(prev_r + 2.f * prev_hl -
+            // 0.5f * prev_ol);
         }
     }
 
     // now build the modules in every ring
-    for (size_t ir = 0; ir < radii.size(); ++ir) {
+    for (std::size_t ir = 0u; ir < radii.size(); ++ir) {
         // generate the z value
         // convention inner ring is closer to origin : makes sense
-        scalar rz{
-            radii.size() == 1
-                ? cfg.edc_position
-                : (ir % 2 ? cfg.edc_position + scalar{0.5} * cfg.ring_stagger
-                          : cfg.edc_position - scalar{0.5} * cfg.ring_stagger)};
+        scalar rz{radii.size() == 1u
+                      ? cfg.edc_position
+                      : (ir % 2u ? cfg.edc_position + 0.5f * cfg.ring_stagger
+                                 : cfg.edc_position - 0.5f * cfg.ring_stagger)};
         // fill the ring module positions
         scalar ps_stagger{
-            cfg.m_phi_sub_stagger.size() ? cfg.m_phi_sub_stagger[ir] : 0};
+            cfg.m_phi_sub_stagger.size() ? cfg.m_phi_sub_stagger[ir] : 0.f};
 
         std::vector<point3> r_postitions =
             module_positions_ring(rz, radii[ir], cfg.m_phi_stagger[ir],
@@ -545,7 +544,7 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
             masks.template emplace_back<trapezoid_id>(
                 empty_context{}, mask_volume_link, cfg.m_half_x_min_y[ir],
                 cfg.m_half_x_max_y[ir], cfg.m_half_y[ir],
-                static_cast<scalar>(1. / (2. * cfg.m_half_y[ir])));
+                1.f / (2.f * cfg.m_half_y[ir]));
 
             materials.template emplace_back<slab_id>(empty_context{}, cfg.mat,
                                                      cfg.thickness);
@@ -560,9 +559,9 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
             // the center position of the modules
             point3 m_center{static_cast<scalar>(cfg.side) * m_position};
             // the rotation matrix of the module
-            vector3 m_local_y{math_ns::cos(m_phi), std::sin(m_phi), 0.};
+            vector3 m_local_y{math_ns::cos(m_phi), std::sin(m_phi), 0.f};
             // take different axis to have the same readout direction
-            vector3 m_local_z{0., 0., cfg.side * scalar{1.}};
+            vector3 m_local_z{0.f, 0.f, static_cast<scalar>(cfg.side)};
             vector3 m_local_x = algebra::vector::cross(m_local_y, m_local_z);
 
             // Create the module transform
@@ -593,33 +592,33 @@ inline void add_beampipe(
 
     const dindex leaving_world = dindex_invalid;
 
-    scalar max_z =
-        n_edc_layers <= 0 ? brl_half_z : edc_lay_sizes[n_edc_layers - 1].second;
-    scalar min_z = -max_z;
+    scalar max_z{n_edc_layers == 0u ? brl_half_z
+                                    : edc_lay_sizes[n_edc_layers - 1u].second};
+    scalar min_z{-max_z};
 
     typename detector_t::surface_container surfaces(&resource);
     typename detector_t::mask_container masks(resource);
     typename detector_t::material_container materials(resource);
     typename detector_t::transform_container transforms(resource);
 
-    auto &beampipe =
-        det.new_volume(volume_id::e_cylinder,
-                       {beampipe_vol_size.first, beampipe_vol_size.second,
-                        min_z, max_z, -M_PI, M_PI});
+    auto &beampipe = det.new_volume(
+        volume_id::e_cylinder,
+        {beampipe_vol_size.first, beampipe_vol_size.second, min_z, max_z,
+         -constant<scalar>::pi, constant<scalar>::pi});
     const auto beampipe_idx = beampipe.index();
-    beampipe.set_sf_finder(detector_t::sf_finders::id::e_default, 0);
+    beampipe.set_sf_finder(detector_t::sf_finders::id::e_default, 0u);
 
     // This is the beampipe surface
     typename detector_t::surface_type::volume_link_type volume_link{
         beampipe_idx};
     add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
                          transforms, beampipe_r, min_z, max_z, volume_link,
-                         beryllium_tml<scalar>(), 0.8 * unit<scalar>::mm);
+                         beryllium_tml<scalar>(), 0.8f * unit<scalar>::mm);
 
     // Get vol sizes in z, including for gap volumes
     std::vector<std::pair<scalar, scalar>> vol_sizes{
         {brl_half_z, edc_lay_sizes[0].first}};
-    for (std::size_t i = 0; i < n_edc_layers; ++i) {
+    for (std::size_t i = 0u; i < n_edc_layers; ++i) {
         vol_sizes.emplace_back(edc_lay_sizes[i].first, edc_lay_sizes[i].second);
         vol_sizes.emplace_back(edc_lay_sizes[i].second,
                                edc_lay_sizes[i + 1].first);
@@ -628,41 +627,39 @@ inline void add_beampipe(
 
     // negative endcap portals
     dindex link = beampipe_idx;
-
-    int v_size = static_cast<int>(vol_sizes.size());
-
-    for (int i = v_size - 1; i >= 0; --i) {
+    for (int i = static_cast<int>(vol_sizes.size()) - 1; i >= 0; --i) {
         volume_link = ++link;
-        add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
-                             transforms, edc_inner_r, -vol_sizes[i].second,
-                             -vol_sizes[i].first, volume_link, vacuum<scalar>(),
-                             0. * unit<scalar>::mm);
+        add_cylinder_surface(
+            beampipe_idx, ctx, surfaces, masks, materials, transforms,
+            edc_inner_r, -vol_sizes[static_cast<std::size_t>(i)].second,
+            -vol_sizes[static_cast<std::size_t>(i)].first, volume_link,
+            vacuum<scalar>(), 0.f * unit<scalar>::mm);
     }
 
     // barrel portals
-    volume_link = n_brl_layers <= 0 ? leaving_world : link + 1;
+    volume_link = n_brl_layers <= 0u ? leaving_world : link + 1u;
     add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
                          transforms, edc_inner_r, -brl_half_z, brl_half_z,
-                         volume_link, vacuum<scalar>(), 0. * unit<scalar>::mm);
+                         volume_link, vacuum<scalar>(), 0.f * unit<scalar>::mm);
 
     // positive endcap portals
-    link += 7;
-    for (std::size_t i = 0; i < vol_sizes.size(); ++i) {
+    link += 7u;
+    for (std::size_t i = 0u; i < vol_sizes.size(); ++i) {
         volume_link = ++link;
         add_cylinder_surface(beampipe_idx, ctx, surfaces, masks, materials,
                              transforms, edc_inner_r, vol_sizes[i].second,
                              vol_sizes[i].first, volume_link, vacuum<scalar>(),
-                             0. * unit<scalar>::mm);
+                             0.f * unit<scalar>::mm);
     }
 
     // disc portals
     volume_link = leaving_world;
     add_disc_surface(beampipe_idx, ctx, surfaces, masks, materials, transforms,
                      beampipe_vol_size.first, beampipe_vol_size.second, min_z,
-                     volume_link, vacuum<scalar>(), 0. * unit<scalar>::mm);
+                     volume_link, vacuum<scalar>(), 0.f * unit<scalar>::mm);
     add_disc_surface(beampipe_idx, ctx, surfaces, masks, materials, transforms,
                      beampipe_vol_size.first, beampipe_vol_size.second, max_z,
-                     volume_link, vacuum<scalar>(), 0. * unit<scalar>::mm);
+                     volume_link, vacuum<scalar>(), 0.f * unit<scalar>::mm);
 
     det.add_objects_per_volume(ctx, beampipe, surfaces, masks, transforms,
                                materials);
@@ -692,20 +689,21 @@ inline void add_endcap_barrel_connection(
     const scalar edc_inner_r, const scalar edc_outer_r,
     const scalar gap_lower_z, const scalar gap_upper_z, dindex brl_vol_idx,
     const dindex edc_vol_idx) {
-    const scalar min_z = std::min(side * gap_lower_z, side * gap_upper_z);
-    const scalar max_z = std::max(side * gap_lower_z, side * gap_upper_z);
-    scalar edc_disc_z = side < 0 ? min_z : max_z;
-    scalar brl_disc_z = side < 0 ? max_z : min_z;
+    const scalar sign{static_cast<scalar>(side)};
+    const scalar min_z{std::min(sign * gap_lower_z, sign * gap_upper_z)};
+    const scalar max_z{std::max(sign * gap_lower_z, sign * gap_upper_z)};
+    const scalar edc_disc_z{side < 0 ? min_z : max_z};
+    const scalar brl_disc_z{side < 0 ? max_z : min_z};
 
     typename detector_t::surface_container surfaces(&resource);
     typename detector_t::mask_container masks(resource);
     typename detector_t::material_container materials(resource);
     typename detector_t::transform_container transforms(resource);
 
-    auto &connector_gap =
-        det.new_volume(volume_id::e_cylinder,
-                       {edc_inner_r, edc_outer_r, min_z, max_z, -M_PI, M_PI});
-    connector_gap.set_sf_finder(detector_t::sf_finders::id::e_default, 0);
+    auto &connector_gap = det.new_volume(
+        volume_id::e_cylinder, {edc_inner_r, edc_outer_r, min_z, max_z,
+                                -constant<scalar>::pi, constant<scalar>::pi});
+    connector_gap.set_sf_finder(detector_t::sf_finders::id::e_default, 0u);
     dindex connector_gap_idx{det.volumes().back().index()};
     dindex leaving_world = dindex_invalid;
 
@@ -713,31 +711,31 @@ inline void add_endcap_barrel_connection(
         beampipe_idx};
     add_cylinder_surface(connector_gap_idx, ctx, surfaces, masks, materials,
                          transforms, edc_inner_r, min_z, max_z, volume_link,
-                         vacuum<scalar>(), 0. * unit<scalar>::mm);
+                         vacuum<scalar>(), 0.f * unit<scalar>::mm);
     volume_link = leaving_world;
     add_cylinder_surface(connector_gap_idx, ctx, surfaces, masks, materials,
                          transforms, edc_outer_r, min_z, max_z, volume_link,
-                         vacuum<scalar>(), 0. * unit<scalar>::mm);
+                         vacuum<scalar>(), 0.f * unit<scalar>::mm);
     volume_link = edc_vol_idx;
     add_disc_surface(connector_gap_idx, ctx, surfaces, masks, materials,
                      transforms, edc_inner_r, edc_outer_r, edc_disc_z,
-                     volume_link, vacuum<scalar>(), 0. * unit<scalar>::mm);
+                     volume_link, vacuum<scalar>(), 0.f * unit<scalar>::mm);
 
     // Get vol sizes in z also for gap volumes
     std::vector<std::pair<scalar, scalar>> vol_sizes;
-    for (std::size_t i = 1; i <= n_brl_layers; ++i) {
+    for (std::size_t i = 1u; i <= n_brl_layers; ++i) {
         vol_sizes.emplace_back(brl_lay_sizes[i].first, brl_lay_sizes[i].second);
         vol_sizes.emplace_back(brl_lay_sizes[i].second,
-                               brl_lay_sizes[i + 1].first);
+                               brl_lay_sizes[i + 1u].first);
     }
 
     volume_link = brl_vol_idx;
-    for (std::size_t i = 0; i < 2 * n_brl_layers - 1; ++i) {
+    for (std::size_t i = 0u; i < 2u * n_brl_layers - 1u; ++i) {
         volume_link = brl_vol_idx++;
         add_disc_surface(connector_gap_idx, ctx, surfaces, masks, materials,
                          transforms, vol_sizes[i].first, vol_sizes[i].second,
                          brl_disc_z, volume_link, vacuum<scalar>(),
-                         0. * unit<scalar>::mm);
+                         0.f * unit<scalar>::mm);
     }
 
     det.add_objects_per_volume(ctx, connector_gap, surfaces, masks, transforms,
@@ -769,10 +767,10 @@ void add_endcap_detector(
     using volume_link_t = typename detector_t::surface_type::volume_link_type;
     std::vector<std::vector<volume_link_t>> volume_links_vec;
     dindex leaving_world = dindex_invalid;
-    dindex first_vol_idx = det.volumes().back().index() + 1;
-    dindex last_vol_idx = first_vol_idx + 2 * n_layers - 2;
-    dindex prev_vol_idx = first_vol_idx - 1;
-    dindex next_vol_idx = first_vol_idx + 1;
+    dindex first_vol_idx = det.volumes().back().index() + 1u;
+    dindex last_vol_idx = first_vol_idx + 2u * n_layers - 2u;
+    dindex prev_vol_idx = first_vol_idx - 1u;
+    dindex next_vol_idx = first_vol_idx + 1u;
 
     for (int i = 0; i < 2 * static_cast<int>(n_layers) - 3; ++i) {
         volume_links_vec.push_back(
@@ -782,27 +780,27 @@ void add_endcap_detector(
     if (cfg.side < 0) {
         volume_links_vec.insert(
             volume_links_vec.begin(),
-            {beampipe_idx, leaving_world, leaving_world, first_vol_idx + 1});
+            {beampipe_idx, leaving_world, leaving_world, first_vol_idx + 1u});
 
-        volume_links_vec.push_back(
-            {beampipe_idx, leaving_world, last_vol_idx - 1, last_vol_idx + 1});
+        volume_links_vec.push_back({beampipe_idx, leaving_world,
+                                    last_vol_idx - 1u, last_vol_idx + 1u});
     } else {
         // For n_layers=1 no extra gap layer is needed
-        if (n_layers > 1) {
+        if (n_layers > 1u) {
             volume_links_vec.insert(volume_links_vec.begin(),
                                     {beampipe_idx, leaving_world,
-                                     first_vol_idx - 1, first_vol_idx + 1});
+                                     first_vol_idx - 1u, first_vol_idx + 1u});
         }
 
         volume_links_vec.push_back(
-            {beampipe_idx, leaving_world, last_vol_idx - 1, leaving_world});
+            {beampipe_idx, leaving_world, last_vol_idx - 1u, leaving_world});
     }
 
     // Get vol sizes in z, including gap volumes
     std::vector<std::pair<scalar, scalar>> vol_sizes{
         {lay_sizes[0].first, lay_sizes[0].second}};
-    for (std::size_t i = 1; i < n_layers; ++i) {
-        vol_sizes.emplace_back(lay_sizes[i].first, lay_sizes[i - 1].second);
+    for (std::size_t i = 1u; i < n_layers; ++i) {
+        vol_sizes.emplace_back(lay_sizes[i].first, lay_sizes[i - 1u].second);
         vol_sizes.emplace_back(lay_sizes[i].first, lay_sizes[i].second);
     }
 
@@ -813,25 +811,28 @@ void add_endcap_detector(
     auto pos_itr = lay_positions.begin();
     // Reverse iteration for negative endcap
     if (cfg.side < 0) {
-        std::advance(vol_size_itr, 2 * n_layers - 2);
-        std::advance(pos_itr, n_layers - 1);
+        std::advance(vol_size_itr, 2u * n_layers - 2u);
+        std::advance(pos_itr, n_layers - 1u);
     }
     bool is_gap = true;
-    for (std::size_t i = 0; i < 2 * n_layers - 1; ++i) {
+    for (int i = 0; i < 2 * static_cast<int>(n_layers) - 1; ++i) {
         // Every second layer is a gap volume
         is_gap = !is_gap;
+        const scalar sign{static_cast<scalar>(cfg.side)};
         if (is_gap) {
             create_cyl_volume(det, resource, ctx, cfg.inner_r, cfg.outer_r,
-                              cfg.side * (vol_size_itr + cfg.side * i)->first,
-                              cfg.side * (vol_size_itr + cfg.side * i)->second,
-                              volume_links_vec[i], empty_factory);
+                              sign * (vol_size_itr + cfg.side * i)->first,
+                              sign * (vol_size_itr + cfg.side * i)->second,
+                              volume_links_vec[static_cast<std::size_t>(i)],
+                              empty_factory);
 
         } else {
             m_factory.cfg.edc_position = *(pos_itr + cfg.side * i / 2);
             create_cyl_volume(det, resource, ctx, cfg.inner_r, cfg.outer_r,
-                              cfg.side * (vol_size_itr + cfg.side * i)->first,
-                              cfg.side * (vol_size_itr + cfg.side * i)->second,
-                              volume_links_vec[i], m_factory);
+                              sign * (vol_size_itr + cfg.side * i)->first,
+                              sign * (vol_size_itr + cfg.side * i)->second,
+                              volume_links_vec[static_cast<std::size_t>(i)],
+                              m_factory);
             add_disc_grid(ctx, det.volumes().back(), det, cfg);
         }
     }
@@ -862,12 +863,12 @@ void add_barrel_detector(
     // Generate consecutive linking between volumes
     dindex leaving_world = dindex_invalid;
     dindex first_vol_idx = det.volumes().back().index();
-    dindex last_vol_idx = first_vol_idx + 2 * n_layers;
+    dindex last_vol_idx = first_vol_idx + 2u * n_layers;
     dindex prev_vol_idx = first_vol_idx;
-    dindex next_vol_idx = n_layers > 1 ? first_vol_idx + 2 : leaving_world;
+    dindex next_vol_idx = n_layers > 1u ? first_vol_idx + 2u : leaving_world;
 
     // Leave world, if no endcaps are present
-    if (det.volumes().back().index() == 0) {
+    if (det.volumes().back().index() == 0u) {
         first_vol_idx = leaving_world;
         last_vol_idx = leaving_world;
     }
@@ -877,7 +878,7 @@ void add_barrel_detector(
     std::vector<std::vector<volume_link_t>> volume_links_vec{
         {beampipe_idx, next_vol_idx, first_vol_idx, last_vol_idx}};
 
-    for (std::size_t i = 1; i < 2 * n_layers - 2; ++i) {
+    for (std::size_t i = 1u; i < 2u * n_layers - 2u; ++i) {
         volume_links_vec.push_back(
             {++prev_vol_idx, ++next_vol_idx, first_vol_idx, last_vol_idx});
     }
@@ -888,16 +889,16 @@ void add_barrel_detector(
     // Get vol sizes in z, including gap volumes
     std::vector<std::pair<scalar, scalar>> vol_sizes{
         {lay_sizes[1].first, lay_sizes[1].second}};
-    for (std::size_t i = 2; i < n_layers + 1; ++i) {
-        vol_sizes.emplace_back(lay_sizes[i].first, lay_sizes[i - 1].second);
+    for (std::size_t i = 2u; i < n_layers + 1u; ++i) {
+        vol_sizes.emplace_back(lay_sizes[i].first, lay_sizes[i - 1u].second);
         vol_sizes.emplace_back(lay_sizes[i].first, lay_sizes[i].second);
     }
 
     brl_module_factory m_factory{cfg};
     empty_vol_factory empty_factory{};
     bool is_gap = true;
-    for (unsigned int i = 0; i < 2 * n_layers - 1; ++i) {
-        unsigned int j = (i + 2) / 2;
+    for (unsigned int i = 0u; i < 2u * n_layers - 1u; ++i) {
+        unsigned int j = (i + 2u) / 2u;
         // Every second layer is a gap volume
         is_gap = !is_gap;
         if (is_gap) {
@@ -931,7 +932,7 @@ template <typename container_t = host_container_types>
 auto create_toy_geometry(
     vecmem::memory_resource &resource,
     covfie::field<detector_registry::toy_detector::bfield_backend_t> &&bfield,
-    std::size_t n_brl_layers = 4, std::size_t n_edc_layers = 3) {
+    unsigned int n_brl_layers = 4u, unsigned int n_edc_layers = 3u) {
 
     // detector type
     using detector_t =
@@ -943,52 +944,56 @@ auto create_toy_geometry(
     //
     // barrel
     //
-    constexpr scalar brl_half_z{500.};
-    const std::vector<scalar> brl_positions = {19., 32., 72., 116., 172.};
+    constexpr scalar brl_half_z{500.f};
+    const std::vector<scalar> brl_positions = {19.f, 32.f, 72.f, 116.f, 172.f};
     const std::vector<std::pair<scalar, scalar>> brl_lay_sizes = {
-        {0., 27.}, {27., 38.}, {64., 80.}, {108., 124.}, {164., 180.}};
+        {0.f, 27.f},
+        {27.f, 38.f},
+        {64.f, 80.f},
+        {108.f, 124.f},
+        {164.f, 180.f}};
     const std::vector<std::pair<int, int>> brl_binning = {
-        {0., 0.}, {16, 14}, {32, 14}, {52, 14}, {78, 14}};
+        {0.f, 0.f}, {16.f, 14.f}, {32.f, 14.f}, {52.f, 14.f}, {78.f, 14.f}};
     // module parameters
     struct brl_m_config {
-        scalar m_half_x{8.4};
-        scalar m_half_y{36.};
-        scalar m_tilt_phi{0.14};  // 0.145;
-        scalar layer_r{32.};
-        scalar m_radial_stagger{0.5};  // 2.;
-        scalar m_long_overlap{2.};     // 5.;
-        std::pair<std::size_t, std::size_t> m_binning = {16, 14};
+        scalar m_half_x{8.4f};
+        scalar m_half_y{36.f};
+        scalar m_tilt_phi{0.14f};  // 0.145;
+        scalar layer_r{32.f};
+        scalar m_radial_stagger{0.5f};  // 2.;
+        scalar m_long_overlap{2.f};     // 5.;
+        std::pair<unsigned int, unsigned int> m_binning = {16u, 14u};
         material<scalar> mat = silicon_tml<scalar>();
-        scalar thickness = 0.15 * unit<scalar>::mm;
+        scalar thickness{0.15f * unit<scalar>::mm};
     };
 
     //
     // endcaps
     //
-    const std::vector<scalar> edc_positions = {600.,  700.,  820., 960.,
-                                               1100., 1300., 1500.};
+    const std::vector<scalar> edc_positions = {600.f,  700.f,  820.f, 960.f,
+                                               1100.f, 1300.f, 1500.f};
     const std::vector<std::pair<scalar, scalar>> edc_lay_sizes = {
-        {595., 605.},   {695., 705.},   {815., 825.},  {955., 965.},
-        {1095., 1105.}, {1295., 1305.}, {1495., 1505.}};
+        {595.f, 605.f},   {695.f, 705.f},   {815.f, 825.f},  {955.f, 965.f},
+        {1095.f, 1105.f}, {1295.f, 1305.f}, {1495.f, 1505.f}};
     // module params
     struct edc_m_config {
         int side{1};
-        scalar inner_r{27.};
-        scalar outer_r{180.};
-        scalar edc_position{600.};
-        scalar ring_stagger{1.0};
+        scalar inner_r{27.f};
+        scalar outer_r{180.f};
+        scalar edc_position{600.f};
+        scalar ring_stagger{1.f};
         // Parameters for both rings of modules
-        std::vector<scalar> m_phi_stagger = {4.0, 4.0};
-        std::vector<scalar> m_phi_sub_stagger = {0.5, 0.5};
-        std::vector<std::size_t> disc_binning = {40, 68};
-        std::vector<scalar> m_half_y = {36., 36.};
-        // std::vector<scalar> m_half_x_min_y = {8.4, 8.4};
-        // std::vector<scalar> m_half_x_max_y = {10.1, 10.1};
-        std::vector<scalar> m_half_x_min_y = {8.4, 8.4};
-        std::vector<scalar> m_half_x_max_y = {12.4, 12.4};
-        std::vector<scalar> m_tilt = {0., 0.};
+        std::vector<scalar> m_phi_stagger = {4.f, 4.f};
+        std::vector<scalar> m_phi_sub_stagger = {0.5f, 0.5f};
+        std::vector<unsigned int> disc_binning = {40u, 68u};
+        std::vector<scalar> m_half_y = {36.f, 36.f};
+        // std::vector<scalar> m_half_x_min_y = {8.4f, 8.4f};
+        // std::vector<scalar> m_half_x_max_y = {10.1f, 10.1f};
+        std::vector<scalar> m_half_x_min_y = {8.4f, 8.4f};
+        std::vector<scalar> m_half_x_max_y = {12.4f, 12.4f};
+        std::vector<scalar> m_tilt = {0.f, 0.f};
         material<scalar> mat = silicon_tml<scalar>();
-        scalar thickness = 0.15 * unit<scalar>::mm;
+        scalar thickness{0.15f * unit<scalar>::mm};
     };
 
     // Don't create modules in gap volume
@@ -1046,10 +1051,10 @@ auto create_toy_geometry(
             "ERROR: Too many endcap layers requested (max " +
             std::to_string(edc_positions.size()) + ")!");
     }
-    if (n_brl_layers > brl_positions.size() - 1) {
+    if (n_brl_layers > brl_positions.size() - 1u) {
         throw std::invalid_argument(
             "ERROR: Too many barrel layers requested (max " +
-            std::to_string(brl_positions.size() - 1) + ")!");
+            std::to_string(brl_positions.size() - 1u) + ")!");
     }
     // the radius of the endcaps and  the barrel section need to match
     if (n_edc_layers > 0 and
@@ -1060,12 +1065,12 @@ auto create_toy_geometry(
     }
 
     // beampipe
-    dindex beampipe_idx = 0;
+    dindex beampipe_idx = 0u;
     add_beampipe(det, resource, ctx0, n_edc_layers, n_brl_layers, edc_lay_sizes,
                  brl_lay_sizes[0], brl_positions[0], brl_half_z,
                  edc_config.inner_r);
 
-    if (n_edc_layers > 0) {
+    if (n_edc_layers > 0u) {
         edc_config.side = -1;
         // negative endcap layers
         add_endcap_detector<empty_vol_factory, edc_module_factory>(
@@ -1074,31 +1079,31 @@ auto create_toy_geometry(
 
         // gap volume that connects barrel and neg. endcap
         dindex prev_vol_idx = det.volumes().back().index();
-        prev_vol_idx = prev_vol_idx == 0 ? leaving_world : prev_vol_idx;
-        dindex next_vol_idx = n_brl_layers == 0
+        prev_vol_idx = prev_vol_idx == 0u ? leaving_world : prev_vol_idx;
+        dindex next_vol_idx = n_brl_layers == 0u
                                   ? leaving_world
-                                  : det.volumes().back().index() + 2;
+                                  : det.volumes().back().index() + 2u;
 
         add_endcap_barrel_connection(
             det, resource, ctx0, edc_config.side, n_brl_layers, beampipe_idx,
             brl_lay_sizes, edc_config.inner_r, edc_config.outer_r,
             edc_lay_sizes[0].first, brl_half_z, next_vol_idx, prev_vol_idx);
     }
-    if (n_brl_layers > 0) {
+    if (n_brl_layers > 0u) {
         // barrel
         add_barrel_detector<empty_vol_factory, brl_module_factory>(
             det, resource, ctx0, n_brl_layers, beampipe_idx, brl_half_z,
             brl_lay_sizes, brl_positions, brl_binning, brl_config);
     }
-    if (n_edc_layers > 0) {
+    if (n_edc_layers > 0u) {
         // gap layer that connects barrel and pos. endcap
         edc_config.side = 1.;
         // innermost barrel layer volume id
         dindex prev_vol_idx =
-            n_brl_layers == 0 ? leaving_world : 2 * n_edc_layers + 1;
-        dindex next_vol_idx = prev_vol_idx == 1
+            n_brl_layers == 0 ? leaving_world : 2u * n_edc_layers + 1u;
+        dindex next_vol_idx = prev_vol_idx == 1u
                                   ? leaving_world
-                                  : det.volumes().back().index() + 2;
+                                  : det.volumes().back().index() + 2u;
 
         add_endcap_barrel_connection(
             det, resource, ctx0, edc_config.side, n_brl_layers, beampipe_idx,
@@ -1118,8 +1123,8 @@ auto create_toy_geometry(
  */
 template <typename container_t = host_container_types>
 auto create_toy_geometry(vecmem::memory_resource &resource,
-                         std::size_t n_brl_layers = 4,
-                         std::size_t n_edc_layers = 3) {
+                         unsigned int n_brl_layers = 4u,
+                         unsigned int n_edc_layers = 3u) {
     return create_toy_geometry<container_t>(
         resource,
         covfie::field<detector_registry::toy_detector::bfield_backend_t>{

--- a/utils/include/detray/simulation/event_writer.hpp
+++ b/utils/include/detray/simulation/event_writer.hpp
@@ -35,18 +35,17 @@ struct event_writer : actor {
                   get_event_filename(event_id, "-measurement-simhit-map.csv")),
               m_meas_smearer(smearer) {}
 
-        std::size_t particle_id = -1;
+        uint64_t particle_id = 0u;
         particle_writer m_particle_writer;
         hit_writer m_hit_writer;
         measurement_writer m_meas_writer;
         meas_hit_id_writer m_meas_hit_id_writer;
-        std::size_t m_hit_count = 0;
+        uint64_t m_hit_count = 0u;
         smearer_t m_meas_smearer;
 
-        void set_seed(const unsigned int sd) { m_meas_smearer.set_seed(sd); }
+        void set_seed(const uint_fast64_t sd) { m_meas_smearer.set_seed(sd); }
 
         void write_particle(const free_track_parameters<transform3_t>& track) {
-            particle_id++;
 
             csv_particle particle;
             const auto pos = track.pos();
@@ -63,6 +62,8 @@ struct event_writer : actor {
             particle.q = track.charge();
 
             m_particle_writer.append(particle);
+
+            particle_id++;
         }
     };
 

--- a/utils/include/detray/simulation/measurement_smearer.hpp
+++ b/utils/include/detray/simulation/measurement_smearer.hpp
@@ -21,15 +21,15 @@ struct measurement_smearer {
     measurement_smearer(measurement_smearer<scalar_t>& smearer)
         : stddev(smearer.stddev), generator(smearer.generator) {}
 
-    void set_seed(const unsigned int sd) { generator.seed(sd); }
+    void set_seed(const uint_fast64_t sd) { generator.seed(sd); }
 
     std::array<scalar_t, 2> stddev;
     std::random_device rd{};
-    std::mt19937 generator{rd()};
+    std::mt19937_64 generator{rd()};
 
     std::array<scalar_t, 2> get_offset() {
-        return {std::normal_distribution<scalar_t>(0, stddev[0])(generator),
-                std::normal_distribution<scalar_t>(0, stddev[1])(generator)};
+        return {std::normal_distribution<scalar_t>(0.f, stddev[0])(generator),
+                std::normal_distribution<scalar_t>(0.f, stddev[1])(generator)};
     }
 
     template <typename local_parameter_t>
@@ -46,17 +46,17 @@ struct measurement_smearer {
         // positive value
         if (name == "line") {
             ret[0] = std::abs(local[0]) + offset[0];
-            if (ret[0] < 0.) {
-                ret[0] = 0.;
+            if (ret[0] < 0.f) {
+                ret[0] = 0.f;
             }
         } else {
             ret[0] = local[0] + offset[0];
         }
 
         // If the measurement dimension is 1, the second element is null
-        if (meas_dim == 1) {
-            ret[1] = 0.;
-        } else if (meas_dim == 2) {
+        if (meas_dim == 1u) {
+            ret[1] = 0.f;
+        } else if (meas_dim == 2u) {
             ret[1] = local[1] + offset[1];
         }
 

--- a/utils/include/detray/simulation/random_scatterer.hpp
+++ b/utils/include/detray/simulation/random_scatterer.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -28,14 +28,14 @@ struct random_scatterer : actor {
 
     struct state {
         std::random_device rd{};
-        std::mt19937 generator{rd()};
+        std::mt19937_64 generator{rd()};
 
         /// Constructor with seed
         ///
         /// @param sd the seed number
-        state(const unsigned int sd = 0) { generator.seed(sd); }
+        state(const uint_fast64_t sd = 0u) { generator.seed(sd); }
 
-        void set_seed(const unsigned int sd) { generator.seed(sd); }
+        void set_seed(const uint_fast64_t sd) { generator.seed(sd); }
     };
 
     /// Observes a material interactor state @param interactor_state
@@ -51,23 +51,25 @@ struct random_scatterer : actor {
             auto& stepping = prop_state._stepping;
             auto& generator = simulator_state.generator;
 
-            const auto r_theta = std::normal_distribution<scalar_type>(
-                0, M_SQRT2 * interactor_state.scattering_angle)(generator);
-            const auto r_phi =
-                std::uniform_real_distribution<double>(-M_PI, M_PI)(generator);
+            const scalar_type r_theta{std::normal_distribution<scalar_type>(
+                0.f, constant<scalar_type>::sqrt2 *
+                         interactor_state.scattering_angle)(generator)};
+            const scalar_type r_phi{std::uniform_real_distribution<scalar_type>(
+                -constant<scalar_type>::pi,
+                constant<scalar_type>::pi)(generator)};
 
             const auto dir = stepping._bound_params.dir();
 
             // xaxis of curvilinear plane
-            const vector3 u{-dir[1], dir[0], 0};
+            const vector3 u{-dir[1], dir[0], 0.f};
             vector3 new_dir = axis_rotation<transform3_type>(u, r_theta)(dir);
             new_dir = axis_rotation<transform3_type>(dir, r_phi)(new_dir);
 
             auto& vector = stepping._bound_params.vector();
 
-            matrix_operator().element(vector, e_bound_theta, 0) =
+            matrix_operator().element(vector, e_bound_theta, 0u) =
                 getter::theta(new_dir);
-            matrix_operator().element(vector, e_bound_phi, 0) =
+            matrix_operator().element(vector, e_bound_phi, 0u) =
                 getter::phi(new_dir);
         }
     }

--- a/utils/include/detray/simulation/simulator.hpp
+++ b/utils/include/detray/simulation/simulator.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,8 +30,8 @@ struct simulator {
     using scalar_type = typename detector_t::scalar_type;
 
     struct config {
-        scalar_type overstep_tolerance = -10 * detray::unit<scalar_type>::um;
-        scalar_type step_constraint = 10. * detray::unit<scalar_type>::mm;
+        scalar_type overstep_tolerance{-10.f * detray::unit<scalar_type>::um};
+        scalar_type step_constraint{10.f * detray::unit<scalar_type>::mm};
     };
 
     using transform3 = typename detector_t::transform3;
@@ -52,7 +52,7 @@ struct simulator {
     using propagator_type =
         propagator<stepper_type, navigator_type, actor_chain_type>;
 
-    simulator(unsigned int events, const detector_t& det,
+    simulator(std::size_t events, const detector_t& det,
               track_generator_t&& track_gen, smearer_t& smearer,
               const std::string directory = "")
         : m_events(events),
@@ -66,7 +66,7 @@ struct simulator {
 
     void run() {
 
-        for (unsigned int event_id = 0; event_id < m_events; event_id++) {
+        for (std::size_t event_id = 0u; event_id < m_events; event_id++) {
             typename event_writer<transform3, smearer_t>::state writer(
                 event_id, m_smearer, m_directory);
 
@@ -100,7 +100,7 @@ struct simulator {
 
     private:
     config m_cfg;
-    unsigned int m_events = 0;
+    std::size_t m_events{0u};
     std::string m_directory = "";
     std::unique_ptr<detector_t> m_detector;
     std::unique_ptr<track_generator_t> m_track_generator;

--- a/utils/include/detray/simulation/track_generators.hpp
+++ b/utils/include/detray/simulation/track_generators.hpp
@@ -50,17 +50,21 @@ class uniform_track_generator
 
         DETRAY_HOST_DEVICE
         iterator(std::size_t n_theta, std::size_t n_phi,
-                 point3 trk_origin = {0., 0., 0.},
-                 scalar trk_mom = 1. * unit<scalar>::GeV,
-                 std::array<scalar, 2> theta_range = {0.01, M_PI},
-                 std::array<scalar, 2> phi_range = {-M_PI, M_PI},
-                 scalar time = 0. * unit<scalar>::us,
-                 scalar charge = -1. * unit<scalar>::e, std::size_t iph = 1,
-                 std::size_t ith = 0)
+                 point3 trk_origin = {0.f, 0.f, 0.f},
+                 scalar trk_mom = 1.f * unit<scalar>::GeV,
+                 std::array<scalar, 2> theta_range = {0.01f,
+                                                      constant<scalar>::pi},
+                 std::array<scalar, 2> phi_range = {-constant<scalar>::pi,
+                                                    constant<scalar>::pi},
+                 scalar time = 0.f * unit<scalar>::us,
+                 scalar charge = -1.f * unit<scalar>::e, std::size_t iph = 1u,
+                 std::size_t ith = 0u)
             : m_theta_steps{n_theta},
               m_phi_steps{n_phi},
-              m_theta_step_size{(theta_range[1] - theta_range[0]) / n_theta},
-              m_phi_step_size{(phi_range[1] - phi_range[0]) / n_phi},
+              m_theta_step_size{(theta_range[1] - theta_range[0]) /
+                                static_cast<scalar>(n_theta)},
+              m_phi_step_size{(phi_range[1] - phi_range[0]) /
+                              static_cast<scalar>(n_phi)},
               m_phi{phi_range[0]},
               m_theta{theta_range[0]},
               m_origin{trk_origin},
@@ -96,7 +100,8 @@ class uniform_track_generator
                 // Check phi sub-range
                 if (i_phi < m_phi_steps) {
                     // Calculate new phi in the given range
-                    m_phi = m_phi_range[0] + i_phi * m_phi_step_size;
+                    m_phi = m_phi_range[0] +
+                            static_cast<scalar>(i_phi) * m_phi_step_size;
                     ++i_phi;
                     return *this;
                 }
@@ -106,7 +111,8 @@ class uniform_track_generator
                 ;
                 // Calculate new thetain the given range
                 ++i_theta;
-                m_theta = m_theta_range[0] + i_theta * m_theta_step_size;
+                m_theta = m_theta_range[0] +
+                          static_cast<scalar>(i_theta) * m_theta_step_size;
             }
             return *this;
         }
@@ -126,31 +132,32 @@ class uniform_track_generator
         }
 
         /// Start and end values of angle space
-        std::size_t m_theta_steps{50};
-        std::size_t m_phi_steps{50};
-        scalar m_theta_step_size{0};
-        scalar m_phi_step_size{0};
+        std::size_t m_theta_steps{50u};
+        std::size_t m_phi_steps{50u};
+        scalar m_theta_step_size{0.f};
+        scalar m_phi_step_size{0.f};
 
         /// Phi and theta angles of momentum direction
-        scalar m_phi{-M_PI}, m_theta{0.01};
+        scalar m_phi{-constant<scalar>::pi}, m_theta{0.01f};
 
         /// Track origin
-        point3 m_origin{0., 0., 0.};
+        point3 m_origin{0.f, 0.f, 0.f};
 
         /// Magnitude of momentum: Default is one to keep directions normalized
         /// if no momentum information is needed (e.g. for a ray)
-        scalar m_mom_mag{1. * unit<scalar>::GeV};
+        scalar m_mom_mag{1.f * unit<scalar>::GeV};
 
         /// Range for theta and phi
-        std::array<scalar, 2> m_theta_range{0.01, M_PI};
-        std::array<scalar, 2> m_phi_range{-M_PI, M_PI};
+        std::array<scalar, 2> m_theta_range{0.01f, constant<scalar>::pi};
+        std::array<scalar, 2> m_phi_range{-constant<scalar>::pi,
+                                          constant<scalar>::pi};
 
         /// Time parameter and charge of the track
-        scalar m_time{0}, m_charge{0};
+        scalar m_time{0.f}, m_charge{0.f};
 
         /// Iteration indices
-        std::size_t i_phi{0};
-        std::size_t i_theta{0};
+        std::size_t i_phi{0u};
+        std::size_t i_theta{0u};
     };
 
     iterator m_begin{}, m_end{};
@@ -172,17 +179,19 @@ class uniform_track_generator
     /// @param time time measurement (micro seconds)
     /// @param charge charge of particle (e)
     DETRAY_HOST_DEVICE
-    uniform_track_generator(std::size_t n_theta, std::size_t n_phi,
-                            point3 trk_origin = {0., 0., 0.},
-                            scalar trk_mom = 1. * unit<scalar>::GeV,
-                            std::array<scalar, 2> theta_range = {0.01, M_PI},
-                            std::array<scalar, 2> phi_range = {-M_PI, M_PI},
-                            scalar time = 0. * unit<scalar>::us,
-                            scalar charge = -1. * unit<scalar>::e)
+    uniform_track_generator(
+        std::size_t n_theta, std::size_t n_phi,
+        point3 trk_origin = {0.f, 0.f, 0.f},
+        scalar trk_mom = 1.f * unit<scalar>::GeV,
+        std::array<scalar, 2> theta_range = {0.01f, constant<scalar>::pi},
+        std::array<scalar, 2> phi_range = {-constant<scalar>::pi,
+                                           constant<scalar>::pi},
+        scalar time = 0.f * unit<scalar>::us,
+        scalar charge = -1.f * unit<scalar>::e)
         : m_begin{n_theta,   n_phi, trk_origin, trk_mom, theta_range,
-                  phi_range, time,  charge,     1,       0},
+                  phi_range, time,  charge,     1u,      0u},
           m_end{n_theta,   n_phi, trk_origin, trk_mom, theta_range,
-                phi_range, time,  charge,     1,       n_theta} {}
+                phi_range, time,  charge,     1u,      n_theta} {}
 
     /// Copy assignment operator
     DETRAY_HOST_DEVICE
@@ -216,7 +225,7 @@ class uniform_track_generator
 template <typename scalar_t = scalar,
           typename distribution_t = std::uniform_real_distribution<scalar_t>,
           typename generator_t = std::random_device,
-          typename engine_t = std::mt19937>
+          typename engine_t = std::mt19937_64>
 struct random_numbers {
 
     random_numbers(random_numbers &&other) : engine(std::move(other.engine)) {}
@@ -231,7 +240,7 @@ struct random_numbers {
 
     template <typename T = generator_t,
               std::enable_if_t<std::is_same_v<T, std::seed_seq>, bool> = true>
-    random_numbers() : gen{42}, engine{gen} {}
+    random_numbers() : gen{42u}, engine{gen} {}
 
     template <typename T = distribution_t,
               std::enable_if_t<
@@ -284,12 +293,14 @@ class random_track_generator
 
         DETRAY_HOST_DEVICE
         iterator(generator_t &rand_gen, std::size_t n_tracks,
-                 point3 trk_origin = {0., 0., 0.},
-                 scalar trk_mom = 1. * unit<scalar>::GeV,
-                 std::array<scalar, 2> theta_range = {0.01, M_PI},
-                 std::array<scalar, 2> phi_range = {-M_PI, M_PI},
-                 scalar time = 0. * unit<scalar>::us,
-                 scalar charge = -1. * unit<scalar>::e)
+                 point3 trk_origin = {0.f, 0.f, 0.f},
+                 scalar trk_mom = 1.f * unit<scalar>::GeV,
+                 std::array<scalar, 2> theta_range = {0.01f,
+                                                      constant<scalar>::pi},
+                 std::array<scalar, 2> phi_range = {-constant<scalar>::pi,
+                                                    constant<scalar>::pi},
+                 scalar time = 0.f * unit<scalar>::us,
+                 scalar charge = -1.f * unit<scalar>::e)
             : m_rnd_numbers{rand_gen},
               m_tracks{n_tracks},
               m_origin{trk_origin},
@@ -347,24 +358,25 @@ class random_track_generator
         generator_t &m_rnd_numbers;
 
         /// How many tracks will be generated
-        std::size_t m_tracks{0};
+        std::size_t m_tracks{0u};
 
         /// Track origin
-        point3 m_origin{0., 0., 0.};
+        point3 m_origin{0.f, 0.f, 0.f};
 
         /// Magnitude of momentum: Default is one to keep directions normalized
         /// if no momentum information is needed (e.g. for a ray)
-        scalar m_mom_mag{1. * unit<scalar>::GeV};
+        scalar m_mom_mag{1.f * unit<scalar>::GeV};
 
         /// Phi and theta angles of momentum direction (random)
-        scalar m_phi{-M_PI}, m_theta{0.01};
+        scalar m_phi{-constant<scalar>::pi}, m_theta{0.01f};
 
         /// Range for theta and phi
-        std::array<scalar, 2> m_phi_range{-M_PI, M_PI};
-        std::array<scalar, 2> m_theta_range{0.01, M_PI};
+        std::array<scalar, 2> m_phi_range{-constant<scalar>::pi,
+                                          constant<scalar>::pi};
+        std::array<scalar, 2> m_theta_range{0.01f, constant<scalar>::pi};
 
         /// Time parameter and charge of the track
-        scalar m_time{0}, m_charge{0};
+        scalar m_time{0.f}, m_charge{0.f};
     };
 
     generator_t m_gen;
@@ -392,15 +404,16 @@ class random_track_generator
     /// @param time time measurement (micro seconds)
     /// @param charge charge of particle (e)
     DETRAY_HOST_DEVICE
-    random_track_generator(std::size_t n_tracks,
-                           point3 trk_origin = {0., 0., 0.},
-                           scalar trk_mom = 1. * unit<scalar>::GeV,
-                           std::array<scalar, 2> theta_range = {0.01, M_PI},
-                           std::array<scalar, 2> phi_range = {-M_PI, M_PI},
-                           scalar time = 0. * unit<scalar>::us,
-                           scalar charge = -1. * unit<scalar>::e)
+    random_track_generator(
+        std::size_t n_tracks, point3 trk_origin = {0.f, 0.f, 0.f},
+        scalar trk_mom = 1.f * unit<scalar>::GeV,
+        std::array<scalar, 2> theta_range = {0.01f, constant<scalar>::pi},
+        std::array<scalar, 2> phi_range = {-constant<scalar>::pi,
+                                           constant<scalar>::pi},
+        scalar time = 0.f * unit<scalar>::us,
+        scalar charge = -1.f * unit<scalar>::e)
         : m_gen{},
-          m_begin{m_gen,       0,         trk_origin, trk_mom,
+          m_begin{m_gen,       0u,        trk_origin, trk_mom,
                   theta_range, phi_range, time,       charge},
           m_end{m_gen,       n_tracks,  trk_origin, trk_mom,
                 theta_range, phi_range, time,       charge} {}


### PR DESCRIPTION
Adds a number of mathematical constants like ```pi``` and replaces the usage of macros like ```M_PI```. To prevent some of the double to single precision conversions, floating point literals are written as single precision.  To catch more unwanted conversions, the curly brace initialization is used for ```scalar``` variables.
Some of the unsigned long literals in the unittests were converted into simple unsigned literals.

```mask``` and ```material``` constructors are now ```constexpr```, which might allow to resolve the predefined material at compile-time in the future.

Also removed the old ```flip``` function from the track state, since backwards propagation should be solvable by flipping the sign of the step size instead

Additionally, it switches on the ```-Wconversion``` flag in debug builds and cleans out all resulting warnings