### PR TITLE
CI Benchmark Fix, main branch (2023.03.04.)

### DIFF
--- a/tests/scripts/run_benchmarks.sh
+++ b/tests/scripts/run_benchmarks.sh
@@ -2,7 +2,7 @@
 #
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -51,7 +51,7 @@ cat benchmark_${LASTCOMMIT}.csv
 
 echo "===> Install components for benchmark analysis ..."
 
-pip3 install matplotlib numpy pandas
+pip3 install matplotlib==3.7.1 numpy==1.24.2 pandas==1.5.3
 
 echo "===> Download benchmark history ..."
 
@@ -64,9 +64,9 @@ git fetch origin
 git checkout -b gh-pages origin/gh-pages
 
 # Bring analysis script
-git checkout ${LASTCOMMIT} -- ${WORKSPACE}/tests/scripts/analyze_benchmarks.py 
+git checkout ${LASTCOMMIT} -- ${WORKSPACE}/tests/scripts/analyze_benchmarks.py
 
-# Record the benchmark result into benchmarks_history 
+# Record the benchmark result into benchmarks_history
 BENCHMARK_HISTORY_FILE=${WORKSPACE}/archive/benchmarks/benchmarks_history.csv
 cat ${WORKSPACE}/benchmark_${LASTCOMMIT}.csv >> ${BENCHMARK_HISTORY_FILE}
 


### PR DESCRIPTION
Specified the versions of the used Python packages explicitly for the benchmark. Took the versions from the last CI job that was successful. (https://github.com/acts-project/detray/actions/runs/4597364526/jobs/8119958557)