### PR TITLE
Add transform3 type definitions and fix a bug in line coordinate

### DIFF
--- a/core/include/detray/coordinates/cartesian2.hpp
+++ b/core/include/detray/coordinates/cartesian2.hpp
@@ -23,6 +23,8 @@ struct cartesian2 final : public coordinate_base<cartesian2, transform3_t> {
     /// @name Type definitions for the struct
     /// @{
 
+    // Transform type
+    using transform3_type = transform3_t;
     // Base type
     using base_type = coordinate_base<cartesian2, transform3_t>;
     // Sclar type

--- a/core/include/detray/coordinates/coordinate_base.hpp
+++ b/core/include/detray/coordinates/coordinate_base.hpp
@@ -30,6 +30,8 @@ struct coordinate_base {
     /// @name Type definitions for the struct
     /// @{
 
+    // Transform type
+    using transform3_type = transform3_t;
     // Scalar type
     using scalar_type = typename transform3_t::scalar_type;
     // Point in 2D space

--- a/core/include/detray/coordinates/cylindrical2.hpp
+++ b/core/include/detray/coordinates/cylindrical2.hpp
@@ -27,6 +27,8 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
     /// @name Type definitions for the struct
     /// @{
 
+    // Transform type
+    using transform3_type = transform3_t;
     // Base type
     using base_type = coordinate_base<cylindrical2, transform3_t>;
     // Sclar type

--- a/core/include/detray/coordinates/line2.hpp
+++ b/core/include/detray/coordinates/line2.hpp
@@ -20,6 +20,8 @@ struct line2 : public coordinate_base<line2, transform3_t> {
     /// @name Type definitions for the struct
     /// @{
 
+    // Transform type
+    using transform3_type = transform3_t;
     // Base type
     using base_type = coordinate_base<line2, transform3_t>;
     // Sclar type
@@ -148,7 +150,7 @@ struct line2 : public coordinate_base<line2, transform3_t> {
         const vector3 pc = pos - center;
 
         // The local frame z axis
-        const vector3 local_zaxis = getter::vector<3>(trf3, 0u, 2u);
+        const vector3 local_zaxis = getter::vector<3>(trf3.matrix(), 0u, 2u);
 
         // The local z coordinate
         const scalar_type pz = vector::dot(pc, local_zaxis);

--- a/core/include/detray/coordinates/polar2.hpp
+++ b/core/include/detray/coordinates/polar2.hpp
@@ -25,6 +25,8 @@ struct polar2 : public coordinate_base<polar2, transform3_t> {
     /// @name Type definitions for the struct
     /// @{
 
+    // Transform type
+    using transform3_type = transform3_t;
     // Base type
     using base_type = coordinate_base<polar2, transform3_t>;
     // Sclar type


### PR DESCRIPTION
This PR is taken from #457. I just wanted to fix a bug in line coordinate quickly :p