### PR TITLE
feat: detector builder

### DIFF
--- a/core/include/detray/tools/detector_builder.hpp
+++ b/core/include/detray/tools/detector_builder.hpp
@@ -1,0 +1,86 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "detray/core/detector.hpp"
+#include "detray/definitions/geometry.hpp"
+#include "detray/tools/volume_builder_interface.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/memory_resource.hpp>
+
+// Covfie include(s)
+#include <covfie/core/field.hpp>
+
+// System include(s)
+#include <memory>
+
+namespace detray {
+
+/// @brief Provides functionality to build a detray detector volume by volume
+template <typename metadata, template <typename> class volume_builder_t,
+          template <typename...> class volume_data_t = std::vector>
+class detector_builder {
+    public:
+    using detector_type =
+        detector<metadata, covfie::field, host_container_types>;
+
+    /// Empty detector builder
+    detector_builder() = default;
+
+    /// Add a new volume builder
+    template <typename... Args>
+    DETRAY_HOST auto new_volume(const volume_id id, Args&&... args)
+        -> volume_builder_interface<detector_type>* {
+        m_volumes.push_back(std::make_unique<volume_builder_t<detector_type>>(
+            id, static_cast<dindex>(m_volumes.size()),
+            std::forward<Args>(args)...));
+
+        return m_volumes.back().get();
+    }
+
+    /// Decorate a volume builder with more functionality
+    template <template <typename> class builder_t>
+    DETRAY_HOST auto decorate(dindex volume_idx)
+        -> volume_builder_interface<detector_type>* {
+        m_volumes[volume_idx] = std::make_unique<builder_t<detector_type>>(
+            std::move(m_volumes[volume_idx]));
+
+        return m_volumes[volume_idx].get();
+    }
+
+    /// Access a particular volume builder
+    DETRAY_HOST
+    auto operator[](dindex volume_idx)
+        -> volume_builder_interface<detector_type>* {
+        return m_volumes[volume_idx].get();
+    }
+
+    /// Assembles the final detector from the volumes builders
+    DETRAY_HOST
+    auto build(vecmem::memory_resource& resource) -> detector_type {
+
+        detector_type det{resource};
+
+        for (auto& vol_builder : m_volumes) {
+            vol_builder->build(det);
+        }
+
+        // TODO: Add sorting, data deduplication etc. here later...
+
+        return det;
+    }
+
+    protected:
+    /// Data structure that holds a volume builder for every detector volume
+    volume_data_t<std::unique_ptr<volume_builder_interface<detector_type>>>
+        m_volumes{};
+};
+
+}  // namespace detray

