### PR TITLE
CMake Export Fix, main branch (2023.03.24.)

### DIFF
--- a/cmake/detray-config.cmake.in
+++ b/cmake/detray-config.cmake.in
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -15,6 +15,12 @@ set( DETRAY_VC_PLUGIN @DETRAY_VC_PLUGIN@ )
 set( DETRAY_IO_CSV @DETRAY_IO_CSV@ )
 set( DETRAY_DISPLAY @DETRAY_DISPLAY@ )
 set( DETRAY_BUILD_CUDA @DETRAY_BUILD_CUDA@ )
+
+# Set up some simple variables for using the package.
+set( detray_VERSION "@PROJECT_VERSION@" )
+set_and_check( detray_INCLUDE_DIR
+   "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@" )
+set_and_check( detray_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@" )
 
 # Find all packages that Detray needs to function.
 include( CMakeFindDependencyMacro )
@@ -31,12 +37,6 @@ endif()
 # Set up the detray::Thrust target.
 set( DETRAY_THRUST_OPTIONS @DETRAY_THRUST_OPTIONS@ )
 thrust_create_target( detray::Thrust ${DETRAY_THRUST_OPTIONS} )
-
-# Set up some simple variables for using the package.
-set( detray_VERSION "@PROJECT_VERSION@" )
-set_and_check( detray_INCLUDE_DIR
-   "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@" )
-set_and_check( detray_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@" )
 
 # Print a standard information message about the package being found.
 include( FindPackageHandleStandardArgs )


### PR DESCRIPTION
This is a twin of https://github.com/acts-project/algebra-plugins/pull/96, fixing the issue described in https://github.com/acts-project/algebra-plugins/issues/36, and helping with https://github.com/acts-project/traccc/pull/364.

See https://github.com/acts-project/algebra-plugins/pull/96 for an explanation of this change.