### PR TITLE
feat: check detector consistency

### DIFF
--- a/core/include/detray/core/detail/multi_store.hpp
+++ b/core/include/detray/core/detail/multi_store.hpp
@@ -173,6 +173,18 @@ class multi_store {
             .empty();
     }
 
+    /// @returns true if every collection in container is empty.
+    template <std::size_t current_idx = 0>
+    DETRAY_HOST_DEVICE constexpr bool all_empty(const context_type &ctx = {},
+                                                bool is_empty = true) const {
+        is_empty &= empty<value_types::to_id(current_idx)>(ctx);
+
+        if constexpr (current_idx < sizeof...(Ts) - 1) {
+            return all_empty<current_idx + 1>(ctx, is_empty);
+        }
+        return is_empty;
+    }
+
     /// Removes and destructs all elements in a specific collection.
     template <ID id>
     DETRAY_HOST void clear(const context_type & /*ctx*/) {

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -500,8 +500,16 @@ class detector {
     ///
     /// @param v_grid the volume grid to be added
     DETRAY_HOST
-    inline auto add_volume_finder(volume_finder &&v_grid) -> void {
+    inline auto set_volume_finder(volume_finder &&v_grid) -> void {
         _volume_finder = std::move(v_grid);
+    }
+
+    /// Add the volume grid - copy semantics
+    ///
+    /// @param v_grid the volume grid to be added
+    DETRAY_HOST
+    inline auto set_volume_finder(const volume_finder &v_grid) -> void {
+        _volume_finder = v_grid;
     }
 
     /// @return the volume grid - const access

--- a/core/include/detray/definitions/geometry.hpp
+++ b/core/include/detray/definitions/geometry.hpp
@@ -24,7 +24,8 @@ enum class volume_id : std::uint_least8_t {
     e_rectangle = 1u,
     e_trapezoid = 2u,
     e_cone = 3u,
-    e_cuboid = 4u
+    e_cuboid = 4u,
+    e_unknown = 5u
 };
 
 /// surface type, resolved during navigation.
@@ -36,6 +37,7 @@ enum class surface_id : std::uint_least8_t {
     e_portal = 0u,
     e_sensitive = 1u,
     e_passive = 2u,
+    e_unknown = 3u
 };
 
 }  // namespace detray

--- a/core/include/detray/definitions/indexing.hpp
+++ b/core/include/detray/definitions/indexing.hpp
@@ -220,6 +220,18 @@ struct dtyped_index {
         return encoder::template is_invalid<id_mask, index_mask>(m_value);
     }
 
+    /// Check wether the type id is invalid.
+    DETRAY_HOST_DEVICE
+    constexpr bool is_invalid_id() const noexcept {
+        return encoder::template is_invalid<id_mask>(m_value);
+    }
+
+    /// Check wether the index is invalid.
+    DETRAY_HOST_DEVICE
+    constexpr bool is_invalid_index() const noexcept {
+        return encoder::template is_invalid<index_mask>(m_value);
+    }
+
     DETRAY_HOST
     friend std::ostream& operator<<(std::ostream& os, const dtyped_index ti) {
         if (ti.is_invalid()) {

--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -12,6 +12,9 @@
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/tracks/tracks.hpp"
 
+// System include(s)
+#include <ostream>
+
 namespace detray::detail {
 
 /// Functors to be used in the @c surface class
@@ -32,6 +35,27 @@ struct surface_kernels {
     using matrix_type =
         typename matrix_operator::template matrix_type<ROWS, COLS>;
     using free_matrix = matrix_type<e_free_size, e_free_size>;
+
+    /// A functor to retrieve the masks volume link
+    struct get_volume_link {
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline auto operator()(
+            const mask_group_t& mask_group, const index_t& index) const {
+
+            return mask_group.at(index).volume_link();
+        }
+    };
+
+    /// A functor to run the mask self check. Puts error messages into @param os
+    struct mask_self_check {
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline auto operator()(
+            const mask_group_t& mask_group, const index_t& index,
+            std::ostream& os) const {
+
+            return mask_group.at(index).self_check(os);
+        }
+    };
 
     /// A functor get the surface normal at a given local/bound position
     struct normal {

--- a/core/include/detray/geometry/detail/volume_descriptor.hpp
+++ b/core/include/detray/geometry/detail/volume_descriptor.hpp
@@ -113,16 +113,16 @@ class volume_descriptor {
 
     private:
     /// How to interpret the boundary values
-    volume_id m_id = volume_id::e_cylinder;
+    volume_id m_id{volume_id::e_unknown};
 
     /// Volume index in the detector's volume container
-    dindex m_index = dindex_invalid;
+    dindex m_index{dindex_invalid};
 
     /// Volume index in the detector's volume container
-    dindex m_transform = dindex_invalid;
+    dindex m_transform{dindex_invalid};
 
     /// Links for every object type to an acceleration data structure
-    link_type m_sf_finder_links = {};
+    link_type m_sf_finder_links{};
 };
 
 }  // namespace detray

--- a/core/include/detray/masks/annulus2D.hpp
+++ b/core/include/detray/masks/annulus2D.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/coordinates/polar2.hpp"
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
@@ -19,6 +20,7 @@
 // System include(s)
 #include <cmath>
 #include <limits>
+#include <ostream>
 #include <string>
 
 namespace detray {
@@ -127,8 +129,8 @@ class annulus2D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE std::array<scalar_t, 8> stereo_angle(
-        const bounds_t<scalar_t, kDIM>& bounds) const {
+    DETRAY_HOST_DEVICE darray<scalar_t, 8> stereo_angle(
+        const bounds_t<scalar_t, kDIM> &bounds) const {
         // Half stereo angle (phi_s / 2) (y points in the long strip direction)
         return 2.f * math_ns::atan(bounds[e_shift_y] / bounds[e_shift_x]);
     }
@@ -148,7 +150,7 @@ class annulus2D {
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
     DETRAY_HOST_DEVICE inline bool check_boundaries(
-        const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
+        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
         // The two quantities to check: r^2 in beam system, phi in focal system:
@@ -197,8 +199,8 @@ class annulus2D {
               template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE std::array<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& bounds,
+    DETRAY_HOST_DEVICE darray<scalar_t, 6> local_min_bounds(
+        const bounds_t<scalar_t, kDIM> &bounds,
         const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
 
         using point_t = typename algebra_t::point2;
@@ -221,12 +223,12 @@ class annulus2D {
         const point_t t = bounds[e_max_r] * vector::normalize(c + b);
 
         // Find the min/max positions in x and y
-        std::array<scalar_t, 5> x_pos{
-            c_pos[2] * math_ns::cos(c_pos[3]) - o_x, b[0], c[0],
-            c_pos[0] * math_ns::cos(c_pos[1]) - o_x, t[0]};
-        std::array<scalar_t, 5> y_pos{
-            c_pos[2] * math_ns::sin(c_pos[3]) - o_y, b[1], c[1],
-            c_pos[0] * math_ns::sin(c_pos[1]) - o_y, t[1]};
+        darray<scalar_t, 5> x_pos{c_pos[2] * math_ns::cos(c_pos[3]) - o_x, b[0],
+                                  c[0], c_pos[0] * math_ns::cos(c_pos[1]) - o_x,
+                                  t[0]};
+        darray<scalar_t, 5> y_pos{c_pos[2] * math_ns::sin(c_pos[3]) - o_y, b[1],
+                                  c[1], c_pos[0] * math_ns::sin(c_pos[1]) - o_y,
+                                  t[1]};
 
         constexpr scalar_t inf{std::numeric_limits<scalar_t>::infinity()};
         scalar_t min_x{inf}, min_y{inf}, max_x{-inf}, max_y{-inf};
@@ -252,8 +254,8 @@ class annulus2D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE std::array<scalar_t, 8> corners(
-        const bounds_t<scalar_t, kDIM>& bounds) const {
+    DETRAY_HOST_DEVICE darray<scalar_t, 8> corners(
+        const bounds_t<scalar_t, kDIM> &bounds) const {
 
         // Calculate the r-coordinate of a point in the strip system from the
         // circle arc radius (e.g. min_r) and the phi position in the strip
@@ -277,7 +279,7 @@ class annulus2D {
         // Calculate the polar coordinates for the corners
         const scalar_t min_phi{bounds[e_average_phi] + bounds[e_min_phi_rel]};
         const scalar_t max_phi{bounds[e_average_phi] + bounds[e_max_phi_rel]};
-        std::array<scalar_t, 8> corner_pos;
+        darray<scalar_t, 8> corner_pos;
         // bottom left: min_r, min_phi_rel
         corner_pos[0] = get_strips_pc_r(bounds[e_min_r], min_phi);
         corner_pos[1] = min_phi;
@@ -292,6 +294,48 @@ class annulus2D {
         corner_pos[7] = min_phi;
 
         return corner_pos;
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+
+        constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
+
+        if (std::signbit(bounds[e_min_r]) or bounds[e_max_r] < tol) {
+            os << "ERROR: Radial bounds must be in the range [0, numeric_max)";
+            return false;
+        }
+        if (bounds[e_min_r] >= bounds[e_max_r] or
+            std::abs(bounds[e_min_r] - bounds[e_max_r]) < tol) {
+            os << "ERROR: Min radius must be smaller than max radius.";
+            return false;
+        }
+        if ((bounds[e_min_phi_rel] < -constant<scalar_t>::pi or
+             bounds[e_min_phi_rel] > constant<scalar_t>::pi) or
+            (bounds[e_max_phi_rel] < -constant<scalar_t>::pi or
+             bounds[e_max_phi_rel] > constant<scalar_t>::pi) or
+            (bounds[e_average_phi] < -constant<scalar_t>::pi or
+             bounds[e_average_phi] > constant<scalar_t>::pi)) {
+            os << "ERROR: Angles must map onto [-pi, pi] range.";
+            return false;
+        }
+        if (bounds[e_min_phi_rel] >= bounds[e_max_phi_rel] or
+            std::abs(bounds[e_min_phi_rel] - bounds[e_max_phi_rel]) < tol) {
+            os << "ERROR: Min relative angle must be smaller than max relative "
+                  "angle.";
+            return false;
+        }
+
+        return true;
     }
 };
 

--- a/core/include/detray/masks/cuboid3D.hpp
+++ b/core/include/detray/masks/cuboid3D.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/coordinates/cartesian3.hpp"
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/bounding_box/cuboid_intersector.hpp"
 #include "detray/surface_finders/grid/detail/axis_binning.hpp"
@@ -17,6 +18,7 @@
 // System include(s)
 #include <cmath>
 #include <limits>
+#include <ostream>
 #include <string>
 
 namespace detray {
@@ -117,7 +119,7 @@ class cuboid3D {
               template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline std::array<scalar_t, 6> local_min_bounds(
+    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
         const bounds_t<scalar_t, kDIM> &bounds,
         const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
         assert(env > 0.f);
@@ -127,6 +129,39 @@ class cuboid3D {
             o_bounds[i + 3u] += env;
         }
         return o_bounds;
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+
+        constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
+
+        if (bounds[e_min_x] >= bounds[e_max_x] or
+            std::abs(bounds[e_min_x] - bounds[e_max_x]) < tol) {
+            os << "ERROR: Min x must be smaller than max x.";
+            return false;
+        }
+        if (bounds[e_min_y] >= bounds[e_max_y] or
+            std::abs(bounds[e_min_y] - bounds[e_max_y]) < tol) {
+            os << "ERROR: Min y must be smaller than max y.";
+            return false;
+        }
+        if (bounds[e_min_z] >= bounds[e_max_z] or
+            std::abs(bounds[e_min_z] - bounds[e_max_z]) < tol) {
+            os << "ERROR: Min z must be smaller than max z.";
+            return false;
+        }
+
+        return true;
     }
 };
 

--- a/core/include/detray/masks/cylinder2D.hpp
+++ b/core/include/detray/masks/cylinder2D.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/coordinates/cylindrical2.hpp"
 #include "detray/coordinates/cylindrical3.hpp"
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/cylinder_intersector.hpp"
 #include "detray/surface_finders/grid/detail/axis_binning.hpp"
@@ -18,6 +19,7 @@
 // System include(s)
 #include <cmath>
 #include <limits>
+#include <ostream>
 #include <string>
 
 namespace detray {
@@ -109,7 +111,7 @@ class cylinder2D {
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
     DETRAY_HOST_DEVICE inline bool check_boundaries(
-        const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
+        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
         if constexpr (kRadialCheck) {
@@ -134,13 +136,42 @@ class cylinder2D {
               template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline std::array<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& bounds,
+    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
+        const bounds_t<scalar_t, kDIM> &bounds,
         const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
         assert(env > 0.f);
         const scalar_t xy_bound{bounds[e_r] + env};
         return {-xy_bound, -xy_bound, bounds[e_n_half_z] - env,
                 xy_bound,  xy_bound,  bounds[e_p_half_z] + env};
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+
+        constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
+
+        if (bounds[e_r] < tol) {
+            os << "ERROR: Radius must be in the range (0, numeric_max)"
+               << std::endl;
+            return false;
+        }
+        if (bounds[e_n_half_z] >= bounds[e_p_half_z] or
+            std::abs(bounds[e_n_half_z] - bounds[e_p_half_z]) < tol) {
+            os << "ERROR: Neg. half length must be smaller than pos. half "
+                  "length.";
+            return false;
+        }
+
+        return true;
     }
 };
 

--- a/core/include/detray/masks/cylinder3D.hpp
+++ b/core/include/detray/masks/cylinder3D.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/coordinates/cylindrical3.hpp"
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/cylinder_intersector.hpp"
 #include "detray/surface_finders/grid/detail/axis_binning.hpp"
@@ -17,6 +18,7 @@
 // System include(s)
 #include <cmath>
 #include <limits>
+#include <ostream>
 #include <string>
 
 namespace detray {
@@ -116,13 +118,46 @@ class cylinder3D {
               template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline std::array<scalar_t, 6> local_min_bounds(
+    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
         const bounds_t<scalar_t, kDIM> &bounds,
         const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
         assert(env > 0.f);
         const scalar_t r_bound{bounds[e_max_r] + env};
         return {-r_bound, -r_bound, bounds[e_min_z] - env,
                 r_bound,  r_bound,  bounds[e_max_z] + env};
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+
+        constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
+
+        if (bounds[e_min_r] < tol) {
+            os << "ERROR: Radii must be in the range (0, numeric_max)"
+               << std::endl;
+            return false;
+        }
+        if (bounds[e_min_r] >= bounds[e_max_r] or
+            std::abs(bounds[e_min_r] - bounds[e_max_r]) < tol) {
+            os << "ERROR: Min Radius must be smaller than max Radius.";
+            return false;
+        }
+        if (bounds[e_min_z] >= bounds[e_max_z] or
+            std::abs(bounds[e_min_z] - bounds[e_max_z]) < tol) {
+            os << "ERROR: Min z must be smaller than max z.";
+            return false;
+        }
+
+        return true;
     }
 };
 

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "detray/coordinates/cartesian3.hpp"
 #include "detray/coordinates/line2.hpp"
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/line_intersector.hpp"
 #include "detray/surface_finders/grid/detail/axis_binning.hpp"
@@ -18,6 +19,7 @@
 // System include(s)
 #include <cmath>
 #include <limits>
+#include <ostream>
 #include <type_traits>
 
 namespace detray {
@@ -112,7 +114,7 @@ class line {
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == 2u, bool> = true>
     DETRAY_HOST_DEVICE inline bool check_boundaries(
-        const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
+        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
         // For a square cross section (e.g. a cell of drift chamber), we check
@@ -150,13 +152,41 @@ class line {
               template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline std::array<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& bounds,
+    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
+        const bounds_t<scalar_t, kDIM> &bounds,
         const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
         assert(env > 0.f);
         const scalar_t xy_bound{bounds[e_cross_section] + env};
         const scalar_t z_bound{bounds[e_half_z] + env};
         return {-xy_bound, -xy_bound, -z_bound, xy_bound, xy_bound, z_bound};
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+
+        constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
+
+        if (bounds[e_cross_section] < tol) {
+            os << "ERROR: Radius/sides must be in the range (0, numeric_max)"
+               << std::endl;
+            return false;
+        }
+        if (bounds[e_half_z] < tol) {
+            os << "ERROR: Half length z must be in the range (0, numeric_max)"
+               << std::endl;
+            return false;
+        }
+
+        return true;
     }
 };
 

--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -25,6 +25,7 @@
 // System include(s)
 #include <algorithm>
 #include <cassert>
+#include <ostream>
 #include <sstream>
 #include <vector>
 
@@ -217,6 +218,19 @@ class mask {
         static_assert(bounds.size() == cuboid3D<>::e_size,
                       "Shape returns incompatible bounds for bound box");
         return {bounds, std::numeric_limits<unsigned int>::max()};
+    }
+
+    /// @returns true if the mask boundary values are consistent
+    DETRAY_HOST
+    constexpr bool self_check(std::ostream& os) const {
+
+        const bool result = _shape.check_consistency(_values, os);
+
+        if (not result) {
+            os << to_string();
+        }
+
+        return result;
     }
 
     /// @returns a string representation of the mask

--- a/core/include/detray/masks/rectangle2D.hpp
+++ b/core/include/detray/masks/rectangle2D.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/coordinates/cartesian2.hpp"
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/surface_finders/grid/detail/axis_binning.hpp"
@@ -17,6 +18,7 @@
 // System include(s)
 #include <cmath>
 #include <limits>
+#include <ostream>
 #include <string>
 
 namespace detray {
@@ -97,7 +99,7 @@ class rectangle2D {
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
     DETRAY_HOST_DEVICE inline bool check_boundaries(
-        const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
+        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         return (std::abs(loc_p[0]) <= bounds[e_half_x] + tol and
                 std::abs(loc_p[1]) <= bounds[e_half_y] + tol);
@@ -116,13 +118,36 @@ class rectangle2D {
               template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline std::array<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& bounds,
+    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
+        const bounds_t<scalar_t, kDIM> &bounds,
         const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
         assert(env > 0.f);
         const scalar_t x_bound{bounds[e_half_x] + env};
         const scalar_t y_bound{bounds[e_half_y] + env};
         return {-x_bound, -y_bound, -env, x_bound, y_bound, env};
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+
+        constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
+
+        if (bounds[e_half_x] < tol or bounds[e_half_y] < tol) {
+            os << "ERROR: Half lengths must be in the range (0, numeric_max)"
+               << std::endl;
+            return false;
+        }
+
+        return true;
     }
 };
 

--- a/core/include/detray/masks/ring2D.hpp
+++ b/core/include/detray/masks/ring2D.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/coordinates/polar2.hpp"
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/surface_finders/grid/detail/axis_binning.hpp"
@@ -17,6 +18,7 @@
 // System include(s)
 #include <cmath>
 #include <limits>
+#include <ostream>
 #include <string>
 
 namespace detray {
@@ -98,7 +100,7 @@ class ring2D {
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
     DETRAY_HOST_DEVICE inline bool check_boundaries(
-        const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
+        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
         return (loc_p[0] + tol >= bounds[e_inner_r] and
@@ -118,12 +120,40 @@ class ring2D {
               template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline std::array<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& bounds,
+    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
+        const bounds_t<scalar_t, kDIM> &bounds,
         const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
         assert(env > 0.f);
         const scalar_t r_bound{env + bounds[e_outer_r]};
         return {-r_bound, -r_bound, -env, r_bound, r_bound, env};
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+
+        constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
+
+        if (std::signbit(bounds[e_inner_r]) or bounds[e_outer_r] < tol) {
+            os << "ERROR: Radius must be in the range [0, numeric_max)"
+               << std::endl;
+            return false;
+        }
+        if (bounds[e_inner_r] >= bounds[e_outer_r] or
+            std::abs(bounds[e_inner_r] - bounds[e_outer_r]) < tol) {
+            os << "ERROR: Inner radius must be smaller outer radius.";
+            return false;
+        }
+
+        return true;
     }
 };
 

--- a/core/include/detray/masks/single3D.hpp
+++ b/core/include/detray/masks/single3D.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/coordinates/cartesian2.hpp"
 #include "detray/coordinates/cartesian3.hpp"
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/surface_finders/grid/detail/axis_binning.hpp"
@@ -18,6 +19,7 @@
 // System include(s)
 #include <cmath>
 #include <limits>
+#include <ostream>
 #include <string>
 
 namespace detray {
@@ -93,7 +95,7 @@ class single3D {
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
     DETRAY_HOST_DEVICE inline bool check_boundaries(
-        const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
+        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         return (bounds[e_lower] - tol <= loc_p[kCheckIndex] and
                 loc_p[kCheckIndex] <= bounds[e_upper] + tol);
@@ -112,14 +114,34 @@ class single3D {
               template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline std::array<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& bounds,
+    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
+        const bounds_t<scalar_t, kDIM> &bounds,
         const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
         assert(env > 0.f);
-        std::array<scalar_t, 6> o_bounds{-env, -env, -env, env, env, env};
+        darray<scalar_t, 6> o_bounds{-env, -env, -env, env, env, env};
         o_bounds[kCheckIndex] += bounds[e_lower];
         o_bounds[3u + kCheckIndex] += bounds[e_upper];
         return o_bounds;
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+
+        if (bounds[e_upper] < bounds[e_lower]) {
+            os << "ERROR: Upper bounds must be smaller than lower bounds ";
+            return false;
+        }
+
+        return true;
     }
 };
 

--- a/core/include/detray/masks/trapezoid2D.hpp
+++ b/core/include/detray/masks/trapezoid2D.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/coordinates/cartesian2.hpp"
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/surface_finders/grid/detail/axis_binning.hpp"
@@ -17,6 +18,7 @@
 // System include(s)
 #include <cmath>
 #include <limits>
+#include <ostream>
 #include <string>
 
 namespace detray {
@@ -102,7 +104,7 @@ class trapezoid2D {
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
     DETRAY_HOST_DEVICE inline bool check_boundaries(
-        const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
+        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         const scalar_t rel_y{(bounds[e_half_length_2] + loc_p[1]) *
                              bounds[e_divisor]};
@@ -126,8 +128,8 @@ class trapezoid2D {
               template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline std::array<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& bounds,
+    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
+        const bounds_t<scalar_t, kDIM> &bounds,
         const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
         assert(env > 0.f);
         const scalar_t x_bound{
@@ -137,6 +139,41 @@ class trapezoid2D {
             env};
         const scalar_t y_bound{bounds[e_half_length_2] + env};
         return {-x_bound, -y_bound, -env, x_bound, y_bound, env};
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+
+        constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
+
+        if (bounds[e_half_length_0] < tol or bounds[e_half_length_1] < tol) {
+            os << "ERROR: Half length in x must be in the range (0, "
+                  "numeric_max)"
+               << std::endl;
+            return false;
+        }
+        if (bounds[e_half_length_2] < tol) {
+            os << "ERROR: Half length in y must be in the range (0, "
+                  "numeric_max)"
+               << std::endl;
+            return false;
+        }
+        const auto div{1.f / (2.f * bounds[e_half_length_2])};
+        if (std::abs(bounds[e_divisor] - div) > tol) {
+            os << "ERROR: Divisor incorrect. Should be: " << div << std::endl;
+            return false;
+        }
+
+        return true;
     }
 };
 

--- a/core/include/detray/masks/unbounded.hpp
+++ b/core/include/detray/masks/unbounded.hpp
@@ -8,11 +8,13 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 
 // System include(s)
 #include <array>
 #include <limits>
+#include <ostream>
 #include <string>
 
 namespace detray {
@@ -52,7 +54,7 @@ class unbounded {
     /// @return always true
     template <typename bounds_t, typename point_t, typename scalar_t>
     DETRAY_HOST_DEVICE inline constexpr bool check_boundaries(
-        const bounds_t& /*bounds*/, const point_t& /*loc_p*/,
+        const bounds_t & /*bounds*/, const point_t & /*loc_p*/,
         const scalar_t /*tol*/) const {
         return true;
     }
@@ -76,10 +78,26 @@ class unbounded {
         typename algebra_t, template <typename, std::size_t> class bounds_t,
         typename scalar_t, std::size_t kDIM,
         typename std::enable_if_t<kDIM == boundaries::e_size, bool> = true>
-    DETRAY_HOST_DEVICE constexpr std::array<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& bounds,
+    DETRAY_HOST_DEVICE constexpr darray<scalar_t, 6> local_min_bounds(
+        const bounds_t<scalar_t, kDIM> &bounds,
         const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
         return shape{}.template local_min_bounds<algebra_t>(bounds, env);
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <
+        template <typename, std::size_t> class bounds_t, typename scalar_t,
+        std::size_t kDIM,
+        typename std::enable_if_t<kDIM == boundaries::e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM> & /*bounds*/,
+        std::ostream & /*os*/) const {
+        return true;
     }
 };
 

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -9,12 +9,15 @@
 
 // Project include(s)
 #include "detray/coordinates/cartesian2.hpp"
+#include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/surface_finders/grid/detail/axis_binning.hpp"
 #include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
+#include <limits>
+#include <ostream>
 #include <string>
 
 namespace detray {
@@ -89,12 +92,27 @@ class unmasked {
               template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE constexpr std::array<scalar_t, 6> local_min_bounds(
+    DETRAY_HOST_DEVICE constexpr darray<scalar_t, 6> local_min_bounds(
         const bounds_t<scalar_t, kDIM>& /*bounds*/,
         const scalar_t /*env*/ =
             std::numeric_limits<scalar_t>::epsilon()) const {
         constexpr scalar_t inf{std::numeric_limits<scalar_t>::infinity()};
         return {-inf, -inf, -inf, inf, inf, inf};
+    }
+
+    /// @brief Check consistency of boundary values.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param os output stream for error messages
+    ///
+    /// @return true if the bounds are consistent.
+    template <template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST constexpr bool check_consistency(
+        const bounds_t<scalar_t, kDIM>& /*bounds*/,
+        std::ostream& /*os*/) const {
+        return true;
     }
 };
 

--- a/core/include/detray/surface_finders/accelerator_grid.hpp
+++ b/core/include/detray/surface_finders/accelerator_grid.hpp
@@ -13,4 +13,13 @@
 #include "detray/surface_finders/grid/grid_collection.hpp"
 #include "detray/surface_finders/grid/populator.hpp"
 #include "detray/surface_finders/grid/serializer.hpp"
-#include "detray/tools/grid_builder.hpp"
+#include "detray/utils/type_traits.hpp"
+
+namespace detray::detail {
+
+template <typename multi_axis_t, typename value_t,
+          template <std::size_t> class serializer_t, typename populator_impl_t>
+struct is_grid<grid<multi_axis_t, value_t, serializer_t, populator_impl_t>>
+    : public std::true_type {};
+
+}  // namespace detray::detail

--- a/core/include/detray/tools/grid_factory.hpp
+++ b/core/include/detray/tools/grid_factory.hpp
@@ -26,41 +26,6 @@
 
 namespace detray {
 
-namespace detail {
-
-/// @brief Helper type to assemble an multi-axis from bounds tuple and binnings
-template <bool is_owning, typename containers, typename local_frame, typename,
-          typename>
-struct multi_axis_assembler;
-
-/// @brief Specialized struct to extract axis bounds from a tuple
-template <bool is_owning, typename containers, typename local_frame,
-          typename... axis_bounds, typename... binning_ts>
-struct multi_axis_assembler<is_owning, containers, local_frame,
-                            dtuple<axis_bounds...>, dtuple<binning_ts...>> {
-
-    static_assert(sizeof...(axis_bounds) == sizeof...(binning_ts),
-                  "Number of axis bounds for this mask and given binning types "
-                  "don't match!");
-
-    using type =
-        n_axis::multi_axis<is_owning, local_frame,
-                           n_axis::single_axis<axis_bounds, binning_ts>...>;
-};
-
-}  // namespace detail
-
-/// Typedef for easier construction @c multi_axis from mask shapes
-template <typename shape_t, bool is_owning = true,
-          typename containers = host_container_types,
-          typename algebra_t = __plugin::transform3<detray::scalar>>
-using coordinate_axes = typename detail::multi_axis_assembler<
-    is_owning, containers,
-    typename shape_t::template coordinate_type<algebra_t>,
-    typename shape_t::axes::types,
-    typename shape_t::axes::template binning<
-        containers, typename algebra_t::scalar_type>>::type;
-
 /// @brief Provides functionality to instantiate grids and grid collections.
 ///
 /// @tparam value_t type of entries in the grid bins

--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -1,0 +1,242 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/geometry/detector_volume.hpp"
+#include "detray/geometry/surface.hpp"
+#include "detray/utils/ranges.hpp"
+
+// System include(s)
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+namespace detray::detail {
+
+/// Checks every collection in a multistore to be emtpy and prints a warning
+template <typename store_t, std::size_t... I>
+void report_empty(const store_t &store, const std::string &store_name,
+                  std::index_sequence<I...> /*seq*/) {
+
+    ((store.template empty<store_t::value_types::to_id(I)>()
+          ? std::cout << "WARNING: " << store_name
+                      << " has empty collection no. " << I << std::endl
+          : std::cout << ""),
+     ...);
+}
+
+/// A functor that checks the surface descriptor and correct volume index in
+/// every acceleration data structure for a given volume
+struct surface_checker {
+
+    /// Test the contained surfaces for consistency
+    template <typename detector_t>
+    DETRAY_HOST_DEVICE void operator()(
+        const typename detector_t::surface_type &sf_descr,
+        const detector_t &det, const unsigned int vol_idx) const {
+
+        const auto sf = surface{det, sf_descr};
+        std::stringstream err_stream{};
+
+        if (not sf.self_check(err_stream)) {
+            throw std::invalid_argument(err_stream.str());
+        }
+
+        if (sf.volume() != vol_idx) {
+            err_stream << "Incorrect volume index on surface: " << sf;
+
+            throw std::invalid_argument(err_stream.str());
+        }
+
+        // Check that the same surface is registered in the detector surface
+        // lookup
+        const auto sf_from_lkp = surface{det, det.surface(sf.barcode())};
+        if (not(sf_from_lkp == sf)) {
+            err_stream << "Surfaces in volume and detector lookups differ:\n"
+                       << "In volume acceleration data structure: " << sf
+                       << "\nIn detector surface lookup: " << sf_from_lkp;
+
+            throw std::runtime_error(err_stream.str());
+        }
+    }
+
+    /// Test wether a given surface @param check_desc is properly registered at
+    /// least once in one of the volume acceleration data structures
+    ///
+    /// @param ref_descr one of the surfaces in the volumes acceleration data
+    /// @param check_descr surface that we are searching for
+    /// @param success communicate success to the outside
+    template <typename detector_t>
+    DETRAY_HOST_DEVICE void operator()(
+        const typename detector_t::surface_type &ref_descr,
+        const typename detector_t::surface_type &check_descr, bool &success,
+        const detector_t &det) const {
+
+        // Check that the surface is being searched for in the right volume
+        // The volume index of the ref_descr must be checked to be correct
+        // beforehand, e.g. by the call operator above
+        if (ref_descr.volume() != check_descr.volume()) {
+            std::stringstream err_stream{};
+            err_stream << "Incorrect volume index on surface: "
+                       << surface{det, check_descr};
+
+            throw std::invalid_argument(err_stream.str());
+        }
+
+        // Check if it is the surface we are looking for
+        if (ref_descr == check_descr) {
+            success = true;
+        }
+    }
+};
+
+/// @brief Checks wether the data containers of a detector are empty
+///
+/// In case the default metadata is used, the unused containers are allowed to
+/// be empty.
+template <typename detector_t>
+inline void check_empty(const detector_t &det) {
+
+    // Check if there is at least one portal in the detector
+    auto find_portals = [&det]() -> bool {
+        if (det.portals().empty()) {
+            return false;
+        }
+        // In the brute force finder, also other surfaces can be contained, e.g.
+        // passive surfaces (depends on the detector)
+        for (const auto &pt_desc : det.portals()) {
+            if (pt_desc.is_portal()) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // Check if there is at least one volume in the detector volume finder
+    auto find_volumes =
+        [](const typename detector_t::volume_finder &vf) -> bool {
+        for (const auto &v : vf.all()) {
+            if (not is_invalid_value(v)) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // Fatal errors
+    if (det.volumes().empty()) {
+        throw std::runtime_error("ERROR: No volumes in detector");
+    }
+    if (det.surface_lookup().empty()) {
+        throw std::runtime_error("ERROR: No surfaces found");
+    }
+    if (det.transform_store().empty()) {
+        throw std::runtime_error("ERROR: No transforms in detector");
+    }
+    if (det.mask_store().all_empty()) {
+        throw std::runtime_error("ERROR: No masks in detector");
+    }
+    if (not find_portals()) {
+        throw std::runtime_error("ERROR: No portals in detector");
+    }
+
+    // Warnings
+
+    // Check for empty mask collections
+    detail::report_empty(
+        det.mask_store(), "mask store",
+        std::make_index_sequence<detector_t::masks::n_types>{});
+
+    // Check the material description
+    if (det.material_store().all_empty()) {
+        std::cout << "WARNING: No material in detector" << std::endl;
+    } else {
+        // Check for empty material collections
+        detail::report_empty(
+            det.material_store(), "material store",
+            std::make_index_sequence<detector_t::materials::n_types>{});
+    }
+
+    // Check for empty acceleration data structure collections (e.g. grids)
+    detail::report_empty(
+        det.surface_store(), "acceleration data structures store",
+        std::make_index_sequence<detector_t::sf_finders::n_types>{});
+
+    // Check volume search data structure
+    if (not find_volumes(det.volume_search_grid())) {
+        std::cout << "WARNING: No entries in volume finder" << std::endl;
+    }
+}
+
+/// @brief Checks the internal consistency of a detector
+template <typename detector_t>
+inline bool check_consistency(const detector_t &det) {
+    check_empty(det);
+
+    std::stringstream err_stream{};
+    // Check the volumes
+    for (const auto &[idx, vol_desc] :
+         detray::views::enumerate(det.volumes())) {
+        const auto vol = detector_volume{det, vol_desc};
+
+        // Check that nothing is obviously broken
+        if (not vol.self_check(err_stream)) {
+            throw std::invalid_argument(err_stream.str());
+        }
+
+        // Check consistency in the context of the owning detector
+        if (vol.index() != idx) {
+            err_stream << "ERROR: Incorrect volume index! Found volume:\n"
+                       << vol << "\nat index " << idx;
+            throw std::invalid_argument(err_stream.str());
+        }
+
+        // Go through the acceleration data structures and check the surfaces
+        vol.template visit_surfaces<detail::surface_checker>(det, vol.index());
+    }
+
+    // Check the surfaces in the detector's surface lookup
+    for (const auto &[idx, sf_desc] :
+         detray::views::enumerate(det.surface_lookup())) {
+        const auto sf = surface{det, sf_desc};
+
+        // Check that nothing is obviously broken
+        if (not sf.self_check(err_stream)) {
+            throw std::invalid_argument(err_stream.str());
+        }
+
+        // Check consistency in the context of the owning detector
+        if (sf.index() != idx) {
+            err_stream << "ERROR: Incorrect surface index! Found surface:\n"
+                       << sf << "\nat index " << idx;
+            throw std::invalid_argument(err_stream.str());
+        }
+
+        // Check that the surface can be found in its volume's acceleration
+        // data structures (if there are no grids, must at least be in the
+        // brute force method)
+        const auto vol = det.volume_by_index(sf.volume());
+        bool is_registered = false;
+
+        vol.template visit_surfaces<detail::surface_checker>(
+            sf_desc, is_registered, det);
+
+        if (not is_registered) {
+            err_stream << "ERROR: Found surface that is not part of its "
+                       << "volume's navigation acceleration data structures:\n"
+                       << "Surface: " << sf;
+            throw std::invalid_argument(err_stream.str());
+        }
+    }
+
+    return true;
+}
+
+}  // namespace detray::detail

--- a/core/include/detray/utils/type_traits.hpp
+++ b/core/include/detray/utils/type_traits.hpp
@@ -130,4 +130,10 @@ template <typename T, typename... Ts>
 inline constexpr std::size_t get_type_pos_v = get_type_pos<T, Ts...>::value;
 /// @}
 
+template <class grid_t>
+struct is_grid : public std::false_type {};
+
+template <typename T>
+inline constexpr bool is_grid_v = is_grid<T>::value;
+
 }  // namespace detray::detail

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -13,6 +13,7 @@
 #include "detray/io/common/io_interface.hpp"
 #include "detray/io/common/payloads.hpp"
 #include "detray/tools/detector_builder.hpp"
+#include "detray/tools/grid_builder.hpp"
 #include "detray/tools/surface_factory.hpp"
 #include "detray/tools/volume_builder.hpp"
 
@@ -125,9 +126,13 @@ class geometry_reader : public reader_interface<detector_t> {
                     case surface_id::e_passive:
                         vbuilder->add_passives(sf_factory_ptr, geo_ctx);
                         break;
+                    case surface_id::e_unknown:
+                        break;
                 };
             }
         }
+
+        det_builder.template set_volume_finder();
     }
 
     /// @returns a link from its io payload @param link_data
@@ -211,6 +216,9 @@ class geometry_reader : public reader_interface<detector_t> {
                             surface_factory<detector_t, shape_t, mask_id,
                                             surface_id::e_passive>;
                         return std::make_shared<ps_factory_t>();
+                    case surface_id::e_unknown:
+                        throw std::runtime_error(
+                            "Unknown surface type in geometry file");
                 };
             }
         }

--- a/io/include/detray/io/common/geometry_writer.hpp
+++ b/io/include/detray/io/common/geometry_writer.hpp
@@ -12,7 +12,6 @@
 #include "detray/geometry/surface.hpp"
 #include "detray/io/common/detail/definitions.hpp"
 #include "detray/io/common/detail/utils.hpp"
-#include "detray/io/common/grid_writer.hpp"
 #include "detray/io/common/io_interface.hpp"
 #include "detray/io/common/payloads.hpp"
 #include "detray/masks/masks.hpp"

--- a/io/include/detray/io/common/grid_writer.hpp
+++ b/io/include/detray/io/common/grid_writer.hpp
@@ -25,21 +25,6 @@
 
 namespace detray {
 
-namespace detail {
-
-template <class grid_t>
-struct is_grid : public std::false_type {};
-
-template <typename multi_axis_t, typename value_t,
-          template <std::size_t> class serializer_t, typename populator_impl_t>
-struct is_grid<grid<multi_axis_t, value_t, serializer_t, populator_impl_t>>
-    : public std::true_type {};
-
-template <typename T>
-inline constexpr bool is_grid_v = is_grid<T>::value;
-
-}  // namespace detail
-
 /// @brief Abstract base class for accelerator grid writers
 template <class detector_t>
 class grid_writer : public writer_interface<detector_t> {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ unset( _detray_test_headers )
 
 # Include all of the code-holding sub-directories.
 add_subdirectory( common )
+add_subdirectory( checks )
 add_subdirectory( unit_tests )
 add_subdirectory( simulation )
 if( DETRAY_BENCHMARKS )

--- a/tests/checks/CMakeLists.txt
+++ b/tests/checks/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+add_library( detray_checks INTERFACE )
+target_include_directories( detray_checks
+   INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+target_link_libraries( detray_checks
+   INTERFACE GTest::gtest GTest::gtest_main detray::core_array
+             detray::test detray_tests_common covfie::core vecmem::core
+             detray::io detray::utils )
+
+add_subdirectory( src )

--- a/tests/checks/include/detray/checks/detector_consistency.hpp
+++ b/tests/checks/include/detray/checks/detector_consistency.hpp
@@ -1,0 +1,43 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/utils/consistency_checker.hpp"
+#include "tests/common/test_base/fixture_base.hpp"
+
+// System include(s)
+#include <iostream>
+
+namespace detray {
+
+/// @brief Test class that runs the consistency check on a given detector.
+///
+/// @note The lifetime of the detector needs to be guaranteed.
+template <typename detector_t>
+class consistency_check : public detray::test::fixture_base<> {
+    public:
+    using fixture_type = detray::test::fixture_base<>;
+
+    explicit consistency_check(const detector_t &det,
+                               const typename detector_t::name_map &names)
+        : m_det{det}, m_names{names} {}
+
+    /// Run the consistency check
+    void TestBody() override {
+        std::cout << "INFO: Running consistency check on: " << m_names.at(0)
+                  << std::endl;
+        ASSERT_TRUE(detail::check_consistency(m_det));
+    }
+
+    private:
+    /// The detector to be checked
+    const detector_t &m_det;
+    /// Volume names
+    const typename detector_t::name_map &m_names;
+};
+
+}  // namespace detray

--- a/tests/checks/src/CMakeLists.txt
+++ b/tests/checks/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Build the executable.
+detray_add_executable( detector_checker
+      "checks_main.cpp"
+      LINK_LIBRARIES GTest::gtest GTest::gtest_main detray_checks)

--- a/tests/checks/src/checks_main.cpp
+++ b/tests/checks/src/checks_main.cpp
@@ -1,0 +1,63 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/checks/detector_consistency.hpp"
+#include "detray/core/detector.hpp"
+#include "detray/io/common/detector_reader.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// GTest include(s)
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <stdexcept>
+#include <string>
+
+template <typename check_t, typename detector_t>
+void register_checks(const detector_t &det,
+                     const typename detector_t::name_map &vol_names,
+                     const std::string &test_name) {
+
+    ::testing::RegisterTest("detray_check", test_name.c_str(), nullptr,
+                            test_name.c_str(), __FILE__, __LINE__,
+                            [=]() -> typename check_t::fixture_type * {
+                                return new check_t(det, vol_names);
+                            });
+}
+
+int main(int argc, char **argv) {
+
+    // Filter out the google test flags
+    ::testing::InitGoogleTest(&argc, argv);
+
+    // Input data files
+    detray::io::detector_reader_config reader_cfg{};
+    if (argc > 1) {
+        for (int i = 1; i < argc; ++i) {
+            reader_cfg.add_file(argv[i]);
+        }
+    } else {
+        throw std::runtime_error("Please specify an input file name!");
+    }
+
+    // Use the most general type to be able to read in all detector files
+    using detector_t = detray::detector<>;
+
+    vecmem::host_memory_resource host_mr;
+
+    const auto [det, names] =
+        detray::io::read_detector<detector_t>(host_mr, reader_cfg);
+
+    register_checks<detray::consistency_check<detector_t>>(
+        det, names, "detector_consistency");
+
+    // Run the checks
+    return RUN_ALL_TESTS();
+}

--- a/tests/common/include/tests/common/test_base/fixture_base.hpp
+++ b/tests/common/include/tests/common/test_base/fixture_base.hpp
@@ -1,0 +1,123 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/algebra.hpp"
+#include "detray/definitions/units.hpp"
+
+// GTest include(s)
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <limits>
+#include <ostream>
+#include <string>
+
+namespace detray::test {
+
+/// Base type for test fixtures with google test
+template <typename scope = ::testing::Test>
+class fixture_base : public scope {
+    public:
+    /// Useful typedefs
+    /// @{
+    using scalar = detray::scalar;
+    using point2 = __plugin::point2<scalar>;
+    using point3 = __plugin::point3<scalar>;
+    using vector3 = __plugin::vector3<scalar>;
+    using transform3 = __plugin::transform3<detray::scalar>;
+    /// @}
+
+    /// Local configuration type
+    struct configuration {
+        /// General testing
+        /// @{
+        /// Tolerance to compare two floating point values
+        scalar m_tolerance{std::numeric_limits<scalar>::epsilon()};
+        /// Shorthand for infinity
+        scalar inf{std::numeric_limits<scalar>::infinity()};
+        /// Shorthand for the floating point epsilon
+        scalar epsilon{std::numeric_limits<scalar>::epsilon()};
+        /// @}
+
+        /// Propagation
+        /// @{
+        /// Maximum total pathlength for a track
+        scalar m_path_limit{5.f * unit<scalar>::cm};
+        scalar m_overstep_tolerance{-5.f * unit<scalar>::um};
+        scalar m_step_constraint{std::numeric_limits<scalar>::max()};
+        /// @}
+
+        /// Setters
+        /// @{
+        configuration& tol(scalar t) {
+            m_tolerance = t;
+            return *this;
+        }
+        configuration& path_limit(scalar lim) {
+            assert(lim > 0.f);
+            m_path_limit = lim;
+            return *this;
+        }
+        configuration& overstepping_tolerance(scalar t) {
+            assert(t <= 0.f);
+            m_overstep_tolerance = t;
+            return *this;
+        }
+        configuration& step_constraint(scalar constr) {
+            assert(constr > 0.f);
+            m_step_constraint = constr;
+            return *this;
+        }
+        /// @}
+
+        /// Getters
+        /// @{
+        scalar tol() const { return m_tolerance; }
+        scalar path_limit() const { return m_path_limit; }
+        scalar overstepping_tolerance() const { return m_overstep_tolerance; }
+        scalar step_constraint() const { return m_step_constraint; }
+        /// @}
+
+        /// Print configuration
+        std::ostream& operator<<(std::ostream& os) {
+            os << " -> test tolerance:  \t " << tol() << std::endl;
+            os << " -> trk path limit:  \t " << path_limit() << std::endl;
+            os << " -> overstepping tol:\t " << overstepping_tolerance()
+               << std::endl;
+            os << " -> step constraint:  \t " << step_constraint() << std::endl;
+            os << std::endl;
+
+            return os;
+        }
+    };
+
+    /// Constructor
+    fixture_base(const configuration& cfg = {})
+        : tolerance{cfg.tol()},
+          inf{cfg.inf},
+          epsilon{cfg.epsilon},
+          path_limit{cfg.path_limit()},
+          overstep_tolerance{cfg.overstepping_tolerance()},
+          step_constraint{cfg.step_constraint()} {}
+
+    /// @returns the benchmark name
+    std::string name() const { return "detray_test"; };
+
+    protected:
+    scalar tolerance{}, inf{}, epsilon{}, path_limit{}, overstep_tolerance{},
+        step_constraint{};
+
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+    virtual void SetUp() override {}
+    virtual void TearDown() override {}
+};
+
+}  // namespace detray::test

--- a/tests/common/include/tests/common/test_toy_detector.hpp
+++ b/tests/common/include/tests/common/test_toy_detector.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s)
 #include "detray/test/types.hpp"
+#include "detray/utils/consistency_checker.hpp"
 
 // GTest include(s)
 #include <gtest/gtest.h>
@@ -66,6 +67,9 @@ inline bool test_toy_detector(const detector<toy_metadata<>>& toy_det,
     using sf_finder_link_t = typename volume_t::link_type::index_type;
 
     EXPECT_EQ(names.at(0u), "toy_detector");
+
+    // Test general consistency
+    detail::check_consistency(toy_det);
 
     geo_context_t ctx{};
     auto& volumes = toy_det.volumes();

--- a/tests/common/include/tests/common/tools/intersectors/helix_intersection_kernel.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_intersection_kernel.hpp
@@ -11,6 +11,7 @@
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/utils/ranges.hpp"
 #include "tests/common/tools/intersectors/helix_cylinder_intersector.hpp"
+#include "tests/common/tools/intersectors/helix_line_intersector.hpp"
 #include "tests/common/tools/intersectors/helix_plane_intersector.hpp"
 
 namespace detray {

--- a/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/intersection/intersection.hpp"
+#include "detray/intersection/line_intersector.hpp"
 #include "tests/common/tools/intersectors/helix_intersector.hpp"
 
 // System include(s)

--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/intersection/intersection.hpp"
+#include "detray/intersection/plane_intersector.hpp"
 #include "tests/common/tools/intersectors/helix_intersector.hpp"
 
 // System include(s)

--- a/tests/unit_tests/cpu/check_geometry_linking.cpp
+++ b/tests/unit_tests/cpu/check_geometry_linking.cpp
@@ -9,11 +9,10 @@
 
 #include <vecmem/memory/host_memory_resource.hpp>
 
-#include "detray/geometry/volume_graph.hpp"
-#include "tests/common/tools/hash_tree.hpp"
-// #include "tests/common/tools/read_geometry.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
+#include "detray/geometry/volume_graph.hpp"
 #include "detray/test/types.hpp"
+#include "tests/common/tools/hash_tree.hpp"
 
 using namespace detray;
 

--- a/tests/unit_tests/cpu/test_telescope_detector.cpp
+++ b/tests/unit_tests/cpu/test_telescope_detector.cpp
@@ -16,6 +16,7 @@
 #include "detray/propagator/rk_stepper.hpp"
 #include "detray/test/types.hpp"
 #include "detray/tracks/tracks.hpp"
+#include "detray/utils/consistency_checker.hpp"
 #include "detray/utils/inspectors.hpp"
 
 // Vecmem include(s)
@@ -106,11 +107,17 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     EXPECT_EQ(z_tel_names1.at(0u), "telescope_detector");
     EXPECT_EQ(z_tel_names1.at(1u), "telescope_world_0");
 
+    // Check general consistency of the detector
+    detail::check_consistency(z_tel_det1);
+
     // Build the same telescope detector with rectangular planes and given
     // length/number of surfaces
     tel_cfg.positions({}).n_surfaces(11u).length(500.f * unit<scalar>::mm);
     const auto [z_tel_det2, z_tel_names2] =
         create_telescope_detector(host_mr, tel_cfg);
+
+    // Check general consistency of the detector
+    detail::check_consistency(z_tel_det2);
 
     // Compare
     for (std::size_t i{0u}; i < z_tel_det1.surface_lookup().size(); ++i) {
@@ -132,6 +139,9 @@ GTEST_TEST(detray_detectors, telescope_detector) {
 
     const auto [x_tel_det, x_tel_names] =
         create_telescope_detector(host_mr, tel_cfg.pilot_track(x_track));
+
+    // Check general consistency of the detector
+    detail::check_consistency(x_tel_det);
 
     //
     // test propagation in all telescope detector instances
@@ -232,6 +242,9 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     htel_cfg.n_surfaces(11u).length(500.f * unit<scalar>::mm);
     const auto [tel_detector, tel_names] =
         create_telescope_detector(host_mr, htel_cfg);
+
+    // Check general consistency of the detector
+    detail::check_consistency(tel_detector);
 
     // make at least sure it is navigatable
     navigator<decltype(tel_detector), inspector_t> tel_navigator;

--- a/tests/unit_tests/device/cuda/detector_cuda.cpp
+++ b/tests/unit_tests/device/cuda/detector_cuda.cpp
@@ -45,8 +45,8 @@ TEST(detector_cuda, detector) {
     // copied outpus from device side
     vecmem::vector<volume_t> volumes_device(volumes_host.size(), &mng_mr);
     vecmem::vector<surface_t> surfaces_device(surfaces_host.size(), &mng_mr);
-    vecmem::vector<transform_t> transforms_device(transforms_host.size(),
-                                                  &mng_mr);
+    vecmem::vector<transform3_t> transforms_device(transforms_host.size(),
+                                                   &mng_mr);
     vecmem::vector<rectangle_t> rectangles_device(rectangles_host.size(),
                                                   &mng_mr);
     vecmem::vector<disc_t> discs_device(discs_host.size(), &mng_mr);

--- a/tests/unit_tests/device/cuda/detector_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/detector_cuda_kernel.cu
@@ -15,7 +15,7 @@ __global__ void detector_test_kernel(
     typename detector_host_t::detector_view_type det_data,
     vecmem::data::vector_view<volume_t> volumes_data,
     vecmem::data::vector_view<surface_t> surfaces_data,
-    vecmem::data::vector_view<transform_t> transforms_data,
+    vecmem::data::vector_view<transform3_t> transforms_data,
     vecmem::data::vector_view<rectangle_t> rectangles_data,
     vecmem::data::vector_view<disc_t> discs_data,
     vecmem::data::vector_view<cylinder_t> cylinders_data) {
@@ -26,7 +26,7 @@ __global__ void detector_test_kernel(
     // convert subdetector data objects into objects w/ device vectors
     vecmem::device_vector<volume_t> volumes_device(volumes_data);
     vecmem::device_vector<surface_t> surfaces_device(surfaces_data);
-    vecmem::device_vector<transform_t> transforms_device(transforms_data);
+    vecmem::device_vector<transform3_t> transforms_device(transforms_data);
     vecmem::device_vector<rectangle_t> rectangles_device(rectangles_data);
     vecmem::device_vector<disc_t> discs_device(discs_data);
     vecmem::device_vector<cylinder_t> cylinders_device(cylinders_data);
@@ -87,7 +87,7 @@ __global__ void detector_test_kernel(
 void detector_test(typename detector_host_t::detector_view_type det_data,
                    vecmem::data::vector_view<volume_t> volumes_data,
                    vecmem::data::vector_view<surface_t> surfaces_data,
-                   vecmem::data::vector_view<transform_t> transforms_data,
+                   vecmem::data::vector_view<transform3_t> transforms_data,
                    vecmem::data::vector_view<rectangle_t> rectangles_data,
                    vecmem::data::vector_view<disc_t> discs_data,
                    vecmem::data::vector_view<cylinder_t> cylinders_data) {

--- a/tests/unit_tests/device/cuda/detector_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/detector_cuda_kernel.hpp
@@ -26,8 +26,7 @@ using detector_device_t =
     detector<toy_metadata<>, covfie::field_view, device_container_types>;
 using volume_t = typename detector_host_t::volume_type;
 using surface_t = typename detector_host_t::surface_type;
-using transform_t = typename detector_host_t::transform3;
-using transform_store_t = typename detector_host_t::transform_container;
+using transform3_t = typename detector_host_t::transform3;
 using mask_defs = typename detector_host_t::masks;
 
 constexpr auto rectangle_id = mask_defs::id::e_rectangle2;
@@ -42,7 +41,7 @@ using cylinder_t = typename mask_defs::template get_type<cylinder_id>::type;
 void detector_test(typename detector_host_t::detector_view_type det_data,
                    vecmem::data::vector_view<volume_t> volumes_data,
                    vecmem::data::vector_view<surface_t> surfaces_data,
-                   vecmem::data::vector_view<transform_t> transforms_data,
+                   vecmem::data::vector_view<transform3_t> transforms_data,
                    vecmem::data::vector_view<rectangle_t> rectangles_data,
                    vecmem::data::vector_view<disc_t> discs_data,
                    vecmem::data::vector_view<cylinder_t> cylinders_data);

--- a/tests/unit_tests/io/io_json_detector_reader.cpp
+++ b/tests/unit_tests/io/io_json_detector_reader.cpp
@@ -12,6 +12,7 @@
 #include "detray/io/common/detector_writer.hpp"
 #include "detray/io/json/json_reader.hpp"
 #include "detray/io/json/json_writer.hpp"
+#include "detray/utils/consistency_checker.hpp"
 #include "tests/common/test_toy_detector.hpp"
 
 // Vecmem include(s)
@@ -72,6 +73,8 @@ TEST(io, json_toy_geometry) {
     EXPECT_EQ(masks.template size<mask_id::e_portal_ring2>(), 52u);
     EXPECT_EQ(masks.template size<mask_id::e_straw_wire>(), 0u);
     EXPECT_EQ(masks.template size<mask_id::e_cell_wire>(), 0u);
+
+    detail::check_consistency(comp_det);
 }
 
 /// Test the reading and writing of a toy detector geometry


### PR DESCRIPTION
Add a number of utility functions that perform some simple consistency checks on a detector object 
and its volumes and surfaces:

  -  check for empty data stores
  -  check for any invalid links in volumes and surfaces
  -  check that volumes and surfaces have the correct volume index set
  -  check that mask boundaries are consistent
  -  check that sensitive/passive and portals surfaces have a navigation link either to their mother volume or not, respectively
  -  check that every surface in the brute force method/grids can be found via the detector lookup and vice versa

To avoid a segfault during the checking run, I added an empty (and in the IO a dummy) volume grid to the detector. 
This will be handled properly in a future PR.

To check different detectors read in from json, I added a folder called checks, where 
all of the consistency check will be called in the future. There is a test now that 
inherits from the google test test via a new default test fixture, which call the new
consistency check.