### PR TITLE
feat: portal access for the voume

### DIFF
--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -92,6 +92,19 @@ class detector_volume {
         return transform().translation();
     }
 
+    /// @returns all portals of the volume - const
+    /// @note Depending on the detector type, this can also contain other
+    /// surfaces
+    DETRAY_HOST_DEVICE auto portals() const {
+        // In case of portals, we know where they live
+        constexpr auto brute_force{detector_t::sf_finders::id::e_brute_force};
+        const auto &bf_finder =
+            m_detector.surface_store().template get<brute_force>();
+
+        constexpr auto portal_id{descr_t::object_id::e_portal};
+        return bf_finder[m_desc.template link<portal_id>().index()];
+    }
+
     /// Apply a functor to all surfaces in the volume.
     ///
     /// @tparam functor_t the prescription to be applied to the surfaces

--- a/tests/unit_tests/cpu/geometry_volume.cpp
+++ b/tests/unit_tests/cpu/geometry_volume.cpp
@@ -7,7 +7,10 @@
 
 // Project include(s)
 #include "detray/definitions/units.hpp"
+#include "detray/detectors/create_toy_geometry.hpp"
 #include "detray/geometry/detail/volume_descriptor.hpp"
+#include "detray/geometry/detector_volume.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/test/types.hpp"
 
 // GTest include(s)
@@ -15,6 +18,8 @@
 
 // TODO: Move these into the test defs
 namespace {
+
+constexpr detray::scalar tol{1e-6f};
 
 // geo object ids for testing
 enum geo_objects : unsigned int {
@@ -32,8 +37,8 @@ enum sf_finder_ids : unsigned int {
 
 }  // namespace
 
-// This tests the detector volume class and its many links
-GTEST_TEST(detray_geometry, detector_volume) {
+// This tests the detector volume descriptor and its many links
+GTEST_TEST(detray_geometry, detector_volume_descriptor) {
     using namespace detray;
 
     using sf_finder_link_t = dtyped_index<sf_finder_ids, dindex>;
@@ -65,4 +70,42 @@ GTEST_TEST(detray_geometry, detector_volume) {
     ASSERT_TRUE(v2.template link<geo_objects::e_sensitive>().id() ==
                 sf_finder_ids::e_grid);
     ASSERT_TRUE(v2.template link<geo_objects::e_sensitive>().index() == 12u);
+}
+
+// This tests the detector volume interface class
+GTEST_TEST(detray_geometry, detector_volume) {
+    using namespace detray;
+
+    using detector_t = detector<toy_metadata<>>;
+
+    vecmem::host_memory_resource host_mr;
+    const auto toy_det = create_toy_geometry(host_mr);
+
+    // This is the beampipe volume
+    const auto vol = toy_det.volume_by_index(0u);
+
+    // TODO: Add beampipe name once name map PR is merged
+    ASSERT_EQ(vol.id(), volume_id::e_cylinder);
+    ASSERT_EQ(vol.index(), 0u);
+    // Identity
+    ASSERT_TRUE(vol.transform() == detector_t::transform3{});
+    const auto c = vol.center();
+    ASSERT_NEAR(c[0], 0.f, tol);
+    ASSERT_NEAR(c[1], 0.f, tol);
+    ASSERT_NEAR(c[2], 0.f, tol);
+    // The beampipe + all portals
+    ASSERT_EQ(vol.n_max_candidates(), 16u);
+
+    // Check the portal access
+    const auto portals = vol.portals();
+    ASSERT_EQ(portals.size(), 16u);
+    for (const auto [idx, pt_desc] : detray::views::enumerate(portals)) {
+        const auto portal = surface{toy_det, pt_desc};
+
+        // In this volume, also the beampipe will be among the portals
+        ASSERT_TRUE(portal.is_portal() or portal.is_passive())
+            << "Not a portal/passive: " << portal;
+        ASSERT_EQ(portal.volume(), 0u) << "Wrong volume: " << portal;
+        ASSERT_EQ(portal.index(), idx) << "Wrong index: " << portal;
+    }
 }


### PR DESCRIPTION
This PR add a portal access to the detector volume and adds a unittest for the class. Accessing the portals like this is a bit tricky, because depending on the detector type, also other surfaces could be part of the brute force surface finder method...