### PR TITLE
refactor ray and helix

### DIFF
--- a/core/include/detray/tracks/bound_track_parameters.hpp
+++ b/core/include/detray/tracks/bound_track_parameters.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 // Project include(s).
-#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/track_parametrization.hpp"
@@ -130,24 +129,13 @@ struct bound_track_parameters {
     vector3 dir() const { return track_helper().dir(m_vector); }
 
     DETRAY_HOST_DEVICE
-    scalar_type time() const {
-        return matrix_operator().element(m_vector, e_bound_time, 0u);
-    }
+    scalar_type time() const { return track_helper().time(m_vector); }
 
     DETRAY_HOST_DEVICE
-    scalar_type charge() const {
-        if (std::signbit(
-                matrix_operator().element(m_vector, e_bound_qoverp, 0u))) {
-            return -1.f;
-        } else {
-            return 1.f;
-        }
-    }
+    scalar_type charge() const { return track_helper().charge(m_vector); }
 
     DETRAY_HOST_DEVICE
-    scalar_type qop() const {
-        return matrix_operator().element(m_vector, e_bound_qoverp, 0u);
-    }
+    scalar_type qop() const { return track_helper().qop(m_vector); }
 
     DETRAY_HOST_DEVICE
     void set_qop(const scalar_type qop) {
@@ -155,10 +143,10 @@ struct bound_track_parameters {
     }
 
     DETRAY_HOST_DEVICE
-    scalar_type p() const { return charge() / qop(); }
+    scalar_type p() const { return track_helper().p(m_vector); }
 
     DETRAY_HOST_DEVICE
-    vector3 mom() const { return this->p() * this->dir(); }
+    vector3 mom() const { return track_helper().mom(m_vector); }
 
     private:
     geometry::barcode m_barcode;

--- a/core/include/detray/tracks/detail/track_helper.hpp
+++ b/core/include/detray/tracks/detail/track_helper.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/track_parametrization.hpp"
@@ -88,6 +89,62 @@ struct track_helper {
 
         return {math_ns::cos(phi) * sinTheta, math_ns::sin(phi) * sinTheta,
                 math_ns::cos(theta)};
+    }
+
+    DETRAY_HOST_DEVICE
+    inline scalar_type p(const free_vector& free_vec) const {
+        return charge(free_vec) / qop(free_vec);
+    }
+
+    DETRAY_HOST_DEVICE
+    inline scalar_type p(const bound_vector& bound_vec) const {
+        return charge(bound_vec) / qop(bound_vec);
+    }
+
+    DETRAY_HOST_DEVICE
+    inline vector3 mom(const free_vector& free_vec) const {
+        return p(free_vec) * dir(free_vec);
+    }
+
+    DETRAY_HOST_DEVICE
+    inline vector3 mom(const bound_vector& bound_vec) const {
+        return p(bound_vec) * dir(bound_vec);
+    }
+
+    DETRAY_HOST_DEVICE
+    inline scalar_type qop(const free_vector& free_vec) const {
+        return matrix_operator().element(free_vec, e_free_qoverp, 0u);
+    }
+
+    DETRAY_HOST_DEVICE
+    inline scalar_type qop(const bound_vector& bound_vec) const {
+        return matrix_operator().element(bound_vec, e_bound_qoverp, 0u);
+    }
+
+    DETRAY_HOST_DEVICE
+    inline scalar_type time(const free_vector& free_vec) const {
+        return matrix_operator().element(free_vec, e_free_time, 0u);
+    }
+
+    DETRAY_HOST_DEVICE
+    inline scalar_type time(const bound_vector& bound_vec) const {
+        return matrix_operator().element(bound_vec, e_bound_time, 0u);
+    }
+
+    DETRAY_HOST_DEVICE
+    inline scalar_type charge(const free_vector& free_vec) const {
+        return std::signbit(
+                   matrix_operator().element(free_vec, e_free_qoverp, 0u))
+                   ? -1.f
+                   : 1.f;
+    }
+
+    DETRAY_HOST_DEVICE
+    inline scalar_type charge(const bound_vector& bound_vec) const {
+        return std::signbit(
+                   matrix_operator().element(bound_vec, e_bound_qoverp, 0u))
+                   ? -1.f
+                   : 1.f;
     }
 };
 

--- a/core/include/detray/tracks/free_track_parameters.hpp
+++ b/core/include/detray/tracks/free_track_parameters.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 // Project include(s).
-#include "detray/definitions/algebra.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/track_parametrization.hpp"
 #include "detray/tracks/detail/track_helper.hpp"
@@ -131,22 +130,13 @@ struct free_track_parameters {
     void set_dir(const vector3& dir) { track_helper().set_dir(m_vector, dir); }
 
     DETRAY_HOST_DEVICE
-    scalar_type time() const {
-        return matrix_operator().element(m_vector, e_free_time, 0u);
-    }
+    scalar_type time() const { return track_helper().time(m_vector); }
 
     DETRAY_HOST_DEVICE
-    scalar_type charge() const {
-        return std::signbit(
-                   matrix_operator().element(m_vector, e_free_qoverp, 0u))
-                   ? -1.f
-                   : 1.f;
-    }
+    scalar_type charge() const { return track_helper().charge(m_vector); }
 
     DETRAY_HOST_DEVICE
-    scalar_type qop() const {
-        return matrix_operator().element(m_vector, e_free_qoverp, 0u);
-    }
+    scalar_type qop() const { return track_helper().qop(m_vector); }
 
     DETRAY_HOST_DEVICE
     void set_qop(const scalar_type qop) {
@@ -154,10 +144,10 @@ struct free_track_parameters {
     }
 
     DETRAY_HOST_DEVICE
-    scalar_type p() const { return charge() / qop(); }
+    scalar_type p() const { return track_helper().p(m_vector); }
 
     DETRAY_HOST_DEVICE
-    vector3 mom() const { return this->p() * this->dir(); }
+    vector3 mom() const { return track_helper().mom(m_vector); }
 
     DETRAY_HOST_DEVICE
     scalar_type pT() const {

--- a/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
@@ -93,7 +93,7 @@ struct helix_cylinder_intersector
         // try to guess good starting path by calculating the intersection path
         // of the helix tangential with the cylinder. This only has a chance
         // of working for tracks with reasonably high p_T !
-        detail::ray<transform3_type> t{h.pos(), h.time(), h_dir, h.charge()};
+        detail::ray<transform3_type> t{h.pos(), h.time(), h_dir, h.qop()};
         const auto qe = this->solve_intersection(t, mask, trf);
 
         // Note: the default path length might be smaller than either solution

--- a/tests/unit_tests/cpu/tools_helix_trajectory.cpp
+++ b/tests/unit_tests/cpu/tools_helix_trajectory.cpp
@@ -44,6 +44,8 @@ GTEST_TEST(detray_intersection, helix_trajectory) {
 
     // helix trajectory
     detail::helix helix_traj(vertex, &B);
+    EXPECT_NEAR(helix_traj.time(), 0.f, tol);
+    EXPECT_NEAR(helix_traj.qop(), -constant<scalar>::inv_sqrt2, tol);
 
     // radius of helix
     scalar R{helix_traj.radius()};
@@ -120,6 +122,8 @@ GTEST_TEST(detray_intersection, helix_trajectory_small_pT) {
 
     // helix trajectory
     detail::helix helix_traj(vertex, &B);
+    EXPECT_NEAR(helix_traj.time(), 0.f, tol);
+    EXPECT_NEAR(helix_traj.qop(), -1.f, tol);
 
     // After 10 mm
     const scalar path_length{10.f * unit<scalar>::mm};


### PR DESCRIPTION
The motivation for this PR is to construct a ray with `free_vector` (Required for CKF). The constructors for both ray and helix also refactored  consistently
Also I removed the inheritance of free_track_parameter in helix class. I thought it is pretty weird that we are calling the free track parameter constructor which creates a covariance matrix