### PR TITLE
perf: Optimize propagation benchmark kernel launch

### DIFF
--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
@@ -10,7 +10,7 @@
 
 namespace detray {
 
-__global__ void propagator_benchmark_kernel(
+__global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
     typename detector_host_type::detector_view_type det_data,
     vecmem::data::vector_view<free_track_parameters<transform3>> tracks_data,
     vecmem::data::jagged_vector_view<intersection_t> candidates_data,
@@ -61,8 +61,9 @@ void propagator_benchmark(
     vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
     const propagate_option opt) {
 
-    constexpr int thread_dim = 2 * WARP_SIZE;
-    int block_dim = static_cast<int>(tracks_data.size()) / thread_dim + 1;
+    constexpr int thread_dim = 256;
+    int block_dim =
+        static_cast<int>(tracks_data.size() + thread_dim - 1) / thread_dim;
 
     // run the test kernel
     propagator_benchmark_kernel<<<block_dim, thread_dim>>>(


### PR DESCRIPTION
This commit makes three optimizations to the kernel launch parameters used to launch the propagation benchmark.

Firstly, it removes an unnecessary extra block from the launch. Rather than unconditionally adding an extra block, this now adds an extra block only if there are some left-over work items that need to be handled.

Secondly, it increases the block size. This was previously 64 threads, but this is not ideal for some NVIDIA GPUs. As a prime example, the A5000 that we use for a lot of our benchmarks is Compute Capability 8.6, meaning that it supports a maximum of 1536 threads across 16 blocks per SM. If we launch blocks of 64 threads and we can only launch 16 of them, we are capped at a total of 1024 threads rather than the theoretical maximum of the SM. This commit increases the block size to 256, which seems to work well.

Thirdly, it adds launch bounds to the kernel itself. This is very useful when the block size is always known, because it allows us to control the register usage of the kernel. By specifying that we always want at least 4 blocks per SM, we can increase occupancy significantly by telling the compiler to reduce thread count.