### PR TITLE
Remove Problematic printf-s, main branch (2023.02.24.)

### DIFF
--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -52,7 +52,6 @@ struct pathlimit_aborter : actor {
         // Check the path limit
         abrt_state._path_limit -= std::abs(prop_state._stepping.step_size());
         if (abrt_state.path_limit() <= 0) {
-            // printf("Abort: Stepper above maximal path length!\n");
             // Stop navigation
             prop_state._heartbeat &= nav_state.abort();
         }

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -241,8 +241,6 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
         if (std::abs(stepping._step_size) <
             std::abs(stepping._step_size_cutoff)) {
             // Not moving due to too low momentum needs an aborter
-            printf("Stepper: step size is too small. will break. \n");
-            // State is broken
             return navigation.abort();
         }
 
@@ -250,8 +248,6 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
         // appropriate
         if (n_step_trials > stepping._max_rk_step_trials) {
             // Too many trials, have to abort
-            printf("Stepper: too many rk4 trials. will break. \n");
-            // State is broken
             return navigation.abort();
         }
         n_step_trials++;


### PR DESCRIPTION
Removed the `printf(...)` statements that prevent using the code making those calls in SYCL kernels. Currently any modern oneAPI version, as long as you try to compile "not only" for an NVIDIA backend, would fail like:

```
[ 68%] Building SYCL object device/sycl/CMakeFiles/traccc_sycl.dir/src/fitting/fitting_algorithm.sycl.o
In file included from /data/ssd-1tb/projects/traccc/traccc/device/sycl/src/fitting/fitting_algorithm.sycl:17:
In file included from /data/ssd-1tb/projects/traccc/build/_deps/detray-src/core/include/detray/propagator/rk_stepper.hpp:113:
/data/ssd-1tb/projects/traccc/build/_deps/detray-src/core/include/detray/propagator/rk_stepper.ipp:244:69: error: SYCL kernel cannot call a variadic function
            printf("Stepper: step size is too small. will break. \n");
                                                                    ^
...
/data/ssd-1tb/projects/traccc/traccc/device/sycl/src/fitting/fitting_algorithm.sycl:88:29: note: called by 'operator()'
                    device::fit<fitter_t>(item.get_global_linear_id(), det_view,
                            ^
/home/krasznaa/software/intel/clang/2022-12/x86_64-ubuntu2004-gcc9-opt/bin/../include/sycl/handler.hpp:1202:5: note: called by 'kernel_parallel_for<traccc::sycl::kernels::fit, sycl::nd_item<1>, (lambda at /data/ssd-1tb/projects/traccc/traccc/device/sycl/src/fitting/fitting_algorithm.sycl:86:17)>'
    KernelFunc(detail::Builder::getElement(detail::declptr<ElementType>()));
    ^
In file included from /data/ssd-1tb/projects/traccc/traccc/device/sycl/src/fitting/fitting_algorithm.sycl:17:
In file included from /data/ssd-1tb/projects/traccc/build/_deps/detray-src/core/include/detray/propagator/rk_stepper.hpp:113:
/data/ssd-1tb/projects/traccc/build/_deps/detray-src/core/include/detray/propagator/rk_stepper.ipp:253:66: error: SYCL kernel cannot call a variadic function
            printf("Stepper: too many rk4 trials. will break. \n");
                                                                 ^
2 errors generated.
make[2]: *** [device/sycl/CMakeFiles/traccc_sycl.dir/build.make:80: device/sycl/CMakeFiles/traccc_sycl.dir/src/fitting/fitting_algorithm.sycl.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:4288: device/sycl/CMakeFiles/traccc_sycl.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```

Removed a commented-out line as well. Just for cleanliness.

I'm fine with whatever solution being developed for a "nice" error propagation in the code. But removing these two calls is very high priority right now...