### PR TITLE
Add make_curvilinear_unit_vector function and fix some bugs

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -141,5 +141,6 @@ detray_add_library( detray_core core
    "include/detray/utils/statistics.hpp"
    "include/detray/utils/tuple_helpers.hpp"
    "include/detray/utils/type_registry.hpp"
-   "include/detray/utils/type_traits.hpp" )
+   "include/detray/utils/type_traits.hpp"
+   "include/detray/utils/unit_vectors.hpp" )
 target_link_libraries( detray_core INTERFACE detray_io vecmem::core detray::Thrust)

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -134,6 +134,9 @@ struct propagator {
         // Run all registered actors/aborters after init
         run_actors(actor_states, propagation);
 
+        // Find next candidate
+        propagation._heartbeat &= _navigator.update(propagation);
+
         // Run while there is a heartbeat
         while (propagation._heartbeat) {
 
@@ -175,6 +178,9 @@ struct propagator {
 
         // Run all registered actors/aborters after init
         run_actors(actor_states, propagation);
+
+        // Find next candidate
+        propagation._heartbeat &= _navigator.update(propagation);
 
         while (propagation._heartbeat) {
 

--- a/core/include/detray/utils/axis_rotation.hpp
+++ b/core/include/detray/utils/axis_rotation.hpp
@@ -35,11 +35,14 @@ struct axis_rotation {
     /// @param theta rotation angle
     DETRAY_HOST_DEVICE
     axis_rotation(const vector3& axis, const scalar_type theta) {
+        // normalize the axis
+        const auto U = vector::normalize(axis);
+
         scalar_type cos_theta{math_ns::cos(theta)};
 
         matrix_type<3, 3> I = matrix_operator().template identity<3, 3>();
-        matrix_type<3, 3> axis_cross = mat_helper().cross_matrix(axis);
-        matrix_type<3, 3> axis_outer = mat_helper().outer_product(axis, axis);
+        matrix_type<3, 3> axis_cross = mat_helper().cross_matrix(U);
+        matrix_type<3, 3> axis_outer = mat_helper().outer_product(U, U);
 
         R = cos_theta * I + std::sin(theta) * axis_cross +
             (1.f - cos_theta) * axis_outer;
@@ -48,7 +51,7 @@ struct axis_rotation {
     /// @param v vector to be rotated
     /// @returns Get the rotated vector
     template <typename vector3_t>
-    DETRAY_HOST_DEVICE vector3_t operator()(const vector3_t& v) {
+    DETRAY_HOST_DEVICE vector3_t operator()(const vector3_t& v) const {
         return R * v;
     }
 

--- a/core/include/detray/utils/unit_vectors.hpp
+++ b/core/include/detray/utils/unit_vectors.hpp
@@ -1,0 +1,80 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "detray/definitions/qualifiers.hpp"
+
+// Thrust include(s)
+#include <thrust/pair.h>
+
+namespace detray {
+
+template <typename vector3_t>
+struct unit_vectors {
+
+    /// Construct the first curvilinear unit vector `U` for the given direction.
+    ///
+    /// @param dir is the input direction vector
+    /// @returns a normalized vector in the x-y plane orthogonal to the
+    /// direction.
+    ///
+    /// The special case of the direction vector pointing along the z-axis is
+    /// handled by forcing the unit vector to along the x-axis.
+    DETRAY_HOST_DEVICE inline vector3_t make_curvilinear_unit_u(
+        const vector3_t& dir) {
+
+        vector3_t unit_u{0.f, 0.f, 0.f};
+        // explicit version of U = Z x T
+        unit_u[0] = -dir[1];
+        unit_u[1] = dir[0];
+
+        const auto scale = getter::norm(unit_u);
+
+        // if the absolute scale is tiny, the initial direction vector is
+        // aligned with the z-axis. the ZxT product is ill-defined since any
+        // vector in the x-y plane would be orthogonal to the direction. fix the
+        // U unit vector along the x-axis to avoid this numerical instability.
+        if (scale < 1e-6f) {
+            unit_u[0] = 1;
+            unit_u[1] = 0;
+        } else {
+            unit_u = unit_u * (1.f / scale);
+        }
+
+        return unit_u;
+    }
+
+    /// Construct the curvilinear unit vectors `U` and `V` for the given
+    /// direction.
+    ///
+    /// @param dir is the input direction vector
+    /// @returns normalized unit vectors `U` and `V` orthogonal to the
+    /// direction.
+    ///
+    /// With `T` the normalized input direction, the three vectors `U`, `V`, and
+    /// `T` form an orthonormal basis set, i.e. they satisfy
+    ///
+    ///     U x V = T
+    ///     V x T = U
+    ///     T x U = V
+    ///
+    /// with the additional condition that `U` is located in the global x-y
+    /// plane.
+    DETRAY_HOST_DEVICE inline thrust::pair<vector3_t, vector3_t>
+    make_curvilinear_unit_vectors(const vector3_t& dir) {
+
+        thrust::pair<vector3_t, vector3_t> uv;
+        uv.first = make_curvilinear_unit_u(dir);
+        uv.second = vector::normalize(vector::cross(dir, uv.first));
+
+        return uv;
+    }
+};
+
+}  // namespace detray

--- a/tests/common/include/tests/common/axis_rotation.inl
+++ b/tests/common/include/tests/common/axis_rotation.inl
@@ -24,7 +24,7 @@ constexpr scalar isclose{1e-5f};
 
 TEST(utils, axis_rotation) {
 
-    const vector3 axis{0.f, 0.f, 1.f};
+    const vector3 axis{0.f, 0.f, 3.f};
 
     const vector3 v1{1.f, 0.f, 0.f};
 

--- a/tests/common/include/tests/common/utils_unit_vectors.inl
+++ b/tests/common/include/tests/common/utils_unit_vectors.inl
@@ -1,0 +1,52 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/utils/unit_vectors.hpp"
+
+// Google Test include(s)
+#include <gtest/gtest.h>
+
+using namespace detray;
+using transform3 = __plugin::transform3<scalar>;
+using vector3 = typename transform3::vector3;
+
+TEST(utils, curvilinear_unit_vectors) {
+
+    constexpr const scalar tolerance = 1e-5f;
+
+    // General case
+    vector3 w{2.f, 3.f, 4.f};
+
+    auto uv_pair = unit_vectors<vector3>().make_curvilinear_unit_vectors(w);
+    auto u = uv_pair.first;
+    auto v = uv_pair.second;
+
+    EXPECT_NEAR(u[0], -3.f / getter::perp(w), tolerance);
+    EXPECT_NEAR(u[1], 2.f / getter::perp(w), tolerance);
+    EXPECT_NEAR(u[2], 0.f, tolerance);
+
+    const auto test_v = vector::normalize(vector::cross(w, u));
+    EXPECT_NEAR(v[0], test_v[0], tolerance);
+    EXPECT_NEAR(v[1], test_v[1], tolerance);
+    EXPECT_NEAR(v[2], test_v[2], tolerance);
+
+    // Special case where w is aligned with z axis
+    w = {0.f, 0.f, 23.f};
+
+    uv_pair = unit_vectors<vector3>().make_curvilinear_unit_vectors(w);
+    u = uv_pair.first;
+    v = uv_pair.second;
+
+    EXPECT_NEAR(u[0], 1.f, tolerance);
+    EXPECT_NEAR(u[1], 0.f, tolerance);
+    EXPECT_NEAR(u[2], 0.f, tolerance);
+
+    EXPECT_NEAR(v[0], 0.f, tolerance);
+    EXPECT_NEAR(v[1], 1.f, tolerance);
+    EXPECT_NEAR(v[2], 0.f, tolerance);
+}

--- a/tests/unit_tests/cpu/array/CMakeLists.txt
+++ b/tests/unit_tests/cpu/array/CMakeLists.txt
@@ -62,6 +62,7 @@ detray_add_test( array
    "array_trapezoid2D.cpp"
    "array_track_generators.cpp"
    "array_unbounded.cpp"
+   "array_unit_vectors.cpp"
    "array_unmasked.cpp"
    "array_volume.cpp"
    LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::array )

--- a/tests/unit_tests/cpu/array/array_unit_vectors.cpp
+++ b/tests/unit_tests/cpu/array/array_unit_vectors.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/array_definitions.hpp"
+#include "tests/common/utils_unit_vectors.inl"

--- a/tests/unit_tests/cpu/eigen/CMakeLists.txt
+++ b/tests/unit_tests/cpu/eigen/CMakeLists.txt
@@ -62,6 +62,7 @@ detray_add_test( eigen
    "eigen_transform_store.cpp"
    "eigen_trapezoid2D.cpp"
    "eigen_unbounded.cpp"
+   "eigen_unit_vectors.cpp"
    "eigen_unmasked.cpp"
    "eigen_volume.cpp"
    LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::eigen )

--- a/tests/unit_tests/cpu/eigen/eigen_unit_vectors.cpp
+++ b/tests/unit_tests/cpu/eigen/eigen_unit_vectors.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/eigen_definitions.hpp"
+#include "tests/common/utils_unit_vectors.inl"

--- a/tests/unit_tests/cpu/smatrix/CMakeLists.txt
+++ b/tests/unit_tests/cpu/smatrix/CMakeLists.txt
@@ -62,6 +62,7 @@ detray_add_test( smatrix
    "smatrix_transform_store.cpp"
    "smatrix_trapezoid2D.cpp"
    "smatrix_unbounded.cpp"
+   "smatrix_unit_vectors.cpp"
    "smatrix_unmasked.cpp"
    "smatrix_volume.cpp"
    LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::smatrix )

--- a/tests/unit_tests/cpu/smatrix/smatrix_unit_vectors.cpp
+++ b/tests/unit_tests/cpu/smatrix/smatrix_unit_vectors.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/smatrix_definitions.hpp"
+#include "tests/common/utils_unit_vectors.inl"

--- a/tests/unit_tests/cpu/vc/CMakeLists.txt
+++ b/tests/unit_tests/cpu/vc/CMakeLists.txt
@@ -62,6 +62,7 @@ detray_add_test( vc_array
    "vc_array_transform_store.cpp"
    "vc_array_trapezoid2D.cpp"
    "vc_array_unbounded.cpp"
+   "vc_array_unit_vectors.cpp"
    "vc_array_unmasked.cpp"
    "vc_array_volume.cpp"
    LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::vc_array )

--- a/tests/unit_tests/cpu/vc/vc_array_unit_vectors.cpp
+++ b/tests/unit_tests/cpu/vc/vc_array_unit_vectors.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/vc_array_definitions.hpp"
+#include "tests/common/utils_unit_vectors.inl"

--- a/utils/include/detray/simulation/random_scatterer.hpp
+++ b/utils/include/detray/simulation/random_scatterer.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/utils/axis_rotation.hpp"
+#include "detray/utils/unit_vectors.hpp"
 
 // System include(s).
 #include <random>
@@ -61,7 +62,9 @@ struct random_scatterer : actor {
             const auto dir = stepping._bound_params.dir();
 
             // xaxis of curvilinear plane
-            const vector3 u{-dir[1], dir[0], 0.f};
+            const vector3 u =
+                unit_vectors<vector3>().make_curvilinear_unit_u(dir);
+
             vector3 new_dir = axis_rotation<transform3_type>(u, r_theta)(dir);
             new_dir = axis_rotation<transform3_type>(dir, r_phi)(new_dir);
 


### PR DESCRIPTION
Copied from `UnitVectors.hpp` of ACTS core.

Update: I found that the curvilinear vector used in `random_scatterer` was not normlized and made wrong results. After fixing it, the `check_simulation` didn't pass the unit test, which was because the navigator was not updated after the first call of actors. So I added `update()` after the `run_actors()` of `propagate()` function