--- a/core/include/detray/tools/grid_builder.hpp
+++ b/core/include/detray/tools/grid_builder.hpp
@@ -123,6 +123,7 @@ class grid_builder final : public volume_decorator<detector_t> {
         for (auto &sf_desc : m_grid.all()) {
             const auto sf = surface{det, sf_desc};
             sf.template visit_mask<detail::mask_index_update>(sf_desc);
+            sf_desc.set_volume(vol_ptr->index());
             sf_desc.update_transform(trf_offset);
         }
 

--- a/core/include/detray/tools/volume_builder.hpp
+++ b/core/include/detray/tools/volume_builder.hpp
@@ -36,7 +36,13 @@ class volume_builder : public volume_builder_interface<detector_t> {
     using volume_type = typename detector_t::volume_type;
     using geo_obj_ids = typename detector_t::geo_obj_ids;
 
-    volume_builder() = default;
+    volume_builder(const volume_id id, const dindex idx = dindex_invalid)
+        : m_volume{id} {
+        m_volume.set_index(idx);
+        m_volume
+            .template set_link<static_cast<typename volume_type::object_id>(0)>(
+                detector_t::sf_finders::id::e_default, 0);
+    };
 
     /// Adds the @param name of the volume to a name map
     template <typename name_map>
@@ -45,41 +51,34 @@ class volume_builder : public volume_builder_interface<detector_t> {
     }
 
     DETRAY_HOST
-    void init_vol(detector_t& det, const volume_id id) override {
-        det.volumes().emplace_back(id);
-        m_volume = &(det.volumes().back());
-        m_volume->set_index(static_cast<dindex>(det.volumes().size()) - 1);
-        m_volume->template set_link<
-            static_cast<typename volume_type::object_id>(0)>(
-            detector_t::sf_finders::id::e_default, 0);
-    };
-
-    DETRAY_HOST
-    auto vol_index() -> dindex override { return m_volume->index(); }
+    auto vol_index() -> dindex override { return m_volume.index(); }
 
     DETRAY_HOST
     auto operator()() const -> const
         typename detector_t::volume_type& override {
-        return *m_volume;
+        return m_volume;
     }
     DETRAY_HOST
     auto operator()() -> typename detector_t::volume_type& override {
-        return *m_volume;
+        return m_volume;
     }
 
     DETRAY_HOST
     auto build(detector_t& det, typename detector_t::geometry_context ctx = {})
         -> typename detector_t::volume_type* override {
-        m_volume->set_transform(det.transform_store().size());
+        m_volume.set_index(static_cast<dindex>(det.volumes().size()));
+
+        m_volume.set_transform(det.transform_store().size());
         det.transform_store().push_back(m_trf);
 
         add_objects_per_volume(ctx, det);
+
         m_surfaces.clear();
         m_transforms.clear(ctx);
         m_masks.clear_all();
 
         // Pass to decorator builders
-        return m_volume;
+        return &(det.volumes().back());
     }
 
     DETRAY_HOST
@@ -104,21 +103,21 @@ class volume_builder : public volume_builder_interface<detector_t> {
     void add_portals(
         std::shared_ptr<surface_factory_interface<detector_t>> pt_factory,
         typename detector_t::geometry_context ctx = {}) override {
-        (*pt_factory)(*m_volume, m_surfaces, m_transforms, m_masks, ctx);
+        (*pt_factory)(m_volume, m_surfaces, m_transforms, m_masks, ctx);
     }
 
     DETRAY_HOST
     void add_sensitives(
         std::shared_ptr<surface_factory_interface<detector_t>> sf_factory,
         typename detector_t::geometry_context ctx = {}) override {
-        (*sf_factory)(*m_volume, m_surfaces, m_transforms, m_masks, ctx);
+        (*sf_factory)(m_volume, m_surfaces, m_transforms, m_masks, ctx);
     }
 
     DETRAY_HOST
     void add_passives(
         std::shared_ptr<surface_factory_interface<detector_t>> ps_factory,
         typename detector_t::geometry_context ctx = {}) override {
-        (*ps_factory)(*m_volume, m_surfaces, m_transforms, m_masks, ctx);
+        (*ps_factory)(m_volume, m_surfaces, m_transforms, m_masks, ctx);
     }
 
     protected:
@@ -152,6 +151,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
         for (auto& sf_desc : m_surfaces) {
             const auto sf = surface{det, sf_desc};
             sf.template visit_mask<detail::mask_index_update>(sf_desc);
+            sf_desc.set_volume(m_volume.index());
             sf_desc.update_transform(trf_offset);
             sf_desc.set_index(sf_offset++);
             det.add_surface_to_lookup(sf_desc);
@@ -165,15 +165,18 @@ class volume_builder : public volume_builder_interface<detector_t> {
         // For the other accelerators (grid etc.) there need to be dedicated
         // builders
         constexpr auto default_acc_id{detector_t::sf_finders::id::e_default};
-        m_volume->template set_link<surface_id>(
+        m_volume.template set_link<surface_id>(
             default_acc_id,
             det.surface_store().template size<default_acc_id>() - 1u);
 
         // Append masks
         det.append_masks(std::move(m_masks));
+
+        // Finally, add the volume descriptor
+        det.volumes().push_back(m_volume);
     }
 
-    typename detector_t::volume_type* m_volume{};
+    typename detector_t::volume_type m_volume{};
     typename detector_t::transform3 m_trf{};
 
     typename detector_t::surface_container_t m_surfaces{};

--- a/core/include/detray/tools/volume_builder_interface.hpp
+++ b/core/include/detray/tools/volume_builder_interface.hpp
@@ -35,11 +35,6 @@ class volume_builder_interface {
 
     virtual ~volume_builder_interface() = default;
 
-    /// @brief Initializes a new volume with shape id @param id in detector
-    /// @param det
-    DETRAY_HOST
-    virtual void init_vol(detector_t &det, const volume_id id) = 0;
-
     /// @returns the global index for the volume
     /// @note the correct index is only available after calling @c init_vol
     DETRAY_HOST
@@ -125,13 +120,6 @@ class volume_decorator : public volume_builder_interface<detector_t> {
     volume_decorator(
         std::unique_ptr<volume_builder_interface<detector_t>> vol_builder)
         : m_builder(std::move(vol_builder)) {}
-
-    /// Overwrite interface functions using callbacks to the volume builder
-    /// @{
-    DETRAY_HOST
-    void init_vol(detector_t &det, const volume_id id) override {
-        m_builder->init_vol(det, id);
-    }
 
     DETRAY_HOST
     auto operator()() -> typename detector_t::volume_type & override {

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -77,9 +77,9 @@ class geometry_reader : public reader_interface<detector_t> {
         // Deserialize the volumes one-by-one
         for (const auto& vol_data : det_data.volumes) {
             // Get a generic volume builder first and decorate it later
-            volume_builder<detector_t> vbuilder{};
-
-            vbuilder.init_vol(det, static_cast<volume_id>(vol_data.type));
+            volume_builder<detector_t> vbuilder{
+                static_cast<volume_id>(vol_data.type),
+                deserialize(vol_data.index)};
 
             // Set the volume name if available
             name_map[vbuilder.vol_index() + 1u] = vol_data.name;

--- a/tutorials/src/cpu/detector/do_it_yourself_detector.cpp
+++ b/tutorials/src/cpu/detector/do_it_yourself_detector.cpp
@@ -40,10 +40,7 @@ int main() {
     // Now fill the detector
 
     // Get a generic volume builder first and decorate it later
-    detray::volume_builder<detector_t> vbuilder{};
-
-    // Create a new cuboid volume in the detector
-    vbuilder.init_vol(det, detray::volume_id::e_cuboid);
+    detray::volume_builder<detector_t> vbuilder{detray::volume_id::e_cuboid};
 
     // Fill some squares into the volume
     using square_factory_t =


### PR DESCRIPTION
Adds a detector builder that holds the volume builders for a given detector in a specific data structure (currently flat vector). When all of the data for the single volumes is accumulated, either generated or read in, then the full detector is assembled. Here, data de-duplication and sorting will be implemented in the future. If additional detector components, like e.g. material, need to be added, the volume builders can be decorated with specialized volume builders that will add the required component during the building step.