### PR TITLE
ref: surface barcode

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -28,6 +28,7 @@ detray_add_library( detray_core core
    "include/detray/core/detector.hpp"
    # definitions include(s)
    "include/detray/definitions/detail/algorithms.hpp"
+   "include/detray/definitions/detail/bit_encoder.hpp"
    "include/detray/definitions/containers.hpp"
    "include/detray/definitions/cuda_definitions.hpp"
    "include/detray/definitions/indexing.hpp"

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -247,11 +247,11 @@ class detector {
     }
 
     /// @returns a surface by index - const
-    // TODO: Implement surface barcode
     DETRAY_HOST_DEVICE
-    constexpr auto surfaces(dindex sf_index) const -> const surface_type & {
+    constexpr auto surfaces(geometry::barcode bcd) const
+        -> const surface_type & {
         return _surfaces.template get<sf_finders::id::e_brute_force>()
-            .all()[sf_index];
+            .all()[bcd.index()];
     }
 
     /// @returns surfaces of a given type (@tparam sf_id) by volume - const
@@ -356,7 +356,7 @@ class detector {
         for (auto &sf : surfaces_per_vol) {
             _masks.template visit<detail::mask_index_update>(sf.mask(), sf);
             sf.update_transform(trf_offset);
-            sf.set_barcode(sf_offset++);
+            sf.set_index(sf_offset++);
         }
 
         // Append surfaces to base surface collection

--- a/core/include/detray/definitions/detail/bit_encoder.hpp
+++ b/core/include/detray/definitions/detail/bit_encoder.hpp
@@ -1,0 +1,71 @@
+
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/qualifiers.hpp"
+
+// System include(s)
+#include <cstdint>
+#include <type_traits>
+
+namespace detray::detail {
+
+/// @brief Sets masked bits to a given value.
+///
+/// Given a mask and an input value, the corresponding bits are set on a target
+/// value. Used e.g. in the surface barcode.
+///
+/// @see
+/// https://github.com/acts-project/acts/blob/main/Core/include/Acts/Geometry/GeometryIdentifier.hpp
+template <typename value_t = uint64_t>
+class bit_encoder {
+
+    public:
+    bit_encoder() = delete;
+
+    /// Check wether the set @param v encodes valid values according to the
+    /// given masks (@tparam head and @tparam tail)
+    template <value_t... masks>
+    DETRAY_HOST_DEVICE static constexpr bool is_invalid(value_t v) noexcept {
+        // All bits set to one in the range of a given mask defined as invalid
+        return (((v & masks) == masks) | ...);
+    }
+
+    /// @returns the masked bits from the encoded value as value of the same
+    /// type.
+    template <value_t mask,
+              std::enable_if_t<mask != static_cast<value_t>(0), bool> = true>
+    DETRAY_HOST_DEVICE static constexpr value_t get_bits(
+        const value_t v) noexcept {
+        // Use integral constant to enforce compile time evaluation of shift
+        return (v & mask) >> std::integral_constant<int, extract_shift(mask)>();
+    }
+
+    /// Set the masked bits to id in the encoded value.
+    template <value_t mask,
+              std::enable_if_t<mask != static_cast<value_t>(0), bool> = true>
+    DETRAY_HOST_DEVICE static constexpr void set_bits(
+        value_t& v, const value_t id) noexcept {
+        // Use integral constant to enforce compile time evaluation of shift
+        v = (v & ~mask) |
+            ((id << std::integral_constant<int, extract_shift(mask)>()) & mask);
+    }
+
+    private:
+    /// Extract the bit shift necessary to access the masked values.
+    ///
+    /// @note undefined behaviour for mask == 0 which we should not have.
+    DETRAY_HOST_DEVICE
+    static constexpr int extract_shift(value_t mask) noexcept {
+        return __builtin_ctzll(mask);
+    }
+};
+
+}  // namespace detray::detail

--- a/core/include/detray/geometry/barcode.hpp
+++ b/core/include/detray/geometry/barcode.hpp
@@ -1,15 +1,173 @@
 
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
+
 #pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/bit_encoder.hpp"
+#include "detray/definitions/geometry.hpp"
+#include "detray/definitions/qualifiers.hpp"
+
+// System include(s)
+#include <cstdint>
+#include <ostream>
 
 namespace detray::geometry {
 
-/// Unique identifier for geometry objects
-using barcode = dindex;
+/// @brief Unique identifier for geometry objects, based on the ACTS
+/// GeometryIdentifier
+///
+/// Encodes the volume index, the type of surface (portal, sensitive, passive
+/// etc), an index to identify a surface in a geometry accelerator structure,
+/// as well as two extra bytes that can be used to tag surfaces arbitrarily.
+///
+/// @note the detray barcode is not compatible with the ACTS GeometryIdentifier!
+///
+/// @see
+/// https://github.com/acts-project/acts/blob/main/Core/include/Acts/Geometry/GeometryIdentifier.hpp
+class barcode {
+
+    public:
+    using value_t = uint64_t;
+    using encoder = detail::bit_encoder<value_t>;
+
+    /// Construct from an already encoded value.
+    DETRAY_HOST_DEVICE
+    constexpr explicit barcode(value_t encoded) : m_value(encoded) {}
+
+    /// Construct default barcode with all values set to 1.
+    constexpr barcode() = default;
+
+    /// @returns the encoded value.
+    DETRAY_HOST_DEVICE
+    constexpr value_t value() const noexcept { return m_value; }
+
+    /// @returns the volume index.
+    DETRAY_HOST_DEVICE
+    constexpr value_t volume() const {
+        return encoder::template get_bits<k_volume_mask>(m_value);
+    }
+
+    /// @returns the surface id.
+    DETRAY_HOST_DEVICE
+    constexpr surface_id id() const {
+        return static_cast<surface_id>(
+            encoder::template get_bits<k_id_mask>(m_value));
+    }
+
+    /// @returns the surface index.
+    DETRAY_HOST_DEVICE
+    constexpr value_t index() const {
+        return encoder::template get_bits<k_index_mask>(m_value);
+    }
+
+    /// @returns the extra identifier
+    DETRAY_HOST_DEVICE
+    constexpr value_t extra() const {
+        return encoder::template get_bits<k_extra_mask>(m_value);
+    }
+
+    /// Set the volume index.
+    DETRAY_HOST_DEVICE
+    constexpr barcode& set_volume(value_t volume) {
+        encoder::template set_bits<k_volume_mask>(m_value, volume);
+        return *this;
+    }
+
+    /// Set the surface id.
+    DETRAY_HOST_DEVICE
+    constexpr barcode& set_id(surface_id id) {
+        encoder::template set_bits<k_id_mask>(m_value,
+                                              static_cast<value_t>(id));
+        return *this;
+    }
+
+    /// Set the surface index.
+    DETRAY_HOST_DEVICE
+    constexpr barcode& set_index(value_t index) {
+        encoder::template set_bits<k_index_mask>(m_value, index);
+        return *this;
+    }
+
+    /// Set the extra identifier.
+    DETRAY_HOST_DEVICE
+    constexpr barcode& set_extra(value_t extra) {
+        encoder::template set_bits<k_extra_mask>(m_value, extra);
+        return *this;
+    }
+
+    /// Check wether the barcode is valid to use.
+    /// @note The extra bits are allowed to be invalid and will not be checked
+    DETRAY_HOST_DEVICE
+    constexpr bool is_invalid() const noexcept {
+        return encoder::template is_invalid<k_volume_mask, k_id_mask,
+                                            k_index_mask>(m_value);
+    }
+
+    private:
+    // clang-format off
+    static constexpr value_t k_volume_mask = 0xfff0000000000000; // (2^12)-1 = 4095 volumes 
+    static constexpr value_t k_id_mask     = 0x000f000000000000; // (2^4)-1 = 15 surface categories 
+    static constexpr value_t k_index_mask  = 0x0000ffffffffff00; // (2^40)-1 = 1099511627775 surfaces (per volume and id)
+    static constexpr value_t k_extra_mask  = 0x00000000000000ff; // (2^8)-1 = 255 extra values
+    // clang-format on
+
+    /// The encoded value. Default: All bits set to 1 (invalid)
+    value_t m_value{~static_cast<value_t>(0)};
+
+    DETRAY_HOST_DEVICE
+    friend constexpr bool operator==(barcode lhs, barcode rhs) noexcept {
+        return lhs.m_value == rhs.m_value;
+    }
+
+    DETRAY_HOST_DEVICE
+    friend constexpr bool operator!=(barcode lhs, barcode rhs) noexcept {
+        return lhs.m_value != rhs.m_value;
+    }
+
+    DETRAY_HOST_DEVICE
+    friend constexpr bool operator<(barcode lhs, barcode rhs) noexcept {
+        return lhs.m_value < rhs.m_value;
+    }
+
+    DETRAY_HOST
+    friend std::ostream& operator<<(std::ostream& os, const barcode c) {
+        if (c.is_invalid()) {
+            return (os << "undefined");
+        }
+
+        static const char* const names[] = {
+            "vol = ", "id = ", "index = ", "extra = "};
+        const value_t levels[] = {c.volume(), static_cast<value_t>(c.id()),
+                                  c.index(), c.extra()};
+
+        bool writeSeparator = false;
+        for (auto i = 0u; i < 4u; ++i) {
+            if (writeSeparator) {
+                os << " | ";
+            }
+            os << names[i] << levels[i];
+            writeSeparator = true;
+        }
+        return os;
+    }
+};
 
 }  // namespace detray::geometry
+
+namespace std {
+
+// specialize std::hash so barcode can be used e.g. in an unordered_map
+template <>
+struct hash<detray::geometry::barcode> {
+    auto operator()(detray::geometry::barcode gid) const noexcept {
+        return std::hash<detray::geometry::barcode::value_t>()(gid.value());
+    }
+};
+
+}  // namespace std

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -74,9 +74,6 @@ struct line_plane_intersection {
     /// Navigation information
     dindex volume_link{dindex_invalid};
 
-    /// Surface id for this intersection (sensitive, portal, passive)
-    surface_id sf_id{surface_id::e_sensitive};
-
     // cosine of incidence angle
     scalar cos_incidence_angle{1.f};
 
@@ -105,8 +102,8 @@ struct line_plane_intersection {
         std::stringstream out_stream;
         scalar r{getter::perp(p3)};
         out_stream << "dist:" << path << " [r:" << r << ", z:" << p3[2]
-                   << "], (sf index:" << barcode
-                   << ", links to vol:" << volume_link << ")";
+                   << "], (suface: " << barcode << ", links: vol "
+                   << volume_link << ")";
         switch (status) {
             case intersection::status::e_outside:
                 out_stream << ", status: outside";

--- a/core/include/detray/intersection/intersection_kernel.hpp
+++ b/core/include/detray/intersection/intersection_kernel.hpp
@@ -61,7 +61,6 @@ struct intersection_initialize {
                 if (is.status == intersection::status::e_inside &&
                     is.path >= traj.overstep_tolerance()) {
                     is.barcode = surface.barcode();
-                    is.sf_id = surface.id();
                     is_container.push_back(is);
                     count++;
                 }
@@ -119,7 +118,6 @@ struct intersection_update {
             if (sfi[0].status == intersection::status::e_inside &&
                 sfi[0].path >= traj.overstep_tolerance()) {
                 sfi[0].barcode = surface.barcode();
-                sfi[0].sf_id = surface.id();
                 return sfi[0];
             }
         }

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -68,7 +68,7 @@ struct target_aborter : actor {
     /// Keeps the index for the target surface
     struct state {
         /// Unique surface id of the target
-        dindex _target_surface_index{dindex_invalid};
+        geometry::barcode _target_surface;
     };
 
     /// Exits the navigation as soon as the target surface has been found.
@@ -85,8 +85,7 @@ struct target_aborter : actor {
         // In case the propagation starts on a module, make sure to not abort
         // directly
         if (navigation.is_on_module() and
-            (navigation.current_object() ==
-             abrt_state._target_surface_index) and
+            (navigation.current_object() == abrt_state._target_surface) and
             (stepping.path_length() > 0.f)) {
             prop_state._heartbeat &= navigation.exit();
         }

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/intersection.hpp"
+#include "detray/propagator/navigator.hpp"
 #include "detray/tracks/tracks.hpp"
 
 namespace detray {

--- a/core/include/detray/tools/volume_builder.hpp
+++ b/core/include/detray/tools/volume_builder.hpp
@@ -117,7 +117,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
             det.mask_store().template visit<detail::mask_index_update>(
                 sf.mask(), sf);
             sf.update_transform(trf_offset);
-            sf.set_barcode(sf_offset++);
+            sf.set_index(sf_offset++);
         }
 
         // Append surfaces

--- a/core/include/detray/tracks/bound_track_parameters.hpp
+++ b/core/include/detray/tracks/bound_track_parameters.hpp
@@ -45,7 +45,7 @@ struct bound_track_parameters {
 
     DETRAY_HOST_DEVICE
     bound_track_parameters()
-        : m_barcode(dindex_invalid),
+        : m_barcode(),
           m_vector(matrix_operator().template zero<e_bound_size, 1>()),
           m_covariance(
               matrix_operator().template zero<e_bound_size, e_bound_size>()) {}

--- a/tests/common/include/tests/common/check_geometry_navigation.inl
+++ b/tests/common/include/tests/common/check_geometry_navigation.inl
@@ -99,20 +99,21 @@ TEST(ALGEBRA_PLUGIN, straight_line_navigation) {
 
         // Check every single recorded intersection
         for (std::size_t i = 0u; i < obj_tracer.object_trace.size(); ++i) {
-            if (obj_tracer[i].barcode != intersection_trace[i].second.barcode) {
+            if (obj_tracer[i].barcode.index() !=
+                intersection_trace[i].second.barcode.index()) {
                 // Intersection record at portal bound might be flipped
                 // (the portals overlap completely)
-                if (obj_tracer[i].barcode ==
-                        intersection_trace[i + 1u].second.barcode and
-                    obj_tracer[i + 1u].barcode ==
-                        intersection_trace[i].second.barcode) {
+                if (obj_tracer[i].barcode.index() ==
+                        intersection_trace[i + 1u].second.barcode.index() and
+                    obj_tracer[i + 1u].barcode.index() ==
+                        intersection_trace[i].second.barcode.index()) {
                     // Have already checked the next record
                     ++i;
                     continue;
                 }
             }
-            EXPECT_EQ(obj_tracer[i].barcode,
-                      intersection_trace[i].second.barcode)
+            EXPECT_EQ(obj_tracer[i].barcode.index(),
+                      intersection_trace[i].second.barcode.index())
                 << debug_printer.to_string() << debug_stream.str();
         }
     }
@@ -200,20 +201,22 @@ TEST(ALGEBRA_PLUGIN, helix_navigation) {
 
         // Check every single recorded intersection
         for (std::size_t i = 0u; i < obj_tracer.object_trace.size(); ++i) {
-            if (obj_tracer[i].barcode != intersection_trace[i].second.barcode) {
-                // Intersection record at portal bound might be flipped
-                // (the portals overlap completely)
-                if (obj_tracer[i].barcode ==
-                        intersection_trace[i + 1u].second.barcode and
-                    obj_tracer[i + 1u].barcode ==
-                        intersection_trace[i].second.barcode) {
+            if (obj_tracer[i].barcode.index() !=
+                intersection_trace[i].second.barcode.index()) {
+                // Intersection record at portal bound might be flipped during
+                // sorting (the portals overlap completely)
+                if (obj_tracer[i].barcode.index() ==
+                        intersection_trace[i + 1u].second.barcode.index() and
+                    obj_tracer[i + 1u].barcode.index() ==
+                        intersection_trace[i].second.barcode.index()) {
                     // Have already checked the next record
                     ++i;
                     continue;
                 }
             }
-            EXPECT_EQ(obj_tracer[i].barcode,
-                      intersection_trace[i].second.barcode);
+            EXPECT_EQ(obj_tracer[i].barcode.index(),
+                      intersection_trace[i].second.barcode.index())
+                << "error at surface: " << obj_tracer[i].barcode;
         }
     }
 }

--- a/tests/common/include/tests/common/core_detector.inl
+++ b/tests/common/include/tests/common/core_detector.inl
@@ -629,7 +629,9 @@ TEST(detector, detector_volume_construction) {
     volume_links.insert(volume_links.end(), 16u, 1u);
     volume_links.reserve(d.surfaces().size());
     for (const auto [idx, sf_id] : detray::views::enumerate(sf_ids)) {
-        const auto& sf = d.surfaces(idx);
+        geometry::barcode bcd{};
+        bcd.set_index(idx);
+        const auto& sf = d.surfaces(bcd);
         EXPECT_EQ(sf.id(), sf_id) << "error at index: " << idx;
         EXPECT_EQ(sf.volume(), volume_links.at(idx))
             << "error at index: " << idx;
@@ -638,7 +640,9 @@ TEST(detector, detector_volume_construction) {
     // check that the transform indices are continuous
     for (std::size_t idx :
          detray::views::iota(d.transform_store().size() - 1)) {
-        EXPECT_EQ(d.surfaces(idx).transform(), idx)
+        geometry::barcode bcd{};
+        bcd.set_index(idx);
+        EXPECT_EQ(d.surfaces(bcd).transform(), idx)
             << "error at index: " << idx;
     }
 
@@ -664,7 +668,9 @@ TEST(detector, detector_volume_construction) {
         {mask_id::e_rectangle2, 5u},
         {mask_id::e_rectangle2, 6u}};
     for (const auto [idx, m_link] : detray::views::enumerate(mask_links)) {
-        EXPECT_EQ(d.surfaces(idx).mask(), m_link) << "error at index: " << idx;
+        geometry::barcode bcd{};
+        bcd.set_index(idx);
+        EXPECT_EQ(d.surfaces(bcd).mask(), m_link) << "error at index: " << idx;
     }
 
     // check mask volume links

--- a/tests/common/include/tests/common/geometry_barcode.inl
+++ b/tests/common/include/tests/common/geometry_barcode.inl
@@ -1,0 +1,54 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+// Detray include(s)
+#include "detray/definitions/detail/bit_encoder.hpp"
+#include "detray/geometry/barcode.hpp"
+
+using namespace detray;
+
+/// Test retrieval of surface from collection using brute force searching
+TEST(geometry, barcode) {
+
+    auto bcd = geometry::barcode{};
+
+    // Check a empty barcode
+    EXPECT_EQ(bcd.volume(), (1UL << 12) - 1UL);
+    EXPECT_EQ(bcd.id(), static_cast<surface_id>((1UL << 4) - 1UL));
+    EXPECT_EQ(bcd.index(), (1UL << 40) - 1UL);
+    EXPECT_EQ(bcd.extra(), (1UL << 8) - 1UL);
+
+    bcd.set_volume(2UL)
+        .set_id(surface_id::e_passive)
+        .set_index(42UL)
+        .set_extra(24UL);
+
+    // Check the values after setting them
+    EXPECT_EQ(bcd.volume(), 2UL);
+    EXPECT_EQ(bcd.id(), surface_id::e_passive);
+    EXPECT_EQ(bcd.index(), 42UL);
+    EXPECT_EQ(bcd.extra(), 24UL);
+
+    // Check invalid barcode
+    EXPECT_FALSE(bcd.is_invalid());
+    bcd.set_volume((1UL << 12) - 1UL);
+    EXPECT_TRUE(bcd.is_invalid());
+    bcd.set_volume(2UL);
+    EXPECT_FALSE(bcd.is_invalid());
+    bcd.set_id(static_cast<surface_id>((1UL << 4) - 1UL));
+    EXPECT_TRUE(bcd.is_invalid());
+    bcd.set_id(surface_id::e_passive);
+    EXPECT_FALSE(bcd.is_invalid());
+    bcd.set_index((1UL << 40) - 1UL);
+    EXPECT_TRUE(bcd.is_invalid());
+    bcd.set_index(42UL);
+    EXPECT_FALSE(bcd.is_invalid());
+    bcd.set_extra((1UL << 8) - 1UL);
+    EXPECT_FALSE(bcd.is_invalid());
+}

--- a/tests/common/include/tests/common/line_stepper.inl
+++ b/tests/common/include/tests/common/line_stepper.inl
@@ -75,8 +75,8 @@ TEST(line_stepper, covariance_transport) {
     getter::element(bound_cov, e_bound_theta, e_bound_theta) = 0.f;
 
     // Bound track parameter
-    const bound_track_parameters<transform3> bound_param0(0, bound_vector,
-                                                          bound_cov);
+    const bound_track_parameters<transform3> bound_param0(
+        geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
 
     // Actors
     parameter_transporter<transform3>::state bound_updater{};
@@ -94,9 +94,12 @@ TEST(line_stepper, covariance_transport) {
     // const auto bound_vec0 = bound_param0.vector();
     // const auto bound_vec1 = bound_param1.vector();
 
-    // Check if the track starts at the first and reaches the final surface
-    EXPECT_EQ(bound_param0.surface_link(), 0u);
-    EXPECT_EQ(bound_param1.surface_link(), 6u);
+    // Check if the track reaches the final surface
+    EXPECT_EQ(bound_param0.surface_link().volume(), 4095u);
+    EXPECT_EQ(bound_param0.surface_link().index(), 0u);
+    EXPECT_EQ(bound_param1.surface_link().volume(), 0u);
+    EXPECT_EQ(bound_param1.surface_link().id(), surface_id::e_sensitive);
+    EXPECT_EQ(bound_param1.surface_link().index(), 6u);
 
     const auto bound_cov0 = bound_param0.covariance();
     const auto bound_cov1 = bound_param1.covariance();
@@ -112,7 +115,6 @@ TEST(line_stepper, covariance_transport) {
     // Check covaraince
     for (unsigned int i = 0u; i < e_bound_size; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
-
             EXPECT_NEAR(matrix_operator().element(bound_cov0, i, j),
                         matrix_operator().element(bound_cov1, i, j), tol);
         }

--- a/tests/common/include/tests/common/material_interaction.inl
+++ b/tests/common/include/tests/common/material_interaction.inl
@@ -254,8 +254,8 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
         matrix_operator().template zero<e_bound_size, e_bound_size>();
 
     // bound track parameter at first physical plane
-    const bound_track_parameters<transform3> bound_param(0u, bound_vector,
-                                                         bound_cov);
+    const bound_track_parameters<transform3> bound_param(
+        geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
 
     propagation::print_inspector::state print_insp_state{};
     pathlimit_aborter::state aborter_state{};
@@ -335,8 +335,8 @@ TEST(material_interaction, telescope_geometry_energy_loss) {
     using alt_propagator_t =
         propagator<stepper_t, navigator_t, alt_actor_chain_t>;
 
-    bound_track_parameters<transform3> alt_bound_param(0u, bound_vector,
-                                                       bound_cov);
+    bound_track_parameters<transform3> alt_bound_param(
+        geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
 
     scalar altE(0);
 
@@ -429,8 +429,8 @@ TEST(material_interaction, telescope_geometry_scattering_angle) {
         matrix_operator().template zero<e_bound_size, e_bound_size>();
 
     // bound track parameter
-    const bound_track_parameters<transform3> bound_param(0u, bound_vector,
-                                                         bound_cov);
+    const bound_track_parameters<transform3> bound_param(
+        geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
 
     std::size_t n_samples{100000u};
     std::vector<scalar> phi_vec;

--- a/tests/common/include/tests/common/path_correction.inl
+++ b/tests/common/include/tests/common/path_correction.inl
@@ -125,11 +125,13 @@ TEST(path_correction, cartesian2D) {
     getter::element(bound_cov, e_bound_time, e_bound_time) = 1.f;
 
     // bound track parameter
-    const bound_track_parameters<transform3> bound_param0(0u, bound_vector,
+    geometry::barcode bcd{};
+    bcd.set_volume(0u).set_id(surface_id::e_sensitive).set_index(0u);
+    const bound_track_parameters<transform3> bound_param0(bcd, bound_vector,
                                                           bound_cov);
 
     // Actors
-    target_aborter::state targeter{0u};
+    target_aborter::state targeter{bcd};
     pathlimit_aborter::state pathlimit_state{path_limit};
     propagation::print_inspector::state print_insp_state{};
     parameter_transporter<transform3>::state bound_updater{};
@@ -271,11 +273,13 @@ TEST(path_correction, polar) {
     getter::element(bound_cov, e_bound_time, e_bound_time) = 1.f;
 
     // bound track parameter
-    const bound_track_parameters<transform3> bound_param0(0u, bound_vector,
+    geometry::barcode bcd{};
+    bcd.set_volume(0u).set_id(surface_id::e_sensitive).set_index(0u);
+    const bound_track_parameters<transform3> bound_param0(bcd, bound_vector,
                                                           bound_cov);
 
     // Actors
-    target_aborter::state targeter{0u};
+    target_aborter::state targeter{bcd};
     pathlimit_aborter::state pathlimit_state{path_limit};
     propagation::print_inspector::state print_insp_state{};
     parameter_transporter<transform3>::state bound_updater{};
@@ -406,11 +410,13 @@ TEST(path_correction, cylindrical) {
     getter::element(bound_cov, e_bound_time, e_bound_time) = 1.f;
 
     // bound track parameter
-    const bound_track_parameters<transform3> bound_param0(0, bound_vector,
+    geometry::barcode bcd{};
+    bcd.set_volume(0u).set_id(surface_id::e_sensitive).set_index(0u);
+    const bound_track_parameters<transform3> bound_param0(bcd, bound_vector,
                                                           bound_cov);
 
     // Actors
-    target_aborter::state targeter{0u};
+    target_aborter::state targeter{bcd};
     pathlimit_aborter::state pathlimit_state{path_limit};
     propagation::print_inspector::state print_insp_state{};
     parameter_transporter<transform3>::state bound_updater{};

--- a/tests/common/include/tests/common/test_telescope_detector.inl
+++ b/tests/common/include/tests/common/test_telescope_detector.inl
@@ -104,7 +104,12 @@ TEST(ALGEBRA_PLUGIN, telescope_detector) {
 
     // Compare
     for (std::size_t i{0u}; i < z_tel_det1.surfaces().size(); ++i) {
-        EXPECT_TRUE(z_tel_det1.surfaces(i) == z_tel_det2.surfaces(i));
+        geometry::barcode bcd{};
+        bcd.set_volume(0u).set_index(i);
+        bcd.set_id((i == z_tel_det1.surfaces().size() - 1u)
+                       ? surface_id::e_portal
+                       : surface_id::e_sensitive);
+        EXPECT_TRUE(z_tel_det1.surfaces(bcd) == z_tel_det2.surfaces(bcd));
     }
 
     //

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -88,7 +88,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     using detector_t = decltype(toy_det);
     using geo_obj_ids = typename detector_t::geo_obj_ids;
     using volume_t = typename detector_t::volume_type;
-    using geo_context_t = typename decltype(toy_det)::geometry_context;
+    using geo_context_t = typename detector_t::geometry_context;
     using mask_ids = typename detector_t::masks::id;
     using mask_link_t = typename detector_t::surface_type::mask_link;
     using material_ids = typename detector_t::materials::id;
@@ -112,7 +112,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     auto pixel_mat =
         material_slab<scalar>(silicon_tml<scalar>(), 0.15f * unit<scalar>::mm);
 
-    /** Link to outer world (leaving detector) */
+    // Link to outer world (leaving detector)
     const dindex leaving_world = dindex_invalid;
 
     // Check number of geomtery objects
@@ -169,7 +169,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                                  const dvector<dindex>&& volume_links) {
         for (dindex pti = range[0]; pti < range[1]; ++pti) {
             EXPECT_EQ(sf_itr->volume(), vol_index);
-            EXPECT_EQ(sf_itr->barcode(), pti);
+            EXPECT_EQ(sf_itr->id(), surface_id::e_portal);
+            EXPECT_EQ(sf_itr->index(), pti);
             EXPECT_EQ(sf_itr->transform(), trf_index);
             EXPECT_EQ(sf_itr->mask(), mask_link);
             const auto volume_link =
@@ -205,7 +206,8 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
                                  const dvector<dindex>&& volume_links) {
         for (dindex pti = range[0]; pti < range[1]; ++pti) {
             EXPECT_EQ(sf_itr->volume(), vol_index);
-            EXPECT_EQ(sf_itr->barcode(), pti);
+            EXPECT_FALSE(sf_itr->id() == surface_id::e_portal);
+            EXPECT_EQ(sf_itr->index(), pti);
             EXPECT_EQ(sf_itr->transform(), trf_index);
             EXPECT_EQ(sf_itr->mask(), mask_index);
             EXPECT_EQ(sf_itr->material(), material_index);

--- a/tests/common/include/tests/common/tools/inspectors.hpp
+++ b/tests/common/include/tests/common/tools/inspectors.hpp
@@ -96,7 +96,7 @@ struct print_inspector {
         debug_stream << msg << std::endl;
 
         debug_stream << "Volume" << tabs << state.volume() << std::endl;
-        debug_stream << "surface kernel size\t\t" << state.n_candidates()
+        debug_stream << "No. reachable\t\t" << state.n_candidates()
                      << std::endl;
 
         debug_stream << "Surface candidates: " << std::endl;
@@ -210,7 +210,7 @@ struct print_inspector : actor {
                            << navigation.volume();
         }
 
-        if (navigation.current_object() == dindex_invalid) {
+        if (navigation.current_object().is_invalid()) {
             printer.stream << "surface: " << std::setw(14) << "invalid";
         } else {
             printer.stream << "surface: " << std::setw(14)
@@ -230,7 +230,5 @@ struct print_inspector : actor {
 };
 
 }  // namespace propagation
-
-namespace step {}  // namespace step
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools/ray_scan_utils.hpp
+++ b/tests/common/include/tests/common/tools/ray_scan_utils.hpp
@@ -164,7 +164,7 @@ inline auto trace_intersections(const record_container &intersection_records,
         const typename record_container::value_type &entry;
 
         // getter
-        inline auto &object_id() const { return entry.second.barcode; }
+        inline auto object_id() const { return entry.second.barcode.index(); }
         inline auto &inters() const { return entry.second; }
         inline auto &volume_id() const { return entry.first; }
         inline auto &volume_link() const { return entry.second.volume_link; }

--- a/tests/common/include/tests/common/tools/test_surfaces.hpp
+++ b/tests/common/include/tests/common/tools/test_surfaces.hpp
@@ -68,7 +68,7 @@ planes_along_direction(const dvector<scalar> &distances, vector3 direction) {
         surfaces.emplace_back(std::move(trf), std::move(mask_link),
                               std::move(material_link), 0u, false,
                               surface_id::e_sensitive);
-        surfaces.back().set_barcode(idx);
+        surfaces.back().set_index(idx);
     }
     return surfaces;
 }

--- a/tests/common/include/tests/common/tools_guided_navigator.inl
+++ b/tests/common/include/tests/common/tools_guided_navigator.inl
@@ -83,13 +83,18 @@ TEST(ALGEBRA_PLUGIN, guided_navigator) {
     ASSERT_TRUE(nav_state.is_complete()) << debug_printer.to_string();
 
     // Sequence of surface ids we expect to see
-    const std::vector<geometry::barcode> sf_sequence = {
-        0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u, 9u, 10u, 11u};
+    const std::vector<unsigned int> sf_sequence = {0u, 1u, 2u, 3u, 4u,  5u,
+                                                   6u, 7u, 8u, 9u, 10u, 11u};
     // Check the surfaces that have been visited by the navigation
     EXPECT_EQ(obj_tracer.object_trace.size(), sf_sequence.size())
         << debug_printer.to_string();
     for (std::size_t i = 0u; i < sf_sequence.size(); ++i) {
         const auto &candidate = obj_tracer.object_trace[i];
-        EXPECT_TRUE(candidate.barcode == sf_sequence[i]);
+        auto bcd = geometry::barcode{};
+        bcd.set_volume(0u).set_index(sf_sequence[i]);
+        bcd.set_id((i == 11u) ? surface_id::e_portal : surface_id::e_sensitive);
+        EXPECT_TRUE(candidate.barcode == bcd)
+            << "error at intersection on surface:\n"
+            << "Expected: " << bcd << "\nFound: " << candidate.barcode;
     }
 }

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -254,7 +254,7 @@ TEST_P(PropagatorWithRkStepper, propagator_rk_stepper) {
         // Propagate the entire detector
         ASSERT_TRUE(p.propagate(state, actor_states))
             << print_insp_state.to_string() << std::endl;
-        //<< state._navigation.inspector().to_string() << std::endl;
+        // << state._navigation.inspector().to_string() << std::endl;
 
         // Propagate with path limit
         ASSERT_NEAR(pathlimit_aborter_state.path_limit(), path_limit, tol);

--- a/tests/common/include/tests/common/tools_track.inl
+++ b/tests/common/include/tests/common/tools_track.inl
@@ -60,8 +60,8 @@ TEST(tools, bound_track_parameters) {
     typename bound_track_parameters<transform3>::covariance_type bound_cov1 =
         matrix_operator().template zero<e_bound_size, e_bound_size>();
 
-    bound_track_parameters<transform3> bound_param1(sf_idx1, bound_vec1,
-                                                    bound_cov1);
+    bound_track_parameters<transform3> bound_param1(
+        geometry::barcode{}.set_index(sf_idx1), bound_vec1, bound_cov1);
 
     // second track
     dindex sf_idx2 = 1u;
@@ -77,10 +77,10 @@ TEST(tools, bound_track_parameters) {
     typename bound_track_parameters<transform3>::covariance_type bound_cov2 =
         matrix_operator().template zero<e_bound_size, e_bound_size>();
 
-    bound_track_parameters<transform3> bound_param2(sf_idx2, bound_vec2,
-                                                    bound_cov2);
-    bound_track_parameters<transform3> bound_param3(sf_idx2, bound_vec2,
-                                                    bound_cov2);
+    bound_track_parameters<transform3> bound_param2(
+        geometry::barcode{}.set_index(sf_idx2), bound_vec2, bound_cov2);
+    bound_track_parameters<transform3> bound_param3(
+        geometry::barcode{}.set_index(sf_idx2), bound_vec2, bound_cov2);
 
     /// Check the elements
 

--- a/tests/unit_tests/cpu/array/CMakeLists.txt
+++ b/tests/unit_tests/cpu/array/CMakeLists.txt
@@ -24,6 +24,7 @@ detray_add_test( array
    "array_cylinder_intersection.cpp"
    "array_cylinder.cpp"
    "array_detector.cpp"
+   "array_geometry_barcode.cpp"
    "array_geometry_volume_graph.cpp"
    "array_geometry_linking.cpp"
    "array_geometry_navigation.cpp" 

--- a/tests/unit_tests/cpu/array/array_geometry_barcode.cpp
+++ b/tests/unit_tests/cpu/array/array_geometry_barcode.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/array_definitions.hpp"
+#include "tests/common/geometry_barcode.inl"

--- a/tests/unit_tests/cpu/eigen/CMakeLists.txt
+++ b/tests/unit_tests/cpu/eigen/CMakeLists.txt
@@ -24,6 +24,7 @@ detray_add_test( eigen
    "eigen_cylinder_intersection.cpp" 
    "eigen_cylinder.cpp"
    "eigen_detector.cpp"
+   "eigen_geometry_barcode.cpp"
    "eigen_geometry_volume_graph.cpp"
    "eigen_geometry_linking.cpp"
    "eigen_geometry_navigation.cpp"

--- a/tests/unit_tests/cpu/eigen/eigen_geometry_barcode.cpp
+++ b/tests/unit_tests/cpu/eigen/eigen_geometry_barcode.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/eigen_definitions.hpp"
+#include "tests/common/geometry_barcode.inl"

--- a/tests/unit_tests/cpu/smatrix/CMakeLists.txt
+++ b/tests/unit_tests/cpu/smatrix/CMakeLists.txt
@@ -24,6 +24,7 @@ detray_add_test( smatrix
    "smatrix_cylinder_intersection.cpp"
    "smatrix_cylinder.cpp"
    "smatrix_detector.cpp"
+   "smatrix_geometry_barcode.cpp"
    "smatrix_geometry_volume_graph.cpp"
    "smatrix_geometry_linking.cpp"
    "smatrix_geometry_navigation.cpp"

--- a/tests/unit_tests/cpu/smatrix/smatrix_geometry_barcode.cpp
+++ b/tests/unit_tests/cpu/smatrix/smatrix_geometry_barcode.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/smatrix_definitions.hpp"
+#include "tests/common/geometry_barcode.inl"

--- a/tests/unit_tests/cpu/vc/CMakeLists.txt
+++ b/tests/unit_tests/cpu/vc/CMakeLists.txt
@@ -24,6 +24,7 @@ detray_add_test( vc_array
    "vc_array_cylinder_intersection.cpp"
    "vc_array_cylinder.cpp"
    "vc_array_detector.cpp"
+   "vc_array_geometry_barcode.cpp"
    "vc_array_geometry_volume_graph.cpp"
    "vc_array_geometry_linking.cpp"
    "vc_array_geometry_navigation.cpp"

--- a/tests/unit_tests/cpu/vc/vc_array_geometry_barcode.cpp
+++ b/tests/unit_tests/cpu/vc/vc_array_geometry_barcode.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/vc_array_definitions.hpp"
+#include "tests/common/geometry_barcode.inl"

--- a/utils/include/detray/simulation/event_writer.hpp
+++ b/utils/include/detray/simulation/event_writer.hpp
@@ -96,7 +96,7 @@ struct event_writer : actor {
             const auto mom = track.mom();
 
             hit.particle_id = writer_state.particle_id;
-            hit.geometry_id = navigation.current_object();
+            hit.geometry_id = navigation.current_object().index();
             hit.tx = pos[0];
             hit.ty = pos[1];
             hit.tz = pos[2];
@@ -113,7 +113,8 @@ struct event_writer : actor {
             const auto bound_params = stepping._bound_params;
             auto det = navigation.detector();
             const auto& mask_store = det->mask_store();
-            const auto& surface = det->surfaces(hit.geometry_id);
+            const auto& surface =
+                det->surfaces(geometry::barcode().set_index(hit.geometry_id));
 
             const auto local = mask_store.template visit<measurement_kernel>(
                 surface.mask(), bound_params, writer_state.m_meas_smearer);


### PR DESCRIPTION
Implement a new surface indexing that can fetch surfaces from accelerator structures. It is using the ACTS geometry identifier implementation to encode the surface mothervolume, id (portal, sensitive etc.), index (spatial index of the surface in the accelerator structure) and some extra bits that can be used for custom tags.

Also fixes a bug in the navigation candidate counting