### PR TITLE
Refactor the path correction and support line coordinate as well

### DIFF
--- a/core/include/detray/coordinates/cartesian2.hpp
+++ b/core/include/detray/coordinates/cartesian2.hpp
@@ -46,6 +46,7 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
     // Matrix types
     using free_to_bound_matrix = typename base_type::free_to_bound_matrix;
     using bound_to_free_matrix = typename base_type::bound_to_free_matrix;
+    using free_to_path_matrix = typename base_type::free_to_path_matrix;
 
     // Local point type in 2D cartesian coordinates
     using loc_point = point2;
@@ -105,6 +106,25 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
     }
 
     template <typename mask_t>
+    DETRAY_HOST_DEVICE inline free_to_path_matrix path_derivative(
+        const transform3_t &trf3, const mask_t &mask, const point3 &pos,
+        const vector3 &dir) const {
+
+        free_to_path_matrix derivative =
+            matrix_operator().template zero<1u, e_free_size>();
+
+        const vector3 normal = this->normal(trf3, mask, pos, dir);
+
+        const vector3 pos_term = -1.f / vector::dot(normal, dir) * normal;
+
+        matrix_operator().element(derivative, 0u, e_free_pos0) = pos_term[0];
+        matrix_operator().element(derivative, 0u, e_free_pos1) = pos_term[1];
+        matrix_operator().element(derivative, 0u, e_free_pos2) = pos_term[2];
+
+        return derivative;
+    }
+
+    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_pos_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
         const mask_t &mask, const point3 &pos, const vector3 &dir) const {
@@ -144,6 +164,7 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
         const point3 & /*pos*/, const vector3 & /*dir*/) const {
         // Do nothing
     }
+
 };  // struct cartesian2
 
 }  // namespace detray

--- a/core/include/detray/coordinates/cylindrical2.hpp
+++ b/core/include/detray/coordinates/cylindrical2.hpp
@@ -50,6 +50,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
     // Matrix types
     using free_to_bound_matrix = typename base_type::free_to_bound_matrix;
     using bound_to_free_matrix = typename base_type::bound_to_free_matrix;
+    using free_to_path_matrix = typename base_type::free_to_path_matrix;
 
     // Local point type in 2D cylindrical coordinates
     using loc_point = point2;
@@ -128,6 +129,25 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
         matrix_operator().element(rot, 2u, 2u) = new_zaxis[2];
 
         return rot;
+    }
+
+    template <typename mask_t>
+    DETRAY_HOST_DEVICE inline free_to_path_matrix path_derivative(
+        const transform3_t &trf3, const mask_t &mask, const point3 &pos,
+        const vector3 &dir) const {
+
+        free_to_path_matrix derivative =
+            matrix_operator().template zero<1u, e_free_size>();
+
+        const vector3 normal = this->normal(trf3, mask, pos, dir);
+
+        const vector3 pos_term = -1.f / vector::dot(normal, dir) * normal;
+
+        matrix_operator().element(derivative, 0u, e_free_pos0) = pos_term[0];
+        matrix_operator().element(derivative, 0u, e_free_pos1) = pos_term[1];
+        matrix_operator().element(derivative, 0u, e_free_pos2) = pos_term[2];
+
+        return derivative;
     }
 
     template <typename mask_t>

--- a/core/include/detray/coordinates/polar2.hpp
+++ b/core/include/detray/coordinates/polar2.hpp
@@ -50,6 +50,7 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
     // Matrix types
     using free_to_bound_matrix = typename base_type::free_to_bound_matrix;
     using bound_to_free_matrix = typename base_type::bound_to_free_matrix;
+    using free_to_path_matrix = typename base_type::free_to_path_matrix;
 
     // Local point type in polar coordinates
     using loc_point = point2;
