### PR TITLE
Change random track generator member variable to the reference

### DIFF
--- a/tests/common/include/tests/common/check_simulation.inl
+++ b/tests/common/include/tests/common/check_simulation.inl
@@ -93,7 +93,7 @@ TEST(check_simulation, toy_geometry) {
                                         170 * unit<scalar>::um);
 
     const unsigned int n_events = 10;
-    auto sim = simulator(n_events, detector, generator, smearer);
+    auto sim = simulator(n_events, detector, std::move(generator), smearer);
 
     // Do the simulation
     sim.run();
@@ -232,7 +232,7 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
 
     unsigned int n_events = 1000;
 
-    auto sim = simulator(n_events, detector, generator, smearer);
+    auto sim = simulator(n_events, detector, std::move(generator), smearer);
 
     // Run simulation
     sim.run();

--- a/tests/common/include/tests/common/check_simulation.inl
+++ b/tests/common/include/tests/common/check_simulation.inl
@@ -64,6 +64,10 @@ TEST(check_simulation, measurement_smearer) {
 
 TEST(check_simulation, toy_geometry) {
 
+    // Use deterministic random number generator for testing
+    using normal_gen_t =
+        random_numbers<scalar, std::normal_distribution<scalar>, std::seed_seq>;
+
     // Create geometry
     vecmem::host_memory_resource host_mr;
 
@@ -77,11 +81,12 @@ TEST(check_simulation, toy_geometry) {
         b_field_t(b_field_t::backend_t::configuration_t{B[0], B[1], B[2]}));
 
     // Create track generator
-    constexpr unsigned int theta_steps{50};
-    constexpr unsigned int phi_steps{50};
+    constexpr unsigned int n_tracks = 2500;
     const vector3 ori{0, 0, 0};
-    auto generator = uniform_track_generator<free_track_parameters<transform3>>(
-        theta_steps, phi_steps, ori, 1 * unit<scalar>::GeV);
+
+    auto generator =
+        random_track_generator<free_track_parameters<transform3>, normal_gen_t>(
+            n_tracks, ori, 1 * unit<scalar>::GeV);
 
     // Create smearer
     measurement_smearer<scalar> smearer(67 * unit<scalar>::um,
@@ -110,7 +115,7 @@ TEST(check_simulation, toy_geometry) {
             particles.push_back(io_particle);
         }
 
-        ASSERT_EQ(particles.size(), theta_steps * phi_steps);
+        ASSERT_EQ(particles.size(), n_tracks);
 
         // Check hit & measurement data
         const auto io_hits_file = get_event_filename(i_event, "-hits.csv");

--- a/tests/simulation/run_simulation.cpp
+++ b/tests/simulation/run_simulation.cpp
@@ -46,7 +46,7 @@ int main() {
                                         100 * unit<scalar>::um);
 
     unsigned int n_events = 2;
-    auto sim = simulator(n_events, detector, generator, smearer);
+    auto sim = simulator(n_events, detector, std::move(generator), smearer);
 
     sim.run();
 

--- a/utils/include/detray/simulation/simulator.hpp
+++ b/utils/include/detray/simulation/simulator.hpp
@@ -55,9 +55,8 @@ struct simulator {
         : m_events(events),
           m_directory(directory),
           m_detector(std::make_unique<detector_t>(det)),
-          m_smearer(smearer) {
-        m_track_generator = track_gen;
-    }
+          m_track_generator(track_gen),
+          m_smearer(smearer) {}
 
     config& get_config() { return m_cfg; }
 
@@ -100,7 +99,7 @@ struct simulator {
     unsigned int m_events = 0;
     std::string m_directory = "";
     std::unique_ptr<detector_t> m_detector;
-    track_generator_t m_track_generator;
+    track_generator_t& m_track_generator;
     smearer_t m_smearer;
 
     /// Actor states

--- a/utils/include/detray/simulation/track_generators.hpp
+++ b/utils/include/detray/simulation/track_generators.hpp
@@ -273,7 +273,7 @@ class random_track_generator
         using reference = track_t &;
         using iterator_category = detray::ranges::input_iterator_tag;
 
-        iterator() = delete;
+        constexpr iterator() = delete;
 
         DETRAY_HOST_DEVICE
         iterator(generator_t &rand_gen, std::size_t n_tracks,
@@ -367,7 +367,7 @@ class random_track_generator
     using iterator_t = iterator;
 
     /// Default constructor
-    random_track_generator() = default;
+    constexpr random_track_generator() = default;
 
     /// Paramtetrized constructor for fine-grained configurations
     ///

--- a/utils/include/detray/simulation/track_generators.hpp
+++ b/utils/include/detray/simulation/track_generators.hpp
@@ -214,6 +214,9 @@ template <typename scalar_t = scalar,
           typename generator_t = std::random_device,
           typename engine_t = std::mt19937>
 struct random_numbers {
+
+    random_numbers(random_numbers &&other) : engine(std::move(other.engine)) {}
+
     generator_t gen;
     engine_t engine;
 
@@ -368,6 +371,12 @@ class random_track_generator
 
     /// Default constructor
     constexpr random_track_generator() = default;
+
+    /// Move constructor
+    random_track_generator(random_track_generator &&other)
+        : m_gen(std::move(other.m_gen)),
+          m_begin(std::move(other.m_begin)),
+          m_end(std::move(other.m_end)) {}
 
     /// Paramtetrized constructor for fine-grained configurations
     ///

--- a/utils/include/detray/simulation/track_generators.hpp
+++ b/utils/include/detray/simulation/track_generators.hpp
@@ -192,6 +192,10 @@ class uniform_track_generator
         return *this;
     }
 
+    /// Move constructor
+    uniform_track_generator(uniform_track_generator &&other)
+        : m_begin(std::move(other.m_begin)), m_end(std::move(other.m_end)) {}
+
     /// @returns the generator in initial state: Default values reflect the
     /// first phi angle iteration.
     DETRAY_HOST_DEVICE


### PR DESCRIPTION
The random track generator didn't work in `simulator` class because its `track_generator` could not have copy constructor. I changed it to the reference to make it work