### PR TITLE
Full three dimsension local coordinates for intersection

### DIFF
--- a/core/include/detray/coordinates/cartesian2.hpp
+++ b/core/include/detray/coordinates/cartesian2.hpp
@@ -53,40 +53,32 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
 
     /// @}
 
-    /** This method transform from a point from 2D cartesian frame to a 2D
-     * cartesian point */
-    DETRAY_HOST_DEVICE
-    inline point2 operator()(const point2 &local2) const { return local2; }
-
-    /** This method transform from a point from 3D cartesian frame to a 2D
-     * cartesian point */
-    DETRAY_HOST_DEVICE
-    inline point2 operator()(const point3 &local3) const {
-
-        return {local3[0], local3[1]};
-    }
-
     /** This method transform from a point from global cartesian 3D frame to a
      * local 2D cartesian point */
     DETRAY_HOST_DEVICE
-    inline point2 global_to_local(const transform3_t &trf3, const point3 &p,
+    inline point3 global_to_local(const transform3_t &trf3, const point3 &p,
                                   const vector3 & /*d*/) const {
-        const auto local3 = trf3.point_to_local(p);
-        return this->operator()(local3);
+        return trf3.point_to_local(p);
+    }
+
+    /** This method transform from a local 2D cartesian point to a point global
+     * cartesian 3D frame*/
+    DETRAY_HOST_DEVICE inline point3 local_to_global(const transform3_t &trf3,
+                                                     const point3 &p) const {
+        return trf3.point_to_global(p);
     }
 
     /** This method transform from a local 2D cartesian point to a point global
      * cartesian 3D frame*/
     template <typename mask_t>
-    DETRAY_HOST_DEVICE inline point3 local_to_global(
+    DETRAY_HOST_DEVICE inline point3 bound_local_to_global(
         const transform3_t &trf3, const mask_t & /*mask*/, const point2 &p,
         const vector3 & /*d*/) const {
-        return trf3.point_to_global(point3{p[0], p[1], 0.f});
+
+        return this->local_to_global(trf3, {p[0], p[1], 0.f});
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline vector3 normal(const transform3_t &trf3,
-                                             const mask_t & /*mask*/,
                                              const point3 & /*pos*/,
                                              const vector3 & /*dir*/) const {
         vector3 ret;
@@ -98,22 +90,19 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
         return ret;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline rotation_matrix reference_frame(
-        const transform3_t &trf3, const mask_t & /*mask*/,
-        const point3 & /*pos*/, const vector3 & /*dir*/) const {
+        const transform3_t &trf3, const point3 & /*pos*/,
+        const vector3 & /*dir*/) const {
         return trf3.rotation();
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline free_to_path_matrix path_derivative(
-        const transform3_t &trf3, const mask_t &mask, const point3 &pos,
-        const vector3 &dir) const {
+        const transform3_t &trf3, const point3 &pos, const vector3 &dir) const {
 
         free_to_path_matrix derivative =
             matrix_operator().template zero<1u, e_free_size>();
 
-        const vector3 normal = this->normal(trf3, mask, pos, dir);
+        const vector3 normal = this->normal(trf3, pos, dir);
 
         const vector3 pos_term = -1.f / vector::dot(normal, dir) * normal;
 
@@ -124,12 +113,11 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
         return derivative;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_pos_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
-        const mask_t &mask, const point3 &pos, const vector3 &dir) const {
+        const point3 &pos, const vector3 &dir) const {
 
-        const rotation_matrix frame = reference_frame(trf3, mask, pos, dir);
+        const rotation_matrix frame = reference_frame(trf3, pos, dir);
 
         // Get d(x,y,z)/d(loc0, loc1)
         const matrix_type<3, 2> bound_pos_to_free_pos_derivative =
@@ -140,12 +128,11 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
                                              e_free_pos0, e_bound_loc0);
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_free_pos_to_bound_pos_derivative(
         free_to_bound_matrix &free_to_bound_jacobian, const transform3_t &trf3,
-        const mask_t &mask, const point3 &pos, const vector3 &dir) const {
+        const point3 &pos, const vector3 &dir) const {
 
-        const rotation_matrix frame = reference_frame(trf3, mask, pos, dir);
+        const rotation_matrix frame = reference_frame(trf3, pos, dir);
         const rotation_matrix frameT = matrix_operator().transpose(frame);
 
         // Get d(loc0, loc1)/d(x,y,z)
@@ -157,11 +144,10 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
                                              e_bound_loc0, e_free_pos0);
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_angle_to_free_pos_derivative(
         bound_to_free_matrix & /*bound_to_free_jacobian*/,
-        const transform3_t & /*trf3*/, const mask_t & /*mask*/,
-        const point3 & /*pos*/, const vector3 & /*dir*/) const {
+        const transform3_t & /*trf3*/, const point3 & /*pos*/,
+        const vector3 & /*dir*/) const {
         // Do nothing
     }
 

--- a/core/include/detray/coordinates/cartesian3.hpp
+++ b/core/include/detray/coordinates/cartesian3.hpp
@@ -37,11 +37,6 @@ struct cartesian3 final : public coordinate_base<cartesian3, transform3_t> {
 
     /// @}
 
-    /** This method transform from a point from 3D cartesian frame to a 3D
-     * cartesian point */
-    DETRAY_HOST_DEVICE
-    inline point3 operator()(const point3 &local3) const { return local3; }
-
     /** This method transform from a point from global cartesian 3D frame to a
      * local 3D cartesian point */
     DETRAY_HOST_DEVICE
@@ -52,10 +47,8 @@ struct cartesian3 final : public coordinate_base<cartesian3, transform3_t> {
 
     /** This method transform from a local 3D cartesian point to a point global
      * cartesian 3D frame*/
-    template <typename mask_t>
-    DETRAY_HOST_DEVICE inline point3 local_to_global(
-        const transform3_t &trf, const mask_t & /*mask*/, const point3 &p,
-        const vector3 & /*d*/) const {
+    DETRAY_HOST_DEVICE inline point3 local_to_global(const transform3_t &trf,
+                                                     const point3 &p) const {
         return trf.point_to_global(p);
     }
 

--- a/core/include/detray/coordinates/coordinate_base.hpp
+++ b/core/include/detray/coordinates/coordinate_base.hpp
@@ -13,6 +13,7 @@
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/propagator/base_stepper.hpp"
 #include "detray/tracks/detail/track_helper.hpp"
+#include "detray/utils/invalid_values.hpp"
 
 // System include(s).
 #include <limits>
@@ -68,7 +69,7 @@ struct coordinate_base {
         const point3 pos = track_helper().pos(free_vec);
         const vector3 dir = track_helper().dir(free_vec);
 
-        const point2 local =
+        const point3 local =
             Derived<transform3_t>().global_to_local(trf3, pos, dir);
 
         bound_vector bound_vec;
@@ -91,11 +92,12 @@ struct coordinate_base {
         const transform3_t& trf3, const mask_t& mask,
         const bound_vector& bound_vec) const {
 
-        const point2 local = track_helper().local(bound_vec);
+        const point2 bound_local = track_helper().bound_local(bound_vec);
+
         const vector3 dir = track_helper().dir(bound_vec);
 
-        const auto pos =
-            Derived<transform3_t>().local_to_global(trf3, mask, local, dir);
+        const auto pos = Derived<transform3_t>().bound_local_to_global(
+            trf3, mask, bound_local, dir);
 
         free_vector free_vec;
         matrix_operator().element(free_vec, e_free_pos0, 0u) = pos[0];
@@ -140,7 +142,7 @@ struct coordinate_base {
 
         // Set d(x,y,z)/d(loc0, loc1)
         Derived<transform3_t>().set_bound_pos_to_free_pos_derivative(
-            jac_to_global, trf3, mask, pos, dir);
+            jac_to_global, trf3, pos, dir);
 
         // Set d(bound time)/d(free time)
         matrix_operator().element(jac_to_global, e_free_time, e_bound_time) =
@@ -162,15 +164,13 @@ struct coordinate_base {
 
         // Set d(x,y,z)/d(phi, theta)
         Derived<transform3_t>().set_bound_angle_to_free_pos_derivative(
-            jac_to_global, trf3, mask, pos, dir);
+            jac_to_global, trf3, pos, dir);
 
         return jac_to_global;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline free_to_bound_matrix free_to_bound_jacobian(
-        const transform3_t& trf3, const mask_t& mask,
-        const free_vector& free_vec) const {
+        const transform3_t& trf3, const free_vector& free_vec) const {
 
         // Declare jacobian for bound to free coordinate transform
         free_to_bound_matrix jac_to_local =
@@ -190,7 +190,7 @@ struct coordinate_base {
 
         // Set d(loc0, loc1)/d(x,y,z)
         Derived<transform3_t>().set_free_pos_to_bound_pos_derivative(
-            jac_to_local, trf3, mask, pos, dir);
+            jac_to_local, trf3, pos, dir);
 
         // Set d(free time)/d(bound time)
         matrix_operator().element(jac_to_local, e_bound_time, e_free_time) =
@@ -216,13 +216,12 @@ struct coordinate_base {
         return jac_to_local;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline free_matrix path_correction(
         const vector3& pos, const vector3& dir, const vector3& dtds,
-        const transform3_t& trf3, const mask_t& mask) const {
+        const transform3_t& trf3) const {
 
         free_to_path_matrix path_derivative =
-            Derived<transform3_t>().path_derivative(trf3, mask, pos, dir);
+            Derived<transform3_t>().path_derivative(trf3, pos, dir);
 
         path_to_free_matrix derivative =
             matrix_operator().template zero<e_free_size, 1u>();

--- a/core/include/detray/coordinates/cylindrical2.hpp
+++ b/core/include/detray/coordinates/cylindrical2.hpp
@@ -11,6 +11,7 @@
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/invalid_values.hpp"
 
 // System include(s).
 #include <cmath>
@@ -57,30 +58,22 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
 
     /// @}
 
-    /** This method transform from a point from 3D cartesian frame to a 2D
-     * cylindrical point */
-    DETRAY_HOST_DEVICE
-    inline point2 operator()(const point3 &p) const {
-
-        return {getter::perp(p) * getter::phi(p), p[2]};
-    }
-
     /** This method transform from a point from global cartesian 3D frame to a
      * local 2D cylindrical point */
     DETRAY_HOST_DEVICE
-    inline point2 global_to_local(const transform3_t &trf, const point3 &p,
+    inline point3 global_to_local(const transform3_t &trf, const point3 &p,
                                   const vector3 & /*d*/) const {
         const auto local3 = trf.point_to_local(p);
-        return this->operator()(local3);
+
+        return {getter::perp(local3) * getter::phi(local3), local3[2],
+                getter::perp(local3)};
     }
 
     /** This method transform from a local 2D cylindrical point to a point
      * global cartesian 3D frame*/
-    template <typename mask_t>
-    DETRAY_HOST_DEVICE inline point3 local_to_global(
-        const transform3_t &trf, const mask_t &mask, const point2 &p,
-        const vector3 & /*d*/) const {
-        const scalar_type r{mask[mask_t::shape::e_r]};
+    DETRAY_HOST_DEVICE inline point3 local_to_global(const transform3_t &trf,
+                                                     const point3 &p) const {
+        const scalar_type r{p[2]};
         const scalar_type phi{p[0] / r};
         const scalar_type x{r * math_ns::cos(phi)};
         const scalar_type y{r * math_ns::sin(phi)};
@@ -89,24 +82,30 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
         return trf.point_to_global(point3{x, y, z});
     }
 
+    /** This method transform from a local 2D cylindrical point to a point
+     * global cartesian 3D frame*/
     template <typename mask_t>
+    DETRAY_HOST_DEVICE inline point3 bound_local_to_global(
+        const transform3_t &trf, const mask_t &mask, const point2 &p,
+        const vector3 & /*dir*/) const {
+
+        return this->local_to_global(trf,
+                                     {p[0], p[1], mask[mask_t::shape::e_r]});
+    }
+
     DETRAY_HOST_DEVICE inline vector3 normal(const transform3_t &trf3,
-                                             const mask_t &mask,
                                              const point3 &pos,
                                              const vector3 &dir) const {
-        const point2 local2 = this->global_to_local(trf3, pos, dir);
-        const scalar_type r{mask[mask_t::shape::e_r]};
-        const scalar_type phi{local2[0] / r};
+        const point3 local = this->global_to_local(trf3, pos, dir);
+        const scalar_type phi{local[0] / local[2]};
         const vector3 local_normal{math_ns::cos(phi), math_ns::sin(phi), 0.f};
 
         // normal vector in local coordinate
         return trf3.rotation() * local_normal;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline rotation_matrix reference_frame(
-        const transform3_t &trf3, const mask_t &mask, const point3 &pos,
-        const vector3 &dir) const {
+        const transform3_t &trf3, const point3 &pos, const vector3 &dir) const {
 
         rotation_matrix rot = matrix_operator().template zero<3, 3>();
 
@@ -115,7 +114,7 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
             matrix_operator().template block<3, 1>(trf3.matrix(), 0u, 2u);
 
         // z axis of the new frame is the vector normal to the cylinder surface
-        const vector3 new_zaxis = normal(trf3, mask, pos, dir);
+        const vector3 new_zaxis = normal(trf3, pos, dir);
 
         // x axis
         const vector3 new_xaxis = vector::cross(new_yaxis, new_zaxis);
@@ -131,15 +130,13 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
         return rot;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline free_to_path_matrix path_derivative(
-        const transform3_t &trf3, const mask_t &mask, const point3 &pos,
-        const vector3 &dir) const {
+        const transform3_t &trf3, const point3 &pos, const vector3 &dir) const {
 
         free_to_path_matrix derivative =
             matrix_operator().template zero<1u, e_free_size>();
 
-        const vector3 normal = this->normal(trf3, mask, pos, dir);
+        const vector3 normal = this->normal(trf3, pos, dir);
 
         const vector3 pos_term = -1.f / vector::dot(normal, dir) * normal;
 
@@ -150,12 +147,11 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
         return derivative;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_pos_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
-        const mask_t &mask, const point3 &pos, const vector3 &dir) const {
+        const point3 &pos, const vector3 &dir) const {
 
-        const auto frame = reference_frame(trf3, mask, pos, dir);
+        const auto frame = reference_frame(trf3, pos, dir);
 
         // Get d(x,y,z)/d(loc0, loc1)
         const auto bound_pos_to_free_pos_derivative =
@@ -166,12 +162,11 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
                                              e_free_pos0, e_bound_loc0);
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_free_pos_to_bound_pos_derivative(
         free_to_bound_matrix &free_to_bound_jacobian, const transform3_t &trf3,
-        const mask_t &mask, const point3 &pos, const vector3 &dir) const {
+        const point3 &pos, const vector3 &dir) const {
 
-        const auto frame = reference_frame(trf3, mask, pos, dir);
+        const auto frame = reference_frame(trf3, pos, dir);
         const auto frameT = matrix_operator().transpose(frame);
 
         // Get d(loc0, loc1)/d(x,y,z)
@@ -183,11 +178,10 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
                                              e_bound_loc0, e_free_pos0);
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_angle_to_free_pos_derivative(
         bound_to_free_matrix & /*bound_to_free_jacobian*/,
-        const transform3_t & /*trf3*/, const mask_t & /*mask*/,
-        const point3 & /*pos*/, const vector3 & /*dir*/) const {
+        const transform3_t & /*trf3*/, const point3 & /*pos*/,
+        const vector3 & /*dir*/) const {
         // Do nothing
     }
 };  // struct cylindrical2

--- a/core/include/detray/coordinates/cylindrical3.hpp
+++ b/core/include/detray/coordinates/cylindrical3.hpp
@@ -39,29 +39,19 @@ struct cylindrical3 final : public coordinate_base<cylindrical3, transform3_t> {
 
     /// @}
 
-    /** This method transform from a point from 3D cartesian frame to a 3D
-     * cartesian point */
-    DETRAY_HOST_DEVICE
-    inline point3 operator()(const point3 &p) const {
-
-        return {getter::perp(p), getter::phi(p), p[2]};
-    }
-
     /** This method transform from a point from global cartesian 3D frame to a
      * local 3D cylindrical point */
     DETRAY_HOST_DEVICE
     inline point3 global_to_local(const transform3_t &trf, const point3 &p,
                                   const vector3 & /*d*/) const {
         const auto local3 = trf.point_to_local(p);
-        return this->operator()(local3);
+        return {getter::perp(local3), getter::phi(local3), local3[2]};
     }
 
     /** This method transform from a local 3D cylindrical point to a point
      * global cartesian 3D frame*/
-    template <typename mask_t>
-    DETRAY_HOST_DEVICE inline point3 local_to_global(
-        const transform3_t &trf, const mask_t & /*mask*/, const point3 &p,
-        const vector3 & /*d*/) const {
+    DETRAY_HOST_DEVICE inline point3 local_to_global(const transform3_t &trf,
+                                                     const point3 &p) const {
         const scalar_type x{p[0] * math_ns::cos(p[1])};
         const scalar_type y{p[0] * math_ns::sin(p[1])};
 

--- a/core/include/detray/coordinates/line2.hpp
+++ b/core/include/detray/coordinates/line2.hpp
@@ -53,18 +53,10 @@ struct line2 : public coordinate_base<line2, transform3_t> {
 
     /// @}
 
-    /** This method transform from a point from 3D cartesian frame to a 2D
-     * line point */
-    DETRAY_HOST_DEVICE
-    inline point2 operator()(const point3 &local3, scalar_type sign) const {
-
-        return {sign * getter::perp(local3), local3[2]};
-    }
-
     /** This method transform from a point from global cartesian 3D frame to a
      * local 2D line point */
     DETRAY_HOST_DEVICE
-    inline point2 global_to_local(const transform3_t &trf, const point3 &p,
+    inline point3 global_to_local(const transform3_t &trf, const point3 &p,
                                   const vector3 &d) const {
 
         const auto local3 = trf.point_to_local(p);
@@ -83,16 +75,26 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         // Left: 1
         const scalar_type sign = vector::dot(r, t - p) > 0.f ? -1.f : 1.f;
 
-        return this->operator()(local3, sign);
+        return {sign * getter::perp(local3), local3[2], getter::phi(local3)};
+    }
+
+    /** This method transform from a local 2D line point to a point global
+     * cartesian 3D frame*/
+    DETRAY_HOST_DEVICE inline point3 local_to_global(const transform3_t &trf,
+                                                     const point3 &p) const {
+        const scalar_type R = std::abs(p[0]);
+        const point3 local = {R * math_ns::cos(p[2]), R * math_ns::sin(p[2]),
+                              p[1]};
+
+        return trf.point_to_global(local);
     }
 
     /** This method transform from a local 2D line point to a point global
      * cartesian 3D frame*/
     template <typename mask_t>
-    DETRAY_HOST_DEVICE inline point3 local_to_global(const transform3_t &trf,
-                                                     const mask_t & /*mask*/,
-                                                     const point2 &p,
-                                                     const vector3 &d) const {
+    DETRAY_HOST_DEVICE inline point3 bound_local_to_global(
+        const transform3_t &trf, const mask_t & /*mask*/, const point2 &p,
+        const vector3 &d) const {
 
         // Line direction
         const vector3 z = trf.z();
@@ -107,10 +109,9 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         return locZ_in_global + p[0] * vector::normalize(r);
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline rotation_matrix reference_frame(
-        const transform3_t &trf3, const mask_t & /*mask*/,
-        const point3 & /*pos*/, const vector3 &dir) const {
+        const transform3_t &trf3, const point3 & /*pos*/,
+        const vector3 &dir) const {
 
         rotation_matrix rot = matrix_operator().template zero<3, 3>();
 
@@ -135,10 +136,8 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         return rot;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline free_to_path_matrix path_derivative(
-        const transform3_t &trf3, const mask_t & /*mask*/, const point3 &pos,
-        const vector3 &dir) const {
+        const transform3_t &trf3, const point3 &pos, const vector3 &dir) const {
 
         free_to_path_matrix derivative =
             matrix_operator().template zero<1u, e_free_size>();
@@ -171,12 +170,11 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         return derivative;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_pos_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
-        const mask_t &mask, const point3 &pos, const vector3 &dir) const {
+        const point3 &pos, const vector3 &dir) const {
 
-        const auto frame = reference_frame(trf3, mask, pos, dir);
+        const auto frame = reference_frame(trf3, pos, dir);
 
         // Get d(x,y,z)/d(loc0, loc1)
         const auto bound_pos_to_free_pos_derivative =
@@ -187,12 +185,11 @@ struct line2 : public coordinate_base<line2, transform3_t> {
                                              e_free_pos0, e_bound_loc0);
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_free_pos_to_bound_pos_derivative(
         free_to_bound_matrix &free_to_bound_jacobian, const transform3_t &trf3,
-        const mask_t &mask, const point3 &pos, const vector3 &dir) const {
+        const point3 &pos, const vector3 &dir) const {
 
-        const auto frame = reference_frame(trf3, mask, pos, dir);
+        const auto frame = reference_frame(trf3, pos, dir);
         const auto frameT = matrix_operator().transpose(frame);
 
         // Get d(loc0, loc1)/d(x,y,z)
@@ -204,16 +201,15 @@ struct line2 : public coordinate_base<line2, transform3_t> {
                                              e_bound_loc0, e_free_pos0);
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_angle_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
-        const mask_t &mask, const point3 &pos, const vector3 &dir) const {
+        const point3 &pos, const vector3 &dir) const {
 
         // local2
         const auto local2 = this->global_to_local(trf3, pos, dir);
 
         // Reference frame
-        const auto frame = reference_frame(trf3, mask, pos, dir);
+        const auto frame = reference_frame(trf3, pos, dir);
 
         // new x_axis
         const auto new_xaxis = getter::vector<3>(frame, 0u, 0u);

--- a/core/include/detray/coordinates/polar2.hpp
+++ b/core/include/detray/coordinates/polar2.hpp
@@ -11,6 +11,7 @@
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/invalid_values.hpp"
 
 // System include(s).
 #include <cmath>
@@ -55,44 +56,36 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
     // Local point type in polar coordinates
     using loc_point = point2;
 
-    /** This method transform from a point from 2D cartesian frame to a 2D
-     * polar point */
-    DETRAY_HOST_DEVICE inline point2 operator()(const point2 &p) const {
-
-        return {getter::perp(p), getter::phi(p)};
-    }
-
-    /** This method transform from a point in 3D cartesian frame to a 2D
-     * polar point */
-    DETRAY_HOST_DEVICE inline point2 operator()(const point3 &p) const {
-
-        return {getter::perp(p), getter::phi(p)};
-    }
-
     /** This method transform from a point from global cartesian 3D frame to a
      * local 2D polar point */
     DETRAY_HOST_DEVICE
-    inline point2 global_to_local(const transform3_t &trf, const point3 &p,
+    inline point3 global_to_local(const transform3_t &trf, const point3 &p,
                                   const vector3 & /*d*/) const {
         const auto local3 = trf.point_to_local(p);
-        return this->operator()(local3);
+        return {getter::perp(local3), getter::phi(local3), local3[2]};
+    }
+
+    /** This method transform from a local 2D polar point to a point global
+     * cartesian 3D frame*/
+    DETRAY_HOST_DEVICE inline point3 local_to_global(const transform3_t &trf,
+                                                     const point3 &p) const {
+        const scalar_type x = p[0] * math_ns::cos(p[1]);
+        const scalar_type y = p[0] * math_ns::sin(p[1]);
+
+        return trf.point_to_global(point3{x, y, p[2]});
     }
 
     /** This method transform from a local 2D polar point to a point global
      * cartesian 3D frame*/
     template <typename mask_t>
-    DETRAY_HOST_DEVICE inline point3 local_to_global(
+    DETRAY_HOST_DEVICE inline point3 bound_local_to_global(
         const transform3_t &trf, const mask_t & /*mask*/, const point2 &p,
         const vector3 & /*d*/) const {
-        const scalar_type x = p[0] * math_ns::cos(p[1]);
-        const scalar_type y = p[0] * math_ns::sin(p[1]);
 
-        return trf.point_to_global(point3{x, y, 0.f});
+        return this->local_to_global(trf, {p[0], p[1], 0.f});
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline vector3 normal(const transform3_t &trf3,
-                                             const mask_t & /*mask*/,
                                              const point3 & /*pos*/,
                                              const vector3 & /*dir*/) const {
         vector3 ret;
@@ -104,22 +97,19 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
         return ret;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline rotation_matrix reference_frame(
-        const transform3_t &trf3, const mask_t & /*mask*/,
-        const point3 & /*pos*/, const vector3 & /*dir*/) const {
+        const transform3_t &trf3, const point3 & /*pos*/,
+        const vector3 & /*dir*/) const {
         return trf3.rotation();
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline free_to_path_matrix path_derivative(
-        const transform3_t &trf3, const mask_t &mask, const point3 &pos,
-        const vector3 &dir) const {
+        const transform3_t &trf3, const point3 &pos, const vector3 &dir) const {
 
         free_to_path_matrix derivative =
             matrix_operator().template zero<1u, e_free_size>();
 
-        const vector3 normal = this->normal(trf3, mask, pos, dir);
+        const vector3 normal = this->normal(trf3, pos, dir);
 
         const vector3 pos_term = -1.f / vector::dot(normal, dir) * normal;
 
@@ -130,23 +120,22 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
         return derivative;
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_pos_to_free_pos_derivative(
         bound_to_free_matrix &bound_to_free_jacobian, const transform3_t &trf3,
-        const mask_t &mask, const point3 &pos, const vector3 &dir) const {
+        const point3 &pos, const vector3 &dir) const {
 
         matrix_type<3, 2> bound_pos_to_free_pos_derivative =
             matrix_operator().template zero<3, 2>();
 
-        const point2 local2 = this->global_to_local(trf3, pos, dir);
-        const scalar_type lrad{local2[0]};
-        const scalar_type lphi{local2[1]};
+        const point3 local = this->global_to_local(trf3, pos, dir);
+        const scalar_type lrad{local[0]};
+        const scalar_type lphi{local[1]};
 
         const scalar_type lcos_phi{math_ns::cos(lphi)};
         const scalar_type lsin_phi{math_ns::sin(lphi)};
 
         // reference matrix
-        const auto frame = reference_frame(trf3, mask, pos, dir);
+        const auto frame = reference_frame(trf3, pos, dir);
 
         // dxdu = d(x,y,z)/du
         const matrix_type<3, 1> dxdL =
@@ -169,15 +158,14 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
                                              e_free_pos0, e_bound_loc0);
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_free_pos_to_bound_pos_derivative(
         free_to_bound_matrix &free_to_bound_jacobian, const transform3_t &trf3,
-        const mask_t &mask, const point3 &pos, const vector3 &dir) const {
+        const point3 &pos, const vector3 &dir) const {
 
         matrix_type<2, 3> free_pos_to_bound_pos_derivative =
             matrix_operator().template zero<2, 3>();
 
-        const auto local = this->global_to_local(trf3, pos, dir);
+        const point3 local = this->global_to_local(trf3, pos, dir);
 
         const scalar_type lrad{local[0]};
         const scalar_type lphi{local[1]};
@@ -186,7 +174,7 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
         const scalar_type lsin_phi{math_ns::sin(lphi)};
 
         // reference matrix
-        const auto frame = reference_frame(trf3, mask, pos, dir);
+        const auto frame = reference_frame(trf3, pos, dir);
         const auto frameT = matrix_operator().transpose(frame);
 
         // dudG = du/d(x,y,z)
@@ -210,11 +198,10 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
                                              e_bound_loc0, e_free_pos0);
     }
 
-    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void set_bound_angle_to_free_pos_derivative(
         bound_to_free_matrix & /*bound_to_free_jacobian*/,
-        const transform3_t & /*trf3*/, const mask_t & /*mask*/,
-        const point3 & /*pos*/, const vector3 & /*dir*/) const {
+        const transform3_t & /*trf3*/, const point3 & /*pos*/,
+        const vector3 & /*dir*/) const {
         // Do nothing
     }
 };

--- a/core/include/detray/core/detail/detector_kernel.hpp
+++ b/core/include/detray/core/detail/detector_kernel.hpp
@@ -32,13 +32,30 @@ struct global_to_local {
     using vector3 = typename algebra_t::vector3;
 
     template <typename mask_group_t, typename index_t>
-    DETRAY_HOST_DEVICE inline auto operator()(const mask_group_t& mask_group,
-                                              const index_t& index,
-                                              const algebra_t& trf3,
-                                              const point3& pos,
-                                              const vector3& dir) const {
+    DETRAY_HOST_DEVICE inline point3 operator()(const mask_group_t& mask_group,
+                                                const index_t& index,
+                                                const algebra_t& trf3,
+                                                const point3& pos,
+                                                const vector3& dir) const {
 
         return mask_group[index].to_local_frame(trf3, pos, dir);
+    }
+};
+
+/// A functor to perform local to global transformation
+template <typename algebra_t>
+struct local_to_global {
+
+    using point3 = typename algebra_t::point3;
+    using vector3 = typename algebra_t::vector3;
+
+    template <typename mask_group_t, typename index_t>
+    DETRAY_HOST_DEVICE inline point3 operator()(const mask_group_t& mask_group,
+                                                const index_t& index,
+                                                const algebra_t& trf3,
+                                                const point3& local) const {
+
+        return mask_group[index].to_global_frame(trf3, local);
     }
 };
 

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -440,13 +440,24 @@ class detector {
     inline const bfield_type &get_bfield() const { return _bfield; }
 
     DETRAY_HOST_DEVICE
-    inline point2 global_to_local(const geometry::barcode bc, const point3 &pos,
+    inline point3 global_to_local(const geometry::barcode bc, const point3 &pos,
                                   const vector3 &dir) const {
         const auto &sf =
             *(surfaces().begin() + static_cast<std::ptrdiff_t>(bc.index()));
         const auto ret =
             _masks.template visit<detail::global_to_local<transform3>>(
                 sf.mask(), _transforms[sf.transform()], pos, dir);
+        return ret;
+    }
+
+    DETRAY_HOST_DEVICE
+    inline point3 local_to_global(const geometry::barcode bc,
+                                  const point3 &local) const {
+        const auto &sf =
+            *(surfaces().begin() + static_cast<std::ptrdiff_t>(bc.index()));
+        const auto ret =
+            _masks.template visit<detail::local_to_global<transform3>>(
+                sf.mask(), _transforms[sf.transform()], local);
         return ret;
     }
 

--- a/core/include/detray/intersection/cylinder_portal_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_portal_intersector.hpp
@@ -54,11 +54,10 @@ struct cylinder_portal_intersector
     /// @param mask_tolerance is the tolerance for mask edges
     ///
     /// @return the closest intersection
-    template <
-        typename mask_t, typename surface_t,
-        std::enable_if_t<std::is_same_v<typename mask_t::measurement_frame_type,
-                                        cylindrical2<transform3_type>>,
-                         bool> = true>
+    template <typename mask_t, typename surface_t,
+              std::enable_if_t<std::is_same_v<typename mask_t::local_frame_type,
+                                              cylindrical2<transform3_type>>,
+                               bool> = true>
     DETRAY_HOST_DEVICE inline intersection_t operator()(
         const ray_type &ray, const surface_t &sf, const mask_t &mask,
         const transform3_type &trf,
@@ -96,11 +95,10 @@ struct cylinder_portal_intersector
     /// @param mask is the input mask that defines the surface extent
     /// @param trf is the surface placement transform
     /// @param mask_tolerance is the tolerance for mask edges
-    template <
-        typename mask_t,
-        std::enable_if_t<std::is_same_v<typename mask_t::measurement_frame_type,
-                                        cylindrical2<transform3_type>>,
-                         bool> = true>
+    template <typename mask_t,
+              std::enable_if_t<std::is_same_v<typename mask_t::local_frame_type,
+                                              cylindrical2<transform3_type>>,
+                               bool> = true>
     DETRAY_HOST_DEVICE inline void update(
         const ray_type &ray, intersection_t &sfi, const mask_t &mask,
         const transform3_type &trf,

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -57,8 +57,9 @@ struct intersection2D {
     surface_descr_t surface;
 
     /// Local position of the intersection on the surface
-    point2 p2{detail::invalid_value<scalar_type>(),
-              detail::invalid_value<scalar_type>()};
+    point3 local{detail::invalid_value<scalar_type>(),
+                 detail::invalid_value<scalar_type>(),
+                 detail::invalid_value<scalar_type>()};
 
     /// Distance between track and candidate
     scalar_type path{detail::invalid_value<scalar_type>()};
@@ -100,62 +101,6 @@ struct intersection2D {
                                     const intersection2D &is) {
         out_stream << "dist:" << is.path
                    << ", (sf index:" << is.surface.barcode()
-                   << ", links to vol:" << is.volume_link << ")";
-        switch (is.status) {
-            case intersection::status::e_outside:
-                out_stream << ", status: outside";
-                break;
-            case intersection::status::e_missed:
-                out_stream << ", status: missed";
-                break;
-            case intersection::status::e_undefined:
-                out_stream << ", status: undefined";
-                break;
-            case intersection::status::e_inside:
-                out_stream << ", status: inside";
-                break;
-        };
-        switch (is.direction) {
-            case intersection::direction::e_undefined:
-                out_stream << ", direction: undefined";
-                break;
-            case intersection::direction::e_opposite:
-                out_stream << ", direction: opposite";
-                break;
-            case intersection::direction::e_along:
-                out_stream << ", direction: along";
-                break;
-        };
-        out_stream << std::endl;
-        return out_stream;
-    }
-};
-
-/// @brief This class holds the intersection information, including the global
-/// point of intersection.
-///
-/// @tparam surface_descr_t is the type of surface descriptor
-template <typename surface_descr_t,
-          typename algebra_t = __plugin::transform3<detray::scalar>>
-struct intersection2D_point
-    : public intersection2D<surface_descr_t, algebra_t> {
-    using scalar_type = typename algebra_t::scalar_type;
-    using point3 = typename algebra_t::point3;
-    using point2 = typename algebra_t::point2;
-
-    /// Intersection point in global 3D cartesian coordinate frame
-    point3 p3{detail::invalid_value<scalar_type>(),
-              detail::invalid_value<scalar_type>(),
-              detail::invalid_value<scalar_type>()};
-
-    /// Transform to a string for output debugging
-    DETRAY_HOST
-    friend std::ostream &operator<<(std::ostream &out_stream,
-                                    const intersection2D_point &is) {
-        scalar_type r{getter::perp(is.p3)};
-        out_stream << "dist:" << is.path << " [glob: r:" << r
-                   << ", z:" << is.p3[2] << " | loc: " << is.p2[0] << ", "
-                   << is.p2[1] << "], (sf index:" << is.surface.barcode()
                    << ", links to vol:" << is.volume_link << ")";
         switch (is.status) {
             case intersection::status::e_outside:

--- a/core/include/detray/intersection/plane_intersector.hpp
+++ b/core/include/detray/intersection/plane_intersector.hpp
@@ -46,10 +46,7 @@ struct plane_intersector {
     /// @param mask_tolerance is the tolerance for mask edges
     ///
     /// @return the intersection
-    template <
-        typename mask_t, typename surface_t,
-        std::enable_if_t<std::is_same_v<typename mask_t::loc_point_t, point2>,
-                         bool> = true>
+    template <typename mask_t, typename surface_t>
     DETRAY_HOST_DEVICE inline intersection_t operator()(
         const ray_type &ray, const surface_t &sf, const mask_t &mask,
         const transform3_type &trf,
@@ -74,20 +71,13 @@ struct plane_intersector {
             if (is.path >= ray.overstep_tolerance()) {
 
                 const point3 p3 = ro + is.path * rd;
-                is.p2 = mask.to_local_frame(trf, p3, ray.dir());
-                is.status = mask.is_inside(is.p2, mask_tolerance);
+                is.local = mask.to_local_frame(trf, p3, ray.dir());
+                is.status = mask.is_inside(is.local, mask_tolerance);
 
                 // prepare some additional information in case the intersection
                 // is valid
                 if (is.status == intersection::status::e_inside) {
                     is.surface = sf;
-
-                    if constexpr (std::is_same_v<
-                                      intersection_t,
-                                      intersection2D_point<surface_t,
-                                                           transform3_type>>) {
-                        is.p3 = p3;
-                    }
 
                     is.direction = detail::signbit(is.path)
                                        ? intersection::direction::e_opposite
@@ -115,10 +105,7 @@ struct plane_intersector {
     /// @param mask is the input mask that defines the surface extent
     /// @param trf is the surface placement transform
     /// @param mask_tolerance is the tolerance for mask edges
-    template <
-        typename mask_t,
-        std::enable_if_t<std::is_same_v<typename mask_t::loc_point_t, point2>,
-                         bool> = true>
+    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void update(
         const ray_type &ray, intersection_t &sfi, const mask_t &mask,
         const transform3_type &trf,

--- a/core/include/detray/masks/annulus2D.hpp
+++ b/core/include/detray/masks/annulus2D.hpp
@@ -70,17 +70,6 @@ class annulus2D {
     /// Local coordinate frame ( focal system )
     template <typename algebra_t>
     using local_frame_type = polar2<algebra_t>;
-    /// Local point type (2D)
-    template <typename algebra_t>
-    using loc_point_type = typename local_frame_type<algebra_t>::point2;
-
-    /// Measurement frame. @todo focal system?
-    template <typename algebra_t>
-    using measurement_frame_type = polar2<algebra_t>;
-    /// Local measurement point (2D)
-    template <typename algebra_t>
-    using measurement_point_type =
-        typename measurement_frame_type<algebra_t>::point2;
 
     /// Underlying surface geometry: planar
     template <typename intersection_t>
@@ -167,7 +156,7 @@ class annulus2D {
         // Now go to beam frame to check r boundaries. Use the origin
         // shift in polar coordinates for that
         // TODO: Put shift in r-phi into the bounds?
-        const point_t shift_xy = {-bounds[e_shift_x], -bounds[e_shift_y]};
+        const point_t shift_xy = {-bounds[e_shift_x], -bounds[e_shift_y], 0.f};
         const scalar_t shift_r{getter::perp(shift_xy)};
         const scalar_t shift_phi{getter::phi(shift_xy)};
 

--- a/core/include/detray/masks/cuboid3D.hpp
+++ b/core/include/detray/masks/cuboid3D.hpp
@@ -47,16 +47,6 @@ class cuboid3D {
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = cartesian3<algebra_t>;
-    /// Local point type (3D)
-    template <typename algebra_t>
-    using loc_point_type = typename local_frame_type<algebra_t>::point3;
-
-    /// Measurement frame
-    template <typename algebra_t>
-    using measurement_frame_type = local_frame_type<algebra_t>;
-    /// Local measurement point (2D)
-    template <typename algebra_t>
-    using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: not a surface
     template <typename = void>

--- a/core/include/detray/masks/cylinder2D.hpp
+++ b/core/include/detray/masks/cylinder2D.hpp
@@ -54,23 +54,7 @@ class cylinder2D {
 
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
-    using local_frame_type =
-        std::conditional_t<kRadialCheck, cylindrical3<algebra_t>,
-                           cylindrical2<algebra_t>>;
-    /// Local point type for boundary checks (2D or 3D)
-    template <typename algebra_t>
-    using loc_point_type =
-        std::conditional_t<kRadialCheck,
-                           typename local_frame_type<algebra_t>::point3,
-                           typename local_frame_type<algebra_t>::point2>;
-
-    /// Measurement frame
-    template <typename algebra_t>
-    using measurement_frame_type = cylindrical2<algebra_t>;
-    /// Local measurement point (2D)
-    template <typename algebra_t>
-    using measurement_point_type =
-        typename measurement_frame_type<algebra_t>::point2;
+    using local_frame_type = cylindrical2<algebra_t>;
 
     /// Underlying surface geometry: cylindrical
     template <typename intersection_t>
@@ -118,14 +102,14 @@ class cylinder2D {
     DETRAY_HOST_DEVICE inline bool check_boundaries(
         const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
+
         if constexpr (kRadialCheck) {
-            return (std::abs(loc_p[0] - bounds[e_r]) <= tol and
-                    bounds[e_n_half_z] - tol <= loc_p[2] and
-                    loc_p[2] <= bounds[e_p_half_z] + tol);
-        } else {
-            return (bounds[e_n_half_z] - tol <= loc_p[1] and
-                    loc_p[1] <= bounds[e_p_half_z] + tol);
+            if (std::abs(loc_p[2] - bounds[e_r]) > tol) {
+                return false;
+            }
         }
+        return (bounds[e_n_half_z] - tol <= loc_p[1] and
+                loc_p[1] <= bounds[e_p_half_z] + tol);
     }
 
     /// @brief Lower and upper point for minimal axis aligned bounding box.

--- a/core/include/detray/masks/cylinder3D.hpp
+++ b/core/include/detray/masks/cylinder3D.hpp
@@ -45,16 +45,6 @@ class cylinder3D {
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = cylindrical3<algebra_t>;
-    /// Local point type (3D)
-    template <typename algebra_t>
-    using loc_point_type = typename local_frame_type<algebra_t>::point3;
-
-    /// Measurement frame
-    template <typename algebra_t>
-    using measurement_frame_type = local_frame_type<algebra_t>;
-    /// Local measurement point (2D)
-    template <typename algebra_t>
-    using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: not a surface.
     template <typename intersection_t>

--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -54,10 +54,7 @@ class mask {
     using mask_values = array_t<scalar_type, boundaries::e_size>;
     using local_frame_type =
         typename shape::template local_frame_type<algebra_t>;
-    using measurement_frame_type =
-        typename shape::template measurement_frame_type<algebra_t>;
     // Linear algebra types
-    using loc_point_t = typename shape::template loc_point_type<algebra_t>;
     using point3_t = typename algebra_t::point3;
     using point2_t = typename algebra_t::point2;
     using matrix_operator = typename algebra_t::matrix_actor;
@@ -136,17 +133,17 @@ class mask {
     template <typename transform3_t>
     DETRAY_HOST_DEVICE inline auto to_local_frame(
         const transform3_t& trf, const point3_t& glob_p,
-        const point3_t& glob_dir = {}) const -> loc_point_t {
+        const point3_t& glob_dir = {}) const -> point3_t {
         return local_frame_type{}.global_to_local(trf, glob_p, glob_dir);
     }
 
-    /// @returns the functor that projects a global cartesian point onto
-    /// the local measurement coordinate system.
+    /// @returns the functor that projects a local point to the global
+    /// coordinate system
     template <typename transform3_t>
-    DETRAY_HOST_DEVICE inline auto to_measurement_frame(
-        const transform3_t& trf, const point3_t& glob_p,
-        const point3_t& glob_dir = {}) const -> point2_t {
-        return measurement_frame_type{}.global_to_local(trf, glob_p, glob_dir);
+    DETRAY_HOST_DEVICE inline auto to_global_frame(const transform3_t& trf,
+                                                   const point3_t& loc) const
+        -> point3_t {
+        return local_frame_type{}.local_to_global(trf, loc);
     }
 
     /// @returns the intersection functor for the underlying surface geometry.
@@ -168,7 +165,7 @@ class mask {
     /// @return an intersection status e_inside / e_outside
     DETRAY_HOST_DEVICE
     inline auto is_inside(
-        const loc_point_t& loc_p,
+        const point3_t& loc_p,
         const scalar_type t = std::numeric_limits<scalar_type>::epsilon()) const
         -> intersection::status {
 
@@ -180,12 +177,6 @@ class mask {
     /// @returns return local frame object (used in geometrical checks)
     DETRAY_HOST_DEVICE inline constexpr local_frame_type local_frame() const {
         return local_frame_type{};
-    }
-
-    /// @returns return local measurement frame object (used for track states)
-    DETRAY_HOST_DEVICE inline constexpr measurement_frame_type
-    measurement_frame() const {
-        return measurement_frame_type{};
     }
 
     /// @returns the boundary values

--- a/core/include/detray/masks/rectangle2D.hpp
+++ b/core/include/detray/masks/rectangle2D.hpp
@@ -47,16 +47,6 @@ class rectangle2D {
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = cartesian2<algebra_t>;
-    /// Local point type (2D)
-    template <typename algebra_t>
-    using loc_point_type = typename local_frame_type<algebra_t>::point2;
-
-    /// Measurement frame
-    template <typename algebra_t>
-    using measurement_frame_type = local_frame_type<algebra_t>;
-    /// Local measurement point (2D)
-    template <typename algebra_t>
-    using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: planar
     template <typename intersection_t>

--- a/core/include/detray/masks/ring2D.hpp
+++ b/core/include/detray/masks/ring2D.hpp
@@ -48,16 +48,6 @@ class ring2D {
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = polar2<algebra_t>;
-    /// Local point type (2D)
-    template <typename algebra_t>
-    using loc_point_type = typename local_frame_type<algebra_t>::point2;
-
-    /// Measurement frame
-    template <typename algebra_t>
-    using measurement_frame_type = local_frame_type<algebra_t>;
-    /// Local measurement point (2D)
-    template <typename algebra_t>
-    using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: planar
     template <typename intersection_t>

--- a/core/include/detray/masks/single3D.hpp
+++ b/core/include/detray/masks/single3D.hpp
@@ -49,16 +49,6 @@ class single3D {
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = cartesian3<algebra_t>;
-    /// Local point type (3D)
-    template <typename algebra_t>
-    using loc_point_type = typename local_frame_type<algebra_t>::point3;
-
-    /// Measurement frame
-    template <typename algebra_t>
-    using measurement_frame_type = local_frame_type<algebra_t>;
-    /// Local measurement point (2D)
-    template <typename algebra_t>
-    using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: planar
     template <typename intersection_t>

--- a/core/include/detray/masks/trapezoid2D.hpp
+++ b/core/include/detray/masks/trapezoid2D.hpp
@@ -52,16 +52,6 @@ class trapezoid2D {
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = cartesian2<algebra_t>;
-    /// Local point type (2D)
-    template <typename algebra_t>
-    using loc_point_type = typename local_frame_type<algebra_t>::point2;
-
-    /// Measurement frame
-    template <typename algebra_t>
-    using measurement_frame_type = local_frame_type<algebra_t>;
-    /// Local measurement point (2D)
-    template <typename algebra_t>
-    using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: planar
     template <typename intersection_t>

--- a/core/include/detray/masks/unbounded.hpp
+++ b/core/include/detray/masks/unbounded.hpp
@@ -34,18 +34,6 @@ class unbounded {
     template <typename algebra_t>
     using local_frame_type =
         typename shape::template local_frame_type<algebra_t>;
-    /// Local point type
-    template <typename algebra_t>
-    using loc_point_type = typename shape::template loc_point_type<algebra_t>;
-
-    /// Measurement frame
-    template <typename algebra_t>
-    using measurement_frame_type =
-        typename shape::template measurement_frame_type<algebra_t>;
-    /// Local measurement point
-    template <typename algebra_t>
-    using measurement_point_type =
-        typename shape::template measurement_point_type<algebra_t>;
 
     /// Underlying surface geometry
     template <typename intersection_t>

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -33,16 +33,6 @@ class unmasked {
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = cartesian2<algebra_t>;
-    /// Local point type (2D)
-    template <typename algebra_t>
-    using loc_point_type = typename local_frame_type<algebra_t>::point2;
-
-    /// Measurement frame
-    template <typename algebra_t>
-    using measurement_frame_type = local_frame_type<algebra_t>;
-    /// Local measurement point (2D)
-    template <typename algebra_t>
-    using measurement_point_type = loc_point_type<algebra_t>;
 
     /// Underlying surface geometry: planar
     template <typename intersection_t>

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -60,16 +60,17 @@ struct material_rod {
     template <typename intersection_t>
     DETRAY_HOST_DEVICE scalar_type
     path_segment(const intersection_t& is) const {
-        // Assume that is.p2[0] is radial distance of line intersector
-        if (is.p2[0] > m_radius) {
+        // Assume that is.local[0] is radial distance of line intersector
+        if (is.local[0] > m_radius) {
             return 0.f;
         }
 
         const scalar_type sin_incidence_angle_2{
             1.f - is.cos_incidence_angle * is.cos_incidence_angle};
 
-        return 2.f * std::sqrt((m_radius * m_radius - is.p2[0] * is.p2[0]) /
-                               sin_incidence_angle_2);
+        return 2.f *
+               std::sqrt((m_radius * m_radius - is.local[0] * is.local[0]) /
+                         sin_incidence_angle_2);
     }
     /// Return the path segment in X0
     template <typename intersection_t>

--- a/core/include/detray/propagator/actors/parameter_resetter.hpp
+++ b/core/include/detray/propagator/actors/parameter_resetter.hpp
@@ -42,7 +42,7 @@ struct parameter_resetter : actor {
             // Note: How is it possible with "range"???
             const auto& mask = mask_group[index];
 
-            auto local_coordinate = mask.measurement_frame();
+            auto local_coordinate = mask.local_frame();
 
             // Reset the free vector
             stepping().set_vector(local_coordinate.bound_to_free_vector(

--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -67,7 +67,7 @@ struct parameter_transporter : actor {
 
             // Mask
             const auto& mask = mask_group[index];
-            auto local_coordinate = mask.measurement_frame();
+            auto local_coordinate = mask.local_frame();
 
             // Free vector
             const auto& free_vec = stepping().vector();
@@ -78,15 +78,14 @@ struct parameter_transporter : actor {
 
             // Free to bound jacobian at the destination surface
             const free_to_bound_matrix free_to_bound_jacobian =
-                local_coordinate.free_to_bound_jacobian(trf3, mask, free_vec);
+                local_coordinate.free_to_bound_jacobian(trf3, free_vec);
 
             // Transport jacobian in free coordinate
             free_matrix& free_transport_jacobian = stepping._jac_transport;
 
             // Path correction factor
             free_matrix path_correction = local_coordinate.path_correction(
-                stepping().pos(), stepping().dir(), stepping.dtds(), trf3,
-                mask);
+                stepping().pos(), stepping().dir(), stepping.dtds(), trf3);
 
             const free_matrix correction_term =
                 matrix_operator()

--- a/core/include/detray/tools/bounding_volume.hpp
+++ b/core/include/detray/tools/bounding_volume.hpp
@@ -166,14 +166,12 @@ class axis_aligned_bounding_volume {
         typename transform3_t::point3 {
 
         using point3_t = typename transform3_t::point3;
-        using loc_point_t =
-            typename shape::template loc_point_type<transform3_t>;
 
         if constexpr (std::is_same_v<shape, cuboid3D<>>) {
-            return trf.point_to_global(loc_min<loc_point_t>());
+            return trf.point_to_global(loc_min<point3_t>());
         } else if constexpr (std::is_same_v<shape, cylinder3D>) {
             return cylindrical3<transform3_t>{}.local_to_global(
-                trf, m_mask, loc_min<loc_point_t>());
+                trf, m_mask, loc_min<point3_t>());
         }
 
         // If the volume shape is not supported, return universal minimum
@@ -190,14 +188,12 @@ class axis_aligned_bounding_volume {
         typename transform3_t::point3 {
 
         using point3_t = typename transform3_t::point3;
-        using loc_point_t =
-            typename shape::template loc_point_type<transform3_t>;
 
         if constexpr (std::is_same_v<shape, cuboid3D<>>) {
-            return trf.point_to_global(loc_max<loc_point_t>());
+            return trf.point_to_global(loc_max<point3_t>());
         } else if constexpr (std::is_same_v<shape, cylinder3D>) {
             return cylindrical3<transform3_t>{}.local_to_global(
-                trf, m_mask, loc_max<loc_point_t>());
+                trf, m_mask, loc_max<point3_t>());
         }
 
         // If the volume shape is not supported, return universal minimum

--- a/core/include/detray/tracks/bound_track_parameters.hpp
+++ b/core/include/detray/tracks/bound_track_parameters.hpp
@@ -113,7 +113,7 @@ struct bound_track_parameters {
     void set_covariance(const covariance_type& c) { m_covariance = c; }
 
     DETRAY_HOST_DEVICE
-    point2 local() const { return track_helper().local(m_vector); }
+    point2 bound_local() const { return track_helper().bound_local(m_vector); }
 
     DETRAY_HOST_DEVICE
     scalar_type phi() const {

--- a/core/include/detray/tracks/detail/track_helper.hpp
+++ b/core/include/detray/tracks/detail/track_helper.hpp
@@ -73,7 +73,7 @@ struct track_helper {
     }
 
     DETRAY_HOST_DEVICE
-    inline point2 local(const bound_vector& bound_vec) const {
+    inline point2 bound_local(const bound_vector& bound_vec) const {
         return {matrix_operator().element(bound_vec, e_bound_loc0, 0u),
                 matrix_operator().element(bound_vec, e_bound_loc1, 0u)};
     }

--- a/tests/benchmarks/cpu/masks.cpp
+++ b/tests/benchmarks/cpu/masks.cpp
@@ -22,6 +22,7 @@
 
 // Use the detray:: namespace implicitly.
 using namespace detray;
+using point3 = __plugin::point3<scalar>;
 
 static constexpr unsigned int steps_x3{1000u};
 static constexpr unsigned int steps_y3{1000u};
@@ -54,8 +55,7 @@ void BM_RECTANGLE_2D_MASK(benchmark::State &state) {
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
-                    mask_type::loc_point_t loc_p{
-                        r.to_local_frame(trf, {x, y, z})};
+                    const point3 loc_p{r.to_local_frame(trf, {x, y, z})};
                     if (r.is_inside(loc_p) == intersection::status::e_inside) {
                         ++inside;
                     } else {
@@ -107,8 +107,7 @@ void BM_TRAPEZOID_2D_MASK(benchmark::State &state) {
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
-                    mask_type::loc_point_t loc_p{
-                        t.to_local_frame(trf, {x, y, z})};
+                    const point3 loc_p{t.to_local_frame(trf, {x, y, z})};
                     if (t.is_inside(loc_p) == intersection::status::e_inside) {
                         ++inside;
                     } else {
@@ -160,8 +159,7 @@ void BM_DISC_2D_MASK(benchmark::State &state) {
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
-                    mask_type::loc_point_t loc_p{
-                        r.to_local_frame(trf, {x, y, z})};
+                    const point3 loc_p{r.to_local_frame(trf, {x, y, z})};
                     if (r.is_inside(loc_p) == intersection::status::e_inside) {
                         ++inside;
                     } else {
@@ -213,8 +211,7 @@ void BM_RING_2D_MASK(benchmark::State &state) {
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
-                    mask_type::loc_point_t loc_p{
-                        r.to_local_frame(trf, {x, y, z})};
+                    const point3 loc_p{r.to_local_frame(trf, {x, y, z})};
                     if (r.is_inside(loc_p) == intersection::status::e_inside) {
                         ++inside;
                     } else {
@@ -266,8 +263,7 @@ void BM_CYLINDER_2D_MASK(benchmark::State &state) {
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
-                    mask_type::loc_point_t loc_p{
-                        c.to_local_frame(trf, {x, y, z})};
+                    const point3 loc_p{c.to_local_frame(trf, {x, y, z})};
                     if (c.is_inside(loc_p, 0.1f) ==
                         intersection::status::e_inside) {
                         ++inside;
@@ -318,8 +314,7 @@ void BM_ANNULUS_2D_MASK(benchmark::State &state) {
 
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
-                    mask_type::loc_point_t loc_p{
-                        ann.to_local_frame(trf, {x, y, z})};
+                    const point3 loc_p{ann.to_local_frame(trf, {x, y, z})};
                     if (ann.is_inside(loc_p) ==
                         intersection::status::e_inside) {
                         ++inside;

--- a/tests/common/include/tests/common/check_geometry_navigation.inl
+++ b/tests/common/include/tests/common/check_geometry_navigation.inl
@@ -43,7 +43,7 @@ TEST(ALGEBRA_PLUGIN, straight_line_navigation) {
     // Straight line navigation
     using detector_t = decltype(det);
     using intersection_t =
-        intersection2D_point<typename detector_t::surface_type, transform3_t>;
+        intersection2D<typename detector_t::surface_type, transform3_t>;
     using object_tracer_t =
         object_tracer<intersection_t, dvector, status::e_on_module,
                       status::e_on_portal>;
@@ -140,7 +140,7 @@ TEST(ALGEBRA_PLUGIN, helix_navigation) {
     // Runge-Kutta based navigation
     using detector_t = decltype(det);
     using intersection_t =
-        intersection2D_point<typename detector_t::surface_type, transform3_t>;
+        intersection2D<typename detector_t::surface_type, transform3_t>;
     using object_tracer_t =
         object_tracer<intersection_t, dvector, status::e_on_module,
                       status::e_on_portal>;

--- a/tests/common/include/tests/common/check_simulation.inl
+++ b/tests/common/include/tests/common/check_simulation.inl
@@ -38,7 +38,7 @@ struct test_param {
     }
 
     point2 loc;
-    point2 local() const { return loc; }
+    point2 bound_local() const { return loc; }
 };
 
 // Test measurement smearer

--- a/tests/common/include/tests/common/coordinate_cartesian2.inl
+++ b/tests/common/include/tests/common/coordinate_cartesian2.inl
@@ -42,14 +42,14 @@ TEST(coordinate, cartesian2) {
     } mask;
 
     // Global to local transformation
-    const point2 local = c2.global_to_local(trf, global1, d);
+    const point3 local = c2.global_to_local(trf, global1, d);
 
     // Check if the local position is correct
     ASSERT_NEAR(local[0], 2.f, isclose);
     ASSERT_NEAR(local[1], 4.f, isclose);
 
     // Local to global transformation
-    const point3 global2 = c2.local_to_global(trf, mask, local, d);
+    const point3 global2 = c2.local_to_global(trf, local);
 
     // Check if the same global position is obtained
     ASSERT_NEAR(global1[0], global2[0], isclose);
@@ -83,14 +83,12 @@ TEST(coordinate, cartesian2) {
     }
 
     // Normal vector
-    const vector3 n =
-        c2.normal(trf, mask, free_params.pos(), free_params.dir());
+    const vector3 n = c2.normal(trf, free_params.pos(), free_params.dir());
     ASSERT_EQ(n, vector3({0.f, 0.f, 1.f}));
 
     // Test Jacobian transformation
-    const matrix_type<6, 6> J =
-        c2.free_to_bound_jacobian(trf, mask, free_vec1) *
-        c2.bound_to_free_jacobian(trf, mask, bound_vec);
+    const matrix_type<6, 6> J = c2.free_to_bound_jacobian(trf, free_vec1) *
+                                c2.bound_to_free_jacobian(trf, mask, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {
         for (unsigned int j = 0u; j < 6u; j++) {

--- a/tests/common/include/tests/common/coordinate_cartesian3.inl
+++ b/tests/common/include/tests/common/coordinate_cartesian3.inl
@@ -33,8 +33,6 @@ TEST(coordinate, cartesian3) {
     const point3 global1 = {4.f, 7.f, 5.f};
     const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
-    struct dummy_mask {
-    } mask;
 
     // Global to local transformation
     const point3 local = c3.global_to_local(trf, global1, d);
@@ -45,7 +43,7 @@ TEST(coordinate, cartesian3) {
     ASSERT_NEAR(local[2], 1.f, isclose);
 
     // Local to global transformation
-    const point3 global2 = c3.local_to_global(trf, mask, local, d);
+    const point3 global2 = c3.local_to_global(trf, local);
 
     // Check if the same global position is obtained
     ASSERT_NEAR(global1[0], global2[0], isclose);

--- a/tests/common/include/tests/common/coordinate_cylindrical2.inl
+++ b/tests/common/include/tests/common/coordinate_cylindrical2.inl
@@ -50,14 +50,14 @@ TEST(coordinate, cylindrical2) {
     mask<cylinder2D<>> mask{0u, r, -hz, hz};
 
     // Global to local transformation
-    const point2 local = c2.global_to_local(trf, global1, d);
+    const point3 local = c2.global_to_local(trf, global1, d);
 
     // Check if the local position is correct
     ASSERT_NEAR(local[0], r * constant<scalar>::pi_4, isclose);
     ASSERT_NEAR(local[1], 5.f, isclose);
 
     // Local to global transformation
-    const point3 global2 = c2.local_to_global(trf, mask, local, d);
+    const point3 global2 = c2.local_to_global(trf, local);
 
     // Check if the same global position is obtained
     ASSERT_NEAR(global1[0], global2[0], isclose);
@@ -92,16 +92,14 @@ TEST(coordinate, cylindrical2) {
     }
 
     // Normal vector
-    const vector3 n =
-        c2.normal(trf, mask, free_params.pos(), free_params.dir());
+    const vector3 n = c2.normal(trf, free_params.pos(), free_params.dir());
     ASSERT_NEAR(n[0], constant<scalar>::inv_sqrt2, isclose);
     ASSERT_NEAR(n[1], constant<scalar>::inv_sqrt2, isclose);
     ASSERT_NEAR(n[2], 0.f, isclose);
 
     // Test Jacobian transformation
-    const matrix_type<6, 6> J =
-        c2.free_to_bound_jacobian(trf, mask, free_vec1) *
-        c2.bound_to_free_jacobian(trf, mask, bound_vec);
+    const matrix_type<6, 6> J = c2.free_to_bound_jacobian(trf, free_vec1) *
+                                c2.bound_to_free_jacobian(trf, mask, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {
         for (unsigned int j = 0u; j < 6u; j++) {

--- a/tests/common/include/tests/common/coordinate_cylindrical3.inl
+++ b/tests/common/include/tests/common/coordinate_cylindrical3.inl
@@ -34,8 +34,6 @@ TEST(coordinate, cylindrical3) {
     const point3 global1 = {3.4142136f, 4.4142136f, 9.f};
     const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
-    struct dummy_mask {
-    } mask;
 
     // Global to local transformation
     const point3 local = c3.global_to_local(trf, global1, d);
@@ -46,7 +44,7 @@ TEST(coordinate, cylindrical3) {
     ASSERT_NEAR(local[2], 5.f, isclose);
 
     // Local to global transformation
-    const point3 global2 = c3.local_to_global(trf, mask, local, d);
+    const point3 global2 = c3.local_to_global(trf, local);
 
     // Check if the same global position is obtained
     ASSERT_NEAR(global1[0], global2[0], isclose);

--- a/tests/common/include/tests/common/coordinate_line2.inl
+++ b/tests/common/include/tests/common/coordinate_line2.inl
@@ -44,14 +44,14 @@ TEST(coordinate, line2_case1) {
     } mask;
 
     // Global to local transformation
-    const point2 local = l2.global_to_local(trf, global1, d);
+    const point3 local = l2.global_to_local(trf, global1, d);
 
     // Check if the local position is correct
     ASSERT_NEAR(local[0], -constant<scalar>::inv_sqrt2, isclose);
     ASSERT_NEAR(local[1], std::sqrt(3.f), isclose);
 
     // Local to global transformation
-    const point3 global2 = l2.local_to_global(trf, mask, local, d);
+    const point3 global2 = l2.local_to_global(trf, local);
 
     // Check if the same global position is obtained
     ASSERT_NEAR(global1[0], global2[0], isclose);
@@ -85,9 +85,8 @@ TEST(coordinate, line2_case1) {
     }
 
     // Test Jacobian transformation
-    const matrix_type<6, 6> J =
-        l2.free_to_bound_jacobian(trf, mask, free_vec1) *
-        l2.bound_to_free_jacobian(trf, mask, bound_vec);
+    const matrix_type<6, 6> J = l2.free_to_bound_jacobian(trf, free_vec1) *
+                                l2.bound_to_free_jacobian(trf, mask, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {
         for (unsigned int j = 0u; j < 6u; j++) {
@@ -119,10 +118,10 @@ TEST(coordinate, line2_case2) {
     } mask;
 
     // local to global transformation
-    const point3 global = l2.local_to_global(trf, mask, local1, d);
+    const point3 global = l2.bound_local_to_global(trf, mask, local1, d);
 
     // global to local transform
-    const point2 local2 = l2.global_to_local(trf, global, d);
+    const point3 local2 = l2.global_to_local(trf, global, d);
 
     // Check if the same local position is obtained
     ASSERT_NEAR(local1[0], local2[0], isclose);
@@ -135,7 +134,7 @@ TEST(coordinate, line2_case2) {
     const auto bound_vec = l2.free_to_bound_vector(trf, free_vec);
 
     // Test Jacobian transformation
-    const matrix_type<6, 6> J = l2.free_to_bound_jacobian(trf, mask, free_vec) *
+    const matrix_type<6, 6> J = l2.free_to_bound_jacobian(trf, free_vec) *
                                 l2.bound_to_free_jacobian(trf, mask, bound_vec);
 
     const matrix_operator m;

--- a/tests/common/include/tests/common/coordinate_polar2.inl
+++ b/tests/common/include/tests/common/coordinate_polar2.inl
@@ -42,14 +42,14 @@ TEST(coordinate, polar2) {
     } mask;
 
     // Global to local transformation
-    const point2 local = p2.global_to_local(trf, global1, d);
+    const point3 local = p2.global_to_local(trf, global1, d);
 
     // Check if the local position is correct
     ASSERT_NEAR(local[0], std::sqrt(20.f), isclose);
     ASSERT_NEAR(local[1], std::atan2(4.f, 2.f), isclose);
 
     // Local to global transformation
-    const point3 global2 = p2.local_to_global(trf, mask, local, d);
+    const point3 global2 = p2.local_to_global(trf, local);
 
     // Check if the same global position is obtained
     ASSERT_NEAR(global1[0], global2[0], isclose);
@@ -83,14 +83,12 @@ TEST(coordinate, polar2) {
     }
 
     // Normal vector
-    const vector3 n =
-        p2.normal(trf, mask, free_params.pos(), free_params.dir());
+    const vector3 n = p2.normal(trf, free_params.pos(), free_params.dir());
     ASSERT_EQ(n, vector3({0.f, 0.f, 1.f}));
 
     // Test Jacobian transformation
-    const matrix_type<6, 6> J =
-        p2.free_to_bound_jacobian(trf, mask, free_vec1) *
-        p2.bound_to_free_jacobian(trf, mask, bound_vec);
+    const matrix_type<6, 6> J = p2.free_to_bound_jacobian(trf, free_vec1) *
+                                p2.bound_to_free_jacobian(trf, mask, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {
         for (unsigned int j = 0u; j < 6u; j++) {

--- a/tests/common/include/tests/common/covariance_transport.inl
+++ b/tests/common/include/tests/common/covariance_transport.inl
@@ -22,7 +22,7 @@ using namespace detray;
 using matrix_operator = standard_matrix_operator<scalar>;
 using transform3 = __plugin::transform3<scalar>;
 using vector3 = typename transform3::vector3;
-using intersection_t = intersection2D_point<surface<>, transform3>;
+using intersection_t = intersection2D<surface<>, transform3>;
 
 // Setups
 constexpr const scalar tolerance = scalar(2e-2);
@@ -132,7 +132,7 @@ TEST(helix_covariance_transport, cartesian2D) {
 
         // Reset the free track parameters with the position and direction on
         // the next surface
-        free_trk.set_pos(is.p3);
+        free_trk.set_pos(hlx.pos(path_length));
         free_trk.set_dir(hlx.dir(path_length));
 
         // dtds
@@ -141,7 +141,7 @@ TEST(helix_covariance_transport, cartesian2D) {
         // Path correction
         const cartesian2<transform3>::free_matrix path_correction =
             c2.path_correction(free_trk.pos(), free_trk.dir(), dtds,
-                               trfs[next_index], rectangle);
+                               trfs[next_index]);
 
         // Correction term for the path variation
         const cartesian2<transform3>::free_matrix correction_term =
@@ -150,8 +150,8 @@ TEST(helix_covariance_transport, cartesian2D) {
 
         // Free to bound jacobian
         const typename cartesian2<transform3>::free_to_bound_matrix
-            free_to_bound_jacobi = c2.free_to_bound_jacobian(
-                trfs[next_index], rectangle, free_trk.vector());
+            free_to_bound_jacobi =
+                c2.free_to_bound_jacobian(trfs[next_index], free_trk.vector());
 
         // Full jacobian
         const typename cartesian2<transform3>::bound_matrix full_jacobi =

--- a/tests/common/include/tests/common/masks_annulus2D.inl
+++ b/tests/common/include/tests/common/masks_annulus2D.inl
@@ -12,31 +12,32 @@
 
 using namespace detray;
 using namespace __plugin;
+using point3_t = __plugin::point3<detray::scalar>;
 
 constexpr scalar tol{1e-5f};
 
 /// This tests the basic functionality of a stereo annulus
 TEST(mask, annulus2D) {
-    using point_t = typename mask<annulus2D<>>::loc_point_t;
+    using point_t = point3_t;
 
     constexpr scalar minR{7.2f * unit<scalar>::mm};
     constexpr scalar maxR{12.0f * unit<scalar>::mm};
     constexpr scalar minPhi{0.74195f};
     constexpr scalar maxPhi{1.33970f};
-    point_t offset = {-2.f, 2.f};
+    point_t offset = {-2.f, 2.f, 0.f};
 
     // points in cartesian module frame
-    point_t p2_in = {7.f, 7.f};
-    point_t p2_out1 = {5.f, 5.f};
-    point_t p2_out2 = {10.f, 3.f};
-    point_t p2_out3 = {10.f, 10.f};
-    point_t p2_out4 = {4.f, 10.f};
+    point_t p2_in = {7.f, 7.f, 0.f};
+    point_t p2_out1 = {5.f, 5.f, 0.f};
+    point_t p2_out2 = {10.f, 3.f, 0.f};
+    point_t p2_out3 = {10.f, 10.f, 0.f};
+    point_t p2_out4 = {4.f, 10.f, 0.f};
 
     auto toStripFrame = [&offset](const point_t& xy) -> point_t {
         auto shifted = xy + offset;
         scalar r{getter::perp(shifted)};
         scalar phi{getter::phi(shifted)};
-        return point_t{r, phi};
+        return point_t{r, phi, 0.f};
     };
 
     mask<annulus2D<>> ann2{0u,     minR,      maxR,      minPhi,

--- a/tests/common/include/tests/common/masks_cylinder.inl
+++ b/tests/common/include/tests/common/masks_cylinder.inl
@@ -12,6 +12,7 @@
 
 using namespace detray;
 using namespace __plugin;
+using point3_t = __plugin::point3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
@@ -20,11 +21,11 @@ constexpr scalar hz{4.f * unit<scalar>::mm};
 
 /// This tests the basic functionality of a 2D cylinder
 TEST(mask, cylinder2D) {
-    using point_t = typename mask<cylinder2D<>>::loc_point_t;
+    using point_t = point3_t;
 
-    point_t p2_in = {r, -1.f};
-    point_t p2_edge = {r, hz};
-    point_t p2_out = {3.5f, 4.5f};
+    point_t p2_in = {r, -1.f, r};
+    point_t p2_edge = {r, hz, r};
+    point_t p2_out = {3.5f, 4.5f, 3.5f};
 
     mask<cylinder2D<>> c{0u, r, -hz, hz};
 
@@ -63,7 +64,7 @@ TEST(mask, cylinder2D) {
 
 /// This tests the basic functionality of a 3D cylinder
 TEST(mask, cylinder3D) {
-    using point_t = typename mask<cylinder3D>::loc_point_t;
+    using point_t = point3_t;
 
     point_t p3_in = {r, 0.f, -1.f};
     point_t p3_edge = {0.f, r, hz};

--- a/tests/common/include/tests/common/masks_line.inl
+++ b/tests/common/include/tests/common/masks_line.inl
@@ -12,6 +12,7 @@
 
 using namespace detray;
 using namespace __plugin;
+using point3_t = __plugin::point3<detray::scalar>;
 
 namespace {
 
@@ -25,12 +26,12 @@ constexpr scalar hz{50.f * unit<scalar>::mm};
 
 /// This tests the basic functionality of a line with a radial cross section
 TEST(mask, line_radial_cross_sect) {
-    using point_t = typename mask<line<>>::loc_point_t;
+    using point_t = point3_t;
 
-    const point_t ln_in{0.09f, 0.5f};
-    const point_t ln_edge{1.f, 50.f};
-    const point_t ln_out1{1.2f, 0.f};
-    const point_t ln_out2{0.09f, -51.f};
+    const point_t ln_in{0.09f, 0.5f, 0.f};
+    const point_t ln_edge{1.f, 50.f, 0.f};
+    const point_t ln_out1{1.2f, 0.f, 0.f};
+    const point_t ln_out2{0.09f, -51.f, 0.f};
 
     const mask<line<>> ln{0u, cell_size, hz};
 
@@ -67,11 +68,12 @@ TEST(mask, line_radial_cross_sect) {
 
 /// This tests the basic functionality of a line with a square cross section
 TEST(mask, line_square_cross_sect) {
-    using point_t = typename mask<line<true>>::loc_point_t;
+    using point_t = point3_t;
 
-    const point_t ln_in{0.9f, 0.9f, 0.f};
+    const point_t ln_in{1.1f, 0.9f, constant<scalar>::pi_4};
     const point_t ln_edge{1.f, 1.f, 0.f};
-    const point_t ln_out{1.1f, 0.f, 0.f};
+    const point_t ln_out1{1.1f, 0.f, 0.f};
+    const point_t ln_out2{0.09f, -51.f, 0.f};
 
     // 50 mm wire with 1 mm square cell sizes
     const mask<line<true>> ln{0u, cell_size, hz};
@@ -83,7 +85,8 @@ TEST(mask, line_square_cross_sect) {
     ASSERT_TRUE(ln.is_inside(ln_edge, 1e-5f) == intersection::status::e_inside);
     ASSERT_TRUE(ln.is_inside(ln_edge, -1e-5f) ==
                 intersection::status::e_outside);
-    ASSERT_TRUE(ln.is_inside(ln_out) == intersection::status::e_outside);
+    ASSERT_TRUE(ln.is_inside(ln_out1) == intersection::status::e_outside);
+    ASSERT_TRUE(ln.is_inside(ln_out2) == intersection::status::e_outside);
 
     // Check projection matrix
     const auto proj = ln.projection_matrix<e_bound_size>();

--- a/tests/common/include/tests/common/masks_rectangle2D.inl
+++ b/tests/common/include/tests/common/masks_rectangle2D.inl
@@ -12,6 +12,7 @@
 
 using namespace detray;
 using namespace __plugin;
+using point3_t = __plugin::point3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
@@ -21,11 +22,11 @@ constexpr scalar hz{0.5f * unit<scalar>::mm};
 
 /// This tests the basic functionality of a rectangle
 TEST(mask, rectangle2D) {
-    using point_t = typename mask<rectangle2D<>>::loc_point_t;
+    using point_t = point3_t;
 
-    point_t p2_in = {0.5f, -9.f};
-    point_t p2_edge = {1.f, 9.3f};
-    point_t p2_out = {1.5f, -9.f};
+    point_t p2_in = {0.5f, -9.f, 0.f};
+    point_t p2_edge = {1.f, 9.3f, 0.f};
+    point_t p2_out = {1.5f, -9.f, 0.f};
 
     mask<rectangle2D<>> r2{0u, hx, hy};
 
@@ -63,7 +64,7 @@ TEST(mask, rectangle2D) {
 
 /// This tests the basic functionality of a cuboid3D
 TEST(mask, cuboid3D) {
-    using point_t = typename mask<cuboid3D<>>::loc_point_t;
+    using point_t = point3_t;
 
     point_t p2_in = {0.5f, 8.0f, -0.4f};
     point_t p2_edge = {1.f, 9.3f, 0.5f};

--- a/tests/common/include/tests/common/masks_ring2D.inl
+++ b/tests/common/include/tests/common/masks_ring2D.inl
@@ -11,16 +11,17 @@
 #include "detray/masks/masks.hpp"
 
 using namespace detray;
+using point3_t = __plugin::point3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
 /// This tests the basic functionality of a ring
 TEST(mask, ring2D) {
-    using point_t = typename mask<ring2D<>>::loc_point_t;
+    using point_t = point3_t;
 
-    point_t p2_pl_in = {0.5f, -2.f};
-    point_t p2_pl_edge = {0.f, 3.5f};
-    point_t p2_pl_out = {3.6f, 5.f};
+    point_t p2_pl_in = {0.5f, -2.f, 0.f};
+    point_t p2_pl_edge = {0.f, 3.5f, 0.f};
+    point_t p2_pl_out = {3.6f, 5.f, 0.f};
 
     constexpr scalar inner_r{0.f * unit<scalar>::mm};
     constexpr scalar outer_r{3.5f * unit<scalar>::mm};

--- a/tests/common/include/tests/common/masks_single3D.inl
+++ b/tests/common/include/tests/common/masks_single3D.inl
@@ -12,12 +12,13 @@
 
 using namespace detray;
 using namespace __plugin;
+using point3_t = __plugin::point3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
 /// This tests the basic functionality of a single value mask (index 0)
 TEST(mask, single3_0) {
-    using point_t = typename mask<single3D<>>::loc_point_t;
+    using point_t = point3_t;
 
     point_t p3_in = {0.5f, -9.f, 0.f};
     point_t p3_edge = {1.f, 9.3f, 2.f};
@@ -48,7 +49,7 @@ TEST(mask, single3_0) {
 
 /// This tests the basic functionality of a single value mask (index 1)
 TEST(mask, single3_1) {
-    using point_t = typename mask<single3D<1>>::loc_point_t;
+    using point_t = point3_t;
 
     point_t p3_in = {0.5f, -9.f, 0.f};
     point_t p3_edge = {1.f, 9.3f, 2.f};
@@ -91,7 +92,7 @@ TEST(mask, single3_1) {
 
 /// This tests the basic functionality of a single value mask (index 2)
 TEST(mask, single3_2) {
-    using point_t = typename mask<single3D<2>>::loc_point_t;
+    using point_t = point3_t;
 
     point_t p3_in = {0.5f, -9.f, 0.f};
     point_t p3_edge = {1.f, 9.3f, 2.f};

--- a/tests/common/include/tests/common/masks_trapezoid2D.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2D.inl
@@ -12,16 +12,17 @@
 
 using namespace detray;
 using namespace __plugin;
+using point3_t = __plugin::point3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
 /// This tests the basic functionality of a trapezoid
 TEST(mask, trapezoid2D) {
-    using point_t = typename mask<trapezoid2D<>>::loc_point_t;
+    using point_t = point3_t;
 
-    point_t p2_in = {1.f, -0.5f};
-    point_t p2_edge = {2.5f, 1.f};
-    point_t p2_out = {3.f, 1.5f};
+    point_t p2_in = {1.f, -0.5f, 0.f};
+    point_t p2_edge = {2.5f, 1.f, 0.f};
+    point_t p2_out = {3.f, 1.5f, 0.f};
 
     constexpr scalar hx_miny{1.f * unit<scalar>::mm};
     constexpr scalar hx_maxy{3.f * unit<scalar>::mm};

--- a/tests/common/include/tests/common/masks_unbounded.inl
+++ b/tests/common/include/tests/common/masks_unbounded.inl
@@ -18,6 +18,7 @@
 #include <type_traits>
 
 using namespace detray;
+using point3_t = __plugin::point3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
@@ -42,20 +43,6 @@ TEST(mask, unbounded) {
                        shape_t::template local_frame_type<transform3_t>>,
         "incorrect local frame");
     static_assert(
-        std::is_same_v<unbounded_t::template loc_point_type<transform3_t>,
-                       shape_t::template loc_point_type<transform3_t>>,
-        "incorrect local point");
-    static_assert(
-        std::is_same_v<
-            unbounded_t::template measurement_frame_type<transform3_t>,
-            shape_t::template measurement_frame_type<transform3_t>>,
-        "incorrect measurement frame");
-    static_assert(
-        std::is_same_v<
-            unbounded_t::template measurement_point_type<transform3_t>,
-            shape_t::template measurement_point_type<transform3_t>>,
-        "incorrect measurement point");
-    static_assert(
         std::is_same_v<unbounded_t::template intersector_type<transform3_t>,
                        shape_t::template intersector_type<transform3_t>>,
         "incorrect intersector");
@@ -65,7 +52,7 @@ TEST(mask, unbounded) {
     EXPECT_TRUE(unbounded_t::meas_dim == 2u);
 
     // Test boundary check
-    typename mask<unbounded_t>::loc_point_t p2 = {0.5f, -9.f};
+    typename mask<unbounded_t>::point3_t p2 = {0.5f, -9.f, 0.f};
     ASSERT_TRUE(u.is_inside(p2, 0.f) == intersection::status::e_inside);
 
     // Check projection matrix

--- a/tests/common/include/tests/common/masks_unmasked.inl
+++ b/tests/common/include/tests/common/masks_unmasked.inl
@@ -11,12 +11,13 @@
 #include "detray/masks/unmasked.hpp"
 
 using namespace detray;
+using point3_t = __plugin::point3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
 /// This tests the basic functionality of an unmasked plane
 TEST(mask, unmasked) {
-    typename mask<unmasked>::loc_point_t p2 = {0.5f, -9.f};
+    point3_t p2 = {0.5f, -9.f, 0.f};
 
     mask<unmasked> u{};
 

--- a/tests/common/include/tests/common/test_core.inl
+++ b/tests/common/include/tests/common/test_core.inl
@@ -8,6 +8,7 @@
 // Project include(s)
 #include "detray/geometry/surface.hpp"
 #include "detray/intersection/intersection.hpp"
+#include "detray/utils/invalid_values.hpp"
 
 // Google test include(s)
 #include <gtest/gtest.h>
@@ -61,7 +62,7 @@ TEST(ALGEBRA_PLUGIN, intersection) {
     using intersection_t = intersection2D<surface_t, transform3>;
 
     intersection_t i0 = {surface_t{},
-                         point2{0.2f, 0.4f},
+                         point3{0.2f, 0.4f, 0.f},
                          2.f,
                          1.f,
                          1u,
@@ -70,7 +71,7 @@ TEST(ALGEBRA_PLUGIN, intersection) {
 
     intersection_t i1 = {
         surface_t{},
-        point2{0.2f, 0.4f},
+        point3{0.2f, 0.4f, 0.f},
         1.7f,
         -1.f,
         0u,

--- a/tests/common/include/tests/common/tools/inspectors.hpp
+++ b/tests/common/include/tests/common/tools/inspectors.hpp
@@ -101,6 +101,12 @@ struct print_inspector {
 
         debug_stream << "Surface candidates: " << std::endl;
         for (const auto &sf_cand : state.candidates()) {
+            const auto &local = sf_cand.local;
+            const auto pos = state.detector()->local_to_global(
+                sf_cand.surface.barcode(), local);
+            const auto r{getter::perp(pos)};
+            debug_stream << "[glob: r:" << r << ", z:" << pos[2]
+                         << " | loc: " << local[0] << ", " << local[1] << "] ";
             debug_stream << sf_cand;
         }
         if (not state.candidates().empty()) {

--- a/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
@@ -145,10 +145,9 @@ struct helix_line_intersector {
 
         // Build intersection struct from helix parameters
         sfi.path = s;
-        sfi.p2 = mask.to_measurement_frame(trf, h.pos(s), h.dir(s));
+        sfi.local = mask.to_local_frame(trf, h.pos(s), h.dir(s));
 
-        const typename mask_t::loc_point_t local =
-            mask.to_local_frame(trf, h.pos(s), h.dir(s));
+        const point3 local = mask.to_local_frame(trf, h.pos(s), h.dir(s));
         sfi.status = mask.is_inside(local, mask_tolerance);
 
         // Compute some additional information if the intersection is valid

--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -94,9 +94,8 @@ struct helix_plane_intersector {
 
         // Build intersection struct from helix parameters
         sfi.path = s;
-        sfi.p3 = h.pos(s);
-        sfi.p2 = mask.to_measurement_frame(trf, sfi.p3, h.dir(s));
-        sfi.status = mask.is_inside(sfi.p2, mask_tolerance);
+        sfi.local = mask.to_local_frame(trf, h.pos(s), h.dir(s));
+        sfi.status = mask.is_inside(sfi.local, mask_tolerance);
 
         // Compute some additional information if the intersection is valid
         if (sfi.status == intersection::status::e_inside) {

--- a/tests/common/include/tests/common/tools/particle_gun.hpp
+++ b/tests/common/include/tests/common/tools/particle_gun.hpp
@@ -40,9 +40,8 @@ struct particle_gun {
         typename detector_t::scalar_type mask_tolerance =
             1.f * unit<typename detector_t::scalar_type>::um) {
 
-        using intersection_t =
-            intersection2D_point<typename detector_t::surface_type,
-                                 typename detector_t::transform3>;
+        using intersection_t = intersection2D<typename detector_t::surface_type,
+                                              typename detector_t::transform3>;
 
         std::vector<std::pair<dindex, intersection_t>> intersection_record;
 

--- a/tests/common/include/tests/common/tools/ray_scan_utils.hpp
+++ b/tests/common/include/tests/common/tools/ray_scan_utils.hpp
@@ -170,11 +170,6 @@ inline auto trace_intersections(const record_container &intersection_records,
         inline auto &volume_id() const { return entry.first; }
         inline auto &volume_link() const { return entry.second.volume_link; }
         inline auto &dist() const { return entry.second.path; }
-        inline auto r() const {
-            return std::sqrt(entry.second.p3[0] * entry.second.p3[0] +
-                             entry.second.p3[1] * entry.second.p3[1]);
-        }
-        inline auto z() const { return entry.second.p3[2]; }
 
         // A portal links to another volume than it belongs to
         inline bool is_portal() const {

--- a/tests/common/include/tests/common/tools_particle_gun.inl
+++ b/tests/common/include/tests/common/tools_particle_gun.inl
@@ -40,9 +40,8 @@ TEST(tools, particle_gun) {
 
     // Record ray tracing
     using detector_t = decltype(toy_det);
-    using intersection_t =
-        intersection2D_point<typename detector_t::surface_type,
-                             typename detector_t::transform3>;
+    using intersection_t = intersection2D<typename detector_t::surface_type,
+                                          typename detector_t::transform3>;
     std::vector<std::vector<std::pair<dindex, intersection_t>>> expected;
     //  Iterate through uniformly distributed momentum directions with ray
     for (const auto test_ray :

--- a/tests/common/include/tests/common/tools_planar_intersection.inl
+++ b/tests/common/include/tests/common/tools_planar_intersection.inl
@@ -27,7 +27,7 @@ using namespace detray;
 using vector3 = __plugin::vector3<scalar>;
 using point3 = __plugin::point3<scalar>;
 using transform3 = __plugin::transform3<detray::scalar>;
-using intersection_t = intersection2D_point<surface<>, transform3>;
+using intersection_t = intersection2D<surface<>, transform3>;
 
 constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
 constexpr auto not_defined{detail::invalid_value<scalar>()};
@@ -50,12 +50,14 @@ TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
 
     ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
     // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound.p3[0], 2.f, tol);
-    ASSERT_NEAR(hit_bound.p3[1], 1.f, tol);
-    ASSERT_NEAR(hit_bound.p3[2], 10.f, tol);
+    const auto global0 =
+        unmasked_bound.to_global_frame(shifted, hit_bound.local);
+    ASSERT_NEAR(global0[0], 2.f, tol);
+    ASSERT_NEAR(global0[1], 1.f, tol);
+    ASSERT_NEAR(global0[2], 10.f, tol);
     // Local intersection information
-    ASSERT_NEAR(hit_bound.p2[0], -1.f, tol);
-    ASSERT_NEAR(hit_bound.p2[1], -1.f, tol);
+    ASSERT_NEAR(hit_bound.local[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound.local[1], -1.f, tol);
     // Incidence angle
     ASSERT_NEAR(hit_bound.cos_incidence_angle, 1.f, tol);
 
@@ -64,12 +66,14 @@ TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
     const auto hit_bound_inside = pi(r, surface<>{}, rect_for_inside, shifted);
     ASSERT_TRUE(hit_bound_inside.status == intersection::status::e_inside);
     // Global intersection information - unchanged
-    ASSERT_NEAR(hit_bound_inside.p3[0], 2.f, tol);
-    ASSERT_NEAR(hit_bound_inside.p3[1], 1.f, tol);
-    ASSERT_NEAR(hit_bound_inside.p3[2], 10.f, tol);
+    const auto global1 =
+        rect_for_inside.to_global_frame(shifted, hit_bound_inside.local);
+    ASSERT_NEAR(global1[0], 2.f, tol);
+    ASSERT_NEAR(global1[1], 1.f, tol);
+    ASSERT_NEAR(global1[2], 10.f, tol);
     // Local intersection infoimation - unchanged
-    ASSERT_NEAR(hit_bound_inside.p2[0], -1.f, tol);
-    ASSERT_NEAR(hit_bound_inside.p2[1], -1.f, tol);
+    ASSERT_NEAR(hit_bound_inside.local[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound_inside.local[1], -1.f, tol);
 
     // The same test but bound to local frame & masked - outside
     mask<rectangle2D<>> rect_for_outside{0u, 0.5f, 3.5f};
@@ -77,12 +81,14 @@ TEST(ALGEBRA_PLUGIN, translated_plane_ray) {
         pi(r, surface<>{}, rect_for_outside, shifted);
     ASSERT_TRUE(hit_bound_outside.status == intersection::status::e_outside);
     // Global intersection information - not written out anymore
-    ASSERT_NEAR(hit_bound_outside.p3[0], not_defined, tol);
-    ASSERT_NEAR(hit_bound_outside.p3[1], not_defined, tol);
-    ASSERT_NEAR(hit_bound_outside.p3[2], not_defined, tol);
+    const auto global2 =
+        rect_for_outside.to_global_frame(shifted, hit_bound_outside.local);
+    ASSERT_NEAR(global2[0], 2.f, tol);
+    ASSERT_NEAR(global2[1], 1.f, tol);
+    ASSERT_NEAR(global2[2], 10.f, tol);
     // Local intersection infoimation - unchanged
-    ASSERT_NEAR(hit_bound_outside.p2[0], -1.f, tol);
-    ASSERT_NEAR(hit_bound_outside.p2[1], -1.f, tol);
+    ASSERT_NEAR(hit_bound_outside.local[0], -1.f, tol);
+    ASSERT_NEAR(hit_bound_outside.local[1], -1.f, tol);
 }
 
 // This defines the local frame test suite

--- a/tests/common/include/tests/common/tools_propagator.inl
+++ b/tests/common/include/tests/common/tools_propagator.inl
@@ -66,7 +66,7 @@ struct helix_inspector : actor {
 
             const auto& mask = mask_group[index];
 
-            auto local_coordinate = mask.measurement_frame();
+            auto local_coordinate = mask.local_frame();
 
             return local_coordinate.bound_to_free_vector(
                 trf3, mask, stepping._bound_params.vector());

--- a/tests/common/include/tests/common/tools_track.inl
+++ b/tests/common/include/tests/common/tools_track.inl
@@ -85,9 +85,9 @@ TEST(tools, bound_track_parameters) {
     /// Check the elements
 
     // first track
-    EXPECT_NEAR(bound_param1.local()[0],
+    EXPECT_NEAR(bound_param1.bound_local()[0],
                 getter::element(bound_vec1, e_bound_loc0, 0u), tol);
-    EXPECT_NEAR(bound_param1.local()[1],
+    EXPECT_NEAR(bound_param1.bound_local()[1],
                 getter::element(bound_vec1, e_bound_loc1, 0u), tol);
     EXPECT_NEAR(bound_param1.phi(),
                 getter::element(bound_vec1, e_bound_phi, 0u), tol);
@@ -110,9 +110,9 @@ TEST(tools, bound_track_parameters) {
                 bound_param1.p() * std::cos(bound_param1.theta()), tol);
 
     // second track
-    EXPECT_NEAR(bound_param2.local()[0],
+    EXPECT_NEAR(bound_param2.bound_local()[0],
                 getter::element(bound_vec2, e_bound_loc0, 0u), tol);
-    EXPECT_NEAR(bound_param2.local()[1],
+    EXPECT_NEAR(bound_param2.bound_local()[1],
                 getter::element(bound_vec2, e_bound_loc1, 0u), tol);
     EXPECT_NEAR(bound_param2.phi(),
                 getter::element(bound_vec2, e_bound_phi, 0u), tol);

--- a/tests/unit_tests/cpu/tools_bounding_volume.cpp
+++ b/tests/unit_tests/cpu/tools_bounding_volume.cpp
@@ -14,6 +14,8 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
+using namespace __plugin;
+using point_t = __plugin::point3<detray::scalar>;
 
 namespace {
 
@@ -27,7 +29,6 @@ constexpr scalar tol{1e-5f};
 
 /// This tests the basic functionality cuboid axis aligned bounding box
 GTEST_TEST(detray_tools, bounding_cuboid3D) {
-    using point_t = typename mask<cylinder3D>::loc_point_t;
 
     // cuboid
     constexpr scalar hx{1.f * unit<scalar>::mm};
@@ -63,7 +64,6 @@ GTEST_TEST(detray_tools, bounding_cuboid3D) {
 
 /// This tests the basic functionality cylindrical axis aligned bounding box
 GTEST_TEST(detray_tools, bounding_cylinder3D) {
-    using point_t = typename mask<cylinder3D>::loc_point_t;
 
     // cylinder
     constexpr scalar r{3.f * unit<scalar>::mm};

--- a/tests/unit_tests/device/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda.cpp
@@ -45,12 +45,13 @@ TEST(mask_store_cuda, mask_store) {
     ASSERT_FALSE(store.empty<e_trapezoid2>());
 
     /** Generate random points for test **/
-    vecmem::vector<point2> input_point2(n_points, &mng_mr);
+    vecmem::vector<point3> input_point3(n_points, &mng_mr);
 
     for (unsigned int i = 0u; i < n_points; i++) {
-        point2 rand_point2 = {static_cast<scalar>(rand() % 100) / 10.f,
+        point3 rand_point3 = {static_cast<scalar>(rand() % 100) / 10.f,
+                              static_cast<scalar>(rand() % 100) / 10.f,
                               static_cast<scalar>(rand() % 100) / 10.f};
-        input_point2[i] = rand_point2;
+        input_point3[i] = rand_point3;
     }
 
     /** host output for intersection status **/
@@ -65,11 +66,11 @@ TEST(mask_store_cuda, mask_store) {
 
     /** get host results from is_inside function **/
     for (unsigned int i = 0u; i < n_points; i++) {
-        output_host[0].push_back(rectangle_mask.is_inside(input_point2[i]));
-        output_host[1].push_back(trapezoid_mask.is_inside(input_point2[i]));
-        output_host[2].push_back(ring_mask.is_inside(input_point2[i]));
-        output_host[3].push_back(cylinder_mask.is_inside(input_point2[i]));
-        output_host[4].push_back(annulus_mask.is_inside(input_point2[i]));
+        output_host[0].push_back(rectangle_mask.is_inside(input_point3[i]));
+        output_host[1].push_back(trapezoid_mask.is_inside(input_point3[i]));
+        output_host[2].push_back(ring_mask.is_inside(input_point3[i]));
+        output_host[3].push_back(cylinder_mask.is_inside(input_point3[i]));
+        output_host[4].push_back(annulus_mask.is_inside(input_point3[i]));
     }
 
     /** Helper object for performing memory copies. **/
@@ -82,12 +83,12 @@ TEST(mask_store_cuda, mask_store) {
 
     copy.setup(output_buffer);
 
-    auto input_point2_data = vecmem::get_data(input_point2);
+    auto input_point3_data = vecmem::get_data(input_point3);
     // auto input_point3_data = vecmem::get_data(input_point3);
     auto store_data = get_data(store);
 
     /** run the kernel **/
-    mask_test(store_data, input_point2_data, output_buffer);
+    mask_test(store_data, input_point3_data, output_buffer);
 
     vecmem::jagged_vector<intersection::status> output_device(&mng_mr);
     copy(output_buffer, output_device);

--- a/tests/unit_tests/device/cuda/mask_store_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/mask_store_cuda_kernel.cu
@@ -14,14 +14,14 @@ namespace detray {
 /// return values
 __global__ void mask_test_kernel(
     typename host_store_type::view_type store_data,
-    vecmem::data::vector_view<point2> input_point2_data,
+    vecmem::data::vector_view<point3> input_point3_data,
     vecmem::data::jagged_vector_view<intersection::status> output_data) {
 
     /** get mask store **/
     device_store_type store(store_data);
 
     /** get mask objects **/
-    vecmem::device_vector<point2> input_point2(input_point2_data);
+    vecmem::device_vector<point3> input_point3(input_point3_data);
     vecmem::jagged_device_vector<intersection::status> output_device(
         output_data);
 
@@ -33,24 +33,24 @@ __global__ void mask_test_kernel(
 
     /** get device results from is_inside function **/
     for (int i = 0; i < n_points; i++) {
-        output_device[0].push_back(rectangle_mask.is_inside(input_point2[i]));
-        output_device[1].push_back(trapezoid_mask.is_inside(input_point2[i]));
-        output_device[2].push_back(ring_mask.is_inside(input_point2[i]));
-        output_device[3].push_back(cylinder_mask.is_inside(input_point2[i]));
-        output_device[4].push_back(annulus_mask.is_inside(input_point2[i]));
+        output_device[0].push_back(rectangle_mask.is_inside(input_point3[i]));
+        output_device[1].push_back(trapezoid_mask.is_inside(input_point3[i]));
+        output_device[2].push_back(ring_mask.is_inside(input_point3[i]));
+        output_device[3].push_back(cylinder_mask.is_inside(input_point3[i]));
+        output_device[4].push_back(annulus_mask.is_inside(input_point3[i]));
     }
 }
 
 void mask_test(
     typename host_store_type::view_type store_data,
-    vecmem::data::vector_view<point2> input_point2_data,
+    vecmem::data::vector_view<point3> input_point3_data,
     vecmem::data::jagged_vector_view<intersection::status> output_data) {
 
     int block_dim = 1;
     int thread_dim = 1;
 
     // run the test kernel
-    mask_test_kernel<<<block_dim, thread_dim>>>(store_data, input_point2_data,
+    mask_test_kernel<<<block_dim, thread_dim>>>(store_data, input_point3_data,
                                                 output_data);
 
     // cuda error check

--- a/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
@@ -69,7 +69,7 @@ using device_store_type =
 /// test function for mask store
 void mask_test(
     typename host_store_type::view_type store_data,
-    vecmem::data::vector_view<point2> input_point2_data,
+    vecmem::data::vector_view<point3> input_point3_data,
     vecmem::data::jagged_vector_view<intersection::status> output_data);
 
 }  // namespace detray

--- a/utils/include/detray/simulation/measurement_smearer.hpp
+++ b/utils/include/detray/simulation/measurement_smearer.hpp
@@ -42,7 +42,7 @@ struct measurement_smearer {
 
         std::array<scalar_t, 2> ret;
 
-        const auto local = param.local();
+        const auto local = param.bound_local();
 
         // The radial element of line measurement (ret[0]) always have a
         // positive value


### PR DESCRIPTION
This PR removes the `intersection2D_point` - This a bit complicates the test code but I think it is better to clean up the codes not used in the actual applications 

## UPDATE

I made more changes to simplify the intersector and coordinates.

### Coordinates

So far the local coordinate has been described by two bound parameters
1. cartesian2 (x,y)
2. polar2 (r, phi)
3. cylinder2 (r*phi, z)
4. line2 (r, z)

The problem was that two bound local parameters are not enough to reconstruct the global position for some coordinates. Thus I decided to describe local position with three parameters:

1. cartesian2 (x,y,z)
2. polar2 (r, phi, z)
3. cylinder2 (r*phi, z, r)
4. line2 (r, z, phi) 

The bound track parameters take only the first two local parameters so there is no change in actual tracking algorithm.

There are three coordinate transform functions for every coordinates.  
1. `global_to_local` converts `point3` global position to `point3` local position.
2. `local_to_global` converts `point3` local position to `point3` global position.
3. `bound_local_to_global` converts `point2` bound local position to `point3` global position. This is equivalent to `local_to_global` function of the main branch.

It was also nice that I could remove `mask` input argument from the most of functions in coordinates

### Masks

The advantage of using full three parameters in coordinate is that we don't have to separate the `local_frame` and `measurement_frame`  anymore. And `cylindrical2D` also doesn't need to be defined with `cylindrical3` for radial check because radial information is in the local coordinate

### Intersector

We don't have to have if statement for `radial_check` and `square_cross_section`  for `is_inside` argument because local coordinate holds all information we need