### PR TITLE
ref: Reduce size of navigator memory alloc

### DIFF
--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -147,6 +147,34 @@ class detector_volume {
                     rhs._sf_finder_links[ID::e_sensitive]);
     }
 
+    /// @return the maximum number of surface candidates during a neighborhood
+    /// lookup
+    template <int I = static_cast<int>(ID::e_size) - 1,
+              typename surface_store_t>
+    DETRAY_HOST_DEVICE constexpr auto n_max_candidates(
+        const surface_store_t &sf_collections, unsigned int n = 0u) const
+        -> unsigned int {
+        // Get the index of the surface collection with type index 'I'
+        constexpr auto sf_col_id{static_cast<typename surface_store_t::ids>(I)};
+        const dindex coll_idx{detail::get<1>(link<static_cast<ID>(I)>())};
+
+        // Check if this volume holds such a collection and, if so, add max
+        // number of candidates that we can expect from it
+        if (coll_idx != dindex_invalid) {
+            const unsigned int n_max{
+                sf_collections.template get<sf_col_id>()[coll_idx]
+                    .n_max_candidates()};
+            // @todo: Remove when local navigation becomes available !!!!
+            n += n_max > 20u ? 20u : n_max;
+        }
+        // Check the next surface collection type
+        if constexpr (I > 0) {
+            return n_max_candidates<I - 1>(sf_collections, n);
+        } else {
+            return n;
+        }
+    }
+
     private:
     /// How to interpret the boundary values
     volume_id _id = volume_id::e_cylinder;

--- a/core/include/detray/propagator/navigator.hpp
+++ b/core/include/detray/propagator/navigator.hpp
@@ -801,8 +801,9 @@ create_candidates_buffer(
     const detector_t &det, const std::size_t n_tracks,
     vecmem::memory_resource &device_resource,
     vecmem::memory_resource *host_access_resource = nullptr) {
+    // Build the buffer from capacities, device and host accessible resources
     return vecmem::data::jagged_vector_buffer<line_plane_intersection>(
-        std::vector<std::size_t>(n_tracks, det.get_n_max_objects_per_volume()),
+        std::vector<std::size_t>(n_tracks, det.n_max_candidates()),
         device_resource, host_access_resource,
         vecmem::data::buffer_type::resizable);
 }

--- a/core/include/detray/surface_finders/brute_force_finder.hpp
+++ b/core/include/detray/surface_finders/brute_force_finder.hpp
@@ -63,6 +63,13 @@ class brute_force_collection {
 
         /// @returns an iterator over all surfaces in the data structure
         DETRAY_HOST_DEVICE constexpr auto all() const { return *this; }
+
+        /// @return the maximum number of surface candidates during a
+        /// neighborhood lookup
+        DETRAY_HOST_DEVICE constexpr auto n_max_candidates() const
+            -> unsigned int {
+            return static_cast<unsigned int>(this->size());
+        }
     };
 
     using value_type = brute_forcer;

--- a/core/include/detray/surface_finders/grid/grid.hpp
+++ b/core/include/detray/surface_finders/grid/grid.hpp
@@ -293,6 +293,13 @@ class grid {
     }
     /// @}
 
+    /// @return the maximum number of surface candidates during a
+    /// neighborhood lookup
+    DETRAY_HOST_DEVICE constexpr auto n_max_candidates() const -> unsigned int {
+        // @todo: Hotfix for the toy geometry
+        return 20u;
+    }
+
     static constexpr auto serializer() -> serializer_t<Dim> { return {}; }
 
     /// @returns view of a grid, including the grids mulit_axis. Also valid if

--- a/core/include/detray/tools/volume_builder.hpp
+++ b/core/include/detray/tools/volume_builder.hpp
@@ -135,9 +135,6 @@ class volume_builder : public volume_builder_interface<detector_t> {
 
         // Append masks
         det.append_masks(std::move(m_masks));
-
-        // Update max objects per volume
-        det.update_n_max_objects_per_volume(m_surfaces.size());
     }
 
     typename detector_t::volume_type* m_volume{};

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -353,6 +353,10 @@ auto create_telescope_detector(
     using detector_t = detector<telescope_types<typename mask_t::shape>,
                                 covfie::field, container_t>;
 
+    // @todo: Temporal restriction due to missing local navigation
+    assert((dists.size() < 20u) &&
+           "Due to WIP, please choose less than 20 surfaces for now");
+
     // module parameters
     struct surface_config {
         const typename mask_t::mask_values &mask_values;


### PR DESCRIPTION
As a first try, until the grids are available, sets the number to an arbitrary value that works for the current testing detectors. Obviously, this is just a hotfix and will be corrected in the future.