### PR TITLE
ref: surface interface in navigation state

### DIFF
--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -84,6 +84,10 @@ class surface {
     DETRAY_HOST_DEVICE
     constexpr auto id() const -> surface_id { return barcode().id(); }
 
+    /// @returns the extra bits in the barcode
+    DETRAY_HOST_DEVICE
+    constexpr auto extra() const -> dindex { return barcode().extra(); }
+
     /// @returns an id for the surface type (e.g. 'rectangle')
     DETRAY_HOST_DEVICE
     constexpr auto shape_id() const { return m_desc.mask().id(); }
@@ -194,7 +198,7 @@ class surface {
     /// @tparam functor_t the prescription to be applied to the mask
     /// @tparam Args      types of additional arguments to the functor
     template <typename functor_t, typename... Args>
-    DETRAY_HOST_DEVICE constexpr auto visit_mask(Args &&... args) const {
+    DETRAY_HOST_DEVICE constexpr auto visit_mask(Args &&...args) const {
         const auto &masks = m_detector.mask_store();
 
         return masks.template visit<functor_t>(m_desc.mask(),
@@ -206,7 +210,7 @@ class surface {
     /// @tparam functor_t the prescription to be applied to the mask
     /// @tparam Args      types of additional arguments to the functor
     template <typename functor_t, typename... Args>
-    DETRAY_HOST_DEVICE constexpr auto visit_material(Args &&... args) const {
+    DETRAY_HOST_DEVICE constexpr auto visit_material(Args &&...args) const {
         const auto &materials = m_detector.material_store();
 
         return materials.template visit<functor_t>(m_desc.material(),
@@ -234,10 +238,10 @@ class surface {
 
 template <typename detector_t, typename descr_t>
 DETRAY_HOST_DEVICE surface(const detector_t &, const descr_t &)
-    ->surface<detector_t>;
+    -> surface<detector_t>;
 
 template <typename detector_t>
 DETRAY_HOST_DEVICE surface(const detector_t &, const geometry::barcode)
-    ->surface<detector_t>;
+    -> surface<detector_t>;
 
 }  // namespace detray

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -198,7 +198,7 @@ class surface {
     /// @tparam functor_t the prescription to be applied to the mask
     /// @tparam Args      types of additional arguments to the functor
     template <typename functor_t, typename... Args>
-    DETRAY_HOST_DEVICE constexpr auto visit_mask(Args &&...args) const {
+    DETRAY_HOST_DEVICE constexpr auto visit_mask(Args &&... args) const {
         const auto &masks = m_detector.mask_store();
 
         return masks.template visit<functor_t>(m_desc.mask(),
@@ -210,7 +210,7 @@ class surface {
     /// @tparam functor_t the prescription to be applied to the mask
     /// @tparam Args      types of additional arguments to the functor
     template <typename functor_t, typename... Args>
-    DETRAY_HOST_DEVICE constexpr auto visit_material(Args &&...args) const {
+    DETRAY_HOST_DEVICE constexpr auto visit_material(Args &&... args) const {
         const auto &materials = m_detector.material_store();
 
         return materials.template visit<functor_t>(m_desc.material(),
@@ -238,10 +238,10 @@ class surface {
 
 template <typename detector_t, typename descr_t>
 DETRAY_HOST_DEVICE surface(const detector_t &, const descr_t &)
-    -> surface<detector_t>;
+    ->surface<detector_t>;
 
 template <typename detector_t>
 DETRAY_HOST_DEVICE surface(const detector_t &, const geometry::barcode)
-    -> surface<detector_t>;
+    ->surface<detector_t>;
 
 }  // namespace detray

--- a/core/include/detray/intersection/concentric_cylinder_intersector.hpp
+++ b/core/include/detray/intersection/concentric_cylinder_intersector.hpp
@@ -117,7 +117,7 @@ struct concentric_cylinder_intersector {
                 // prepare some additional information in case the intersection
                 // is valid
                 if (is.status == intersection::status::e_inside) {
-                    is.surface = sf;
+                    is.sf_desc = sf;
                     is.direction = detail::signbit(is.path)
                                        ? intersection::direction::e_opposite
                                        : intersection::direction::e_along;
@@ -150,7 +150,7 @@ struct concentric_cylinder_intersector {
         const ray_type &ray, intersection_t &sfi, const mask_t &mask,
         const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
-        sfi = this->operator()(ray, sfi.surface, mask, trf, mask_tolerance)[0];
+        sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance)[0];
     }
 };
 

--- a/core/include/detray/intersection/cylinder_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_intersector.hpp
@@ -63,7 +63,7 @@ struct cylinder_intersector {
             case 2:
                 ret[1] = build_candidate(ray, mask, trf, qe.larger(),
                                          mask_tolerance);
-                ret[1].surface = sf;
+                ret[1].sf_desc = sf;
                 // If there are two solutions, reuse the case for a single
                 // solution to setup the intersection with the smaller path
                 // in ret[0]
@@ -71,7 +71,7 @@ struct cylinder_intersector {
             case 1:
                 ret[0] = build_candidate(ray, mask, trf, qe.smaller(),
                                          mask_tolerance);
-                ret[0].surface = sf;
+                ret[0].sf_desc = sf;
                 break;
             case 0:
                 ret[0].status = intersection::status::e_missed;

--- a/core/include/detray/intersection/cylinder_portal_intersector.hpp
+++ b/core/include/detray/intersection/cylinder_portal_intersector.hpp
@@ -78,7 +78,7 @@ struct cylinder_portal_intersector
                                     : qe.larger()};
             is = this->template build_candidate(ray, mask, trf, t,
                                                 mask_tolerance);
-            is.surface = sf;
+            is.sf_desc = sf;
         } else {
             is.status = intersection::status::e_missed;
         }
@@ -103,7 +103,7 @@ struct cylinder_portal_intersector
         const ray_type &ray, intersection_t &sfi, const mask_t &mask,
         const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
-        sfi = this->operator()(ray, sfi.surface, mask, trf, mask_tolerance);
+        sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance);
     }
 };
 

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -54,7 +54,7 @@ struct intersection2D {
     using nav_link_type = typename surface_descr_t::navigation_link;
 
     /// Descriptor of the surface this intersection belongs to
-    surface_descr_t surface;
+    surface_descr_t sf_desc;
 
     /// Local position of the intersection on the surface
     point3 local{detail::invalid_value<scalar_type>(),
@@ -100,7 +100,7 @@ struct intersection2D {
     friend std::ostream &operator<<(std::ostream &out_stream,
                                     const intersection2D &is) {
         out_stream << "dist:" << is.path
-                   << "\tsurface: " << is.surface.barcode() << ", loc ["
+                   << "\tsurface: " << is.sf_desc.barcode() << ", loc ["
                    << is.local[0] << ", " << is.local[1] << ", " << is.local[2]
                    << "]"
                    << ", links to vol:" << is.volume_link << ")";

--- a/core/include/detray/intersection/intersection_kernel.hpp
+++ b/core/include/detray/intersection/intersection_kernel.hpp
@@ -118,7 +118,7 @@ struct intersection_update {
         const transform_container_t &contextual_transforms,
         const scalar mask_tolerance = 0.f) const {
 
-        const auto &ctf = contextual_transforms[sfi.surface.transform()];
+        const auto &ctf = contextual_transforms[sfi.sf_desc.transform()];
 
         // Run over the masks that belong to the surface
         for (const auto &mask :

--- a/core/include/detray/intersection/line_intersector.hpp
+++ b/core/include/detray/intersection/line_intersector.hpp
@@ -107,7 +107,7 @@ struct line_intersector {
             // prepare some additional information in case the intersection
             // is valid
             if (is.status == intersection::status::e_inside) {
-                is.surface = sf;
+                is.sf_desc = sf;
 
                 is.direction = detail::signbit(is.path)
                                    ? intersection::direction::e_opposite
@@ -138,7 +138,7 @@ struct line_intersector {
         const ray_type &ray, intersection_t &sfi, const mask_t &mask,
         const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
-        sfi = this->operator()(ray, sfi.surface, mask, trf, mask_tolerance);
+        sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance);
     }
 };
 

--- a/core/include/detray/intersection/plane_intersector.hpp
+++ b/core/include/detray/intersection/plane_intersector.hpp
@@ -77,7 +77,7 @@ struct plane_intersector {
                 // prepare some additional information in case the intersection
                 // is valid
                 if (is.status == intersection::status::e_inside) {
-                    is.surface = sf;
+                    is.sf_desc = sf;
 
                     is.direction = detail::signbit(is.path)
                                        ? intersection::direction::e_opposite
@@ -110,7 +110,7 @@ struct plane_intersector {
         const ray_type &ray, intersection_t &sfi, const mask_t &mask,
         const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
-        sfi = this->operator()(ray, sfi.surface, mask, trf, mask_tolerance);
+        sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance);
     }
 };
 

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -85,7 +85,7 @@ struct target_aborter : actor {
         // In case the propagation starts on a module, make sure to not abort
         // directly
         if (navigation.is_on_module() and
-            (navigation.current_object() == abrt_state._target_surface) and
+            (navigation.surface_barcode() == abrt_state._target_surface) and
             (stepping.path_length() > 0.f)) {
             prop_state._heartbeat &= navigation.exit();
         }

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -85,7 +85,7 @@ struct target_aborter : actor {
         // In case the propagation starts on a module, make sure to not abort
         // directly
         if (navigation.is_on_module() and
-            (navigation.surface_barcode() == abrt_state._target_surface) and
+            (navigation.barcode() == abrt_state._target_surface) and
             (stepping.path_length() > 0.f)) {
             prop_state._heartbeat &= navigation.exit();
         }

--- a/core/include/detray/propagator/actors/parameter_resetter.hpp
+++ b/core/include/detray/propagator/actors/parameter_resetter.hpp
@@ -78,8 +78,7 @@ struct parameter_resetter : actor {
         const geo_cxt_t ctx{};
 
         // Surface
-        const auto sf =
-            surface{*navigation.detector(), navigation.current()->surface};
+        const auto sf = navigation.current_surface();
 
         sf.template visit_mask<kernel>(sf.transform(ctx), stepping);
     }

--- a/core/include/detray/propagator/actors/parameter_resetter.hpp
+++ b/core/include/detray/propagator/actors/parameter_resetter.hpp
@@ -78,7 +78,7 @@ struct parameter_resetter : actor {
         const geo_cxt_t ctx{};
 
         // Surface
-        const auto sf = navigation.current_surface();
+        const auto sf = navigation.get_surface();
 
         sf.template visit_mask<kernel>(sf.transform(ctx), stepping);
     }

--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -141,8 +141,7 @@ struct parameter_transporter : actor {
         const geo_cxt_t ctx{};
 
         // Surface
-        const auto sf =
-            surface{*navigation.detector(), navigation.current()->surface};
+        const auto sf = navigation.current_surface();
 
         sf.template visit_mask<kernel>(sf.transform(ctx), propagation);
 

--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -141,7 +141,7 @@ struct parameter_transporter : actor {
         const geo_cxt_t ctx{};
 
         // Surface
-        const auto sf = navigation.current_surface();
+        const auto sf = navigation.get_surface();
 
         sf.template visit_mask<kernel>(sf.transform(ctx), propagation);
 

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -123,7 +123,7 @@ struct pointwise_material_interactor : actor {
 
             this->update(stepping._bound_params, interactor_state,
                          static_cast<int>(navigation.direction()),
-                         *navigation.current(), navigation.current_surface());
+                         *navigation.current(), navigation.get_surface());
         }
     }
 

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -120,12 +120,10 @@ struct pointwise_material_interactor : actor {
         if (navigation.is_on_module()) {
 
             auto &stepping = prop_state._stepping;
-            const auto *det = navigation.detector();
 
             this->update(stepping._bound_params, interactor_state,
                          static_cast<int>(navigation.direction()),
-                         *navigation.current(),
-                         surface{*det, navigation.current()->surface});
+                         *navigation.current(), navigation.current_surface());
         }
     }
 

--- a/core/include/detray/propagator/navigator.hpp
+++ b/core/include/detray/propagator/navigator.hpp
@@ -239,11 +239,20 @@ class navigator {
             _volume_index = static_cast<nav_link_type>(v);
         }
 
-        /// @returns current object the navigator is on (might be invalid if
-        /// between objects) - const
+        /// @returns barcode of the detector surface the navigator is on
+        /// (might be invalid if between objects) - const
         DETRAY_HOST_DEVICE
-        inline auto current_object() const -> geometry::barcode {
+        inline auto surface_barcode() const -> geometry::barcode {
             return _object_index;
+        }
+
+        /// @returns current detector surface the navigator is on
+        /// (might be invalid if between objects) - const
+        DETRAY_HOST_DEVICE
+        inline auto current_surface() const
+            -> const surface<const detector_type> {
+            assert(is_on_module() or is_on_portal());
+            return surface<const detector_type>{*_detector, _object_index};
         }
 
         /// @returns the next object the navigator indends to reach
@@ -326,7 +335,7 @@ class navigator {
         DETRAY_HOST_DEVICE
         inline auto is_on_sensitive() const -> bool {
             return (_status == navigation::status::e_on_module) &&
-                   (this->current_object().id() == surface_id::e_sensitive);
+                   (_object_index.id() == surface_id::e_sensitive);
         }
 
         /// Helper method to check the track has reached a portal surface

--- a/core/include/detray/utils/inspectors.hpp
+++ b/core/include/detray/utils/inspectors.hpp
@@ -145,13 +145,22 @@ struct print_inspector {
                 debug_stream << "status" << tabs << "on_portal" << std::endl;
                 break;
         };
-        debug_stream << "current object\t\t\t" << state.barcode() << std::endl;
+
+        debug_stream << "current object\t\t\t";
+        if (state.is_on_portal() or state.is_on_module() or
+            state.status() == status::e_on_target) {
+            debug_stream << state.barcode() << std::endl;
+        } else {
+            debug_stream << "undefined" << std::endl;
+        }
+
         debug_stream << "distance to next\t\t";
         if (std::abs(state()) < state.tolerance()) {
             debug_stream << "on obj (within tol)" << std::endl;
         } else {
             debug_stream << state() << std::endl;
         }
+
         switch (state.trust_level()) {
             case trust_level::e_no_trust:
                 debug_stream << "trust" << tabs << "no_trust" << std::endl;
@@ -221,7 +230,13 @@ struct print_inspector : actor {
                            << navigation.volume();
         }
 
-        printer.stream << "surface: " << std::setw(14) << navigation.barcode();
+        printer.stream << "surface: " << std::setw(14);
+        if (navigation.is_on_portal() or navigation.is_on_module() or
+            navigation.status() == navigation::status::e_on_target) {
+            printer.stream << navigation.barcode();
+        } else {
+            printer.stream << "undefined";
+        }
 
         printer.stream << "step_size: " << std::setw(10) << stepping._step_size
                        << std::endl;

--- a/core/include/detray/utils/inspectors.hpp
+++ b/core/include/detray/utils/inspectors.hpp
@@ -144,7 +144,7 @@ struct print_inspector {
                 debug_stream << "status" << tabs << "on_portal" << std::endl;
                 break;
         };
-        debug_stream << "current object\t\t\t" << state.current_object()
+        debug_stream << "current object\t\t\t" << state.surface_barcode()
                      << std::endl;
         debug_stream << "distance to next\t\t";
         if (std::abs(state()) < state.tolerance()) {
@@ -214,19 +214,15 @@ struct print_inspector : actor {
                 break;
         };
 
-        if (navigation.volume() == dindex_invalid) {
+        if (is_invalid_value(navigation.volume())) {
             printer.stream << "volume: " << std::setw(10) << "invalid";
         } else {
             printer.stream << "volume: " << std::setw(10)
                            << navigation.volume();
         }
 
-        if (navigation.current_object().is_invalid()) {
-            printer.stream << "surface: " << std::setw(14) << "invalid";
-        } else {
-            printer.stream << "surface: " << std::setw(14)
-                           << navigation.current_object();
-        }
+        printer.stream << "surface: " << std::setw(14)
+                       << navigation.surface_barcode();
 
         printer.stream << "step_size: " << std::setw(10) << stepping._step_size
                        << std::endl;

--- a/core/include/detray/utils/inspectors.hpp
+++ b/core/include/detray/utils/inspectors.hpp
@@ -107,7 +107,7 @@ struct print_inspector {
         for (const auto &sf_cand : state.candidates()) {
             const auto &local = sf_cand.local;
             const auto pos =
-                surface{*state.detector(), sf_cand.surface}.local_to_global(
+                surface{*state.detector(), sf_cand.sf_desc}.local_to_global(
                     geo_ctx_t{}, local);
 
             debug_stream << sf_cand;
@@ -119,7 +119,8 @@ struct print_inspector {
             if (state.is_exhausted()) {
                 debug_stream << "exhausted" << std::endl;
             } else {
-                debug_stream << " -> " << state.next_object() << std::endl;
+                debug_stream << " -> " << state.next_surface().barcode()
+                             << std::endl;
             }
         }
 
@@ -144,8 +145,7 @@ struct print_inspector {
                 debug_stream << "status" << tabs << "on_portal" << std::endl;
                 break;
         };
-        debug_stream << "current object\t\t\t" << state.surface_barcode()
-                     << std::endl;
+        debug_stream << "current object\t\t\t" << state.barcode() << std::endl;
         debug_stream << "distance to next\t\t";
         if (std::abs(state()) < state.tolerance()) {
             debug_stream << "on obj (within tol)" << std::endl;
@@ -221,8 +221,7 @@ struct print_inspector : actor {
                            << navigation.volume();
         }
 
-        printer.stream << "surface: " << std::setw(14)
-                       << navigation.surface_barcode();
+        printer.stream << "surface: " << std::setw(14) << navigation.barcode();
 
         printer.stream << "step_size: " << std::setw(10) << stepping._step_size
                        << std::endl;

--- a/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
@@ -161,7 +161,7 @@ struct helix_cylinder_intersector
 
             // Compute some additional information if the intersection is valid
             if (is.status == intersection::status::e_inside) {
-                is.surface = sf;
+                is.sf_desc = sf;
                 is.direction = std::signbit(s)
                                    ? intersection::direction::e_opposite
                                    : intersection::direction::e_along;

--- a/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
@@ -152,7 +152,7 @@ struct helix_line_intersector {
 
         // Compute some additional information if the intersection is valid
         if (sfi.status == intersection::status::e_inside) {
-            sfi.surface = sf;
+            sfi.sf_desc = sf;
             sfi.direction = std::signbit(s)
                                 ? intersection::direction::e_opposite
                                 : intersection::direction::e_along;

--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -99,7 +99,7 @@ struct helix_plane_intersector {
 
         // Compute some additional information if the intersection is valid
         if (sfi.status == intersection::status::e_inside) {
-            sfi.surface = sf;
+            sfi.sf_desc = sf;
             sfi.direction = std::signbit(s)
                                 ? intersection::direction::e_opposite
                                 : intersection::direction::e_along;

--- a/tests/common/include/tests/common/tools/particle_gun.hpp
+++ b/tests/common/include/tests/common/tools/particle_gun.hpp
@@ -68,7 +68,7 @@ struct particle_gun {
             // Candidate is invalid if it lies in the opposite direction
             for (auto &sfi : intersections) {
                 if (sfi.direction == intersection::direction::e_along) {
-                    sfi.surface = sf_desc;
+                    sfi.sf_desc = sf_desc;
                     // Volume the candidate belongs to
                     intersection_record.emplace_back(sf.volume(), sfi);
                 }

--- a/tests/common/include/tests/common/tools/ray_scan_utils.hpp
+++ b/tests/common/include/tests/common/tools/ray_scan_utils.hpp
@@ -189,20 +189,20 @@ inline auto trace_intersections(const record_container &intersection_records,
 
         /// getter
         /// @{
-        inline auto surface_idx() const { return entry.second.surface.index(); }
+        inline auto surface_idx() const { return entry.second.sf_desc.index(); }
         inline auto surface_volume_idx() const {
-            return entry.second.surface.volume();
+            return entry.second.sf_desc.volume();
         }
         inline auto &inters() const { return entry.second; }
         inline auto &volume_idx() const { return entry.first; }
         inline auto &volume_link() const { return entry.second.volume_link; }
         inline auto &dist() const { return entry.second.path; }
         inline bool is_portal() const {
-            return entry.second.surface.is_portal();
+            return entry.second.sf_desc.is_portal();
         }
         inline bool is_portal(
             const typename record_container::value_type &inters_record) const {
-            return inters_record.second.surface.is_portal();
+            return inters_record.second.sf_desc.is_portal();
         }
         /// @}
     };

--- a/tests/unit_tests/cpu/check_geometry_navigation.cpp
+++ b/tests/unit_tests/cpu/check_geometry_navigation.cpp
@@ -98,21 +98,21 @@ GTEST_TEST(detray_propagator, straight_line_navigation) {
 
         // Check every single recorded intersection
         for (std::size_t i = 0u; i < obj_tracer.object_trace.size(); ++i) {
-            if (obj_tracer[i].surface.barcode() !=
-                intersection_trace[i].second.surface.barcode()) {
+            if (obj_tracer[i].sf_desc.barcode() !=
+                intersection_trace[i].second.sf_desc.barcode()) {
                 // Intersection record at portal bound might be flipped
                 // (the portals overlap completely)
-                if (obj_tracer[i].surface.barcode() ==
-                        intersection_trace[i + 1u].second.surface.barcode() and
-                    obj_tracer[i + 1u].surface.barcode() ==
-                        intersection_trace[i].second.surface.barcode()) {
+                if (obj_tracer[i].sf_desc.barcode() ==
+                        intersection_trace[i + 1u].second.sf_desc.barcode() and
+                    obj_tracer[i + 1u].sf_desc.barcode() ==
+                        intersection_trace[i].second.sf_desc.barcode()) {
                     // Have already checked the next record
                     ++i;
                     continue;
                 }
             }
-            EXPECT_EQ(obj_tracer[i].surface.barcode(),
-                      intersection_trace[i].second.surface.barcode())
+            EXPECT_EQ(obj_tracer[i].sf_desc.barcode(),
+                      intersection_trace[i].second.sf_desc.barcode())
                 << debug_printer.to_string() << debug_stream.str();
         }
     }
@@ -210,21 +210,21 @@ GTEST_TEST(detray_propagator, helix_navigation) {
 
         // Check every single recorded intersection
         for (std::size_t i = 0u; i < max_entries; ++i) {
-            if (obj_tracer[i].surface.barcode() !=
-                intersection_trace[i].second.surface.barcode()) {
+            if (obj_tracer[i].sf_desc.barcode() !=
+                intersection_trace[i].second.sf_desc.barcode()) {
                 // Intersection record at portal bound might be flipped
                 // (the portals overlap completely)
-                if (obj_tracer[i].surface.barcode() ==
-                        intersection_trace[i + 1u].second.surface.barcode() and
-                    obj_tracer[i + 1u].surface.barcode() ==
-                        intersection_trace[i].second.surface.barcode()) {
+                if (obj_tracer[i].sf_desc.barcode() ==
+                        intersection_trace[i + 1u].second.sf_desc.barcode() and
+                    obj_tracer[i + 1u].sf_desc.barcode() ==
+                        intersection_trace[i].second.sf_desc.barcode()) {
                     // Have already checked the next record
                     ++i;
                     continue;
                 }
             }
-            EXPECT_EQ(obj_tracer[i].surface.barcode(),
-                      intersection_trace[i].second.surface.barcode())
+            EXPECT_EQ(obj_tracer[i].sf_desc.barcode(),
+                      intersection_trace[i].second.sf_desc.barcode())
                 << " intersection: " << i << "/" << n_inters_nav
                 << " on track: " << n_tracks << "/"
                 << trk_state_generator.size();

--- a/tests/unit_tests/cpu/tools_guided_navigator.cpp
+++ b/tests/unit_tests/cpu/tools_guided_navigator.cpp
@@ -98,9 +98,9 @@ GTEST_TEST(detray_propagator, guided_navigator) {
         auto bcd = geometry::barcode{};
         bcd.set_volume(0u).set_index(sf_sequence[i]);
         bcd.set_id((i == 11u) ? surface_id::e_portal : surface_id::e_sensitive);
-        EXPECT_TRUE(candidate.surface.barcode() == bcd)
+        EXPECT_TRUE(candidate.sf_desc.barcode() == bcd)
             << "error at intersection on surface:\n"
             << "Expected: " << bcd
-            << "\nFound: " << candidate.surface.barcode();
+            << "\nFound: " << candidate.sf_desc.barcode();
     }
 }

--- a/tests/unit_tests/cpu/tools_intersection_kernel.cpp
+++ b/tests/unit_tests/cpu/tools_intersection_kernel.cpp
@@ -160,28 +160,28 @@ GTEST_TEST(detray_intersection, intersection_kernel_ray) {
 
         vector3 global;
 
-        if (sfi_init[i].surface.mask().id() == e_rectangle2) {
+        if (sfi_init[i].sf_desc.mask().id() == e_rectangle2) {
             global =
                 rect.to_global_frame(transform_store[0], sfi_init[i].local);
-        } else if (sfi_init[i].surface.mask().id() == e_trapezoid2) {
+        } else if (sfi_init[i].sf_desc.mask().id() == e_trapezoid2) {
             global =
                 trap.to_global_frame(transform_store[1], sfi_init[i].local);
-        } else if (sfi_init[i].surface.mask().id() == e_annulus2) {
+        } else if (sfi_init[i].sf_desc.mask().id() == e_annulus2) {
             global =
                 annl.to_global_frame(transform_store[2], sfi_init[i].local);
-        } else if (sfi_init[i].surface.mask().id() == e_cylinder2) {
+        } else if (sfi_init[i].sf_desc.mask().id() == e_cylinder2) {
             global = cyl.to_global_frame(transform_store[3], sfi_init[i].local);
-        } else if (sfi_init[i].surface.mask().id() == e_cylinder2_portal) {
+        } else if (sfi_init[i].sf_desc.mask().id() == e_cylinder2_portal) {
             global = cyl_portal.to_global_frame(transform_store[4],
                                                 sfi_init[i].local);
         }
 
         EXPECT_NEAR(global[0], expected_points[i][0], 1e-3f)
-            << " at surface " << sfi_init[i].surface.barcode();
+            << " at surface " << sfi_init[i].sf_desc.barcode();
         EXPECT_NEAR(global[1], expected_points[i][1], 1e-3f)
-            << " at surface " << sfi_init[i].surface.barcode();
+            << " at surface " << sfi_init[i].sf_desc.barcode();
         EXPECT_NEAR(global[2], expected_points[i][2], 1e-3f)
-            << " at surface " << sfi_init[i].surface.barcode();
+            << " at surface " << sfi_init[i].sf_desc.barcode();
     }
 
     // Update kernel
@@ -192,7 +192,7 @@ GTEST_TEST(detray_intersection, intersection_kernel_ray) {
     sfi_update.resize(5);
 
     for (const auto [idx, surface] : detray::views::enumerate(surfaces)) {
-        sfi_update[idx].surface = surface;
+        sfi_update[idx].sf_desc = surface;
         mask_store.visit<intersection_update>(
             surface.mask(), detail::ray(track), sfi_update[idx],
             transform_store);

--- a/tests/unit_tests/cpu/tools_navigator.cpp
+++ b/tests/unit_tests/cpu/tools_navigator.cpp
@@ -43,11 +43,11 @@ inline void check_towards_surface(state_t &state, dindex vol_id,
     ASSERT_EQ(state.n_candidates(), n_candidates);
     // If we are towards some object, we have no current one (even if we are
     // geometrically still there)
-    ASSERT_EQ(state.surface_barcode().volume(), 4095u);
-    ASSERT_EQ(state.surface_barcode().id(), static_cast<surface_id>(15u));
-    ASSERT_EQ(state.surface_barcode().extra(), 255u);
+    ASSERT_EQ(state.barcode().volume(), 4095u);
+    ASSERT_EQ(state.barcode().id(), static_cast<surface_id>(15u));
+    ASSERT_EQ(state.barcode().extra(), 255u);
     // the portal is still the next object, since we did not step
-    ASSERT_EQ(state.next_object().index(), next_id);
+    ASSERT_EQ(state.next_surface().index(), next_id);
     ASSERT_TRUE((state.trust_level() == navigation::trust_level::e_full) or
                 (state.trust_level() == navigation::trust_level::e_high));
 }
@@ -65,10 +65,10 @@ inline void check_on_surface(state_t &state, dindex vol_id,
     ASSERT_TRUE(std::abs(state()) > state.tolerance());
     ASSERT_EQ(state.volume(), vol_id);
     ASSERT_EQ(state.n_candidates(), n_candidates);
-    ASSERT_EQ(state.surface_barcode().volume(), vol_id);
-    ASSERT_EQ(state.surface_barcode().index(), current_id);
+    ASSERT_EQ(state.barcode().volume(), vol_id);
+    ASSERT_EQ(state.barcode().index(), current_id);
     // points to the next surface now
-    ASSERT_EQ(state.next_object().index(), next_id);
+    ASSERT_EQ(state.next_surface().index(), next_id);
     ASSERT_EQ(state.trust_level(), navigation::trust_level::e_full);
 }
 

--- a/tests/unit_tests/cpu/tools_navigator.cpp
+++ b/tests/unit_tests/cpu/tools_navigator.cpp
@@ -41,11 +41,6 @@ inline void check_towards_surface(state_t &state, dindex vol_id,
     ASSERT_EQ(state.status(), navigation::status::e_towards_object);
     ASSERT_EQ(state.volume(), vol_id);
     ASSERT_EQ(state.n_candidates(), n_candidates);
-    // If we are towards some object, we have no current one (even if we are
-    // geometrically still there)
-    ASSERT_EQ(state.barcode().volume(), 4095u);
-    ASSERT_EQ(state.barcode().id(), static_cast<surface_id>(15u));
-    ASSERT_EQ(state.barcode().extra(), 255u);
     // the portal is still the next object, since we did not step
     ASSERT_EQ(state.next_surface().index(), next_id);
     ASSERT_TRUE((state.trust_level() == navigation::trust_level::e_full) or

--- a/tests/unit_tests/cpu/tools_navigator.cpp
+++ b/tests/unit_tests/cpu/tools_navigator.cpp
@@ -43,9 +43,9 @@ inline void check_towards_surface(state_t &state, dindex vol_id,
     ASSERT_EQ(state.n_candidates(), n_candidates);
     // If we are towards some object, we have no current one (even if we are
     // geometrically still there)
-    ASSERT_EQ(state.current_object().volume(), 4095u);
-    ASSERT_EQ(state.current_object().id(), static_cast<surface_id>(15u));
-    ASSERT_EQ(state.current_object().extra(), 255u);
+    ASSERT_EQ(state.surface_barcode().volume(), 4095u);
+    ASSERT_EQ(state.surface_barcode().id(), static_cast<surface_id>(15u));
+    ASSERT_EQ(state.surface_barcode().extra(), 255u);
     // the portal is still the next object, since we did not step
     ASSERT_EQ(state.next_object().index(), next_id);
     ASSERT_TRUE((state.trust_level() == navigation::trust_level::e_full) or
@@ -65,8 +65,8 @@ inline void check_on_surface(state_t &state, dindex vol_id,
     ASSERT_TRUE(std::abs(state()) > state.tolerance());
     ASSERT_EQ(state.volume(), vol_id);
     ASSERT_EQ(state.n_candidates(), n_candidates);
-    ASSERT_EQ(state.current_object().volume(), vol_id);
-    ASSERT_EQ(state.current_object().index(), current_id);
+    ASSERT_EQ(state.surface_barcode().volume(), vol_id);
+    ASSERT_EQ(state.surface_barcode().index(), current_id);
     // points to the next surface now
     ASSERT_EQ(state.next_object().index(), next_id);
     ASSERT_EQ(state.trust_level(), navigation::trust_level::e_full);

--- a/utils/include/detray/simulation/event_writer.hpp
+++ b/utils/include/detray/simulation/event_writer.hpp
@@ -103,7 +103,7 @@ struct event_writer : actor {
             const auto pos = track.pos();
             const auto mom = track.mom();
 
-            const auto sf = navigation.current_surface();
+            const auto sf = navigation.get_surface();
 
             hit.particle_id = writer_state.particle_id;
             hit.geometry_id = sf.barcode().value();

--- a/utils/include/detray/simulation/event_writer.hpp
+++ b/utils/include/detray/simulation/event_writer.hpp
@@ -103,8 +103,10 @@ struct event_writer : actor {
             const auto pos = track.pos();
             const auto mom = track.mom();
 
+            const auto sf = navigation.current_surface();
+
             hit.particle_id = writer_state.particle_id;
-            hit.geometry_id = navigation.current_object().value();
+            hit.geometry_id = sf.barcode().value();
             hit.tx = pos[0];
             hit.ty = pos[1];
             hit.tz = pos[2];
@@ -119,8 +121,6 @@ struct event_writer : actor {
             csv_measurement meas;
 
             const auto bound_params = stepping._bound_params;
-            const auto sf = surface{*navigation.detector(),
-                                    geometry::barcode(hit.geometry_id)};
 
             const auto local = sf.template visit_mask<measurement_kernel>(
                 bound_params, writer_state.m_meas_smearer);

--- a/utils/include/detray/simulation/random_scatterer.hpp
+++ b/utils/include/detray/simulation/random_scatterer.hpp
@@ -123,7 +123,7 @@ struct random_scatterer : actor {
         auto& stepping = prop_state._stepping;
         auto& bound_params = stepping._bound_params;
         const auto& is = *navigation.current();
-        const auto sf = navigation.current_surface();
+        const auto sf = navigation.get_surface();
 
         sf.template visit_material<kernel>(is, simulator_state, bound_params);
 

--- a/utils/include/detray/simulation/random_scatterer.hpp
+++ b/utils/include/detray/simulation/random_scatterer.hpp
@@ -123,7 +123,7 @@ struct random_scatterer : actor {
         auto& stepping = prop_state._stepping;
         auto& bound_params = stepping._bound_params;
         const auto& is = *navigation.current();
-        const auto sf = surface{*navigation.detector(), is.surface};
+        const auto sf = navigation.current_surface();
 
         sf.template visit_material<kernel>(is, simulator_state, bound_params);
 


### PR DESCRIPTION
Use the surface interface in the navigation state directly to simplify some client code. Also removes the ```_object_index``` from the navigator state, which allowed to get rid of the ```set_sate``` method. Updates the names of the navigation state members