### PR TITLE
Refactor covariance transport test and Add more cases

### DIFF
--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -100,7 +100,7 @@ struct helix_plane_intersector {
         // Compute some additional information if the intersection is valid
         if (sfi.status == intersection::status::e_inside) {
             sfi.surface = sf;
-            sfi.direction = std::signbit(vector::dot(st, h.dir(s)))
+            sfi.direction = std::signbit(s)
                                 ? intersection::direction::e_opposite
                                 : intersection::direction::e_along;
             sfi.volume_link = mask.volume_link();

--- a/tests/unit_tests/cpu/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/covariance_transport.cpp
@@ -13,112 +13,179 @@
 #include "detray/test/types.hpp"
 #include "detray/tracks/tracks.hpp"
 #include "detray/utils/axis_rotation.hpp"
+#include "tests/common/tools/intersectors/helix_cylinder_intersector.hpp"
+#include "tests/common/tools/intersectors/helix_line_intersector.hpp"
 #include "tests/common/tools/intersectors/helix_plane_intersector.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/host_memory_resource.hpp>
 
 // google-test include(s).
 #include <gtest/gtest.h>
 
 using namespace detray;
 
+// Algebra types
 using matrix_operator = standard_matrix_operator<scalar>;
 using transform3 = test::transform3;
 using vector3 = typename transform3::vector3;
 using intersection_t = intersection2D<surface<>, transform3>;
 
-// Setups
-constexpr const scalar tolerance = scalar(2e-2);
-const vector3 z_axis{0.f, 0.f, 1.f};
-const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
+// Mask types to be tested
+using rectangle_type = detray::mask<detray::rectangle2D<>>;
+using trapezoid_type = detray::mask<detray::trapezoid2D<>>;
+using ring_type = detray::mask<detray::ring2D<>>;
+using cylinder_type = detray::mask<detray::cylinder2D<>>;
+using straw_wire_type = detray::mask<detray::line<false>>;
+using cell_wire_type = detray::mask<detray::line<true>>;
 
-// Algebra objects
-constexpr const cartesian2<transform3> c2;
-constexpr const detail::helix_plane_intersector<intersection_t> hpi;
+// Test class for covariance transport
+template <typename T>
+class HelixCovarianceTransportValidation : public ::testing::Test {
+    public:
+    // Environment Setup
+    const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
+    const vector3 y_axis{0.f, 1.f, 0.f};
+    const vector3 z_axis{0.f, 0.f, 1.f};
+    static constexpr const scalar mask_tolerance{1e-3f};
+    static constexpr const scalar tolerance{3e-2f};
 
-/// Test the path correction on a rectangular surface (cartesian coordinates)
-GTEST_TEST(detray_propagation, helix_covariance_transport_cartesian2D) {
+    // Test types
+    using mask_type = T;
+    using local_frame_type = typename mask_type::local_frame_type;
+    using helix_intersector_type = helix_intersector<intersection_t, mask_type>;
 
-    // Rectangle surface with enough size
-    const detray::mask<detray::unbounded<detray::rectangle2D<>>> rectangle{
-        0u, 1e5f * unit<scalar>::mm, 1e5f * unit<scalar>::mm};
+    // First mask at the origin is always rectangle
+    using first_mask_type = rectangle_type;
+    using first_local_frame_type = typename first_mask_type::local_frame_type;
+    using first_helix_intersector_type =
+        detail::helix_plane_intersector<intersection_t>;
 
-    // @NOTE: The test with high energy (>1 GeV) and SINGLE precision fails due
-    // to the numerical instability
-    free_track_parameters<transform3> free_trk(
-        {0.f, 0.f, 0.f}, 0.f, {0.1f * unit<scalar>::GeV, 0.f, 0.f}, -1.f);
+    // Transform3 type
+    using transform3_type = typename local_frame_type::transform3_type;
+    // Scalar type
+    using scalar_type = typename transform3_type::scalar_type;
 
-    // Path length per turn
-    const scalar r{free_trk.p() / getter::norm(B)};
-    const scalar S{2.f * constant<scalar>::pi * r};
+    // Vector and matrix types
+    using free_vector = typename local_frame_type::free_vector;
+    using bound_vector = typename local_frame_type::bound_vector;
+    using bound_matrix = typename local_frame_type::bound_matrix;
+    using free_to_bound_matrix =
+        typename local_frame_type::free_to_bound_matrix;
+    using bound_to_free_matrix =
+        typename local_frame_type::bound_to_free_matrix;
+    using free_matrix = typename local_frame_type::free_matrix;
 
-    // Number of planes and step size between two planes
-    const std::size_t n_planes = 10;
-    const scalar step_size = S / n_planes;
+    std::tuple<rectangle_type, trapezoid_type, ring_type, cylinder_type,
+               straw_wire_type, cell_wire_type>
+        masks = std::make_tuple(
+            rectangle_type{0u, 50 * unit<scalar>::mm, 50 * unit<scalar>::mm},
+            trapezoid_type{0u, 50 * unit<scalar>::mm, 100 * unit<scalar>::mm,
+                           50 * unit<scalar>::mm,
+                           1.f / (2.f * 50 * unit<scalar>::mm)},
+            ring_type{0u, 0.f, 50.f * unit<scalar>::mm},
+            cylinder_type{0u, 0.3f * unit<scalar>::mm,
+                          -100.f * unit<scalar>::mm, 100.f * unit<scalar>::mm},
+            straw_wire_type{0u, 50.f * unit<scalar>::mm,
+                            100.f * unit<scalar>::mm},
+            cell_wire_type{0u, 50.f * unit<scalar>::mm,
+                           100.f * unit<scalar>::mm});
 
-    // Reference Helix
-    detail::helix<transform3> reference_helix(free_trk, &B);
+    // Create transform matrices
+    std::vector<transform3_type> create_transforms(
+        detail::helix<transform3>& reference_helix,
+        const std::size_t n_planes) {
 
-    // Rotation axis in z direction with 20 degree (Can be an arbitrary angle)
-    axis_rotation<transform3> axis_rot(z_axis, constant<scalar>::pi / 9.f);
+        std::vector<transform3> trfs;
 
-    // Prepare transform matrices
-    std::vector<transform3> trfs;
-    for (std::size_t i = 0; i < n_planes; i++) {
+        // Step size between two neighbor planes
+        const scalar_type S{2.f * constant<scalar>::pi /
+                            std::abs(reference_helix._K)};
+        const scalar_type step_size = S / static_cast<scalar_type>(n_planes);
 
-        const scalar s = step_size * scalar(i);
+        for (std::size_t i = 0u; i < n_planes; i++) {
+            const scalar_type s = step_size * scalar_type(i);
 
-        // Translation of the new surface
-        const auto T = reference_helix(s);
+            // Translation of the new surface
+            vector3 trl = reference_helix(s);
 
-        // Normal vector of the new surface
-        auto w = reference_helix.dir(s);
-        w = axis_rot(w);
+            // Normal vector of the new surface
+            vector3 w = reference_helix.dir(s);
+            vector3 v = vector::cross(z_axis, w);
 
-        // Vector on the surface
-        const auto v = vector::cross(z_axis, w);
+            if (i > 0u &&
+                (std::is_same_v<local_frame_type, cylindrical2<transform3>> ||
+                 std::is_same_v<local_frame_type, line2<transform3>>)) {
 
-        // Add transform matrix
-        trfs.emplace_back(T, w, v);
+                const vector3 r_axis = vector::cross(w, z_axis);
+
+                // Rotate for cylinder and wire
+                axis_rotation<transform3> axis_rot(r_axis,
+                                                   constant<scalar>::pi / 2.f);
+
+                // Test masks are rotated
+                w = axis_rot(w);
+                EXPECT_NEAR(getter::norm(r_axis), 1.f, tolerance);
+
+                v = vector::cross(r_axis, w);
+
+                /*
+                const vector3 offset{0.f, 0.f, 10.f * unit<scalar>::mm};
+                trl = trl + offset;
+                */
+            } else {
+
+                // @note why does this offset (in y-direction) fail the test???
+                // const vector3 offset{0.f, 10.f * unit<scalar>::mm, 10.f *
+                // unit<scalar>::mm};
+                const vector3 offset{0.f, 0.f, 10.f * unit<scalar>::mm};
+                trl = trl + offset;
+            }
+
+            // Add transform matrix
+            trfs.emplace_back(trl, w, v);
+        }
+
+        return trfs;
     }
 
-    // Set the initial bound covariance
-    typename bound_track_parameters<transform3>::covariance_type bound_cov0 =
-        matrix_operator().template zero<e_bound_size, e_bound_size>();
-    getter::element(bound_cov0, e_bound_loc0, e_bound_loc0) = 1.f;
-    getter::element(bound_cov0, e_bound_loc1, e_bound_loc1) = 1.f;
-    getter::element(bound_cov0, e_bound_phi, e_bound_phi) = 1.f;
-    // Set theta error to zero, to suppress the loc1 (z) divergence
-    getter::element(bound_cov0, e_bound_theta, e_bound_theta) = 0.f;
-    getter::element(bound_cov0, e_bound_qoverp, e_bound_qoverp) = 1.f;
-    getter::element(bound_cov0, e_bound_time, e_bound_time) = 0.f;
+    // Error propagation
+    template <typename departure_mask_type, typename destination_mask_type>
+    bound_track_parameters<transform3_type> propagate(
+        const bound_track_parameters<transform3>& bound_params,
+        const transform3_type& trf_0, const transform3_type& trf_1,
+        const departure_mask_type& mask_0, const destination_mask_type& mask_1,
+        scalar_type& total_path_length, std::vector<intersection_t>& sfis) {
 
-    // Copy the covariance
-    typename bound_track_parameters<transform3>::covariance_type bound_cov =
-        bound_cov0;
+        const auto departure_frame =
+            typename departure_mask_type::local_frame_type{};
+        const auto destination_frame =
+            typename destination_mask_type::local_frame_type{};
 
-    // Total path length, just for testing purpose
-    scalar total_path_length = 0.f;
+        const bound_vector& bound_vec_0 = bound_params.vector();
+        const bound_matrix& bound_cov_0 = bound_params.covariance();
 
-    // Iterate over the planes until we reach the first plane (one loop)
-    for (std::size_t i_p = 0u; i_p < n_planes; i_p++) {
+        // Free vector at the departure surface
+        const auto free_vec_0 =
+            departure_frame.bound_to_free_vector(trf_0, mask_0, bound_vec_0);
 
-        // Next surface index (circular)
-        const std::size_t next_index = i_p == n_planes - 1 ? 0u : i_p + 1;
+        // Free track at the departure surface
+        free_track_parameters<transform3> free_trk_0;
+        free_trk_0.set_vector(free_vec_0);
 
-        // Helix on the current surface
-        detail::helix<transform3> hlx(free_trk, &B);
+        // Helix from the departure surface
+        detail::helix<transform3> hlx(free_trk_0, &B);
 
-        // bound vector on the current surface
-        const auto bound_vec =
-            c2.free_to_bound_vector(trfs[i_p], free_trk.vector());
-
-        // Bound-to-free jacobian on the current surface
-        const typename cartesian2<transform3>::bound_to_free_matrix
-            bound_to_free_jacobi =
-                c2.bound_to_free_jacobian(trfs[i_p], rectangle, bound_vec);
+        // Bound-to-free jacobian at the departure surface
+        const bound_to_free_matrix bound_to_free_jacobi =
+            departure_frame.bound_to_free_jacobian(trf_0, mask_0, bound_vec_0);
 
         // Get the intersection on the next surface
-        const auto is = hpi(hlx, surface<>{}, rectangle, trfs[next_index]);
-        ASSERT_TRUE(is.status == intersection::status::e_inside);
+        const intersection_t is = get_intersection(
+            helix_intersector<intersection_t, destination_mask_type>{}(
+                hlx, surface<>{}, mask_1, trf_1, this->mask_tolerance));
+
+        sfis.push_back(is);
 
         // Helical path length between two surfaces
         const auto path_length = is.path;
@@ -127,50 +194,165 @@ GTEST_TEST(detray_propagation, helix_covariance_transport_cartesian2D) {
         total_path_length += path_length;
 
         // Free transport jacobian between two surfaces
-        const cartesian2<transform3>::free_matrix transport_jacobi =
-            hlx.jacobian(path_length);
+        const free_matrix transport_jacobi = hlx.jacobian(path_length);
 
-        // Reset the free track parameters with the position and direction on
-        // the next surface
-        free_trk.set_pos(hlx.pos(path_length));
-        free_trk.set_dir(hlx.dir(path_length));
+        // r at the destination surface
+        const vector3 r = hlx.pos(path_length);
 
-        // dtds
-        const vector3 dtds = free_trk.qop() * vector::cross(free_trk.dir(), B);
+        // dr/ds, or t at the destination surface
+        const vector3 t = hlx.dir(path_length);
+
+        // d^2r/ds^2, or dt/ds at the destination surface
+        const vector3 dtds = hlx.qop() * vector::cross(t, B);
+
+        // Free track at the destination surface
+        free_track_parameters<transform3> free_trk_1;
+        free_trk_1.set_pos(r);
+        free_trk_1.set_dir(t);
+        free_trk_1.set_qop(free_trk_0.qop());
 
         // Path correction
-        const cartesian2<transform3>::free_matrix path_correction =
-            c2.path_correction(free_trk.pos(), free_trk.dir(), dtds,
-                               trfs[next_index]);
+        const free_matrix path_correction =
+            destination_frame.path_correction(r, t, dtds, trf_1);
 
         // Correction term for the path variation
-        const cartesian2<transform3>::free_matrix correction_term =
+        const free_matrix correction_term =
             matrix_operator().template identity<e_free_size, e_free_size>() +
             path_correction;
 
-        // Free to bound jacobian
-        const typename cartesian2<transform3>::free_to_bound_matrix
-            free_to_bound_jacobi =
-                c2.free_to_bound_jacobian(trfs[next_index], free_trk.vector());
+        // Free-to-bound jacobian at the destination surface
+        const free_to_bound_matrix free_to_bound_jacobi =
+            destination_frame.free_to_bound_jacobian(trf_1,
+                                                     free_trk_1.vector());
+
+        // Bound vector at the destination surface
+        const bound_vector bound_vec_1 =
+            destination_frame.free_to_bound_vector(trf_1, free_trk_1.vector());
 
         // Full jacobian
-        const typename cartesian2<transform3>::bound_matrix full_jacobi =
-            free_to_bound_jacobi * correction_term * transport_jacobi *
-            bound_to_free_jacobi;
+        const bound_matrix full_jacobi = free_to_bound_jacobi *
+                                         correction_term * transport_jacobi *
+                                         bound_to_free_jacobi;
 
-        // Update the covariance at the next surface
-        bound_cov =
-            full_jacobi * bound_cov * matrix_operator().transpose(full_jacobi);
+        // Update the covariance at the destination surface
+        const bound_matrix bound_cov_1 =
+            full_jacobi * bound_cov_0 *
+            matrix_operator().transpose(full_jacobi);
+
+        bound_track_parameters<transform3> ret;
+        ret.set_vector(bound_vec_1);
+        ret.set_covariance(bound_cov_1);
+
+        return ret;
+    }
+
+    const intersection_t get_intersection(
+        const std::array<intersection_t, 2>& inters) const {
+        return inters[0];
+    }
+
+    const intersection_t get_intersection(const intersection_t& inters) const {
+        return inters;
+    }
+};
+
+using TestTypes =
+    ::testing::Types<rectangle_type, trapezoid_type, ring_type, cylinder_type,
+                     straw_wire_type, cell_wire_type>;
+TYPED_TEST_SUITE(HelixCovarianceTransportValidation, TestTypes, );
+
+TYPED_TEST(HelixCovarianceTransportValidation, one_loop_test) {
+
+    // @NOTE: The test with high energy (>1 GeV) might fail due
+    // to the numerical instability
+    free_track_parameters<transform3> free_trk(
+        {0.f, 0.f, 0.f}, 0.f, {0.1f * unit<scalar>::GeV, 0.f, 0.f}, -1.f);
+
+    detail::helix<transform3> reference_helix(free_trk, &this->B);
+
+    const std::size_t n_planes = 10u;
+    std::vector<transform3> trfs =
+        this->create_transforms(reference_helix, n_planes);
+    ASSERT_EQ(trfs.size(), 10u);
+
+    // Set the initial bound vector
+    typename bound_track_parameters<transform3>::vector_type bound_vec_0 =
+        typename TestFixture::first_local_frame_type{}.free_to_bound_vector(
+            trfs[0], free_trk.vector());
+
+    // Set the initial bound covariance
+    typename bound_track_parameters<transform3>::covariance_type bound_cov_0 =
+        matrix_operator().template zero<e_bound_size, e_bound_size>();
+    getter::element(bound_cov_0, e_bound_loc0, e_bound_loc0) = 1.f;
+    getter::element(bound_cov_0, e_bound_loc1, e_bound_loc1) = 1.f;
+    getter::element(bound_cov_0, e_bound_phi, e_bound_phi) = 1.f;
+    // Set theta error to zero, to suppress the loc1 (z) divergence
+    getter::element(bound_cov_0, e_bound_theta, e_bound_theta) = 0.f;
+    getter::element(bound_cov_0, e_bound_qoverp, e_bound_qoverp) = 1.f;
+    getter::element(bound_cov_0, e_bound_time, e_bound_time) = 0.f;
+
+    // Set bound track parameters
+    bound_track_parameters<transform3> bound_params;
+    bound_params.set_vector(bound_vec_0);
+    bound_params.set_covariance(bound_cov_0);
+
+    // Create masks
+    const auto first_mask = std::get<rectangle_type>(this->masks);
+    const auto test_mask =
+        std::get<typename TestFixture::mask_type>(this->masks);
+
+    // Total path length, just for testing purpose
+    scalar total_path_length = 0.f;
+
+    // Intersections for testing purporse
+    std::vector<intersection_t> sfis;
+
+    // Iterate over the planes until we reach the first plane (one loop)
+    for (std::size_t i_p = 0u; i_p < n_planes; i_p++) {
+
+        if (i_p == 0) {
+            bound_params =
+                this->propagate(bound_params, trfs[i_p], trfs[i_p + 1],
+                                first_mask, test_mask, total_path_length, sfis);
+        } else if (i_p > 0 && i_p < n_planes - 1) {
+
+            bound_params =
+                this->propagate(bound_params, trfs[i_p], trfs[i_p + 1],
+                                test_mask, test_mask, total_path_length, sfis);
+
+        } else if (i_p == n_planes - 1) {
+
+            bound_params =
+                this->propagate(bound_params, trfs[i_p], trfs[0], test_mask,
+                                first_mask, total_path_length, sfis);
+        }
     }
 
     // Check if the total path length is the expected value
-    ASSERT_NEAR(total_path_length, S, tolerance);
+    ASSERT_TRUE(total_path_length > 1e-3);
+    ASSERT_NEAR(total_path_length,
+                2.f * constant<scalar>::pi / std::abs(reference_helix._K),
+                this->tolerance);
 
+    ASSERT_EQ(sfis.size(), n_planes);
+    for (std::size_t i = 0u; i < n_planes; i++) {
+        EXPECT_TRUE(sfis[i].status == intersection::status::e_inside);
+        EXPECT_TRUE(sfis[i].direction == intersection::direction::e_along);
+    }
+
+    // Check if the same vector is obtained after one loop
+    for (unsigned int i = 0u; i < e_bound_size; i++) {
+        EXPECT_NEAR(matrix_operator().element(bound_vec_0, i, 0u),
+                    matrix_operator().element(bound_params.vector(), i, 0u),
+                    this->tolerance);
+    }
     // Check if the same covariance is obtained after one loop
     for (unsigned int i = 0u; i < e_bound_size; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
-            EXPECT_NEAR(matrix_operator().element(bound_cov0, i, j),
-                        matrix_operator().element(bound_cov, i, j), tolerance);
+            EXPECT_NEAR(
+                matrix_operator().element(bound_cov_0, i, j),
+                matrix_operator().element(bound_params.covariance(), i, j),
+                this->tolerance);
         }
     }
 }


### PR DESCRIPTION
This PR refactors covariance transport test to include the other mask types.

The test itself remains the same - deploy the surfaces over the loop and do the propagation for one loop and check that we get the same covariance matrix.

The major change is that the first surface is fixed to be the rectangle regardless of the tested mask type. Otherwise it is hard to propagate the exact one loop for cylinder or line types.