### PR TITLE
ref: telescope detector config

### DIFF
--- a/core/include/detray/intersection/detail/trajectories.hpp
+++ b/core/include/detray/intersection/detail/trajectories.hpp
@@ -37,6 +37,8 @@ class ray {
     using matrix_operator = typename transform3_t::matrix_actor;
     using track_helper = detail::track_helper<matrix_operator>;
 
+    ray() = default;
+
     /// Parametrized constructor that complies with track interface
     ///
     /// @param pos the track position

--- a/tests/unit_tests/cpu/check_geometry_scan.cpp
+++ b/tests/unit_tests/cpu/check_geometry_scan.cpp
@@ -121,15 +121,13 @@ GTEST_TEST(detray_geometry, telescope_geometry_scan) {
 
     vecmem::host_memory_resource host_mr;
 
-    // Use rectangle surfaces
-    mask<rectangle2D<>> rectangle{0u, 20.f * unit<scalar>::mm,
-                                  20.f * unit<scalar>::mm};
-
     // Build telescope detector with 10 rectangles
-    const std::size_t n_surfaces{10u};
-    const scalar length{500.f * unit<scalar>::mm};
-    const auto tel_det =
-        create_telescope_detector(host_mr, rectangle, n_surfaces, length);
+    tel_det_config<rectangle2D<>> tel_cfg{20.f * unit<scalar>::mm,
+                                          20.f * unit<scalar>::mm};
+    tel_cfg.n_surfaces(10u).length(500.f * unit<scalar>::mm);
+
+    const auto tel_det = create_telescope_detector(host_mr, tel_cfg);
+
     using nav_link_t =
         typename decltype(tel_det)::surface_type::navigation_link;
     constexpr auto leaving_world{detail::invalid_value<nav_link_t>()};

--- a/tests/unit_tests/cpu/check_simulation.cpp
+++ b/tests/unit_tests/cpu/check_simulation.cpp
@@ -214,31 +214,19 @@ TEST_P(TelescopeDetectorSimulation, telescope_detector_simulation) {
     // Create geometry
     vecmem::host_memory_resource host_mr;
 
-    // Use rectangle surfaces
-    mask<rectangle2D<>> rectangle{0u, 1000.f * unit<scalar>::mm,
-                                  1000.f * unit<scalar>::mm};
-
     // Build from given module positions
     std::vector<scalar> positions = {0.f,   50.f,  100.f, 150.f, 200.f, 250.f,
                                      300.f, 350.f, 400.f, 450.f, 500.f};
 
-    const auto mat = silicon_tml<scalar>();
     // A thickness larger than 0.1 cm will flip the track direction of low
     // energy (or non-relativistic) particle due to the large scattering
     const scalar thickness = 0.005f * unit<scalar>::cm;
 
-    // Detector type
-    using detector_type =
-        detray::detector<telescope_metadata<rectangle2D<>>, covfie::field>;
+    tel_det_config<rectangle2D<>> tel_cfg{1000.f * unit<scalar>::mm,
+                                          1000.f * unit<scalar>::mm};
+    tel_cfg.positions(positions).mat_thickness(thickness);
 
-    // Create B field
-    const vector3 B{0.f, 0.f, 2.f * unit<scalar>::T};
-    using b_field_t = typename detector_type::bfield_type;
-
-    const auto detector = create_telescope_detector(
-        host_mr,
-        b_field_t(b_field_t::backend_t::configuration_t{B[0], B[1], B[2]}),
-        rectangle, positions, mat, thickness);
+    const auto detector = create_telescope_detector(host_mr, tel_cfg);
 
     // Momentum
     const scalar mom = std::get<0>(GetParam());

--- a/tests/unit_tests/cpu/line_stepper.cpp
+++ b/tests/unit_tests/cpu/line_stepper.cpp
@@ -39,18 +39,16 @@ GTEST_TEST(detray_propagator, covariance_transport) {
 
     vecmem::host_memory_resource host_mr;
 
-    // Use unbounded rectangle surfaces
-    mask<rectangle2D<>> rectangle{0u, 200.f * unit<scalar>::mm,
-                                  200.f * unit<scalar>::mm};
-
     // Build in x-direction from given module positions
     detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
     std::vector<scalar> positions = {0.f, 10.f, 20.f, 30.f, 40.f, 50.f, 60.f};
 
+    tel_det_config<rectangle2D<>> tel_cfg{200.f * unit<scalar>::mm,
+                                          200.f * unit<scalar>::mm};
+    tel_cfg.positions(positions).pilot_track(traj);
+
     // Build telescope detector with unbounded planes
-    const auto det = create_telescope_detector(host_mr, rectangle, positions,
-                                               silicon_tml<scalar>(),
-                                               80.f * unit<scalar>::um, traj);
+    const auto det = create_telescope_detector(host_mr, tel_cfg);
 
     using navigator_t = navigator<decltype(det)>;
     using cline_stepper_t = line_stepper<transform3>;

--- a/tests/unit_tests/cpu/material_interaction.cpp
+++ b/tests/unit_tests/cpu/material_interaction.cpp
@@ -44,10 +44,6 @@ GTEST_TEST(detray_materials, telescope_geometry_energy_loss) {
 
     vecmem::host_memory_resource host_mr;
 
-    // Use rectangle surfaces in telescope
-    mask<rectangle2D<>> rectangle{0u, 20.f * unit<scalar>::mm,
-                                  20.f * unit<scalar>::mm};
-
     // Build in x-direction from given module positions
     detail::ray<transform3> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
     std::vector<scalar> positions = {0.f,   50.f,  100.f, 150.f, 200.f, 250.f,
@@ -56,8 +52,14 @@ GTEST_TEST(detray_materials, telescope_geometry_energy_loss) {
     const auto mat = silicon_tml<scalar>();
     constexpr scalar thickness{0.17f * unit<scalar>::cm};
 
-    const auto det = create_telescope_detector(host_mr, rectangle, positions,
-                                               mat, thickness, traj);
+    tel_det_config<rectangle2D<>> tel_cfg{20.f * unit<scalar>::mm,
+                                          20.f * unit<scalar>::mm};
+    tel_cfg.positions(positions)
+        .pilot_track(traj)
+        .module_material(mat)
+        .mat_thickness(thickness);
+
+    const auto det = create_telescope_detector(host_mr, tel_cfg);
 
     using navigator_t = navigator<decltype(det)>;
     using stepper_t = line_stepper<transform3>;
@@ -227,13 +229,15 @@ GTEST_TEST(detray_materials, telescope_geometry_scattering_angle) {
     const auto mat = silicon_tml<scalar>();
     const scalar thickness = 100.f * unit<scalar>::cm;
 
-    // Use rectangle surfaces in the telescope
-    mask<rectangle2D<>> rectangle{0u, 2000.f * unit<scalar>::mm,
-                                  2000.f * unit<scalar>::mm};
-
     // Create telescope geometry
-    const auto det = create_telescope_detector(host_mr, rectangle, positions,
-                                               mat, thickness, traj);
+    tel_det_config<rectangle2D<>> tel_cfg{2000.f * unit<scalar>::mm,
+                                          2000.f * unit<scalar>::mm};
+    tel_cfg.positions(positions)
+        .pilot_track(traj)
+        .module_material(mat)
+        .mat_thickness(thickness);
+
+    const auto det = create_telescope_detector(host_mr, tel_cfg);
 
     using navigator_t = navigator<decltype(det)>;
     using stepper_t = line_stepper<transform3>;

--- a/tests/unit_tests/cpu/test_telescope_detector.cpp
+++ b/tests/unit_tests/cpu/test_telescope_detector.cpp
@@ -21,6 +21,11 @@
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
 
+// Covfie include(s)
+#include <covfie/core/backend/primitive/constant.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/vector.hpp>
+
 // GTest include
 #include <gtest/gtest.h>
 
@@ -59,11 +64,13 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     // Use rectangle surfaces
     mask<rectangle2D<>> rectangle{0u, 20.f * unit<scalar>::mm,
                                   20.f * unit<scalar>::mm};
+    tel_det_config<> tel_cfg{rectangle};
 
-    using b_field_t = decltype(create_telescope_detector(
-        std::declval<vecmem::host_memory_resource &>(),
-        std::declval<mask<rectangle2D<>> &>(),
-        std::declval<std::vector<scalar> &>()))::bfield_type;
+    using const_bfield_bknd_t =
+        covfie::backend::constant<covfie::vector::vector_d<scalar, 3>,
+                                  covfie::vector::vector_d<scalar, 3>>;
+    using b_field_t = covfie::field<const_bfield_bknd_t>;
+
     using rk_stepper_t = rk_stepper<b_field_t::view_t, transform3>;
     using inspector_t = navigation::print_inspector;
 
@@ -93,14 +100,12 @@ GTEST_TEST(detray_detectors, telescope_detector) {
                                      300.f, 350.f, 400.f, 450.f, 500.f};
     // Build telescope detector with unbounded planes
     const auto z_tel_det1 =
-        create_telescope_detector(host_mr, rectangle, positions);
+        create_telescope_detector(host_mr, tel_cfg.positions(positions));
 
     // Build the same telescope detector with rectangular planes and given
     // length/number of surfaces
-    const std::size_t n_surfaces{11u};
-    const scalar tel_length{500.f * unit<scalar>::mm};
-    const auto z_tel_det2 =
-        create_telescope_detector(host_mr, rectangle, n_surfaces, tel_length);
+    tel_cfg.positions({}).n_surfaces(11u).length(500.f * unit<scalar>::mm);
+    const auto z_tel_det2 = create_telescope_detector(host_mr, tel_cfg);
 
     // Compare
     for (std::size_t i{0u}; i < z_tel_det1.surface_lookup().size(); ++i) {
@@ -120,9 +125,8 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     detail::ray<transform3> x_track({0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f},
                                     -1.f);
 
-    const auto x_tel_det = create_telescope_detector(
-        host_mr, rectangle, n_surfaces, tel_length, silicon_tml<scalar>(),
-        80.f * unit<scalar>::um, x_track);
+    const auto x_tel_det =
+        create_telescope_detector(host_mr, tel_cfg.pilot_track(x_track));
 
     //
     // test propagation in all telescope detector instances
@@ -219,9 +223,9 @@ GTEST_TEST(detray_detectors, telescope_detector) {
 
     detail::helix<transform3> helix_bz(pilot_track, &B_z);
 
-    const auto tel_detector = create_telescope_detector(
-        host_mr, rectangle, n_surfaces, tel_length, silicon_tml<scalar>(),
-        80.f * unit<scalar>::um, helix_bz);
+    tel_det_config htel_cfg{rectangle, helix_bz};
+    htel_cfg.n_surfaces(11u).length(500.f * unit<scalar>::mm);
+    const auto tel_detector = create_telescope_detector(host_mr, htel_cfg);
 
     // make at least sure it is navigatable
     navigator<decltype(tel_detector), inspector_t> tel_navigator;

--- a/tests/unit_tests/cpu/tools_guided_navigator.cpp
+++ b/tests/unit_tests/cpu/tools_guided_navigator.cpp
@@ -33,17 +33,16 @@ GTEST_TEST(detray_propagator, guided_navigator) {
 
     vecmem::host_memory_resource host_mr;
 
-    // Use unbounded rectangle surfaces that cannot be missed
-    mask<unbounded<rectangle2D<>>> urectangle{0u, 20.f * unit<scalar>::mm,
-                                              20.f * unit<scalar>::mm};
-
     // Module positions along z-axis
     const std::vector<scalar> positions = {0.f,  10.f, 20.f, 30.f, 40.f, 50.f,
                                            60.f, 70.f, 80.f, 90.f, 100.f};
 
     // Build telescope detector with unbounded rectangles
+    tel_det_config<unbounded<rectangle2D<>>> tel_cfg{20.f * unit<scalar>::mm,
+                                                     20.f * unit<scalar>::mm};
+
     const auto telescope_det =
-        create_telescope_detector(host_mr, urectangle, positions);
+        create_telescope_detector(host_mr, tel_cfg.positions(positions));
 
     // Inspectors are optional, of course
     using detector_t = decltype(telescope_det);

--- a/tests/unit_tests/io/io_json_detector_writer.cpp
+++ b/tests/unit_tests/io/io_json_detector_writer.cpp
@@ -39,6 +39,8 @@ mask<annulus2D<>> ann2{0u, minR, maxR, minPhi, maxPhi, offset_x, offset_y, 0.f};
 std::vector<scalar> positions = {0.f,   50.f,  100.f, 150.f, 200.f, 250.f,
                                  300.f, 350.f, 400.f, 450.f, 500.f};
 
+tel_det_config<annulus2D<>> tel_cfg{ann2};
+
 }  // anonymous namespace
 
 /// Test the writing of a telescope detector geometry to json
@@ -48,7 +50,8 @@ TEST(io, json_telescope_geometry_writer) {
 
     // Telescope detector
     vecmem::host_memory_resource host_mr;
-    detector_t det = create_telescope_detector(host_mr, ann2, positions);
+    detector_t det =
+        create_telescope_detector(host_mr, tel_cfg.positions(positions));
 
     json_geometry_writer<detector_t> geo_writer;
     geo_writer.write(det, {{0u, "telescope_detector"}}, std::ios_base::out);
@@ -61,7 +64,9 @@ TEST(io, json_telescope_material_writer) {
 
     // Telescope detector
     vecmem::host_memory_resource host_mr;
-    detector_t det = create_telescope_detector(host_mr, ann2, positions);
+
+    detector_t det =
+        create_telescope_detector(host_mr, tel_cfg.positions(positions));
 
     json_homogeneous_material_writer<detector_t> mat_writer;
     mat_writer.write(det, {{0u, "telescope_detector"}}, std::ios_base::out);

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -20,10 +20,15 @@
 #include <vecmem/memory/memory_resource.hpp>
 
 // Covfie include(s)
+#include <covfie/core/backend/primitive/constant.hpp>
 #include <covfie/core/field.hpp>
+#include <covfie/core/vector.hpp>
 
 // System include(s)
+#include <algorithm>
+#include <iterator>
 #include <limits>
+#include <type_traits>
 
 namespace detray {
 
@@ -31,6 +36,108 @@ namespace {
 
 template <typename mask_shape_t>
 using telescope_types = telescope_metadata<mask_shape_t>;
+
+/// Configure the toy detector
+template <typename mask_shape_t = rectangle2D<>,
+          typename trajectory_t = detail::ray<__plugin::transform3<scalar>>>
+struct tel_det_config {
+
+    using vector3 = __plugin::vector3<detray::scalar>;
+
+    /// Construct from existing mask
+    tel_det_config(const mask<mask_shape_t> &m, const trajectory_t &t = {})
+        : m_mask(m), m_trajectory(t) {}
+
+    /// Construct from mask parameters (except volume link, which is not needed)
+    template <
+        typename... Args,
+        std::enable_if_t<(std::is_same_v<Args, scalar> || ...), bool> = true>
+    tel_det_config(Args &&... args) : m_mask(0u, std::forward<Args>(args)...) {}
+
+    /// Mask of the test surfaces
+    mask<mask_shape_t> m_mask;
+    /// No. of test surfaces in the telescope
+    unsigned int m_n_surfaces{10u};
+    /// Length of the telescope
+    scalar m_length{500.f * unit<scalar>::mm};
+    /// Concrete positions where to place the surfaces along the pilot track
+    std::vector<scalar> m_positions{};
+    /// Material for the test surfaces
+    material<scalar> m_material = silicon_tml<scalar>();
+    /// Thickness of the material
+    scalar m_thickness{80.f * unit<scalar>::um};
+    /// Pilot track along which to place the surfaces
+    trajectory_t m_trajectory{};
+    /// Safety envelope between the test surfaces and the portals
+    scalar m_envelope{0.1f * unit<scalar>::mm};
+    /// Field vector for an homogenoues b-field
+    vector3 m_bfield_vec{0.f, 0.f, 2.f * unit<scalar>::T};
+
+    /// Setters
+    /// @{
+    constexpr tel_det_config &module_mask(const mask<mask_shape_t> &m) {
+        m_mask = m;
+        return *this;
+    }
+    constexpr tel_det_config &n_surfaces(const unsigned int n) {
+        m_n_surfaces = n;
+        return *this;
+    }
+    constexpr tel_det_config &length(const scalar l) {
+        assert((l > 0.f) &&
+               "Telescope detector length must be greater than zero");
+        m_length = l;
+        return *this;
+    }
+    constexpr tel_det_config &positions(const std::vector<scalar> &dists) {
+        std::copy_if(dists.begin(), dists.end(),
+                     std::back_inserter(m_positions),
+                     [](scalar d) { return (d >= 0.f); });
+        return *this;
+    }
+    constexpr tel_det_config &module_material(const material<scalar> &mat) {
+        m_material = mat;
+        return *this;
+    }
+    constexpr tel_det_config &mat_thickness(const scalar t) {
+        assert(t > 0.f && "Material thickness must be greater than zero");
+        m_thickness = t;
+        return *this;
+    }
+    constexpr tel_det_config &pilot_track(const trajectory_t &traj) {
+        m_trajectory = traj;
+        return *this;
+    }
+    constexpr tel_det_config &envelope(const scalar e) {
+        assert(e > 0.f && "Portal envelope must be greater than zero");
+        m_envelope = e;
+        return *this;
+    }
+    tel_det_config &bfield_vec(const vector3 &field_vec) {
+        m_bfield_vec = field_vec;
+        return *this;
+    }
+    tel_det_config &bfield_vec(const scalar x, const scalar y, const scalar z) {
+        m_bfield_vec = {x, y, z};
+        return *this;
+    }
+    /// @}
+
+    /// Getters
+    /// @{
+    constexpr const mask<mask_shape_t> &module_mask() const { return m_mask; }
+    constexpr unsigned int n_surfaces() const { return m_n_surfaces; }
+    constexpr scalar length() const { return m_length; }
+    const std::vector<scalar> &positions() const { return m_positions; }
+    constexpr const material<scalar> &module_material() const {
+        return m_material;
+    }
+    constexpr scalar mat_thickness() const { return m_thickness; }
+    const trajectory_t &pilot_track() const { return m_trajectory; }
+    constexpr scalar envelope() const { return m_envelope; }
+    constexpr const vector3 &bfield_vec() const { return m_bfield_vec; }
+    /// @}
+};
 
 /// Where and how to place the telescope modules.
 struct module_placement {
@@ -235,16 +342,17 @@ inline void create_cuboid_portals(context_t &ctx, const scalar pt_envelope,
 /// @param masks container to add new cylinder mask to
 /// @param transforms container to add new transform to
 /// @param cfg config struct for module creation
-template <auto mask_id, typename context_t, typename trajectory_t,
-          typename volume_t, typename surface_container_t,
-          typename mask_container_t, typename material_container_t,
-          typename transform_container_t, typename config_t>
-inline void create_telescope(context_t &ctx, const trajectory_t &traj,
-                             volume_t &volume, surface_container_t &surfaces,
+template <auto mask_id, typename context_t, typename volume_t,
+          typename surface_container_t, typename mask_container_t,
+          typename material_container_t, typename transform_container_t,
+          typename config_t>
+inline void create_telescope(context_t &ctx, volume_t &volume,
+                             surface_container_t &surfaces,
                              mask_container_t &masks,
                              material_container_t &materials,
                              transform_container_t &transforms,
-                             const config_t &cfg) {
+                             const config_t &cfg,
+                             const std::vector<scalar> &positions) {
     // @Note: These type definitions should be removed at some point
     using vector3 = __plugin::vector3<detray::scalar>;
 
@@ -258,7 +366,7 @@ inline void create_telescope(context_t &ctx, const trajectory_t &traj,
 
     // Create the module centers
     const std::vector<module_placement> m_placements =
-        module_positions(traj, cfg.dists);
+        module_positions(cfg.pilot_track(), positions);
 
     // Create geometry data
     for (const auto &m_placement : m_placements) {
@@ -274,17 +382,17 @@ inline void create_telescope(context_t &ctx, const trajectory_t &traj,
                               dindex_invalid, surface_id::e_sensitive);
 
         // The rectangle bounds for this module
-        masks.template emplace_back<mask_id>(empty_context{}, cfg.mask_values,
-                                             mask_volume_link);
+        masks.template emplace_back<mask_id>(
+            empty_context{}, cfg.module_mask().values(), mask_volume_link);
 
         // Lines need different material
         using mask_t = typename mask_container_t::template get_type<mask_id>;
         if (mask_t::shape::name == "line") {
             materials.template emplace_back<material_container_t::ids::e_rod>(
-                empty_context{}, cfg.m_mat, cfg.m_thickness);
+                empty_context{}, cfg.module_material(), cfg.mat_thickness());
         } else {
             materials.template emplace_back<material_container_t::ids::e_slab>(
-                empty_context{}, cfg.m_mat, cfg.m_thickness);
+                empty_context{}, cfg.module_material(), cfg.mat_thickness());
         }
 
         // Build the transform
@@ -321,54 +429,55 @@ inline void create_telescope(context_t &ctx, const trajectory_t &traj,
 ///
 /// @tparam mask_t the type of mask for the telescope surfaces
 /// @tparam trajectory_t the type of the pilot trajectory
-/// @tparam container_t the containers used in the detector data structure
-/// @tparam Args value type for the mask boundaries
 ///
 /// @param resource the memory resource for the detector containers
-/// @param bfield the magnetic field description for the detector
-/// @param pos the module positions. These only correspond to the actual module
-///            positions for a straight line pilot trajectory
-/// @param traj the pilot trajectory along which the surfaces are positioned
-/// @param mat the surface material
-/// @param thickness the thisckness of the surface material (slab/rod)
-/// @param msk the surface boundary mask
+/// @param bfield
 ///
 /// @returns a complete detector object
-template <typename mask_t = mask<rectangle2D<>>,
-          typename trajectory_t = detail::ray<__plugin::transform3<scalar>>,
-          typename container_t = host_container_types>
-auto create_telescope_detector(
+template <typename mask_shape_t = rectangle2D<>,
+          typename trajectory_t = detail::ray<__plugin::transform3<scalar>>>
+inline auto create_telescope_detector(
     vecmem::memory_resource &resource,
-    covfie::field<
-        typename telescope_types<typename mask_t::shape>::bfield_backend_t>
-        &&bfield,
-    const mask_t &msk, std::vector<scalar> dists,
-    const material<scalar> mat = silicon_tml<scalar>(),
-    const scalar thickness = 80.f * unit<scalar>::um,
-    const trajectory_t traj = {{0.f, 0.f, 0.f}, 0.f, {0.f, 0.f, 1.f}, -1.f},
-    const scalar envelope = 0.1f * unit<scalar>::mm) {
+    const tel_det_config<mask_shape_t, trajectory_t> &cfg = {
+        20.f * unit<scalar>::mm, 20.f * unit<scalar>::mm}) {
 
     // detector type
-    using detector_t = detector<telescope_types<typename mask_t::shape>,
-                                covfie::field, container_t>;
+    using detector_t = detector<telescope_types<mask_shape_t>, covfie::field,
+                                host_container_types>;
+
+    // Infer the snesitive surface placement from the telescope length if no
+    // concrete positions were given
+    std::vector<scalar> positions;
+    if (cfg.positions().empty()) {
+        scalar pos{0.f};
+        scalar dist{cfg.n_surfaces() > 1u
+                        ? cfg.length() /
+                              static_cast<scalar>(cfg.n_surfaces() - 1u)
+                        : 0.f};
+        for (std::size_t i = 0u; i < cfg.n_surfaces(); ++i) {
+            positions.push_back(pos);
+            pos += dist;
+        }
+    } else {
+        std::copy(cfg.positions().begin(), cfg.positions().end(),
+                  std::back_inserter(positions));
+    }
 
     // @todo: Temporal restriction due to missing local navigation
-    assert((dists.size() < 20u) &&
+    assert((positions.size() < 20u) &&
            "Due to WIP, please choose less than 20 surfaces for now");
 
-    // module parameters
-    struct surface_config {
-        const typename mask_t::mask_values &mask_values;
-        const std::vector<scalar> &dists;
-        material<scalar> m_mat;
-        scalar m_thickness;
-    };
+    using const_bfield_bknd_t =
+        covfie::backend::constant<covfie::vector::vector_d<scalar, 3>,
+                                  covfie::vector::vector_d<scalar, 3>>;
+    const auto &B = cfg.bfield_vec();
+    auto bfield = covfie::field<const_bfield_bknd_t>(
+        const_bfield_bknd_t::configuration_t{B[0], B[1], B[2]});
 
     // create empty detector
     detector_t det(resource, std::move(bfield));
 
     typename detector_t::geometry_context ctx{};
-    const surface_config sf_config{msk.values(), dists, mat, thickness};
 
     // The telescope detector has only one volume with default placement
     auto &vol = det.new_volume(volume_id::e_cuboid,
@@ -383,100 +492,18 @@ auto create_telescope_detector(
     typename detector_t::transform_container transforms(resource);
 
     constexpr auto mask_id{
-        detector_t::mask_container::template get_id<mask_t>::value};
+        detector_t::mask_container::template get_id<mask<mask_shape_t>>::value};
 
-    create_telescope<mask_id>(ctx, traj, vol, surfaces, masks, materials,
-                              transforms, sf_config);
+    create_telescope<mask_id>(ctx, vol, surfaces, masks, materials, transforms,
+                              cfg, positions);
     // Add portals to volume
-    create_cuboid_portals<mask_id>(ctx, envelope, vol, surfaces, masks,
+    create_cuboid_portals<mask_id>(ctx, cfg.envelope(), vol, surfaces, masks,
                                    materials, transforms);
     // Add volme to the detector
     det.add_objects_per_volume(ctx, vol, surfaces, masks, transforms,
                                materials);
 
     return det;
-}
-
-/// Build the telescope geometry from a fixed length and number of surfaces.
-///
-/// @param n_surfaces the number of surfaces that are placed in the geometry
-/// @param tel_length the total length of the steps by the stepper
-template <typename mask_t = mask<rectangle2D<>>,
-          typename trajectory_t = detail::ray<__plugin::transform3<scalar>>,
-          typename container_t = host_container_types>
-auto create_telescope_detector(
-    vecmem::memory_resource &resource,
-    covfie::field<
-        typename telescope_types<typename mask_t::shape>::bfield_backend_t>
-        &&bfield,
-    const mask_t &msk, std::size_t n_surfaces = 10u,
-    const scalar tel_length = 500.f * unit<scalar>::mm,
-    const material<scalar> mat = silicon_tml<scalar>(),
-    const scalar thickness = 80.f * unit<scalar>::um,
-    const trajectory_t traj = {{0.f, 0.f, 0.f}, 0.f, {0.f, 0.f, 1.f}, -1.f},
-    const scalar envelope = 0.01f * unit<scalar>::mm) {
-    // Generate equidistant positions
-    std::vector<scalar> distances = {};
-    scalar pos = 0.f;
-    scalar dist{n_surfaces > 1u
-                    ? tel_length / static_cast<scalar>(n_surfaces - 1u)
-                    : 0.f};
-    for (std::size_t i = 0u; i < n_surfaces; ++i) {
-        distances.push_back(pos);
-        pos += dist;
-    }
-
-    // Build the geometry
-    return create_telescope_detector<mask_t>(resource, std::move(bfield), msk,
-                                             distances, mat, thickness, traj,
-                                             envelope);
-}
-
-/// Wrapper for create_telescope_geometry with constant zero bfield.
-template <typename mask_t = mask<rectangle2D<>>,
-          typename trajectory_t = detail::ray<__plugin::transform3<scalar>>,
-          typename container_t = host_container_types>
-auto create_telescope_detector(
-    vecmem::memory_resource &resource, const mask_t &msk,
-    const std::vector<scalar> dists,
-    const material<scalar> mat = silicon_tml<scalar>(),
-    const scalar thickness = 80.f * unit<scalar>::um,
-    const trajectory_t traj = {{0.f, 0.f, 0.f}, 0.f, {0.f, 0.f, 1.f}, -1.f},
-    const scalar envelope = 0.1f * unit<scalar>::mm) {
-
-    using covfie_bkdn_t =
-        typename telescope_types<typename mask_t::shape>::bfield_backend_t;
-
-    // Build the geometry
-    return create_telescope_detector<mask_t, trajectory_t, container_t>(
-        resource,
-        covfie::field<covfie_bkdn_t>{
-            typename covfie_bkdn_t::configuration_t{0.f, 0.f, 0.f}},
-        msk, dists, mat, thickness, traj, envelope);
-}
-
-/// Wrapper for create_telescope_geometry with constant zero bfield.
-template <typename mask_t = mask<rectangle2D<>>,
-          typename trajectory_t = detail::ray<__plugin::transform3<scalar>>,
-          typename container_t = host_container_types>
-auto create_telescope_detector(
-    vecmem::memory_resource &resource, const mask_t &msk,
-    std::size_t n_surfaces = 10u,
-    const scalar tel_length = 500.f * unit<scalar>::mm,
-    const material<scalar> mat = silicon_tml<scalar>(),
-    const scalar thickness = 80.f * unit<scalar>::um,
-    const trajectory_t traj = {{0.f, 0.f, 0.f}, 0.f, {0.f, 0.f, 1.f}, -1.f},
-    const scalar envelope = 0.1f * unit<scalar>::mm) {
-
-    using covfie_bkdn_t =
-        typename telescope_types<typename mask_t::shape>::bfield_backend_t;
-
-    // Build the geometry
-    return create_telescope_detector<mask_t, trajectory_t, container_t>(
-        resource,
-        covfie::field<covfie_bkdn_t>{
-            typename covfie_bkdn_t::configuration_t{0.f, 0.f, 0.f}},
-        msk, n_surfaces, tel_length, mat, thickness, traj, envelope);
 }
 
 }  // namespace detray


### PR DESCRIPTION
Adds a config structure to the telescope geometry, which reduces the number of overloaded ```create_telescope_detector``` functions and allows more flexible configuration of the detector. The functionality of the telescope detector stays the same.