### PR TITLE
ref: additional navigation call after random scattering

### DIFF
--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -134,11 +134,14 @@ struct propagator {
             // Take the step
             propagation._heartbeat &= _stepper.step(propagation);
 
-            // And check the status
+            // Find next candidate
             propagation._heartbeat &= _navigator.update(propagation);
 
             // Run all registered actors/aborters after update
             run_actors(actor_states, propagation);
+
+            // And check the status
+            propagation._heartbeat &= _navigator.update(propagation);
         }
 
         // Pass on the whether the propagation was successful
@@ -174,7 +177,7 @@ struct propagator {
                 // Take the step
                 propagation._heartbeat &= _stepper.step(propagation);
 
-                // And check the status
+                // Find next candidate
                 propagation._heartbeat &= _navigator.update(propagation);
 
                 // If the track is on a sensitive surface, break the loop to
@@ -183,12 +186,18 @@ struct propagator {
                     break;
                 } else {
                     run_actors(actor_states, propagation);
+
+                    // And check the status
+                    propagation._heartbeat &= _navigator.update(propagation);
                 }
             }
 
             // Synchornized actor
             if (propagation._heartbeat) {
                 run_actors(actor_states, propagation);
+
+                // And check the status
+                propagation._heartbeat &= _navigator.update(propagation);
             }
         }
 

--- a/tests/common/include/tests/common/check_simulation.inl
+++ b/tests/common/include/tests/common/check_simulation.inl
@@ -98,6 +98,9 @@ TEST(check_simulation, toy_geometry) {
     std::size_t n_events{10u};
     auto sim = simulator(n_events, detector, std::move(generator), smearer);
 
+    // Lift step size constraints
+    sim.get_config().step_constraint = std::numeric_limits<scalar>::max();
+
     // Do the simulation
     sim.run();
 
@@ -236,6 +239,9 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
     std::size_t n_events{1000u};
 
     auto sim = simulator(n_events, detector, std::move(generator), smearer);
+
+    // Lift step size constraints
+    sim.get_config().step_constraint = std::numeric_limits<scalar>::max();
 
     // Run simulation
     sim.run();

--- a/utils/include/detray/simulation/random_scatterer.hpp
+++ b/utils/include/detray/simulation/random_scatterer.hpp
@@ -71,6 +71,9 @@ struct random_scatterer : actor {
                 getter::theta(new_dir);
             matrix_operator().element(vector, e_bound_phi, 0u) =
                 getter::phi(new_dir);
+
+            // Flag renavigation of the current candidate
+            prop_state._navigation.set_high_trust();
         }
     }
 };

--- a/utils/include/detray/simulation/simulator.hpp
+++ b/utils/include/detray/simulation/simulator.hpp
@@ -20,6 +20,7 @@
 #include "detray/simulation/random_scatterer.hpp"
 
 // System include(s).
+#include <limits>
 #include <memory>
 
 namespace detray {
@@ -31,7 +32,7 @@ struct simulator {
 
     struct config {
         scalar_type overstep_tolerance{-10.f * detray::unit<scalar_type>::um};
-        scalar_type step_constraint{10.f * detray::unit<scalar_type>::mm};
+        scalar_type step_constraint{std::numeric_limits<scalar_type>::max()};
     };
 
     using transform3 = typename detector_t::transform3;


### PR DESCRIPTION
If an actor changes the track state after initial navigation, re-navigation is needed. This PR adds an additional call to the navigator after the actor chain runs and modifies the random_scatterer, so that it reduces the trust level to request the navigator to update the current candidate.