### PR TITLE
Fix typo in `nlohmann_json` CMake config :rat: 

### DIFF
--- a/extern/nlohmann_json/CMakeLists.txt
+++ b/extern/nlohmann_json/CMakeLists.txt
@@ -12,7 +12,7 @@ message( STATUS "Building nlohmann_json as part of the detray project" )
 # Declare where to get nlohmann from.
 set( DETRAY_NLOHMANN_JSON_GIT_TAG "v3.10.5" CACHE STRING "Version of nlohmann_json to build" )
 set( DETRAY_NLOHMANN_JSON_SHA1 "8969f5ad1a422e01f040ff48dcae9c0e6ad0811d" CACHE STRING "SHA1 hash of the downloaded zip" )
-mark_as_advanced( DETRAY_NLOHMANN_JSON_GIT_REPOSITORY DETRAT_NLOHMANN_JSON_GIT_TAG )
+mark_as_advanced( DETRAY_NLOHMANN_JSON_GIT_REPOSITORY DETRAY_NLOHMANN_JSON_GIT_TAG )
 FetchContent_Declare( nlohmann_json
    URL "https://github.com/nlohmann/json/archive/refs/tags/${DETRAY_NLOHMANN_JSON_GIT_TAG}.tar.gz"
    URL_HASH SHA1=${DETRAY_NLOHMANN_JSON_SHA1})


### PR DESCRIPTION
Although the spelling is quite funny, `DETRAT` is not the name of this package. I don't know what an "advanced" variable is or why CMake doesn't warn about it, but whatever.