### PR TITLE
Add concurrency group for CI jobs

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
 
+# Cancel existing jobs on new pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 # All the different build/test jobs.
 jobs:
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,10 @@
 name: Checks
 
+# Cancel existing jobs on new pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
As it stands, an arbitrary number of CI jobs can be running for a given pull request, which means that sometimes the CI will be running for a commit that has been superceded by several newer commits. Adding a concurrency group to the CI jobs allows GitHub to automatically cancel old jobs if a new commit is pushed that makes the run obsolete.