### PR TITLE
Algebra Plugins Update, main branch (2023.04.03.)

### DIFF
--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@ message(STATUS "Building Algebra Plugins as part of the Detray project")
 
 # Declare where to get Algebra Plugins from.
 set( DETRAY_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.18.0.tar.gz;URL_MD5;d4b4a784a4e95f5c06ff3331fb6e16ab"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.19.0.tar.gz;URL_MD5;8357b024b1bcdb70350d8a378055cfee"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced(DETRAY_ALGEBRA_PLUGINS_SOURCE)
 FetchContent_Declare(AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE})


### PR DESCRIPTION
Upgraded the project to use [algebra-plugins-0.19.0](https://github.com/acts-project/algebra-plugins/releases/tag/v0.19.0). This will be necessary for some upcoming changes, that will rely on fixes introduced in this algebra-plugins version.