### PR TITLE
feat: Implement `detray::tuple`

### DIFF
--- a/core/include/detray/core/detail/container_views.hpp
+++ b/core/include/detray/core/detail/container_views.hpp
@@ -10,23 +10,21 @@
 // Project include(s)
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/tuple.hpp"
+#include "detray/utils/tuple_helpers.hpp"
 
 // Vecmem include(s)
 #include <vecmem/containers/device_vector.hpp>
 #include <vecmem/containers/jagged_device_vector.hpp>
 
-// Thrust include(s)
-#include <thrust/tuple.h>
-
 // System include(s)
-#include <tuple>
 #include <type_traits>
 
 namespace detray {
 
 /// Container types used in device code
 using device_container_types =
-    container_types<vecmem::device_vector, thrust::tuple, darray,
+    container_types<vecmem::device_vector, detray::tuple, darray,
                     vecmem::jagged_device_vector>;
 
 /// How to obtain views for vecmem types
@@ -56,13 +54,13 @@ class dmulti_view_helper<false, view_ts...> {};
 /// member constructors.
 template <typename... view_ts>
 struct dmulti_view_helper<true, view_ts...> : public dbase_view {
-    thrust::tuple<std::remove_reference_t<std::remove_cv_t<view_ts>>...> m_view;
+    detray::tuple<std::remove_reference_t<std::remove_cv_t<view_ts>>...> m_view;
 
     dmulti_view_helper() = default;
 
     /// Tie multiple views together
     DETRAY_HOST
-    dmulti_view_helper(view_ts&&... views) { m_view = thrust::tie(views...); }
+    dmulti_view_helper(view_ts&&... views) { m_view = ::detray::tie(views...); }
 };
 
 /// Helper trait to determine if a type can be interpreted as a (composite)

--- a/core/include/detray/definitions/containers.hpp
+++ b/core/include/detray/definitions/containers.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/tuple.hpp"
 
 // Vecmem include(s)
 #include <vecmem/containers/jagged_vector.hpp>
@@ -17,7 +18,6 @@
 // System include(s)
 #include <array>
 #include <map>
-#include <tuple>
 #include <type_traits>
 #include <vector>
 
@@ -36,7 +36,7 @@ template <typename key_t, typename value_t>
 using dmap = std::map<key_t, value_t>;
 
 template <class... types>
-using dtuple = std::tuple<types...>;
+using dtuple = detray::tuple<types...>;
 
 /// @brief Bundle container type definitions
 template <template <typename...> class vector_t = dvector,

--- a/core/include/detray/intersection/concentric_cylinder_intersector.hpp
+++ b/core/include/detray/intersection/concentric_cylinder_intersector.hpp
@@ -80,9 +80,9 @@ struct concentric_cylinder_intersector {
                                               d * d - r * r};
         auto qe_solution = qe();
 
-        if (std::get<0>(qe_solution) > 0) {
+        if (detail::get<0>(qe_solution) > 0) {
             std::array<point3, 2> candidates;
-            const auto u01 = std::get<1>(qe_solution);
+            const auto u01 = detail::get<1>(qe_solution);
             std::array<scalar_type, 2> t01 = {0.f, 0.f};
 
             candidates[0][_x] = u01[0];

--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -76,8 +76,8 @@ struct cylinder_intersector {
         quadratic_equation<scalar_type> qe = {a, b, c};
         auto qe_solution = qe();
 
-        if (std::get<0>(qe_solution) > 0) {
-            const auto t01 = std::get<1>(qe_solution);
+        if (detail::get<0>(qe_solution) > 0) {
+            const auto t01 = detail::get<1>(qe_solution);
             const scalar_type t{(t01[0] > overstep_tolerance) ? t01[0]
                                                               : t01[1]};
 

--- a/core/include/detray/masks/annulus2D.hpp
+++ b/core/include/detray/masks/annulus2D.hpp
@@ -20,7 +20,6 @@
 #include <cmath>
 #include <limits>
 #include <string>
-#include <tuple>
 
 namespace detray {
 
@@ -97,15 +96,15 @@ class annulus2D {
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_phi;
         static constexpr std::size_t dim{2u};
 
-        using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
-                                 n_axis::circular<axis_loc1>>;
+        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
+                             n_axis::circular<axis_loc1>>;
 
         /// Local coordinate frame (both for disc and focal system ?)
         template <typename algebra_t>
         using coordinate_type = local_frame_type<algebra_t>;
 
         template <typename C, typename S>
-        using binning = std::tuple<binning_loc0<C, S>, binning_loc1<C, S>>;
+        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
     };
 
     /// Given a local polar point given in the disc frame, @returns the

--- a/core/include/detray/masks/cuboid3D.hpp
+++ b/core/include/detray/masks/cuboid3D.hpp
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <limits>
 #include <string>
-#include <tuple>
 
 namespace detray {
 
@@ -80,13 +79,13 @@ class cuboid3D {
         template <typename algebra_t>
         using coordinate_type = local_frame_type<algebra_t>;
 
-        using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
-                                 n_axis::bounds_t<e_s, axis_loc1>,
-                                 n_axis::bounds_t<e_s, axis_loc2>>;
+        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
+                             n_axis::bounds_t<e_s, axis_loc1>,
+                             n_axis::bounds_t<e_s, axis_loc2>>;
 
         template <typename C, typename S>
-        using binning = std::tuple<binning_loc0<C, S>, binning_loc1<C, S>,
-                                   binning_loc2<C, S>>;
+        using binning =
+            dtuple<binning_loc0<C, S>, binning_loc1<C, S>, binning_loc2<C, S>>;
     };
 
     /// @brief Check boundary values for a local point.

--- a/core/include/detray/masks/cylinder2D.hpp
+++ b/core/include/detray/masks/cylinder2D.hpp
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <limits>
 #include <string>
-#include <tuple>
 
 namespace detray {
 
@@ -87,15 +86,15 @@ class cylinder2D {
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_cyl_z;
         static constexpr std::size_t dim{2u};
 
-        using types = std::tuple<n_axis::circular<axis_loc0>,
-                                 n_axis::bounds_t<e_s, axis_loc1>>;
+        using types = dtuple<n_axis::circular<axis_loc0>,
+                             n_axis::bounds_t<e_s, axis_loc1>>;
 
         /// How to convert into the local axis system and back
         template <typename algebra_t>
         using coordinate_type = cylindrical2<algebra_t>;
 
         template <typename C, typename S>
-        using binning = std::tuple<binning_loc0<C, S>, binning_loc1<C, S>>;
+        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
     };
 
     /// @brief Check boundary values for a local point.

--- a/core/include/detray/masks/cylinder3D.hpp
+++ b/core/include/detray/masks/cylinder3D.hpp
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <limits>
 #include <string>
-#include <tuple>
 
 namespace detray {
 
@@ -74,17 +73,17 @@ class cylinder3D {
         static constexpr n_axis::label axis_loc2 = n_axis::label::e_z;
         static constexpr std::size_t dim{3u};
 
-        using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
-                                 n_axis::circular<axis_loc1>,
-                                 n_axis::bounds_t<e_s, axis_loc2>>;
+        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
+                             n_axis::circular<axis_loc1>,
+                             n_axis::bounds_t<e_s, axis_loc2>>;
 
         /// How to convert into the local axis system and back
         template <typename algebra_t>
         using coordinate_type = local_frame_type<algebra_t>;
 
         template <typename C, typename S>
-        using binning = std::tuple<binning_loc0<C, S>, binning_loc1<C, S>,
-                                   binning_loc2<C, S>>;
+        using binning =
+            dtuple<binning_loc0<C, S>, binning_loc1<C, S>, binning_loc2<C, S>>;
     };
 
     /// @brief Check boundary values for a local point.

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -18,7 +18,6 @@
 // System include(s)
 #include <cmath>
 #include <limits>
-#include <tuple>
 #include <type_traits>
 
 namespace detray {
@@ -89,15 +88,15 @@ class line {
         static constexpr n_axis::label axis_loc1 = n_axis::label::e_z;
         static constexpr std::size_t dim{2u};
 
-        using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
-                                 n_axis::bounds_t<e_s, axis_loc1>>;
+        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
+                             n_axis::bounds_t<e_s, axis_loc1>>;
 
         /// How to convert into the local axis system and back
         template <typename algebra_t>
         using coordinate_type = line2<algebra_t>;
 
         template <typename C, typename S>
-        using binning = std::tuple<binning_loc0<C, S>, binning_loc1<C, S>>;
+        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
     };
 
     /// @brief Check boundary values for a local point.

--- a/core/include/detray/masks/rectangle2D.hpp
+++ b/core/include/detray/masks/rectangle2D.hpp
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <limits>
 #include <string>
-#include <tuple>
 
 namespace detray {
 
@@ -77,11 +76,11 @@ class rectangle2D {
         template <typename algebra_t>
         using coordinate_type = local_frame_type<algebra_t>;
 
-        using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
-                                 n_axis::bounds_t<e_s, axis_loc1>>;
+        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
+                             n_axis::bounds_t<e_s, axis_loc1>>;
 
         template <typename C, typename S>
-        using binning = std::tuple<binning_loc0<C, S>, binning_loc1<C, S>>;
+        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
     };
 
     /// @brief Check boundary values for a local point.

--- a/core/include/detray/masks/ring2D.hpp
+++ b/core/include/detray/masks/ring2D.hpp
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <limits>
 #include <string>
-#include <tuple>
 
 namespace detray {
 
@@ -78,11 +77,11 @@ class ring2D {
         template <typename algebra_t>
         using coordinate_type = local_frame_type<algebra_t>;
 
-        using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
-                                 n_axis::circular<axis_loc1>>;
+        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
+                             n_axis::circular<axis_loc1>>;
 
         template <typename C, typename S>
-        using binning = std::tuple<binning_loc0<C, S>, binning_loc1<C, S>>;
+        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
     };
 
     /// @brief Check boundary values for a local point.

--- a/core/include/detray/masks/single3D.hpp
+++ b/core/include/detray/masks/single3D.hpp
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <limits>
 #include <string>
-#include <tuple>
 
 namespace detray {
 
@@ -78,10 +77,10 @@ class single3D {
         template <typename algebra_t>
         using coordinate_type = local_frame_type<algebra_t>;
 
-        using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>>;
+        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>>;
 
         template <typename C, typename S>
-        using binning = std::tuple<binning_loc0<C, S>>;
+        using binning = dtuple<binning_loc0<C, S>>;
     };
 
     /// @brief Check boundary values for a local point.

--- a/core/include/detray/masks/trapezoid2D.hpp
+++ b/core/include/detray/masks/trapezoid2D.hpp
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <limits>
 #include <string>
-#include <tuple>
 
 namespace detray {
 
@@ -82,11 +81,11 @@ class trapezoid2D {
         template <typename algebra_t>
         using coordinate_type = local_frame_type<algebra_t>;
 
-        using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
-                                 n_axis::bounds_t<e_s, axis_loc1>>;
+        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
+                             n_axis::bounds_t<e_s, axis_loc1>>;
 
         template <typename C, typename S>
-        using binning = std::tuple<binning_loc0<C, S>, binning_loc1<C, S>>;
+        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
     };
 
     /// @brief Check boundary values for a local point.

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -16,7 +16,6 @@
 
 // System include(s)
 #include <string>
-#include <tuple>
 
 namespace detray {
 
@@ -63,11 +62,11 @@ class unmasked {
         template <typename algebra_t>
         using coordinate_type = local_frame_type<algebra_t>;
 
-        using types = std::tuple<n_axis::bounds_t<e_s, axis_loc0>,
-                                 n_axis::bounds_t<e_s, axis_loc1>>;
+        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
+                             n_axis::bounds_t<e_s, axis_loc1>>;
 
         template <typename C, typename S>
-        using binning = std::tuple<binning_loc0<C, S>, binning_loc1<C, S>>;
+        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
     };
 
     /// @brief Check boundary values for a local point.

--- a/core/include/detray/tools/grid_factory.hpp
+++ b/core/include/detray/tools/grid_factory.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/surface_finders/grid/axis.hpp"

--- a/core/include/detray/utils/quadratic_equation.hpp
+++ b/core/include/detray/utils/quadratic_equation.hpp
@@ -33,9 +33,9 @@ struct quadratic_equation {
         scalar_t discriminant =
             _params[1] * _params[1] - 4.f * _params[0] * _params[2];
         if (discriminant < 0.f) {
-            return {0,
-                    {std::numeric_limits<scalar_t>::infinity(),
-                     std::numeric_limits<scalar_t>::infinity()}};
+            return {0, array_t<scalar_t, 2>{
+                           std::numeric_limits<scalar_t>::infinity(),
+                           std::numeric_limits<scalar_t>::infinity()}};
         } else {
             int solutions = (discriminant == 0.f) ? 1 : 2;
             scalar_t q =

--- a/core/include/detray/utils/tuple.hpp
+++ b/core/include/detray/utils/tuple.hpp
@@ -1,0 +1,69 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include "detray/definitions/qualifiers.hpp"
+
+namespace detray {
+template <typename... Ts>
+struct tuple {
+    DETRAY_HOST_DEVICE constexpr tuple() {}
+};
+
+template <typename T, typename... Ts>
+struct tuple<T, Ts...> {
+    DETRAY_HOST_DEVICE constexpr tuple() {}
+
+    template <typename U, typename... Us>
+    DETRAY_HOST_DEVICE constexpr tuple(const tuple<U, Us...> &o)
+        : v(o.v), r(o.r) {}
+
+    template <
+        typename U, typename... Us,
+        std::enable_if_t<std::is_constructible_v<T, U &&> &&
+                             std::is_constructible_v<tuple<Ts...>, Us &&...>,
+                         bool> = true>
+    DETRAY_HOST_DEVICE constexpr tuple(U &&_v, Us &&... _r)
+        : v(std::forward<U>(_v)), r(std::forward<Us>(_r)...) {}
+
+    T v;
+    tuple<Ts...> r;
+};
+
+template <std::size_t I, typename... Ts>
+DETRAY_HOST_DEVICE const auto &get(const detray::tuple<Ts...> &t) noexcept {
+    static_assert(I < sizeof...(Ts),
+                  "Attempt to access index greater than tuple size.");
+
+    if constexpr (I == 0) {
+        return t.v;
+    } else {
+        return ::detray::get<I - 1>(t.r);
+    }
+}
+
+template <std::size_t I, typename... Ts>
+DETRAY_HOST_DEVICE auto &get(detray::tuple<Ts...> &t) noexcept {
+    static_assert(I < sizeof...(Ts),
+                  "Attempt to access index greater than tuple size.");
+
+    if constexpr (I == 0) {
+        return t.v;
+    } else {
+        return ::detray::get<I - 1>(t.r);
+    }
+}
+
+template <typename... Ts>
+DETRAY_HOST_DEVICE constexpr detray::tuple<Ts &...> tie(Ts &... args) {
+    return detray::tuple<Ts &...>(args...);
+}
+}  // namespace detray

--- a/core/include/detray/utils/tuple_helpers.hpp
+++ b/core/include/detray/utils/tuple_helpers.hpp
@@ -9,10 +9,8 @@
 
 // Project include(s)
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/tuple.hpp"
 #include "detray/utils/type_traits.hpp"
-
-// Thrust include(s)
-#include <thrust/tuple.h>
 
 // System include(s)
 #include <limits>
@@ -22,54 +20,63 @@
 
 namespace detray::detail {
 
-/// get function accessor for either std::tuple or thrust::tuple
+/// get function accessor for std::tuple
 ///
 /// usage example:
 /// detail::get<0>(tuple)
 /// @{
 using std::get;
-using thrust::get;
 
-/// Retrieve an element from a thrust tuple by value. No perfect forwarding for
-/// composite types like tuple_t<value_types...> - const
-template <typename query_t, typename... value_types>
+template <std::size_t I, typename... value_types>
 DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
-    const thrust::tuple<value_types...>& tuple) noexcept {
-    return thrust::get<get_type_pos_v<query_t, value_types...>>(tuple);
+    const ::detray::tuple<value_types...>& tuple) noexcept {
+    return ::detray::get<I>(tuple);
 }
 
-/// Retrieve an element from a thrust tuple by value. No perfect forwarding for
-/// composite types like tuple_t<value_types...> - non-const
+template <std::size_t I, typename... value_types>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    ::detray::tuple<value_types...>& tuple) noexcept {
+    return ::detray::get<I>(tuple);
+}
+
 template <typename query_t, typename... value_types>
 DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
-    thrust::tuple<value_types...>& tuple) noexcept {
-    return thrust::get<get_type_pos_v<query_t, value_types...>>(tuple);
+    const ::detray::tuple<value_types...>& tuple) noexcept {
+    return ::detray::get<get_type_pos_v<query_t, value_types...>>(tuple);
+}
+
+template <typename query_t, typename... value_types>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    ::detray::tuple<value_types...>& tuple) noexcept {
+    return ::detray::get<get_type_pos_v<query_t, value_types...>>(tuple);
 }
 /// @}
 
-/// tuple_element for either std::tuple or thrust::tuple
+/// tuple_element for std::tuple
 ///
 /// usage example:
 /// detail::tuple_element< int, tuple_t >::type
 /// @{
-template <int N, class T>
+template <std::size_t N, class T>
 struct tuple_element;
 
 // std::tuple
-template <int N, typename... value_types>
+template <std::size_t N, typename... value_types>
 struct tuple_element<N, std::tuple<value_types...>>
     : std::tuple_element<N, std::tuple<value_types...>> {};
 
-// thrust::tuple
-template <int N, typename... value_types>
-struct tuple_element<N, thrust::tuple<value_types...>>
-    : thrust::tuple_element<N, thrust::tuple<value_types...>> {};
+// detray::tuple
+template <std::size_t N, typename... value_types>
+struct tuple_element<N, detray::tuple<value_types...>> {
+    using type = std::decay_t<decltype(
+        ::detray::get<N>(std::declval<detray::tuple<value_types...>>()))>;
+};
 
-template <int N, class T>
+template <std::size_t N, class T>
 using tuple_element_t = typename tuple_element<N, T>::type;
 /// @}
 
-/// tuple_size for either std::tuple or thrust::tuple
+/// tuple_size for std::tuple
 ///
 /// usage example:
 /// detail::tuple_size< tuple_t >::value
@@ -82,16 +89,17 @@ template <typename... value_types>
 struct tuple_size<std::tuple<value_types...>>
     : std::tuple_size<std::tuple<value_types...>> {};
 
-// thrust::tuple
+// detray::tuple
 template <typename... value_types>
-struct tuple_size<thrust::tuple<value_types...>>
-    : thrust::tuple_size<thrust::tuple<value_types...>> {};
+struct tuple_size<::detray::tuple<value_types...>> {
+    static constexpr std::size_t value = sizeof...(value_types);
+};
 
 template <class T>
 inline constexpr std::size_t tuple_size_v{tuple_size<T>::value};
 /// @}
 
-/// make_tuple for either std::tuple or thrust::tuple
+/// make_tuple for std::tuple
 /// users have to specifiy tuple_t for detail::make_tuple
 ///
 /// usage example
@@ -121,16 +129,15 @@ make_tuple(value_types&&... args) {
     return std::make_tuple(args...);
 }
 
-// make_tuple for thrust::tuple
+// make_tuple for detray::tuple
 template <template <typename...> class tuple_t, class... value_types,
           std::enable_if_t<std::is_same_v<tuple_t<value_types...>,
-                                          thrust::tuple<value_types...>>,
+                                          detray::tuple<value_types...>>,
                            bool> = true>
-DETRAY_HOST_DEVICE inline constexpr thrust::tuple<
+DETRAY_HOST_DEVICE inline constexpr detray::tuple<
     unwrap_decay_t<value_types>...>
 make_tuple(value_types&&... args) {
-    return thrust::make_tuple(args...);
+    return detray::tuple<unwrap_decay_t<value_types>...>{args...};
 }
 /// @}
-
 }  // namespace detray::detail

--- a/core/include/detray/utils/type_registry.hpp
+++ b/core/include/detray/utils/type_registry.hpp
@@ -118,7 +118,7 @@ class type_registry {
     /// a compiler error.
     template <ID type_id, template <typename...> class tuple_t = dtuple>
     struct get_type {
-        using type = std::remove_reference_t<decltype(
+        using type = std::decay_t<decltype(
             detail::get<to_index(type_id)>(tuple_t<registered_types...>{}))>;
     };
 

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -83,8 +83,8 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
             pointwise_material_interactor<transform3>::state interactor_state{};
             parameter_resetter<transform3>::state resetter_state{};
 
-            auto actor_states = thrust::tie(transporter_state, interactor_state,
-                                            resetter_state);
+            auto actor_states =
+                tie(transporter_state, interactor_state, resetter_state);
 
             // Create the propagator state
             propagator_host_type::state p_state(track, det.get_bfield(), det);

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
@@ -42,7 +42,7 @@ __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
 
     // Create the actor states
     auto actor_states =
-        thrust::tie(transporter_state, interactor_state, resetter_state);
+        tie(transporter_state, interactor_state, resetter_state);
     // Create the propagator state
     propagator_device_type::state p_state(tracks.at(gid), det.get_bfield(), det,
                                           candidates.at(gid));

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
@@ -48,10 +48,9 @@ using navigator_host_type = navigator<detector_host_type>;
 using navigator_device_type = navigator<detector_device_type>;
 using field_type = detector_host_type::bfield_type;
 using rk_stepper_type = rk_stepper<field_type::view_t, transform3>;
-using actor_chain_t =
-    actor_chain<thrust::tuple, parameter_transporter<transform3>,
-                pointwise_material_interactor<transform3>,
-                parameter_resetter<transform3>>;
+using actor_chain_t = actor_chain<tuple, parameter_transporter<transform3>,
+                                  pointwise_material_interactor<transform3>,
+                                  parameter_resetter<transform3>>;
 using propagator_host_type =
     propagator<rk_stepper_type, navigator_host_type, actor_chain_t>;
 using propagator_device_type =

--- a/tests/common/include/tests/common/core_container.inl
+++ b/tests/common/include/tests/common/core_container.inl
@@ -43,7 +43,7 @@ TEST(container, tuple_container) {
                                 vecmem::vector<int*>>;
 
     using device_tuple_t =
-        detail::tuple_container<thrust::tuple, vecmem::device_vector<float>,
+        detail::tuple_container<tuple, vecmem::device_vector<float>,
                                 vecmem::device_vector<std::size_t>,
                                 vecmem::device_vector<int*>>;
 

--- a/tests/common/include/tests/common/test_base/propagator_test.hpp
+++ b/tests/common/include/tests/common/test_base/propagator_test.hpp
@@ -120,12 +120,12 @@ struct track_inspector : actor {
 using inspector_host_t = track_inspector<vecmem::vector>;
 using inspector_device_t = track_inspector<vecmem::device_vector>;
 using actor_chain_host_t =
-    actor_chain<thrust::tuple, inspector_host_t, pathlimit_aborter,
+    actor_chain<tuple, inspector_host_t, pathlimit_aborter,
                 parameter_transporter<transform3>,
                 pointwise_material_interactor<transform3>,
                 parameter_resetter<transform3>>;
 using actor_chain_device_t =
-    actor_chain<thrust::tuple, inspector_device_t, pathlimit_aborter,
+    actor_chain<tuple, inspector_device_t, pathlimit_aborter,
                 parameter_transporter<transform3>,
                 pointwise_material_interactor<transform3>,
                 parameter_resetter<transform3>>;

--- a/tests/common/include/tests/common/tools/test_surfaces.hpp
+++ b/tests/common/include/tests/common/tools/test_surfaces.hpp
@@ -181,9 +181,9 @@ create_endcap_components(scalar inner_r, scalar outer_r, scalar pos_z,
     local_zone_finder<disc_grid> ecn_finder(std::move(ec_grid_n));
     local_zone_finder<disc_grid> ecp_finder(std::move(ec_grid_p));
 
-    return {trapezoid_values,
-            transforms,
-            {inner_finder, outer_finder, ecn_finder, ecp_finder}};
+    return {trapezoid_values, transforms,
+            dvector<endcap_surface_finder>{inner_finder, outer_finder,
+                                           ecn_finder, ecp_finder}};
 }
 
 using barrel_surface_finder = std::function<dvector<dindex>(
@@ -300,9 +300,9 @@ create_barrel_components(scalar r, scalar stagger_r, unsigned int n_phi,
     local_zone_finder<disc_grid> ecn_finder(std::move(barrel_grid_n));
     local_zone_finder<disc_grid> ecp_finder(std::move(barrel_grid_p));
 
-    return {rectangle_bounds,
-            transforms,
-            {inner_finder, outer_finder, ecn_finder, ecp_finder}};
+    return {rectangle_bounds, transforms,
+            dvector<barrel_surface_finder>{inner_finder, outer_finder,
+                                           ecn_finder, ecp_finder}};
 }
 
 }  // anonymous namespace

--- a/tests/unit_tests/core/tuple_helpers.cpp
+++ b/tests/unit_tests/core/tuple_helpers.cpp
@@ -48,25 +48,25 @@ TEST(utils, tuple_helpers) {
     EXPECT_EQ(detail::get<std::string>(s_tuple), std::string("std::tuple"));
     EXPECT_EQ(detail::get<unsigned long>(s_tuple), 4UL);
 
-    // thrust::tuple test
-    auto t_tuple = detail::make_tuple<thrust::tuple>(
-        1.0f, 2UL, std::string("thrust::tuple"));
+    // detray::tuple test
+    auto d_tuple = detail::make_tuple<detray::tuple>(
+        1.0f, 2UL, std::string("detray::tuple"));
     static_assert(
-        std::is_same_v<thrust::tuple<float, unsigned long, std::string>,
-                       decltype(t_tuple)>,
-        "detail::make_tuple failed for thrust::tuple");
+        std::is_same_v<detray::tuple<float, unsigned long, std::string>,
+                       decltype(d_tuple)>,
+        "detail::make_tuple failed for detray::tuple");
 
-    static_assert(std::is_same_v<detail::tuple_element_t<1, decltype(t_tuple)>,
+    static_assert(std::is_same_v<detail::tuple_element_t<1, decltype(d_tuple)>,
                                  unsigned long>,
-                  "detail::tuple_element retrieval failed for thrust::tuple");
+                  "detail::tuple_element retrieval failed for detray::tuple");
 
-    const auto t_tuple_size = detail::tuple_size_v<decltype(t_tuple)>;
-    EXPECT_EQ(t_tuple_size, 3UL);
+    const auto d_tuple_size = detail::tuple_size_v<decltype(d_tuple)>;
+    EXPECT_EQ(d_tuple_size, 3UL);
 
-    EXPECT_FLOAT_EQ(detail::get<0>(t_tuple), 1.0f);
-    EXPECT_EQ(detail::get<1>(t_tuple), 2UL);
-    EXPECT_EQ(detail::get<2>(t_tuple), std::string("thrust::tuple"));
-    EXPECT_FLOAT_EQ(detail::get<float>(t_tuple), 1.0f);
-    EXPECT_EQ(detail::get<unsigned long>(t_tuple), 2UL);
-    EXPECT_EQ(detail::get<std::string>(t_tuple), std::string("thrust::tuple"));
+    EXPECT_FLOAT_EQ(detail::get<0>(d_tuple), 1.0f);
+    EXPECT_EQ(detail::get<1>(d_tuple), 2UL);
+    EXPECT_EQ(detail::get<2>(d_tuple), std::string("detray::tuple"));
+    EXPECT_FLOAT_EQ(detail::get<float>(d_tuple), 1.0f);
+    EXPECT_EQ(detail::get<unsigned long>(d_tuple), 2UL);
+    EXPECT_EQ(detail::get<std::string>(d_tuple), std::string("detray::tuple"));
 }

--- a/tests/unit_tests/core/utils_quadratic_equation.cpp
+++ b/tests/unit_tests/core/utils_quadratic_equation.cpp
@@ -13,6 +13,7 @@
 // detray core
 #include "detray/definitions/algebra.hpp"
 #include "detray/utils/quadratic_equation.hpp"
+#include "detray/utils/tuple_helpers.hpp"
 
 using namespace detray;
 
@@ -21,7 +22,7 @@ TEST(utils, quad_equation) {
     quadratic_equation<scalar> qe = {{2.f, 5.f, -3.f}};
     auto solution = qe();
 
-    ASSERT_EQ(std::get<0>(solution), 2);
-    ASSERT_NEAR(std::get<1>(solution)[0], -3.f, 1e-7f);
-    ASSERT_NEAR(std::get<1>(solution)[1], 0.5f, 1e-7f);
+    ASSERT_EQ(detail::get<0>(solution), 2);
+    ASSERT_NEAR(detail::get<1>(solution)[0], -3.f, 1e-7f);
+    ASSERT_NEAR(detail::get<1>(solution)[1], 0.5f, 1e-7f);
 }

--- a/tests/unit_tests/device/cuda/container_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/container_cuda_kernel.hpp
@@ -23,8 +23,8 @@ using host_store_type =
                         float, double>;
 
 using device_store_type =
-    regular_multi_store<int, empty_context, thrust::tuple,
-                        vecmem::device_vector, std::size_t, float, double>;
+    regular_multi_store<int, empty_context, dtuple, vecmem::device_vector,
+                        std::size_t, float, double>;
 
 void get_sum(typename host_store_type::view_type store_view,
              vecmem::data::vector_view<double> sum_data);

--- a/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
@@ -63,9 +63,8 @@ using host_store_type =
                         rectangle, trapezoid, ring, cylinder, single, annulus>;
 
 using device_store_type =
-    regular_multi_store<mask_ids, empty_context, thrust::tuple,
-                        vecmem::device_vector, rectangle, trapezoid, ring,
-                        cylinder, single, annulus>;
+    regular_multi_store<mask_ids, empty_context, dtuple, vecmem::device_vector,
+                        rectangle, trapezoid, ring, cylinder, single, annulus>;
 
 /// test function for mask store
 void mask_test(

--- a/tests/unit_tests/device/cuda/propagator_cuda.cpp
+++ b/tests/unit_tests/device/cuda/propagator_cuda.cpp
@@ -80,8 +80,8 @@ TEST_P(CudaPropagatorWithRkStepper, propagator) {
         pointwise_material_interactor<transform3>::state interactor_state{};
         parameter_resetter<transform3>::state resetter_state{};
         auto actor_states =
-            thrust::tie(insp_state, pathlimit_state, transporter_state,
-                        interactor_state, resetter_state);
+            ::detray::tie(insp_state, pathlimit_state, transporter_state,
+                          interactor_state, resetter_state);
 
         propagator_host_type::state state(trk, det.get_bfield(), det);
 

--- a/tests/unit_tests/device/cuda/propagator_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/propagator_cuda_kernel.cu
@@ -54,8 +54,8 @@ __global__ void propagator_test_kernel(
 
     // Create the actor states
     auto actor_states =
-        thrust::tie(insp_state, aborter_state, transporter_state,
-                    interactor_state, resetter_state);
+        ::detray::tie(insp_state, aborter_state, transporter_state,
+                      interactor_state, resetter_state);
     // Create the propagator state
     propagator_device_type::state state(tracks[gid], B_field, det,
                                         candidates.at(gid));

--- a/tests/unit_tests/device/sycl/propagator.sycl
+++ b/tests/unit_tests/device/sycl/propagator.sycl
@@ -96,8 +96,8 @@ TEST_P(SyclPropagatorWithRkStepper, propagator) {
         pointwise_material_interactor<transform3>::state interactor_state{};
         parameter_resetter<transform3>::state resetter_state{};
         auto actor_states =
-            thrust::tie(insp_state, pathlimit_state, transporter_state,
-                        interactor_state, resetter_state);
+            ::detray::tie(insp_state, pathlimit_state, transporter_state,
+                          interactor_state, resetter_state);
 
         propagator_host_type::state state(trk, det.get_bfield(), det);
 

--- a/tests/unit_tests/device/sycl/propagator_kernel.sycl
+++ b/tests/unit_tests/device/sycl/propagator_kernel.sycl
@@ -80,8 +80,8 @@ void propagator_test(
 
                 // Create the actor states
                 auto actor_states =
-                    thrust::tie(insp_state, aborter_state, transporter_state,
-                                interactor_state, resetter_state);
+                    ::detray::tie(insp_state, aborter_state, transporter_state,
+                                  interactor_state, resetter_state);
                 // Create the propagator state
                 propagator_device_type::state state(tracks[gid], B_field, det,
                                                     candidates.at(gid));


### PR DESCRIPTION
As discussed in #355, it might be worth implementing a tuple type in detray that can use an arbitrary number of elements. This commit implements such a thing, replacing `thrust::tuple` by `detray::tuple`.