### PR TITLE
Algebra Plugins Update, main branch (2023.03.24.)

### DIFF
--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@ message(STATUS "Building Algebra Plugins as part of the Detray project")
 
 # Declare where to get Algebra Plugins from.
 set( DETRAY_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.17.0.tar.gz;URL_MD5;eba42274c7ca7fb6d9b0acb7f82e7119"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.18.0.tar.gz;URL_MD5;d4b4a784a4e95f5c06ff3331fb6e16ab"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced(DETRAY_ALGEBRA_PLUGINS_SOURCE)
 FetchContent_Declare(AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE})


### PR DESCRIPTION
Updated to using [algebra-plugins-0.18.0](https://github.com/acts-project/algebra-plugins/releases/tag/v0.18.0) by default.

This is mainly to pick up the CMake fix from https://github.com/acts-project/algebra-plugins/pull/96.