### PR TITLE
fix: write volume transform to file

### DIFF
--- a/io/include/detray/io/common/geometry_writer.hpp
+++ b/io/include/detray/io/common/geometry_writer.hpp
@@ -189,8 +189,8 @@ class geometry_writer : public writer_interface<detector_t> {
         volume_payload vol_data;
 
         vol_data.index = serialize(vol_desc.index());
-        // @todo volumes don't have transforms, yet
-        vol_data.transform = serialize(typename detector_t::transform3());
+        vol_data.transform =
+            serialize(det.transform_store()[vol_desc.transform()]);
         vol_data.type = vol_desc.id();
 
         for (const auto& sf : det.surface_lookup()) {


### PR DESCRIPTION
After adding the placement transforms to the volumes, fetch them and write them to file in the geometry writer.