### PR TITLE
ref: generalize telescope to switch module shape

### DIFF
--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -72,6 +72,11 @@ class mask {
                                                Args&&... args)
         : _values({{std::forward<Args>(args)...}}), _volume_link(link) {}
 
+    /// Constructor from mask boundary array
+    DETRAY_HOST_DEVICE
+    constexpr mask(const mask_values& values, const links_type& link)
+        : _values{values}, _volume_link{link} {}
+
     /// Constructor from mask boundary vector
     DETRAY_HOST mask(const std::vector<scalar_type>& values,
                      const links_type& link)

--- a/tests/common/include/tests/common/check_simulation.inl
+++ b/tests/common/include/tests/common/check_simulation.inl
@@ -9,6 +9,8 @@
 #include "detray/detectors/create_telescope_detector.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
 #include "detray/io/utils.hpp"
+#include "detray/masks/masks.hpp"
+#include "detray/masks/unbounded.hpp"
 #include "detray/simulation/simulator.hpp"
 #include "detray/simulation/track_generators.hpp"
 #include "detray/utils/statistics.hpp"
@@ -198,8 +200,11 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
     // Create geometry
     vecmem::host_memory_resource host_mr;
 
+    // Use rectangle surfaces
+    mask<unbounded<rectangle2D<>>> rectangle{0u, 20.f * unit<scalar>::mm,
+                                             20.f * unit<scalar>::mm};
+
     // Build from given module positions
-    detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {0.f, 0.f, 1.f}, -1.f};
     std::vector<scalar> positions = {0.f,   50.f,  100.f, 150.f, 200.f, 250.f,
                                      300.f, 350.f, 400.f, 450.f, 500.f};
 
@@ -208,7 +213,8 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
 
     // Detector type
     using detector_type =
-        detray::detector<detray::detector_registry::telescope_detector,
+        detray::detector<detray::detector_registry::template telescope_detector<
+                             unbounded<rectangle2D<>>>,
                          covfie::field>;
 
     // Create B field
@@ -218,8 +224,7 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
     const auto detector = create_telescope_detector(
         host_mr,
         b_field_t(b_field_t::backend_t::configuration_t{B[0], B[1], B[2]}),
-        positions, traj, std::numeric_limits<scalar>::infinity(),
-        std::numeric_limits<scalar>::infinity(), mat, thickness);
+        rectangle, positions, mat, thickness);
 
     // Momentum
     const scalar mom = std::get<0>(GetParam());

--- a/tests/common/include/tests/common/line_stepper.inl
+++ b/tests/common/include/tests/common/line_stepper.inl
@@ -8,6 +8,8 @@
 // Project include(s).
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/masks/masks.hpp"
+#include "detray/masks/unbounded.hpp"
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/actors/parameter_resetter.hpp"
 #include "detray/propagator/actors/parameter_transporter.hpp"
