### PR TITLE
Improve energy loss

### DIFF
--- a/core/include/detray/materials/detail/density_effect_data.hpp
+++ b/core/include/detray/materials/detail/density_effect_data.hpp
@@ -11,9 +11,6 @@
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 
-// System include(s)
-#include <limits>
-
 namespace detray::detail {
 
 /// @note Ported from Geant4 and simplified

--- a/core/include/detray/materials/detail/density_effect_data.hpp
+++ b/core/include/detray/materials/detail/density_effect_data.hpp
@@ -72,17 +72,17 @@ struct density_effect_data {
 
     /// Fitting parameters of Eq. 33.7 of RPP 2018
     /// @{
-    scalar_type m_a = std::numeric_limits<scalar_type>::epsilon();
-    scalar_type m_m = std::numeric_limits<scalar_type>::epsilon();
-    scalar_type m_X0 = std::numeric_limits<scalar_type>::epsilon();
-    scalar_type m_X1 = std::numeric_limits<scalar_type>::epsilon();
+    scalar_type m_a = 0.f;
+    scalar_type m_m = 0.f;
+    scalar_type m_X0 = 0.f;
+    scalar_type m_X1 = 0.f;
     /// @}
     /// Mean excitation energy in eV
-    scalar_type m_I = std::numeric_limits<scalar_type>::epsilon();
+    scalar_type m_I = 0.f;
     /// -C
-    scalar_type m_nC = std::numeric_limits<scalar_type>::epsilon();
+    scalar_type m_nC = 0.f;
     /// Density-effect value delta(X_0)
-    scalar_type m_delta0 = std::numeric_limits<scalar_type>::epsilon();
+    scalar_type m_delta0 = 0.f;
 };
 
 }  // namespace detray::detail

--- a/core/include/detray/materials/detail/relativistic_quantities.hpp
+++ b/core/include/detray/materials/detail/relativistic_quantities.hpp
@@ -136,8 +136,8 @@ struct relativistic_quantities {
                 return 0.f;
             }
             // pre-factor according to RPP2019 table 33.1
-            const scalar_type plasmaEnergy{PlasmaEnergyScale *
-                                           std::sqrt(molar_electron_density)};
+            const scalar_type plasmaEnergy{
+                PlasmaEnergyScale * std::sqrt(1000.f * molar_electron_density)};
             return math_ns::log(m_betaGamma) +
                    math_ns::log(plasmaEnergy / mean_exitation_energy) - 0.5f;
         }

--- a/tests/common/include/tests/common/material_interaction.inl
+++ b/tests/common/include/tests/common/material_interaction.inl
@@ -162,6 +162,13 @@ constexpr const material<scalar> Si_approx(
     static_cast<scalar>(2.329 * unit<double>::g / unit<double>::cm3),
     material_state::e_solid, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
 
+TEST(Si_approx, density_effect_data_check) {
+
+    // Make sure that density effect data is empty
+    EXPECT_EQ(Si_approx.density_effect_data(),
+              detail::density_effect_data<scalar>{});
+}
+
 INSTANTIATE_TEST_SUITE_P(Bethe_0p1GeV_Si_approx, EnergyLossBetheValidation,
                          ::testing::Values(std::make_tuple(
                              Si_approx, 0.1003f * unit<scalar>::GeV, 2.608f)));

--- a/tests/common/include/tests/common/material_interaction.inl
+++ b/tests/common/include/tests/common/material_interaction.inl
@@ -38,12 +38,6 @@ using namespace detray;
 using transform3 = __plugin::transform3<scalar>;
 using matrix_operator = typename transform3::matrix_actor;
 
-// Declare Silicon without density effect data
-material<scalar> Si_approx(
-    93.7f * unit<scalar>::mm, 465.2f * unit<scalar>::mm, 28.0855f, 14.f,
-    static_cast<scalar>(2.329 * unit<double>::g / unit<double>::cm3),
-    material_state::e_solid, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
-
 // Test class for MUON energy loss with Bethe function
 // Input tuple: < material / energy / expected output from
 // https://pdg.lbl.gov/2022/AtomicNuclearProperties for Muon dEdX and range >
@@ -161,6 +155,12 @@ INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_Si, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
                                       100.1f * unit<scalar>::GeV, 2.451f)));
