### PR TITLE
feat: re-introduce unbounded mask

### DIFF
--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -19,7 +19,6 @@
 #include "detray/masks/ring2D.hpp"
 #include "detray/masks/single3D.hpp"
 #include "detray/masks/trapezoid2D.hpp"
-#include "detray/masks/unmasked.hpp"
 
 // System include(s)
 #include <algorithm>

--- a/core/include/detray/masks/unbounded.hpp
+++ b/core/include/detray/masks/unbounded.hpp
@@ -1,0 +1,74 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/qualifiers.hpp"
+
+// System include(s)
+#include <string>
+
+namespace detray {
+
+/// @brief Wraps any shape, but does not enforce boundaries
+template <typename shape_t>
+class unbounded {
+    public:
+    using shape = shape_t;
+    using boundaries = typename shape::boundaries;
+
+    /// The name for this shape
+    inline static const std::string name = "unbounded " + shape::name;
+
+    /// The measurement dimension
+    inline static constexpr const std::size_t meas_dim = shape::meas_dim;
+
+    /// Local coordinate frame for boundary checks
+    template <typename algebra_t>
+    using local_frame_type =
+        typename shape::template local_frame_type<algebra_t>;
+    /// Local point type (2D)
+    template <typename algebra_t>
+    using loc_point_type = typename shape::template loc_point_type<algebra_t>;
+
+    /// Measurement frame
+    template <typename algebra_t>
+    using measurement_frame_type =
+        typename shape::template measurement_frame_type<algebra_t>;
+    /// Local measurement point (2D)
+    template <typename algebra_t>
+    using measurement_point_type =
+        typename shape::template measurement_point_type<algebra_t>;
+
+    /// Underlying surface geometry
+    template <typename algebra_t>
+    using intersector_type =
+        typename shape::template intersector_type<algebra_t>;
+
+    /// @brief Check boundary values for a local point.
+    ///
+    /// @tparam bounds_t any type of boundary values
+    ///
+    /// @note the parameters are ignored
+    ///
+    /// @return always true
+    template <typename bounds_t, typename point_t, typename scalar_t>
+    DETRAY_HOST_DEVICE inline constexpr bool check_boundaries(
+        const bounds_t& /*bounds*/, const point_t& /*loc_p*/,
+        const scalar_t /*tol*/) const {
+        return true;
+    }
+
+    template <typename param_t>
+    DETRAY_HOST_DEVICE inline typename param_t::point2 to_measurement(
+        param_t& param, const typename param_t::point2& offset = {0, 0}) const {
+        return param.local() + offset;
+    }
+};
+
+}  // namespace detray

--- a/tests/common/include/tests/common/masks_unbounded.inl
+++ b/tests/common/include/tests/common/masks_unbounded.inl
@@ -1,0 +1,77 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/masks/masks.hpp"
+#include "detray/masks/unbounded.hpp"
+
+// GTest include(s)
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <cassert>
+#include <type_traits>
+
+using namespace detray;
+
+/// This tests the basic functionality of an unbounded rectangle shape
+TEST(mask, unbounded) {
+    using transform3_t = __plugin::transform3<scalar>;
+
+    using shape_t = rectangle2D<>;
+    using unbounded_t = unbounded<shape_t>;
+
+    mask<unbounded_t> u{};
+
+    // Test local typedefs
+    static_assert(std::is_same_v<unbounded_t::shape, shape_t>,
+                  "incorrect shape");
+    static_assert(std::is_same_v<unbounded_t::boundaries, shape_t::boundaries>,
+                  "incorrect boundaries");
+    static_assert(
+        std::is_same_v<unbounded_t::template local_frame_type<transform3_t>,
+                       shape_t::template local_frame_type<transform3_t>>,
+        "incorrect local frame");
+    static_assert(
+        std::is_same_v<unbounded_t::template loc_point_type<transform3_t>,
+                       shape_t::template loc_point_type<transform3_t>>,
+        "incorrect local point");
+    static_assert(
+        std::is_same_v<
+            unbounded_t::template measurement_frame_type<transform3_t>,
+            shape_t::template measurement_frame_type<transform3_t>>,
+        "incorrect measurement frame");
+    static_assert(
+        std::is_same_v<
+            unbounded_t::template measurement_point_type<transform3_t>,
+            shape_t::template measurement_point_type<transform3_t>>,
+        "incorrect measurement point");
+    static_assert(
+        std::is_same_v<unbounded_t::template intersector_type<transform3_t>,
+                       shape_t::template intersector_type<transform3_t>>,
+        "incorrect intersector");
+
+    // Test static members
+    EXPECT_TRUE(unbounded_t::name == "unbounded rectangle2D");
+    EXPECT_TRUE(unbounded_t::meas_dim == 2u);
+
+    // Test boundary check
+    typename mask<unbounded_t>::loc_point_t p2 = {0.5f, -9.f};
+    ASSERT_TRUE(u.is_inside(p2, 0.f) == intersection::status::e_inside);
+
+    // Check projection matrix
+    const auto proj = u.projection_matrix<e_bound_size>();
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == j) {
+                ASSERT_EQ(getter::element(proj, i, j), 1u);
+            } else {
+                ASSERT_EQ(getter::element(proj, i, j), 0u);
+            }
+        }
+    }
+}