@@ -108,6 +109,25 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
         const transform3_t &trf3, const mask_t & /*mask*/,
         const point3 & /*pos*/, const vector3 & /*dir*/) const {
         return trf3.rotation();
+    }
+
+    template <typename mask_t>
+    DETRAY_HOST_DEVICE inline free_to_path_matrix path_derivative(
+        const transform3_t &trf3, const mask_t &mask, const point3 &pos,
+        const vector3 &dir) const {
+
+        free_to_path_matrix derivative =
+            matrix_operator().template zero<1u, e_free_size>();
+
+        const vector3 normal = this->normal(trf3, mask, pos, dir);
+
+        const vector3 pos_term = -1.f / vector::dot(normal, dir) * normal;
+
+        matrix_operator().element(derivative, 0u, e_free_pos0) = pos_term[0];
+        matrix_operator().element(derivative, 0u, e_free_pos1) = pos_term[1];
+        matrix_operator().element(derivative, 0u, e_free_pos2) = pos_term[2];
+
+        return derivative;
     }
 
     template <typename mask_t>

--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -84,8 +84,9 @@ struct parameter_transporter : actor {
             free_matrix& free_transport_jacobian = stepping._jac_transport;
 
             // Path correction factor
-            free_matrix path_correction =
-                local_coordinate.path_correction(stepping, trf3, mask);
+            free_matrix path_correction = local_coordinate.path_correction(
+                stepping().pos(), stepping().dir(), stepping.dtds(), trf3,
+                mask);
 
             const free_matrix correction_term =
                 matrix_operator()

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -33,6 +33,7 @@ class line_stepper final
         typename base_type::bound_track_parameters_type;
     using matrix_operator = typename base_type::matrix_operator;
     using size_type = typename matrix_operator::size_ty;
+    using vector3 = typename transform3_type::vector3;
     template <size_type ROWS, size_type COLS>
     using matrix_type =
         typename matrix_operator::template matrix_type<ROWS, COLS>;
@@ -77,6 +78,9 @@ class line_stepper final
 
             this->_jac_transport = D * this->_jac_transport;
         }
+
+        DETRAY_HOST_DEVICE
+        inline vector3 dtds() const { return vector3{0.f, 0.f, 0.f}; }
     };
 
     /// Take a step, regulared by a constrained step

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -38,7 +38,6 @@ class rk_stepper final
     using vector3 = typename transform3_type::vector3;
     using matrix_operator = typename base_type::matrix_operator;
     using mat_helper = matrix_helper<matrix_operator>;
-
     using free_track_parameters_type =
         typename base_type::free_track_parameters_type;
     using bound_track_parameters_type =
@@ -100,6 +99,9 @@ class rk_stepper final
         DETRAY_HOST_DEVICE
         inline vector3 evaluate_k(const vector3& b_field, const int i,
                                   const scalar h, const vector3& k_prev);
+
+        DETRAY_HOST_DEVICE
+        inline vector3 dtds() const { return this->_step_data.k4; }
     };
 
     /// Take a step, using an adaptive Runge-Kutta algorithm.

--- a/tests/common/include/tests/common/covariance_transport.inl
+++ b/tests/common/include/tests/common/covariance_transport.inl
@@ -133,9 +133,13 @@ TEST(helix_covariance_transport, cartesian2D) {
         free_trk.set_pos(is.p3);
         free_trk.set_dir(hlx.dir(path_length));
 
+        // dtds
+        const vector3 dtds = free_trk.qop() * vector::cross(free_trk.dir(), B);
+
         // Path correction
         const cartesian2<transform3>::free_matrix path_correction =
-            c2.path_correction(free_trk, trfs[next_index], rectangle, B);
+            c2.path_correction(free_trk.pos(), free_trk.dir(), dtds,
+                               trfs[next_index], rectangle);
 
         // Correction term for the path variation
         const cartesian2<transform3>::free_matrix correction_term =


### PR DESCRIPTION
I found that ACTS has fully implemented path correction that I wrote in #425 (yeah there was no missing term)
Its implementation is also better than my implementation in detray so I refactored it.

There is no change in the algorithm while the interface of `coordinate_base` is way better now

The covariance transport test for polar, cylinder, and line will follow in the next PR