### PR TITLE
fix: add const specialization for is_device_view trait

### DIFF
--- a/core/include/detray/core/detail/container_views.hpp
+++ b/core/include/detray/core/detail/container_views.hpp
@@ -149,6 +149,12 @@ template <typename T>
 struct detail::is_device_view<vecmem::data::vector_view<T>, void>
     : public std::true_type {};
 
+/// Specialization of 'is view' for constant @c vecmem::data::vector_view
+/// containers
+template <typename T>
+struct detail::is_device_view<const vecmem::data::vector_view<T>, void>
+    : public std::true_type {};
+
 /// Specialization of the view getter for @c vecmem::vector
 template <typename T>
 struct detail::get_view<vecmem::vector<T>, void> : public std::true_type {
@@ -169,6 +175,12 @@ using djagged_vector_view = vecmem::data::jagged_vector_view<T>;
 /// containers
 template <typename T>
 struct detail::is_device_view<vecmem::data::jagged_vector_view<T>, void>
+    : public std::true_type {};
+
+/// Specialization of 'is view' for constant @c vecmem::data::jagged_vector_view
+/// containers
+template <typename T>
+struct detail::is_device_view<const vecmem::data::jagged_vector_view<T>, void>
     : public std::true_type {};
 
 /// Specialization of the view getter for @c vecmem::jagged_vector

--- a/core/include/detray/core/detail/single_store.hpp
+++ b/core/include/detray/core/detail/single_store.hpp
@@ -57,19 +57,26 @@ class single_store {
     /// Copy construct from element types
     constexpr explicit single_store(const T &arg) : m_container(arg) {}
 
-    DETRAY_HOST explicit single_store(vecmem::memory_resource &resource)
+    /// Construct with a specific memory resource @param resource
+    /// (host-side only)
+    template <typename allocator_t = vecmem::memory_resource,
+              std::enable_if_t<not detail::is_device_view_v<allocator_t>,
+                               bool> = true>
+    DETRAY_HOST explicit single_store(allocator_t &resource)
         : m_container(&resource) {}
 
-    template <typename C = container_t<T>,
+    /// Copy Construct with a specific memory resource @param resource
+    /// (host-side only)
+    template <typename allocator_t = vecmem::memory_resource,
+              typename C = container_t<T>,
               std::enable_if_t<std::is_same_v<C, std::vector<T>>, bool> = true>
-    DETRAY_HOST explicit single_store(vecmem::memory_resource &resource,
-                                      const T &arg)
+    DETRAY_HOST explicit single_store(allocator_t &resource, const T &arg)
         : m_container(&resource, arg) {}
 
+    /// Construct from the container @param view . Mainly used device-side.
     template <typename container_view_t,
-              std::enable_if_t<
-                  !std::is_base_of_v<vecmem::memory_resource, container_view_t>,
-                  bool> = true>
+              std::enable_if_t<detail::is_device_view_v<container_view_t>,
+                               bool> = true>
     DETRAY_HOST_DEVICE single_store(container_view_t &view)
         : m_container(view) {}
 

--- a/core/include/detray/core/detail/tuple_container.hpp
+++ b/core/include/detray/core/detail/tuple_container.hpp
@@ -21,9 +21,7 @@
 #include <memory>
 #include <type_traits>
 
-namespace detray {
-
-namespace detail {
+namespace detray::detail {
 
 /// @brief detray tuple wrapper.
 ///
@@ -211,6 +209,4 @@ DETRAY_HOST_DEVICE constexpr decltype(auto) get(
 }
 /// @}
 
-}  // namespace detail
-
-}  // namespace detray
+}  // namespace detray::detail


### PR DESCRIPTION
This adds a ```const``` specilization for the ```is_device_view``` trait and restores the constructors in the ```single_store``` class