--- a/tests/common/include/tests/common/masks_unmasked.inl
+++ b/tests/common/include/tests/common/masks_unmasked.inl
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "detray/masks/masks.hpp"
+#include "detray/masks/unmasked.hpp"
 
 using namespace detray;
 

--- a/tests/common/include/tests/common/tools_planar_intersection.inl
+++ b/tests/common/include/tests/common/tools_planar_intersection.inl
@@ -10,6 +10,7 @@
 #include "detray/intersection/intersection.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/masks/unmasked.hpp"
 #include "tests/common/tools/intersectors/helix_plane_intersector.hpp"
 
 // GTest include

--- a/tests/unit_tests/cpu/array/CMakeLists.txt
+++ b/tests/unit_tests/cpu/array/CMakeLists.txt
@@ -55,6 +55,7 @@ detray_add_test( array
    "array_transform_store.cpp"
    "array_trapezoid2D.cpp"
    "array_track_generators.cpp"
+   "array_unbounded.cpp"
    "array_unmasked.cpp"
    "array_volume.cpp"
    LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::array )

--- a/tests/unit_tests/cpu/array/array_unbounded.cpp
+++ b/tests/unit_tests/cpu/array/array_unbounded.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/array_definitions.hpp"
+#include "tests/common/masks_unbounded.inl"

--- a/tests/unit_tests/cpu/eigen/CMakeLists.txt
+++ b/tests/unit_tests/cpu/eigen/CMakeLists.txt
@@ -55,6 +55,7 @@ detray_add_test( eigen
    "eigen_track_generators.cpp"
    "eigen_transform_store.cpp"
    "eigen_trapezoid2D.cpp"
+   "eigen_unbounded.cpp"
    "eigen_unmasked.cpp"
    "eigen_volume.cpp"
    LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::eigen )

--- a/tests/unit_tests/cpu/eigen/eigen_unbounded.cpp
+++ b/tests/unit_tests/cpu/eigen/eigen_unbounded.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/eigen_definitions.hpp"
+#include "tests/common/masks_unbounded.inl"

--- a/tests/unit_tests/cpu/smatrix/CMakeLists.txt
+++ b/tests/unit_tests/cpu/smatrix/CMakeLists.txt
@@ -55,6 +55,7 @@ detray_add_test( smatrix
    "smatrix_track_generators.cpp"
    "smatrix_transform_store.cpp"
    "smatrix_trapezoid2D.cpp"
+   "smatrix_unbounded.cpp"
    "smatrix_unmasked.cpp"
    "smatrix_volume.cpp"
    LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::smatrix )

--- a/tests/unit_tests/cpu/smatrix/smatrix_unbounded.cpp
+++ b/tests/unit_tests/cpu/smatrix/smatrix_unbounded.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/smatrix_definitions.hpp"
+#include "tests/common/masks_unbounded.inl"

--- a/tests/unit_tests/cpu/vc/CMakeLists.txt
+++ b/tests/unit_tests/cpu/vc/CMakeLists.txt
@@ -55,7 +55,8 @@ detray_add_test( vc_array
    "vc_array_track_generators.cpp"
    "vc_array_transform_store.cpp"
    "vc_array_trapezoid2D.cpp"
-   "vc_array_unmasked.cpp" 
+   "vc_array_unbounded.cpp"
+   "vc_array_unmasked.cpp"
    "vc_array_volume.cpp"
    LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::vc_array )
 

--- a/tests/unit_tests/cpu/vc/vc_array_unbounded.cpp
+++ b/tests/unit_tests/cpu/vc/vc_array_unbounded.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/vc_array_definitions.hpp"
+#include "tests/common/masks_unbounded.inl"

--- a/utils/include/detray/detectors/detector_metadata.hpp
+++ b/utils/include/detray/detectors/detector_metadata.hpp
@@ -15,6 +15,7 @@
 #include "detray/intersection/cylinder_intersector.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/masks/unmasked.hpp"
 #include "detray/materials/material_rod.hpp"
 #include "detray/materials/material_slab.hpp"
 #include "detray/surface_finders/accelerator_grid.hpp"


### PR DESCRIPTION
Introduces an unbounded shape that takes all necessary definitions, e.g. ```local_frame``` or ```intersector```, from the shape type it wraps, but replaces the ```check_bounds``` so that it always returns ```true```.