### PR TITLE
detray::core Refactor, main branch (2023.04.03.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -7,140 +7,77 @@
 # Let the user know what's happening.
 message(STATUS "Building 'detray::core' component")
 
-# Set up the library.
+# Set up the "core library".
+file( GLOB _detray_core_public_headers
+   RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+   "include/detray/coordinates/*.hpp"
+   "include/detray/core/*.hpp"
+   "include/detray/definitions/*.hpp"
+   "include/detray/geometry/*.hpp"
+   "include/detray/grids/*.hpp"
+   "include/detray/intersection/bounding_box/*.hpp"
+   "include/detray/intersection/*.hpp"
+   "include/detray/masks/*.hpp"
+   "include/detray/materials/*.hpp"
+   "include/detray/propagator/actors/*.hpp"
+   "include/detray/propagator/*.hpp"
+   "include/detray/surface_finders/grid/*.hpp"
+   "include/detray/surface_finders/*.hpp"
+   "include/detray/tools/*.hpp"
+   "include/detray/tracks/*.hpp"
+   "include/detray/utils/ranges/*.hpp"
+   "include/detray/utils/*.hpp" )
+file( GLOB _detray_core_private_headers
+   "include/detray/*/detail/*.hpp"
+   "include/detray/*/*/detail/*.hpp" )
 detray_add_library( detray_core core
-   # coordinate include(s)
-   "include/detray/coordinates/cartesian2.hpp"
-   "include/detray/coordinates/cartesian3.hpp"
-   "include/detray/coordinates/coordinate_base.hpp"
-   "include/detray/coordinates/coordinates.hpp"
-   "include/detray/coordinates/cylindrical2.hpp"
-   "include/detray/coordinates/cylindrical3.hpp"
-   "include/detray/coordinates/line2.hpp"
-   "include/detray/coordinates/polar2.hpp"
-   # core include(s)
-   "include/detray/core/detail/container_view.hpp"
-   "include/detray/core/detail/data_context.hpp"
-   "include/detray/core/detail/detector_kernel.hpp"
-   "include/detray/core/detail/multi_store.hpp"
-   "include/detray/core/detail/single_store.hpp"
-   "include/detray/core/detail/tuple_container.hpp"
-   "include/detray/core/detector.hpp"
-   # definitions include(s)
-   "include/detray/definitions/detail/algorithms.hpp"
-   "include/detray/definitions/detail/bit_encoder.hpp"
-   "include/detray/definitions/containers.hpp"
-   "include/detray/definitions/cuda_definitions.hpp"
-   "include/detray/definitions/indexing.hpp"
-   "include/detray/definitions/pdg_particle.hpp"
-   "include/detray/definitions/qualifiers.hpp"
-   "include/detray/definitions/units.hpp"
-   "include/detray/definitions/track_parametrization.hpp"
-   # geometry include(s)
-   "include/detray/geometry/barcode.hpp"
-   "include/detray/geometry/detector_volume.hpp"
-   "include/detray/geometry/surface.hpp"
-   "include/detray/geometry/volume_connector.hpp"
-   "include/detray/geometry/volume_graph.hpp"
-   # grids include(s)
-   "include/detray/grids/axis.hpp"
-   "include/detray/grids/grid2.hpp"
-   "include/detray/grids/populator.hpp"
-   "include/detray/grids/serializer2.hpp"
-   # intersection include(s)
-   "include/detray/intersection/bounding_box/cuboid_intersector.hpp"
-   "include/detray/intersection/concentric_cylinder_intersector.hpp"
-   "include/detray/intersection/cylinder_intersector.hpp"
-   "include/detray/intersection/detail/trajectories.hpp"
-   "include/detray/intersection/intersection_kernel.hpp"
-   "include/detray/intersection/intersection.hpp"
-   "include/detray/intersection/line_intersector.hpp"
-   "include/detray/intersection/plane_intersector.hpp"
-   # masks include(s)
-   "include/detray/masks/annulus2D.hpp"
-   "include/detray/masks/cuboid3D.hpp"
-   "include/detray/masks/cylinder3D.hpp"
-   "include/detray/masks/line.hpp"
-   "include/detray/masks/masks.hpp"
-   "include/detray/masks/rectangle2D.hpp"
-   "include/detray/masks/ring2D.hpp"
-   "include/detray/masks/single3D.hpp"
-   "include/detray/masks/trapezoid2D.hpp"
-   "include/detray/masks/unmasked.hpp"
-   # materials include(s)
-   "include/detray/materials/detail/density_effect_data.hpp"
-   "include/detray/materials/detail/relativistic_quantities.hpp"
-   "include/detray/materials/interaction.hpp"
-   "include/detray/materials/material.hpp"
-   "include/detray/materials/material_rod.hpp"
-   "include/detray/materials/material_slab.hpp"
-   "include/detray/materials/mixture.hpp"
-   "include/detray/materials/predefined_materials.hpp"
-   # propagator include(s)
-   "include/detray/propagator/actors/aborters.hpp"
-   "include/detray/propagator/actors/parameter_resetter.hpp"
-   "include/detray/propagator/actors/parameter_transporter.hpp"
-   "include/detray/propagator/actors/pointwise_material_interactor.hpp"
-   "include/detray/propagator/actor_chain.hpp"
-   "include/detray/propagator/base_actor.hpp"
-   "include/detray/propagator/base_stepper.hpp"
-   "include/detray/propagator/constrained_step.hpp"
-   "include/detray/propagator/line_stepper.hpp"
-   "include/detray/propagator/navigation_policies.hpp"
-   "include/detray/propagator/navigator.hpp"
-   "include/detray/propagator/propagator.hpp"
-   "include/detray/propagator/rk_stepper.hpp"
-   # surface finder include(s)
-   "include/detray/surface_finders/brute_force_finder.hpp"
-   "include/detray/surface_finders/grid/detail/axis_binning.hpp"
-   "include/detray/surface_finders/grid/detail/axis_bounds.hpp"
-   "include/detray/surface_finders/grid/detail/axis_helpers.hpp"
-   "include/detray/surface_finders/grid/detail/grid_helpers.hpp"
-   "include/detray/surface_finders/grid/detail/populator_impl.hpp"
-   "include/detray/surface_finders/grid/detail/serializer_impl.hpp"
-   "include/detray/surface_finders/grid/axis.hpp"
-   "include/detray/surface_finders/grid/grid_collection.hpp"
-   "include/detray/surface_finders/grid/grid.hpp"
-   "include/detray/surface_finders/grid/populator.hpp"
-   "include/detray/surface_finders/grid/serializer.hpp"
-   "include/detray/surface_finders/neighborhood_kernel.hpp"
-   # tools include(s)
-   "include/detray/tools/associator.hpp"
-   "include/detray/tools/bin_association.hpp"
-   "include/detray/tools/bin_fillers.hpp"
-   "include/detray/tools/bounding_volume.hpp"
-   "include/detray/tools/generators.hpp"
-   "include/detray/tools/grid_builder.hpp"
-   "include/detray/tools/grid_factory.hpp"
-   "include/detray/tools/local_object_finder.hpp"
-   "include/detray/tools/surface_factory.hpp"
-   "include/detray/tools/surface_factory_interface.hpp"
-   "include/detray/tools/volume_builder.hpp"
-   "include/detray/tools/volume_builder_interface.hpp"
-   # tracks include(s)
-   "include/detray/tracks/detail/track_helper.hpp"
-   "include/detray/tracks/bound_track_parameters.hpp"
-   "include/detray/tracks/free_track_parameters.hpp"
-   "include/detray/tracks/tracks.hpp"
-   # utils include(s)
-   "include/detray/utils/axis_rotation.hpp"
-   "include/detray/utils/column_wise_operator.hpp"
-   "include/detray/utils/ranges/detail/iterator_functions.hpp"
-   "include/detray/utils/ranges/empty.hpp"
-   "include/detray/utils/ranges/enumerate.hpp"
-   "include/detray/utils/ranges/iota.hpp"
-   "include/detray/utils/ranges/join.hpp"
-   "include/detray/utils/ranges/pick.hpp"
-   "include/detray/utils/ranges/ranges.hpp"
-   "include/detray/utils/ranges/single.hpp"
-   "include/detray/utils/ranges/subrange.hpp"
-   "include/detray/utils/invalid_values.hpp"
-   "include/detray/utils/matrix_helper.hpp"
-   "include/detray/utils/quadratic_equation.hpp"
-   "include/detray/utils/ratio.hpp"
-   "include/detray/utils/statistics.hpp"
-   "include/detray/utils/tuple_helpers.hpp"
-   "include/detray/utils/type_registry.hpp"
-   "include/detray/utils/type_traits.hpp"
-   "include/detray/utils/unit_vectors.hpp" )
-target_link_libraries( detray_core INTERFACE detray_io vecmem::core detray::Thrust)
+   ${_detray_core_public_headers} ${_detray_core_private_headers} )
+target_link_libraries( detray_core
+   INTERFACE covfie::core vecmem::core detray::Thrust )
+
+# Set up the libraries that use specific algebra plugins.
+detray_add_library( detray_core_array core_array )
+target_link_libraries( detray_core_array
+   INTERFACE detray::core detray::algebra_array )
+
+if( DETRAY_EIGEN_PLUGIN )
+   detray_add_library( detray_core_eigen core_eigen )
+   target_link_libraries( detray_core_eigen
+      INTERFACE detray::core detray::algebra_eigen )
+endif()
+
+if( DETRAY_SMATRIX_PLUGIN )
+   detray_add_library( detray_core_smatrix core_smatrix )
+   target_link_libraries( detray_core_smatrix
+      INTERFACE detray::core detray::algebra_smatrix )
+endif()
+
+if( DETRAY_VC_PLUGIN )
+   detray_add_library( detray_core_vc core_vc )
+   target_link_libraries( detray_core_vc
+      INTERFACE detray::core detray::algebra_vc )
+endif()
+
+# Test the public headers of the detray core libraries.
+if( BUILD_TESTING AND DETRAY_BUILD_TESTING )
+   string( REPLACE "include/" "" _detray_core_public_headers
+      "${_detray_core_public_headers}" )
+   detray_test_public_headers( detray_core_array
+      ${_detray_core_public_headers} )
+   if( DETRAY_EIGEN_PLUGIN )
+      detray_test_public_headers( detray_core_eigen
+         ${_detray_core_public_headers} )
+   endif()
+   if( DETRAY_SMATRIX_PLUGIN )
+      detray_test_public_headers( detray_core_smatrix
+         ${_detray_core_public_headers} )
+   endif()
+   if( DETRAY_VC_PLUGIN )
+      detray_test_public_headers( detray_core_vc
+         ${_detray_core_public_headers} )
+   endif()
+endif()
+
+# Clean up.
+unset( _detray_core_public_headers )
+unset( _detray_core_private_headers )

