### PR TITLE
Add support for C++20 concepts

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -50,15 +50,24 @@ jobs:
       matrix:
         BUILD_TYPE: ["Release", "Debug"]
         SCALAR_TYPE: ["float", "double"]
+        CXX_STANDARD: ["17"]
         PLATFORM:
           - NAME: "HOST"
             CONTAINER: "ghcr.io/acts-project/ubuntu2004:v30"
             OPTIONS: -DDETRAY_EIGEN_PLUGIN=ON -DDETRAY_SMATRIX_PLUGIN=ON -DDETRAY_VC_PLUGIN=ON
+        include:
+          - BUILD_TYPE: "Debug"
+            SCALAR_TYPE: "float"
+            CXX_STANDARD: "20"
+            PLATFORM:
+              - NAME: "HOST"
+                CONTAINER: "ghcr.io/acts-project/ubuntu2004:v30"
+                OPTIONS: -DDETRAY_EIGEN_PLUGIN=ON -DDETRAY_SMATRIX_PLUGIN=ON -DDETRAY_VC_PLUGIN=ON
 
     # The system to run on.
     runs-on: ubuntu-latest
     container: ${{ matrix.PLATFORM.CONTAINER }}
-    name: "host-container (${{ matrix.PLATFORM.NAME }})"
+    name: "host-container (${{ matrix.PLATFORM.NAME }}, C++${{ matrix.CXX_STANDARD }})"
 
     # Use BASH as the shell from the image.
     defaults:
@@ -73,7 +82,7 @@ jobs:
     - name: Configure
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DDETRAY_CUSTOM_SCALARTYPE=${{ matrix.SCALAR_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -S ${GITHUB_WORKSPACE} -B build
+        cmake -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DDETRAY_CUSTOM_SCALARTYPE=${{ matrix.SCALAR_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -S ${GITHUB_WORKSPACE} -B build
     # Perform the build.
     - name: Build
       run: |
@@ -132,4 +141,3 @@ jobs:
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
         cmake --build build
-

--- a/core/include/detray/concepts/algebra.hpp
+++ b/core/include/detray/concepts/algebra.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept algebra = true;
+}
+#endif

--- a/core/include/detray/concepts/axis.hpp
+++ b/core/include/detray/concepts/axis.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept axis = true;
+}
+#endif

--- a/core/include/detray/concepts/bit_field.hpp
+++ b/core/include/detray/concepts/bit_field.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept bit_field = true;
+}
+#endif

--- a/core/include/detray/concepts/concept.hpp
+++ b/core/include/detray/concepts/concept.hpp
@@ -1,0 +1,15 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#if __cpp_concepts >= 201907L
+#define CONSTRAINT(x) x
+#define DETRAY_HAVE_CONCEPTS
+#else
+#define CONSTRAINT(x) typename
+#endif

--- a/core/include/detray/concepts/container_view.hpp
+++ b/core/include/detray/concepts/container_view.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept container_view = true;
+}
+#endif

--- a/core/include/detray/concepts/context.hpp
+++ b/core/include/detray/concepts/context.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept context = true;
+}
+#endif

--- a/core/include/detray/concepts/detector.hpp
+++ b/core/include/detray/concepts/detector.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept detector = true;
+}
+#endif

--- a/core/include/detray/concepts/detector_metadata.hpp
+++ b/core/include/detray/concepts/detector_metadata.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept detector_metadata = true;
+}
+#endif

--- a/core/include/detray/concepts/index.hpp
+++ b/core/include/detray/concepts/index.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept index = true;
+}
+#endif

--- a/core/include/detray/concepts/mask.hpp
+++ b/core/include/detray/concepts/mask.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept mask = true;
+}
+#endif

--- a/core/include/detray/concepts/mask_group.hpp
+++ b/core/include/detray/concepts/mask_group.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept mask_group = true;
+}
+#endif

--- a/core/include/detray/concepts/scalar.hpp
+++ b/core/include/detray/concepts/scalar.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept scalar = true;
+}
+#endif

--- a/core/include/detray/concepts/stepper_state.hpp
+++ b/core/include/detray/concepts/stepper_state.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept stepper_state = true;
+}
+#endif

--- a/core/include/detray/concepts/track.hpp
+++ b/core/include/detray/concepts/track.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept track = true;
+}
+#endif

--- a/core/include/detray/concepts/transform.hpp
+++ b/core/include/detray/concepts/transform.hpp
@@ -1,0 +1,19 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T, std::size_t N>
+concept transform = true;
+}
+#endif

--- a/core/include/detray/concepts/type_container.hpp
+++ b/core/include/detray/concepts/type_container.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/concepts/concept.hpp"
+
+#ifdef DETRAY_HAVE_CONCEPTS
+namespace detray::concepts {
+template <typename T>
+concept type_container = true;
+}
+#endif

