### PR TITLE
grid: non-owning single view

### DIFF
--- a/core/include/detray/utils/ranges.hpp
+++ b/core/include/detray/utils/ranges.hpp
@@ -13,6 +13,7 @@
 #include "detray/utils/ranges/iota.hpp"
 #include "detray/utils/ranges/join.hpp"
 #include "detray/utils/ranges/pick.hpp"
+#include "detray/utils/ranges/pointer.hpp"
 #include "detray/utils/ranges/single.hpp"
 #include "detray/utils/ranges/subrange.hpp"
 

--- a/core/include/detray/utils/ranges/pointer.hpp
+++ b/core/include/detray/utils/ranges/pointer.hpp
@@ -1,0 +1,134 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/ranges/ranges.hpp"
+
+namespace detray::ranges {
+
+/// @brief Struct that implements a pointer based view on a single element.
+///
+/// @tparam value_t type of the single element (outside of a container)
+///
+/// @note Does not take ownership of the value it operates on. Its lifetime
+/// needs to be guaranteed throughout iteration or between iterations with the
+/// same view instance.
+/// @note Is not fit for lazy evaluation.
+template <typename value_t>
+class pointer_view
+    : public detray::ranges::view_interface<pointer_view<value_t>> {
+
+    public:
+    using iterator_t = value_t*;
+
+    /// Default constructor
+    pointer_view() = default;
+
+    /// Construct iterator from the single @param value - copy
+    DETRAY_HOST_DEVICE constexpr explicit pointer_view(value_t& value)
+        : m_value{&value} {}
+
+    /// Copy constructor
+    DETRAY_HOST_DEVICE
+    constexpr pointer_view(const pointer_view& other)
+        : m_value{other.m_value} {}
+
+    /// Move constructor for the pointer view
+    constexpr pointer_view(pointer_view&& other) = default;
+
+    /// Default destructor
+    DETRAY_HOST_DEVICE ~pointer_view() {}
+
+    /// Copy assignment operator
+    DETRAY_HOST_DEVICE
+    pointer_view& operator=(const pointer_view& other) {
+        m_value = other.m_value;
+        return *this;
+    }
+
+    /// @return the pointer value
+    DETRAY_HOST_DEVICE
+    constexpr auto operator*() const -> const value_t& { return *m_value; }
+
+    /// @return the pointer value
+    DETRAY_HOST_DEVICE
+    constexpr auto operator*() -> value_t& { return *m_value; }
+
+    /// @returns value pointer.
+    DETRAY_HOST_DEVICE
+    constexpr auto begin() noexcept -> value_t* { return m_value; }
+
+    /// @returns value pointer - const
+    DETRAY_HOST_DEVICE
+    constexpr auto begin() const noexcept -> const value_t* { return m_value; }
+
+    /// @returns sentinel position.
+    DETRAY_HOST_DEVICE
+    constexpr auto end() noexcept -> value_t* { return m_value + 1; }
+
+    /// @returns sentinel position - const
+    DETRAY_HOST_DEVICE
+    constexpr auto end() const noexcept -> const value_t* {
+        return m_value + 1;
+    }
+
+    /// @returns a pointer to the beginning of the data
+    DETRAY_HOST_DEVICE
+    constexpr auto data() noexcept -> value_t* { return m_value; }
+
+    /// @returns a pointer to the beginning of the data - const
+    DETRAY_HOST_DEVICE
+    constexpr auto data() const noexcept -> const value_t* { return m_value; }
+
+    /// @returns the size of the pointer view, which is always 'one'.
+    DETRAY_HOST_DEVICE
+    static constexpr auto size() noexcept -> std::size_t { return 1; }
+
+    /// @returns the value directly
+    DETRAY_HOST_DEVICE
+    constexpr auto front() noexcept -> value_t { return *m_value; }
+
+    /// @returns the value directly
+    DETRAY_HOST_DEVICE
+    constexpr auto back() noexcept -> value_t { return *m_value; }
+
+    /// @returns the value directly
+    DETRAY_HOST_DEVICE constexpr auto operator[](const dindex) const
+        -> value_t {
+        return *m_value;
+    }
+
+    private:
+    value_t* m_value{};
+};
+
+namespace views {
+
+/// @brief interface type to construct a @c pointer_view with CTAD
+template <typename value_t>
+struct pointer : public detray::ranges::pointer_view<value_t> {
+
+    using base_type = detray::ranges::pointer_view<value_t>;
+
+    constexpr pointer() = default;
+
+    template <typename deduced_value_t>
+    DETRAY_HOST_DEVICE constexpr explicit pointer(deduced_value_t& value)
+        : base_type(value) {}
+};
+
+// deduction guides
+
+template <typename deduced_value_t>
+pointer(deduced_value_t&) -> pointer<deduced_value_t>;
+
+}  // namespace views
+
+}  // namespace detray::ranges