+
+// Declare Silicon without density effect data
+constexpr const material<scalar> Si_approx(
+    93.7f * unit<scalar>::mm, 465.2f * unit<scalar>::mm, 28.0855f, 14.f,
+    static_cast<scalar>(2.329 * unit<double>::g / unit<double>::cm3),
+    material_state::e_solid, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
 
 INSTANTIATE_TEST_SUITE_P(Bethe_0p1GeV_Si_approx, EnergyLossBetheValidation,
                          ::testing::Values(std::make_tuple(

--- a/tests/common/include/tests/common/material_interaction.inl
+++ b/tests/common/include/tests/common/material_interaction.inl
@@ -38,6 +38,12 @@ using namespace detray;
 using transform3 = __plugin::transform3<scalar>;
 using matrix_operator = typename transform3::matrix_actor;
 
+// Declare Silicon without density effect data
+material<scalar> Si_approx(
+    93.7f * unit<scalar>::mm, 465.2f * unit<scalar>::mm, 28.0855f, 14.f,
+    static_cast<scalar>(2.329 * unit<double>::g / unit<double>::cm3),
+    material_state::e_solid, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
+
 // Test class for MUON energy loss with Bethe function
 // Input tuple: < material / energy / expected output from
 // https://pdg.lbl.gov/2022/AtomicNuclearProperties for Muon dEdX and range >
@@ -155,6 +161,22 @@ INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_Si, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(silicon<scalar>(),
                                       100.1f * unit<scalar>::GeV, 2.451f)));
+
+INSTANTIATE_TEST_SUITE_P(Bethe_0p1GeV_Si_approx, EnergyLossBetheValidation,
+                         ::testing::Values(std::make_tuple(
+                             Si_approx, 0.1003f * unit<scalar>::GeV, 2.608f)));
+
+INSTANTIATE_TEST_SUITE_P(Bethe_1GeV_Si_approx, EnergyLossBetheValidation,
+                         ::testing::Values(std::make_tuple(
+                             Si_approx, 1.101f * unit<scalar>::GeV, 1.803f)));
+
+INSTANTIATE_TEST_SUITE_P(Bethe_10GeV_Si_approx, EnergyLossBetheValidation,
+                         ::testing::Values(std::make_tuple(
+                             Si_approx, 10.11f * unit<scalar>::GeV, 2.177f)));
+
+INSTANTIATE_TEST_SUITE_P(Bethe_100GeV_Si_approx, EnergyLossBetheValidation,
+                         ::testing::Values(std::make_tuple(
+                             Si_approx, 100.1f * unit<scalar>::GeV, 2.451f)));
 
 // Test class for MUON energy loss with Landau function
 // Input tuple: < material / energy / expected energy loss  / expected fwhm  >

--- a/tests/common/include/tests/common/materials.inl
+++ b/tests/common/include/tests/common/materials.inl
@@ -33,13 +33,13 @@ TEST(density_effect_data, density_effect_data) {
     // Check the default constructor of density effect data
     constexpr detail::density_effect_data<scalar> D{};
 
-    EXPECT_EQ(D.get_A_density(), epsilon);
-    EXPECT_EQ(D.get_M_density(), epsilon);
-    EXPECT_EQ(D.get_X0_density(), epsilon);
-    EXPECT_EQ(D.get_X1_density(), epsilon);
-    EXPECT_EQ(D.get_mean_excitation_energy(), epsilon);
-    EXPECT_EQ(D.get_C_density(), epsilon);
-    EXPECT_EQ(D.get_delta0_density(), epsilon);
+    EXPECT_EQ(D.get_A_density(), 0.f);
+    EXPECT_EQ(D.get_M_density(), 0.f);
+    EXPECT_EQ(D.get_X0_density(), 0.f);
+    EXPECT_EQ(D.get_X1_density(), 0.f);
+    EXPECT_EQ(D.get_mean_excitation_energy(), 0.f);
+    EXPECT_EQ(D.get_C_density(), 0.f);
+    EXPECT_EQ(D.get_delta0_density(), 0.f);
 }
 
 // This tests the material functionalities


### PR DESCRIPTION
Here are some bug fix/improvement in energy loss

1. Set the default value of density effect data to zero (With epsilon it is hard to declare a material without density effect data because of `unit::eV` multiplication to `m_I` )
2. Multiply 1000 to plasma energy

