### PR TITLE
ref: use barcode in event writer

### DIFF
--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -439,10 +439,10 @@ class detector {
     inline const bfield_type &get_bfield() const { return _bfield; }
 
     DETRAY_HOST_DEVICE
-    inline point2 global_to_local(const dindex sf_idx, const point3 &pos,
+    inline point2 global_to_local(const geometry::barcode bc, const point3 &pos,
                                   const vector3 &dir) const {
         const auto &sf =
-            *(surfaces().begin() + static_cast<std::ptrdiff_t>(sf_idx));
+            *(surfaces().begin() + static_cast<std::ptrdiff_t>(bc.index()));
         const auto ret =
             _masks.template visit<detail::global_to_local<transform3>>(
                 sf.mask(), _transforms[sf.transform()], pos, dir);

--- a/tests/common/include/tests/common/check_simulation.inl
+++ b/tests/common/include/tests/common/check_simulation.inl
@@ -172,8 +172,9 @@ TEST(check_simulation, toy_geometry) {
         for (std::size_t i = 0u; i < nhits; i++) {
             const point3 pos{hits[i].tx, hits[i].ty, hits[i].tz};
             const vector3 mom{hits[i].tpx, hits[i].tpy, hits[i].tpz};
-            const auto truth_local = detector.global_to_local(
-                hits[i].geometry_id, pos, vector::normalize(mom));
+            const auto truth_local =
+                detector.global_to_local(geometry::barcode(hits[i].geometry_id),
+                                         pos, vector::normalize(mom));
 
             local0_diff.push_back(truth_local[0] - measurements[i].local0);
             local1_diff.push_back(truth_local[1] - measurements[i].local1);

--- a/utils/include/detray/simulation/event_writer.hpp
+++ b/utils/include/detray/simulation/event_writer.hpp
@@ -103,7 +103,7 @@ struct event_writer : actor {
             const auto mom = track.mom();
 
             hit.particle_id = writer_state.particle_id;
-            hit.geometry_id = navigation.current_object().index();
+            hit.geometry_id = navigation.current_object().value();
             hit.tx = pos[0];
             hit.ty = pos[1];
             hit.tz = pos[2];
@@ -121,7 +121,7 @@ struct event_writer : actor {
             auto det = navigation.detector();
             const auto& mask_store = det->mask_store();
             const auto& surface =
-                det->surfaces(geometry::barcode().set_index(hit.geometry_id));
+                det->surfaces(geometry::barcode(hit.geometry_id));
 
             const auto local = mask_store.template visit<measurement_kernel>(
                 surface.mask(), bound_params, writer_state.m_meas_smearer);


### PR DESCRIPTION
This PR uses the detray geometry barcode as geometry_id in the csv event writer instead of the surface index.