--- a/tests/unit_tests/core/utils_ranges.cpp
+++ b/tests/unit_tests/core/utils_ranges.cpp
@@ -156,6 +156,37 @@ TEST(utils, ranges_single) {
     }
 }
 
+// Unittest for the generation of a pointer to an element
+TEST(utils, ranges_pointer) {
+
+    const dindex value{251u};
+
+    auto ptr = detray::views::pointer(value);
+
+    // general tests
+    static_assert(std::is_copy_assignable_v<decltype(ptr)>);
+    static_assert(detray::ranges::range_v<decltype(ptr)>);
+    static_assert(detray::ranges::view<decltype(ptr)>);
+    static_assert(detray::ranges::random_access_range_v<decltype(ptr)>);
+
+    // Test prerequisits for LagacyIterator
+    static_assert(
+        std::is_copy_constructible_v<typename decltype(ptr)::iterator_t>);
+    static_assert(
+        std::is_copy_assignable_v<typename decltype(ptr)::iterator_t>);
+    static_assert(std::is_destructible_v<typename decltype(ptr)::iterator_t>);
+
+    // Test inherited member functions
+    ASSERT_EQ(ptr[0], value);
+    ASSERT_EQ(ptr.size(), 1u);
+    ASSERT_EQ(ptr.front(), 251u);
+    ASSERT_EQ(ptr.back(), 251u);
+
+    for (auto i : ptr) {
+        ASSERT_EQ(251u, i);
+    }
+}
+
 // Unittest for the generation of a single element sequence
 TEST(utils, ranges_iota_single) {
 

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda.cpp
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda.cpp
@@ -27,6 +27,19 @@ TEST(utils_ranges_cuda, single) {
     ASSERT_EQ(value, check);
 }
 
+// This tests the non-owning single value view
+TEST(utils_ranges_cuda, pointer) {
+
+    dindex value{251u};
+    dindex check{std::numeric_limits<dindex>::max()};
+
+    // Run the test code
+    test_pointer(value, check);
+
+    // Check result value
+    ASSERT_EQ(value, check);
+}
+
 // This tests the iota range generator
 TEST(utils_ranges_cuda, iota) {
 

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.cu
@@ -38,6 +38,33 @@ void test_single(const dindex value, dindex& check) {
 }
 
 //
+// pointer
+//
+__global__ void pointer_kernel(const dindex value, dindex* result) {
+
+    // pointer view should ony add the value 'i' once
+    for (auto i : detray::views::pointer(value)) {
+        *result += i;
+    }
+}
+
+void test_pointer(const dindex value, dindex& check) {
+    dindex* result{nullptr};
+    cudaMallocManaged(&result, sizeof(dindex));
+    *result = 0u;
+
+    // run the kernel
+    pointer_kernel<<<1, 1>>>(value, result);
+
+    // cuda error check
+    DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());
+    DETRAY_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+
+    check = *result;
+    cudaFree(result);
+}
+
+//
 // iota
 //
 __global__ void iota_kernel(const darray<dindex, 2> range,

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.hpp
@@ -27,6 +27,9 @@ struct uint_holder {
 /// Test @c detray::views::single
 void test_single(const dindex value, dindex& check);
 
+/// Test @c detray::views::pointer
+void test_pointer(const dindex value, dindex& check);
+
 /// Test @c detray::views::iota
 void test_iota(const darray<dindex, 2> range,
                vecmem::data::vector_view<dindex> check_data);


### PR DESCRIPTION
Implement an iterator view that acts like 'single' https://en.cppreference.com/w/cpp/ranges/single_view but does not take ownership of the value. This is used in grids that can hold only one element per bin (like for example the volume grid) but still need to be compatible with the same interfaces as grids that hold iterable collections of data per bin. Previously, I used the ```single``` view for this, but this resulted in a dangling reference and also meant, the grid would copy the value in the bin at every lookup.