--- a/core/include/detray/definitions/algebra.hpp
+++ b/core/include/detray/definitions/algebra.hpp
@@ -1,0 +1,20 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#if DETRAY_ALGEBRA_ARRAY
+#include "detray/plugins/algebra/array_definitions.hpp"
+#elif DETRAY_ALGEBRA_EIGEN
+#include "detray/plugins/algebra/eigen_definitions.hpp"
+#elif DETRAY_ALGEBRA_SMATRIX
+#include "detray/plugins/algebra/smatrix_definitions.hpp"
+#elif DETRAY_ALGEBRA_VC
+#include "detray/plugins/algebra/vc_array_definitions.hpp"
+#else
+#error "No algebra plugin selected! Please link to one of the algebra plugins."
+#endif

--- a/core/include/detray/definitions/grid_axis.hpp
+++ b/core/include/detray/definitions/grid_axis.hpp
@@ -1,11 +1,14 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
+
+// System include(s).
+#include <type_traits>
 
 namespace detray::n_axis {
 

--- a/core/include/detray/definitions/math.hpp
+++ b/core/include/detray/definitions/math.hpp
@@ -7,8 +7,6 @@
 
 #pragma once
 
-namespace detray {
-
 // SYCL include(s).
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
 #include <CL/sycl.hpp>
@@ -16,6 +14,8 @@ namespace detray {
 
 // System include(s).
 #include <cmath>
+
+namespace detray {
 
 /// Namespace to pick up math functions from
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)

--- a/core/include/detray/definitions/pdg_particle.hpp
+++ b/core/include/detray/definitions/pdg_particle.hpp
@@ -1,11 +1,14 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
+
+// System include(s).
+#include <cstdint>
 
 namespace detray {
 

--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/geometry.hpp"
 #include "detray/definitions/indexing.hpp"

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/utils/invalid_values.hpp"

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/geometry.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"

--- a/core/include/detray/masks/single3D.hpp
+++ b/core/include/detray/masks/single3D.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/coordinates/cartesian2.hpp"
+#include "detray/coordinates/cartesian3.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/surface_finders/grid/detail/axis_binning.hpp"

--- a/core/include/detray/masks/unbounded.hpp
+++ b/core/include/detray/masks/unbounded.hpp
@@ -11,6 +11,8 @@
 #include "detray/definitions/qualifiers.hpp"
 
 // System include(s)
+#include <array>
+#include <limits>
 #include <string>
 
 namespace detray {

--- a/core/include/detray/materials/predefined_materials.hpp
+++ b/core/include/detray/materials/predefined_materials.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/materials/detail/density_effect_data.hpp"
 #include "detray/materials/material.hpp"

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/definitions/track_parametrization.hpp"
 #include "detray/materials/interaction.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/utils/axis_rotation.hpp"

--- a/core/include/detray/propagator/constrained_step.hpp
+++ b/core/include/detray/propagator/constrained_step.hpp
@@ -8,11 +8,13 @@
 #pragma once
 
 // detray definitions
-#include <climits>
-#include <type_traits>
-
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
+
+// System include(s).
+#include <climits>
+#include <type_traits>
 
 namespace detray {
 

--- a/core/include/detray/propagator/navigation_policies.hpp
+++ b/core/include/detray/propagator/navigation_policies.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,6 +8,7 @@
 #pragma once
 
 // detray definitions
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/propagator/base_actor.hpp"
 

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/intersection.hpp"
+#include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/navigator.hpp"
 #include "detray/tracks/tracks.hpp"
 

--- a/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/detail/algorithms.hpp"
 #include "detray/definitions/grid_axis.hpp"
 #include "detray/definitions/indexing.hpp"
@@ -59,7 +60,7 @@ struct regular {
     /// @returns the total number of bins, which for the regular axis is simply
     /// the second entry in the range
     DETRAY_HOST_DEVICE
-    std::size_t nbins() const { return detail::get<1>(*m_edges_range); }
+    std::size_t nbins() const { return detray::detail::get<1>(*m_edges_range); }
 
     /// Access function to a single bin from a value v
     ///
@@ -121,7 +122,7 @@ struct regular {
         // Output vector has to be constructed, because the edges are
         // calculated on the fly
         vector_type<scalar_t> edges;
-        detail::call_reserve(edges, nbins());
+        detray::detail::call_reserve(edges, nbins());
 
         // Calculate bin edges from number of bins and axis span
         const array_type<scalar_t, 2> sp = span();
@@ -138,7 +139,7 @@ struct regular {
     DETRAY_HOST_DEVICE
     scalar_t bin_width() const {
         // Get the binning information
-        const dindex ibin{detail::get<0>(*m_edges_range)};
+        const dindex ibin{detray::detail::get<0>(*m_edges_range)};
         const scalar_t min{(*m_bin_edges)[ibin]};
         const scalar_t max{(*m_bin_edges)[ibin + 1]};
 
@@ -152,7 +153,7 @@ struct regular {
     DETRAY_HOST_DEVICE
     array_type<scalar_t, 2> span() const {
         // Get the binning information
-        const dindex ibin{detail::get<0>(*m_edges_range)};
+        const dindex ibin{detray::detail::get<0>(*m_edges_range)};
         const scalar_t min{(*m_bin_edges)[ibin]};
         const scalar_t max{(*m_bin_edges)[ibin + 1]};
 
@@ -202,7 +203,8 @@ struct irregular {
     /// @returns the total number of bins
     DETRAY_HOST_DEVICE
     std::size_t nbins() const {
-        return detail::get<1>(*m_edges_range) - detail::get<0>(*m_edges_range);
+        return detray::detail::get<1>(*m_edges_range) -
+               detray::detail::get<0>(*m_edges_range);
     }
 
     /// Access function to a single bin from a value v
@@ -214,12 +216,14 @@ struct irregular {
     int bin(const scalar_t v) const {
         auto bins_begin =
             m_bin_edges->begin() +
-            static_cast<index_type>(detail::get<0>(*m_edges_range));
-        auto bins_end = m_bin_edges->begin() +
-                        static_cast<index_type>(detail::get<1>(*m_edges_range));
+            static_cast<index_type>(detray::detail::get<0>(*m_edges_range));
+        auto bins_end =
+            m_bin_edges->begin() +
+            static_cast<index_type>(detray::detail::get<1>(*m_edges_range));
 
-        return static_cast<int>(detail::lower_bound(bins_begin, bins_end, v) -
-                                bins_begin) -
+        return static_cast<int>(
+                   detray::detail::lower_bound(bins_begin, bins_end, v) -
+                   bins_begin) -
                1;
     }
 
@@ -257,7 +261,7 @@ struct irregular {
     DETRAY_HOST_DEVICE
     array_type<scalar_t, 2> bin_edges(const dindex ibin) const {
         // Offset into global container for this binning
-        const dindex offset{detail::get<0>(*m_edges_range)};
+        const dindex offset{detray::detail::get<0>(*m_edges_range)};
 
         return {(*m_bin_edges)[offset + ibin],
                 (*m_bin_edges)[offset + ibin + 1u]};
@@ -269,14 +273,14 @@ struct irregular {
     vector_type<scalar_t> bin_edges() const {
         // Transcribe the subvector for this binning from the global storage
         vector_type<scalar_t> edges;
-        detail::call_reserve(edges, nbins());
+        detray::detail::call_reserve(edges, nbins());
 
         edges.insert(
             edges->end(),
             m_bin_edges->begin() +
-                static_cast<index_type>(detail::get<0>(*m_edges_range)),
-            m_bin_edges->begin() +
-                static_cast<index_type>(detail::get<1>(*m_edges_range)));
+                static_cast<index_type>(detray::detail::get<0>(*m_edges_range)),
+            m_bin_edges->begin() + static_cast<index_type>(
+                                       detray::detail::get<1>(*m_edges_range)));
 
         return edges;
     }
@@ -296,8 +300,10 @@ struct irregular {
     DETRAY_HOST_DEVICE
     array_type<scalar_t, 2> span() const {
         // Get the binning information
-        const scalar_t min{(*m_bin_edges)[detail::get<0>(*m_edges_range)]};
-        const scalar_t max{(*m_bin_edges)[detail::get<1>(*m_edges_range)]};
+        const scalar_t min{
+            (*m_bin_edges)[detray::detail::get<0>(*m_edges_range)]};
+        const scalar_t max{
+            (*m_bin_edges)[detray::detail::get<1>(*m_edges_range)]};
 
         return {min, max};
     }

--- a/core/include/detray/surface_finders/grid/detail/axis_helpers.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_helpers.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "detray/core/detail/container_views.hpp"
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 

--- a/core/include/detray/tools/associator.hpp
+++ b/core/include/detray/tools/associator.hpp
@@ -7,6 +7,11 @@
 
 #pragma once
 
+// Project include(s).
+#include "detray/definitions/algebra.hpp"
+#include "detray/definitions/qualifiers.hpp"
+
+// System include(s).
 #include <limits>
 #include <vector>
 

--- a/core/include/detray/tools/local_object_finder.hpp
+++ b/core/include/detray/tools/local_object_finder.hpp
@@ -1,12 +1,16 @@
 
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
+
+// Project include(s).
+#include "detray/definitions/algebra.hpp"
+#include "detray/definitions/indexing.hpp"
 
 namespace detray {
 /** A zone finder based on a grid

--- a/core/include/detray/tools/surface_factory.hpp
+++ b/core/include/detray/tools/surface_factory.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,14 +8,16 @@
 #pragma once
 
 // Project include(s)
+#include "detray/core/detail/data_context.hpp"
 #include "detray/definitions/indexing.hpp"
+#include "detray/definitions/qualifiers.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/masks/unmasked.hpp"
 #include "detray/tools/surface_factory_interface.hpp"
 #include "detray/utils/ranges.hpp"
 
 // System include(s)
 #include <cassert>
-#include <iterator>
 #include <limits>
 #include <memory>
 #include <tuple>

--- a/core/include/detray/tools/surface_factory_interface.hpp
+++ b/core/include/detray/tools/surface_factory_interface.hpp
@@ -1,11 +1,15 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
+
+// Project include(s).
+#include "detray/definitions/indexing.hpp"
+#include "detray/definitions/qualifiers.hpp"
 
 // System include(s)
 #include <tuple>

--- a/core/include/detray/tracks/bound_track_parameters.hpp
+++ b/core/include/detray/tracks/bound_track_parameters.hpp
@@ -149,7 +149,7 @@ struct bound_track_parameters {
     }
 
     DETRAY_HOST_DEVICE
-    void set_qop(const scalar qop) {
+    void set_qop(const scalar_type qop) {
         matrix_operator().element(m_vector, e_bound_qoverp, 0u) = qop;
     }
 

--- a/core/include/detray/tracks/free_track_parameters.hpp
+++ b/core/include/detray/tracks/free_track_parameters.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/track_parametrization.hpp"
 #include "detray/tracks/detail/track_helper.hpp"
@@ -148,7 +149,7 @@ struct free_track_parameters {
     }
 
     DETRAY_HOST_DEVICE
-    void set_qop(const scalar qop) {
+    void set_qop(const scalar_type qop) {
         matrix_operator().element(m_vector, e_free_qoverp, 0u) = qop;
     }
 

--- a/core/include/detray/utils/matrix_helper.hpp
+++ b/core/include/detray/utils/matrix_helper.hpp
@@ -1,6 +1,6 @@
 /** Detray plugins library, part of the ACTS project
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
 namespace detray {

--- a/core/include/detray/utils/quadratic_equation.hpp
+++ b/core/include/detray/utils/quadratic_equation.hpp
@@ -7,11 +7,13 @@
 
 #pragma once
 
-#include <algorithm>
-#include <climits>
-#include <cmath>
-
+// Project include(s).
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
+
+// System include(s).
+#include <cmath>
+#include <limits>
 
 namespace detray {
 

--- a/core/include/detray/utils/unit_vectors.hpp
+++ b/core/include/detray/utils/unit_vectors.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
 // Thrust include(s)

--- a/tests/benchmarks/core/CMakeLists.txt
+++ b/tests/benchmarks/core/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 detray_add_executable( benchmark_grids "benchmark_grids.cpp"
    LINK_LIBRARIES benchmark::benchmark vecmem::core detray_tests_common
-                  detray::core )
+                  detray::core_array )

--- a/tests/benchmarks/core/benchmark_grids.cpp
+++ b/tests/benchmarks/core/benchmark_grids.cpp
@@ -65,8 +65,8 @@ auto construct_irregular_grid() {
     dvector<scalar> yboundaries = {};
     yboundaries.reserve(60u);
 
-    for (unsigned int i = 0u; i < 61u; ++i) {
-        if (i < 26u) {
+    for (scalar i = 0.f; i < 61.f; i += 1.f) {
+        if (i < 26.f) {
             xboundaries.push_back(i);
         }
         yboundaries.push_back(i);

--- a/tests/common/include/tests/common/test_defs.hpp
+++ b/tests/common/include/tests/common/test_defs.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,10 +19,7 @@ using detray_scalar = DETRAY_CUSTOM_SCALARTYPE;
 using detray_scalar = double;
 #endif
 
-#define __plugin test
-
 namespace detray {
-using scalar = detray_scalar;
 
 namespace test {
 
@@ -32,18 +29,6 @@ template <typename T>
 using point3 = darray<T, 3>;
 
 }  // namespace test
-
-namespace getter {
-
-/** Define the perpendicular length
- * @param  is the input vector
- * @return a scalar type */
-template <typename point_type>
-scalar perp(const point_type &p) {
-    return std::sqrt(p[0] * p[0] + p[1] * p[1]);
-}
-
-}  // namespace getter
 
 template <typename T>
 inline test::point2<T> operator-(const test::point2<T> &a,

--- a/tests/unit_tests/core/CMakeLists.txt
+++ b/tests/unit_tests/core/CMakeLists.txt
@@ -17,4 +17,4 @@ detray_add_test( core
    "utils_ranges.cpp"
    "utils_quadratic_equation.cpp"
    "utils_sort.cpp"
-   LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::core )
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common detray::core_array )

--- a/tests/unit_tests/core/utils_quadratic_equation.cpp
+++ b/tests/unit_tests/core/utils_quadratic_equation.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,6 +11,7 @@
 #include "tests/common/test_defs.hpp"
 
 // detray core
+#include "detray/definitions/algebra.hpp"
 #include "detray/utils/quadratic_equation.hpp"
 
 using namespace detray;

--- a/tests/unit_tests/device/cuda/CMakeLists.txt
+++ b/tests/unit_tests/device/cuda/CMakeLists.txt
@@ -19,7 +19,8 @@ detray_add_test(core_cuda
    "grids_grid2_cuda.cpp" "grids_grid2_cuda_kernel.hpp"
    "grids_grid2_cuda_kernel.cu" "utils_ranges_cuda.cpp"
    "utils_ranges_cuda_kernel.hpp" "utils_ranges_cuda_kernel.cu"
-   LINK_LIBRARIES GTest::gtest_main detray_tests_common vecmem::cuda )
+   LINK_LIBRARIES GTest::gtest_main detray_tests_common vecmem::cuda
+                  detray::core_array )
 
 # make unit tests for multiple algebras
 # Currently vc and smatrix is not supported


### PR DESCRIPTION
This is the "next step" in the cleanup started in #430, which we discussed at our meeting a little while ago.

This PR changes `detray::core` a bit. First off, since there are just so many headers associated with this library by now, and I anyway found that some of their names had typos in `core/CMakeLists.txt`, I now switched to collecting the file names using [file(GLOB ...)](https://cmake.org/cmake/help/latest/command/file.html#filesystem).

Then, I added `detray/definition/primitives.hpp` similar to [traccc/definitions/primitives.hpp](https://github.com/acts-project/traccc/blob/main/core/include/traccc/definitions/primitives.hpp), which the other `detray::core` headers could depend on when they needed to use some "algebra plugin functionality" directly. (And not through templating.)

To make sure that the new header would be used correctly, I added `detray::core_array`, `detray::core_eigen`, `detray::core_smatrix`  and `detray::core_vc` targets that would link `detray::core` against `detray::algebra_array`, `detray::algebra_eigen`, `detray::algebra_smatrix` and `detray::algebra_vc` respectively. And then, using `detray_test_public_headers(...)`, set up tests for all of the public headers through these new targets. (Though one could argue that just testing the headers "through a single algebra plugin" could be enough.)

Then I fixed all the imperfections in the `detray::core` headers. Which ranged from simple missing includes to actual coding errors, which were missed by chance so far.

Finally I made some small changes in the tests to make them work with these updates. A larger cleanup in the tests will be possible once the rest of the libraries in the project are also cleaned up in a similar way. :wink: