### PR TITLE
grid: join view

### DIFF
--- a/core/include/detray/utils/ranges.hpp
+++ b/core/include/detray/utils/ranges.hpp
@@ -15,6 +15,7 @@
 #include "detray/utils/ranges/pick.hpp"
 #include "detray/utils/ranges/pointer.hpp"
 #include "detray/utils/ranges/single.hpp"
+#include "detray/utils/ranges/static_join.hpp"
 #include "detray/utils/ranges/subrange.hpp"
 
 namespace detray::views {

--- a/core/include/detray/utils/ranges/static_join.hpp
+++ b/core/include/detray/utils/ranges/static_join.hpp
@@ -1,0 +1,373 @@
+
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/containers.hpp"
+#include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/ranges/ranges.hpp"
+#include "detray/utils/type_traits.hpp"
+
+// System include(s)
+#include <type_traits>
+
+namespace detray::ranges {
+
+namespace detail {
+
+template <typename T>
+struct static_join_iterator;
+
+}
+
+/// @brief Range adaptor that joins different ranges of the same type (static)
+///
+/// @see https://en.cppreference.com/w/cpp/ranges/join_view
+///
+/// @tparam I the number of ranges in the join.
+/// @tparam range_itr_t the iterator type of the ranges.
+///
+/// @note Static implementation: The number of ranges needs to be know at
+/// compile time
+/// @note Does not take ownership of the ranges it operates on. Their lifetime
+/// needs to be guranteed throughout iteration or between iterations with the
+/// same join instance.
+/// @note Is not fit for lazy evaluation.
+/// @todo improve performance of e.g. @c operator+ and @c operator+=
+template <std::size_t I, typename range_itr_t>
+struct static_join_view
+    : public detray::ranges::view_interface<static_join_view<I, range_itr_t>> {
+
+    using iterator_coll_t = std::array<range_itr_t, I>;
+    using iterator_t =
+        detray::ranges::detail::static_join_iterator<iterator_coll_t>;
+    using value_t = typename std::iterator_traits<iterator_t>::value_type;
+
+    /// Default constructor
+    constexpr static_join_view() = default;
+
+    /// Construct from a pack of @param ranges.
+    template <typename... ranges_t>
+    DETRAY_HOST_DEVICE constexpr explicit static_join_view(
+        ranges_t &&... ranges)
+        : m_begins{detray::ranges::begin(ranges)...},
+          m_ends{detray::ranges::end(ranges)...} {}
+
+    /// Construct from a pack of @param ranges - const
+    template <typename... ranges_t>
+    DETRAY_HOST_DEVICE constexpr explicit static_join_view(
+        const ranges_t &... ranges)
+        : m_begins{detray::ranges::cbegin(ranges)...},
+          m_ends{detray::ranges::cend(ranges)...} {}
+
+    /// Copy constructor
+    DETRAY_HOST_DEVICE
+    constexpr static_join_view(const static_join_view &other)
+        : m_begins{other.m_begins}, m_ends{other.m_ends} {}
+
+    /// Default destructor
+    DETRAY_HOST_DEVICE ~static_join_view() {}
+
+    /// Copy assignment operator
+    DETRAY_HOST_DEVICE
+    static_join_view &operator=(const static_join_view &other) {
+        m_begins = other.m_begins;
+        m_ends = other.m_ends;
+        return *this;
+    }
+
+    /// @return start position of range - const
+    DETRAY_HOST_DEVICE
+    constexpr auto begin() const -> iterator_t { return {m_begins, m_ends}; }
+
+    /// @return sentinel of the range.
+    DETRAY_HOST_DEVICE
+    constexpr auto end() const -> iterator_t {
+        // Build a joined itr from the last value in the iterator collection
+        return {m_begins, m_ends, detray::detail::get<I - 1>(m_ends), I - 1};
+    }
+
+    /// @returns a pointer to the beginning of the data of the first underlying
+    /// range - const
+    DETRAY_HOST_DEVICE
+    constexpr auto data() const -> const value_t * {
+        return &(*(detray::detail::get<0>(m_begins())));
+    }
+
+    /// @returns a pointer to the beginning of the data of the first underlying
+    /// range - non-const
+    DETRAY_HOST_DEVICE
+    constexpr auto data() -> value_t * {
+        return &(*(detray::detail::get<0>(m_begins())));
+    }
+
+    /// @returns sum of the number elements of all ranges in the join
+    DETRAY_HOST_DEVICE
+    constexpr auto size() const noexcept -> std::size_t {
+        std::size_t size{0};
+        for (std::size_t i{0}; i < I; ++i) {
+            const range_itr_t &begin = m_begins[i];
+            const range_itr_t &end = m_ends[i];
+            size +=
+                static_cast<std::size_t>(detray::ranges::distance(begin, end));
+        }
+        return size;
+    }
+
+    /// Start and end position of the subranges
+    iterator_coll_t m_begins{}, m_ends{};
+};
+
+namespace views {
+
+/// @brief interface type to construct a @c static_join_view with CTAD
+template <std::size_t I, typename range_itr_t>
+struct static_join : public ranges::static_join_view<I, range_itr_t> {
+
+    using base_type = ranges::static_join_view<I, range_itr_t>;
+
+    constexpr static_join() = default;
+
+    template <typename... ranges_t>
+    DETRAY_HOST_DEVICE constexpr explicit static_join(
+        const ranges_t &... ranges)
+        : base_type(ranges...) {}
+
+    template <typename... ranges_t>
+    DETRAY_HOST_DEVICE constexpr explicit static_join(ranges_t &&... ranges)
+        : base_type(std::forward<ranges_t>(ranges)...) {}
+};
+
+// deduction guides
+
+template <typename... ranges_t>
+DETRAY_HOST_DEVICE static_join(const ranges_t &... ranges)
+    ->static_join<sizeof...(ranges_t),
+                  typename detray::ranges::const_iterator_t<
+                      detray::detail::first_t<ranges_t...>>>;
+
+template <typename... ranges_t>
+DETRAY_HOST_DEVICE static_join(ranges_t &&... ranges)
+    ->static_join<sizeof...(ranges_t),
+                  typename detray::ranges::iterator_t<
+                      detray::detail::first_t<ranges_t...>>>;
+
+}  // namespace views
+
+namespace detail {
+
+/// @brief Sequentially iterate through multiple ranges of the same type.
+///
+/// Once the sentinel of one range is reached, set the current iterator to the
+/// next ranges 'begin' (or 'end' if decrementing)
+///
+/// @tparam iterator_coll_t type of iterator collection of ranges to be joined.
+///         Can contain const iterators.
+///
+/// @note The iterator must not be typed on the current range index, so that
+/// begin and sentinel type are the same.
+template <typename iterator_coll_t>
+struct static_join_iterator {
+
+    using iterator_t = detray::detail::get_value_t<iterator_coll_t>;
+
+    using difference_type =
+        typename std::iterator_traits<iterator_t>::difference_type;
+    using value_type = typename std::iterator_traits<iterator_t>::value_type;
+    using pointer = typename std::iterator_traits<iterator_t>::pointer;
+    using reference = typename std::iterator_traits<iterator_t>::reference;
+    using iterator_category =
+        typename std::iterator_traits<iterator_t>::iterator_category;
+
+    /// Default constructor required by LegacyIterator trait
+    constexpr static_join_iterator() = default;
+
+    /// Construct from a collection of @param begin and @param  end positions
+    DETRAY_HOST_DEVICE
+    constexpr static_join_iterator(const iterator_coll_t &begins,
+                                   const iterator_coll_t &ends)
+        : m_begins(&begins), m_ends(&ends), m_iter{(*m_begins)[0]}, m_idx{0u} {}
+
+    /// Fully parametrized construction
+    DETRAY_HOST_DEVICE
+    constexpr static_join_iterator(const iterator_coll_t &begins,
+                                   const iterator_coll_t &ends,
+                                   iterator_t current, const std::size_t i)
+        : m_begins(&begins), m_ends(&ends), m_iter{current}, m_idx{i} {}
+
+    /// @returns true if it points to the same value.
+    DETRAY_HOST_DEVICE constexpr bool operator==(
+        const static_join_iterator &rhs) const {
+        return (m_iter == rhs.m_iter);
+    }
+
+    /// @returns false if it points to the same value (usually the global
+    /// sentinel of the join).
+    DETRAY_HOST_DEVICE constexpr bool operator!=(
+        const static_join_iterator &rhs) const {
+        return (m_iter != rhs.m_iter);
+    }
+
+    /// Increment current iterator and check for switch between ranges.
+    DETRAY_HOST_DEVICE constexpr auto operator++() -> static_join_iterator & {
+        ++m_iter;
+        // Switch to next range in the collection
+        constexpr std::size_t max_idx{
+            sizeof(iterator_coll_t) / sizeof(iterator_t) - 1u};
+        if ((m_iter == (*m_ends)[m_idx]) and (m_idx < max_idx)) {
+            ++m_idx;
+            m_iter = (*m_begins)[m_idx];
+        }
+        return *this;
+    }
+
+    /// Decrement current iterator and check for switch between ranges.
+    template <typename I = iterator_t,
+              std::enable_if_t<detray::ranges::bidirectional_iterator_v<I>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE constexpr auto operator--() -> static_join_iterator & {
+        if (m_iter != (*m_begins)[m_idx]) {
+            // Normal case
+            --m_iter;
+        } else if (m_idx > 0u) {
+            // Iterator has reached last valid position in this range during the
+            // previous decrement. Now go to the end of the previous range
+            --m_idx;
+            m_iter = (*m_ends)[m_idx] - 1;
+        }
+        return *this;
+    }
+
+    /// @returns the single value that the iterator points to.
+    DETRAY_HOST_DEVICE
+    constexpr auto operator*() -> value_type & { return *m_iter; }
+
+    /// @returns the single value that the iterator points to - const
+    DETRAY_HOST_DEVICE
+    constexpr auto operator*() const -> const value_type & { return *m_iter; }
+
+    /// @returns an iterator advanced by @param j through the join.
+    template <typename I = iterator_t,
+              std::enable_if_t<detray::ranges::random_access_iterator_v<I>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE constexpr auto operator+(const difference_type j) const
+        -> static_join_iterator {
+        static_join_iterator<iterator_coll_t> tmp(*this);
+        // walk through join to catch the switch between intermediate ranges
+        difference_type i{j};
+        if (i >= 0) {
+            while (i--) {
+                ++tmp;
+            };
+        } else {
+            while (i++) {
+                --tmp;
+            };
+        }
+        return tmp;
+    }
+
+    /// @returns an iterator advanced by @param j through the join.
+    template <typename I = iterator_t,
+              std::enable_if_t<detray::ranges::random_access_iterator_v<I>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE constexpr auto operator-(const difference_type j) const
+        -> static_join_iterator {
+        return *this + (-j);
+    }
+
+    /// @returns the positional difference between two iterators
+    template <typename I = iterator_t,
+              std::enable_if_t<detray::ranges::random_access_iterator_v<I>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE constexpr auto operator-(
+        const static_join_iterator &other) const -> difference_type {
+        if (m_idx == other.m_idx) {
+            return m_iter - other.m_iter;
+        }
+        if (m_idx < other.m_idx) {
+            // Negative distance
+            difference_type diff{m_iter - (*m_ends)[m_idx]};
+            for (std::size_t i{m_idx + 1u}; i < other.m_idx; ++i) {
+                diff += (*m_begins)[i] - (*m_ends)[i];
+            }
+            diff += (*other.m_begins)[m_idx] - other.m_iter;
+            return diff;
+        } else {
+            // Positive distance
+            difference_type diff{m_iter - (*m_begins)[m_idx]};
+            for (std::size_t i{m_idx - 1u}; i > other.m_idx; --i) {
+                diff += (*m_ends)[i] - (*m_begins)[i];
+            }
+            diff += (*other.m_ends)[other.m_idx] - other.m_iter;
+            return diff;
+        }
+    }
+
+    /// @returns advance this iterator state by @param j.
+    template <typename I = iterator_t,
+              std::enable_if_t<detray::ranges::random_access_iterator_v<I>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE constexpr auto operator+=(const difference_type j)
+        -> static_join_iterator & {
+        // walk through join to catch the switch between intermediate ranges
+        difference_type i{j};
+        if (i >= difference_type{0}) {
+            while (i--) {
+                ++(*this);
+            };
+        } else {
+            while (i++) {
+                --(*this);
+            };
+        }
+        return *this;
+    }
+
+    /// @returns advance this iterator state by @param j.
+    template <typename I = iterator_t,
+              std::enable_if_t<detray::ranges::random_access_iterator_v<I>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE constexpr auto operator-=(const difference_type j)
+        -> static_join_iterator & {
+        m_iter += (-j);
+        return *this;
+    }
+
+    /// @returns the value at a given position - const
+    template <typename I = iterator_t,
+              std::enable_if_t<detray::ranges::random_access_iterator_v<I>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE constexpr auto operator[](const difference_type i) const
+        -> const value_type & {
+        difference_type offset{i - (m_iter - (*m_begins)[0])};
+        return *(*this + offset);
+    }
+
+    /// @returns the value at a given position - const
+    template <typename I = iterator_t,
+              std::enable_if_t<detray::ranges::random_access_iterator_v<I>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE constexpr auto operator[](const difference_type i)
+        -> value_type & {
+        difference_type offset{i - (m_iter - (*m_begins)[0])};
+        return *(*this + offset);
+    }
+
+    /// Global range collection of begin and end iterators
+    const iterator_coll_t *m_begins{nullptr}, *m_ends{nullptr};
+    /// This is the actual iterator state that will be advanced during iteration
+    iterator_t m_iter{};
+    /// Index of the current range in the join
+    std::size_t m_idx{0};
+};
+
+}  // namespace detail
+
+}  // namespace detray::ranges

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.cu
@@ -162,8 +162,9 @@ __global__ void join_kernel(
     vecmem::device_vector<uint_holder> seq_1(seq_data_1);
     vecmem::device_vector<uint_holder> seq_2(seq_data_2);
     vecmem::device_vector<dindex> check_value(check_value_data);
+    std::array<vecmem::device_vector<uint_holder>, 2> vectors{seq_1, seq_2};
 
-    for (auto v : detray::views::join(seq_1, seq_2)) {
+    for (auto v : detray::views::join(vectors)) {
         check_value.push_back(v.ui);
     }
 }
@@ -174,6 +175,35 @@ void test_join(vecmem::data::vector_view<uint_holder> seq_data_1,
 
     // run the kernel
     join_kernel<<<1, 1>>>(seq_data_1, seq_data_2, check_value_data);
+
+    // cuda error check
+    DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());
+    DETRAY_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+}
+
+//
+// static_join
+//
+__global__ void static_join_kernel(
+    vecmem::data::vector_view<uint_holder> seq_data_1,
+    vecmem::data::vector_view<uint_holder> seq_data_2,
+    vecmem::data::vector_view<dindex> check_value_data) {
+
+    vecmem::device_vector<uint_holder> seq_1(seq_data_1);
+    vecmem::device_vector<uint_holder> seq_2(seq_data_2);
+    vecmem::device_vector<dindex> check_value(check_value_data);
+
+    for (auto v : detray::views::static_join(seq_1, seq_2)) {
+        check_value.push_back(v.ui);
+    }
+}
+
+void test_static_join(vecmem::data::vector_view<uint_holder> seq_data_1,
+                      vecmem::data::vector_view<uint_holder> seq_data_2,
+                      vecmem::data::vector_view<dindex> check_value_data) {
+
+    // run the kernel
+    static_join_kernel<<<1, 1>>>(seq_data_1, seq_data_2, check_value_data);
 
     // cuda error check
     DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.hpp
@@ -50,6 +50,11 @@ void test_join(vecmem::data::vector_view<uint_holder> seq_data_1,
                vecmem::data::vector_view<uint_holder> seq_data_2,
                vecmem::data::vector_view<dindex> check_value_data);
 
+/// Test @c detray::views::static_join
+void test_static_join(vecmem::data::vector_view<uint_holder> seq_data_1,
+                      vecmem::data::vector_view<uint_holder> seq_data_2,
+                      vecmem::data::vector_view<dindex> check_value_data);
+
 /// Test @c detray::views::subrange
 void test_subrange(vecmem::data::vector_view<int> seq_data,
                    vecmem::data::vector_view<int> check_value_data,


### PR DESCRIPTION
Implement a join iterator that operates on a range of inner iterators. The previous join iterator, which could only hold a number of inner iterators that was defined at compile-time, has been renamed to 'static_join'. This join iterator is used to iterate over bins that contain a collection of data as if it were one bin and can hence emulate the behavior of the final grid implementation, while making it possible to keep the navigation untouched. Since all bins can be checked with this iterator in the same search call, all surfaces in the volume are tested, as before, and no changes in the navigation logic will occur by #456 