### PR TITLE
ref: address performance changes after portal cylinder was added

### DIFF
--- a/core/include/detray/coordinates/cylindrical3.hpp
+++ b/core/include/detray/coordinates/cylindrical3.hpp
@@ -61,7 +61,7 @@ struct cylindrical3 final : public coordinate_base<cylindrical3, transform3_t> {
     template <typename mask_t>
     DETRAY_HOST_DEVICE inline point3 local_to_global(
         const transform3_t &trf, const mask_t & /*mask*/, const point3 &p,
-        const vector3 & /*d*/ = {}) const {
+        const vector3 & /*d*/) const {
         const scalar_type x{p[0] * math_ns::cos(p[1])};
         const scalar_type y{p[0] * math_ns::sin(p[1])};
 

--- a/core/include/detray/core/detail/multi_store.hpp
+++ b/core/include/detray/core/detail/multi_store.hpp
@@ -146,8 +146,9 @@ class multi_store {
     /// @returns the size of a data collection by @tparam ID
     template <ID id>
     DETRAY_HOST_DEVICE constexpr auto size(
-        const context_type & /*ctx*/ = {}) const noexcept -> std::size_t {
-        return detail::get<value_types::to_index(id)>(m_tuple_container).size();
+        const context_type & /*ctx*/ = {}) const noexcept -> dindex {
+        return static_cast<dindex>(
+            detail::get<value_types::to_index(id)>(m_tuple_container).size());
     }
 
     /// @returns true if the collection given by @tparam ID is empty
@@ -302,7 +303,7 @@ class multi_store {
     DETRAY_HOST_DEVICE decltype(auto) visit(const link_t link,
                                             Args &&... args) const {
         return m_tuple_container.template visit<functor_t>(
-            value_types::to_index(detail::get<0>(link)), detail::get<1>(link),
+            static_cast<dindex>(detail::get<0>(link)), detail::get<1>(link),
             std::forward<Args>(args)...);
     }
 

--- a/core/include/detray/core/detail/single_store.hpp
+++ b/core/include/detray/core/detail/single_store.hpp
@@ -94,8 +94,8 @@ class single_store {
     /// @returns the size of the underlying container
     DETRAY_HOST_DEVICE
     constexpr auto size(const context_type & /*ctx*/ = {}) const noexcept
-        -> std::size_t {
-        return m_container.size();
+        -> dindex {
+        return static_cast<dindex>(m_container.size());
     }
 
     /// @returns true if the underlying container is empty

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -183,7 +183,7 @@ class detector {
         const volume_id id, const array_type<scalar, 6> &bounds,
         typename volume_type::link_type::index_type srf_finder_link = {}) {
         volume_type &cvolume = _volumes.emplace_back(id, bounds);
-        cvolume.set_index(_volumes.size() - 1);
+        cvolume.set_index(static_cast<dindex>(_volumes.size()) - 1u);
         cvolume.set_link(srf_finder_link);
 
         return cvolume;
@@ -258,7 +258,7 @@ class detector {
     /// @returns surfaces of a given type (@tparam sf_id) by volume - const
     template <geo_obj_ids sf_id = geo_obj_ids::e_portal>
     DETRAY_HOST_DEVICE constexpr auto surfaces(const volume_type &v) const {
-        std::size_t coll_idx{v.template link<sf_id>().index()};
+        dindex coll_idx{v.template link<sf_id>().index()};
         const auto sf_coll =
             _surfaces.template get<sf_finders::id::e_brute_force>()[coll_idx];
         return sf_coll.all();
@@ -351,9 +351,10 @@ class detector {
 
         // Update mask, material and transform index of surfaces and set a
         // unique barcode (index of surface in container)
-        dindex sf_offset{_surfaces.template get<sf_finders::id::e_brute_force>()
-                             .all()
-                             .size()};
+        dindex sf_offset{static_cast<dindex>(
+            _surfaces.template get<sf_finders::id::e_brute_force>()
+                .all()
+                .size())};
         for (auto &sf : surfaces_per_vol) {
             _masks.template visit<detail::mask_index_update>(sf.mask(), sf);
             sf.update_transform(trf_offset);

--- a/core/include/detray/definitions/detail/algorithms.hpp
+++ b/core/include/detray/definitions/detail/algorithms.hpp
@@ -27,21 +27,6 @@
 
 namespace detray::detail {
 
-/// Composes a floating point value with the magnitude of @param mag and the
-/// sign of @param sgn
-template <typename scalar_t>
-DETRAY_HOST_DEVICE inline scalar_t copysign(scalar_t mag, scalar_t sgn) {
-#if defined(__CUDACC__)
-    if constexpr (std::is_same_v<scalar_t, float>) {
-        return copysignf(mag, sgn);
-    } else {
-        return copysign(mag, sgn);
-    }
-#elif !defined(__CUDACC__)
-    return std::copysign(mag, sgn);
-#endif
-}
-
 /// @brief sequential (single thread) sort function
 template <class RandomIt>
 DETRAY_HOST_DEVICE inline void sequential_sort(RandomIt first, RandomIt last) {
@@ -54,13 +39,13 @@ DETRAY_HOST_DEVICE inline void sequential_sort(RandomIt first, RandomIt last) {
 }
 
 /// @brief sequential sort for host/devcie (single thread) - custom comparison
-template <class RandomIt, class Compare>
+template <class RandomIt, class Predicate>
 DETRAY_HOST_DEVICE inline void sequential_sort(RandomIt first, RandomIt last,
-                                               Compare&& comp) {
+                                               Predicate&& comp) {
 #if defined(__CUDACC__)
-    thrust::sort(thrust::seq, first, last, comp);
+    thrust::sort(thrust::seq, first, last, std::forward<Predicate>(comp));
 #elif !defined(__CUDACC__)
-    std::sort(first, last, std::forward<Compare>(comp));
+    std::sort(first, last, std::forward<Predicate>(comp));
 #endif
 }
 

--- a/core/include/detray/definitions/indexing.hpp
+++ b/core/include/detray/definitions/indexing.hpp
@@ -10,14 +10,15 @@
 // Project include(s)
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/invalid_values.hpp"
 
 // System include(s)
 #include <limits>
 
 namespace detray {
 
-using dindex = unsigned long;
-inline constexpr dindex dindex_invalid = std::numeric_limits<dindex>::max();
+using dindex = unsigned int;
+inline constexpr dindex dindex_invalid = detail::invalid_value<dindex>();
 using dindex_range = darray<dindex, 2>;
 using dindex_sequence = dvector<dindex>;
 

--- a/core/include/detray/definitions/math.hpp
+++ b/core/include/detray/definitions/math.hpp
@@ -24,4 +24,36 @@ namespace math_ns = cl::sycl;
 namespace math_ns = std;
 #endif  // SYCL
 
+namespace detail {
+
+using math_ns::copysign;
+using math_ns::signbit;
+
+/// Composes a floating point value with the magnitude of @param mag and the
+/// sign of @param sgn
+/*template <typename scalar_t>
+DETRAY_HOST_DEVICE inline scalar_t copysign(scalar_t mag, scalar_t sgn) {
+#if defined(__CUDACC__)
+    if constexpr (std::is_same_v<scalar_t, float>) {
+        return copysignf(mag, sgn);
+    } else {
+        return copysign(mag, sgn);
+    }
+#elif !defined(__CUDACC__)
+    return math_ns::copysign(mag, sgn);
+#endif
+}
+
+/// Gets the signbit from a variable
+template <typename scalar_t>
+DETRAY_HOST_DEVICE inline bool signbit(scalar_t arg) {
+#if defined(__CUDACC__)
+    return signbit(arg);
+#elif !defined(__CUDACC__)
+    return math_ns::signbit(arg);
+#endif
+}*/
+
+}  // namespace detail
+
 }  // namespace detray

--- a/core/include/detray/geometry/barcode.hpp
+++ b/core/include/detray/geometry/barcode.hpp
@@ -11,6 +11,7 @@
 // Project include(s)
 #include "detray/definitions/detail/bit_encoder.hpp"
 #include "detray/definitions/geometry.hpp"
+#include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
 // System include(s)
@@ -49,8 +50,9 @@ class barcode {
 
     /// @returns the volume index.
     DETRAY_HOST_DEVICE
-    constexpr value_t volume() const {
-        return encoder::template get_bits<k_volume_mask>(m_value);
+    constexpr dindex volume() const {
+        return static_cast<dindex>(
+            encoder::template get_bits<k_volume_mask>(m_value));
     }
 
     /// @returns the surface id.
@@ -62,14 +64,16 @@ class barcode {
 
     /// @returns the surface index.
     DETRAY_HOST_DEVICE
-    constexpr value_t index() const {
-        return encoder::template get_bits<k_index_mask>(m_value);
+    constexpr dindex index() const {
+        return static_cast<dindex>(
+            encoder::template get_bits<k_index_mask>(m_value));
     }
 
     /// @returns the extra identifier
     DETRAY_HOST_DEVICE
-    constexpr value_t extra() const {
-        return encoder::template get_bits<k_extra_mask>(m_value);
+    constexpr dindex extra() const {
+        return static_cast<dindex>(
+            encoder::template get_bits<k_extra_mask>(m_value));
     }
 
     /// Set the volume index.
@@ -143,8 +147,8 @@ class barcode {
 
         static const char* const names[] = {
             "vol = ", "id = ", "index = ", "extra = "};
-        const value_t levels[] = {c.volume(), static_cast<value_t>(c.id()),
-                                  c.index(), c.extra()};
+        const dindex levels[] = {c.volume(), static_cast<dindex>(c.id()),
+                                 c.index(), c.extra()};
 
         bool writeSeparator = false;
         for (auto i = 0u; i < 4u; ++i) {

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -29,12 +29,13 @@ namespace detray {
 /// @tparam source_link_t the type of the source link representation
 template <typename mask_link_t = dtyped_index<dindex, dindex>,
           typename material_link_t = dtyped_index<dindex, dindex>,
-          typename transform_link_t = dindex, typename source_link_t = dindex>
+          typename transform_link_t = dindex,
+          typename navigation_link_t = dindex, typename source_link_t = dindex>
 class surface {
 
     public:
     /// Link type of the mask to a volume.
-    using volume_link_type = dindex;
+    using navigation_link = navigation_link_t;
     // Broadcast the type of links
     using transform_link = transform_link_t;
     /// might be a single mask, a range of masks or a multiindex in the future

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -455,7 +455,7 @@ struct irregular {
     /** Constructor with vecmem memory resource - rvalue **/
     DETRAY_HOST irregular(vector_t<scalar> &&bins,
                           vecmem::memory_resource &resource)
-        : n_bins(bins.size() - 1u),
+        : n_bins(static_cast<dindex>(bins.size()) - 1u),
           min(bins[0]),
           max(bins[n_bins]),
           boundaries(bins, &resource) {}
@@ -463,7 +463,7 @@ struct irregular {
     /** Constructor with vecmem memory resource - lvalue **/
     DETRAY_HOST irregular(const vector_t<scalar> &bins,
                           vecmem::memory_resource &resource)
-        : n_bins(bins.size() - 1u),
+        : n_bins(static_cast<dindex>(bins.size()) - 1u),
           min(bins[0]),
           max(bins[n_bins]),
           boundaries(bins, &resource) {}

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -10,10 +10,12 @@
 // Project include(s)
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/indexing.hpp"
+#include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/invalid_values.hpp"
 
 // System include(s)
-#include <cmath>
+#include <cstdint>
 #include <limits>
 #include <ostream>
 
@@ -22,60 +24,56 @@ namespace detray {
 namespace intersection {
 
 /// Intersection direction with respect to the normal of the surface
-enum class direction {
-    e_undefined = -1,  //!< the undefined direction at intersection
-    e_opposite = 0,    //!< opposite the surface normal at the intersection
-    e_along = 1        //!< along the surface normal at the intersection
+enum class direction : std::uint_least8_t {
+    e_undefined = 0u,  //!< the undefined direction at intersection
+    e_opposite = 1u,   //!< opposite the surface normal at the intersection
+    e_along = 2u       //!< along the surface normal at the intersection
 };
 
 /// Intersection status: outside, missed, inside, hit ( w/o maks status)
-enum class status {
-    e_outside = -1,   //!< surface hit but outside
-    e_missed = 0,     //!< surface missed
-    e_undefined = 1,  //!< surface hit but status not checked
-    e_inside = 2      //!< surface hit and inside confirmed
+enum class status : std::uint_least8_t {
+    e_outside = 0u,    //!< surface hit but outside
+    e_missed = 1u,     //!< surface missed
+    e_undefined = 2u,  //!< surface hit but status not checked
+    e_inside = 3u      //!< surface hit and inside confirmed
 };
 
 }  // namespace intersection
 
-/// @brief This class holds the intersection information
+/// @brief This class holds the intersection information.
 ///
-/// @tparam point3 is the type of global intsersection vector
-/// @tparam point2 is the type of the local intersection vector
-template <typename surface_handle_t,
+/// @tparam surface_descr_t is the type of surface descriptor
+template <typename surface_descr_t,
           typename algebra_t = __plugin::transform3<detray::scalar>>
 struct intersection2D {
 
-    using scalar_t = typename algebra_t::scalar_type;
+    using transform3_type = algebra_t;
+    using scalar_type = typename algebra_t::scalar_type;
     using point3 = typename algebra_t::point3;
     using point2 = typename algebra_t::point2;
+    using nav_link_type = typename surface_descr_t::navigation_link;
+
+    /// Descriptor of the surface this intersection belongs to
+    surface_descr_t surface;
+
+    /// Local position of the intersection on the surface
+    point2 p2{detail::invalid_value<scalar_type>(),
+              detail::invalid_value<scalar_type>()};
+
+    /// Distance between track and candidate
+    scalar_type path{detail::invalid_value<scalar_type>()};
+
+    /// cosine of incidence angle
+    scalar_type cos_incidence_angle{detail::invalid_value<scalar_type>()};
+
+    /// Navigation information (next volume to go to)
+    nav_link_type volume_link{detail::invalid_value<nav_link_type>()};
 
     /// Result of the intersection
     intersection::status status{intersection::status::e_undefined};
 
     /// Direction of the intersection with respect to the track
     intersection::direction direction{intersection::direction::e_undefined};
-
-    /// Distance between track and candidate
-    scalar_t path{std::numeric_limits<scalar_t>::infinity()};
-
-    /// cosine of incidence angle
-    scalar_t cos_incidence_angle{std::numeric_limits<scalar_t>::infinity()};
-
-    /// Navigation information (next volume to go to)
-    dindex volume_link{dindex_invalid};
-
-    /// Handle of the surface this intersection belongs to
-    surface_handle_t surface{};
-
-    /// Intersection point in global 3D cartesian coordinate frame
-    point3 p3{std::numeric_limits<scalar_t>::infinity(),
-              std::numeric_limits<scalar_t>::infinity(),
-              std::numeric_limits<scalar_t>::infinity()};
-
-    /// Local position of the intersection on the surface
-    point2 p2{std::numeric_limits<scalar_t>::infinity(),
-              std::numeric_limits<scalar_t>::infinity()};
 
     /// @param rhs is the right hand side intersection for comparison
     DETRAY_HOST_DEVICE
@@ -93,14 +91,68 @@ struct intersection2D {
     DETRAY_HOST_DEVICE
     bool operator==(const intersection2D &rhs) const {
         return std::abs(path - rhs.path) <
-               std::numeric_limits<scalar_t>::epsilon();
+               std::numeric_limits<scalar_type>::epsilon();
     }
 
     /// Transform to a string for output debugging
     DETRAY_HOST
     friend std::ostream &operator<<(std::ostream &out_stream,
                                     const intersection2D &is) {
-        scalar_t r{getter::perp(is.p3)};
+        out_stream << "dist:" << is.path
+                   << ", (sf index:" << is.surface.barcode()
+                   << ", links to vol:" << is.volume_link << ")";
+        switch (is.status) {
+            case intersection::status::e_outside:
+                out_stream << ", status: outside";
+                break;
+            case intersection::status::e_missed:
+                out_stream << ", status: missed";
+                break;
+            case intersection::status::e_undefined:
+                out_stream << ", status: undefined";
+                break;
+            case intersection::status::e_inside:
+                out_stream << ", status: inside";
+                break;
+        };
+        switch (is.direction) {
+            case intersection::direction::e_undefined:
+                out_stream << ", direction: undefined";
+                break;
+            case intersection::direction::e_opposite:
+                out_stream << ", direction: opposite";
+                break;
+            case intersection::direction::e_along:
+                out_stream << ", direction: along";
+                break;
+        };
+        out_stream << std::endl;
+        return out_stream;
+    }
+};
+
+/// @brief This class holds the intersection information, including the global
+/// point of intersection.
+///
+/// @tparam surface_descr_t is the type of surface descriptor
+template <typename surface_descr_t,
+          typename algebra_t = __plugin::transform3<detray::scalar>>
+struct intersection2D_point
+    : public intersection2D<surface_descr_t, algebra_t> {
+    using scalar_type = typename algebra_t::scalar_type;
+    using point3 = typename algebra_t::point3;
+    using point2 = typename algebra_t::point2;
+
+    /// Intersection point in global 3D cartesian coordinate frame
+    point3 p3{detail::invalid_value<scalar_type>(),
+              detail::invalid_value<scalar_type>(),
+              detail::invalid_value<scalar_type>()};
+
+    /// Transform to a string for output debugging
+    DETRAY_HOST
+    friend std::ostream &operator<<(std::ostream &out_stream,
+                                    const intersection2D_point &is) {
+        scalar_type r{getter::perp(is.p3)};
         out_stream << "dist:" << is.path << " [glob: r:" << r
                    << ", z:" << is.p3[2] << " | loc: " << is.p2[0] << ", "
                    << is.p2[1] << "], (sf index:" << is.surface.barcode()

--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -9,28 +9,31 @@
 
 // Project include(s)
 #include "detray/coordinates/line2.hpp"
+#include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/intersection/intersection.hpp"
 
 // System include(s)
-#include <cmath>
 #include <type_traits>
 
 namespace detray {
 
 /// A functor to find intersections between trajectory and line mask
-template <typename transform3_t>
+template <typename intersection_t>
 struct line_intersector {
 
     /// linear algebra types
     /// @{
-    using scalar_type = typename transform3_t::scalar_type;
-    using point3 = typename transform3_t::point3;
-    using point2 = typename transform3_t::point2;
-    using vector3 = typename transform3_t::vector3;
+    using transform3_type = typename intersection_t::transform3_type;
+    using scalar_type = typename transform3_type::scalar_type;
+    using point3 = typename transform3_type::point3;
+    using point2 = typename transform3_type::point2;
+    using vector3 = typename transform3_type::vector3;
     /// @}
-    using ray_type = detail::ray<transform3_t>;
+
+    using intersection_type = intersection_t;
+    using ray_type = detail::ray<transform3_type>;
 
     /// Operator function to find intersections between ray and line mask
     ///
@@ -47,15 +50,14 @@ struct line_intersector {
     template <
         typename mask_t, typename surface_t,
         std::enable_if_t<std::is_same_v<typename mask_t::measurement_frame_type,
-                                        line2<transform3_t>>,
+                                        line2<transform3_type>>,
                          bool> = true>
-    DETRAY_HOST_DEVICE inline intersection2D<surface_t, transform3_t>
-    operator()(const ray_type &ray, const surface_t sf, const mask_t &mask,
-               const transform3_t &trf,
-               const scalar_type mask_tolerance = 0.f) const {
+    DETRAY_HOST_DEVICE inline intersection_t operator()(
+        const ray_type &ray, const surface_t &sf, const mask_t &mask,
+        const transform3_type &trf,
+        const scalar_type mask_tolerance = 0.f) const {
 
-        using intersection_t = intersection2D<surface_t, transform3_t>;
-        intersection_t is;
+        intersection_type is;
 
         // line direction
         const vector3 _z = getter::vector<3>(trf.matrix(), 0u, 2u);
@@ -94,59 +96,63 @@ struct line_intersector {
 
         is.path = A;
         // Intersection is not valid for navigation - return early
-        if (is.path < ray.overstep_tolerance()) {
-            return is;
+        if (is.path >= ray.overstep_tolerance()) {
+
+            // distance to the point of closest approarch on the
+            // line from line center
+            const scalar_type B{zd * A - t2l_on_line};
+
+            // point of closest approach on the track
+            const point3 m = _p + _d * A;
+
+            // For the radial cross section, the calculation does not need to be
+            // repeated
+            if constexpr (mask_t::shape::square_cross_sect) {
+                // This is cartesian3 for square cross section
+                auto loc3D = mask.to_local_frame(trf, m);
+                is.status = mask.is_inside(loc3D, mask_tolerance);
+
+                // Determine the measurement point from the local point
+
+                // assign the sign depending on the position w.r.t line surface
+                // Right: -1
+                // Left: 1
+                const auto r = vector::cross(_z, _d);
+                is.p2[0] =
+                    -detail::copysign(getter::perp(loc3D), vector::dot(r, t2l));
+            } else {
+                // local frame and measurement frame are identical
+                is.p2 = mask.to_measurement_frame(trf, m, _d);
+                is.status = mask.is_inside(is.p2, mask_tolerance);
+            }
+
+            // prepare some additional information in case the intersection
+            // is valid
+            if (is.status == intersection::status::e_inside) {
+                is.p2[1] = B;
+                is.surface = sf;
+
+                if constexpr (std::is_same_v<intersection_t,
+                                             intersection2D_point<
+                                                 surface_t, transform3_type>>) {
+                    is.p3 = m;
+                }
+
+                is.direction = detail::signbit(is.path)
+                                   ? intersection::direction::e_opposite
+                                   : intersection::direction::e_along;
+                is.volume_link = mask.volume_link();
+
+                // Get incidence angle
+                is.cos_incidence_angle = std::abs(zd);
+            }
         }
-
-        // distance to the point of closest approarch on the
-        // line from line center
-        const scalar_type B{zd * A - t2l_on_line};
-
-        // point of closest approach on the track
-        const vector3 m = _p + _d * A;
-        is.p3 = m;
-
-        // For the radial cross section, the calculation does not need to be
-        // repeated
-        if constexpr (mask_t::shape::square_cross_sect) {
-            // This is cartesian3 for square cross section
-            auto loc3D = mask.to_local_frame(trf, is.p3);
-            is.status = mask.is_inside(loc3D, mask_tolerance);
-
-            // Determine the measurement point from the local point
-
-            // assign the sign depending on the position w.r.t line surface
-            // Right: -1
-            // Left: 1
-            const auto r = vector::cross(_z, _d);
-            is.p2[0] = -std::copysign(getter::perp(loc3D), vector::dot(r, t2l));
-        } else {
-            // local frame and measurement frame are identical
-            is.p2 = mask.to_measurement_frame(trf, is.p3, _d);
-            is.status = mask.is_inside(is.p2, mask_tolerance);
-        }
-
-        // prepare some additional information in case the intersection
-        // is valid
-        if (is.status == intersection::status::e_inside) {
-            is.p2[1] = B;
-            is.surface = sf;
-            is.direction = std::signbit(is.path)
-                               ? intersection::direction::e_opposite
-                               : intersection::direction::e_along;
-            is.volume_link = mask.volume_link();
-
-            // Get incidence angle
-            is.cos_incidence_angle = std::abs(zd);
-        }
-
         return is;
     }
 
     /// Operator function to find intersections between a ray and a line.
     ///
     /// @tparam mask_t is the input mask type
-    /// @tparam surface_t is the type of surface handle
     ///
     /// @param ray is the input ray trajectory
     /// @param sfi the intersection to be updated
@@ -154,13 +160,13 @@ struct line_intersector {
     /// @param trf is the surface placement transform
     /// @param mask_tolerance is the tolerance for mask edges
     template <
-        typename mask_t, typename surface_t,
+        typename mask_t,
         std::enable_if_t<std::is_same_v<typename mask_t::measurement_frame_type,
-                                        line2<transform3_t>>,
+                                        line2<transform3_type>>,
                          bool> = true>
     DETRAY_HOST_DEVICE inline void update(
-        const ray_type &ray, intersection2D<surface_t, transform3_t> &sfi,
-        const mask_t &mask, const transform3_t &trf,
+        const ray_type &ray, intersection_t &sfi, const mask_t &mask,
+        const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
         sfi = this->operator()(ray, sfi.surface, mask, trf, mask_tolerance);
     }

--- a/core/include/detray/intersection/plane_intersector.hpp
+++ b/core/include/detray/intersection/plane_intersector.hpp
@@ -8,28 +8,31 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/intersection/intersection.hpp"
 
 // System include(s)
-#include <cmath>
 #include <type_traits>
 
 namespace detray {
 
 /// A functor to find intersections between straight line and planar surface
-template <typename transform3_t>
+template <typename intersection_t>
 struct plane_intersector {
 
     /// linear algebra types
     /// @{
-    using scalar_type = typename transform3_t::scalar_type;
-    using point3 = typename transform3_t::point3;
-    using point2 = typename transform3_t::point2;
-    using vector3 = typename transform3_t::vector3;
+    using transform3_type = typename intersection_t::transform3_type;
+    using scalar_type = typename transform3_type::scalar_type;
+    using point3 = typename transform3_type::point3;
+    using point2 = typename transform3_type::point2;
+    using vector3 = typename transform3_type::vector3;
     /// @}
-    using ray_type = detail::ray<transform3_t>;
+
+    using intersection_type = intersection_t;
+    using ray_type = detail::ray<transform3_type>;
 
     /// Operator function to find intersections between ray and planar mask
     ///
@@ -47,12 +50,11 @@ struct plane_intersector {
         typename mask_t, typename surface_t,
         std::enable_if_t<std::is_same_v<typename mask_t::loc_point_t, point2>,
                          bool> = true>
-    DETRAY_HOST_DEVICE inline intersection2D<surface_t, transform3_t>
-    operator()(const ray_type &ray, const surface_t sf, const mask_t &mask,
-               const transform3_t &trf,
-               const scalar_type mask_tolerance = 0.f) const {
+    DETRAY_HOST_DEVICE inline intersection_t operator()(
+        const ray_type &ray, const surface_t &sf, const mask_t &mask,
+        const transform3_type &trf,
+        const scalar_type mask_tolerance = 0.f) const {
 
-        using intersection_t = intersection2D<surface_t, transform3_t>;
         intersection_t is;
 
         // Retrieve the surface normal & translation (context resolved)
@@ -68,26 +70,33 @@ struct plane_intersector {
         if (denom != 0.f) {
             is.path = vector::dot(sn, st - ro) / denom;
 
-            // Intersection is not valid for navigation - return early
-            if (is.path < ray.overstep_tolerance()) {
-                return is;
-            }
+            // Intersection is valid for navigation - continue
+            if (is.path >= ray.overstep_tolerance()) {
 
-            is.surface = sf;
-            is.p3 = ro + is.path * rd;
-            is.p2 = mask.to_local_frame(trf, is.p3, ray.dir());
-            is.status = mask.is_inside(is.p2, mask_tolerance);
+                const point3 p3 = ro + is.path * rd;
+                is.p2 = mask.to_local_frame(trf, p3, ray.dir());
+                is.status = mask.is_inside(is.p2, mask_tolerance);
 
-            // prepare some additional information in case the intersection
-            // is valid
-            if (is.status == intersection::status::e_inside) {
-                is.direction = std::signbit(is.path)
-                                   ? intersection::direction::e_opposite
-                                   : intersection::direction::e_along;
-                is.volume_link = mask.volume_link();
+                // prepare some additional information in case the intersection
+                // is valid
+                if (is.status == intersection::status::e_inside) {
+                    is.surface = sf;
 
-                // Get incidene angle
-                is.cos_incidence_angle = std::abs(denom);
+                    if constexpr (std::is_same_v<
+                                      intersection_t,
+                                      intersection2D_point<surface_t,
+                                                           transform3_type>>) {
+                        is.p3 = p3;
+                    }
+
+                    is.direction = detail::signbit(is.path)
+                                       ? intersection::direction::e_opposite
+                                       : intersection::direction::e_along;
+                    is.volume_link = mask.volume_link();
+
+                    // Get incidene angle
+                    is.cos_incidence_angle = std::abs(denom);
+                }
             }
         } else {
             is.status = intersection::status::e_missed;
@@ -100,7 +109,6 @@ struct plane_intersector {
     /// surface.
     ///
     /// @tparam mask_t is the input mask type
-    /// @tparam surface_t is the type of surface handle
     ///
     /// @param ray is the input ray trajectory
     /// @param sfi the intersection to be updated
@@ -108,12 +116,12 @@ struct plane_intersector {
     /// @param trf is the surface placement transform
     /// @param mask_tolerance is the tolerance for mask edges
     template <
-        typename mask_t, typename surface_t,
+        typename mask_t,
         std::enable_if_t<std::is_same_v<typename mask_t::loc_point_t, point2>,
                          bool> = true>
     DETRAY_HOST_DEVICE inline void update(
-        const ray_type &ray, intersection2D<surface_t, transform3_t> &sfi,
-        const mask_t &mask, const transform3_t &trf,
+        const ray_type &ray, intersection_t &sfi, const mask_t &mask,
+        const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
         sfi = this->operator()(ray, sfi.surface, mask, trf, mask_tolerance);
     }

--- a/core/include/detray/masks/annulus2D.hpp
+++ b/core/include/detray/masks/annulus2D.hpp
@@ -83,8 +83,8 @@ class annulus2D {
         typename measurement_frame_type<algebra_t>::point2;
 
     /// Underlying surface geometry: planar
-    template <typename algebra_t>
-    using intersector_type = intersector_t<algebra_t>;
+    template <typename intersection_t>
+    using intersector_type = intersector_t<intersection_t>;
 
     /// Behaviour of the two local axes (linear in r, circular in phi)
     template <

--- a/core/include/detray/masks/cylinder2D.hpp
+++ b/core/include/detray/masks/cylinder2D.hpp
@@ -73,8 +73,8 @@ class cylinder2D {
         typename measurement_frame_type<algebra_t>::point2;
 
     /// Underlying surface geometry: cylindrical
-    template <typename algebra_t>
-    using intersector_type = intersector_t<algebra_t>;
+    template <typename intersection_t>
+    using intersector_type = intersector_t<intersection_t>;
 
     /// Behaviour of the two local axes (circular in r_phi, linear in z)
     template <
@@ -119,7 +119,7 @@ class cylinder2D {
         const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         if constexpr (kRadialCheck) {
-            return (std::abs(loc_p[0] - bounds[e_r]) <= 10.f * tol and
+            return (std::abs(loc_p[0] - bounds[e_r]) <= tol and
                     bounds[e_n_half_z] - tol <= loc_p[2] and
                     loc_p[2] <= bounds[e_p_half_z] + tol);
         } else {

--- a/core/include/detray/masks/cylinder3D.hpp
+++ b/core/include/detray/masks/cylinder3D.hpp
@@ -57,7 +57,7 @@ class cylinder3D {
     using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: not a surface.
-    template <typename algebra_t>
+    template <typename intersection_t>
     using intersector_type = void;
 
     /// Behaviour of the three local axes (linear in r, circular in phi,

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -74,9 +74,9 @@ class line {
     using measurement_point_type =
         typename measurement_frame_type<algebra_t>::point2;
 
-    /// Underlying surface geometry: planar
-    template <typename algebra_t>
-    using intersector_type = intersector_t<algebra_t>;
+    /// Underlying surface geometry: line
+    template <typename intersection_t>
+    using intersector_type = intersector_t<intersection_t>;
 
     /// Behaviour of the two local axes (linear in r/x, linear in z)
     template <

--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -42,7 +42,7 @@ namespace detray {
 /// @tparam shape_t underlying geometrical shape of the mask, rectangle etc
 /// @tparam links_t the type of link into the volume container
 ///                 (e.g. single index vs range)
-template <typename shape_t, typename links_t = dindex,
+template <typename shape_t, typename links_t = std::uint_least16_t,
           typename algebra_t = __plugin::transform3<detray::scalar>,
           template <typename, std::size_t> class array_t = darray>
 class mask {
@@ -150,9 +150,9 @@ class mask {
     }
 
     /// @returns the intersection functor for the underlying surface geometry.
-    DETRAY_HOST_DEVICE
-    inline constexpr auto intersector() const ->
-        typename shape::template intersector_type<algebra_t> {
+    template <typename intersection_t>
+    DETRAY_HOST_DEVICE inline constexpr auto intersector() const ->
+        typename shape::template intersector_type<intersection_t> {
         return {};
     }
 

--- a/core/include/detray/masks/rectangle2D.hpp
+++ b/core/include/detray/masks/rectangle2D.hpp
@@ -59,8 +59,8 @@ class rectangle2D {
     using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename algebra_t>
-    using intersector_type = intersector_t<algebra_t>;
+    template <typename intersection_t>
+    using intersector_type = intersector_t<intersection_t>;
 
     /// Behaviour of the two local axes (linear in x, y)
     template <

--- a/core/include/detray/masks/ring2D.hpp
+++ b/core/include/detray/masks/ring2D.hpp
@@ -60,8 +60,8 @@ class ring2D {
     using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename algebra_t>
-    using intersector_type = intersector_t<algebra_t>;
+    template <typename intersection_t>
+    using intersector_type = intersector_t<intersection_t>;
 
     /// Behaviour of the two local axes (linear in r, circular in phi)
     template <

--- a/core/include/detray/masks/single3D.hpp
+++ b/core/include/detray/masks/single3D.hpp
@@ -61,8 +61,8 @@ class single3D {
     using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename algebra_t>
-    using intersector_type = intersector_t<algebra_t>;
+    template <typename intersection_t>
+    using intersector_type = intersector_t<intersection_t>;
 
     /// Behaviour of the two local axes (linear in single coordinate x, y or z)
     template <n_axis::bounds e_s = n_axis::bounds::e_closed,

--- a/core/include/detray/masks/trapezoid2D.hpp
+++ b/core/include/detray/masks/trapezoid2D.hpp
@@ -64,8 +64,8 @@ class trapezoid2D {
     using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename algebra_t>
-    using intersector_type = intersector_t<algebra_t>;
+    template <typename intersection_t>
+    using intersector_type = intersector_t<intersection_t>;
 
     /// Behaviour of the two local axes (linear in x, y)
     template <

--- a/core/include/detray/masks/unbounded.hpp
+++ b/core/include/detray/masks/unbounded.hpp
@@ -48,9 +48,9 @@ class unbounded {
         typename shape::template measurement_point_type<algebra_t>;
 
     /// Underlying surface geometry
-    template <typename algebra_t>
+    template <typename intersection_t>
     using intersector_type =
-        typename shape::template intersector_type<algebra_t>;
+        typename shape::template intersector_type<intersection_t>;
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -45,8 +45,8 @@ class unmasked {
     using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename algebra_t>
-    using intersector_type = plane_intersector<algebra_t>;
+    template <typename intersection_t>
+    using intersector_type = plane_intersector<intersection_t>;
 
     /// Behaviour of the two local axes (linear in x, y)
     template <

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -57,9 +57,9 @@ struct material_rod {
     constexpr scalar_type radius() const { return m_radius; }
 
     /// Return the path segment
-    template <typename surface_t, typename algebra_t>
+    template <typename intersection_t>
     DETRAY_HOST_DEVICE scalar_type
-    path_segment(const intersection2D<surface_t, algebra_t>& is) const {
+    path_segment(const intersection_t& is) const {
         // Assume that is.p2[0] is radial distance of line intersector
         if (is.p2[0] > m_radius) {
             return 0.f;
@@ -72,15 +72,15 @@ struct material_rod {
                                sin_incidence_angle_2);
     }
     /// Return the path segment in X0
-    template <typename surface_t, typename algebra_t>
+    template <typename intersection_t>
     DETRAY_HOST_DEVICE scalar_type
-    path_segment_in_X0(const intersection2D<surface_t, algebra_t>& is) const {
+    path_segment_in_X0(const intersection_t& is) const {
         return this->path_segment(is) / m_material.X0();
     }
     /// Return the path segment in L0
-    template <typename surface_t, typename algebra_t>
+    template <typename intersection_t>
     DETRAY_HOST_DEVICE scalar_type
-    path_segment_in_L0(const intersection2D<surface_t, algebra_t>& is) const {
+    path_segment_in_L0(const intersection_t& is) const {
         return this->path_segment(is) / m_material.L0();
     }
 

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -69,21 +69,21 @@ struct material_slab {
     DETRAY_HOST_DEVICE
     constexpr scalar_type thickness_in_L0() const { return m_thickness_in_L0; }
     /// Return the path segment
-    template <typename surface_t, typename algebra_t>
+    template <typename intersection_t>
     DETRAY_HOST_DEVICE constexpr scalar_type path_segment(
-        const intersection2D<surface_t, algebra_t>& is) const {
+        const intersection_t& is) const {
         return m_thickness / is.cos_incidence_angle;
     }
     /// Return the path segment in X0
-    template <typename surface_t, typename algebra_t>
+    template <typename intersection_t>
     DETRAY_HOST_DEVICE constexpr scalar_type path_segment_in_X0(
-        const intersection2D<surface_t, algebra_t>& is) const {
+        const intersection_t& is) const {
         return m_thickness_in_X0 / is.cos_incidence_angle;
     }
     /// Return the path segment in L0
-    template <typename surface_t, typename algebra_t>
+    template <typename intersection_t>
     DETRAY_HOST_DEVICE constexpr scalar_type path_segment_in_L0(
-        const intersection2D<surface_t, algebra_t>& is) const {
+        const intersection_t& is) const {
         return m_thickness_in_L0 / is.cos_incidence_angle;
     }
 

--- a/core/include/detray/surface_finders/brute_force_finder.hpp
+++ b/core/include/detray/surface_finders/brute_force_finder.hpp
@@ -82,7 +82,7 @@ class brute_force_collection {
     /// Default constructor
     constexpr brute_force_collection() {
         // Start of first subrange
-        m_offsets.push_back(0);
+        m_offsets.push_back(0u);
     };
 
     /// Constructor from memory resource
@@ -90,7 +90,7 @@ class brute_force_collection {
     explicit constexpr brute_force_collection(vecmem::memory_resource* resource)
         : m_offsets(resource), m_surfaces(resource) {
         // Start of first subrange
-        m_offsets.push_back(0);
+        m_offsets.push_back(0u);
     }
 
     /// Device-side construction from a vecmem based view type
@@ -105,7 +105,7 @@ class brute_force_collection {
     DETRAY_HOST_DEVICE
     constexpr auto size() const noexcept -> size_type {
         // The start index of the first range is always present
-        return m_offsets.size() - 1;
+        return static_cast<dindex>(m_offsets.size()) - 1u;
     }
 
     /// @note outside of navigation, the number of elements is unknown
@@ -125,7 +125,7 @@ class brute_force_collection {
     /// Create brute force surface finder from surface container - const
     DETRAY_HOST_DEVICE
     auto operator[](const size_type i) const -> value_type {
-        return {m_surfaces, dindex_range{m_offsets[i], m_offsets[i + 1]}};
+        return {m_surfaces, dindex_range{m_offsets[i], m_offsets[i + 1u]}};
     }
 
     /// Add a new surface collection
@@ -141,7 +141,7 @@ class brute_force_collection {
         m_surfaces.reserve(m_surfaces.size() + surfaces.size());
         m_surfaces.insert(m_surfaces.end(), surfaces.begin(), surfaces.end());
         // End of this range is the start of the next range
-        m_offsets.push_back(m_surfaces.size());
+        m_offsets.push_back(static_cast<dindex>(m_surfaces.size()));
     }
 
     /// @return the view on the brute force finders - non-const

--- a/core/include/detray/surface_finders/grid/axis.hpp
+++ b/core/include/detray/surface_finders/grid/axis.hpp
@@ -85,11 +85,11 @@ struct single_axis {
 
     /// @returns the total number of bins
     DETRAY_HOST_DEVICE
-    inline constexpr std::size_t nbins() const {
+    inline constexpr dindex nbins() const {
         // The open axis boundary has extra over- and underflow bins that are
         // automatically added beyond the axis span
         if constexpr (bounds_type::type == n_axis::bounds::e_open) {
-            return m_binning.nbins() + 2;
+            return m_binning.nbins() + 2u;
         } else {
             return m_binning.nbins();
         }

--- a/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
@@ -60,7 +60,7 @@ struct regular {
     /// @returns the total number of bins, which for the regular axis is simply
     /// the second entry in the range
     DETRAY_HOST_DEVICE
-    std::size_t nbins() const { return detray::detail::get<1>(*m_edges_range); }
+    dindex nbins() const { return detray::detail::get<1>(*m_edges_range); }
 
     /// Access function to a single bin from a value v
     ///
@@ -202,7 +202,7 @@ struct irregular {
 
     /// @returns the total number of bins
     DETRAY_HOST_DEVICE
-    std::size_t nbins() const {
+    dindex nbins() const {
         return detray::detail::get<1>(*m_edges_range) -
                detray::detail::get<0>(*m_edges_range);
     }

--- a/core/include/detray/surface_finders/grid/detail/populator_impl.hpp
+++ b/core/include/detray/surface_finders/grid/detail/populator_impl.hpp
@@ -147,8 +147,8 @@ class ranged_bin
     ranged_bin(const content_t &bin_content, const dindex size)
         : base_type{bin_content}, n_elements{size} {}
 
-    constexpr std::size_t n_entries() { return n_elements; }
-    constexpr std::size_t n_entries() const { return n_elements; }
+    constexpr dindex n_entries() { return n_elements; }
+    constexpr dindex n_entries() const { return n_elements; }
 
     constexpr void push_back(
         const typename content_t::value_type &entry) noexcept {
@@ -157,7 +157,7 @@ class ranged_bin
     }
 
     protected:
-    std::size_t n_elements{0u};
+    dindex n_elements{0u};
 };
 
 /// A complete populator that adds elements to a bin content which contains an
@@ -188,7 +188,7 @@ struct completer {
     DETRAY_HOST_DEVICE void operator()(bin_storage_t &storage,
                                        const dindex gbin,
                                        const entry_t &entry) const noexcept {
-        for (std::size_t i{storage[gbin].n_entries()};
+        for (dindex i{storage[gbin].n_entries()};
              i < storage[gbin].content().size(); ++i) {
             storage[gbin].push_back(entry);
         }
@@ -223,8 +223,7 @@ struct completer {
 
         // The first entry always exists
         stored[0] = entry;
-        std::size_t n_elem =
-            entry == detail::invalid_value<entry_t>() ? 0u : 1u;
+        dindex n_elem = entry == detail::invalid_value<entry_t>() ? 0u : 1u;
 
         return {{stored}, n_elem};
     }
@@ -290,8 +289,7 @@ struct regular_attacher {
 
         // The first element always exists
         stored[0] = entry;
-        std::size_t n_elem =
-            entry == detail::invalid_value<entry_t>() ? 0u : 1u;
+        dindex n_elem = entry == detail::invalid_value<entry_t>() ? 0u : 1u;
 
         return {{stored}, n_elem};
     }

--- a/core/include/detray/tools/bounding_volume.hpp
+++ b/core/include/detray/tools/bounding_volume.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/intersection/intersection.hpp"
 #include "detray/masks/masks.hpp"
 
 // System include(s)
@@ -101,8 +102,9 @@ class axis_aligned_bounding_volume {
                 max_z = max_point[2] > max_z ? max_point[2] : max_z;
             }
         }
-        m_mask = mask<shape>{box_id,      min_x - env, min_y - env, min_z - env,
-                             max_x + env, max_y + env, max_z + env};
+        m_mask = mask<shape, std::size_t>{box_id,      min_x - env, min_y - env,
+                                          min_z - env, max_x + env, max_y + env,
+                                          max_z + env};
     }
 
     /// Subscript operator @returns a single box boundary.
@@ -117,7 +119,9 @@ class axis_aligned_bounding_volume {
 
     /// @returns the bounds of the box, depending on its shape
     DETRAY_HOST_DEVICE
-    constexpr auto bounds() const -> const mask<shape>& { return m_mask; }
+    constexpr auto bounds() const -> const mask<shape, std::size_t>& {
+        return m_mask;
+    }
 
     /// @returns the minimum bounds of the volume in local coordinates
     template <typename point_t>
@@ -308,7 +312,8 @@ class axis_aligned_bounding_volume {
         const scalar_t t = std::numeric_limits<scalar_t>::epsilon()) const {
         static_assert(std::is_same_v<shape, cuboid3D<>>,
                       "aabbs are only implemented in cuboid shape for now");
-        return m_mask.intersector()(ray, m_mask, t);
+        return m_mask.template intersector<intersection2D<bool, algebra_t>>()(
+            ray, m_mask, t);
     }
 
     /// @TODO: Overlapping aabbs
@@ -333,7 +338,7 @@ class axis_aligned_bounding_volume {
 
     private:
     /// Keeps the box boundary values and id
-    mask<shape> m_mask;
+    mask<shape, std::size_t> m_mask;
 };
 
 template <typename shape_t, typename scalar_t = scalar>

--- a/core/include/detray/tools/surface_factory.hpp
+++ b/core/include/detray/tools/surface_factory.hpp
@@ -66,9 +66,9 @@ class surface_factory final
     /// @returns the current number of surfaces that will be built by this
     /// factory
     DETRAY_HOST
-    auto size() const -> std::size_t {
+    auto size() const -> dindex {
         check();
-        return m_components.size();
+        return static_cast<dindex>(m_components.size());
     }
 
     /// @returns the mask boundaries currently held by the factory
@@ -97,7 +97,7 @@ class surface_factory final
         assert(bounds.size() == mask_shape_t::boundaries::e_size);
 
         if constexpr (sf_id != surface_id::e_portal) {
-            if (size() == 0) {
+            if (size() == 0u) {
                 *m_volume_link = vlink;
             } else {
                 assert(*m_volume_link == vlink);
@@ -116,7 +116,8 @@ class surface_factory final
     auto add_components(sf_data_collection &&surface_data)
         -> std::shared_ptr<surface_factory<detector_t, mask_shape_t, mask_id,
                                            sf_id, volume_link_t>> {
-        const std::size_t n_surfaces{size() + surface_data.size()};
+        const auto n_surfaces{
+            static_cast<dindex>(size() + surface_data.size())};
 
         m_transforms.reserve(n_surfaces);
         m_components.reserve(n_surfaces);
@@ -167,10 +168,10 @@ class surface_factory final
         // The material will be added in a later step
         constexpr auto no_material = surface_t::material_id::e_none;
         // In case the surfaces container is prefilled with other surfaces
-        std::size_t surfaces_offset = surfaces.size();
+        dindex surfaces_offset = static_cast<dindex>(surfaces.size());
 
         // Nothing to construct
-        if (size() == 0UL) {
+        if (size() == 0u) {
             return {surfaces_offset, surfaces_offset};
         }
 
@@ -189,14 +190,14 @@ class surface_factory final
             }
 
             // Add surface with all links set (relative to the given containers)
-            mask_link_t mask_link{mask_id, masks.template size<mask_id>() - 1};
+            mask_link_t mask_link{mask_id, masks.template size<mask_id>() - 1u};
             material_link_t material_link{no_material, dindex_invalid};
-            surfaces.emplace_back(transforms.size(ctx) - 1, mask_link,
+            surfaces.emplace_back(transforms.size(ctx) - 1u, mask_link,
                                   material_link, volume.index(), dindex_invalid,
                                   sf_id);
         }
 
-        return {surfaces_offset, surfaces.size()};
+        return {surfaces_offset, static_cast<dindex>(surfaces.size())};
     }
 
     private:

--- a/core/include/detray/tools/volume_builder.hpp
+++ b/core/include/detray/tools/volume_builder.hpp
@@ -48,7 +48,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
                   const array_type<scalar_type, 6>& bounds) override {
         det.volumes().emplace_back(id, bounds);
         m_volume = &(det.volumes().back());
-        m_volume->set_index(det.volumes().size() - 1);
+        m_volume->set_index(static_cast<dindex>(det.volumes().size()) - 1);
         m_volume->set_link(detector_t::sf_finders::id::e_default, 0);
     };
 
@@ -112,7 +112,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
 
         // Update mask and transform index of surfaces and set a
         // unique barcode (index of surface in container)
-        auto sf_offset = det.surfaces().size();
+        auto sf_offset{static_cast<dindex>(det.surfaces().size())};
         for (auto& sf : m_surfaces) {
             det.mask_store().template visit<detail::mask_index_update>(
                 sf.mask(), sf);
@@ -131,7 +131,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
             detector_t::sf_finders::id::e_brute_force};
         m_volume->template set_link<surface_id>(
             default_acc_id,
-            det.surface_store().template size<default_acc_id>() - 1);
+            det.surface_store().template size<default_acc_id>() - 1u);
 
         // Append masks
         det.append_masks(std::move(m_masks));
@@ -153,7 +153,7 @@ struct mask_index_update {
     DETRAY_HOST inline void operator()(const group_t& group,
                                        const index_t& /*index*/,
                                        surface_t& sf) const {
-        sf.update_mask(group.size());
+        sf.update_mask(static_cast<dindex>(group.size()));
     }
 };
 

--- a/core/include/detray/tools/volume_builder_interface.hpp
+++ b/core/include/detray/tools/volume_builder_interface.hpp
@@ -151,7 +151,7 @@ struct material_index_update {
     DETRAY_HOST inline void operator()(const group_t &group,
                                        const index_t & /*index*/,
                                        surface_t &sf) const {
-        sf.update_material(group.size());
+        sf.update_material(static_cast<dindex>(group.size()));
     }
 };
 

--- a/core/include/detray/utils/invalid_values.hpp
+++ b/core/include/detray/utils/invalid_values.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,12 +14,14 @@
 #include <limits>
 #include <type_traits>
 
-namespace detray::detail {
+namespace detray {
+
+namespace detail {
 
 /// Invalid value for fundamental types - constexpr
 template <typename T,
           typename std::enable_if_t<std::is_fundamental_v<T>, bool> = true>
-DETRAY_HOST_DEVICE inline constexpr T invalid_value() {
+DETRAY_HOST_DEVICE inline constexpr T invalid_value() noexcept {
     return std::numeric_limits<T>::max();
 }
 
@@ -28,8 +30,24 @@ template <typename T,
           typename std::enable_if_t<not std::is_fundamental_v<T> and
                                         std::is_default_constructible_v<T>,
                                     bool> = true>
-DETRAY_HOST_DEVICE inline T invalid_value() {
+DETRAY_HOST_DEVICE inline T invalid_value() noexcept {
     return T{};
 }
 
-}  // namespace detray::detail
+}  // namespace detail
+
+template <typename T,
+          typename std::enable_if_t<std::is_fundamental_v<T>, bool> = true>
+DETRAY_HOST_DEVICE inline constexpr bool is_invalid_value(
+    const T value) noexcept {
+    return (value == detail::invalid_value<T>());
+}
+
+template <typename T,
+          typename std::enable_if_t<!std::is_fundamental_v<T>, bool> = true>
+DETRAY_HOST_DEVICE inline constexpr bool is_invalid_value(
+    const T& value) noexcept {
+    return (value == detail::invalid_value<T>());
+}
+
+}  // namespace detray

--- a/core/include/detray/utils/quadratic_equation.hpp
+++ b/core/include/detray/utils/quadratic_equation.hpp
@@ -9,10 +9,11 @@
 
 // Project include(s)
 #include "detray/definitions/containers.hpp"
+#include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/invalid_values.hpp"
 
 // System include(s)
-#include <cmath>
 #include <limits>
 
 namespace detray::detail {
@@ -37,7 +38,7 @@ class quadratic_equation {
         const scalar_t a, const scalar_t b, const scalar_t c,
         const scalar_t tolerance = std::numeric_limits<scalar_t>::epsilon()) {
         // linear case
-        if (std::abs(a) <= tolerance) {
+        if (math_ns::abs(a) <= tolerance) {
             m_solutions = 1;
             m_values[0] = -c / b;
         } else {
@@ -46,7 +47,8 @@ class quadratic_equation {
             if (discriminant > tolerance) {
                 m_solutions = 2;
                 const scalar_t q{
-                    -0.5f * (b + std::copysign(std::sqrt(discriminant), b))};
+                    -0.5f *
+                    (b + detail::copysign(math_ns::sqrt(discriminant), b))};
                 m_values = {q / a, c / q};
                 // Sort the two solutions
                 if (m_values[0] > m_values[1]) {
@@ -74,8 +76,8 @@ class quadratic_equation {
     /// Number of solutions of the equation
     int m_solutions{0};
     /// The solutions
-    std::array<scalar_t, 2> m_values{std::numeric_limits<scalar_t>::infinity(),
-                                     std::numeric_limits<scalar_t>::infinity()};
+    std::array<scalar_t, 2> m_values{detail::invalid_value<scalar_t>(),
+                                     detail::invalid_value<scalar_t>()};
 };
 
 }  // namespace detray::detail

--- a/io/include/detray/io/common/detail/file_handle.hpp
+++ b/io/include/detray/io/common/detail/file_handle.hpp
@@ -38,7 +38,7 @@ class file_handle final {
         // Count the new file
         ++n_files;
         ++n_open_files;
-        assert(n_files < std::numeric_limits<std::uint16_t>::max());
+        assert(n_files < std::numeric_limits<std::uint_least16_t>::max());
         assert(n_open_files < 1000u);
 
         // Open file

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -105,7 +105,7 @@ static void BM_INTERSECT_ALL(benchmark::State &state) {
                 hits += intersections.size();
                 missed += n_surfaces - intersections.size();
 
-                n_surfaces = 0;
+                n_surfaces = 0u;
                 intersections.clear();
             }
         }

--- a/tests/common/include/tests/common/check_geometry_scan.inl
+++ b/tests/common/include/tests/common/check_geometry_scan.inl
@@ -67,6 +67,9 @@ TEST(ALGEBRA_PLUGIN, toy_geometry_scan) {
     // Build the geometry (modeled as a unified index geometry)
     vecmem::host_memory_resource host_mr;
     auto toy_det = create_toy_geometry(host_mr);
+    using nav_link_t =
+        typename decltype(toy_det)::surface_type::navigation_link;
+    constexpr auto leaving_world{detail::invalid_value<nav_link_t>()};
 
     // Build the graph
     volume_graph graph(toy_det);
@@ -93,14 +96,15 @@ TEST(ALGEBRA_PLUGIN, toy_geometry_scan) {
             particle_gun::shoot_particle(toy_det, test_ray);
 
         // Create a trace of the volume indices that were encountered
-        auto [portal_trace, surface_trace] =
-            trace_intersections(intersection_record, start_index);
+        auto [portal_trace, surface_trace] = trace_intersections<leaving_world>(
+            intersection_record, start_index);
 
         // Is this a sensible trace to be further examined?
-        ASSERT_TRUE(check_connectivity(portal_trace));
+        ASSERT_TRUE(check_connectivity<leaving_world>(portal_trace));
 
         // Discover new linking information from this trace
-        build_adjacency(portal_trace, surface_trace, adj_mat_scan, obj_hashes);
+        build_adjacency<leaving_world>(portal_trace, surface_trace,
+                                       adj_mat_scan, obj_hashes);
     }
 
     // print_adj(adj_scan);
@@ -126,6 +130,9 @@ TEST(ALGEBRA_PLUGIN, telescope_geometry_scan) {
     const scalar length{500.f * unit<scalar>::mm};
     const auto tel_det =
         create_telescope_detector(host_mr, rectangle, n_surfaces, length);
+    using nav_link_t =
+        typename decltype(tel_det)::surface_type::navigation_link;
+    constexpr auto leaving_world{detail::invalid_value<nav_link_t>()};
 
     // Build the graph
     volume_graph graph(tel_det);
@@ -153,14 +160,15 @@ TEST(ALGEBRA_PLUGIN, telescope_geometry_scan) {
             particle_gun::shoot_particle(tel_det, test_ray);
 
         // Create a trace of the volume indices that were encountered
-        auto [portal_trace, surface_trace] =
-            trace_intersections(intersection_record, start_index);
+        auto [portal_trace, surface_trace] = trace_intersections<leaving_world>(
+            intersection_record, start_index);
 
         // Is this a sensible trace to be further examined?
-        ASSERT_TRUE(check_connectivity(portal_trace));
+        ASSERT_TRUE(check_connectivity<leaving_world>(portal_trace));
 
         // Discover new linking information from this trace
-        build_adjacency(portal_trace, surface_trace, adj_mat_scan, obj_hashes);
+        build_adjacency<leaving_world>(portal_trace, surface_trace,
+                                       adj_mat_scan, obj_hashes);
     }
 }
 

--- a/tests/common/include/tests/common/covariance_transport.inl
+++ b/tests/common/include/tests/common/covariance_transport.inl
@@ -7,6 +7,7 @@
 
 // Project include(s).
 #include "detray/definitions/units.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/masks/unbounded.hpp"
 #include "detray/tracks/tracks.hpp"
@@ -21,6 +22,7 @@ using namespace detray;
 using matrix_operator = standard_matrix_operator<scalar>;
 using transform3 = __plugin::transform3<scalar>;
 using vector3 = typename transform3::vector3;
+using intersection_t = intersection2D_point<surface<>, transform3>;
 
 // Setups
 constexpr const scalar tolerance = scalar(2e-2);
@@ -30,7 +32,7 @@ const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
 
 // Algebra objects
 constexpr const cartesian2<transform3> c2;
-constexpr const detail::helix_plane_intersector<transform3> hpi;
+constexpr const detail::helix_plane_intersector<intersection_t> hpi;
 
 /// Test the path correction on a rectangular surface (cartesian coordinates)
 TEST(helix_covariance_transport, cartesian2D) {
@@ -115,7 +117,7 @@ TEST(helix_covariance_transport, cartesian2D) {
                 c2.bound_to_free_jacobian(trfs[i_p], rectangle, bound_vec);
 
         // Get the intersection on the next surface
-        const auto is = hpi(hlx, dindex_invalid, rectangle, trfs[next_index]);
+        const auto is = hpi(hlx, surface<>{}, rectangle, trfs[next_index]);
         ASSERT_TRUE(is.status == intersection::status::e_inside);
 
         // Helical path length between two surfaces

--- a/tests/common/include/tests/common/geometry_barcode.inl
+++ b/tests/common/include/tests/common/geometry_barcode.inl
@@ -19,10 +19,10 @@ TEST(geometry, barcode) {
     auto bcd = geometry::barcode{};
 
     // Check a empty barcode
-    EXPECT_EQ(bcd.volume(), (1UL << 12) - 1UL);
+    EXPECT_EQ(bcd.volume(), static_cast<dindex>((1UL << 12) - 1UL));
     EXPECT_EQ(bcd.id(), static_cast<surface_id>((1UL << 4) - 1UL));
-    EXPECT_EQ(bcd.index(), (1UL << 40) - 1UL);
-    EXPECT_EQ(bcd.extra(), (1UL << 8) - 1UL);
+    EXPECT_EQ(bcd.index(), static_cast<dindex>((1UL << 40) - 1UL));
+    EXPECT_EQ(bcd.extra(), static_cast<dindex>((1UL << 8) - 1UL));
 
     bcd.set_volume(2UL)
         .set_id(surface_id::e_passive)

--- a/tests/common/include/tests/common/materials.inl
+++ b/tests/common/include/tests/common/materials.inl
@@ -7,6 +7,7 @@
 
 /// Project include(s)
 #include "detray/definitions/units.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/intersection/line_intersector.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/materials/material.hpp"
@@ -27,9 +28,7 @@ using point2 = __plugin::point2<scalar>;
 using point3 = __plugin::point3<scalar>;
 using transform3 = __plugin::transform3<detray::scalar>;
 using vector3 = __plugin::vector3<scalar>;
-using intersection_t = intersection2D<dindex, transform3>;
-
-constexpr dindex sf_handle = std::numeric_limits<dindex>::max();
+using intersection_t = intersection2D<surface<>, transform3>;
 
 constexpr scalar tol{1e-7f};
 constexpr scalar epsilon{std::numeric_limits<scalar>::epsilon()};
@@ -164,8 +163,8 @@ TEST(materials, material_rod) {
     const mask<line<>> ln{0u, 1.f * unit<scalar>::mm,
                           std::numeric_limits<scalar>::infinity()};
 
-    intersection_t is = line_intersector<transform3>()(
-        detail::ray<transform3>(trk), sf_handle, ln, tf);
+    intersection_t is = line_intersector<intersection_t>()(
+        detail::ray<transform3>(trk), surface<>{}, ln, tf);
 
     EXPECT_NEAR(rod.path_segment(is), 2.f * std::sqrt(10.f - 10.f / 36.f),
                 1e-5f);

--- a/tests/common/include/tests/common/test_core.inl
+++ b/tests/common/include/tests/common/test_core.inl
@@ -51,8 +51,8 @@ TEST(ALGEBRA_PLUGIN, surface) {
 
     mask_link_t mask_id{mask_ids::e_unmasked, 0u};
     material_link_t material_id{material_ids::e_slab, 0u};
-    surface_t s(std::move(trf), mask_id, material_id, dindex_invalid, false,
-                surface_id::e_sensitive);
+    surface_t s(std::move(trf), mask_id, material_id, dindex_invalid,
+                dindex_invalid, surface_id::e_sensitive);
 }
 
 // This tests the construction of a intresection
@@ -60,26 +60,22 @@ TEST(ALGEBRA_PLUGIN, intersection) {
 
     using intersection_t = intersection2D<surface_t, transform3>;
 
-    intersection_t i0 = {
-        intersection::status::e_outside,
-        intersection::direction::e_along,
-        2.f,
-        1.f,
-        1u,
-        surface_t{},
-        point3{0.3f, 0.5f, 0.7f},
-        point2{0.2f, 0.4f},
-    };
+    intersection_t i0 = {surface_t{},
+                         point2{0.2f, 0.4f},
+                         2.f,
+                         1.f,
+                         1u,
+                         intersection::status::e_outside,
+                         intersection::direction::e_along};
 
     intersection_t i1 = {
-        intersection::status::e_inside,
-        intersection::direction::e_opposite,
+        surface_t{},
+        point2{0.2f, 0.4f},
         1.7f,
         -1.f,
         0u,
-        surface_t{},
-        point3{0.2f, 0.3f, 0.f},
-        point2{0.2f, 0.4f},
+        intersection::status::e_inside,
+        intersection::direction::e_opposite,
     };
 
     intersection_t invalid;
@@ -90,5 +86,5 @@ TEST(ALGEBRA_PLUGIN, intersection) {
 
     ASSERT_NEAR(intersections[0].path, 1.7f, tol);
     ASSERT_NEAR(intersections[1].path, 2.f, tol);
-    ASSERT_TRUE(std::isinf(intersections[2].path));
+    ASSERT_TRUE(is_invalid_value(intersections[2].path));
 }

--- a/tests/common/include/tests/common/test_toy_geometry.inl
+++ b/tests/common/include/tests/common/test_toy_geometry.inl
@@ -91,6 +91,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
     using detector_t = decltype(toy_det);
     using geo_obj_ids = typename detector_t::geo_obj_ids;
     using volume_t = typename detector_t::volume_type;
+    using nav_link_t = typename detector_t::surface_type::navigation_link;
     using geo_context_t = typename detector_t::geometry_context;
     using mask_ids = typename detector_t::masks::id;
     using mask_link_t = typename detector_t::surface_type::mask_link;
@@ -116,7 +117,7 @@ TEST(ALGEBRA_PLUGIN, toy_geometry) {
         material_slab<scalar>(silicon_tml<scalar>(), 0.15f * unit<scalar>::mm);
 
     // Link to outer world (leaving detector)
-    const dindex leaving_world = dindex_invalid;
+    constexpr auto leaving_world{detail::invalid_value<nav_link_t>()};
 
     // Check number of geomtery objects
     EXPECT_EQ(volumes.size(), 20u);

--- a/tests/common/include/tests/common/tools/hash_tree.hpp
+++ b/tests/common/include/tests/common/tools/hash_tree.hpp
@@ -122,10 +122,10 @@ class hash_tree {
         // Size of the tree is already known (all iterators stay valid in
         // recursion)
         // we might need to add one dummy node per level
-        auto n_levels = static_cast<std::size_t>(std::log(input_data.size()));
+        auto n_levels = static_cast<dindex>(std::log(input_data.size()));
         _tree.reserve(2u * _tree.size() + n_levels);
         // Build next level
-        build(_tree.begin(), _tree.size());
+        build(_tree.begin(), static_cast<dindex>(_tree.size()));
     }
 
     /// Build the hash tree recursively.
@@ -133,7 +133,7 @@ class hash_tree {
     /// @param first_child the beginning of the nodes for which to construct
     ///                    the parents in this iteration.
     template <typename iterator_t>
-    void build(iterator_t &&first_child, std::size_t n_prev_level) {
+    void build(iterator_t &&first_child, dindex n_prev_level) {
         // base case
         if (n_prev_level <= 1u) {
             return;
@@ -150,15 +150,16 @@ class hash_tree {
             hashed_node parent = _tree.emplace_back(parent_digest);
 
             // Parent node index is at the back of the tree
-            current_child->set_parent(_tree.size() - 1u);
-            (current_child + 1)->set_parent(_tree.size() - 1u);
+            current_child->set_parent(static_cast<dindex>(_tree.size()) - 1u);
+            (current_child + 1)
+                ->set_parent(static_cast<dindex>(_tree.size()) - 1u);
 
             // Set the indices as distances in the contiguous container
             auto left_child_idx = std::distance(current_child, _tree.begin());
             parent.set_children(static_cast<dindex>(left_child_idx),
                                 static_cast<dindex>(left_child_idx) + 1u);
         }
-        std::size_t n_level = n_prev_level / 2u;
+        dindex n_level = n_prev_level / 2u;
         // Need dummy leaf node for next level?
         if (n_level % 2u != 0u and n_level > 1u) {
             _tree.emplace_back(0);

--- a/tests/common/include/tests/common/tools/intersectors/helix_intersection_kernel.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_intersection_kernel.hpp
@@ -44,8 +44,8 @@ struct helix_intersection_initialize {
         const transform_container_t &contextual_transforms,
         const scalar mask_tolerance = 0.f) const {
 
+        using intersection_t = typename is_container_t::value_type;
         using mask_t = typename mask_group_t::value_type;
-        using transform3_t = typename transform_container_t::value_type;
 
         const auto &ctf = contextual_transforms[surface.transform()];
 
@@ -54,7 +54,7 @@ struct helix_intersection_initialize {
              detray::ranges::subrange(mask_group, mask_range)) {
 
             if (place_in_collection(
-                    helix_intersector<transform3_t, mask_t>()(
+                    helix_intersector<intersection_t, mask_t>()(
                         traj, surface, mask, ctf, mask_tolerance),
                     is_container)) {
                 return;

--- a/tests/common/include/tests/common/tools/intersectors/helix_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_intersector.hpp
@@ -17,7 +17,7 @@ namespace detray {
 ///
 /// @note specialized into @c helix_plane_intersector and
 /// @c helix_cylinder_intersector
-template <typename transform3_t, typename mask_t, typename = void>
+template <typename intersection_t, typename mask_t, typename = void>
 struct helix_intersector {};
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools/particle_gun.hpp
+++ b/tests/common/include/tests/common/tools/particle_gun.hpp
@@ -36,10 +36,13 @@ struct particle_gun {
     ///         intersections of the surfaces that were encountered.
     template <typename detector_t, typename trajectory_t>
     DETRAY_HOST_DEVICE inline static auto shoot_particle(
-        const detector_t &detector, const trajectory_t &traj) {
+        const detector_t &detector, const trajectory_t &traj,
+        typename detector_t::scalar_type mask_tolerance =
+            1.f * unit<typename detector_t::scalar_type>::um) {
 
-        using intersection_t = intersection2D<typename detector_t::surface_type,
-                                              typename detector_t::transform3>;
+        using intersection_t =
+            intersection2D_point<typename detector_t::surface_type,
+                                 typename detector_t::transform3>;
 
         std::vector<std::pair<dindex, intersection_t>> intersection_record;
 
@@ -62,12 +65,12 @@ struct particle_gun {
                 // Retrieve candidate(s) from the surface
                 mask_store.template visit<intersection_kernel_t>(
                     sf.mask(), intersections, traj, sf, tf_store,
-                    1.f * unit<typename detector_t::scalar_type>::um);
+                    mask_tolerance);
                 // Candidate is invalid if it lies in the opposite direction
                 for (auto &sfi : intersections) {
                     if (sfi.direction == intersection::direction::e_along) {
-                        // Volume the candidate belongs to
                         sfi.surface = sf;
+                        // Volume the candidate belongs to
                         intersection_record.emplace_back(volume.index(), sfi);
                     }
                 }

--- a/tests/common/include/tests/common/tools/ray_scan_utils.hpp
+++ b/tests/common/include/tests/common/tools/ray_scan_utils.hpp
@@ -33,7 +33,7 @@ namespace detray {
 /// @param start_volume where the ray started
 ///
 /// @return true if the volumes indices form a connected chain.
-template <bool check_sorted_trace = true,
+template <dindex invalid_value = dindex_invalid, bool check_sorted_trace = true,
           typename entry_type = std::pair<dindex, dindex>>
 inline bool check_connectivity(
     std::vector<std::pair<entry_type, entry_type>> trace,
@@ -118,7 +118,7 @@ inline bool check_connectivity(
 
     // There are unconnected elements left (we didn't leave world before
     // termination)
-    if (on_volume != dindex_invalid) {
+    if (on_volume != invalid_value) {
         std::cerr << "\n<<<<<<<<<<<<<<< ERROR while checking volume trace"
                   << std::endl;
         std::cerr << "Didn't leave world or unconnected elements left in trace:"
@@ -146,7 +146,7 @@ inline bool check_connectivity(
 ///
 /// @return a set of volume connections that were found by portal intersection
 ///         of a ray.
-template <typename record_container>
+template <dindex invalid_value = dindex_invalid, typename record_container>
 inline auto trace_intersections(const record_container &intersection_records,
                                 dindex start_volume = 0) {
     // obj id and obj mother volume
@@ -301,8 +301,8 @@ inline auto trace_intersections(const record_container &intersection_records,
 ///
 /// @return an adjacency list from the traced ray scan of a given geometry.
 template <
-    typename portal_trace_type, typename module_trace_type,
-    typename entry_type = std::pair<dindex, dindex>,
+    dindex invalid_value = dindex_invalid, typename portal_trace_type,
+    typename module_trace_type, typename entry_type = std::pair<dindex, dindex>,
     std::enable_if_t<std::is_same_v<typename portal_trace_type::value_type,
                                     std::pair<entry_type, entry_type>>,
                      bool> = true,
@@ -338,7 +338,7 @@ inline auto build_adjacency(
             obj_hashes.insert(pt_index_1);
         }
         // Assume the return link for now (filter out portal that leaves world)
-        if (vol_index_2 != dindex_invalid) {
+        if (vol_index_2 != invalid_value) {
             if (obj_hashes.find(pt_index_2) == obj_hashes.end()) {
                 adj_list[vol_index_2][vol_index_1]++;
                 obj_hashes.insert(pt_index_2);
@@ -361,8 +361,8 @@ inline auto build_adjacency(
 ///
 /// @return an adjacency list from the traced ray scan of a given geometry.
 template <
-    typename portal_trace_type, typename module_trace_type,
-    typename entry_type = std::pair<dindex, dindex>,
+    dindex invalid_value = dindex_invalid, typename portal_trace_type,
+    typename module_trace_type, typename entry_type = std::pair<dindex, dindex>,
     std::enable_if_t<std::is_same_v<typename portal_trace_type::value_type,
                                     std::pair<entry_type, entry_type>>,
                      bool> = true,
@@ -398,7 +398,7 @@ inline auto build_adjacency(const portal_trace_type &portal_trace,
             dindex mat_elem_vol1;
             // Assume the return link for now (filtering out portals that leave
             // world)
-            if (vol_index_2 != dindex_invalid) {
+            if (vol_index_2 != invalid_value) {
                 mat_elem_vol1 = dim * vol_index_1 + vol_index_2;
 
                 if (obj_hashes.find(pt_index_2) == obj_hashes.end()) {

--- a/tests/common/include/tests/common/tools/test_surfaces.hpp
+++ b/tests/common/include/tests/common/tools/test_surfaces.hpp
@@ -158,14 +158,14 @@ create_endcap_components(scalar inner_r, scalar outer_r, scalar pos_z,
                    static_cast<scalar>(iphi) * step_phi};
 
         // Populate the grids
+        dindex transform_idx{static_cast<dindex>(transforms.size()) +
+                             transform_offset};
         ec_grid_inner.populate(cylinder_point2{volume_inner_r * phi, pos_z},
-                               transforms.size() + transform_offset);
+                               transform_idx + 0u);
         ec_grid_outer.populate(cylinder_point2{volume_outer_r * phi, pos_z},
-                               transforms.size() + transform_offset);
-        ec_grid_n.populate(disc_point2{r, phi},
-                           transforms.size() + transform_offset);
-        ec_grid_p.populate(disc_point2{r, phi},
-                           transforms.size() + transform_offset);
+                               transform_idx + 0u);
+        ec_grid_n.populate(disc_point2{r, phi}, transform_idx + 0u);
+        ec_grid_p.populate(disc_point2{r, phi}, transform_idx + 0u);
 
         scalar z_addon = (iphi % 2u) ? -stagger_z : stagger_z;
         scalar cos_phi = std::cos(phi);
@@ -270,19 +270,19 @@ create_barrel_components(scalar r, scalar stagger_r, unsigned int n_phi,
             scalar phi{-constant<scalar>::pi +
                        static_cast<scalar>(iphi) * step_phi};
             // Populate the grids
+            dindex transform_idx{static_cast<dindex>(transforms.size()) +
+                                 transform_offset};
             barrel_grid_inner.populate(
                 cylinder_point2{volume_inner_r * phi, pos_z},
-                transforms.size() + transform_offset);
+                transform_idx + 0u);
             barrel_grid_outer.populate(
                 cylinder_point2{volume_outer_r * phi, pos_z},
-                transforms.size() + transform_offset);
+                transform_idx + 0u);
             if (iz == 0u) {
-                barrel_grid_n.populate(disc_point2{r, phi},
-                                       transforms.size() + transform_offset);
+                barrel_grid_n.populate(disc_point2{r, phi}, transform_idx + 0u);
             }
             if (iz == n_z - 1u) {
-                barrel_grid_p.populate(disc_point2{r, phi},
-                                       transforms.size() + transform_offset);
+                barrel_grid_p.populate(disc_point2{r, phi}, transform_idx + 0u);
             }
             // Finally create the transform
             scalar r_addon = (iz % 2u) ? -stagger_r : stagger_r;

--- a/tests/common/include/tests/common/tools_helix_intersectors.inl
+++ b/tests/common/include/tests/common/tools_helix_intersectors.inl
@@ -7,8 +7,10 @@
 
 // Project include(s).
 #include "detray/definitions/units.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/masks/unmasked.hpp"
 #include "detray/tracks/tracks.hpp"
 #include "tests/common/tools/intersectors/helix_cylinder_intersector.hpp"
 #include "tests/common/tools/intersectors/helix_plane_intersector.hpp"
@@ -16,58 +18,122 @@
 // Google Test include(s).
 #include <gtest/gtest.h>
 
-// System include(s).
+// System include(s)
+#include <cmath>
 #include <limits>
 
 using namespace detray;
 
-using transform3 = __plugin::transform3<detray::scalar>;
-using vector3 = typename transform3::vector3;
-using surface_handle_t = dindex;
+namespace {
 
-constexpr const scalar tol = scalar(1e-4);
+// Three-dimensional definitions
+using transform3_t = __plugin::transform3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
+using point3 = __plugin::point3<detray::scalar>;
+using helix_t = detray::detail::helix<transform3_t>;
+using intersection_t = intersection2D_point<surface<>, transform3_t>;
 
-// dummy surface
-constexpr surface_handle_t sf_handle{};
+constexpr auto not_defined{detail::invalid_value<scalar>()};
+constexpr scalar tol{1e-4f};
 
+// z axis
+const vector3 z_axis{0.f, 0.f, 1.f};
+
+// Track defined on origin point
+const free_track_parameters<transform3_t> free_trk(
+    {0.f, 0.f, 0.f}, 0.f, {0.1f * unit<scalar>::GeV, 0.f, 0.f}, -1.f);
+
+// Magnetic field
+const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
+const vector3 B_0{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                  tol* unit<scalar>::T};
+
+// Test helix
+const helix_t hlx(free_trk, &B);
+
+// Path along the helix
+const scalar path = 10.f * unit<scalar>::cm;
+
+// Transform translation vector
+const vector3 trl = hlx(path);
+
+// Surface normal vector
+const vector3 w = hlx.dir(path);
+
+}  // anonymous namespace
+
+/// This defines the local frame test suite
+TEST(tools, helix_plane_intersector_no_bfield) {
+    // Create a shifted plane
+    const transform3_t shifted(vector3{3.f, 2.f, 10.f});
+
+    // Test helix
+    const point3 pos{2.f, 1.f, 0.f};
+    const vector3 mom{0.f, 0.f, 1.f};
+    const detail::helix<transform3_t> h({pos, 0.f, mom, -1.f}, &B_0);
+
+    // The same test but bound to local frame
+    detail::helix_plane_intersector<intersection_t> pi;
+    mask<unmasked> unmasked_bound{};
+    const auto hit_bound = pi(h, surface<>{}, unmasked_bound, shifted);
+
+    ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
+    // Global intersection information - unchanged
+    ASSERT_NEAR(hit_bound.p3[0], 2.f, tol);
+    ASSERT_NEAR(hit_bound.p3[1], 1.f, tol);
+    ASSERT_NEAR(hit_bound.p3[2], 10.f, tol);
+    // Local intersection information
+    ASSERT_NEAR(hit_bound.p2[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound.p2[1], -1.f, tol);
+    // Incidence angle
+    ASSERT_TRUE(is_invalid_value(hit_bound.cos_incidence_angle));
+
+    // The same test but bound to local frame & masked - inside
+    mask<rectangle2D<>> rect_for_inside{0u, 3.f, 3.f};
+    const auto hit_bound_inside = pi(h, surface<>{}, rect_for_inside, shifted);
+    ASSERT_TRUE(hit_bound_inside.status == intersection::status::e_inside);
+    // Global intersection information - unchanged
+    ASSERT_NEAR(hit_bound_inside.p3[0], 2.f, tol);
+    ASSERT_NEAR(hit_bound_inside.p3[1], 1.f, tol);
+    ASSERT_NEAR(hit_bound_inside.p3[2], 10.f, tol);
+    // Local intersection infoimation - unchanged
+    ASSERT_NEAR(hit_bound_inside.p2[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound_inside.p2[1], -1.f, tol);
+
+    // The same test but bound to local frame & masked - outside
+    mask<rectangle2D<>> rect_for_outside{0u, 0.5f, 3.5f};
+    const auto hit_bound_outside =
+        pi(h, surface<>{}, rect_for_outside, shifted);
+    ASSERT_TRUE(hit_bound_outside.status == intersection::status::e_outside);
+    // Global intersection information - unchanged
+    ASSERT_NEAR(hit_bound_outside.p3[0], 2.f, tol);
+    ASSERT_NEAR(hit_bound_outside.p3[1], 1.f, tol);
+    ASSERT_NEAR(hit_bound_outside.p3[2], 10.f, tol);
+    // Local intersection infoimation - unchanged
+    ASSERT_NEAR(hit_bound_outside.p2[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound_outside.p2[1], -1.f, tol);
+}
+
+/// Test the intersection between a helical trajectory and a plane
 TEST(tools, helix_plane_intersector) {
 
-    // Track defined on origin point
-    const free_track_parameters<transform3> free_trk(
-        {0.f, 0.f, 0.f}, 0.f, {0.1f * unit<scalar>::GeV, 0.f, 0.f}, -1.f);
-
-    // Magnetic field
-    const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
-
-    const detail::helix<transform3> hlx(free_trk, &B);
-
-    const scalar path = 10.f * unit<scalar>::cm;
-
-    // Transform translation vector
-    const auto trl = hlx(path);
-
-    // Surface normal vector
-    const auto w = hlx.dir(path);
-
-    // z axis
-    const vector3 z_axis{0.f, 0.f, 1.f};
-
     // Vector on the surface
-    const auto v = vector::cross(z_axis, w);
+    const vector3 v = vector::cross(z_axis, w);
 
     // Transform matrix
-    const transform3 trf(trl, w, v);
+    const transform3_t trf(trl, w, v);
 
     // Rectangle surface
-    const detray::mask<detray::rectangle2D<>> rectangle{
-        0u, 10.f * unit<scalar>::cm, 10.f * unit<scalar>::cm};
+    const mask<rectangle2D<>> rectangle{0u, 10.f * unit<scalar>::cm,
+                                        10.f * unit<scalar>::cm};
 
-    const detail::helix_plane_intersector<transform3> hpi;
+    const detail::helix_plane_intersector<intersection_t> hpi;
 
     // Get the intersection on the next surface
-    const auto is = hpi(hlx, sf_handle, rectangle, trf);
+    const auto is = hpi(hlx, surface<>{}, rectangle, trf, tol);
 
     // Check the values
+    EXPECT_TRUE(is.status == intersection::status::e_inside);
     EXPECT_NEAR(is.path, path, tol);
     EXPECT_NEAR(is.p2[0], 0.f, tol);
     EXPECT_NEAR(is.p2[1], 0.f, tol);
@@ -76,49 +142,99 @@ TEST(tools, helix_plane_intersector) {
     EXPECT_NEAR(is.p3[2], trl[2], tol);
 }
 
+/// This checks the closest solution of a helix-cylinder intersection
+TEST(tools, helix_cylinder_intersector_no_bfield) {
+
+    const scalar r{4.f * unit<scalar>::mm};
+    const scalar hz{10.f * unit<scalar>::mm};
+
+    // Create a translated cylinder and test untersection
+    const transform3_t shifted(vector3{3.f, 2.f, 10.f});
+    detail::helix_cylinder_intersector<intersection_t> hi;
+
+    // Test helix
+    const point3 pos{3.f, 2.f, 5.f};
+    const vector3 mom{1.f, 0.f, 0.f};
+    const helix_t h({pos, 0.f * unit<scalar>::s, mom, -1 * unit<scalar>::e},
+                    &B_0);
+
+    // Intersect
+    mask<cylinder2D<false, detail::helix_cylinder_intersector>,
+         std::uint_least16_t, transform3_t>
+        cylinder{0u, r, -hz, hz};
+    const auto hits_bound = hi(h, surface<>{}, cylinder, shifted, tol);
+
+    // No magnetic field, so the solutions must be the same as for a ray
+
+    // second intersection lies in front of the track
+    EXPECT_TRUE(hits_bound[0].status == intersection::status::e_inside);
+    EXPECT_TRUE(hits_bound[0].direction == intersection::direction::e_opposite);
+    EXPECT_NEAR(hits_bound[0].p3[0], -1.f, tol);
+    EXPECT_NEAR(hits_bound[0].p3[1], 2.f, tol);
+    EXPECT_NEAR(hits_bound[0].p3[2], 5.f, tol);
+    ASSERT_TRUE(hits_bound[0].p2[0] != not_defined &&
+                hits_bound[0].p2[1] != not_defined);
+    // p2[0] = r * phi : 180deg in the opposite direction with r = 4
+    EXPECT_NEAR(hits_bound[0].p2[0], 4.f * M_PI, tol);
+    EXPECT_NEAR(hits_bound[0].p2[1], -5.f, tol);
+    EXPECT_TRUE(is_invalid_value(hits_bound[0].cos_incidence_angle));
+
+    // first intersection lies behind the track
+    EXPECT_TRUE(hits_bound[1].status == intersection::status::e_inside);
+    EXPECT_TRUE(hits_bound[1].direction == intersection::direction::e_along);
+    EXPECT_NEAR(hits_bound[1].p3[0], 7.f, tol);
+    EXPECT_NEAR(hits_bound[1].p3[1], 2.f, tol);
+    EXPECT_NEAR(hits_bound[1].p3[2], 5.f, tol);
+    ASSERT_TRUE(hits_bound[1].p2[0] != not_defined &&
+                hits_bound[1].p2[1] != not_defined);
+    EXPECT_NEAR(hits_bound[1].p2[0], 0.f, tol);
+    EXPECT_NEAR(hits_bound[1].p2[1], -5., tol);
+    EXPECT_TRUE(is_invalid_value(hits_bound[1].cos_incidence_angle));
+}
+
+/// Test the intersection between a helical trajectory and a cylinder
 TEST(tools, helix_cylinder_intersector) {
 
-    // Track defined on origin point
-    const free_track_parameters<transform3> free_trk(
-        {0.f, 0.f, 0.f}, 0.f, {0.1f * unit<scalar>::GeV, 0.f, 0.f}, -1.f);
-
-    // Magnetic field
-    const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
-
-    const detail::helix<transform3> hlx(free_trk, &B);
-
-    const scalar path = 10.f * unit<scalar>::cm;
-
-    // Transform translation vector
-    const auto trl = hlx(path);
-
-    // Vector on the surface
-    const auto v = hlx.dir(path);
-
-    // z axis
-    const vector3 z_axis{0.f, 0.f, 1.f};
-
     // Transform matrix
-    const transform3 trf(trl, z_axis, v);
-
-    const scalar c_rad = 5.f * unit<scalar>::cm;
+    const transform3_t trf(trl, z_axis, w);
 
     // Cylinder surface (5 cm radius)
-    const detray::mask<detray::cylinder2D<>> cylinder{
-        0u, c_rad, 10.f * unit<scalar>::cm, 10.f * unit<scalar>::cm};
+    const scalar r{4.f * unit<scalar>::cm};
+    const scalar hz{10.f * unit<scalar>::cm};
+    const mask<cylinder2D<>> cylinder{0u, r, -hz, hz};
 
-    const detail::helix_cylinder_intersector<transform3> hci;
+    const detail::helix_cylinder_intersector<intersection_t> hci;
 
     // Get the intersection on the next surface
-    const auto is = hci(hlx, sf_handle, cylinder, trf)[0];
-    const auto pos = hlx.pos(is.path);
-    const auto loc = pos - trl;
-    const auto phi =
-        std::acos(vector::dot(v, loc) / (getter::norm(v) * getter::norm(loc)));
+    const auto is = hci(hlx, surface<>{}, cylinder, trf, tol);
 
-    EXPECT_NEAR(is.p2[0], c_rad * phi, tol);
-    EXPECT_NEAR(is.p2[1], 0.f, tol);
-    EXPECT_NEAR(is.p3[0], pos[0], tol);
-    EXPECT_NEAR(is.p3[1], pos[1], tol);
-    EXPECT_NEAR(is.p3[2], pos[2], tol);
+    // First solution
+    const vector3 pos_near = hlx.pos(is[0].path);
+    const vector3 loc_near = pos_near - trl;
+    const scalar phi_near = std::acos(
+        vector::dot(w, loc_near) / (getter::norm(w) * getter::norm(loc_near)));
+
+    EXPECT_TRUE(is[0].status == intersection::status::e_inside);
+    // Not precise due to helix curvature
+    EXPECT_NEAR(is[0].path, path - r, 5000.f * tol);
+    EXPECT_NEAR(is[0].p2[0], r * phi_near, tol);
+    EXPECT_NEAR(is[0].p2[1], 0.f, tol);
+    EXPECT_NEAR(is[0].p3[0], pos_near[0], tol);
+    EXPECT_NEAR(is[0].p3[1], pos_near[1], tol);
+    EXPECT_NEAR(is[0].p3[2], pos_near[2], tol);
+
+    // Second solution
+    const vector3 pos_far = hlx.pos(is[1].path);
+    const vector3 loc_far = pos_far - trl;
+    const scalar phi_far = std::acos(vector::dot(w, loc_far) /
+                                     (getter::norm(w) * getter::norm(loc_far)));
+
+    EXPECT_TRUE(is[1].status == intersection::status::e_inside);
+    // Not precise due to helix curvature
+    EXPECT_NEAR(is[1].path, path + r, 5000.f * tol);
+    EXPECT_NEAR(is[1].p2[0], r * phi_far, tol);
+    EXPECT_NEAR(is[1].p2[1], 0.f, tol);
+    EXPECT_NEAR(is[1].p3[0], pos_far[0], tol);
+    EXPECT_NEAR(is[1].p3[1], pos_far[1], tol);
+    EXPECT_NEAR(is[1].p3[2], pos_far[2], tol);
 }

--- a/tests/common/include/tests/common/tools_line_intersection.inl
+++ b/tests/common/include/tests/common/tools_line_intersection.inl
@@ -6,6 +6,7 @@
  */
 
 // Project include(s)
+#include "detray/geometry/surface.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/intersection/intersection.hpp"
 #include "detray/intersection/line_intersector.hpp"
@@ -28,11 +29,10 @@ using cartesian = cartesian2<transform3>;
 using vector3 = __plugin::vector3<scalar>;
 using point3 = __plugin::point3<scalar>;
 using point2 = __plugin::point2<scalar>;
-using line_intersector_type = line_intersector<transform3>;
-using intersection_t = intersection2D<dindex, transform3>;
+using intersection_t = intersection2D_point<surface<>, transform3>;
+using line_intersector_type = line_intersector<intersection_t>;
 
 constexpr scalar tol{1e-5f};
-constexpr dindex sf_handle = std::numeric_limits<dindex>::max();
 
 // Test simplest case
 TEST(tools, line_intersector_case1) {
@@ -54,9 +54,9 @@ TEST(tools, line_intersector_case1) {
 
     // Test intersect
     std::vector<intersection_t> is(3u);
-    is[0] = line_intersector_type()(detail::ray(trks[0]), sf_handle, ln, tf);
-    is[1] = line_intersector_type()(detail::ray(trks[1]), sf_handle, ln, tf);
-    is[2] = line_intersector_type()(detail::ray(trks[2]), sf_handle, ln, tf);
+    is[0] = line_intersector_type()(detail::ray(trks[0]), surface<>{}, ln, tf);
+    is[1] = line_intersector_type()(detail::ray(trks[1]), surface<>{}, ln, tf);
+    is[2] = line_intersector_type()(detail::ray(trks[2]), surface<>{}, ln, tf);
 
     EXPECT_EQ(is[0].status, intersection::status::e_inside);
     EXPECT_EQ(is[0].path, 1.f);
@@ -99,7 +99,7 @@ TEST(tools, line_intersector_case2) {
 
     // Test intersect
     const intersection_t is = line_intersector_type()(
-        detail::ray<transform3>(trk), sf_handle, ln, tf);
+        detail::ray<transform3>(trk), surface<>{}, ln, tf);
 
     EXPECT_EQ(is.status, intersection::status::e_inside);
     EXPECT_NEAR(is.path, 2.f, tol);
@@ -146,14 +146,14 @@ TEST(tools, line_intersector_square_scope) {
                       -1.f);
 
     // Infinite wire with 1 mm square cell size
-    mask<line<true, line_intersector>, dindex, transform3> ln{
+    mask<line<true, line_intersector>, std::uint_least16_t, transform3> ln{
         0u, 1.f, std::numeric_limits<scalar>::infinity()};
 
     // Test intersect
     std::vector<intersection_t> is;
     for (const auto& trk : trks) {
         is.push_back(line_intersector_type()(detail::ray<transform3>(trk),
-                                             sf_handle, ln, tf, 1e-5f));
+                                             surface<>{}, ln, tf, 1e-5f));
     }
 
     EXPECT_EQ(is[0].status, intersection::status::e_inside);

--- a/tests/common/include/tests/common/tools_navigator.inl
+++ b/tests/common/include/tests/common/tools_navigator.inl
@@ -256,7 +256,7 @@ TEST(ALGEBRA_PLUGIN, navigator) {
             // The status is: exited
             ASSERT_EQ(navigation.status(), status::e_on_target);
             // Switch to next volume leads out of the detector world -> exit
-            ASSERT_EQ(navigation.volume(), dindex_invalid);
+            ASSERT_TRUE(is_invalid_value(navigation.volume()));
             // We know we went out of the detector
             ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
         } else {

--- a/tests/common/include/tests/common/tools_particle_gun.inl
+++ b/tests/common/include/tests/common/tools_particle_gun.inl
@@ -40,8 +40,9 @@ TEST(tools, particle_gun) {
 
     // Record ray tracing
     using detector_t = decltype(toy_det);
-    using intersection_t = intersection2D<typename detector_t::surface_type,
-                                          typename detector_t::transform3>;
+    using intersection_t =
+        intersection2D_point<typename detector_t::surface_type,
+                             typename detector_t::transform3>;
     std::vector<std::vector<std::pair<dindex, intersection_t>>> expected;
     //  Iterate through uniformly distributed momentum directions with ray
     for (const auto test_ray :

--- a/tests/common/include/tests/common/tools_planar_intersection.inl
+++ b/tests/common/include/tests/common/tools_planar_intersection.inl
@@ -6,12 +6,12 @@
  */
 
 // Project include(s)
+#include "detray/geometry/surface.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/intersection/intersection.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/masks/unmasked.hpp"
-#include "tests/common/tools/intersectors/helix_plane_intersector.hpp"
 
 // GTest include(s)
 #include <gtest/gtest.h>
@@ -27,11 +27,11 @@ using namespace detray;
 using vector3 = __plugin::vector3<scalar>;
 using point3 = __plugin::point3<scalar>;
 using transform3 = __plugin::transform3<detray::scalar>;
+using intersection_t = intersection2D_point<surface<>, transform3>;
 
 constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
-constexpr scalar not_defined{std::numeric_limits<scalar>::infinity()};
+constexpr auto not_defined{detail::invalid_value<scalar>()};
 constexpr scalar isclose{1e-5f};
-constexpr dindex sf_handle = std::numeric_limits<dindex>::max();
 
 // This defines the local frame test suite
 TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
@@ -44,9 +44,9 @@ TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
     const detail::ray<transform3> r(pos, 0.f, mom, 0.f);
 
     // The same test but bound to local frame
-    plane_intersector<transform3> pi;
+    plane_intersector<intersection_t> pi;
     mask<unmasked> unmasked_bound{};
-    const auto hit_bound = pi(r, sf_handle, unmasked_bound, shifted);
+    const auto hit_bound = pi(r, surface<>{}, unmasked_bound, shifted);
 
     ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
     // Global intersection information - unchanged
@@ -61,7 +61,7 @@ TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
 
     // The same test but bound to local frame & masked - inside
     mask<rectangle2D<>> rect_for_inside{0u, 3.f, 3.f};
-    const auto hit_bound_inside = pi(r, sf_handle, rect_for_inside, shifted);
+    const auto hit_bound_inside = pi(r, surface<>{}, rect_for_inside, shifted);
     ASSERT_TRUE(hit_bound_inside.status == intersection::status::e_inside);
     // Global intersection information - unchanged
     ASSERT_NEAR(hit_bound_inside.p3[0], 2.f, tol);
@@ -73,12 +73,13 @@ TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
 
     // The same test but bound to local frame & masked - outside
     mask<rectangle2D<>> rect_for_outside{0u, 0.5f, 3.5f};
-    const auto hit_bound_outside = pi(r, sf_handle, rect_for_outside, shifted);
+    const auto hit_bound_outside =
+        pi(r, surface<>{}, rect_for_outside, shifted);
     ASSERT_TRUE(hit_bound_outside.status == intersection::status::e_outside);
-    // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound_outside.p3[0], 2.f, tol);
-    ASSERT_NEAR(hit_bound_outside.p3[1], 1.f, tol);
-    ASSERT_NEAR(hit_bound_outside.p3[2], 10.f, tol);
+    // Global intersection information - not written out anymore
+    ASSERT_NEAR(hit_bound_outside.p3[0], not_defined, tol);
+    ASSERT_NEAR(hit_bound_outside.p3[1], not_defined, tol);
+    ASSERT_NEAR(hit_bound_outside.p3[2], not_defined, tol);
     // Local intersection infoimation - unchanged
     ASSERT_NEAR(hit_bound_outside.p2[0], -1.f, tol);
     ASSERT_NEAR(hit_bound_outside.p2[1], -1.f, tol);
@@ -93,7 +94,7 @@ TEST(ALGEBRA_PLUGIN, plane_incidence_angle) {
 
     const transform3 rotated{t, vector::normalize(z), vector::normalize(x)};
 
-    plane_intersector<transform3> pi;
+    plane_intersector<intersection_t> pi;
 
     // Test ray
     const point3 pos{-1.f, 0.f, 0.f};
@@ -103,60 +104,7 @@ TEST(ALGEBRA_PLUGIN, plane_incidence_angle) {
     // The same test but bound to local frame & masked - inside
     mask<rectangle2D<>> rect{0u, 3.f, 3.f};
 
-    const auto is = pi(r, sf_handle, rect, rotated);
+    const auto is = pi(r, surface<>{}, rect, rotated);
 
     ASSERT_NEAR(is.cos_incidence_angle, std::cos(constant<scalar>::pi_4), tol);
-}
-
-// This defines the local frame test suite
-TEST(ALGEBRA_PLUGIN, translated_plane_helix) {
-    // Create a shifted plane
-    const transform3 shifted(vector3{3.f, 2.f, 10.f});
-
-    // Test helix
-    const point3 pos{2.f, 1.f, 0.f};
-    const vector3 mom{0.f, 0.f, 1.f};
-    const vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
-                    tol * unit<scalar>::T};
-    const detail::helix<transform3> h({pos, 0.f, mom, -1.f}, &B);
-
-    // The same test but bound to local frame
-    detail::helix_plane_intersector<transform3> pi;
-    mask<unmasked> unmasked_bound{};
-    const auto hit_bound = pi(h, sf_handle, unmasked_bound, shifted);
-
-    ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
-    // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound.p3[0], 2.f, tol);
-    ASSERT_NEAR(hit_bound.p3[1], 1.f, tol);
-    ASSERT_NEAR(hit_bound.p3[2], 10.f, tol);
-    // Local intersection information
-    ASSERT_NEAR(hit_bound.p2[0], -1.f, tol);
-    ASSERT_NEAR(hit_bound.p2[1], -1.f, tol);
-    // Incidence angle
-    ASSERT_TRUE(std::isinf(hit_bound.cos_incidence_angle));
-
-    // The same test but bound to local frame & masked - inside
-    mask<rectangle2D<>> rect_for_inside{0u, 3.f, 3.f};
-    const auto hit_bound_inside = pi(h, sf_handle, rect_for_inside, shifted);
-    ASSERT_TRUE(hit_bound_inside.status == intersection::status::e_inside);
-    // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound_inside.p3[0], 2.f, tol);
-    ASSERT_NEAR(hit_bound_inside.p3[1], 1.f, tol);
-    ASSERT_NEAR(hit_bound_inside.p3[2], 10.f, tol);
-    // Local intersection infoimation - unchanged
-    ASSERT_NEAR(hit_bound_inside.p2[0], -1.f, tol);
-    ASSERT_NEAR(hit_bound_inside.p2[1], -1.f, tol);
-
-    // The same test but bound to local frame & masked - outside
-    mask<rectangle2D<>> rect_for_outside{0u, 0.5f, 3.5f};
-    const auto hit_bound_outside = pi(h, sf_handle, rect_for_outside, shifted);
-    ASSERT_TRUE(hit_bound_outside.status == intersection::status::e_outside);
-    // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound_outside.p3[0], 2.f, tol);
-    ASSERT_NEAR(hit_bound_outside.p3[1], 1.f, tol);
-    ASSERT_NEAR(hit_bound_outside.p3[2], 10.f, tol);
-    // Local intersection infoimation - unchanged
-    ASSERT_NEAR(hit_bound_outside.p2[0], -1.f, tol);
-    ASSERT_NEAR(hit_bound_outside.p2[1], -1.f, tol);
 }

--- a/tests/unit_tests/core/CMakeLists.txt
+++ b/tests/unit_tests/core/CMakeLists.txt
@@ -13,6 +13,7 @@ detray_add_test( core
    "thrust_tuple.cpp"
    "tools_hash_tree.cpp"
    "tuple_helpers.cpp"
+   "utils_invalid_values.cpp"
    "utils_local_object_finder.cpp"
    "utils_ranges.cpp"
    "utils_quadratic_equation.cpp"

--- a/tests/unit_tests/core/grids_grid2.cpp
+++ b/tests/unit_tests/core/grids_grid2.cpp
@@ -57,7 +57,7 @@ TEST(grids, grid2_replace_populator) {
             for (unsigned int ib1 = 0; ib1 < 10u; ++ib1) {
                 p = {-4.5f + static_cast<scalar>(ib0),
                      -4.5f + static_cast<scalar>(ib1)};
-                g2.populate(p, counter);
+                g2.populate(p, counter + 0u);
                 EXPECT_EQ(g2.bin(p), counter++);
             }
         }

--- a/tests/unit_tests/core/utils_invalid_values.cpp
+++ b/tests/unit_tests/core/utils_invalid_values.cpp
@@ -1,0 +1,85 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "detray/utils/invalid_values.hpp"
+
+// Google Test include(s).
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <cstdint>
+#include <limits>
+
+using namespace detray;
+
+// Test sort functions
+TEST(utils, invalid_values) {
+
+    ASSERT_EQ(std::numeric_limits<int>::max(), detail::invalid_value<int>());
+    ASSERT_EQ(std::numeric_limits<std::int_least8_t>::max(),
+              detail::invalid_value<std::int_least8_t>());
+    ASSERT_EQ(std::numeric_limits<std::int_least16_t>::max(),
+              detail::invalid_value<std::int_least16_t>());
+    ASSERT_EQ(std::numeric_limits<std::int_least32_t>::max(),
+              detail::invalid_value<std::int_least32_t>());
+    ASSERT_EQ(std::numeric_limits<std::int_least64_t>::max(),
+              detail::invalid_value<std::int_least64_t>());
+    ASSERT_EQ(std::numeric_limits<std::intmax_t>::max(),
+              detail::invalid_value<std::intmax_t>());
+
+    ASSERT_EQ(std::numeric_limits<unsigned int>::max(),
+              detail::invalid_value<unsigned int>());
+    ASSERT_EQ(std::numeric_limits<std::size_t>::max(),
+              detail::invalid_value<std::size_t>());
+    ASSERT_EQ(std::numeric_limits<std::uint_least8_t>::max(),
+              detail::invalid_value<std::uint_least8_t>());
+    ASSERT_EQ(std::numeric_limits<std::uint_least16_t>::max(),
+              detail::invalid_value<std::uint_least16_t>());
+    ASSERT_EQ(std::numeric_limits<std::uint_least32_t>::max(),
+              detail::invalid_value<std::uint_least32_t>());
+    ASSERT_EQ(std::numeric_limits<std::uint_least64_t>::max(),
+              detail::invalid_value<std::uint_least64_t>());
+    ASSERT_EQ(std::numeric_limits<std::uintmax_t>::max(),
+              detail::invalid_value<std::uintmax_t>());
+
+    ASSERT_EQ(std::numeric_limits<float>::max(),
+              detail::invalid_value<float>());
+    ASSERT_EQ(std::numeric_limits<double>::max(),
+              detail::invalid_value<double>());
+
+    ASSERT_TRUE(is_invalid_value(std::numeric_limits<int>::max()));
+    ASSERT_TRUE(
+        is_invalid_value(std::numeric_limits<std::int_least8_t>::max()));
+    ASSERT_TRUE(
+        is_invalid_value(std::numeric_limits<std::int_least16_t>::max()));
+    ASSERT_TRUE(
+        is_invalid_value(std::numeric_limits<std::int_least32_t>::max()));
+    ASSERT_TRUE(
+        is_invalid_value(std::numeric_limits<std::int_least64_t>::max()));
+    ASSERT_TRUE(is_invalid_value(std::numeric_limits<unsigned int>::max()));
+    ASSERT_TRUE(is_invalid_value(std::numeric_limits<std::size_t>::max()));
+    ASSERT_TRUE(
+        is_invalid_value(std::numeric_limits<std::uint_least8_t>::max()));
+    ASSERT_TRUE(
+        is_invalid_value(std::numeric_limits<std::uint_least16_t>::max()));
+    ASSERT_TRUE(
+        is_invalid_value(std::numeric_limits<std::uint_least32_t>::max()));
+    ASSERT_TRUE(
+        is_invalid_value(std::numeric_limits<std::uint_least64_t>::max()));
+    ASSERT_TRUE(is_invalid_value(std::numeric_limits<std::uintmax_t>::max()));
+    ASSERT_TRUE(is_invalid_value(std::numeric_limits<float>::max()));
+    ASSERT_TRUE(is_invalid_value(std::numeric_limits<double>::max()));
+
+    ASSERT_FALSE(is_invalid_value(1));
+    ASSERT_FALSE(is_invalid_value(0));
+    ASSERT_FALSE(is_invalid_value(-1));
+    ASSERT_FALSE(is_invalid_value(1u));
+    ASSERT_FALSE(is_invalid_value(1ul));
+    ASSERT_FALSE(is_invalid_value(1.));
+    ASSERT_FALSE(is_invalid_value(1.f));
+}

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
@@ -39,8 +39,8 @@ TEST(grids_cuda, grid2_replace_populator) {
                           test::point3<detray::scalar>{0.f, 0.f, 0.f});
 
     // pre-check
-    for (std::size_t i_x = 0u; i_x < xaxis.bins(); i_x++) {
-        for (std::size_t i_y = 0u; i_y < yaxis.bins(); i_y++) {
+    for (unsigned int i_x = 0u; i_x < xaxis.bins(); i_x++) {
+        for (unsigned int i_y = 0u; i_y < yaxis.bins(); i_y++) {
 
             const auto& data = g2.bin(i_x, i_y);
 
@@ -55,8 +55,8 @@ TEST(grids_cuda, grid2_replace_populator) {
     grid_replace_test(g2_data);
 
     // post-check
-    for (std::size_t i_x = 0u; i_x < xaxis.bins(); i_x++) {
-        for (std::size_t i_y = 0u; i_y < yaxis.bins(); i_y++) {
+    for (unsigned int i_x = 0u; i_x < xaxis.bins(); i_x++) {
+        for (unsigned int i_y = 0u; i_y < yaxis.bins(); i_y++) {
             auto bin_id = static_cast<detray::scalar>(i_x + i_y * xaxis.bins());
             const auto& data = g2.bin(i_x, i_y);
 
@@ -85,8 +85,8 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
                              test::point3<detray::scalar>{0.f, 0.f, 0.f});
 
     // pre-check
-    for (std::size_t i_x = 0u; i_x < caxis.bins(); i_x++) {
-        for (std::size_t i_y = 0u; i_y < iaxis.bins(); i_y++) {
+    for (unsigned int i_x = 0u; i_x < caxis.bins(); i_x++) {
+        for (unsigned int i_y = 0u; i_y < iaxis.bins(); i_y++) {
 
             const auto& data = g2.bin(i_x, i_y);
 
@@ -101,8 +101,8 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     grid_replace_ci_test(g2_data);
 
     // post-check
-    for (std::size_t i_x = 0u; i_x < caxis.bins(); i_x++) {
-        for (std::size_t i_y = 0u; i_y < iaxis.bins(); i_y++) {
+    for (unsigned int i_x = 0u; i_x < caxis.bins(); i_x++) {
+        for (unsigned int i_y = 0u; i_y < iaxis.bins(); i_y++) {
             auto y_interval = iaxis.boundaries[i_y + 1] - iaxis.boundaries[i_y];
             auto bin_id = static_cast<detray::scalar>(i_x + i_y * caxis.bins());
 
@@ -130,8 +130,8 @@ TEST(grids_cuda, grid2_complete_populator) {
                            test::point3<detray::scalar>{0.f, 0.f, 0.f});
 
     // pre-check
-    for (std::size_t i_x = 0u; i_x < xaxis.bins(); i_x++) {
-        for (std::size_t i_y = 0u; i_y < yaxis.bins(); i_y++) {
+    for (unsigned int i_x = 0u; i_x < xaxis.bins(); i_x++) {
+        for (unsigned int i_y = 0u; i_y < yaxis.bins(); i_y++) {
 
             const auto& data = g2.bin(i_x, i_y);
 
@@ -153,12 +153,12 @@ TEST(grids_cuda, grid2_complete_populator) {
         (yaxis.max - yaxis.min) / static_cast<detray::scalar>(yaxis.n_bins);
 
     // post-check
-    for (std::size_t i_y = 0u; i_y < yaxis.bins(); i_y++) {
-        for (std::size_t i_x = 0u; i_x < xaxis.bins(); i_x++) {
+    for (unsigned int i_y = 0u; i_y < yaxis.bins(); i_y++) {
+        for (unsigned int i_x = 0u; i_x < xaxis.bins(); i_x++) {
 
             const auto& data = g2.bin(i_x, i_y);
 
-            for (std::size_t i_p = 0u; i_p < data.size(); i_p++) {
+            for (unsigned int i_p = 0u; i_p < data.size(); i_p++) {
                 auto& pt = data[i_p];
 
                 auto bin_id = i_x + i_y * xaxis.bins();
@@ -191,10 +191,10 @@ TEST(grids_cuda, grid2_attach_populator) {
     host_grid2_attach g2(xaxis, yaxis, mng_mr,
                          test::point3<detray::scalar>{0.f, 0.f, 0.f});
 
-    for (std::size_t i_y = 0u; i_y < yaxis.bins(); i_y++) {
-        for (std::size_t i_x = 0u; i_x < xaxis.bins(); i_x++) {
+    for (unsigned int i_y = 0u; i_y < yaxis.bins(); i_y++) {
+        for (unsigned int i_x = 0u; i_x < xaxis.bins(); i_x++) {
 
-            for (std::size_t i_p = 0; i_p < 100; i_p++) {
+            for (unsigned int i_p = 0u; i_p < 100u; i_p++) {
 
                 auto bin_id = i_x + i_y * xaxis.bins();
                 auto gid = static_cast<detray::scalar>(i_p + bin_id * 100u);

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
@@ -93,9 +93,9 @@ TEST(grids_cuda, grid3_replace_populator) {
     const auto& axis_z = g3.template get_axis<n_axis::label::e_z>();
 
     // pre-check
-    for (std::size_t i_x = 0u; i_x < axis_x.nbins(); i_x++) {
-        for (std::size_t i_y = 0u; i_y < axis_y.nbins(); i_y++) {
-            for (std::size_t i_z = 0u; i_z < axis_z.nbins(); i_z++) {
+    for (unsigned int i_x = 0u; i_x < axis_x.nbins(); i_x++) {
+        for (unsigned int i_y = 0u; i_y < axis_y.nbins(); i_y++) {
+            for (unsigned int i_z = 0u; i_z < axis_z.nbins(); i_z++) {
                 const auto& bin = g3.at({i_x, i_y, i_z});
                 auto invalid_bin = populator<
                     host_grid3_replace::populator_impl>::init<point3>();
@@ -107,9 +107,9 @@ TEST(grids_cuda, grid3_replace_populator) {
     grid_replace_test(get_data(g3), axis_x.nbins(), axis_y.nbins(),
                       axis_z.nbins());
     // post-check
-    for (std::size_t i_x = 0u; i_x < axis_x.nbins(); i_x++) {
-        for (std::size_t i_y = 0u; i_y < axis_y.nbins(); i_y++) {
-            for (std::size_t i_z = 0u; i_z < axis_z.nbins(); i_z++) {
+    for (unsigned int i_x = 0u; i_x < axis_x.nbins(); i_x++) {
+        for (unsigned int i_y = 0u; i_y < axis_y.nbins(); i_y++) {
+            for (unsigned int i_z = 0u; i_z < axis_z.nbins(); i_z++) {
                 const dindex gbin_idx = g3.serializer()(
                     g3.axes(), detray::n_axis::multi_bin<3>{i_x, i_y, i_z});
 
@@ -157,8 +157,8 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     const auto& axis_phi = g2.template get_axis<n_axis::label::e_phi>();
 
     // pre-check
-    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
+    for (unsigned int i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (unsigned int i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
             const auto& bin = g2.at({i_r, i_phi});
             auto invalid_bin = populator<
                 host_grid2_replace_ci::populator_impl>::init<point3>();
@@ -171,8 +171,8 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     grid_replace_ci_test(get_data(g2), axis_r.nbins(), axis_phi.nbins());
 
     // post-check
-    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
+    for (unsigned int i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (unsigned int i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
             const dindex gbin_idx = g2.serializer()(
                 g2.axes(), detray::n_axis::multi_bin<2>{i_r, i_phi});
             const auto& bin = g2.at(gbin_idx);
@@ -223,8 +223,8 @@ populator<host_grid2_complete::populator_impl>::init<point3>(first_tp));
     auto width_phi = axis_phi.bin_width();
 
     // pre-check
-    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
+    for (unsigned int i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (unsigned int i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
             auto bin = g2.at({i_r, i_phi});
             auto invalid_bin =
                 populator<host_grid2_complete::populator_impl>::init<point3>(first_tp);
@@ -237,8 +237,8 @@ populator<host_grid2_complete::populator_impl>::init<point3>(first_tp));
     grid_complete_test(get_data(g2), axis_r.nbins(), axis_phi.nbins());
 
     // post-check
-    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
+    for (unsigned int i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (unsigned int i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
             const dindex gbin_idx = g2.serializer()(
                 g2.axes(), detray::n_axis::multi_bin<2>{i_r, i_phi});
             const auto& bin = g2.at(gbin_idx);
@@ -299,8 +299,8 @@ constant<scalar>::pi});
     auto width_phi = axis_phi.bin_width();
 
     // pre-check
-    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
+    for (unsigned int i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (unsigned int i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
             auto bin = g2.at({i_r, i_phi});
             auto invalid_bin =
                 populator<host_grid2_complete::populator_impl>::init<point3>(first_tp);
@@ -313,8 +313,8 @@ constant<scalar>::pi});
     grid_attach_test(get_data(g2), axis_r.nbins(), axis_phi.nbins());
 
     // post-check
-    for (std::size_t i_r = 0u; i_r < axis_r.nbins(); i_r++) {
-        for (std::size_t i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
+    for (unsigned int i_r = 0u; i_r < axis_r.nbins(); i_r++) {
+        for (unsigned int i_phi = 0u; i_phi < axis_phi.nbins(); i_phi++) {
             const dindex gbin_idx = g2.serializer()(
                 g2.axes(), detray::n_axis::multi_bin<2>{i_r, i_phi});
             const auto& bin = g2.at(gbin_idx);
@@ -382,7 +382,7 @@ TEST(grids_cuda, cylindrical3D_collection) {
         bin_content_sequence<populator<n_own_host_grid2_attach::populator_impl>,
                              dindex>());
 
-    vecmem::vector<std::size_t> n_bins(9u, &mng_mr);
+    vecmem::vector<unsigned int> n_bins(9u, &mng_mr);
     vecmem::vector<std::array<dindex, 3>> result_bins(bin_data.size(), &mng_mr);
 
     grid_collection_t grid_coll(std::move(grid_offsets), std::move(bin_data),
@@ -409,7 +409,7 @@ TEST(grids_cuda, cylindrical3D_collection) {
     EXPECT_EQ(5u, n_bins[7]);
     EXPECT_EQ(7u, n_bins[8]);
 
-    for (std::size_t i{0u}; i < bin_data.size(); ++i) {
+    for (unsigned int i{0u}; i < bin_data.size(); ++i) {
         EXPECT_EQ(bin_data[i].content(), result_bins[i]);
     }
 }

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.cu
@@ -201,11 +201,11 @@ void grid_attach_read_test(const_host_grid2_attach::view_type grid_view,
 /// cuda kernel for grid_collection_test
 __global__ void grid_collection_test_kernel(
     grid_collection<n_own_host_grid2_attach>::view_type grid_coll_view,
-    vecmem::data::vector_view<std::size_t> n_bins_view,
+    vecmem::data::vector_view<dindex> n_bins_view,
     vecmem::data::vector_view<std::array<dindex, 3>> result_bins_view) {
     // Let's try building the grid object
     grid_collection<n_own_device_grid2_attach> device_coll(grid_coll_view);
-    vecmem::device_vector<std::size_t> n_bins(n_bins_view);
+    vecmem::device_vector<dindex> n_bins(n_bins_view);
     vecmem::device_vector<std::array<dindex, 3>> result_bins(result_bins_view);
 
     // test the grid axes of the second grid in the collection

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.hpp
@@ -129,7 +129,7 @@ void grid_attach_test(host_grid2_attach::view_type grid_view, std::size_t dim_x,
 // test function for a collection of grids
 void grid_collection_test(
     grid_collection<n_own_host_grid2_attach>::view_type grid_collection_view,
-    vecmem::data::vector_view<std::size_t> n_bins_view,
+    vecmem::data::vector_view<dindex> n_bins_view,
     vecmem::data::vector_view<std::array<dindex, 3>> result_bins_view,
     std::size_t n_grids, std::size_t dim_x, std::size_t dim_y,
     std::size_t dim_z);

--- a/tests/unit_tests/device/cuda/transform_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/transform_store_cuda.cpp
@@ -63,7 +63,7 @@ TEST(transform_store_cuda, transform_store) {
     ASSERT_EQ(static_store.size(ctx0), 5u);
 
     // Compare the transform operation results
-    std::size_t n_transforms = static_store.size(ctx0);
+    dindex n_transforms = static_store.size(ctx0);
 
     // Fill input vector
     vecmem::vector<point3> input(&mng_mr);

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -100,7 +100,7 @@ inline void create_cuboid_portals(context_t &ctx, const scalar pt_envelope,
     using vector3 = __plugin::vector3<detray::scalar>;
 
     using surface_t = typename surface_container_t::value_type;
-    using volume_link_t = typename surface_t::volume_link_type;
+    using nav_link_t = typename surface_t::navigation_link;
     using mask_link_t = typename surface_t::mask_link;
     using material_link_t = typename surface_t::material_link;
 
@@ -144,7 +144,7 @@ inline void create_cuboid_portals(context_t &ctx, const scalar pt_envelope,
 
     // Volume links for the portal descriptors and the masks
     const dindex volume_idx{volume.index()};
-    const volume_link_t volume_link{dindex_invalid};
+    const nav_link_t volume_link{detail::invalid_value<nav_link_t>()};
 
     // Construct portals in the...
 
@@ -250,7 +250,7 @@ inline void create_telescope(context_t &ctx, const trajectory_t &traj,
     using vector3 = __plugin::vector3<detray::scalar>;
 
     using surface_type = typename surface_container_t::value_type;
-    using volume_link_t = typename surface_type::volume_link_type;
+    using nav_link_t = typename surface_type::navigation_link;
     using mask_link_t = typename surface_type::mask_link;
     using material_link_t = typename surface_type::material_link;
 
@@ -264,7 +264,7 @@ inline void create_telescope(context_t &ctx, const trajectory_t &traj,
     // Create geometry data
     for (const auto &m_placement : m_placements) {
 
-        volume_link_t mask_volume_link{volume_idx};
+        auto mask_volume_link{static_cast<nav_link_t>(volume_idx)};
 
         // Surfaces with the linking into the local containers
         mask_link_t mask_link{mask_id, masks.template size<mask_id>()};

--- a/utils/include/detray/detectors/detector_metadata.hpp
+++ b/utils/include/detray/detectors/detector_metadata.hpp
@@ -34,18 +34,18 @@ struct volume_stats {
 };
 
 /// mask to (next) volume link: next volume(s)
-using volume_link_type = dindex;
+using nav_link = std::uint_least16_t;
 
 /// mask types
-using rectangle = mask<rectangle2D<>, volume_link_type>;
-using trapezoid = mask<trapezoid2D<>, volume_link_type>;
-using annulus = mask<annulus2D<>, volume_link_type>;
-using cylinder = mask<cylinder2D<true>, volume_link_type>;
+using rectangle = mask<rectangle2D<>, nav_link>;
+using trapezoid = mask<trapezoid2D<>, nav_link>;
+using annulus = mask<annulus2D<>, nav_link>;
+using cylinder = mask<cylinder2D<true>, nav_link>;
 using cylinder_portal =
-    mask<cylinder2D<false, cylinder_portal_intersector>, volume_link_type>;
-using disc = mask<ring2D<>, volume_link_type>;
-using unbounded_plane = mask<unmasked, volume_link_type>;
-using lines = mask<line<>, volume_link_type>;
+    mask<cylinder2D<false, cylinder_portal_intersector>, nav_link>;
+using disc = mask<ring2D<>, nav_link>;
+using unbounded_plane = mask<unmasked, nav_link>;
+using lines = mask<line<>, nav_link>;
 
 /// material types
 using slab = material_slab<detray::scalar>;
@@ -139,8 +139,8 @@ struct full_metadata {
     using mask_link = typename mask_store<>::single_link;
     using material_link = typename material_store<>::single_link;
     using source_link = dindex;
-    using surface_type =
-        surface<mask_link, material_link, transform_link, source_link>;
+    using surface_type = surface<mask_link, material_link, transform_link,
+                                 nav_link, source_link>;
 
     /// Surface finders
     enum class sf_finder_ids {
@@ -234,8 +234,8 @@ struct toy_metadata {
     using mask_link = typename mask_store<>::single_link;
     using material_link = typename material_store<>::single_link;
     using source_link = dindex;
-    using surface_type =
-        surface<mask_link, material_link, transform_link, source_link>;
+    using surface_type = surface<mask_link, material_link, transform_link,
+                                 nav_link, source_link>;
 
     /// Surface finders
     enum class sf_finder_ids {
@@ -339,8 +339,8 @@ struct telescope_metadata {
     using mask_link = typename mask_store<>::single_link;
     using material_link = typename material_store<>::single_link;
     using source_link = dindex;
-    using surface_type =
-        surface<mask_link, material_link, transform_link, source_link>;
+    using surface_type = surface<mask_link, material_link, transform_link,
+                                 nav_link, source_link>;
 
     /// Surface finders
     enum class sf_finder_ids {


### PR DESCRIPTION
Perform some optimizations to get propagation performance on the GPU back (now its quite a bit faster, even):

- shrink intersection struct by removing the global intersection point (right now it is only needed in the validation).
    It is, however, still available in the new ```intersection2D_point``` type,
- switched ```dindex``` from ```std::size_t``` to ```unsigned int``` to make ```surface``` and ```intersection2D``` smaller,
    use ```invalid_value<T>()``` instead of ```dindex_invalid```, because it depends on the index type (via ```std::numeric_limits<dindex>::max()```),
- navigation link type was reduced in size and the type (not the value) is available in the surface

In addition, the navigation tolerances were adjusted a bit better to fulfill the helix navigation
validation.