### PR TITLE
ref: pathcorrection unittest runs on telescope detector

### DIFF
--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -96,7 +96,7 @@ struct cylinder_intersector {
                     is.p2 = mask.to_local_frame(trf, is.p3);
                     is.status = mask.is_inside(is.p2, mask_tolerance);
                 }
-                is.direction = vector::dot(is.p3, rd) > 0.f
+                is.direction = is.path >= 0.f
                                    ? intersection::direction::e_along
                                    : intersection::direction::e_opposite;
                 is.link = mask.volume_link();

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -80,10 +80,15 @@ struct target_aborter : actor {
                                        propagator_state_t &prop_state) const {
 
         auto &navigation = prop_state._navigation;
+        const auto &stepping = prop_state._stepping;
 
+        // In case the propagation starts on a module, make sure to not abort
+        // directly
         if (navigation.is_on_module() and
-            navigation.current_object() == abrt_state._target_surface_index) {
-            navigation.exit();
+            (navigation.current_object() ==
+             abrt_state._target_surface_index) and
+            (stepping.path_length() > 0.f)) {
+            prop_state._heartbeat &= navigation.exit();
         }
     }
 };

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -77,9 +77,10 @@ class rk_stepper final
             array_t<scalar, 4> k_qop;
         } _step_data;
 
+        /// Magnetic field view
         const magnetic_field_t _magnetic_field;
 
-        // Set the local error tolerenace
+        /// Set the local error tolerenace
         DETRAY_HOST_DEVICE
         inline void set_tolerance(scalar tol) { _tolerance = tol; };
 
@@ -91,11 +92,11 @@ class rk_stepper final
         DETRAY_HOST_DEVICE
         inline void advance_track();
 
-        // Update the jacobian transport from free propagation
+        /// Update the jacobian transport from free propagation
         DETRAY_HOST_DEVICE
         inline void advance_jacobian();
 
-        // evaulate k_n for runge kutta stepping
+        /// evaulate k_n for runge kutta stepping
         DETRAY_HOST_DEVICE
         inline vector3 evaluate_k(const vector3& b_field, const int i,
                                   const scalar h, const vector3& k_prev);

--- a/tests/common/include/tests/common/tools/inspectors.hpp
+++ b/tests/common/include/tests/common/tools/inspectors.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/intersection/detail/trajectories.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/utils/tuple_helpers.hpp"
 
@@ -218,6 +219,13 @@ struct print_inspector : actor {
 
         printer.stream << "step_size: " << std::setw(10) << stepping._step_size
                        << std::endl;
+
+        printer.stream
+            << std::setw(10)
+            << detail::ray<
+                   typename propagation_state_t::detector_type::transform3>(
+                   stepping())
+            << std::endl;
     }
 };
 

--- a/tests/common/include/tests/common/tools_guided_navigator.inl
+++ b/tests/common/include/tests/common/tools_guided_navigator.inl
@@ -27,6 +27,8 @@ TEST(ALGEBRA_PLUGIN, guided_navigator) {
     using namespace detray;
     using namespace navigation;
     using transform3_type = __plugin::transform3<scalar>;
+    using point3 = typename transform3_type::point3;
+    using vector3 = typename transform3_type::vector3;
 
     vecmem::host_memory_resource host_mr;
 

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -29,17 +29,17 @@ namespace detray {
 
 namespace {
 
-// @Note: These type definitions should be removed at some point
-using point3 = __plugin::point3<detray::scalar>;
-using vector3 = __plugin::vector3<detray::scalar>;
-using point2 = __plugin::point2<detray::scalar>;
-
 template <typename mask_shape_t>
 using telescope_types =
     typename detector_registry::template telescope_detector<mask_shape_t>;
 
 /// Where and how to place the telescope modules.
 struct module_placement {
+
+    // @Note: These type definitions should be removed at some point
+    using point3 = __plugin::point3<detray::scalar>;
+    using vector3 = __plugin::vector3<detray::scalar>;
+
     /// Module position
     point3 _pos;
     /// Module normal
@@ -95,6 +95,9 @@ inline void create_cuboid_portals(context_t &ctx, const scalar pt_envelope,
                                   mask_container_t &masks,
                                   material_container_t &materials,
                                   transform_container_t &transforms) {
+    // @Note: These type definitions should be removed at some point
+    using point3 = __plugin::point3<detray::scalar>;
+    using vector3 = __plugin::vector3<detray::scalar>;
 
     using surface_t = typename surface_container_t::value_type;
     using volume_link_t = typename surface_t::volume_link_type;
@@ -243,6 +246,9 @@ inline void create_telescope(context_t &ctx, const trajectory_t &traj,
                              material_container_t &materials,
                              transform_container_t &transforms,
                              const config_t &cfg) {
+    // @Note: These type definitions should be removed at some point
+    using vector3 = __plugin::vector3<detray::scalar>;
+
     using surface_type = typename surface_container_t::value_type;
     using volume_link_t = typename surface_type::volume_link_type;
     using mask_link_t = typename surface_type::mask_link;


### PR DESCRIPTION
Switch the pathcorrection unittest to use the telescope detector. With the portals around the test surface and the target aborter, propagation is now possible without a special actor.