--- a/core/include/detray/coordinates/cartesian2.hpp
+++ b/core/include/detray/coordinates/cartesian2.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "detray/concepts/mask.hpp"
+#include "detray/concepts/transform.hpp"
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
@@ -15,7 +17,7 @@ namespace detray {
 
 /** Frame projection into a cartesian coordinate frame
  */
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
 
     /// @name Type definitions for the struct
@@ -76,14 +78,14 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
 
     /** This method transform from a local 2D cartesian point to a point global
      * cartesian 3D frame*/
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline point3 local_to_global(
         const transform3_t &trf3, const mask_t & /*mask*/, const point2 &p,
         const vector3 & /*d*/) const {
         return trf3.point_to_global(point3{p[0], p[1], 0.f});
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline vector3 normal(const transform3_t &trf3,
                                              const mask_t & /*mask*/,
                                              const point3 & /*pos*/,
@@ -97,14 +99,14 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
         return ret;
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline rotation_matrix reference_frame(
         const transform3_t &trf3, const mask_t & /*mask*/,
         const point3 & /*pos*/, const vector3 & /*dir*/) const {
         return trf3.rotation();
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_pos_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
         const mask_t &mask, const point3 &pos, const vector3 &dir) const {
@@ -120,7 +122,7 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
                                              e_free_pos0, e_bound_loc0);
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_free_pos_to_bound_pos_derivative(
         free_to_bound_matrix &free_to_bound_jacobian, const transform3_t &trf3,
         const mask_t &mask, const point3 &pos, const vector3 &dir) const {
@@ -137,7 +139,7 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
                                              e_bound_loc0, e_free_pos0);
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_angle_to_free_pos_derivative(
         bound_to_free_matrix & /*bound_to_free_jacobian*/,
         const transform3_t & /*trf3*/, const mask_t & /*mask*/,

--- a/core/include/detray/coordinates/cartesian3.hpp
+++ b/core/include/detray/coordinates/cartesian3.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "detray/concepts/mask.hpp"
+#include "detray/concepts/transform.hpp"
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
@@ -15,7 +17,7 @@ namespace detray {
 
 /** Frame projection into a cartesian coordinate frame
  */
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct cartesian3 final : public coordinate_base<cartesian3, transform3_t> {
 
     /// @name Type definitions for the struct
@@ -52,7 +54,7 @@ struct cartesian3 final : public coordinate_base<cartesian3, transform3_t> {
 
     /** This method transform from a local 3D cartesian point to a point global
      * cartesian 3D frame*/
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline point3 local_to_global(
         const transform3_t &trf, const mask_t & /*mask*/, const point3 &p,
         const vector3 & /*d*/) const {

--- a/core/include/detray/coordinates/coordinate_base.hpp
+++ b/core/include/detray/coordinates/coordinate_base.hpp
@@ -8,6 +8,9 @@
 #pragma once
 
 // Project include(s).
+#include "detray/concepts/mask.hpp"
+#include "detray/concepts/stepper_state.hpp"
+#include "detray/concepts/transform.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
@@ -21,7 +24,8 @@ namespace detray {
 
 /** Coordinate base struct
  */
-template <template <class> class Derived, typename transform3_t>
+template <template <class> class Derived,
+          CONSTRAINT(concepts::transform<3>) transform3_t>
 struct coordinate_base {
 
     /// @name Type definitions for the struct
@@ -85,7 +89,7 @@ struct coordinate_base {
         return bound_vec;
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline free_vector bound_to_free_vector(
         const transform3_t& trf3, const mask_t& mask,
         const bound_vector& bound_vec) const {
@@ -111,7 +115,7 @@ struct coordinate_base {
         return free_vec;
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline bound_to_free_matrix bound_to_free_jacobian(
         const transform3_t& trf3, const mask_t& mask,
         const bound_vector& bound_vec) const {
@@ -166,7 +170,7 @@ struct coordinate_base {
         return jac_to_global;
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline free_to_bound_matrix free_to_bound_jacobian(
         const transform3_t& trf3, const mask_t& mask,
         const free_vector& free_vec) const {
@@ -215,7 +219,8 @@ struct coordinate_base {
         return jac_to_local;
     }
 
-    template <typename mask_t, typename stepper_state_t>
+    template <CONSTRAINT(concepts::mask) mask_t,
+              CONSTRAINT(concepts::stepper_state) stepper_state_t>
     DETRAY_HOST_DEVICE inline free_matrix path_correction(
         const stepper_state_t& stepping, const transform3_t& trf3,
         const mask_t& mask) {

--- a/core/include/detray/coordinates/cylindrical2.hpp
+++ b/core/include/detray/coordinates/cylindrical2.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "detray/concepts/mask.hpp"
+#include "detray/concepts/transform.hpp"
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
@@ -19,7 +21,7 @@ namespace detray {
 
 /** Local frame projection into a 2D cylindrical coordinate frame
  */
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
 
     /// @name Type definitions for the struct
@@ -75,7 +77,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
 
     /** This method transform from a local 2D cylindrical point to a point
      * global cartesian 3D frame*/
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline point3 local_to_global(
         const transform3_t &trf, const mask_t &mask, const point2 &p,
         const vector3 & /*d*/) const {
@@ -88,7 +90,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
         return trf.point_to_global(point3{x, y, z});
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline vector3 normal(const transform3_t &trf3,
                                              const mask_t &mask,
                                              const point3 &pos,
@@ -102,7 +104,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
         return trf3.rotation() * local_normal;
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline rotation_matrix reference_frame(
         const transform3_t &trf3, const mask_t &mask, const point3 &pos,
         const vector3 &dir) const {
@@ -130,7 +132,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
         return rot;
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_pos_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
         const mask_t &mask, const point3 &pos, const vector3 &dir) const {
@@ -146,7 +148,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
                                              e_free_pos0, e_bound_loc0);
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_free_pos_to_bound_pos_derivative(
         free_to_bound_matrix &free_to_bound_jacobian, const transform3_t &trf3,
         const mask_t &mask, const point3 &pos, const vector3 &dir) const {
@@ -163,7 +165,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
                                              e_bound_loc0, e_free_pos0);
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_angle_to_free_pos_derivative(
         bound_to_free_matrix & /*bound_to_free_jacobian*/,
         const transform3_t & /*trf3*/, const mask_t & /*mask*/,

--- a/core/include/detray/coordinates/cylindrical3.hpp
+++ b/core/include/detray/coordinates/cylindrical3.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "detray/concepts/mask.hpp"
+#include "detray/concepts/transform.hpp"
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
@@ -16,7 +18,7 @@ namespace detray {
 
 /** Frame projection into a cartesian coordinate frame
  */
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct cylindrical3 final : public coordinate_base<cylindrical3, transform3_t> {
 
     /// @name Type definitions for the struct
@@ -58,7 +60,7 @@ struct cylindrical3 final : public coordinate_base<cylindrical3, transform3_t> {
 
     /** This method transform from a local 3D cylindrical point to a point
      * global cartesian 3D frame*/
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline point3 local_to_global(
         const transform3_t &trf, const mask_t & /*mask*/, const point3 &p,
         const vector3 & /*d*/ = {}) const {

--- a/core/include/detray/coordinates/line2.hpp
+++ b/core/include/detray/coordinates/line2.hpp
@@ -8,12 +8,14 @@
 #pragma once
 
 // Project include(s).
+#include "detray/concepts/mask.hpp"
+#include "detray/concepts/transform.hpp"
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
 namespace detray {
 
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct line2 : public coordinate_base<line2, transform3_t> {
 
     /// @name Type definitions for the struct
@@ -87,7 +89,7 @@ struct line2 : public coordinate_base<line2, transform3_t> {
 
     /** This method transform from a local 2D line point to a point global
      * cartesian 3D frame*/
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline point3 local_to_global(const transform3_t &trf,
                                                      const mask_t & /*mask*/,
                                                      const point2 &p,
@@ -106,7 +108,7 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         return locZ_in_global + p[0] * vector::normalize(r);
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline rotation_matrix reference_frame(
         const transform3_t &trf3, const mask_t & /*mask*/,
         const point3 & /*pos*/, const vector3 &dir) const {
@@ -134,7 +136,7 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         return rot;
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_pos_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
         const mask_t &mask, const point3 &pos, const vector3 &dir) const {
@@ -150,7 +152,7 @@ struct line2 : public coordinate_base<line2, transform3_t> {
                                              e_free_pos0, e_bound_loc0);
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_free_pos_to_bound_pos_derivative(
         free_to_bound_matrix &free_to_bound_jacobian, const transform3_t &trf3,
         const mask_t &mask, const point3 &pos, const vector3 &dir) const {
@@ -167,7 +169,7 @@ struct line2 : public coordinate_base<line2, transform3_t> {
                                              e_bound_loc0, e_free_pos0);
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_angle_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
         const mask_t &mask, const point3 &pos, const vector3 &dir) const {

--- a/core/include/detray/coordinates/polar2.hpp
+++ b/core/include/detray/coordinates/polar2.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s).
+#include "detray/concepts/mask.hpp"
+#include "detray/concepts/transform.hpp"
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
@@ -17,7 +19,7 @@
 
 namespace detray {
 
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct polar2 : public coordinate_base<polar2, transform3_t> {
 
     /// @name Type definitions for the struct
@@ -79,7 +81,7 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
 
     /** This method transform from a local 2D polar point to a point global
      * cartesian 3D frame*/
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline point3 local_to_global(
         const transform3_t &trf, const mask_t & /*mask*/, const point2 &p,
         const vector3 & /*d*/) const {
@@ -89,7 +91,7 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
         return trf.point_to_global(point3{x, y, 0.f});
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline vector3 normal(const transform3_t &trf3,
                                              const mask_t & /*mask*/,
                                              const point3 & /*pos*/,
@@ -103,14 +105,14 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
         return ret;
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline rotation_matrix reference_frame(
         const transform3_t &trf3, const mask_t & /*mask*/,
         const point3 & /*pos*/, const vector3 & /*dir*/) const {
         return trf3.rotation();
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_pos_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
         const mask_t &mask, const point3 &pos, const vector3 &dir) const {
@@ -149,7 +151,7 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
                                              e_free_pos0, e_bound_loc0);
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_free_pos_to_bound_pos_derivative(
         free_to_bound_matrix &free_to_bound_jacobian, const transform3_t &trf3,
         const mask_t &mask, const point3 &pos, const vector3 &dir) const {
@@ -190,7 +192,7 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
                                              e_bound_loc0, e_free_pos0);
     }
 
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_angle_to_free_pos_derivative(
         bound_to_free_matrix & /*bound_to_free_jacobian*/,
         const transform3_t & /*trf3*/, const mask_t & /*mask*/,

--- a/core/include/detray/core/detail/container_views.hpp
+++ b/core/include/detray/core/detail/container_views.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/container_view.hpp"
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/utils/tuple.hpp"
@@ -39,11 +40,11 @@ struct dbase_view {};
 
 /// Container view helper that aggregates multiple vecmem views and performs
 /// compile-time checks.
-template <bool /*check value*/, typename... view_ts>
+template <bool /*check value*/, CONSTRAINT(concepts::container_view)... view_ts>
 class dmulti_view_helper {};
 
 /// In case the checks fail
-template <typename... view_ts>
+template <CONSTRAINT(concepts::container_view)... view_ts>
 class dmulti_view_helper<false, view_ts...> {};
 
 /// @brief General view type that aggregates vecmem based view implementations.
@@ -105,7 +106,7 @@ using get_view_t = typename get_view<T>::type;
 
 /// The detray container view exists, if all contained view types also derive
 /// from @c dbase_view.
-template <typename... view_ts>
+template <CONSTRAINT(concepts::container_view)... view_ts>
 using dmulti_view = detray::detail::dmulti_view_helper<
     std::conjunction_v<detail::is_device_view<view_ts>...>, view_ts...>;
 

--- a/core/include/detray/core/detail/detector_kernel.hpp
+++ b/core/include/detray/core/detail/detector_kernel.hpp
@@ -8,6 +8,9 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/algebra.hpp"
+#include "detray/concepts/index.hpp"
+#include "detray/concepts/mask_group.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
@@ -15,7 +18,7 @@ namespace detray::detail {
 
 /// A functor to retrieve a single surface from an accelerator
 struct get_surface {
-    template <typename collection_t, typename index_t>
+    template <typename collection_t, CONSTRAINT(concepts::index) index_t>
     DETRAY_HOST_DEVICE inline auto operator()(const collection_t& sf_finder,
                                               const index_t& index,
                                               const dindex sf_idx) const {
@@ -25,13 +28,14 @@ struct get_surface {
 };
 
 /// A functor to perform global to local transformation
-template <typename algebra_t>
+template <CONSTRAINT(concepts::algebra) algebra_t>
 struct global_to_local {
 
     using point3 = typename algebra_t::point3;
     using vector3 = typename algebra_t::vector3;
 
-    template <typename mask_group_t, typename index_t>
+    template <CONSTRAINT(concepts::mask_group) mask_group_t,
+              CONSTRAINT(concepts::index) index_t>
     DETRAY_HOST_DEVICE inline auto operator()(const mask_group_t& mask_group,
                                               const index_t& index,
                                               const algebra_t& trf3,

--- a/core/include/detray/core/detail/multi_store.hpp
+++ b/core/include/detray/core/detail/multi_store.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Detray include(s)
+#include "detray/concepts/context.hpp"
 #include "detray/core/detail/container_views.hpp"
 #include "detray/core/detail/data_context.hpp"
 #include "detray/core/detail/tuple_container.hpp"
@@ -33,7 +34,8 @@ namespace detray {
 /// @tparam container_t The type of container to use for the respective
 ///                     data collections.
 /// @tparam Ts the data types (value types of the collections)
-template <typename ID = std::size_t, typename context_t = empty_context,
+template <CONSTRAINT(concepts::index) ID = std::size_t,
+          CONSTRAINT(concepts::context) context_t = empty_context,
           template <typename...> class tuple_t = dtuple, typename... Ts>
 class multi_store {
 
@@ -44,7 +46,7 @@ class multi_store {
     /// How to find and index a data collection in the store
     /// @{
     using ids = ID;
-    template <typename index_t>
+    template <CONSTRAINT(concepts::index) index_t>
     using link_type = dtyped_index<ID, index_t>;
     using single_link = link_type<dindex>;
     using range_link = link_type<dindex_range>;

--- a/core/include/detray/core/detail/single_store.hpp
+++ b/core/include/detray/core/detail/single_store.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/context.hpp"
 #include "detray/core/detail/container_views.hpp"
 #include "detray/core/detail/data_context.hpp"
 #include "detray/definitions/indexing.hpp"
@@ -27,7 +28,7 @@ namespace detray {
 /// @tparam container_t The type of container to use for the data collection.
 /// @tparam context_t the context with which to retrieve the correct data.
 template <typename T, template <typename...> class container_t = dvector,
-          typename context_t = empty_context>
+          CONSTRAINT(concepts::context) context_t = empty_context>
 class single_store {
 
     public:

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/detector_metadata.hpp"
+#include "detray/concepts/type_container.hpp"
 #include "detray/core/detail/detector_kernel.hpp"
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
@@ -30,8 +32,9 @@
 namespace detray {
 
 /// @brief Forward declaration of a detector view type
-template <typename metadata, template <typename> class bfield_t,
-          typename container_t>
+template <CONSTRAINT(concepts::detector_metadata) metadata,
+          template <typename> class bfield_t,
+          CONSTRAINT(concepts::type_container) container_t>
 struct detector_view;
 
 /// @brief The detector definition.
@@ -44,8 +47,10 @@ struct detector_view;
 /// @tparam bfield_t the type of the b-field frontend
 /// @tparam container_t type collection of the underlying containers
 /// @tparam source_link the surface source link
-template <typename metadata, template <typename> class bfield_t = covfie::field,
-          typename container_t = host_container_types>
+template <CONSTRAINT(concepts::detector_metadata) metadata,
+          template <typename> class bfield_t = covfie::field,
+          CONSTRAINT(concepts::type_container) container_t =
+              host_container_types>
 class detector {
 
     // Allow the building of the detector containers
@@ -537,8 +542,9 @@ class detector {
 };
 
 /// @brief A static inplementation of detector data for device
-template <typename metadata, template <typename> class bfield_t,
-          typename container_t>
+template <CONSTRAINT(concepts::detector_metadata) metadata,
+          template <typename> class bfield_t,
+          CONSTRAINT(concepts::type_container) container_t>
 struct detector_view {
 
     using detector_type = detector<metadata, bfield_t, container_t>;

--- a/core/include/detray/definitions/detail/bit_encoder.hpp
+++ b/core/include/detray/definitions/detail/bit_encoder.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/bit_field.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
 // System include(s)
@@ -24,7 +25,7 @@ namespace detray::detail {
 ///
 /// @see
 /// https://github.com/acts-project/acts/blob/main/Core/include/Acts/Geometry/GeometryIdentifier.hpp
-template <typename value_t = uint64_t>
+template <CONSTRAINT(concepts::bit_field) value_t = uint64_t>
 class bit_encoder {
 
     public:

--- a/core/include/detray/definitions/indexing.hpp
+++ b/core/include/detray/definitions/indexing.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/index.hpp"
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
@@ -25,7 +26,7 @@ using dindex_sequence = dvector<dindex>;
 ///
 /// @tparam DIM number of indices that are held by this type
 /// @tparam index_t type of indices
-template <typename index_t = dindex, std::size_t DIM = 3u>
+template <CONSTRAINT(concepts::index) index_t = dindex, std::size_t DIM = 3u>
 struct dmulti_index {
     using index_type = index_t;
 
@@ -55,7 +56,8 @@ struct dmulti_index {
 /// @tparam id_type Represents the type of object that is being indexed
 /// @tparam index_type The type of indexing needed for the indexed type's
 ///         container (e.g. single index, range, multiindex)
-template <typename id_t = unsigned int, typename index_t = dindex>
+template <typename id_t = unsigned int,
+          CONSTRAINT(concepts::index) index_t = dindex>
 struct dtyped_index {
 
     using id_type = id_t;

--- a/core/include/detray/definitions/units.hpp
+++ b/core/include/detray/definitions/units.hpp
@@ -9,10 +9,12 @@
 
 #include <cmath>
 
+#include "detray/concepts/scalar.hpp"
+
 namespace detray {
 
 /// Unit conversion factors
-template <typename scalar_t>
+template <CONSTRAINT(concepts::scalar) scalar_t>
 struct unit {
 
     /// Length, native unit mm
@@ -86,7 +88,7 @@ struct unit {
 };
 
 /// Physical and mathematical constants
-template <typename scalar_t>
+template <CONSTRAINT(concepts::scalar) scalar_t>
 struct constant {
 
     /// Euler's number

--- a/core/include/detray/geometry/volume_connector.hpp
+++ b/core/include/detray/geometry/volume_connector.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/detector.hpp"
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/materials/predefined_materials.hpp"
@@ -23,10 +24,10 @@ namespace detray {
 /// @param d [in,out] the detector to which the portal surfaces are added
 /// @param volume_grid [in] the indexed volume grid
 ///
-template <typename detector_t,
-          template <typename, std::size_t> class array_type = darray,
-          template <typename...> class tuple_type = dtuple,
-          template <typename...> class vector_type = dvector>
+template <CONSTRAINT(concepts::detector) detector_t,
+          template <typename, std::size_t> typename array_type = darray,
+          template <typename...> typename tuple_type = dtuple,
+          template <typename...> typename vector_type = dvector>
 void connect_cylindrical_volumes(
     detector_t &d, const typename detector_t::volume_finder &volume_grid) {
 

--- a/core/include/detray/grids/serializer2.hpp
+++ b/core/include/detray/grids/serializer2.hpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 
+#include "detray/concepts/axis.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
@@ -33,7 +34,8 @@ struct serializer2 {
      *
      * @return a dindex for the memory storage
      */
-    template <typename faxis_t, typename saxis_t>
+    template <CONSTRAINT(concepts::axis) faxis_t,
+              CONSTRAINT(concepts::axis) saxis_t>
     DETRAY_HOST_DEVICE dindex serialize(const faxis_t &faxis,
                                         const saxis_t & /*saxis*/, dindex fbin,
                                         dindex sbin) const {
@@ -53,8 +55,9 @@ struct serializer2 {
      *
      * @return a 2-dim array of dindex
      */
-    template <typename faxis_t, typename saxis_t,
-              template <typename, std::size_t> class array_t = darray>
+    template <CONSTRAINT(concepts::axis) faxis_t,
+              CONSTRAINT(concepts::axis) saxis_t,
+              template <typename, std::size_t> typename array_t = darray>
     DETRAY_HOST_DEVICE array_t<dindex, 2> deserialize(const faxis_t &faxis,
                                                       const saxis_t & /*saxis*/,
                                                       dindex serialbin) const {

--- a/core/include/detray/intersection/bounding_box/cuboid_intersector.hpp
+++ b/core/include/detray/intersection/bounding_box/cuboid_intersector.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/algebra.hpp"
+#include "detray/concepts/mask.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
 
@@ -32,7 +34,8 @@ struct cuboid_intersector {
     /// @param mask_tolerance is the tolerance for mask edges
     ///
     /// @return true if the cuboid aabb was intersected
-    template <typename algebra_t, typename mask_t>
+    template <CONSTRAINT(concepts::algebra) algebra_t,
+              CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE bool operator()(
         const detail::ray<algebra_t> &ray, const mask_t &box,
         const typename algebra_t::scalar_type /*mask_tolerance*/ = 0.f) const {

--- a/core/include/detray/intersection/concentric_cylinder_intersector.hpp
+++ b/core/include/detray/intersection/concentric_cylinder_intersector.hpp
@@ -24,7 +24,7 @@ namespace detray {
 /** A functor to find intersections between trajectory and concentric cylinder
  * mask
  */
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct concentric_cylinder_intersector {
 
     /// Transformation matching this struct
@@ -50,7 +50,7 @@ struct concentric_cylinder_intersector {
      * @return the intersection
      */
     template <
-        typename mask_t,
+        CONSTRAINT(concepts::mask) mask_t,
         std::enable_if_t<std::is_same_v<typename mask_t::measurement_frame_type,
                                         cylindrical2<transform3_t>>,
                          bool> = true>

--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -23,7 +23,7 @@ namespace detray {
 
 /** A functor to find intersections between trajectory and cylinder mask
  */
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct cylinder_intersector {
 
     /// Transformation matching this struct
@@ -48,7 +48,7 @@ struct cylinder_intersector {
      * @return the intersection
      */
     template <
-        typename mask_t,
+        CONSTRAINT(concepts::mask) mask_t,
         std::enable_if_t<std::is_same_v<typename mask_t::measurement_frame_type,
                                         cylindrical2<transform3_t>>,
                          bool> = true>

--- a/core/include/detray/intersection/detail/trajectories.hpp
+++ b/core/include/detray/intersection/detail/trajectories.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/concepts/transform.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/tracks/tracks.hpp"
@@ -23,7 +24,7 @@ namespace detray {
 namespace detail {
 
 /// @brief describes a straight-line trajectory
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 class ray {
     public:
     using transform3_type = transform3_t;
@@ -100,7 +101,7 @@ class ray {
 /// Helix class for the analytical solution of track propagation in
 /// homogeneous B field. This Follows the notation of Eq (4.7) in
 /// DOI:10.1007/978-3-030-65771-0
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 class helix : public free_track_parameters<transform3_t> {
     public:
     using transform3_type = transform3_t;

--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -21,7 +21,7 @@ namespace detray {
 
 /** A functor to find intersections between trajectory and line mask
  */
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct line_intersector {
 
     /// Transformation matching this struct
@@ -44,7 +44,7 @@ struct line_intersector {
      * @return the intersection
      */
     template <
-        typename mask_t,
+        CONSTRAINT(concepts::mask) mask_t,
         std::enable_if_t<std::is_same_v<typename mask_t::measurement_frame_type,
                                         line2<transform3_t>>,
                          bool> = true>

--- a/core/include/detray/intersection/plane_intersector.hpp
+++ b/core/include/detray/intersection/plane_intersector.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/mask.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/intersection/intersection.hpp"
@@ -20,7 +21,7 @@ namespace detray {
 
 /** A functor to find intersections between trajectory and planar mask
  */
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct plane_intersector {
 
     /// Transformation matching this struct
@@ -45,7 +46,7 @@ struct plane_intersector {
      * @return the intersection
      */
     template <
-        typename mask_t,
+        CONSTRAINT(concepts::mask) mask_t,
         std::enable_if_t<std::is_same_v<typename mask_t::loc_point_t, point2>,
                          bool> = true>
     DETRAY_HOST_DEVICE inline std::array<intersection_type, 1> operator()(

--- a/core/include/detray/masks/cuboid3D.hpp
+++ b/core/include/detray/masks/cuboid3D.hpp
@@ -45,17 +45,17 @@ class cuboid3D {
     };
 
     /// Local coordinate frame for boundary checks
-    template <typename algebra_t>
+    template <CONSTRAINT(concepts::algebra) algebra_t>
     using local_frame_type = cartesian3<algebra_t>;
     /// Local point type (3D)
-    template <typename algebra_t>
+    template <CONSTRAINT(concepts::algebra) algebra_t>
     using loc_point_type = typename local_frame_type<algebra_t>::point3;
 
     /// Measurement frame
-    template <typename algebra_t>
+    template <CONSTRAINT(concepts::algebra) algebra_t>
     using measurement_frame_type = local_frame_type<algebra_t>;
     /// Local measurement point (2D)
-    template <typename algebra_t>
+    template <CONSTRAINT(concepts::algebra) algebra_t>
     using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: not a surface
@@ -76,7 +76,7 @@ class cuboid3D {
         static constexpr std::size_t dim{3u};
 
         /// How to convert into the local axis system and back
-        template <typename algebra_t>
+        template <CONSTRAINT(concepts::algebra) algebra_t>
         using coordinate_type = local_frame_type<algebra_t>;
 
         using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
@@ -123,9 +123,9 @@ class cuboid3D {
     ///
     /// @returns and array of coordinates that contains the lower point (first
     /// three values) and the upper point (latter three values) .
-    template <typename algebra_t,
+    template <CONSTRAINT(concepts::algebra) algebra_t,
               template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
+              CONSTRAINT(concepts::scalar) scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
     DETRAY_HOST_DEVICE inline std::array<scalar_t, 6> local_min_bounds(
         const bounds_t<scalar_t, kDIM> &bounds,

--- a/core/include/detray/masks/cylinder2D.hpp
+++ b/core/include/detray/masks/cylinder2D.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/algebra.hpp"
 #include "detray/coordinates/cylindrical2.hpp"
 #include "detray/coordinates/cylindrical3.hpp"
 #include "detray/definitions/qualifiers.hpp"
@@ -53,27 +54,27 @@ class cylinder2D {
     };
 
     /// Local coordinate frame for boundary checks
-    template <typename algebra_t>
+    template <CONSTRAINT(concepts::algebra) algebra_t>
     using local_frame_type =
         std::conditional_t<kRadialCheck, cylindrical3<algebra_t>,
                            cylindrical2<algebra_t>>;
     /// Local point type for boundary checks (2D or 3D)
-    template <typename algebra_t>
+    template <CONSTRAINT(concepts::algebra) algebra_t>
     using loc_point_type =
         std::conditional_t<kRadialCheck,
                            typename local_frame_type<algebra_t>::point3,
                            typename local_frame_type<algebra_t>::point2>;
 
     /// Measurement frame
-    template <typename algebra_t>
+    template <CONSTRAINT(concepts::algebra) algebra_t>
     using measurement_frame_type = cylindrical2<algebra_t>;
     /// Local measurement point (2D)
-    template <typename algebra_t>
+    template <CONSTRAINT(concepts::algebra) algebra_t>
     using measurement_point_type =
         typename measurement_frame_type<algebra_t>::point2;
 
     /// Underlying surface geometry: cylindrical
-    template <typename algebra_t>
+    template <CONSTRAINT(concepts::algebra) algebra_t>
     using intersector_type = intersector_t<algebra_t>;
 
     /// Behaviour of the two local axes (circular in r_phi, linear in z)
@@ -90,7 +91,7 @@ class cylinder2D {
                              n_axis::bounds_t<e_s, axis_loc1>>;
 
         /// How to convert into the local axis system and back
-        template <typename algebra_t>
+        template <CONSTRAINT(concepts::algebra) algebra_t>
         using coordinate_type = cylindrical2<algebra_t>;
 
         template <typename C, typename S>
@@ -113,7 +114,8 @@ class cylinder2D {
     ///
     /// @return true if the local point lies within the given boundaries.
     template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM, typename point_t,
+              CONSTRAINT(concepts::scalar) scalar_t, std::size_t kDIM,
+              typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
     DETRAY_HOST_DEVICE inline bool check_boundaries(
         const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,

--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -24,7 +24,7 @@ namespace detray {
 ///
 /// The algorithm uses the Newton-Raphson method to find an intersection on
 /// the unbounded surface and then applies the mask.
-template <typename transform3_t>
+template <CONSTRAINT(concepts::transform<3>) transform3_t>
 struct helix_plane_intersector {
 
     using scalar_type = typename transform3_t::scalar_type;
@@ -46,7 +46,7 @@ struct helix_plane_intersector {
     /// @param overstep_tolerance is the tolerance for track overstepping
     ///
     /// @return the intersection
-    template <typename mask_t>
+    template <CONSTRAINT(concepts::mask) mask_t>
     DETRAY_HOST_DEVICE inline std::array<intersection_type, 2> operator()(
         const helix_type &h, const mask_t &mask, const transform3_t &trf,
         const scalar mask_tolerance = 0.f) const {

--- a/utils/include/detray/simulation/event_generator/random_track_generator.hpp
+++ b/utils/include/detray/simulation/event_generator/random_track_generator.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/scalar.hpp"
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
@@ -22,7 +23,7 @@
 namespace detray {
 
 /// Wrapper for random number generatrion for the @c random_track_generator
-template <typename scalar_t = scalar,
+template <CONSTRAINT(concepts::scalar) scalar_t = scalar,
           typename distribution_t = std::uniform_real_distribution<scalar_t>,
           typename generator_t = std::random_device,
           typename engine_t = std::mt19937_64>

--- a/utils/include/detray/simulation/event_generator/uniform_track_generator.hpp
+++ b/utils/include/detray/simulation/event_generator/uniform_track_generator.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/concepts/track.hpp"
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
@@ -30,7 +31,7 @@ namespace detray {
 /// the number of generated tracks) are configurable.
 ///
 /// @tparam track_t the type of track parametrization that should be used.
-template <typename track_t>
+template <CONSTRAINT(concepts::track) track_t>
 class uniform_track_generator
     : public detray::ranges::view_interface<uniform_track_generator<track_t>> {
     public:

--- a/utils/include/detray/simulation/measurement_smearer.hpp
+++ b/utils/include/detray/simulation/measurement_smearer.hpp
@@ -12,9 +12,11 @@
 #include <random>
 #include <string>
 
+#include "detray/concepts/scalar.hpp"
+
 namespace detray {
 
-template <typename scalar_t>
+template <CONSTRAINT(concepts::scalar) scalar_t>
 struct measurement_smearer {
 
     measurement_smearer(scalar_t stddev_local0, scalar_t stddev_local1)

--- a/utils/include/detray/simulation/scattering_helper.hpp
+++ b/utils/include/detray/simulation/scattering_helper.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/concepts/algebra.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/utils/axis_rotation.hpp"
@@ -18,7 +19,7 @@
 
 namespace detray {
 
-template <typename algebra_t>
+template <CONSTRAINT(concepts::algebra) algebra_t>
 struct scattering_helper {
     public:
     using matrix_operator = typename algebra_t::matrix_actor;

--- a/utils/include/detray/simulation/simulator.hpp
+++ b/utils/include/detray/simulation/simulator.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/concepts/detector.hpp"
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/actors/aborters.hpp"
 #include "detray/propagator/actors/parameter_resetter.hpp"
@@ -25,7 +26,8 @@
 
 namespace detray {
 
-template <typename detector_t, typename track_generator_t, typename smearer_t>
+template <CONSTRAINT(concepts::detector) detector_t, typename track_generator_t,
+          typename smearer_t>
 struct simulator {
 
     using scalar_type = typename detector_t::scalar_type;


### PR DESCRIPTION
This will likely take some time to finish, but if nobody objects I would like to add _optional_ support for C++20 concepts to detray. This will address the often impossible-to-read error messages that detray produces.