### PR TITLE
feat: Add throughput to propagation benchmarks

### DIFF
--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -60,6 +60,8 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
     // Create propagator
     propagator_host_type p(std::move(s), std::move(n));
 
+    std::size_t total_tracks = 0;
+
     for (auto _ : state) {
 
         // TODO: use fixture to build tracks
@@ -69,6 +71,8 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
         vecmem::vector<free_track_parameters<transform3>> tracks(&host_mr);
         fill_tracks(tracks, static_cast<std::size_t>(state.range(0)),
                     static_cast<std::size_t>(state.range(0)));
+
+        total_tracks += tracks.size();
 
         state.ResumeTiming();
 
@@ -92,6 +96,9 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
             }
         }
     }
+
+    state.counters["TracksPropagated"] = benchmark::Counter(
+        static_cast<double>(total_tracks), benchmark::Counter::kIsRate);
 }
 
 template <propagate_option opt>
@@ -107,6 +114,8 @@ static void BM_PROPAGATOR_CUDA(benchmark::State &state) {
     // vecmem copy helper object
     vecmem::cuda::copy copy;
 
+    std::size_t total_tracks = 0;
+
     for (auto _ : state) {
 
         state.PauseTiming();
@@ -115,6 +124,8 @@ static void BM_PROPAGATOR_CUDA(benchmark::State &state) {
         vecmem::vector<free_track_parameters<transform3>> tracks(&bp_mng_mr);
         fill_tracks(tracks, static_cast<std::size_t>(state.range(0)),
                     static_cast<std::size_t>(state.range(0)));
+
+        total_tracks += tracks.size();
 
         state.ResumeTiming();
 
@@ -129,6 +140,9 @@ static void BM_PROPAGATOR_CUDA(benchmark::State &state) {
         // Run the propagator test for GPU device
         propagator_benchmark(det_data, tracks_data, candidates_buffer, opt);
     }
+
+    state.counters["TracksPropagated"] = benchmark::Counter(
+        static_cast<double>(total_tracks), benchmark::Counter::kIsRate);
 }
 
 BENCHMARK_TEMPLATE(BM_PROPAGATOR_CPU, propagate_option::e_unsync)


### PR DESCRIPTION
Google Benchmark has this cute feature where you can give it user-defined counters and it will print additional information to the command line. This commit adds a counter for the number of tracks processed, so it will tell us the propagation throughput as well as the raw runtime statistics.

Example output is as follows:

```
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
CUDA unsync propagation/8      6457762 ns      6443469 ns           97 TracksPropagated=9.93254k/s
CUDA unsync propagation/16     6121909 ns      6106323 ns          114 TracksPropagated=41.9238k/s
CUDA unsync propagation/32     7526879 ns      7505053 ns           92 TracksPropagated=136.441k/s
CUDA unsync propagation/64    10750558 ns     10728799 ns           65 TracksPropagated=381.776k/s
CUDA unsync propagation/128   21361276 ns     21305348 ns           33 TracksPropagated=769.009k/s
CUDA unsync propagation/256   43920239 ns     43672328 ns           16 TracksPropagated=1.50063M/s
```