### PR TITLE
Add `propagate_sync` function for thread synchornization

### DIFF
--- a/core/include/detray/propagator/navigator.hpp
+++ b/core/include/detray/propagator/navigator.hpp
@@ -299,6 +299,13 @@ class navigator {
             return _status == navigation::status::e_on_module;
         }
 
+        /// Helper method to check the track has reached a sensitive surface
+        DETRAY_HOST_DEVICE
+        inline auto is_on_sensitive() const -> bool {
+            return (_status == navigation::status::e_on_module) &&
+                   (this->current()->sf_id == surface_id::e_sensitive);
+        }
+
         /// Helper method to check the track has reached a portal surface
         DETRAY_HOST_DEVICE
         inline auto is_on_portal() const -> bool {

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -112,8 +112,10 @@ struct propagator {
     /// all registered actors.
     ///
     /// @tparam state_t is the propagation state type
+    /// @tparam actor_state_t is the actor state type
     ///
     /// @param propagation the state of a propagation flow
+    /// @param actor_states the actor state
     ///
     /// @return propagation success.
     template <typename state_t, typename actor_states_t = actor_chain<>::state>
@@ -143,6 +145,18 @@ struct propagator {
         return propagation._navigation.is_complete();
     }
 
+    /// Propagate method with two while loops. In the CPU, propagate and
+    /// propagate_sync() should be equivalent to each other. In the SIMT level
+    /// (e.g. GPU), the instruction of threads in the same warp is synchornized
+    /// after the internal while loop.
+    ///
+    /// @tparam state_t is the propagation state type
+    /// @tparam actor_state_t is the actor state type
+    ///
+    /// @param propagation the state of a propagation flow
+    /// @param actor_states the actor state
+    ///
+    /// @return propagation success.
     template <typename state_t, typename actor_states_t = actor_chain<>::state>
     DETRAY_HOST_DEVICE bool propagate_sync(state_t &propagation,
                                            actor_states_t &&actor_states = {}) {
@@ -163,13 +177,16 @@ struct propagator {
                 // And check the status
                 propagation._heartbeat &= _navigator.update(propagation);
 
-                if (!propagation._navigation.is_on_sensitive()) {
-                    run_actors(actor_states, propagation);
-                } else {
+                // If the track is on a sensitive surface, break the loop to
+                // synchornize the threads
+                if (propagation._navigation.is_on_sensitive()) {
                     break;
+                } else {
+                    run_actors(actor_states, propagation);
                 }
             }
 
+            // Synchornized actor
             if (propagation._heartbeat) {
                 run_actors(actor_states, propagation);
             }

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -84,9 +84,9 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
             propagator_host_type::state p_state(track, det.get_bfield(), det);
 
             // Run propagation
-            if (opt == propagate_option::e_unsync) {
+            if constexpr (opt == propagate_option::e_unsync) {
                 p.propagate(p_state, actor_states);
-            } else if (opt == propagate_option::e_sync) {
+            } else if constexpr (opt == propagate_option::e_sync) {
                 p.propagate_sync(p_state, actor_states);
             }
         }

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
@@ -13,7 +13,8 @@ namespace detray {
 __global__ void propagator_benchmark_kernel(
     typename detector_host_type::detector_view_type det_data,
     vecmem::data::vector_view<free_track_parameters<transform3>> tracks_data,
-    vecmem::data::jagged_vector_view<intersection_t> candidates_data) {
+    vecmem::data::jagged_vector_view<intersection_t> candidates_data,
+    const propagate_option opt) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -47,20 +48,25 @@ __global__ void propagator_benchmark_kernel(
                                           candidates.at(gid));
 
     // Run propagation
-    p.propagate(p_state, actor_states);
+    if (opt == propagate_option::e_unsync) {
+        p.propagate(p_state, actor_states);
+    } else if (opt == propagate_option::e_sync) {
+        p.propagate_sync(p_state, actor_states);
+    }
 }
 
 void propagator_benchmark(
     typename detector_host_type::detector_view_type det_data,
     vecmem::data::vector_view<free_track_parameters<transform3>>& tracks_data,
-    vecmem::data::jagged_vector_view<intersection_t>& candidates_data) {
+    vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
+    const propagate_option opt) {
 
     constexpr int thread_dim = 2 * WARP_SIZE;
     int block_dim = tracks_data.size() / thread_dim + 1;
 
     // run the test kernel
     propagator_benchmark_kernel<<<block_dim, thread_dim>>>(
-        det_data, tracks_data, candidates_data);
+        det_data, tracks_data, candidates_data, opt);
 
     // cuda error check
     DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
@@ -57,12 +57,18 @@ using propagator_host_type =
 using propagator_device_type =
     propagator<rk_stepper_type, navigator_device_type, actor_chain_t>;
 
+enum class propagate_option {
+    e_unsync = 0,
+    e_sync = 1,
+};
+
 namespace detray {
 
 /// test function for propagator with single state
 void propagator_benchmark(
     typename detector_host_type::detector_view_type det_data,
     vecmem::data::vector_view<free_track_parameters<transform3>>& tracks_data,
-    vecmem::data::jagged_vector_view<intersection_t>& candidates_data);
+    vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
+    const propagate_option opt);
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -38,7 +38,10 @@ constexpr scalar path_limit{5 * unit<scalar>::cm};
 struct helix_inspector : actor {
 
     /// Keeps the state of a helix gun to calculate track positions
-    struct state {};
+    struct state {
+        // navigation status for every step
+        std::vector<navigation::status> _nav_status;
+    };
 
     using matrix_operator = standard_matrix_operator<scalar>;
     using size_type = typename matrix_operator::size_ty;
@@ -74,15 +77,16 @@ struct helix_inspector : actor {
     /// Check that the stepper remains on the right helical track for its pos.
     template <typename propagator_state_t>
     DETRAY_HOST_DEVICE void operator()(
-        const state& /*inspector_state*/,
-        const propagator_state_t& prop_state) const {
+        state& inspector_state, const propagator_state_t& prop_state) const {
+
+        const auto& navigation = prop_state._navigation;
+        const auto& stepping = prop_state._stepping;
+
+        inspector_state._nav_status.push_back(navigation.status());
 
         if (prop_state.param_type() == parameter_type::e_free) {
             return;
         }
-
-        const auto& navigation = prop_state._navigation;
-        const auto& stepping = prop_state._stepping;
 
         // Nothing has happened yet (first call of actor chain)
         if (stepping.path_length() < epsilon || stepping._s < epsilon) {
@@ -232,6 +236,9 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
         auto actor_states =
             std::tie(helix_insp_state, print_insp_state, unlimted_aborter_state,
                      transporter_state, interactor_state, resetter_state);
+        auto sync_actor_states =
+            std::tie(helix_insp_state, print_insp_state, unlimted_aborter_state,
+                     transporter_state, interactor_state, resetter_state);
         auto lim_actor_states = std::tie(
             helix_insp_state, lim_print_insp_state, pathlimit_aborter_state,
             transporter_state, interactor_state, resetter_state);
@@ -262,6 +269,15 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
             << "path length: " << lim_state._stepping.path_length()
             << ", path limit: " << path_limit << std::endl;
         //<< state._navigation.inspector().to_string() << std::endl;
+
+        // Compare the navigation status vector between propagate and
+        // propagate_sync function
+        const auto nav_status =
+            std::get<helix_inspector::state&>(actor_states)._nav_status;
+        const auto sync_nav_status =
+            std::get<helix_inspector::state&>(sync_actor_states)._nav_status;
+        ASSERT_TRUE(nav_status.size() > 0);
+        ASSERT_TRUE(nav_status == sync_nav_status);
     }
 }
 

--- a/utils/include/detray/simulation/event_writer.hpp
+++ b/utils/include/detray/simulation/event_writer.hpp
@@ -89,8 +89,7 @@ struct event_writer : actor {
         auto& stepping = propagation._stepping;
 
         // triggered only for sensitive surfaces
-        if (navigation.is_on_module() &&
-            navigation.current()->sf_id == surface_id::e_sensitive) {
+        if (navigation.is_on_sensitive()) {
 
             // Write hits
             csv_hit hit;


### PR DESCRIPTION
This PR adds `propagate_sync` function to synchronize the actor operations on the sensitive surfaces. The motivation is to reduce the thread divergence in the actor operations on the sensitive surface which can be inefficient for combinatorial kalman filtering. 

But there is also a price to pay for this; there will be another thread divergence where the threads that already reached the sensitive surface need to wait for the others which are still propagating. And it will get worse in the case that a constraint step size is small.

The benchmark result with `benchmark_propagator` shows ~10 % improvement though, which is not bad.  We will need to investigate how the performance changes in the various setups.

```
----------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations
----------------------------------------------------------------------
CPU unsync propagation/8       3689792 ns      3675549 ns          192
CPU unsync propagation/16     14075721 ns     14054015 ns           49
CPU unsync propagation/32     55928934 ns     55848691 ns           11
CPU unsync propagation/64    225596027 ns    225288139 ns            3
CPU unsync propagation/128   906377376 ns    904804053 ns            1
CPU unsync propagation/256  3597702560 ns   3592394426 ns            1
CPU sync propagation/8         3681355 ns      3676278 ns          192
CPU sync propagation/16       14386564 ns     14367183 ns           47
CPU sync propagation/32       56847392 ns     56762769 ns           12
CPU sync propagation/64      250199555 ns    249207072 ns            3
CPU sync propagation/128    1031669493 ns   1023662267 ns            1
CPU sync propagation/256    4055531237 ns   4035024267 ns            1
CUDA unsync propagation/8     15095349 ns     15063484 ns           45
CUDA unsync propagation/16    12948308 ns     12917492 ns           54
CUDA unsync propagation/32    14822181 ns     14795374 ns           46
CUDA unsync propagation/64    26047513 ns     26006104 ns           27
CUDA unsync propagation/128   61369870 ns     61280929 ns           13
CUDA unsync propagation/256  233583005 ns    156857427 ns            4
CUDA sync propagation/8       15037536 ns     15015491 ns           38
CUDA sync propagation/16      12849538 ns     12823527 ns           55
CUDA sync propagation/32      13617087 ns     13591253 ns           51
CUDA sync propagation/64      23655296 ns     23615953 ns           30
CUDA sync propagation/128     56163571 ns     56085912 ns           10
CUDA sync propagation/256    216104603 ns    139084108 ns            5
```