### PR TITLE
Refactor projection matrix

### DIFF
--- a/core/include/detray/coordinates/cartesian2.hpp
+++ b/core/include/detray/coordinates/cartesian2.hpp
@@ -10,6 +10,8 @@
 // Project include(s).
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/definitions/track_parametrization.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 namespace detray {
 
@@ -149,6 +151,14 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
         const transform3_t & /*trf3*/, const point3 & /*pos*/,
         const vector3 & /*dir*/) const {
         // Do nothing
+    }
+
+    template <size_type meas_dim, bool normal_order>
+    DETRAY_HOST_DEVICE inline void unsigned_local(
+        matrix_type<meas_dim, e_bound_size> & /*projection_matrix*/,
+        const bound_track_parameters<transform3_t> & /*bound_params*/) {
+        // Do nothing
+        return;
     }
 
 };  // struct cartesian2

--- a/core/include/detray/coordinates/cylindrical2.hpp
+++ b/core/include/detray/coordinates/cylindrical2.hpp
@@ -11,6 +11,7 @@
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 #include "detray/utils/invalid_values.hpp"
 
 // System include(s).
@@ -184,6 +185,15 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
         const vector3 & /*dir*/) const {
         // Do nothing
     }
+
+    template <size_type meas_dim, bool normal_order>
+    DETRAY_HOST_DEVICE inline void unsigned_local(
+        matrix_type<meas_dim, e_bound_size> & /*projection_matrix*/,
+        const bound_track_parameters<transform3_t> & /*bound_params*/) {
+        // Do nothing
+        return;
+    }
+
 };  // struct cylindrical2
 
 }  // namespace detray

--- a/core/include/detray/coordinates/line2.hpp
+++ b/core/include/detray/coordinates/line2.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 namespace detray {
 
@@ -266,6 +267,27 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         matrix_operator().element(bound_to_free_jacobian, e_free_pos2,
                                   e_bound_theta) =
             theta_to_free_pos_derivative[2];
+    }
+
+    template <size_type meas_dim, bool normal_order>
+    DETRAY_HOST_DEVICE inline void unsigned_local(
+        matrix_type<meas_dim, e_bound_size> &projection_matrix,
+        const bound_track_parameters<transform3_t> &bound_params) {
+
+        const auto bound_local = bound_params.bound_local();
+
+        // Change the sign of radial distance if it is negative
+        if (bound_local[0] < 0.f) {
+            if constexpr (normal_order == true) {
+                matrix_operator().element(projection_matrix, 0u, 0u) = -1.f;
+            } else {
+                if constexpr (meas_dim == 2u) {
+                    matrix_operator().element(projection_matrix, 1u, 0u) = -1.f;
+                }
+            }
+        }
+
+        return;
     }
 };
 

--- a/core/include/detray/coordinates/polar2.hpp
+++ b/core/include/detray/coordinates/polar2.hpp
@@ -11,6 +11,7 @@
 #include "detray/coordinates/coordinate_base.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 #include "detray/utils/invalid_values.hpp"
 
 // System include(s).
@@ -203,6 +204,14 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
         const transform3_t & /*trf3*/, const point3 & /*pos*/,
         const vector3 & /*dir*/) const {
         // Do nothing
+    }
+
+    template <size_type meas_dim, bool normal_order>
+    DETRAY_HOST_DEVICE inline void unsigned_local(
+        matrix_type<meas_dim, e_bound_size> & /*projection_matrix*/,
+        const bound_track_parameters<transform3_t> & /*bound_params*/) {
+        // Do nothing
+        return;
     }
 };
 

