### PR TITLE
feat: volume placement transforms

### DIFF
--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -355,7 +355,7 @@ class detector {
         if (_surface_lookup.size() < sf.index() + 1) {
             _surface_lookup.resize(sf.index() + 1);
         }
-        _surface_lookup[sf.index()] = sf;
+        _surface_lookup.at(sf.index()) = sf;
     }
 
     /// Append new portals(surfaces) to the detector

--- a/core/include/detray/geometry/detail/volume_descriptor.hpp
+++ b/core/include/detray/geometry/detail/volume_descriptor.hpp
@@ -8,12 +8,9 @@
 #pragma once
 
 // Project include(s)
-#include "detray/definitions/algebra.hpp"
-#include "detray/definitions/containers.hpp"
 #include "detray/definitions/geometry.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
-#include "detray/definitions/units.hpp"
 
 namespace detray {
 
@@ -54,49 +51,55 @@ class volume_descriptor {
     /// Constructor from shape id.
     ///
     /// @param id id values that determines how to interpret the bounds.
-    explicit constexpr volume_descriptor(const volume_id id) : _id{id} {}
+    explicit constexpr volume_descriptor(const volume_id id) : m_id{id} {}
 
     /// @returns the volume shape id, e.g. 'cylinder'
     DETRAY_HOST_DEVICE
-    constexpr auto id() const -> volume_id { return _id; }
+    constexpr auto id() const -> volume_id { return m_id; }
 
-    /// @return the index of the volume in the detector volume container.
+    /// @returns the index of the volume in the detector volume container.
     DETRAY_HOST_DEVICE
-    constexpr auto index() const -> dindex { return _index; }
+    constexpr auto index() const -> dindex { return m_index; }
 
     /// @param index the index of the volume in the detector volume container.
     DETRAY_HOST
-    constexpr auto set_index(const dindex index) -> void { _index = index; }
+    constexpr auto set_index(const dindex index) -> void { m_index = index; }
+
+    /// @returns the index of the volume tranform in the transform store.
+    DETRAY_HOST_DEVICE
+    constexpr auto transform() const -> dindex { return m_transform; }
+
+    /// @param index the index of the volume in the detector volume container.
+    DETRAY_HOST
+    constexpr auto set_transform(const dindex trf_idx) -> void {
+        m_transform = trf_idx;
+    }
 
     /// @returns link to all acceleration data structures - const access
     DETRAY_HOST_DEVICE constexpr auto full_link() const -> const link_type & {
-        return _sf_finder_links;
+        return m_sf_finder_links;
     }
 
-    /// @returns link for a specific type of object - const access.
+    /// @returns acc data structure link for a specific type of object - const
     template <ID obj_id>
     DETRAY_HOST_DEVICE constexpr auto link() const -> const link_t & {
-        return detail::get<obj_id>(_sf_finder_links);
+        return detail::get<obj_id>(m_sf_finder_links);
     }
 
-    /// @returns link for a specific type of object - non-const access.
-    template <ID obj_id>
-    DETRAY_HOST_DEVICE constexpr auto link() -> link_t & {
-        return detail::get<obj_id>(_sf_finder_links);
-    }
-
-    /// Set surface finder during detector building
+    /// Set surface finder link from @param link
     template <ID obj_id>
     DETRAY_HOST constexpr auto set_link(const link_t &link) -> void {
-        _sf_finder_links[obj_id] = link;
+        m_sf_finder_links[obj_id] = link;
     }
 
-    /// sSt surface finder during detector building
+    /// Set surface finder link from @param id and @param index of the
+    /// acceleration data structure (e.g. type and index of grid in surface
+    /// store)
     template <ID obj_id>
     DETRAY_HOST constexpr auto set_link(const typename link_t::id_type id,
                                         const typename link_t::index_type index)
         -> void {
-        _sf_finder_links[obj_id] = link_t{id, index};
+        m_sf_finder_links[obj_id] = link_t{id, index};
     }
 
     /// Equality operator
@@ -104,21 +107,22 @@ class volume_descriptor {
     /// @param rhs is the right-hand side to compare against.
     DETRAY_HOST_DEVICE
     constexpr auto operator==(const volume_descriptor &rhs) const -> bool {
-        return (_index == rhs._index &&
-                _sf_finder_links == rhs._sf_finder_links &&
-                _sf_finder_links[ID::e_sensitive] ==
-                    rhs._sf_finder_links[ID::e_sensitive]);
+        return (m_id == rhs.m_id && m_index == rhs.m_index &&
+                m_sf_finder_links == rhs.m_sf_finder_links);
     }
 
     private:
     /// How to interpret the boundary values
-    volume_id _id = volume_id::e_cylinder;
+    volume_id m_id = volume_id::e_cylinder;
 
     /// Volume index in the detector's volume container
-    dindex _index = dindex_invalid;
+    dindex m_index = dindex_invalid;
+
+    /// Volume index in the detector's volume container
+    dindex m_transform = dindex_invalid;
 
     /// Links for every object type to an acceleration data structure
-    link_type _sf_finder_links = {};
+    link_type m_sf_finder_links = {};
 };
 
 }  // namespace detray

--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -112,6 +112,20 @@ class detector_volume {
         return names.at(m_desc.index() + 1u);
     }
 
+    /// @returns the (non contextual) transform for the placement of the
+    /// volume in the detector geometry.
+    DETRAY_HOST_DEVICE
+    constexpr auto transform() const -> const
+        typename detector_t::transform3 & {
+        return m_detector.transform_store({})[m_desc.transform()];
+    }
+
+    /// @returns the center point of the volume.
+    DETRAY_HOST_DEVICE
+    constexpr auto center() const -> typename detector_t::point3 {
+        return transform().translation();
+    }
+
     /// Apply a functor to all surfaces in the volume.
     ///
     /// @tparam functor_t the prescription to be applied to the surfaces

--- a/core/include/detray/tools/bin_fillers.hpp
+++ b/core/include/detray/tools/bin_fillers.hpp
@@ -35,11 +35,11 @@ struct fill_by_bin {
         typename grid_t::value_type single_element;
     };
 
-    template <typename grid_t, typename surface_container,
+    template <typename grid_t, typename volume_t, typename surface_container,
               typename mask_container, typename transform_container,
-              typename context_t>
-    DETRAY_HOST auto operator()(grid_t &grid, const surface_container &,
-                                const transform_container &,
+              typename context_t, typename... Args>
+    DETRAY_HOST auto operator()(grid_t &grid, const volume_t &,
+                                const surface_container &,
                                 const mask_container &, const context_t,
                                 std::vector<bin_data<grid_t>> &bins) const
         -> void {
@@ -57,24 +57,24 @@ struct fill_by_bin {
 /// @param ctx the geometry context
 struct fill_by_pos {
 
-    template <typename grid_t, typename surface_container,
+    template <typename grid_t, typename volume_t, typename surface_container,
               typename mask_container, typename transform_container,
               typename context_t, typename... Args>
-    DETRAY_HOST auto operator()(grid_t &grid, const surface_container &surfaces,
+    DETRAY_HOST auto operator()(grid_t &grid, const volume_t &vol,
+                                const surface_container &surfaces,
                                 const transform_container &transforms,
                                 const mask_container & /*masks*/,
                                 const context_t ctx, Args &&...) const -> void {
 
         // Fill the volumes surfaces into the grid
-        for (const auto &sf : surfaces) {
+        for (const auto [idx, sf] : detray::views::enumerate(surfaces)) {
             // no portals in grids allowed
             assert(not sf.is_portal());
 
-            const auto &sf_trf = transforms.at(sf.transform(), ctx);
+            const auto &sf_trf = transforms.at(idx, ctx);
             const auto &t = sf_trf.translation();
             // transform to axis coordinate system
-            const auto loc_pos = grid.global_to_local(
-                typename transform_container::value_type{}, t, t);
+            const auto loc_pos = grid.global_to_local(vol.transform(), t, t);
 
             // Populate
             grid.populate(loc_pos, sf);
@@ -100,10 +100,11 @@ struct bin_associator {
                          det.transform_store(), ctx);
     }
 
-    template <typename grid_t, typename surface_container,
+    template <typename grid_t, typename volume_t, typename surface_container,
               typename mask_container, typename transform_container,
               typename context_t, typename... Args>
-    DETRAY_HOST auto operator()(grid_t &grid, const surface_container &surfaces,
+    DETRAY_HOST auto operator()(grid_t &grid, const volume_t &,
+                                const surface_container &surfaces,
                                 const transform_container &transforms,
                                 const mask_container &masks,
                                 const context_t ctx, Args &&...) const -> void {

--- a/core/include/detray/tools/grid_builder.hpp
+++ b/core/include/detray/tools/grid_builder.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/geometry/detector_volume.hpp"
 #include "detray/tools/bin_association.hpp"
 #include "detray/tools/bin_fillers.hpp"
 #include "detray/tools/grid_factory.hpp"
@@ -64,14 +65,15 @@ class grid_builder final : public volume_decorator<detector_t> {
 
     /// Fill grid from externally provided surfaces - temporary solution until
     /// the volume builders can be deployed in the toy detector
-    template <typename surface_container_t, typename transform_container_t,
-              typename mask_container_t, typename... Args>
+    template <typename volume_type, typename surface_container_t,
+              typename transform_container_t, typename mask_container_t,
+              typename... Args>
     DETRAY_HOST void fill_grid(
-        const surface_container_t &surfaces,
+        const volume_type &vol, const surface_container_t &surfaces,
         const transform_container_t &transforms, const mask_container_t &masks,
         const typename detector_t::geometry_context ctx = {},
         const bin_filler_t bin_filler = {}, Args &&... args) {
-        bin_filler(m_grid, surfaces, transforms, masks, ctx, args...);
+        bin_filler(m_grid, vol, surfaces, transforms, masks, ctx, args...);
     }
 
     /// Overwrite, to add the sensitives to the grid, instead of the surface vec
@@ -104,7 +106,8 @@ class grid_builder final : public volume_decorator<detector_t> {
         // Add the surfaces (portals and/or passives) that are owned by the vol
         typename detector_t::volume_type *vol_ptr =
             volume_decorator<detector_t>::build(det, ctx);
-        m_bin_filler(m_grid, m_surfaces, m_transforms, m_masks, ctx);
+        m_bin_filler(m_grid, detector_volume{det, *vol_ptr}, m_surfaces,
+                     m_transforms, m_masks, ctx);
 
         // Add the surfaces that were filled into the grid directly to the
         // detector and update their links

--- a/core/include/detray/tools/volume_builder.hpp
+++ b/core/include/detray/tools/volume_builder.hpp
@@ -69,6 +69,9 @@ class volume_builder : public volume_builder_interface<detector_t> {
     DETRAY_HOST
     auto build(detector_t& det, typename detector_t::geometry_context ctx = {})
         -> typename detector_t::volume_type* override {
+        m_volume->set_transform(det.transform_store().size());
+        det.transform_store().push_back(m_trf);
+
         add_objects_per_volume(ctx, det);
         m_surfaces.clear();
         m_transforms.clear(ctx);
@@ -76,6 +79,24 @@ class volume_builder : public volume_builder_interface<detector_t> {
 
         // Pass to decorator builders
         return m_volume;
+    }
+
+    DETRAY_HOST
+    void add_volume_placement(
+        const typename detector_t::transform3& trf = {}) override {
+        m_trf = trf;
+    }
+
+    DETRAY_HOST
+    void add_volume_placement(const typename detector_t::point3& t) override {
+        m_trf = typename detector_t::transform3{t};
+    }
+
+    DETRAY_HOST
+    void add_volume_placement(const typename detector_t::point3& t,
+                              const typename detector_t::vector3& x,
+                              const typename detector_t::vector3& z) override {
+        m_trf = typename detector_t::transform3{t, z, x, true};
     }
 
     DETRAY_HOST
@@ -145,6 +166,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
     }
 
     typename detector_t::volume_type* m_volume{};
+    typename detector_t::transform3 m_trf{};
 
     typename detector_t::surface_container_t m_surfaces{};
     typename detector_t::transform_container m_transforms{};

--- a/core/include/detray/tools/volume_builder_interface.hpp
+++ b/core/include/detray/tools/volume_builder_interface.hpp
@@ -29,7 +29,8 @@ class volume_builder_interface {
 
     virtual ~volume_builder_interface() = default;
 
-    /// @brief Initializes a new volume with shape id @param id in @param det
+    /// @brief Initializes a new volume with shape id @param id in detector
+    /// @param det
     DETRAY_HOST
     virtual void init_vol(detector_t &det, const volume_id id) = 0;
 
@@ -50,6 +51,24 @@ class volume_builder_interface {
     virtual auto build(detector_t &det,
                        typename detector_t::geometry_context ctx = {}) ->
         typename detector_t::volume_type * = 0;
+
+    /// @brief Add the transform for the volume placement - copy
+    DETRAY_HOST
+    virtual void add_volume_placement(
+        const typename detector_t::transform3 &trf = {}) = 0;
+
+    /// @brief Add the transform for the volume placement from the translation
+    /// @param t. The rotation will be the identity matrix.
+    DETRAY_HOST
+    virtual void add_volume_placement(const typename detector_t::point3 &t) = 0;
+
+    /// @brief Add the transform for the volume placement from the translation
+    /// @param t , the new x- and z-axis (@param x, @param z).
+    DETRAY_HOST
+    virtual void add_volume_placement(
+        const typename detector_t::point3 &t,
+        const typename detector_t::vector3 &x,
+        const typename detector_t::vector3 &z) = 0;
 
     /// @brief Add the portals to the volume.
     /// @returns the index range of the portals in the temporary surface
@@ -121,6 +140,24 @@ class volume_decorator : public volume_builder_interface<detector_t> {
                typename detector_t::geometry_context /*ctx*/ = {}) ->
         typename detector_t::volume_type * override {
         return m_builder->build(det);
+    }
+
+    DETRAY_HOST
+    void add_volume_placement(
+        const typename detector_t::transform3 &trf = {}) override {
+        return m_builder->add_volume_placement(trf);
+    }
+
+    DETRAY_HOST
+    void add_volume_placement(const typename detector_t::point3 &t) override {
+        return m_builder->add_volume_placement(t);
+    }
+
+    DETRAY_HOST
+    void add_volume_placement(const typename detector_t::point3 &t,
+                              const typename detector_t::vector3 &x,
+                              const typename detector_t::vector3 &z) override {
+        return m_builder->add_volume_placement(t, x, z);
     }
 
     DETRAY_HOST

--- a/tests/common/include/tests/common/test_toy_detector.hpp
+++ b/tests/common/include/tests/common/test_toy_detector.hpp
@@ -90,7 +90,7 @@ inline bool test_toy_detector(
     // Check number of geomtery objects
     EXPECT_EQ(volumes.size(), 20u);
     EXPECT_EQ(toy_det.n_surfaces(), 3244u);
-    EXPECT_EQ(transforms.size(ctx), 3244u);
+    EXPECT_EQ(transforms.size(ctx), 3264u);
     EXPECT_EQ(masks.size<mask_ids::e_rectangle2>(), 2492u);
     EXPECT_EQ(masks.size<mask_ids::e_trapezoid2>(), 648u);
     EXPECT_EQ(masks.size<mask_ids::e_portal_cylinder2>(), 52u);
@@ -142,7 +142,9 @@ inline bool test_toy_detector(
                 EXPECT_EQ(sf_itr->volume(), vol_index);
                 EXPECT_EQ(sf_itr->id(), surface_id::e_portal);
                 EXPECT_EQ(sf_itr->index(), pti);
-                EXPECT_EQ(sf_itr->transform(), trf_index);
+                // The volume index compensates for the number of volume
+                // transforms in the transform store
+                EXPECT_EQ(sf_itr->transform(), trf_index + vol_index + 1);
                 EXPECT_EQ(sf_itr->mask(), mask_link);
                 // EXPECT_EQ(sf_itr->material(), material_index);
                 const auto volume_link =
@@ -180,7 +182,9 @@ inline bool test_toy_detector(
                 EXPECT_FALSE(sf_itr->id() == surface_id::e_portal)
                     << sf_itr->barcode();
                 EXPECT_EQ(sf_itr->index(), pti);
-                EXPECT_EQ(sf_itr->transform(), trf_index);
+                // The volume index compensates for the number of volume
+                // transforms in the transform store
+                EXPECT_EQ(sf_itr->transform(), trf_index + vol_index + 1);
                 EXPECT_EQ(sf_itr->mask(), mask_index);
                 // EXPECT_EQ(sf_itr->material(), material_index);
                 const auto volume_link =

--- a/tests/unit_tests/cpu/grid_grid_builder.cpp
+++ b/tests/unit_tests/cpu/grid_grid_builder.cpp
@@ -296,12 +296,10 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
         d.surface_store()
             .template get<
                 test_detector_t::sf_finders::id::e_cylinder_grid>()[0];
-    dindex trf_idx{3u};
-    for (dindex gbin = 0u; gbin < cyl_grid.nbins(); ++gbin) {
-        for (auto& sf : cyl_grid.bin(gbin)) {
-            EXPECT_TRUE(sf.is_sensitive());
-            EXPECT_EQ(sf.volume(), 0u);
-            EXPECT_EQ(sf.transform(), trf_idx++);
-        }
+    dindex trf_idx{4u};
+    for (const auto& sf : cyl_grid.all()) {
+        EXPECT_TRUE(sf.is_sensitive());
+        EXPECT_EQ(sf.volume(), 0u);
+        EXPECT_EQ(sf.transform(), trf_idx++);
     }
 }

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -371,8 +371,10 @@ auto create_telescope_detector(
     typename detector_t::geometry_context ctx{};
     const surface_config sf_config{msk.values(), dists, mat, thickness};
 
-    // Dummy volume bounds for now, will be set correctly when portals are built
+    // The telescope detector has only one volume with default placement
     auto &vol = det.new_volume(volume_id::e_cuboid);
+    vol.set_transform(det.transform_store().size());
+    det.transform_store().emplace_back();
 
     // Add module surfaces to volume
     typename detector_t::surface_container_t surfaces(&resource);


### PR DESCRIPTION
Adds transforms to the volumes, so that rotations and translations of the volume can be properly included when switching to grid local coordinates for the axes lookup during local navigation. The volume transforms are the first to be added to the transform store respectively and are non contextual (don't need alignment) like the portal transforms that follow immediately after. The volume transforms are also added by a few new methods (```add_volume_placement```) to the volume builders.

Since the transform indices change with the extra transforms in the transform store, the unittests have been adapted. Furthermore, the index updates in the grid filling for the toy detector was simplified/corrected (e.g. ```global_to_local``` in the bin filler can now use proper transform) and the volume descriptor was cleaned up a bit.