### PR TITLE
ref: add world portals to telescope detector

### DIFF
--- a/core/include/detray/core/detail/single_store.hpp
+++ b/core/include/detray/core/detail/single_store.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/definitions/detail/algorithms.hpp
+++ b/core/include/detray/definitions/detail/algorithms.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -5,6 +5,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 #include <memory>

--- a/core/include/detray/geometry/volume_graph.hpp
+++ b/core/include/detray/geometry/volume_graph.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 #include <cstddef>

--- a/core/include/detray/intersection/detail/trajectories.hpp
+++ b/core/include/detray/intersection/detail/trajectories.hpp
@@ -16,6 +16,7 @@
 // System include(s).
 #include <cmath>
 #include <limits>
+#include <ostream>
 
 namespace detray {
 
@@ -70,6 +71,19 @@ class ray {
     /// @returns overstep tolerance to comply with track interface
     DETRAY_HOST_DEVICE
     scalar_type overstep_tolerance() const { return _overstep_tolerance; }
+
+    /// Print
+    DETRAY_HOST
+    friend std::ostream &operator<<(std::ostream &os, const ray &r) {
+        os << "ray: ";
+        os << "ori = [" << r._pos[0] << ", " << r._pos[1] << ", " << r._pos[2]
+           << "], ";
+        os << "dir = [" << r._dir[0] << ", " << r._dir[1] << ", " << r._dir[2]
+           << "], ";
+        os << "tol = " << r._overstep_tolerance << std::endl;
+
+        return os;
+    }
 
     private:
     /// origin of ray

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 #include <cmath>

--- a/core/include/detray/masks/unbounded.hpp
+++ b/core/include/detray/masks/unbounded.hpp
@@ -66,23 +66,27 @@ class unbounded {
 
     /// @brief Lower and upper point for minimal axis aligned bounding box.
     ///
-    /// Computes the min and max vertices in a local cartesian frame.
+    /// Computes the min and max vertices in a local cartesian frame of the
+    /// shape it wraps.
+    ///
+    /// @note The @c check_boundaries method will return 'inside' for points
+    /// that are outside the local min bounds! This results in the bounding box
+    /// to behave reasonably in a BVH, but still be always intersected
+    /// successfully when queried directly.
     ///
     /// @param bounds the boundary values for this shape
     /// @param env dynamic envelope around the shape
     ///
     /// @returns and array of coordinates that contains the lower point (first
-    /// three values) and the upper point (latter three values) .
+    /// three values) and the upper point (latter three values).
     template <
         typename algebra_t, template <typename, std::size_t> class bounds_t,
         typename scalar_t, std::size_t kDIM,
         typename std::enable_if_t<kDIM == boundaries::e_size, bool> = true>
     DETRAY_HOST_DEVICE constexpr std::array<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& /*bounds*/,
-        const scalar_t /*env*/ =
-            std::numeric_limits<scalar_t>::epsilon()) const {
-        constexpr scalar_t inf{std::numeric_limits<scalar_t>::infinity()};
-        return {-inf, -inf, -inf, inf, inf, inf};
+        const bounds_t<scalar_t, kDIM>& bounds,
+        const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
+        return shape{}.template local_min_bounds<algebra_t>(bounds, env);
     }
 
     template <typename param_t>

--- a/core/include/detray/tools/surface_factory_interface.hpp
+++ b/core/include/detray/tools/surface_factory_interface.hpp
@@ -5,10 +5,10 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 // System include(s)
 #include <tuple>
-
-#pragma once
 
 namespace detray {
 

--- a/core/include/detray/utils/quadratic_equation.hpp
+++ b/core/include/detray/utils/quadratic_equation.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 #include <algorithm>

--- a/core/include/detray/utils/ranges.hpp
+++ b/core/include/detray/utils/ranges.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/utils/ranges/detail/iterator_functions.hpp
+++ b/core/include/detray/utils/ranges/detail/iterator_functions.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Thrust include(s)

--- a/core/include/detray/utils/ranges/empty.hpp
+++ b/core/include/detray/utils/ranges/empty.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/utils/ranges/enumerate.hpp
+++ b/core/include/detray/utils/ranges/enumerate.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/utils/ranges/iota.hpp
+++ b/core/include/detray/utils/ranges/iota.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/utils/ranges/join.hpp
+++ b/core/include/detray/utils/ranges/join.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/utils/ranges/pick.hpp
+++ b/core/include/detray/utils/ranges/pick.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/utils/ranges/ranges.hpp
+++ b/core/include/detray/utils/ranges/ranges.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/utils/ranges/single.hpp
+++ b/core/include/detray/utils/ranges/single.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/utils/ranges/subrange.hpp
+++ b/core/include/detray/utils/ranges/subrange.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/core/include/detray/utils/tuple_helpers.hpp
+++ b/core/include/detray/utils/tuple_helpers.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 // Project include(s)

--- a/io/csv/include/detray/io/csv_io_types.hpp
+++ b/io/csv/include/detray/io/csv_io_types.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 #include <dfe/dfe_io_dsv.hpp>
 #include <dfe/dfe_namedtuple.hpp>
 #include <fstream>

--- a/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 // Algebra-Plugins include
 #include "algebra/array_cmath.hpp"
 

--- a/plugins/algebra/eigen/include/detray/plugins/algebra/eigen_definitions.hpp
+++ b/plugins/algebra/eigen/include/detray/plugins/algebra/eigen_definitions.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 // Algebra-Plugins include
 #include "algebra/eigen_eigen.hpp"
 

--- a/plugins/algebra/smatrix/include/detray/plugins/algebra/smatrix_definitions.hpp
+++ b/plugins/algebra/smatrix/include/detray/plugins/algebra/smatrix_definitions.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 // Algebra-Plugins include
 #include "algebra/smatrix_smatrix.hpp"
 

--- a/plugins/algebra/vc/include/detray/plugins/algebra/vc_array_definitions.hpp
+++ b/plugins/algebra/vc/include/detray/plugins/algebra/vc_array_definitions.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 // Algebra-Plugins include
 #include "algebra/vc_cmath.hpp"
 

--- a/tests/common/include/tests/common/check_simulation.inl
+++ b/tests/common/include/tests/common/check_simulation.inl
@@ -201,8 +201,8 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
     vecmem::host_memory_resource host_mr;
 
     // Use rectangle surfaces
-    mask<unbounded<rectangle2D<>>> rectangle{0u, 20.f * unit<scalar>::mm,
-                                             20.f * unit<scalar>::mm};
+    mask<rectangle2D<>> rectangle{0u, 1000.f * unit<scalar>::mm,
+                                  1000.f * unit<scalar>::mm};
 
     // Build from given module positions
     std::vector<scalar> positions = {0.f,   50.f,  100.f, 150.f, 200.f, 250.f,
@@ -212,10 +212,9 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
     const scalar thickness = 0.17f * unit<scalar>::cm;
 
     // Detector type
-    using detector_type =
-        detray::detector<detray::detector_registry::template telescope_detector<
-                             unbounded<rectangle2D<>>>,
-                         covfie::field>;
+    using detector_type = detray::detector<
+        detray::detector_registry::template telescope_detector<rectangle2D<>>,
+        covfie::field>;
 
     // Create B field
     const vector3 B{0.f, 0.f, 2.f * unit<scalar>::T};
@@ -270,7 +269,7 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
 
         // Make sure that number of measurements is equal to the number of
         // physical planes
-        ASSERT_EQ(measurements.size(), positions.size() - 2u);
+        ASSERT_EQ(measurements.size(), positions.size());
     }
 }
 

--- a/tests/common/include/tests/common/line_stepper.inl
+++ b/tests/common/include/tests/common/line_stepper.inl
@@ -38,10 +38,10 @@ TEST(line_stepper, covariance_transport) {
     vecmem::host_memory_resource host_mr;
 
     // Use unbounded rectangle surfaces
-    mask<unbounded<rectangle2D<>>> rectangle{0u, 20.f * unit<scalar>::mm,
-                                             20.f * unit<scalar>::mm};
+    mask<rectangle2D<>> rectangle{0u, 200.f * unit<scalar>::mm,
+                                  200.f * unit<scalar>::mm};
 
-    // Create telescope detector with a single plane
+    // Build in x-direction from given module positions
     detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
     std::vector<scalar> positions = {0.f, 10.f, 20.f, 30.f, 40.f, 50.f, 60.f};
 
@@ -51,7 +51,7 @@ TEST(line_stepper, covariance_transport) {
                                                80.f * unit<scalar>::um, traj);
 
     using navigator_t = navigator<decltype(det)>;
-    using cline_stepper_t = line_stepper<transform3, constrained_step<>>;
+    using cline_stepper_t = line_stepper<transform3>;
     using actor_chain_t = actor_chain<dtuple, parameter_transporter<transform3>,
                                       parameter_resetter<transform3>>;
     using propagator_t =
@@ -63,7 +63,7 @@ TEST(line_stepper, covariance_transport) {
     getter::element(bound_vector, e_bound_loc1, 0u) = 0.f;
     getter::element(bound_vector, e_bound_phi, 0u) = 0.f;
     getter::element(bound_vector, e_bound_theta, 0u) = constant<scalar>::pi_4;
-    getter::element(bound_vector, e_bound_qoverp, 0u) = -1.f / 10.f;
+    getter::element(bound_vector, e_bound_qoverp, 0u) = -0.1f;
     getter::element(bound_vector, e_bound_time, 0u) = 0.f;
 
     // Bound covariance
@@ -94,9 +94,9 @@ TEST(line_stepper, covariance_transport) {
     // const auto bound_vec0 = bound_param0.vector();
     // const auto bound_vec1 = bound_param1.vector();
 
-    // Check if the track reaches the final surface
+    // Check if the track starts at the first and reaches the final surface
     EXPECT_EQ(bound_param0.surface_link(), 0u);
-    EXPECT_EQ(bound_param1.surface_link(), 5u);
+    EXPECT_EQ(bound_param1.surface_link(), 6u);
 
     const auto bound_cov0 = bound_param0.covariance();
     const auto bound_cov1 = bound_param1.covariance();

--- a/tests/common/include/tests/common/masks_unbounded.inl
+++ b/tests/common/include/tests/common/masks_unbounded.inl
@@ -6,6 +6,7 @@
  */
 
 // Project include(s)
+#include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/masks/unbounded.hpp"
 
@@ -18,6 +19,8 @@
 
 using namespace detray;
 
+constexpr scalar tol{1e-7f};
+
 /// This tests the basic functionality of an unbounded rectangle shape
 TEST(mask, unbounded) {
     using transform3_t = __plugin::transform3<scalar>;
@@ -25,7 +28,9 @@ TEST(mask, unbounded) {
     using shape_t = rectangle2D<>;
     using unbounded_t = unbounded<shape_t>;
 
-    mask<unbounded_t> u{};
+    constexpr scalar h{20.f * unit<scalar>::mm};
+
+    mask<unbounded_t> u{0u, h, h};
 
     // Test local typedefs
     static_assert(std::is_same_v<unbounded_t::shape, shape_t>,
@@ -78,10 +83,10 @@ TEST(mask, unbounded) {
     // Check bounding box
     constexpr scalar envelope{0.01f};
     const auto loc_bounds = u.local_min_bounds(envelope);
-    ASSERT_TRUE(std::isinf(loc_bounds[cuboid3D<>::e_min_x]));
-    ASSERT_TRUE(std::isinf(loc_bounds[cuboid3D<>::e_min_y]));
-    ASSERT_TRUE(std::isinf(loc_bounds[cuboid3D<>::e_min_z]));
-    ASSERT_TRUE(std::isinf(loc_bounds[cuboid3D<>::e_max_x]));
-    ASSERT_TRUE(std::isinf(loc_bounds[cuboid3D<>::e_max_y]));
-    ASSERT_TRUE(std::isinf(loc_bounds[cuboid3D<>::e_max_z]));
+    ASSERT_NEAR(loc_bounds[cuboid3D<>::e_min_x], -(h + envelope), tol);
+    ASSERT_NEAR(loc_bounds[cuboid3D<>::e_min_y], -(h + envelope), tol);
+    ASSERT_NEAR(loc_bounds[cuboid3D<>::e_min_z], -envelope, tol);
+    ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], (h + envelope), tol);
+    ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], (h + envelope), tol);
+    ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], envelope, tol);
 }

--- a/tests/common/include/tests/common/material_interaction.inl
+++ b/tests/common/include/tests/common/material_interaction.inl
@@ -211,10 +211,11 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
 
     vecmem::host_memory_resource host_mr;
 
-    // Use unbounded rectangle surfaces
-    mask<unbounded<rectangle2D<>>> rectangle{0u, 20.f * unit<scalar>::mm,
-                                             20.f * unit<scalar>::mm};
-    // Build from given module positions
+    // Use rectangle surfaces in telescope
+    mask<rectangle2D<>> rectangle{0u, 20.f * unit<scalar>::mm,
+                                  20.f * unit<scalar>::mm};
+
+    // Build in x-direction from given module positions
     detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
     std::vector<scalar> positions = {0.f,   50.f,  100.f, 150.f, 200.f, 250.f,
                                      300.f, 350.f, 400.f, 450.f, 500.f};
@@ -308,10 +309,11 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
     // propagation. However, since the energy loss << the track momentum,
     // the assumption is not very bad
 
-    // -2 is required because the first and last surface is a portal
+    // The navigation starts on the first surface, which is therefore not
+    // accounted
     const scalar dE{
         I.compute_energy_loss_bethe(is, slab, pdg, mass, q / iniP, q) *
-        static_cast<scalar>(positions.size() - 2u)};
+        static_cast<scalar>(positions.size() - 1u)};
 
     // Check if the new energy after propagation is enough close to the
     // expected value
@@ -332,11 +334,11 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
 TEST(material_interaction, telescope_geometry_scattering_angle) {
     vecmem::host_memory_resource host_mr;
 
-    // Use unbounded rectangle surfaces
-    mask<unbounded<rectangle2D<>>> rectangle{0u, 20.f * unit<scalar>::mm,
-                                             20.f * unit<scalar>::mm};
+    // Use rectangle surfaces in the telescope
+    mask<rectangle2D<>> rectangle{0u, 2000.f * unit<scalar>::mm,
+                                  2000.f * unit<scalar>::mm};
 
-    // Build from given module positions
+    // Build in x-direction from given module positions
     detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
     std::vector<scalar> positions = {0.f, 1000.f * unit<scalar>::cm,
                                      2000.f * unit<scalar>::cm};

--- a/tests/common/include/tests/common/tools/hash_tree.hpp
+++ b/tests/common/include/tests/common/tools/hash_tree.hpp
@@ -4,6 +4,7 @@
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
 
 #include <cmath>

--- a/tests/common/include/tests/common/tools/ray_scan_utils.hpp
+++ b/tests/common/include/tests/common/tools/ray_scan_utils.hpp
@@ -5,8 +5,11 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <iostream>
 #include <iterator>
 #include <set>

--- a/tests/common/include/tests/common/tools/read_geometry.hpp
+++ b/tests/common/include/tests/common/tools/read_geometry.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 #include <map>
 #include <string>
 #include <vecmem/memory/host_memory_resource.hpp>

--- a/tests/common/include/tests/common/tools_bounding_volume.inl
+++ b/tests/common/include/tests/common/tools_bounding_volume.inl
@@ -316,7 +316,7 @@ TEST(tools, wrap_bounding_cuboid3D) {
     box_t b3{0u, -1.5f, -0.1f, -2.f, 0.f, 0.1f, 2.f};
     box_t b4{0u, 0.f, 0.f, 0.f, 2.f, 2.f, 10.f};
 
-    std::vector<const box_t*> boxes = {&b1, &b2, &b3, &b4};
+    std::vector<box_t> boxes = {b1, b2, b3, b4};
 
     box_t aabb{boxes, 0u, envelope};
 

--- a/tests/common/include/tests/common/tools_guided_navigator.inl
+++ b/tests/common/include/tests/common/tools_guided_navigator.inl
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,20 +30,17 @@ TEST(ALGEBRA_PLUGIN, guided_navigator) {
 
     vecmem::host_memory_resource host_mr;
 
-    // Use unbounded rectangle surfaces
-    mask<unbounded<rectangle2D<>>> rectangle{0u, 20.f * unit<scalar>::mm,
-                                             20.f * unit<scalar>::mm};
-
-    // Builds the telescope alon z-axis
-    detail::ray<transform3_type> default_trk({0, 0, 0}, 0, {0, 0, 1}, -1);
+    // Use unbounded rectangle surfaces that cannot be missed
+    mask<unbounded<rectangle2D<>>> urectangle{0u, 20.f * unit<scalar>::mm,
+                                              20.f * unit<scalar>::mm};
 
     // Module positions along z-axis
-    const std::vector<scalar> positions = {0.,  10., 20., 30., 40., 50.,
-                                           60., 70,  80,  90., 100.};
-    // Build telescope detector with unbounded planes
-    const auto telescope_det = create_telescope_detector(
-        host_mr, rectangle, positions, silicon_tml<scalar>(),
-        80.f * unit<scalar>::um, default_trk);
+    const std::vector<scalar> positions = {0.f,  10.f, 20.f, 30.f, 40.f, 50.f,
+                                           60.f, 70.f, 80.f, 90.f, 100.f};
+
+    // Build telescope detector with unbounded rectangles
+    const auto telescope_det =
+        create_telescope_detector(host_mr, urectangle, positions);
 
     // Inspectors are optional, of course
     using object_tracer_t =
@@ -59,15 +56,15 @@ TEST(ALGEBRA_PLUGIN, guided_navigator) {
         propagator<runge_kutta_stepper, guided_navigator, actor_chain_t>;
 
     // track must point into the direction of the telescope
-    const point3 pos{0., 0., 0.};
-    const vector3 mom{0., 0., 1.};
-    free_track_parameters<transform3_type> track(pos, 0, mom, -1);
-    const vector3 B{0, 0, 1 * unit<scalar>::T};
+    const point3 origin{0.f, 0.f, -0.01f};
+    const vector3 mom{0.f, 0.f, 1.f};
+    free_track_parameters<transform3_type> track(origin, 0.f, mom, -1.f);
+    const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
     const b_field_t b_field(
         b_field_t::backend_t::configuration_t{B[0], B[1], B[2]});
 
     // Actors
-    pathlimit_aborter::state pathlimit{200. * unit<scalar>::cm};
+    pathlimit_aborter::state pathlimit{200.f * unit<scalar>::cm};
 
     // Propagator
     propagator_t p(runge_kutta_stepper{}, guided_navigator{});
@@ -84,10 +81,12 @@ TEST(ALGEBRA_PLUGIN, guided_navigator) {
     ASSERT_TRUE(nav_state.is_complete()) << debug_printer.to_string();
 
     // sequence of surface ids we expect to see
-    const std::vector<dindex> sf_sequence = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    const std::vector<dindex> sf_sequence = {0u, 1u, 2u, 3u, 4u,  5u,
+                                             6u, 7u, 8u, 9u, 10u, 11u};
     // Check the surfaces that have been visited by the navigation
-    EXPECT_EQ(obj_tracer.object_trace.size(), sf_sequence.size());
-    for (size_t i = 0; i < sf_sequence.size(); ++i) {
+    EXPECT_EQ(obj_tracer.object_trace.size(), sf_sequence.size())
+        << debug_printer.to_string();
+    for (std::size_t i = 0u; i < sf_sequence.size(); ++i) {
         const auto &candidate = obj_tracer.object_trace[i];
         EXPECT_TRUE(candidate.index == sf_sequence[i]);
     }

--- a/tests/common/include/tests/common/tools_track_generators.inl
+++ b/tests/common/include/tests/common/tools_track_generators.inl
@@ -72,7 +72,7 @@ TEST(tools, uniform_track_generator) {
     }
     ASSERT_EQ(momenta.size(), n_tracks);
 
-    // Genrate rays
+    // Generate rays
     n_tracks = 0u;
     for (const auto r : uniform_track_generator<detail::ray<transform3>>(
              theta_steps, phi_steps)) {

--- a/tests/unit_tests/device/cuda/detector_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/detector_cuda_kernel.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 #if defined(array)
 #include "detray/plugins/algebra/array_definitions.hpp"
 #elif defined(eigen)
@@ -20,8 +22,6 @@
 #include "detray/core/detector.hpp"
 #include "detray/detectors/detector_metadata.hpp"
 #include "detray/utils/ranges.hpp"
-
-#pragma once
 
 using namespace detray;
 using namespace __plugin;

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda_kernel.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 // detray test
 #include "tests/common/test_defs.hpp"
 
@@ -14,8 +16,6 @@
 #include "detray/grids/grid2.hpp"
 #include "detray/grids/populator.hpp"
 #include "detray/grids/serializer2.hpp"
-
-#pragma once
 
 namespace detray {
 

--- a/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 #if defined(array)
 #include "detray/plugins/algebra/array_definitions.hpp"
 #elif defined(eigen)
@@ -28,8 +30,6 @@
 
 // Thrust include(s)
 #include <thrust/tuple.h>
-
-#pragma once
 
 using namespace detray;
 

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 #if defined(array)
 #include "detray/plugins/algebra/array_definitions.hpp"
 #elif defined(eigen)
@@ -23,8 +25,6 @@
 #include "detray/surface_finders/grid/populator.hpp"
 #include "detray/surface_finders/grid/serializer.hpp"
 #include "detray/tools/grid_builder.hpp"
-
-#pragma once
 
 namespace {
 

--- a/tests/unit_tests/device/cuda/transform_store_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/transform_store_cuda_kernel.hpp
@@ -5,6 +5,8 @@
  * Mozilla Public License Version 2.0
  */
 
+#pragma once
+
 #if defined(array)
 #include "detray/plugins/algebra/array_definitions.hpp"
 #elif defined(eigen)
@@ -20,8 +22,6 @@
 
 // Vecmem include(s)
 #include <vecmem/containers/device_vector.hpp>
-
-#pragma once
 
 using namespace detray;
 using namespace __plugin;

--- a/utils/include/detray/detectors/detector_metadata.hpp
+++ b/utils/include/detray/detectors/detector_metadata.hpp
@@ -280,17 +280,27 @@ struct telescope_metadata {
     using transform_store = single_store<__plugin::transform3<detray::scalar>,
                                          vector_t, geometry_context>;
 
-    /// Give your mask types a name (needs to be consecutive to be matched
-    /// to a type!)
+    /// Rectangles are always needed as portals. Only one mask shape is allowed
+    /// in addition
     enum class mask_ids {
-        e_mask = 0,
+        e_portal_rectangle2 = 0,
+        e_rectangle2 = 0,
+        e_annulus2 = 1,
+        e_cylinder2 = 1,
+        e_ring2 = 1,
+        e_trapezoid2 = 1,
+        e_unbounded = 1
     };
 
     /// How to store and link masks
     template <template <typename...> class tuple_t = dtuple,
               template <typename...> class vector_t = dvector>
-    using mask_store = regular_multi_store<mask_ids, empty_context, tuple_t,
-                                           vector_t, mask<mask_shape_t>>;
+    using mask_store = std::conditional_t<
+        std::is_same_v<mask<mask_shape_t>, rectangle>,
+        regular_multi_store<mask_ids, empty_context, tuple_t, vector_t,
+                            rectangle>,
+        regular_multi_store<mask_ids, empty_context, tuple_t, vector_t,
+                            rectangle, mask<mask_shape_t>>>;
 
     /// Give your material types a name (needs to be consecutive to be matched
     /// to a type!)


### PR DESCRIPTION
Adds a function to the telescope geometry creation that builds local minimum bounding boxes around the module surfaces that are contained in the detector and then constructs the portals from the global bounding volume. The surfaces that are passed to the geometry creation are now all sensitive surfaces (no implicit portals anymore).

As a validation step, the telescope geometry is tested in a ray scan.