### PR TITLE
Replace intersection type template parameter with transform3 type

### DIFF
--- a/core/include/detray/intersection/concentric_cylinder_intersector.hpp
+++ b/core/include/detray/intersection/concentric_cylinder_intersector.hpp
@@ -23,19 +23,19 @@ namespace detray {
 
 /// A functor to find intersections between trajectory and concentric cylinder
 /// mask
-template <typename intersection_t>
+template <typename transform3_t>
 struct concentric_cylinder_intersector {
 
     /// linear algebra types
     /// @{
-    using transform3_type = typename intersection_t::transform3_type;
+    using transform3_type = transform3_t;
     using scalar_type = typename transform3_type::scalar_type;
     using point3 = typename transform3_type::point3;
     using point2 = typename transform3_type::point2;
     using vector3 = typename transform3_type::vector3;
     /// @}
 
-    using intersection_type = intersection_t;
+    using intersection_type = intersection2D<transform3_t>;
     using ray_type = detail::ray<transform3_type>;
 
     /// Operator function to find intersections between ray and concentric

--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -22,19 +22,19 @@
 namespace detray {
 
 /// A functor to find intersections between a ray and a 2D cylinder mask
-template <typename intersection_t>
+template <typename transform3_t>
 struct cylinder_intersector {
 
     /// linear algebra types
     /// @{
-    using transform3_type = typename intersection_t::transform3_type;
+    using transform3_type = transform3_t;
     using scalar_type = typename transform3_type::scalar_type;
     using point3 = typename transform3_type::point3;
     using point2 = typename transform3_type::point2;
     using vector3 = typename transform3_type::vector3;
     /// @}
 
-    using intersection_type = intersection_t;
+    using intersection_type = intersection2D<transform3_type>;
     using ray_type = detail::ray<transform3_type>;
 
     /// Operator function to find intersections between a ray and a 2D cylinder
@@ -50,7 +50,7 @@ struct cylinder_intersector {
     ///
     /// @return the intersections.
     template <typename mask_t, typename surface_t>
-    DETRAY_HOST_DEVICE inline std::array<intersection_t, 2> operator()(
+    DETRAY_HOST_DEVICE inline std::array<intersection_type, 2> operator()(
         const ray_type &ray, const surface_t &sf, const mask_t &mask,
         const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
@@ -58,7 +58,7 @@ struct cylinder_intersector {
         // One or both of these solutions might be invalid
         const auto qe = solve_intersection(ray, mask, trf);
 
-        std::array<intersection_t, 2> ret;
+        std::array<intersection_type, 2> ret;
         switch (qe.solutions()) {
             case 2:
                 ret[1] = build_candidate(ray, mask, trf, qe.larger(),
@@ -98,7 +98,7 @@ struct cylinder_intersector {
                                               cylindrical2<transform3_type>>,
                                bool> = true>
     DETRAY_HOST_DEVICE inline void update(
-        const ray_type &ray, intersection_t &sfi, const mask_t &mask,
+        const ray_type &ray, intersection_type &sfi, const mask_t &mask,
         const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
 
@@ -148,11 +148,11 @@ struct cylinder_intersector {
     /// if the overstepping tolerance is not met or the intersection lies
     /// outside of the mask.
     template <typename mask_t>
-    DETRAY_HOST_DEVICE inline intersection_t build_candidate(
+    DETRAY_HOST_DEVICE inline intersection_type build_candidate(
         const ray_type &ray, const mask_t &mask, const transform3_type &trf,
         const scalar_type path, const scalar_type mask_tolerance = 0.f) const {
 
-        intersection_t is;
+        intersection_type is;
 
         // Construct the candidate only when needed
         if (path >= ray.overstep_tolerance()) {

--- a/core/include/detray/intersection/cylinder_portal_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_portal_intersector.hpp
@@ -26,20 +26,20 @@ namespace detray {
 ///
 /// With the way the navigation works, only the closest one of the two possible
 /// intersection points is needed in the case of a cylinderical portal surface.
-template <typename intersection_t>
+template <typename transform3_t>
 struct cylinder_portal_intersector
     : public cylinder_intersector<intersection_t> {
 
     /// linear algebra types
     /// @{
-    using transform3_type = typename intersection_t::transform3_type;
+    using transform3_type = transform3_t;
     using scalar_type = typename transform3_type::scalar_type;
     using point3 = typename transform3_type::point3;
     using point2 = typename transform3_type::point2;
     using vector3 = typename transform3_type::vector3;
     /// @}
 
-    using intersection_type = intersection_t;
+    using intersection_type = intersection2D<transform3_t>;
     using ray_type = detail::ray<transform3_type>;
 
     /// Operator function to find intersections between ray and cylinder mask

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -12,6 +12,7 @@
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/geometry/barcode.hpp"
 #include "detray/utils/invalid_values.hpp"
 
 // System include(s)
@@ -41,20 +42,21 @@ enum class status : std::uint_least8_t {
 }  // namespace intersection
 
 /// @brief This class holds the intersection information.
-///
-/// @tparam surface_descr_t is the type of surface descriptor
-template <typename surface_descr_t,
-          typename algebra_t = __plugin::transform3<detray::scalar>>
+template <typename algebra_t>
 struct intersection2D {
 
     using transform3_type = algebra_t;
     using scalar_type = typename algebra_t::scalar_type;
     using point3 = typename algebra_t::point3;
     using point2 = typename algebra_t::point2;
-    using nav_link_type = typename surface_descr_t::navigation_link;
+
+    DETRAY_HOST_DEVICE
+    intersection2D(const detray::geometry::barcode &surface_link)
+        : m_surface_link(surface_link) {}
+    intersection2D() = delete;
 
     /// Descriptor of the surface this intersection belongs to
-    surface_descr_t surface;
+    detray::geometry::barcode m_surface_link;
 
     /// Local position of the intersection on the surface
     point3 local{detail::invalid_value<scalar_type>(),
@@ -68,7 +70,7 @@ struct intersection2D {
     scalar_type cos_incidence_angle{detail::invalid_value<scalar_type>()};
 
     /// Navigation information (next volume to go to)
-    nav_link_type volume_link{detail::invalid_value<nav_link_type>()};
+    dindex volume_link{detail::invalid_value<dindex>()};
 
     /// Result of the intersection
     intersection::status status{intersection::status::e_undefined};
@@ -99,8 +101,7 @@ struct intersection2D {
     DETRAY_HOST
     friend std::ostream &operator<<(std::ostream &out_stream,
                                     const intersection2D &is) {
-        out_stream << "dist:" << is.path
-                   << ", (sf index:" << is.surface.barcode()
+        out_stream << "dist:" << is.path << ", (sf index:" << is.m_surface_link
                    << ", links to vol:" << is.volume_link << ")";
         switch (is.status) {
             case intersection::status::e_outside:

--- a/core/include/detray/intersection/intersection_kernel.hpp
+++ b/core/include/detray/intersection/intersection_kernel.hpp
@@ -111,20 +111,22 @@ struct intersection_update {
     ///
     /// @return the intersection
     template <typename mask_group_t, typename mask_range_t, typename traj_t,
-              typename intersection_t, typename transform_container_t>
+              typename surface_t, typename transform3_t,
+              typename transform_container_t>
     DETRAY_HOST_DEVICE inline bool operator()(
         const mask_group_t &mask_group, const mask_range_t &mask_range,
-        const traj_t &traj, intersection_t &sfi,
+        const traj_t &traj, intersection2D<transform3_t> &sfi,
+        const surface_t &surface,
         const transform_container_t &contextual_transforms,
         const scalar mask_tolerance = 0.f) const {
 
-        const auto &ctf = contextual_transforms[sfi.surface.transform()];
+        const auto &ctf = contextual_transforms[surface.transform()];
 
         // Run over the masks that belong to the surface
         for (const auto &mask :
              detray::ranges::subrange(mask_group, mask_range)) {
 
-            mask.template intersector<intersection_t>().update(
+            mask.template intersector<transform3_t>().update(
                 traj, sfi, mask, ctf, mask_tolerance);
 
             if (sfi.status == intersection::status::e_inside) {

--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -20,19 +20,19 @@
 namespace detray {
 
 /// A functor to find intersections between trajectory and line mask
-template <typename intersection_t>
+template <typename transform3_t>
 struct line_intersector {
 
     /// linear algebra types
     /// @{
-    using transform3_type = typename intersection_t::transform3_type;
+    using transform3_type = transform3_t;
     using scalar_type = typename transform3_type::scalar_type;
     using point3 = typename transform3_type::point3;
     using point2 = typename transform3_type::point2;
     using vector3 = typename transform3_type::vector3;
     /// @}
 
-    using intersection_type = intersection_t;
+    using intersection_type = intersection2D<transform3_type>;
     using ray_type = detail::ray<transform3_type>;
 
     /// Operator function to find intersections between ray and line mask
@@ -130,10 +130,7 @@ struct line_intersector {
     /// @param mask is the input mask that defines the surface extent
     /// @param trf is the surface placement transform
     /// @param mask_tolerance is the tolerance for mask edges
-    template <typename mask_t,
-              std::enable_if_t<std::is_same_v<typename mask_t::local_frame_type,
-                                              line2<transform3_type>>,
-                               bool> = true>
+    template <typename mask_t>
     DETRAY_HOST_DEVICE inline void update(
         const ray_type &ray, intersection_t &sfi, const mask_t &mask,
         const transform3_type &trf,

--- a/core/include/detray/intersection/plane_intersector.hpp
+++ b/core/include/detray/intersection/plane_intersector.hpp
@@ -19,19 +19,19 @@
 namespace detray {
 
 /// A functor to find intersections between straight line and planar surface
-template <typename intersection_t>
+template <typename transform3_t>
 struct plane_intersector {
 
     /// linear algebra types
     /// @{
-    using transform3_type = typename intersection_t::transform3_type;
+    using transform3_type = transform3_t;
     using scalar_type = typename transform3_type::scalar_type;
     using point3 = typename transform3_type::point3;
     using point2 = typename transform3_type::point2;
     using vector3 = typename transform3_type::vector3;
     /// @}
 
-    using intersection_type = intersection_t;
+    using intersection_type = intersection2D<transform3_type>;
     using ray_type = detail::ray<transform3_type>;
 
     /// Operator function to find intersections between ray and planar mask
@@ -46,13 +46,13 @@ struct plane_intersector {
     /// @param mask_tolerance is the tolerance for mask edges
     ///
     /// @return the intersection
-    template <typename mask_t, typename surface_t>
-    DETRAY_HOST_DEVICE inline intersection_t operator()(
-        const ray_type &ray, const surface_t &sf, const mask_t &mask,
+    template <typename mask_t>
+    DETRAY_HOST_DEVICE inline intersection_type operator()(
+        const ray_type &ray, const intersection_type &is, const mask_t &mask,
         const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
 
-        intersection_t is;
+        intersection_type is(sf);
 
         // Retrieve the surface normal & translation (context resolved)
         const auto &sm = trf.matrix();
@@ -93,24 +93,6 @@ struct plane_intersector {
         }
 
         return is;
-    }
-
-    /// Operator function to updtae an intersections between a ray and a planar
-    /// surface.
-    ///
-    /// @tparam mask_t is the input mask type
-    ///
-    /// @param ray is the input ray trajectory
-    /// @param sfi the intersection to be updated
-    /// @param mask is the input mask that defines the surface extent
-    /// @param trf is the surface placement transform
-    /// @param mask_tolerance is the tolerance for mask edges
-    template <typename mask_t>
-    DETRAY_HOST_DEVICE inline void update(
-        const ray_type &ray, intersection_t &sfi, const mask_t &mask,
-        const transform3_type &trf,
-        const scalar_type mask_tolerance = 0.f) const {
-        sfi = this->operator()(ray, sfi.surface, mask, trf, mask_tolerance);
     }
 };
 

--- a/core/include/detray/masks/annulus2D.hpp
+++ b/core/include/detray/masks/annulus2D.hpp
@@ -81,8 +81,8 @@ class annulus2D {
     using local_frame_type = polar2<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename intersection_t>
-    using intersector_type = intersector_t<intersection_t>;
+    template <typename algebra_t>
+    using intersector_type = intersector_t<algebra_t>;
 
     /// Behaviour of the two local axes (linear in r, circular in phi)
     template <

--- a/core/include/detray/masks/cylinder2D.hpp
+++ b/core/include/detray/masks/cylinder2D.hpp
@@ -66,8 +66,8 @@ class cylinder2D {
     using local_frame_type = cylindrical2<algebra_t>;
 
     /// Underlying surface geometry: cylindrical
-    template <typename intersection_t>
-    using intersector_type = intersector_t<intersection_t>;
+    template <typename algebra_t>
+    using intersector_type = intersector_t<algebra_t>;
 
     /// Behaviour of the two local axes (circular in r_phi, linear in z)
     template <

--- a/core/include/detray/masks/cylinder3D.hpp
+++ b/core/include/detray/masks/cylinder3D.hpp
@@ -47,7 +47,7 @@ class cylinder3D {
     using local_frame_type = cylindrical3<algebra_t>;
 
     /// Underlying surface geometry: not a surface.
-    template <typename intersection_t>
+    template <typename algebra_t>
     using intersector_type = void;
 
     /// Behaviour of the three local axes (linear in r, circular in phi,

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -68,8 +68,8 @@ class line {
     using local_frame_type = line2<algebra_t>;
 
     /// Underlying surface geometry: line
-    template <typename intersection_t>
-    using intersector_type = intersector_t<intersection_t>;
+    template <typename algebra_t>
+    using intersector_type = intersector_t<algebra_t>;
 
     /// Behaviour of the two local axes (linear in r/x, linear in z)
     template <

--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -149,9 +149,9 @@ class mask {
     }
 
     /// @returns the intersection functor for the underlying surface geometry.
-    template <typename intersection_t>
+    template <typename transform3_t>
     DETRAY_HOST_DEVICE inline constexpr auto intersector() const ->
-        typename shape::template intersector_type<intersection_t> {
+        typename shape::template intersector_type<transform3_t> {
         return {};
     }
 

--- a/core/include/detray/masks/rectangle2D.hpp
+++ b/core/include/detray/masks/rectangle2D.hpp
@@ -58,8 +58,8 @@ class rectangle2D {
     using local_frame_type = cartesian2<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename intersection_t>
-    using intersector_type = intersector_t<intersection_t>;
+    template <typename algebra_t>
+    using intersector_type = intersector_t<algebra_t>;
 
     /// Behaviour of the two local axes (linear in x, y)
     template <

--- a/core/include/detray/masks/ring2D.hpp
+++ b/core/include/detray/masks/ring2D.hpp
@@ -59,8 +59,8 @@ class ring2D {
     using local_frame_type = polar2<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename intersection_t>
-    using intersector_type = intersector_t<intersection_t>;
+    template <typename algebra_t>
+    using intersector_type = intersector_t<algebra_t>;
 
     /// Behaviour of the two local axes (linear in r, circular in phi)
     template <

--- a/core/include/detray/masks/single3D.hpp
+++ b/core/include/detray/masks/single3D.hpp
@@ -56,8 +56,8 @@ class single3D {
     using local_frame_type = cartesian2<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename intersection_t>
-    using intersector_type = intersector_t<intersection_t>;
+    template <typename algebra_t>
+    using intersector_type = intersector_t<algebra_t>;
 
     /// Behaviour of the two local axes (linear in single coordinate x, y or z)
     template <n_axis::bounds e_s = n_axis::bounds::e_closed,

--- a/core/include/detray/masks/trapezoid2D.hpp
+++ b/core/include/detray/masks/trapezoid2D.hpp
@@ -63,8 +63,8 @@ class trapezoid2D {
     using local_frame_type = cartesian2<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename intersection_t>
-    using intersector_type = intersector_t<intersection_t>;
+    template <typename algebra_t>
+    using intersector_type = intersector_t<algebra_t>;
 
     /// Behaviour of the two local axes (linear in x, y)
     template <

--- a/core/include/detray/masks/unbounded.hpp
+++ b/core/include/detray/masks/unbounded.hpp
@@ -39,9 +39,9 @@ class unbounded {
         typename shape::template local_frame_type<algebra_t>;
 
     /// Underlying surface geometry
-    template <typename intersection_t>
+    template <typename algebra_t>
     using intersector_type =
-        typename shape::template intersector_type<intersection_t>;
+        typename shape::template intersector_type<algebra_t>;
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -38,8 +38,8 @@ class unmasked {
     using local_frame_type = cartesian2<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename intersection_t>
-    using intersector_type = plane_intersector<intersection_t>;
+    template <typename algebra_t>
+    using intersector_type = plane_intersector<algebra_t>;
 
     /// Behaviour of the two local axes (linear in x, y)
     template <

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -134,7 +134,7 @@ struct pointwise_material_interactor : actor {
     /// @param[in]  nav_dir navigation direction
     /// @param[in]  is intersection
     /// @param[in]  mat_store material store
-    template <typename intersection_t, typename material_store_t>
+    template <typename material_store_t>
     DETRAY_HOST_DEVICE inline void update(
         bound_track_parameters<transform3_type> &bound_params,
         state &interactor_state, const int nav_dir, const intersection_t &is,

--- a/core/include/detray/propagator/navigator.hpp
+++ b/core/include/detray/propagator/navigator.hpp
@@ -94,10 +94,8 @@ struct void_inspector {
 /// @tparam detector_t the detector to navigate
 /// @tparam inspector_t is a validation inspector that can record information
 ///         about the navaigation state at different points of the nav. flow.
-template <
-    typename detector_t, typename inspector_t = navigation::void_inspector,
-    typename intersection_t = intersection2D<typename detector_t::surface_type,
-                                             typename detector_t::transform3>>
+template <typename detector_t,
+          typename inspector_t = navigation::void_inspector>
 class navigator {
 
     public:
@@ -107,7 +105,8 @@ class navigator {
     using volume_type = typename detector_t::volume_type;
     template <typename T>
     using vector_type = typename detector_t::template vector_type<T>;
-    using intersection_type = intersection_t;
+    using intersection_type = intersection2D<typename detector_t::surface_type,
+                                             typename detector_t::transform3>;
     using nav_link_type = typename detector_t::surface_type::navigation_link;
 
     /// A navigation state object used to cache the information of the

--- a/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
@@ -32,17 +32,18 @@ namespace detail {
 /// The algorithm uses the Newton-Raphson method to find an intersection on
 /// the unbounded surface and then applies the mask.
 /// @note Don't use for low p_t tracks!
-template <typename intersection_t>
+template <typename transform3_t>
 struct helix_cylinder_intersector
     : public cylinder_intersector<intersection_t> {
 
-    using transform3_type = typename intersection_t::transform3_type;
+    using transform3_type = transform3_t;
     using scalar_type = typename transform3_type::scalar_type;
     using matrix_operator = typename transform3_type::matrix_actor;
     using point2 = typename transform3_type::point2;
     using point3 = typename transform3_type::point3;
     using vector3 = typename transform3_type::vector3;
     using helix_type = detail::helix<transform3_type>;
+    using intersection_type = intersection2D<transform3_type>;
 
     /// Operator function to find intersections between helix and cylinder mask
     ///
@@ -176,14 +177,14 @@ struct helix_cylinder_intersector
 }  // namespace detail
 
 /// Specialization of the @c helix_intersector for 2D cylindrical surfaces
-template <typename intersection_t, typename mask_t>
+template <typename transform3_t, typename mask_t>
 struct helix_intersector<
     intersection_t, mask_t,
-    std::enable_if_t<
-        std::is_same_v<typename mask_t::local_frame_type,
-                       cylindrical2<typename intersection_t::transform3_type>>,
-        void>> : public detail::helix_cylinder_intersector<intersection_t> {
-    using intersector_impl = detail::helix_cylinder_intersector<intersection_t>;
+    std::enable_if_t<std::is_same_v<typename mask_t::local_frame_type,
+                                    cylindrical2<transform3_t>>,
+                     void>>
+    : public detail::helix_cylinder_intersector<transform3_t> {
+    using intersector_impl = detail::helix_cylinder_intersector<transform3_t>;
 
     using scalar_type = typename intersector_impl::scalar_type;
     using matrix_operator = typename intersector_impl::matrix_operator;

--- a/tests/common/include/tests/common/tools/intersectors/helix_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_intersector.hpp
@@ -17,7 +17,7 @@ namespace detray {
 ///
 /// @note specialized into @c helix_plane_intersector and
 /// @c helix_cylinder_intersector
-template <typename intersection_t, typename mask_t, typename = void>
+template <typename transform3_t, typename mask_t, typename = void>
 struct helix_intersector {};
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
@@ -26,15 +26,16 @@ namespace detail {
 ///
 /// The algorithm uses the Newton-Raphson method to find an intersection on
 /// the unbounded surface and then applies the mask.
-template <typename intersection_t>
+template <typename transform3_t>
 struct helix_line_intersector {
 
-    using transform3_type = typename intersection_t::transform3_type;
+    using transform3_type = transform3_t;
     using scalar_type = typename transform3_type::scalar_type;
     using matrix_operator = typename transform3_type::matrix_actor;
     using point3 = typename transform3_type::point3;
     using vector3 = typename transform3_type::vector3;
     using helix_type = detail::helix<transform3_type>;
+    using intersection_type = intersection2D<transform3_type>;
 
     /// Operator function to find intersections between helix and line mask
     ///
@@ -166,16 +167,16 @@ struct helix_line_intersector {
 }  // namespace detail
 
 /// Specialization of the @c helix_intersector for line surfaces
-template <typename intersection_t, typename mask_t>
+template <typename transform3_t, typename mask_t>
 struct helix_intersector<
     intersection_t, mask_t,
-    std::enable_if_t<
-        std::is_same_v<
-            typename mask_t::shape::template intersector_type<intersection_t>,
-            line_intersector<intersection_t>>,
-        void>> : public detail::helix_line_intersector<intersection_t> {
+    std::enable_if_t<std::is_same_v<typename mask_t::shape::
+                                        template intersector_type<transform3_t>,
+                                    line_intersector<transform3_t>>,
+                     void>>
+    : public detail::helix_line_intersector<transform3_t> {
 
-    using intersector_impl = detail::helix_line_intersector<intersection_t>;
+    using intersector_impl = detail::helix_line_intersector<transform3_t>;
 
     using scalar_type = typename intersector_impl::scalar_type;
     using matrix_operator = typename intersector_impl::matrix_operator;

--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -26,15 +26,16 @@ namespace detail {
 ///
 /// The algorithm uses the Newton-Raphson method to find an intersection on
 /// the unbounded surface and then applies the mask.
-template <typename intersection_t>
+template <typename transform3_t>
 struct helix_plane_intersector {
 
-    using transform3_type = typename intersection_t::transform3_type;
+    using transform3_type = transform3_t;
     using scalar_type = typename transform3_type::scalar_type;
     using matrix_operator = typename transform3_type::matrix_actor;
     using point3 = typename transform3_type::point3;
     using vector3 = typename transform3_type::vector3;
     using helix_type = detail::helix<transform3_type>;
+    using intersection_type = intersection2D<transform3_type>;
 
     /// Operator function to find intersections between helix and planar mask
     ///
@@ -113,16 +114,16 @@ struct helix_plane_intersector {
 }  // namespace detail
 
 /// Specialization of the @c helix_intersector for planar surfaces
-template <typename intersection_t, typename mask_t>
+template <typename transform3_t, typename mask_t>
 struct helix_intersector<
     intersection_t, mask_t,
-    std::enable_if_t<
-        std::is_same_v<
-            typename mask_t::shape::template intersector_type<intersection_t>,
-            plane_intersector<intersection_t>>,
-        void>> : public detail::helix_plane_intersector<intersection_t> {
+    std::enable_if_t<std::is_same_v<typename mask_t::shape::
+                                        template intersector_type<transform3_t>,
+                                    plane_intersector<transform3_t>>,
+                     void>>
+    : public detail::helix_plane_intersector<transform3_t> {
 
-    using intersector_impl = detail::helix_plane_intersector<intersection_t>;
+    using intersector_impl = detail::helix_plane_intersector<transform3_t>;
 
     using scalar_type = typename intersector_impl::scalar_type;
     using matrix_operator = typename intersector_impl::matrix_operator;

--- a/tutorials/include/detray/tutorial/my_square2D.hpp
+++ b/tutorials/include/detray/tutorial/my_square2D.hpp
@@ -55,8 +55,8 @@ class square2D {
     using local_frame_type = cartesian3<algebra_t>;
 
     /// Underlying surface geometry: planar
-    template <typename intersection_t>
-    using intersector_type = intersector_t<intersection_t>;
+    template <typename algebra_t>
+    using intersector_type = intersector_t<algebra_t>;
 
     /// Behaviour of the two local axes (linear in x, linear in y)
     /// Needed to map a grid onto the square (material maps)


### PR DESCRIPTION
Is this even possible? I stopped working on it after realizing that this requires a huge effort.

Techinically, I want to replace intersection type template parameter with trasnform3 (or algebra), and remove surface description in intersection type. I expect that @niermann999 is not a big fan of this but could you explain the motivation of the current design?