### PR TITLE
perf: Remove Thrust calls inside kernels

### DIFF
--- a/core/include/detray/utils/sort.hpp
+++ b/core/include/detray/utils/sort.hpp
@@ -12,6 +12,7 @@
 
 // System include(s).
 #include <algorithm>
+#include <functional>
 
 namespace detray {
 
@@ -31,6 +32,32 @@ DETRAY_HOST_DEVICE inline void insertion_sort(RandomIt first, RandomIt last) {
 template <template <typename...> class vector_t, typename TYPE>
 DETRAY_HOST_DEVICE inline void insertion_sort(vector_t<TYPE> &vec) {
     insertion_sort(vec.begin(), vec.end());
+}
+
+template <class RandomIt, class Comp = std::less<void>>
+DETRAY_HOST_DEVICE inline void selection_sort(RandomIt first, RandomIt last,
+                                              Comp &&comp = Comp()) {
+    for (RandomIt i = first; i < (last - 1); ++i) {
+        RandomIt k = i;
+
+        for (RandomIt j = i + 1; j < last; ++j) {
+            if (comp(*j, *k)) {
+                k = j;
+            }
+        }
+
+        if (k != i) {
+            auto t = *i;
+            *i = *k;
+            *k = t;
+        }
+    }
+}
+
+// Function to sort the array
+template <template <typename...> class vector_t, typename TYPE>
+DETRAY_HOST_DEVICE inline void selection_sort(vector_t<TYPE> &vec) {
+    selection_sort(vec.begin(), vec.end());
 }
 
 }  // namespace detray

--- a/tests/unit_tests/core/utils_sort.cpp
+++ b/tests/unit_tests/core/utils_sort.cpp
@@ -21,3 +21,13 @@ TEST(utils, insertion_sort) {
 
     ASSERT_EQ(vec, vec_sorted);
 }
+
+TEST(utils, selection_sort) {
+
+    std::vector<double> vec = {4.1, 5., 1.2, 1.4, 9.};
+    std::vector<double> vec_sorted = {1.2, 1.4, 4.1, 5., 9.};
+
+    detray::selection_sort(vec.begin(), vec.end());
+
+    ASSERT_EQ(vec, vec_sorted);
+}


### PR DESCRIPTION
@niermann999 and myself were profiling the propagation kernels in detray and discovered significant overhead originating from calls to Thrust functions in device code. In particular, a call to `thrust::sort` was performing a sorting algorithm with non-constant spatial overhead, meaning it had to allocate memory on the device side, which is quite slow. This commit changes the sorting to use a hand-rolled implementation of selection sort. Note that it also changes the use of insertion sort to selection sort elsewhere, as insertion sort has an average of O(n<sup>2</sup>) swaps (which access global memory) compared to the average of O(n) swaps that selection sort requires.