### PR TITLE
Remove multipliers in path length of helix intersector

### DIFF
--- a/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
@@ -81,7 +81,7 @@ struct helix_cylinder_intersector
         // Try to guess the best starting positions for the iteration
 
         // Direction of the track at the helix origin
-        const auto h_dir = h.dir(tol);
+        const auto h_dir = h.dir(0.f);
         // Default starting path length for the Newton iteration (assumes
         // concentric cylinder)
         const scalar_type default_s{r * getter::perp(h_dir)};
@@ -98,13 +98,13 @@ struct helix_cylinder_intersector
         // Note: the default path length might be smaller than either solution
         switch (qe.solutions()) {
             case 2:
-                paths[1] = 0.95f * qe.larger();
+                paths[1] = qe.larger();
                 // If there are two solutions, reuse the case for a single
                 // solution to setup the intersection with the smaller path
                 // in ret[0]
                 [[fallthrough]];
             case 1:
-                paths[0] = 0.95f * qe.smaller();
+                paths[0] = qe.smaller();
         };
 
         // Obtain both possible solutions by looping over the (different)
@@ -116,7 +116,7 @@ struct helix_cylinder_intersector
             intersection_t &is = ret[i];
 
             // Path length in the previous iteration step
-            scalar_type s_prev{0.99f * s};
+            scalar_type s_prev{0.f};
 
             // f(s) = ((h.pos(s) - sc) x sz)^2 - r^2 == 0
             // Run the iteration on s

--- a/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
@@ -100,7 +100,7 @@ struct helix_line_intersector {
         // @NOTE Ray intersection algorithm is used for the initial guess on the
         // path length
         scalar_type s{1.f / denom * (Q - P * lt0)};
-        scalar_type s_prev{0.95f * s};
+        scalar_type s_prev{0.f};
 
         // Run the iteration on s
         std::size_t n_tries{0u};

--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -69,8 +69,8 @@ struct helix_plane_intersector {
         const point3 st = getter::vector<3>(sm, 0u, 3u);
 
         // Starting point on the helix for the Newton iteration
-        scalar_type s{0.99f * getter::norm(st - h.pos(tol))};
-        scalar_type s_prev{0.95f * s};
+        scalar_type s{getter::norm(st - h.pos(0.f))};
+        scalar_type s_prev{0.f};
 
         // f(s) = sn * (h.pos(s) - st) == 0
         // Run the iteration on s


### PR DESCRIPTION
I don't think we need multiplier (or safety factor I guess?) in the path length of helix intersector as long as CI is OK