--- a/core/include/detray/masks/annulus2D.hpp
+++ b/core/include/detray/masks/annulus2D.hpp
@@ -29,6 +29,8 @@ namespace detray {
 /// @tparam intersector_t defines how to intersect the underlying surface
 ///         geometry
 /// @tparam kMeasDim defines the dimension of the measurement
+/// @tparam kNormalOrder true if the index for measurement parameter follows
+/// the local coordinate system
 ///
 /// The stereo annulus is defined in two different(!) polar coordinate systems
 /// that differ by an origin shift. The boundaries are the inner and outer
@@ -46,7 +48,7 @@ namespace detray {
 /// included (bounds[4], bounds[5]). These are the origin shift in x and y
 /// respectively.
 template <template <typename> class intersector_t = plane_intersector,
-          unsigned int kMeasDim = 2u>
+          unsigned int kMeasDim = 1u, bool kNormalOrder = false>
 class annulus2D {
     public:
     /// The name for this shape
@@ -54,6 +56,13 @@ class annulus2D {
 
     /// The measurement dimension
     inline static constexpr const unsigned int meas_dim{kMeasDim};
+
+    /// Normal ordering
+    inline static constexpr const bool normal_order{kNormalOrder};
+
+    // Measurement dimension check
+    static_assert(meas_dim == 1u || meas_dim == 2u,
+                  "Only 1D or 2D measurement is allowed");
 
     /// Names for the mask boundary values
     enum boundaries : unsigned int {

--- a/core/include/detray/masks/cylinder2D.hpp
+++ b/core/include/detray/masks/cylinder2D.hpp
@@ -29,11 +29,13 @@ namespace detray {
 /// @tparam intersector_t defines how to intersect the underlying surface
 ///         geometry
 /// @tparam kMeasDim defines the dimension of the measurement
+/// @tparam kNormalOrder true if the index for measurement parameter follows
+/// the local coordinate system
 ///
 /// It is defined by r and the two half lengths rel to the coordinate center.
 template <bool kRadialCheck = false,
           template <typename> class intersector_t = cylinder_intersector,
-          unsigned int kMeasDim = 2u>
+          unsigned int kMeasDim = 2u, bool kNormalOrder = true>
 class cylinder2D {
     public:
     /// The name for this shape
@@ -44,6 +46,13 @@ class cylinder2D {
 
     /// The measurement dimension
     inline static constexpr const unsigned int meas_dim{kMeasDim};
+
+    /// Normal ordering
+    inline static constexpr const bool normal_order{kNormalOrder};
+
+    // Measurement dimension check
+    static_assert(meas_dim == 1u || meas_dim == 2u,
+                  "Only 1D or 2D measurement is allowed");
 
     enum boundaries : unsigned int {
         e_r = 0u,

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -29,6 +29,8 @@ namespace detray {
 /// @tparam intersector_t defines how to intersect the underlying surface
 ///         geometry
 /// @tparam kMeasDim defines the dimension of the measurement
+/// @tparam kNormalOrder true if the index for measurement parameter follows
+/// the local coordinate system
 ///
 /// The line can either have a circular or a square cross section. In the first
 /// case bounds[0] refers to the radius, while in the second case it is the
@@ -36,7 +38,7 @@ namespace detray {
 /// in z.
 template <bool kSquareCrossSect = false,
           template <typename> class intersector_t = line_intersector,
-          unsigned int kMeasDim = 1u>
+          unsigned int kMeasDim = 1u, bool kNormalOrder = true>
 class line {
     public:
     /// The name for this shape
@@ -47,6 +49,13 @@ class line {
 
     /// The measurement dimension
     inline static constexpr const unsigned int meas_dim{kMeasDim};
+
+    /// Normal ordering
+    inline static constexpr const bool normal_order{kNormalOrder};
+
+    // Measurement dimension check
+    static_assert(meas_dim == 1u || meas_dim == 2u,
+                  "Only 1D or 2D measurement is allowed");
 
     enum boundaries : unsigned int {
         e_cross_section = 0u,

--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/definitions/track_parametrization.hpp"
 #include "detray/intersection/intersection.hpp"
 #include "detray/masks/annulus2D.hpp"
 #include "detray/masks/cuboid3D.hpp"
@@ -61,6 +62,7 @@ class mask {
     using size_type = typename algebra_t::size_type;
     template <size_type ROWS, size_type COLS>
     using matrix_type = typename algebra_t::template matrix_type<ROWS, COLS>;
+    using projection_matrix_type = matrix_type<shape::meas_dim, e_bound_size>;
 
     /// Default constructor
     constexpr mask() = default;
@@ -191,15 +193,12 @@ class mask {
     DETRAY_HOST_DEVICE
     auto volume_link() -> links_type& { return _volume_link; }
 
-    template <size_type parameter_dim>
-    DETRAY_HOST_DEVICE matrix_type<2, parameter_dim> projection_matrix() const {
-
-        auto ret = matrix_operator().template zero<2, parameter_dim>();
-        for (unsigned int i = 0u; i < shape::meas_dim; i++) {
-            matrix_operator().element(ret, i, i) = 1.f;
-        }
-
-        return ret;
+    /// @returns the projection matrix for measurement
+    DETRAY_HOST_DEVICE projection_matrix_type projection_matrix(
+        const bound_track_parameters<algebra_t>& bound_params) const {
+        return this->local_frame()
+            .template projection_matrix<shape::meas_dim, shape::normal_order>(
+                bound_params);
     }
 
     /// @brief Lower and upper point for minimum axis aligned bounding box.

--- a/core/include/detray/masks/rectangle2D.hpp
+++ b/core/include/detray/masks/rectangle2D.hpp
@@ -26,10 +26,12 @@ namespace detray {
 /// @tparam intersector_t defines how to intersect the underlying surface
 ///         geometry
 /// @tparam kMeasDim defines the dimension of the measurement
+/// @tparam kNormalOrder true if the index for measurement parameter follows
+/// the local coordinate system
 ///
 /// It is defined by half length in local0 coordinates bounds[0] and bounds[1]
 template <template <typename> class intersector_t = plane_intersector,
-          unsigned int kMeasDim = 2u>
+          unsigned int kMeasDim = 2u, bool kNormalOrder = true>
 class rectangle2D {
     public:
     /// The name for this shape
@@ -37,6 +39,13 @@ class rectangle2D {
 
     /// The measurement dimension
     inline static constexpr const unsigned int meas_dim{kMeasDim};
+
+    /// Normal ordering
+    inline static constexpr const bool normal_order{kNormalOrder};
+
+    // Measurement dimension check
+    static_assert(meas_dim == 1u || meas_dim == 2u,
+                  "Only 1D or 2D measurement is allowed");
 
     enum boundaries : unsigned int {
         e_half_x = 0u,

--- a/core/include/detray/masks/ring2D.hpp
+++ b/core/include/detray/masks/ring2D.hpp
@@ -26,11 +26,13 @@ namespace detray {
 /// @tparam intersector_t defines how to intersect the underlying surface
 ///         geometry
 /// @tparam kMeasDim defines the dimension of the measurement
+/// @tparam kNormalOrder true if the index for measurement parameter follows
+/// the local coordinate system
 ///
 /// It is defined by the two radii bounds[0] and bounds[1],
 /// and can be checked with a tolerance in t[0] and t[1].
 template <template <typename> class intersector_t = plane_intersector,
-          unsigned int kMeasDim = 2u>
+          unsigned int kMeasDim = 2u, bool kNormalOrder = true>
 class ring2D {
     public:
     /// The name for this shape
@@ -38,6 +40,13 @@ class ring2D {
 
     /// The measurement dimension
     inline static constexpr const unsigned int meas_dim{kMeasDim};
+
+    /// Normal ordering
+    inline static constexpr const bool normal_order{kNormalOrder};
+
+    // Measurement dimension check
+    static_assert(meas_dim == 1u || meas_dim == 2u,
+                  "Only 1D or 2D measurement is allowed");
 
     enum boundaries : unsigned int {
         e_inner_r = 0u,

--- a/core/include/detray/masks/single3D.hpp
+++ b/core/include/detray/masks/single3D.hpp
@@ -29,9 +29,11 @@ namespace detray {
 /// @tparam intersector_t defines how to intersect the underlying surface
 ///         geometry
 /// @tparam kMeasDim defines the dimension of the measurement
+/// @tparam kNormalOrder true if the index for measurement parameter follows
+/// the local coordinate system
 template <unsigned int kCheckIndex = 0u,
           template <typename> class intersector_t = plane_intersector,
-          unsigned int kMeasDim = 2u>
+          unsigned int kMeasDim = 2u, bool kNormalOrder = true>
 class single3D {
     public:
     /// The name for this shape
@@ -39,6 +41,9 @@ class single3D {
 
     /// The measurement dimension
     inline static constexpr const unsigned int meas_dim{kMeasDim};
+
+    /// Normal ordering
+    inline static constexpr const bool normal_order{kNormalOrder};
 
     enum boundaries : unsigned int {
         e_lower = 0u,
@@ -48,7 +53,7 @@ class single3D {
 
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
-    using local_frame_type = cartesian3<algebra_t>;
+    using local_frame_type = cartesian2<algebra_t>;
 
     /// Underlying surface geometry: planar
     template <typename intersection_t>

--- a/core/include/detray/masks/trapezoid2D.hpp
+++ b/core/include/detray/masks/trapezoid2D.hpp
@@ -26,13 +26,15 @@ namespace detray {
 /// @tparam intersector_t defines how to intersect the underlying surface
 ///         geometry
 /// @tparam kMeasDim defines the dimension of the measurement
+/// @tparam kNormalOrder true if the index for measurement parameter follows
+/// the local coordinate system
 ///
 /// It is defined by half lengths in local0 coordinate bounds[0] and bounds[1]
 /// at -/+ half length in the local1 coordinate bounds[2]. bounds[3] contains
 /// the precomputed value of 1 / (2 * bounds[2]), which avoids
 /// excessive floating point divisions.
 template <template <typename> class intersector_t = plane_intersector,
-          unsigned int kMeasDim = 2u>
+          unsigned int kMeasDim = 2u, bool kNormalOrder = true>
 class trapezoid2D {
     public:
     /// The name for this shape
@@ -40,6 +42,13 @@ class trapezoid2D {
 
     /// The measurement dimension
     inline static constexpr const unsigned int meas_dim{kMeasDim};
+
+    /// Normal ordering
+    inline static constexpr const bool normal_order{kNormalOrder};
+
+    // Measurement dimension check
+    static_assert(meas_dim == 1u || meas_dim == 2u,
+                  "Only 1D or 2D measurement is allowed");
 
     enum boundaries : unsigned int {
         e_half_length_0 = 0u,

--- a/core/include/detray/masks/unbounded.hpp
+++ b/core/include/detray/masks/unbounded.hpp
@@ -30,6 +30,9 @@ class unbounded {
     /// The measurement dimension
     inline static constexpr const std::size_t meas_dim = shape::meas_dim;
 
+    /// normal ordering
+    inline static constexpr const bool normal_order = shape::normal_order;
+
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type =

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -28,6 +28,9 @@ class unmasked {
     /// The measurement dimension
     inline static constexpr const unsigned int meas_dim{2u};
 
+    /// normal ordering
+    inline static constexpr const bool normal_order = true;
+
     enum boundaries : unsigned int { e_size = 1u };
 
     /// Local coordinate frame for boundary checks

--- a/tests/common/include/tests/common/masks_annulus2D.inl
+++ b/tests/common/include/tests/common/masks_annulus2D.inl
@@ -9,10 +9,12 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 using namespace detray;
 using namespace __plugin;
 using point3_t = __plugin::point3<detray::scalar>;
+using transform3_t = __plugin::transform3<detray::scalar>;
 
 constexpr scalar tol{1e-5f};
 
@@ -67,15 +69,16 @@ TEST(mask, annulus2D) {
     ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out4), 0.07f) ==
                 intersection::status::e_inside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+
     // Check projection matrix
-    const auto proj = ann2.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
-        for (unsigned int j = 0u; j < e_bound_size; j++) {
-            if (i == j && i < decltype(ann2)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1u);
-            } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0u);
-            }
+    const auto proj = ann2.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < e_bound_size; i++) {
+        if (i == 1u) {
+            ASSERT_EQ(getter::element(proj, 0u, i), 1u);
+        } else {
+            ASSERT_EQ(getter::element(proj, 0u, i), 0u);
         }
     }
 

--- a/tests/common/include/tests/common/masks_cylinder.inl
+++ b/tests/common/include/tests/common/masks_cylinder.inl
@@ -9,10 +9,12 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 using namespace detray;
 using namespace __plugin;
 using point3_t = __plugin::point3<detray::scalar>;
+using transform3_t = __plugin::transform3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
@@ -21,6 +23,7 @@ constexpr scalar hz{4.f * unit<scalar>::mm};
 
 /// This tests the basic functionality of a 2D cylinder
 TEST(mask, cylinder2D) {
+
     using point_t = point3_t;
 
     point_t p2_in = {r, -1.f, r};
@@ -39,11 +42,14 @@ TEST(mask, cylinder2D) {
     // Move outside point inside using a tolerance
     ASSERT_TRUE(c.is_inside(p2_out, 0.6f) == intersection::status::e_inside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+
     // Check projection matrix
-    const auto proj = c.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
+    const auto proj = c.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < decltype(c)::shape::meas_dim; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
-            if (i == j && i < decltype(c)::shape::meas_dim) {
+            if (i == j) {
                 ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
                 ASSERT_EQ(getter::element(proj, i, j), 0u);
@@ -88,18 +94,6 @@ TEST(mask, cylinder3D) {
     ASSERT_TRUE(c.is_inside(p3_off) == intersection::status::e_outside);
     // Move outside point inside using a tolerance
     ASSERT_TRUE(c.is_inside(p3_out, 0.6f) == intersection::status::e_inside);
-
-    // Check projection matrix
-    const auto proj = c.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
-        for (unsigned int j = 0u; j < e_bound_size; j++) {
-            if (i == j && i < decltype(c)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1u);
-            } else {
-                ASSERT_EQ(getter::element(proj, i, j), 0u);
-            }
-        }
-    }
 
     // Check bounding box
     constexpr scalar envelope{0.01f};

--- a/tests/common/include/tests/common/masks_line.inl
+++ b/tests/common/include/tests/common/masks_line.inl
@@ -9,10 +9,12 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 using namespace detray;
 using namespace __plugin;
 using point3_t = __plugin::point3<detray::scalar>;
+using transform3_t = __plugin::transform3<detray::scalar>;
 
 namespace {
 
@@ -43,11 +45,16 @@ TEST(mask, line_radial_cross_sect) {
     ASSERT_TRUE(ln.is_inside(ln_out1) == intersection::status::e_outside);
     ASSERT_TRUE(ln.is_inside(ln_out2) == intersection::status::e_outside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+    auto& bound_vec = bound_params.vector();
+    getter::element(bound_vec, e_bound_loc0, 0u) = 1.f;
+
     // Check projection matrix
-    const auto proj = ln.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
+    const auto proj = ln.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < decltype(ln)::shape::meas_dim; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
-            if (i == j && i < decltype(ln)::shape::meas_dim) {
+            if (i == j) {
                 ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
                 ASSERT_EQ(getter::element(proj, i, j), 0u);
@@ -88,12 +95,21 @@ TEST(mask, line_square_cross_sect) {
     ASSERT_TRUE(ln.is_inside(ln_out1) == intersection::status::e_outside);
     ASSERT_TRUE(ln.is_inside(ln_out2) == intersection::status::e_outside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+    auto& bound_vec = bound_params.vector();
+    getter::element(bound_vec, e_bound_loc0, 0u) = -1.f;
+
     // Check projection matrix
-    const auto proj = ln.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
+    const auto proj = ln.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < decltype(ln)::shape::meas_dim; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
-            if (i == j && i < decltype(ln)::shape::meas_dim) {
-                ASSERT_EQ(getter::element(proj, i, j), 1u);
+            if (i == j) {
+                if (i == 1) {
+                    ASSERT_EQ(getter::element(proj, i, j), -1.f);
+                } else if (i == 2) {
+                    ASSERT_EQ(getter::element(proj, i, j), 1.f);
+                }
             } else {
                 ASSERT_EQ(getter::element(proj, i, j), 0u);
             }

--- a/tests/common/include/tests/common/masks_rectangle2D.inl
+++ b/tests/common/include/tests/common/masks_rectangle2D.inl
@@ -9,10 +9,12 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 using namespace detray;
 using namespace __plugin;
 using point3_t = __plugin::point3<detray::scalar>;
+using transform3_t = __plugin::transform3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
@@ -39,11 +41,14 @@ TEST(mask, rectangle2D) {
     // Move outside point inside using a tolerance
     ASSERT_TRUE(r2.is_inside(p2_out, 1.f) == intersection::status::e_inside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+
     // Check projection matrix
-    const auto proj = r2.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
+    const auto proj = r2.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < decltype(r2)::shape::meas_dim; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
-            if (i == j && i < decltype(r2)::shape::meas_dim) {
+            if (i == j) {
                 ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
                 ASSERT_EQ(getter::element(proj, i, j), 0u);

--- a/tests/common/include/tests/common/masks_ring2D.inl
+++ b/tests/common/include/tests/common/masks_ring2D.inl
@@ -9,9 +9,11 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 using namespace detray;
 using point3_t = __plugin::point3<detray::scalar>;
+using transform3_t = __plugin::transform3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
@@ -38,11 +40,14 @@ TEST(mask, ring2D) {
     ASSERT_TRUE(r2.is_inside(p2_pl_out, 1.2f) ==
                 intersection::status::e_inside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+
     // Check projection matrix
-    const auto proj = r2.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
+    const auto proj = r2.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < decltype(r2)::shape::meas_dim; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
-            if (i == j && i < decltype(r2)::shape::meas_dim) {
+            if (i == j) {
                 ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
                 ASSERT_EQ(getter::element(proj, i, j), 0u);

--- a/tests/common/include/tests/common/masks_single3D.inl
+++ b/tests/common/include/tests/common/masks_single3D.inl
@@ -9,10 +9,12 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 using namespace detray;
 using namespace __plugin;
 using point3_t = __plugin::point3<detray::scalar>;
+using transform3_t = __plugin::transform3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
@@ -67,11 +69,14 @@ TEST(mask, single3_1) {
     // Move outside point inside using a tolerance - take t1 not t1
     ASSERT_TRUE(m1_1.is_inside(p3_out, 0.6f) == intersection::status::e_inside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+
     // Check projection matrix
-    const auto proj = m1_1.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
+    const auto proj = m1_1.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < decltype(m1_1)::shape::meas_dim; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
-            if (i == j && i < decltype(m1_1)::shape::meas_dim) {
+            if (i == j) {
                 ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
                 ASSERT_EQ(getter::element(proj, i, j), 0u);
@@ -110,11 +115,14 @@ TEST(mask, single3_2) {
     // Move outside point inside using a tolerance - take t1 not t1
     ASSERT_TRUE(m1_2.is_inside(p3_out, 6.1f) == intersection::status::e_inside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+
     // Check projection matrix
-    const auto proj = m1_2.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
+    const auto proj = m1_2.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < decltype(m1_2)::shape::meas_dim; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
-            if (i == j && i < decltype(m1_2)::shape::meas_dim) {
+            if (i == j) {
                 ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
                 ASSERT_EQ(getter::element(proj, i, j), 0u);

--- a/tests/common/include/tests/common/masks_trapezoid2D.inl
+++ b/tests/common/include/tests/common/masks_trapezoid2D.inl
@@ -9,10 +9,12 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 using namespace detray;
 using namespace __plugin;
 using point3_t = __plugin::point3<detray::scalar>;
+using transform3_t = __plugin::transform3<detray::scalar>;
 
 constexpr scalar tol{1e-7f};
 
@@ -42,11 +44,14 @@ TEST(mask, trapezoid2D) {
     // Move outside point inside using a tolerance
     ASSERT_TRUE(t2.is_inside(p2_out, 1.) == intersection::status::e_inside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+
     // Check projection matrix
-    const auto proj = t2.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
+    const auto proj = t2.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < decltype(t2)::shape::meas_dim; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
-            if (i == j && i < decltype(t2)::shape::meas_dim) {
+            if (i == j) {
                 ASSERT_EQ(getter::element(proj, i, j), 1u);
             } else {
                 ASSERT_EQ(getter::element(proj, i, j), 0u);

--- a/tests/common/include/tests/common/masks_unbounded.inl
+++ b/tests/common/include/tests/common/masks_unbounded.inl
@@ -9,6 +9,7 @@
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/masks/unbounded.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 // GTest include(s)
 #include <gtest/gtest.h>
@@ -19,12 +20,12 @@
 
 using namespace detray;
 using point3_t = __plugin::point3<detray::scalar>;
+using transform3_t = __plugin::transform3<scalar>;
 
 constexpr scalar tol{1e-7f};
 
 /// This tests the basic functionality of an unbounded rectangle shape
 TEST(mask, unbounded) {
-    using transform3_t = __plugin::transform3<scalar>;
 
     using shape_t = rectangle2D<>;
     using unbounded_t = unbounded<shape_t>;
@@ -55,9 +56,12 @@ TEST(mask, unbounded) {
     typename mask<unbounded_t>::point3_t p2 = {0.5f, -9.f, 0.f};
     ASSERT_TRUE(u.is_inside(p2, 0.f) == intersection::status::e_inside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+
     // Check projection matrix
-    const auto proj = u.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
+    const auto proj = u.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < decltype(u)::shape::meas_dim; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j) {
                 ASSERT_EQ(getter::element(proj, i, j), 1u);

--- a/tests/common/include/tests/common/masks_unmasked.inl
+++ b/tests/common/include/tests/common/masks_unmasked.inl
@@ -9,9 +9,11 @@
 
 #include "detray/masks/masks.hpp"
 #include "detray/masks/unmasked.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
 
 using namespace detray;
 using point3_t = __plugin::point3<detray::scalar>;
+using transform3_t = __plugin::transform3<scalar>;
 
 constexpr scalar tol{1e-7f};
 
@@ -23,9 +25,12 @@ TEST(mask, unmasked) {
 
     ASSERT_TRUE(u.is_inside(p2, 0.f) == intersection::status::e_inside);
 
+    // Dummy bound track parameter
+    bound_track_parameters<transform3_t> bound_params;
+
     // Check projection matrix
-    const auto proj = u.projection_matrix<e_bound_size>();
-    for (unsigned int i = 0u; i < 2u; i++) {
+    const auto proj = u.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < decltype(u)::shape::meas_dim; i++) {
         for (unsigned int j = 0u; j < e_bound_size; j++) {
             if (i == j) {
                 ASSERT_EQ(getter::element(proj, i, j), 1u);

--- a/tests/common/include/tests/common/projection_matrix.inl
+++ b/tests/common/include/tests/common/projection_matrix.inl
@@ -1,0 +1,239 @@
+/** Detray library, part of the ACTS project
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "detray/masks/masks.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
+
+// Google test include(s).
+#include <gtest/gtest.h>
+
+using namespace detray;
+using transform3_t = __plugin::transform3<detray::scalar>;
+
+/// This tests the basic functionality of projection matrix
+TEST(projection_matrix, rectangle) {
+
+    bound_track_parameters<transform3_t> bound_params;
+
+    // 2D, normal ordering
+    mask<rectangle2D<>> rec_0{0u, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ 1 0 0 0 0 0 ]
+    // [ 0 1 0 0 0 0 ]
+    const auto proj_0 = rec_0.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == j) {
+                ASSERT_EQ(getter::element(proj_0, i, j), 1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_0, i, j), 0.f);
+            }
+        }
+    }
+
+    // 2D, reverse ordering
+    mask<rectangle2D<plane_intersector, 2u, false>> rec_1{0u, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ 0 1 0 0 0 0 ]
+    // [ 1 0 0 0 0 0 ]
+    const auto proj_1 = rec_1.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if ((i == 0 && j == 1) || (i == 1 && j == 0)) {
+                ASSERT_EQ(getter::element(proj_1, i, j), 1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_1, i, j), 0.f);
+            }
+        }
+    }
+
+    // 1D, normal ordering
+    mask<rectangle2D<plane_intersector, 1u>> rec_2{0u, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ 1 0 0 0 0 0 ]
+    const auto proj_2 = rec_2.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 1u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == j) {
+                ASSERT_EQ(getter::element(proj_2, i, j), 1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_2, i, j), 0.f);
+            }
+        }
+    }
+
+    // 1D, reverse ordering
+    mask<rectangle2D<plane_intersector, 1u, false>> rec_3{0u, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ 0 1 0 0 0 0 ]
+    const auto proj_3 = rec_3.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 1u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == 0 && j == 1) {
+                ASSERT_EQ(getter::element(proj_3, i, j), 1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_3, i, j), 0.f);
+            }
+        }
+    }
+}
+
+TEST(projection_matrix, annulus) {
+
+    bound_track_parameters<transform3_t> bound_params;
+
+    // 1D reverse ordering
+    mask<annulus2D<>> ann_0{0u, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ 0 1 0 0 0 0 ]
+    const auto proj_0 = ann_0.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 1u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == 0 && j == 1) {
+                ASSERT_EQ(getter::element(proj_0, i, j), 1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_0, i, j), 0.f);
+            }
+        }
+    }
+
+    // 1D normal ordering
+    mask<annulus2D<plane_intersector, 1u, true>> ann_1{0u,  0.f, 0.f, 0.f,
+                                                       0.f, 0.f, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ 1 0 0 0 0 0 ]
+    const auto proj_1 = ann_1.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 1u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == j) {
+                ASSERT_EQ(getter::element(proj_1, i, j), 1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_1, i, j), 0.f);
+            }
+        }
+    }
+
+    // 2D reverse ordering
+    mask<annulus2D<plane_intersector, 2u>> ann_2{0u,  0.f, 0.f, 0.f,
+                                                 0.f, 0.f, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ 0 1 0 0 0 0 ]
+    // [ 1 0 0 0 0 0 ]
+    const auto proj_2 = ann_2.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if ((i == 0 && j == 1) || (i == 1 && j == 0)) {
+                ASSERT_EQ(getter::element(proj_2, i, j), 1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_2, i, j), 0.f);
+            }
+        }
+    }
+
+    // 2D normal ordering
+    mask<annulus2D<plane_intersector, 2u, true>> ann_3{0u,  0.f, 0.f, 0.f,
+                                                       0.f, 0.f, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ 1 0 0 0 0 0 ]
+    // [ 0 1 0 0 0 0 ]
+    const auto proj_3 = ann_3.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == j) {
+                ASSERT_EQ(getter::element(proj_3, i, j), 1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_3, i, j), 0.f);
+            }
+        }
+    }
+}
+
+TEST(projection_matrix, line) {
+
+    bound_track_parameters<transform3_t> bound_params;
+    auto& bound_vec = bound_params.vector();
+    getter::element(bound_vec, e_bound_loc0, 0u) = -1.f;
+
+    // 1D normal ordering
+    mask<line<>> ln_0{0u, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ -1 0 0 0 0 0 ]
+    const auto proj_0 = ln_0.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 1u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == j) {
+                ASSERT_EQ(getter::element(proj_0, i, j), -1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_0, i, j), 0.f);
+            }
+        }
+    }
+
+    // 1D reverse ordering
+    mask<line<false, line_intersector, 1u, false>> ln_1{0u, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ 0 1 0 0 0 0 ]
+    const auto proj_1 = ln_1.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 1u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == 0 && j == 1) {
+                ASSERT_EQ(getter::element(proj_1, i, j), 1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_1, i, j), 0.f);
+            }
+        }
+    }
+
+    // 2D normal ordering
+    mask<line<false, line_intersector, 2u>> ln_2{0u, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [-1 0 0 0 0 0 ]
+    // [ 0 1 0 0 0 0 ]
+    const auto proj_2 = ln_2.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == 0 && j == 0) {
+                ASSERT_EQ(getter::element(proj_2, i, j), -1.f);
+            } else if (i == 1 && j == 1) {
+                ASSERT_EQ(getter::element(proj_2, i, j), 1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_2, i, j), 0.f);
+            }
+        }
+    }
+
+    // 2D reverse ordering
+    mask<line<false, line_intersector, 2u, false>> ln_3{0u, 0.f, 0.f};
+
+    // Check the projection matrix
+    // [ 0 1 0 0 0 0 ]
+    // [-1 0 0 0 0 0 ]
+    const auto proj_3 = ln_3.projection_matrix(bound_params);
+    for (unsigned int i = 0u; i < 2u; i++) {
+        for (unsigned int j = 0u; j < e_bound_size; j++) {
+            if (i == 0 && j == 1) {
+                ASSERT_EQ(getter::element(proj_3, i, j), 1.f);
+            } else if (i == 1 && j == 0) {
+                ASSERT_EQ(getter::element(proj_3, i, j), -1.f);
+            } else {
+                ASSERT_EQ(getter::element(proj_3, i, j), 0.f);
+            }
+        }
+    }
+}

--- a/tests/simulation/run_simulation.cpp
+++ b/tests/simulation/run_simulation.cpp
@@ -42,8 +42,8 @@ int main() {
         theta_steps, phi_steps, ori, mom);
 
     // Create smearer
-    measurement_smearer<scalar> smearer(100.f * unit<scalar>::um,
-                                        100.f * unit<scalar>::um);
+    measurement_smearer<transform3> smearer(100.f * unit<scalar>::um,
+                                            100.f * unit<scalar>::um);
 
     std::size_t n_events = 2u;
     auto sim = simulator(n_events, detector, std::move(generator), smearer);

--- a/tests/unit_tests/cpu/array/CMakeLists.txt
+++ b/tests/unit_tests/cpu/array/CMakeLists.txt
@@ -46,6 +46,7 @@ detray_add_test( array
    "array_navigator.cpp"
    "array_particle_gun.cpp"
    "array_planar_intersection.cpp"
+   "array_projection_matrix.cpp"
    "array_propagator.cpp"
    "array_rectangle2D.cpp"
    "array_ring2D.cpp"

--- a/tests/unit_tests/cpu/array/array_projection_matrix.cpp
+++ b/tests/unit_tests/cpu/array/array_projection_matrix.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/array_definitions.hpp"
+#include "tests/common/projection_matrix.inl"

--- a/tests/unit_tests/cpu/eigen/CMakeLists.txt
+++ b/tests/unit_tests/cpu/eigen/CMakeLists.txt
@@ -46,6 +46,7 @@ detray_add_test( eigen
    "eigen_navigator.cpp"
    "eigen_particle_gun.cpp"
    "eigen_planar_intersection.cpp"
+   "eigen_projection_matrix.cpp"
    "eigen_propagator.cpp"
    "eigen_rectangle2D.cpp"
    "eigen_ring2D.cpp"

--- a/tests/unit_tests/cpu/eigen/eigen_projection_matrix.cpp
+++ b/tests/unit_tests/cpu/eigen/eigen_projection_matrix.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/eigen_definitions.hpp"
+#include "tests/common/projection_matrix.inl"

--- a/tests/unit_tests/cpu/smatrix/CMakeLists.txt
+++ b/tests/unit_tests/cpu/smatrix/CMakeLists.txt
@@ -46,6 +46,7 @@ detray_add_test( smatrix
    "smatrix_navigator.cpp"
    "smatrix_particle_gun.cpp"
    "smatrix_planar_intersection.cpp"
+   "smatrix_projection_matrix.cpp"
    "smatrix_propagator.cpp"
    "smatrix_rectangle2D.cpp"
    "smatrix_ring2D.cpp"

--- a/tests/unit_tests/cpu/smatrix/smatrix_projection_matrix.cpp
+++ b/tests/unit_tests/cpu/smatrix/smatrix_projection_matrix.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/smatrix_definitions.hpp"
+#include "tests/common/projection_matrix.inl"

--- a/tests/unit_tests/cpu/vc/CMakeLists.txt
+++ b/tests/unit_tests/cpu/vc/CMakeLists.txt
@@ -46,6 +46,7 @@ detray_add_test( vc_array
    "vc_array_navigator.cpp"
    "vc_array_particle_gun.cpp"
    "vc_array_planar_intersection.cpp"
+   "vc_array_projection_matrix.cpp"
    "vc_array_propagator.cpp"
    "vc_array_rectangle2D.cpp"
    "vc_array_ring2D.cpp"

--- a/tests/unit_tests/cpu/vc/vc_array_projection_matrix.cpp
+++ b/tests/unit_tests/cpu/vc/vc_array_projection_matrix.cpp
@@ -1,0 +1,9 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/plugins/algebra/vc_array_definitions.hpp"
+#include "tests/common/projection_matrix.inl"

--- a/utils/include/detray/simulation/event_writer.hpp
+++ b/utils/include/detray/simulation/event_writer.hpp
@@ -75,13 +75,13 @@ struct event_writer : actor {
 
         template <typename mask_group_t, typename index_t>
         inline std::array<scalar_type, 2> operator()(
-            const mask_group_t& /*mask_group*/, const index_t& /*index*/,
+            const mask_group_t& mask_group, const index_t& index,
             const bound_track_parameters<transform3_t>& bound_params,
             smearer_t& smearer) const {
 
-            return smearer(mask_group_t::value_type::shape::name,
-                           mask_group_t::value_type::shape::meas_dim,
-                           smearer.get_offset(), bound_params);
+            const auto& mask = mask_group[index];
+
+            return smearer(mask, smearer.get_offset(), bound_params);
         }
     };
 

--- a/utils/include/detray/simulation/measurement_smearer.hpp
+++ b/utils/include/detray/simulation/measurement_smearer.hpp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Project include(s).
+#include "detray/tracks/bound_track_parameters.hpp"
+
 // System include(s).
 #include <array>
 #include <random>
@@ -14,52 +17,69 @@
 
 namespace detray {
 
-template <typename scalar_t>
+template <typename transform3_t>
 struct measurement_smearer {
 
-    measurement_smearer(scalar_t stddev_local0, scalar_t stddev_local1)
+    using matrix_operator = typename transform3_t::matrix_actor;
+    using scalar_type = typename transform3_t::scalar_type;
+    using size_type = typename matrix_operator::size_ty;
+    template <size_type ROWS, size_type COLS>
+    using matrix_type =
+        typename matrix_operator::template matrix_type<ROWS, COLS>;
+
+    measurement_smearer(const scalar_type stddev_local0,
+                        const scalar_type stddev_local1)
         : stddev({stddev_local0, stddev_local1}) {}
 
-    measurement_smearer(measurement_smearer<scalar_t>& smearer)
+    measurement_smearer(measurement_smearer& smearer)
         : stddev(smearer.stddev), generator(smearer.generator) {}
 
     void set_seed(const uint_fast64_t sd) { generator.seed(sd); }
 
-    std::array<scalar_t, 2> stddev;
+    std::array<scalar_type, 2> stddev;
     std::random_device rd{};
     std::mt19937_64 generator{rd()};
 
-    std::array<scalar_t, 2> get_offset() {
-        return {std::normal_distribution<scalar_t>(0.f, stddev[0])(generator),
-                std::normal_distribution<scalar_t>(0.f, stddev[1])(generator)};
+    std::array<scalar_type, 2> get_offset() {
+        return {
+            std::normal_distribution<scalar_type>(0.f, stddev[0])(generator),
+            std::normal_distribution<scalar_type>(0.f, stddev[1])(generator)};
     }
 
-    template <typename local_parameter_t>
-    std::array<scalar_t, 2> operator()(const std::string& name,
-                                       const std::size_t& meas_dim,
-                                       const std::array<scalar_t, 2>& offset,
-                                       const local_parameter_t& param) {
+    template <typename mask_t>
+    std::array<scalar_type, 2> operator()(
+        const mask_t& mask, const std::array<scalar_type, 2>& offset,
+        const bound_track_parameters<transform3_t>& bound_params) {
 
-        std::array<scalar_t, 2> ret;
+        std::array<scalar_type, 2> ret{0.f, 0.f};
 
-        const auto local = param.bound_local();
+        matrix_type<mask_t::shape::meas_dim, 1u> meas =
+            mask.projection_matrix(bound_params) * bound_params.vector();
 
-        // The radial element of line measurement (ret[0]) always have a
-        // positive value
-        if (name == "line") {
-            ret[0] = std::abs(local[0]) + offset[0];
-            if (ret[0] < 0.f) {
-                ret[0] = 0.f;
+        if constexpr (mask_t::shape::meas_dim == 1u) {
+            ret[0u] = matrix_operator().element(meas, 0u, 0u) + offset[0];
+            ret[1u] = scalar_type{0.f};
+            // Special treatment for line coordinate: we don't allow negative
+            // radial distance
+            if (mask_t::shape::name == "line" &&
+                mask_t::shape::normal_order == true) {
+                ret[0u] = std::max(ret[0u], static_cast<scalar_type>(0.f));
             }
-        } else {
-            ret[0] = local[0] + offset[0];
-        }
 
-        // If the measurement dimension is 1, the second element is null
-        if (meas_dim == 1u) {
-            ret[1] = 0.f;
-        } else if (meas_dim == 2u) {
-            ret[1] = local[1] + offset[1];
+        } else if (mask_t::shape::meas_dim == 2u) {
+            ret[0u] = matrix_operator().element(meas, 0u, 0u) + offset[0];
+            ret[1u] = matrix_operator().element(meas, 1u, 0u) + offset[1];
+
+            // Special treatment for line coordinate: we don't allow negative
+            // radial distance
+            if (mask_t::shape::name == "line") {
+
+                if constexpr (mask_t::shape::normal_order == true) {
+                    ret[0u] = std::max(ret[0u], static_cast<scalar_type>(0.f));
+                } else {
+                    ret[1u] = std::max(ret[1u], static_cast<scalar_type>(0.f));
+                }
+            }
         }
 
         return ret;


### PR DESCRIPTION
This PR refactors the projection matrix function of `masks.hpp` and add one more boolean template parameter.

As it is a quite huge refactoring, let me explain in a detail

### Projection matrix dimension

Before this PR, the `projection_matrix()` has a fixed output type `matrix<2, 6>`;
1. For 1D measurement:
[ 1 0 0 0 0 0 ]
[ 0 0 0 0 0 0 ]

2. For 2D measurement:
[ 1 0 0 0 0 0 ]
[ 0 1 0 0 0 0 ]

This is wrong  for 1D measurement which is supposed to be [ 1 0 0 0 0 0 ]. 
Therefore, this PR fixes the `projection_matrix()` output type to be matrix<meas_dim, 6>

### Measurement ordering

As mentioned eariler, I added one more boolean template parameter in mask types which defines whether the measurement index actually follows the local coordinate index.

This idea is triggered by annulus shape (endcap strip) where the polar local coordinate is `(r, phi)` and measurement is `(phi)` (Right? @paulgessinger )

For this annulus shape the projection matrix should be [ 0 1 0 0 0 0 ], so that `projection_matrix * bound_vector` collapses into local phi. Therefore, the boolean parameter was added determine whether we have to use [ 1 0 0 0 0 0 ] or [ 0 1 0 0 0 0 ] depending on the measurement parameter.


### Unsigned local for line mask

The line measurement (straw tube and drift chamber) always have unsigned measurement for the radial distance while the 2D intersection or line coordinate has a signed radial distance depending on the direction of track. When we have a negative radial distance, the projection matrix of [ 1 0 0 0 0 0 ] will produce the nagative measurement which might be wrong

Let's imagine an ideal situation where we do Kalman filtering without any material interaction thru simulation and reconstruction.
There is an interseciton on line whose value is [-3 * cm, 4 * cm ] (The first element is radial and the second one is longitudinal distance). Its measurement will be [ 3* cm]. And if we just use projection matrix of [1 0 0 0 0 0] in Kalman filtering, the residual vector won't be zero as it is supposed to be:
projection_matrix * bound_vector - measurement = [-3 * cm] - [3 * cm] = [-6 * cm]

Therefore, I set up the projection matrix to be [ -1 0 0 0 0 0 ] if the radial distance of the intersection is negatvie, so we have a reasonable residual vector.

Ah,, of course it is a very experimental approach and could be fixed or rolled back later if I don't get a satisfactory result from the KF with line detector