@@ -35,15 +37,18 @@ TEST(line_stepper, covariance_transport) {
 
     vecmem::host_memory_resource host_mr;
 
-    // Use rectangular surfaces
-    constexpr bool unbounded = true;
+    // Use unbounded rectangle surfaces
+    mask<unbounded<rectangle2D<>>> rectangle{0u, 20.f * unit<scalar>::mm,
+                                             20.f * unit<scalar>::mm};
 
     // Create telescope detector with a single plane
     detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
     std::vector<scalar> positions = {0.f, 10.f, 20.f, 30.f, 40.f, 50.f, 60.f};
 
-    const auto det =
-        create_telescope_detector<unbounded>(host_mr, positions, traj);
+    // Build telescope detector with unbounded planes
+    const auto det = create_telescope_detector(host_mr, rectangle, positions,
+                                               silicon_tml<scalar>(),
+                                               80.f * unit<scalar>::um, traj);
 
     using navigator_t = navigator<decltype(det)>;
     using cline_stepper_t = line_stepper<transform3, constrained_step<>>;

--- a/tests/common/include/tests/common/material_interaction.inl
+++ b/tests/common/include/tests/common/material_interaction.inl
@@ -9,6 +9,8 @@
 #include "detray/definitions/pdg_particle.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/masks/masks.hpp"
+#include "detray/masks/unbounded.hpp"
 #include "detray/materials/interaction.hpp"
 #include "detray/materials/material.hpp"
 #include "detray/materials/material_slab.hpp"
@@ -209,6 +211,9 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
 
     vecmem::host_memory_resource host_mr;
 
+    // Use unbounded rectangle surfaces
+    mask<unbounded<rectangle2D<>>> rectangle{0u, 20.f * unit<scalar>::mm,
+                                             20.f * unit<scalar>::mm};
     // Build from given module positions
     detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
     std::vector<scalar> positions = {0.f,   50.f,  100.f, 150.f, 200.f, 250.f,
@@ -217,9 +222,8 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
     const auto mat = silicon_tml<scalar>();
     constexpr scalar thickness{0.17f * unit<scalar>::cm};
 
-    const auto det = create_telescope_detector(
-        host_mr, positions, traj, 20.f * unit<scalar>::mm,
-        20.f * unit<scalar>::mm, mat, thickness);
+    const auto det = create_telescope_detector(host_mr, rectangle, positions,
+                                               mat, thickness, traj);
 
     using navigator_t = navigator<decltype(det)>;
     using constraints_t = constrained_step<>;
@@ -328,19 +332,20 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
 TEST(material_interaction, telescope_geometry_scattering_angle) {
     vecmem::host_memory_resource host_mr;
 
+    // Use unbounded rectangle surfaces
+    mask<unbounded<rectangle2D<>>> rectangle{0u, 20.f * unit<scalar>::mm,
+                                             20.f * unit<scalar>::mm};
+
     // Build from given module positions
     detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
     std::vector<scalar> positions = {0.f, 1000.f * unit<scalar>::cm,
                                      2000.f * unit<scalar>::cm};
 
     const auto mat = silicon_tml<scalar>();
-    constexpr scalar thickness{500.f * unit<scalar>::cm};
-    // Use unbounded surfaces
-    constexpr bool unbounded = true;
+    const scalar thickness = 500.f * unit<scalar>::cm;
 
-    const auto det = create_telescope_detector<unbounded>(
-        host_mr, positions, traj, 2000.f * unit<scalar>::mm,
-        2000.f * unit<scalar>::mm, mat, thickness);
+    const auto det = create_telescope_detector(host_mr, rectangle, positions,
+                                               mat, thickness, traj);
 
     using navigator_t = navigator<decltype(det)>;
     using constraints_t = constrained_step<>;

--- a/tests/common/include/tests/common/tools_guided_navigator.inl
+++ b/tests/common/include/tests/common/tools_guided_navigator.inl
@@ -11,6 +11,8 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/masks/masks.hpp"
+#include "detray/masks/unbounded.hpp"
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/actors/aborters.hpp"
 #include "detray/propagator/navigation_policies.hpp"
@@ -28,17 +30,20 @@ TEST(ALGEBRA_PLUGIN, guided_navigator) {
 
     vecmem::host_memory_resource host_mr;
 
-    // Use unbounded surfaces
-    constexpr bool unbounded = true;
+    // Use unbounded rectangle surfaces
+    mask<unbounded<rectangle2D<>>> rectangle{0u, 20.f * unit<scalar>::mm,
+                                             20.f * unit<scalar>::mm};
 
+    // Builds the telescope alon z-axis
     detail::ray<transform3_type> default_trk({0, 0, 0}, 0, {0, 0, 1}, -1);
 
     // Module positions along z-axis
     const std::vector<scalar> positions = {0.,  10., 20., 30., 40., 50.,
                                            60., 70,  80,  90., 100.};
     // Build telescope detector with unbounded planes
-    const auto telescope_det =
-        create_telescope_detector<unbounded>(host_mr, positions, default_trk);
+    const auto telescope_det = create_telescope_detector(
+        host_mr, rectangle, positions, silicon_tml<scalar>(),
+        80.f * unit<scalar>::um, default_trk);
 
     // Inspectors are optional, of course
     using object_tracer_t =

--- a/utils/include/detray/detectors/detector_metadata.hpp
+++ b/utils/include/detray/detectors/detector_metadata.hpp
@@ -254,7 +254,8 @@ struct toy_metadata {
 };
 
 /// Defines a detector with only rectangle/unbounded surfaces
-template <typename _bfield_backend_t =
+template <typename mask_shape_t = rectangle2D<>,
+          typename _bfield_backend_t =
               covfie::backend::constant<covfie::vector::vector_d<scalar, 3>,
                                         covfie::vector::vector_d<scalar, 3>>>
 struct telescope_metadata {
@@ -282,21 +283,20 @@ struct telescope_metadata {
     /// Give your mask types a name (needs to be consecutive to be matched
     /// to a type!)
     enum class mask_ids {
-        e_rectangle2 = 0,
-        e_unbounded_plane2 = 1,
+        e_mask = 0,
     };
 
     /// How to store and link masks
     template <template <typename...> class tuple_t = dtuple,
               template <typename...> class vector_t = dvector>
-    using mask_store =
-        regular_multi_store<mask_ids, empty_context, tuple_t, vector_t,
-                            rectangle, unbounded_plane>;
+    using mask_store = regular_multi_store<mask_ids, empty_context, tuple_t,
+                                           vector_t, mask<mask_shape_t>>;
 
     /// Give your material types a name (needs to be consecutive to be matched
     /// to a type!)
     enum class material_ids {
         e_slab = 0,
+        e_rod = 0,
         e_none = 1,
     };
 
@@ -304,7 +304,7 @@ struct telescope_metadata {
     template <template <typename...> class tuple_t = dtuple,
               template <typename...> class vector_t = dvector>
     using material_store = regular_multi_store<material_ids, empty_context,
-                                               tuple_t, vector_t, slab>;
+                                               tuple_t, vector_t, slab, rod>;
 
     /// Surface type used for sensitives, passives and portals
     using transform_link = typename transform_store<>::link_type;
@@ -340,7 +340,8 @@ struct detector_registry {
     using default_detector = full_metadata<volume_stats, 1>;
     using tml_detector = full_metadata<volume_stats, 192>;
     using toy_detector = toy_metadata<>;
-    using telescope_detector = telescope_metadata<>;
+    template <typename mask_shape_t>
+    using telescope_detector = telescope_metadata<mask_shape_t>;
 };
 
 }  // namespace detray


### PR DESCRIPTION
This adds a template to the telescope geometry that defines the module surface shape. The mask has to be passed to the ```create_telescope_detector``` function directly.