### PR TITLE
Refer to `nlohmann_json` target by namespace

### DIFF
--- a/io/json/CMakeLists.txt
+++ b/io/json/CMakeLists.txt
@@ -13,7 +13,7 @@ detray_add_library( detray_io_json io_json
 "include/detray/io/json_io.hpp"
 "include/detray/io/json_algebra_io.hpp"
 "include/detray/io/json_geometry_io.hpp")
-target_link_libraries( detray_io_json INTERFACE nlohmann_json vecmem::core )
+target_link_libraries( detray_io_json INTERFACE nlohmann_json::nlohmann_json vecmem::core )
 
 # Make the "main I/O library" link against it.
 target_link_libraries( detray_io INTERFACE detray::io_json )


### PR DESCRIPTION
This was a real pain in the ass to find and fix for acts-project/traccc#364, but as it turns out `nlohmann_json` is not actually a valid target, and the library has been exporting its targets in a dedicated namespace since version 3.2. CMake expectedly handles this poorly and translates it to a `-lnlohmann_json` flag if the target is not available, leading to compilation errors. This commit applies the namespace to resolve this issue.