### PR TITLE
feat: detector and material reader

### DIFF
--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -48,16 +48,18 @@ struct detector_view;
 /// @tparam bfield_t the type of the b-field frontend
 /// @tparam container_t type collection of the underlying containers
 /// @tparam source_link the surface source link
-template <typename metadata = default_metadata,
+template <typename metadata_t = default_metadata,
           template <typename> class bfield_t = covfie::field,
           typename container_t = host_container_types>
 class detector {
 
     // Allow the building of the detector containers
     friend class volume_builder_interface<
-        detector<metadata, bfield_t, container_t>>;
+        detector<metadata_t, bfield_t, container_t>>;
 
     public:
+    using metadata = metadata_t;
+
     /// Algebra types
     /// @TODO: scalar as a template parameter
     using scalar_type = scalar;

--- a/core/include/detray/materials/predefined_materials.hpp
+++ b/core/include/detray/materials/predefined_materials.hpp
@@ -27,8 +27,8 @@ namespace detray {
  * charge number (Z) are doubled
  */
 // Vacuum
-DETRAY_DECLARE_MATERIAL(vacuum, std::numeric_limits<scalar>::infinity(),
-                        std::numeric_limits<scalar>::infinity(), 0.f, 0.f, 0.f,
+DETRAY_DECLARE_MATERIAL(vacuum, std::numeric_limits<scalar>::max(),
+                        std::numeric_limits<scalar>::max(), 0.f, 0.f, 0.f,
                         material_state::e_gas);
 
 // H₂ (1): Hydrogen Gas

--- a/core/include/detray/tools/detector_builder.hpp
+++ b/core/include/detray/tools/detector_builder.hpp
@@ -9,7 +9,9 @@
 
 // Project include(s).
 #include "detray/core/detector.hpp"
+#include "detray/core/detector_metadata.hpp"
 #include "detray/definitions/geometry.hpp"
+#include "detray/tools/volume_builder.hpp"
 #include "detray/tools/volume_builder_interface.hpp"
 
 // Vecmem include(s)
@@ -20,11 +22,18 @@
 
 // System include(s)
 #include <memory>
+#include <vector>
 
 namespace detray {
 
 /// @brief Provides functionality to build a detray detector volume by volume
-template <typename metadata, template <typename> class volume_builder_t,
+///
+/// @tparam metadata the type definitions for the detector
+/// @tparam volume_builder_t the basic volume builder to be used for the
+///                          geometry data
+/// @tparam volume_data_t the data structure that hold the volume builders
+template <typename metadata = default_metadata,
+          template <typename> class volume_builder_t = volume_builder,
           template <typename...> class volume_data_t = std::vector>
 class detector_builder {
     public:
@@ -34,10 +43,12 @@ class detector_builder {
     /// Empty detector builder
     detector_builder() = default;
 
-    /// Add a new volume builder
+    /// Add a new volume builder that will build a volume of the shape given by
+    /// @param id
     template <typename... Args>
     DETRAY_HOST auto new_volume(const volume_id id, Args&&... args)
         -> volume_builder_interface<detector_type>* {
+
         m_volumes.push_back(std::make_unique<volume_builder_t<detector_type>>(
             id, static_cast<dindex>(m_volumes.size()),
             std::forward<Args>(args)...));
@@ -45,24 +56,27 @@ class detector_builder {
         return m_volumes.back().get();
     }
 
-    /// Decorate a volume builder with more functionality
+    /// Decorate a volume builder at position @param volume_idx with more
+    /// functionality
     template <template <typename> class builder_t>
     DETRAY_HOST auto decorate(dindex volume_idx)
         -> volume_builder_interface<detector_type>* {
+
         m_volumes[volume_idx] = std::make_unique<builder_t<detector_type>>(
             std::move(m_volumes[volume_idx]));
 
         return m_volumes[volume_idx].get();
     }
 
-    /// Access a particular volume builder
+    /// Access a particular volume builder by volume index @param volume_idx
     DETRAY_HOST
     auto operator[](dindex volume_idx)
         -> volume_builder_interface<detector_type>* {
         return m_volumes[volume_idx].get();
     }
 
-    /// Assembles the final detector from the volumes builders
+    /// Assembles the final detector from the volumes builders and allocates
+    /// the detector containers with the memory resource @param resource
     DETRAY_HOST
     auto build(vecmem::memory_resource& resource) -> detector_type {
 

--- a/io/include/detray/io/common/detail/utils.hpp
+++ b/io/include/detray/io/common/detail/utils.hpp
@@ -44,4 +44,6 @@ inline std::string get_detray_version() {
     return "detray - " + std::string(detray::version);
 }
 
+inline static const std::string minimal_io_version{"detray - 0.35.0"};
+
 }  // namespace detray::detail

--- a/io/include/detray/io/common/detector_reader.hpp
+++ b/io/include/detray/io/common/detector_reader.hpp
@@ -1,0 +1,124 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/io/common/detail/detector_components_io.hpp"
+#include "detray/io/common/detail/type_traits.hpp"
+#include "detray/io/json/json_reader.hpp"
+#include "detray/tools/detector_builder.hpp"
+
+// System include(s)
+#include <filesystem>
+#include <ios>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace detray {
+
+namespace io {
+
+/// @brief config struct for detector reading.
+struct detector_reader_config {
+    /// Input files
+    std::vector<std::string> m_files;
+
+    /// Getters
+    /// @{
+    const std::vector<std::string>& files() const { return m_files; }
+    /// @}
+
+    /// Setters
+    /// @{
+    detector_reader_config& add_file(const std::string file_name) {
+        m_files.push_back(std::move(file_name));
+        return *this;
+    }
+    /// @}
+};
+
+}  // namespace io
+
+namespace detail {
+
+/// From the list of file that are given as part of the config @param cfg,
+/// infer the readers that are needed by peeking into the file header
+template <class detector_t>
+auto assemble_reader(const io::detector_reader_config& cfg) {
+
+    detail::detector_component_readers<detector_t> readers;
+
+    // Read the name of the detector from file
+    std::string det_name{""};
+
+    for (const std::string& file_name : cfg.files()) {
+
+        std::string extension{std::filesystem::path{file_name}.extension()};
+        if (extension == ".json") {
+            // Peek at the header to determine the kind of reader that is needed
+            common_header_payload header = read_json_header(file_name);
+
+            if (header.tag == "geometry") {
+                det_name = header.detector;
+                readers.template add<json_geometry_reader>(file_name);
+            } else if (header.tag == "homogeneous_material") {
+                readers.template add<json_homogeneous_material_reader>(
+                    file_name);
+            } else {
+                throw std::invalid_argument("Unsupported file tag '" +
+                                            header.tag +
+                                            "' in input file: " + file_name);
+            }
+        } else {
+            throw std::runtime_error("Unsupported file format '" + extension +
+                                     "' for input file: " + file_name);
+        }
+    }
+
+    return std::make_pair(std::move(readers), std::move(det_name));
+}
+
+}  // namespace detail
+
+namespace io {
+
+/// @brief Reader function for detray detectors.
+///
+/// @tparam detector_t the type of detector to be built
+/// @tparam volume_builder_t the type of base volume builder to be used
+///
+/// @param resc the memory resource to be used for the detector container allocs
+/// @param cfg the detector reader configuration
+///
+/// @returns a complete detector object + a map that contains the volume names
+template <class detector_t,
+          template <typename> class volume_builder_t = volume_builder>
+auto read_detector(vecmem::memory_resource& resc,
+                   const detector_reader_config& cfg) {
+    // Map the volue names to their indices
+    typename detector_t::name_map names{};
+
+    detector_builder<typename detector_t::metadata, volume_builder_t>
+        det_builder;
+
+    // Find all required the readers
+    auto [reader, det_name] = detray::detail::assemble_reader<detector_t>(cfg);
+
+    names.emplace(0u, std::move(det_name));
+    reader.read(det_builder, names);
+
+    // Build and return the detector
+    return std::make_pair(det_builder.build(resc), std::move(names));
+}
+
+}  // namespace io
+
+}  // namespace detray

--- a/io/include/detray/io/common/geometry_writer.hpp
+++ b/io/include/detray/io/common/geometry_writer.hpp
@@ -48,13 +48,12 @@ class geometry_writer : public writer_interface<detector_t> {
                                            const std::string_view det_name) {
         geo_header_payload header_data;
 
-        header_data.version = detail::get_detray_version();
-        header_data.detector = det_name;
-        header_data.tag = tag;
-        header_data.date = detail::get_current_date();
+        header_data.common = base_type::serialize(det_name, tag);
 
-        header_data.n_volumes = det.volumes().size();
-        header_data.n_surfaces = det.n_surfaces();
+        header_data.sub_header.emplace();
+        auto& geo_sub_header = header_data.sub_header.value();
+        geo_sub_header.n_volumes = det.volumes().size();
+        geo_sub_header.n_surfaces = det.n_surfaces();
 
         return header_data;
     }

--- a/io/include/detray/io/common/homogeneous_material_reader.hpp
+++ b/io/include/detray/io/common/homogeneous_material_reader.hpp
@@ -1,0 +1,107 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/indexing.hpp"
+#include "detray/io/common/detail/type_traits.hpp"
+#include "detray/io/common/io_interface.hpp"
+#include "detray/io/common/payloads.hpp"
+#include "detray/materials/material.hpp"
+#include "detray/tools/detector_builder.hpp"
+#include "detray/tools/material_builder.hpp"
+#include "detray/tools/material_factory.hpp"
+
+// System include(s)
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace detray {
+
+/// @brief Abstract base class for tracking geometry readers
+template <class detector_t>
+class homogeneous_material_reader : public reader_interface<detector_t> {
+
+    using base_type = reader_interface<detector_t>;
+    /// IO material ids do not need to coincide with the detector ids,
+    /// they are shared with ACTS
+    using material_type = io::detail::material_type;
+    using scalar_type = typename detector_t::scalar_type;
+
+    protected:
+    /// Tag the reader as "homogeneous material"
+    inline static const std::string tag = "homogeneous_material";
+
+    public:
+    /// Same constructors for this class as for base_type
+    using base_type::base_type;
+
+    protected:
+    /// Deserialize the detector material @param det_mat_data from its IO
+    /// payload
+    static void deserialize(
+        detector_builder<typename detector_t::metadata, volume_builder>&
+            det_builder,
+        typename detector_t::name_map& /*name_map*/,
+        const detector_homogeneous_material_payload& det_mat_data) {
+        using mat_types = typename detector_t::material_container::value_types;
+        using material_id = typename detector_t::materials::id;
+
+        // Deserialize the material volume by volume
+        for (const auto& mv_data : det_mat_data.volumes) {
+            // Decorate the current volume builder with material
+            auto vm_builder = det_builder.template decorate<material_builder>(
+                static_cast<dindex>(mv_data.index));
+
+            // Add the material data to the factory
+            auto mat_factory = std::make_shared<material_factory<detector_t>>();
+            for (const auto& slab_data : mv_data.mat_slabs) {
+
+                mat_factory->add_material(material_id::e_slab,
+                                          deserialize(slab_data));
+            }
+            if constexpr (mat_types::n_types == 2u) {
+                if (mv_data.mat_rods.has_value()) {
+                    for (const auto& rod_data : *(mv_data.mat_rods)) {
+
+                        mat_factory->add_material(material_id::e_rod,
+                                                  deserialize(rod_data));
+                    }
+                }
+            }
+
+            // Add the material to the volume
+            vm_builder->add_sensitives(mat_factory);
+        }
+    }
+
+    /// @returns material data for a material factory from a slab io payload
+    /// @param slab_data
+    static material_data<scalar_type> deserialize(
+        const material_slab_payload& slab_data) {
+
+        return {static_cast<scalar_type>(slab_data.thickness),
+                deserialize(slab_data.mat)};
+    }
+
+    /// @returns the material from its IO payload @param mat_data
+    static auto deserialize(const material_payload& mat_data) {
+
+        return material<scalar_type>{
+            static_cast<scalar_type>(mat_data.params[0]),
+            static_cast<scalar_type>(mat_data.params[1]),
+            static_cast<scalar_type>(mat_data.params[2]),
+            static_cast<scalar_type>(mat_data.params[3]),
+            static_cast<scalar_type>(mat_data.params[4]),
+            // The molar density is calculated on the fly
+            static_cast<material_state>(mat_data.params[6])};
+    }
+};
+
+}  // namespace detray

--- a/io/include/detray/io/common/homogeneous_material_writer.hpp
+++ b/io/include/detray/io/common/homogeneous_material_writer.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Project include(s)
-#include "detray/io/common/detail/utils.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/io/common/io_interface.hpp"
 #include "detray/io/common/payloads.hpp"
 #include "detray/materials/material_rod.hpp"
@@ -43,18 +43,19 @@ class homogeneous_material_writer : public writer_interface<detector_t> {
 
         homogeneous_material_header_payload header_data;
 
-        header_data.version = detail::get_detray_version();
-        header_data.detector = det_name;
-        header_data.tag = tag;
-        header_data.date = detail::get_current_date();
+        header_data.common = base_type::serialize(det_name, tag);
 
         const auto& materials = det.material_store();
-        header_data.n_slabs = materials.template size<mat_types::to_id(0u)>();
-        header_data.n_rods = 0u;
+
+        header_data.sub_header.emplace();
+        auto& mat_sub_header = header_data.sub_header.value();
+        mat_sub_header.n_slabs =
+            materials.template size<mat_types::to_id(0u)>();
+        mat_sub_header.n_rods = 0u;
         if constexpr (mat_types::n_types == 2u) {
             // The compiler looks at this code, even if the number of material
             // types is one. Therefore, "mat_types::n_types - 1" is safer to use
-            header_data.n_rods =
+            mat_sub_header.n_rods =
                 materials
                     .template size<mat_types::to_id(mat_types::n_types - 1)>();
         }
@@ -66,27 +67,51 @@ class homogeneous_material_writer : public writer_interface<detector_t> {
     /// payload
     static detector_homogeneous_material_payload serialize(
         const detector_t& det, const typename detector_t::name_map&) {
-        using mat_types = typename detector_t::material_container::value_types;
-
         detector_homogeneous_material_payload dm_data;
+        dm_data.volumes.reserve((det.volumes().size()));
 
-        const auto& materials = det.material_store();
-
-        // Serialize material slabs and rods
-        for (const auto [idx, mat] : detray::views::enumerate(
-                 materials.template get<mat_types::to_id(0u)>())) {
-            dm_data.mat_slabs.push_back(serialize(mat, idx));
-        }
-        if constexpr (mat_types::n_types == 2u) {
-            dm_data.mat_rods = {};
-            for (const auto [idx, mat] : detray::views::enumerate(
-                     materials.template get<mat_types::to_id(
-                         mat_types::n_types - 1)>())) {
-                dm_data.mat_rods->push_back(serialize(mat, idx));
-            }
+        for (const auto& vol : det.volumes()) {
+            dm_data.volumes.push_back(serialize(vol, det));
         }
 
         return dm_data;
+    }
+
+    /// Serialize the material description of a volume @param vol_desc into its
+    /// io payload
+    static material_volume_payload serialize(
+        const typename detector_t::volume_type& vol_desc,
+        const detector_t& det) {
+        using material_type = material_slab_payload::material_type;
+
+        material_volume_payload mv_data;
+        mv_data.index = vol_desc.index();
+
+        // Find all surfaces that belong to the volume
+        for (const auto& sf_desc : det.surface_lookup()) {
+            if (sf_desc.volume() != vol_desc.index()) {
+                continue;
+            }
+            // Serialize material slabs and rods
+            const auto sf = surface{det, sf_desc};
+            const material_slab_payload mslp =
+                sf.template visit_material<get_material_payload>();
+
+            if (mslp.type == material_type::slab) {
+                mv_data.mat_slabs.push_back(mslp);
+            } else if (mslp.type == material_type::rod) {
+                if (not mv_data.mat_rods.has_value()) {
+                    mv_data.mat_rods.emplace();
+                }
+                mv_data.mat_rods->push_back(mslp);
+            } else {
+                throw std::runtime_error(
+                    "Material could not be matched to payload (found type " +
+                    std::to_string(static_cast<int>(mslp.type)) + ")");
+            }
+        }
+
+        return mv_data;
     }
 
     /// Serialize surface material @param mat into its io payload
@@ -110,6 +135,7 @@ class homogeneous_material_writer : public writer_interface<detector_t> {
         std::size_t idx) {
         material_slab_payload mat_data;
 
+        mat_data.type = material_slab_payload::material_type::slab;
         mat_data.index = idx;
         mat_data.thickness = mat_slab.thickness();
         mat_data.mat = serialize(mat_slab.get_material());
@@ -123,12 +149,24 @@ class homogeneous_material_writer : public writer_interface<detector_t> {
         std::size_t idx) {
         material_slab_payload mat_data;
 
+        mat_data.type = material_slab_payload::material_type::rod;
         mat_data.index = idx;
         mat_data.thickness = mat_rod.radius();
         mat_data.mat = serialize(mat_rod.get_material());
 
         return mat_data;
     }
+
+    private:
+    /// Retrieve @c material_slab_payload from a material store element
+    struct get_material_payload {
+        template <typename material_group_t, typename index_t>
+        inline auto operator()(const material_group_t& material_group,
+                               const index_t& index) const {
+            return homogeneous_material_writer<detector_t>::serialize(
+                material_group[index], index);
+        }
+    };
 };
 
 }  // namespace detray

--- a/io/include/detray/io/common/io_interface.hpp
+++ b/io/include/detray/io/common/io_interface.hpp
@@ -7,9 +7,15 @@
 
 #pragma once
 
+// Project include(s)
+#include "detray/io/common/detail/utils.hpp"
+#include "detray/io/common/payloads.hpp"
+#include "detray/tools/detector_builder.hpp"
+
 // System include(s)
 #include <ios>
 #include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -30,8 +36,9 @@ class reader_interface {
     /// Reads the respective detector component from file. Since the detector
     /// does not keep the volume names, the name map is also passed and
     /// filled.
-    virtual void read(detector_t&, typename detector_t::name_map&,
-                      const std::string&) = 0;
+    virtual void read(
+        detector_builder<typename detector_t::metadata, volume_builder>&,
+        typename detector_t::name_map&, const std::string&) = 0;
 
     protected:
     /// Extension that matches the file format of the respective reader
@@ -59,6 +66,21 @@ class writer_interface {
                               const std::ios_base::openmode) = 0;
 
     protected:
+    /// Serialize the common header information using the detector name
+    /// @param det_name and the file tag @param tag that describes the data file
+    /// content
+    static common_header_payload serialize(const std::string_view det_name,
+                                           const std::string_view tag) {
+        common_header_payload header_data;
+
+        header_data.version = detail::get_detray_version();
+        header_data.detector = det_name;
+        header_data.tag = tag;
+        header_data.date = detail::get_current_date();
+
+        return header_data;
+    }
+
     /// Extension that matches the file format of the respective writer
     std::string m_file_extension;
 };

--- a/io/include/detray/io/common/payloads.hpp
+++ b/io/include/detray/io/common/payloads.hpp
@@ -24,6 +24,18 @@
 /// @c single_link_payload
 namespace detray {
 
+/// @brief a payload for common information
+struct common_header_payload {
+    std::string version, detector, tag, date;
+};
+
+/// @brief a payload for common and extra information
+template <typename sub_header_payload_t = bool>
+struct header_payload {
+    common_header_payload common;
+    std::optional<sub_header_payload_t> sub_header;
+};
+
 /// @brief A payload for a single object link
 struct single_link_payload {
     std::size_t link;
@@ -32,11 +44,13 @@ struct single_link_payload {
 /// Geometry payloads
 /// @{
 
-/// @brief a payload for the geometry file header
-struct geo_header_payload {
-    std::string version, detector, tag, date;
+/// @brief a payload for the geometry specific part of the file header
+struct geo_sub_header_payload {
     std::size_t n_volumes, n_surfaces;
 };
+
+/// @brief a payload for the geometry file header
+using geo_header_payload = header_payload<geo_sub_header_payload>;
 
 /// @brief A payload for an affine transformation in homogeneous coordinates
 struct transform_payload {
@@ -95,18 +109,21 @@ struct volume_payload {
 /// Material payloads
 /// @{
 
-/// @brief a payload for the simple material file header
-struct homogeneous_material_header_payload {
-    std::string version, detector, tag, date;
+/// @brief a payload for the material specific part of the file header
+struct homogeneous_material_sub_header_payload {
     std::size_t n_slabs, n_rods;
 };
+
+/// @brief a payload for the homogeneous material file header
+using homogeneous_material_header_payload =
+    header_payload<homogeneous_material_sub_header_payload>;
 
 /// @brief A payload object for a material parametrization
 struct material_payload {
     std::array<real_io, 7u> params;
 };
 
-/// @brief A payload object for a material slab
+/// @brief A payload object for a material slab/rod
 struct material_slab_payload {
     using material_type = io::detail::material_type;
     material_type type = material_type::unknown;
@@ -115,10 +132,16 @@ struct material_slab_payload {
     material_payload mat;
 };
 
-/// @brief A payload for a simple detector material description
-struct detector_homogeneous_material_payload {
+/// @brief A payload object for the material contained in a volume
+struct material_volume_payload {
+    std::size_t index;
     std::vector<material_slab_payload> mat_slabs = {};
     std::optional<std::vector<material_slab_payload>> mat_rods;
+};
+
+/// @brief A payload for the homogeneous material description of a detector
+struct detector_homogeneous_material_payload {
+    std::vector<material_volume_payload> volumes = {};
 };
 
 /// @}

--- a/io/include/detray/io/json/json_geometry_io.hpp
+++ b/io/include/detray/io/json/json_geometry_io.hpp
@@ -11,6 +11,7 @@
 #include "detray/io/common/payloads.hpp"
 #include "detray/io/json/json.hpp"
 #include "detray/io/json/json_algebra_io.hpp"
+#include "detray/io/json/json_header_io.hpp"
 
 // System include(s)
 #include <array>
@@ -23,21 +24,25 @@
 namespace detray {
 
 void to_json(nlohmann::ordered_json& j, const geo_header_payload& h) {
-    j["version"] = h.version;
-    j["detector"] = h.detector;
-    j["date"] = h.date;
-    j["tag"] = h.tag;
-    j["volume_count"] = h.n_volumes;
-    j["surface_count"] = h.n_surfaces;
+    j["common"] = h.common;
+
+    if (h.sub_header.has_value()) {
+        const auto& geo_sub_header = h.sub_header.value();
+        j["volume_count"] = geo_sub_header.n_volumes;
+        j["surface_count"] = geo_sub_header.n_surfaces;
+    }
 }
 
 void from_json(const nlohmann::ordered_json& j, geo_header_payload& h) {
-    h.version = j["version"];
-    h.detector = j["detector"];
-    h.date = j["date"];
-    h.tag = j["tag"];
-    h.n_volumes = j["volume_count"];
-    h.n_surfaces = j["surface_count"];
+    h.common = j["common"];
+
+    if (j.find("volume_count") != j.end() and
+        j.find("surface_count") != j.end()) {
+        h.sub_header.emplace();
+        auto& geo_sub_header = h.sub_header.value();
+        geo_sub_header.n_volumes = j["volume_count"];
+        geo_sub_header.n_surfaces = j["surface_count"];
+    }
 }
 
 void to_json(nlohmann::ordered_json& j, const single_link_payload& so) {

--- a/io/include/detray/io/json/json_header_io.hpp
+++ b/io/include/detray/io/json/json_header_io.hpp
@@ -1,0 +1,40 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/io/common/payloads.hpp"
+#include "detray/io/json/json.hpp"
+
+namespace detray {
+
+void to_json(nlohmann::ordered_json& j, const common_header_payload& h) {
+    j["version"] = h.version;
+    j["detector"] = h.detector;
+    j["date"] = h.date;
+    j["tag"] = h.tag;
+}
+
+void from_json(const nlohmann::ordered_json& j, common_header_payload& h) {
+    h.version = j["version"];
+    h.detector = j["detector"];
+    h.date = j["date"];
+    h.tag = j["tag"];
+}
+
+void to_json(nlohmann::ordered_json& j, const header_payload<bool>& h) {
+    j["common"] = h.common;
+    // Do write the optional subheader here, but in the dedicated serializers
+}
+
+void from_json(const nlohmann::ordered_json& j, header_payload<bool>& h) {
+    h.common = j["common"];
+    // Do not look at the optional subheader here
+}
+
+}  // namespace detray

--- a/io/include/detray/io/json/json_material_io.hpp
+++ b/io/include/detray/io/json/json_material_io.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/io/common/payloads.hpp"
 #include "detray/io/json/json.hpp"
+#include "detray/io/json/json_header_io.hpp"
 
 // System include(s)
 #include <array>
@@ -21,22 +22,25 @@ namespace detray {
 
 void to_json(nlohmann::ordered_json& j,
              const homogeneous_material_header_payload& h) {
-    j["version"] = h.version;
-    j["detector"] = h.detector;
-    j["date"] = h.date;
-    j["tag"] = h.tag;
-    j["slab_count"] = h.n_slabs;
-    j["rod_count"] = h.n_rods;
+    j["common"] = h.common;
+
+    if (h.sub_header.has_value()) {
+        const auto& mat_sub_header = h.sub_header.value();
+        j["slab_count"] = mat_sub_header.n_slabs;
+        j["rod_count"] = mat_sub_header.n_rods;
+    }
 }
 
 void from_json(const nlohmann::ordered_json& j,
                homogeneous_material_header_payload& h) {
-    h.version = j["version"];
-    h.detector = j["detector"];
-    h.date = j["date"];
-    h.tag = j["tag"];
-    h.n_slabs = j["slab_count"];
-    h.n_rods = j["rod_count"];
+    h.common = j["common"];
+
+    if (j.find("slab_count") != j.end() and j.find("rod_count") != j.end()) {
+        h.sub_header.emplace();
+        auto& mat_sub_header = h.sub_header.value();
+        mat_sub_header.n_slabs = j["slab_count"];
+        mat_sub_header.n_rods = j["rod_count"];
+    }
 }
 
 void to_json(nlohmann::ordered_json& j, const material_payload& m) {
@@ -44,7 +48,7 @@ void to_json(nlohmann::ordered_json& j, const material_payload& m) {
 }
 
 void from_json(const nlohmann::ordered_json& j, material_payload& m) {
-    m.params = j["params"];
+    m.params = j["params"].get<std::array<real_io, 7>>();
 }
 
 void to_json(nlohmann::ordered_json& j, const material_slab_payload& m) {
@@ -61,37 +65,59 @@ void from_json(const nlohmann::ordered_json& j, material_slab_payload& m) {
     m.mat = j["material"];
 }
 
-void to_json(nlohmann::ordered_json& j,
-             const detector_homogeneous_material_payload& d) {
-    if (not d.mat_slabs.empty()) {
+void to_json(nlohmann::ordered_json& j, const material_volume_payload& mv) {
+    j["index"] = mv.index;
+
+    if (not mv.mat_slabs.empty()) {
         nlohmann::ordered_json jmats;
-        for (const auto& m : d.mat_slabs) {
+        for (const auto& m : mv.mat_slabs) {
             jmats.push_back(m);
         }
         j["material_slabs"] = jmats;
     }
-    if (d.mat_rods.has_value() and not d.mat_rods->empty()) {
+    if (mv.mat_rods.has_value() and not mv.mat_rods->empty()) {
         nlohmann::ordered_json jmats;
-        for (const auto& m : d.mat_rods.value()) {
+        for (const auto& m : mv.mat_rods.value()) {
             jmats.push_back(m);
         }
         j["material_rods"] = jmats;
     }
 }
 
-void from_json(const nlohmann::ordered_json& j,
-               detector_homogeneous_material_payload& d) {
+void from_json(const nlohmann::ordered_json& j, material_volume_payload& mv) {
+    mv.index = j["index"];
+
     if (j.find("material_slabs") != j.end()) {
         for (auto jmats : j["material_slabs"]) {
             material_slab_payload mslp = jmats;
-            d.mat_slabs.push_back(mslp);
+            mv.mat_slabs.push_back(mslp);
         }
     }
     if (j.find("material_rods") != j.end()) {
-        d.mat_rods = {};
+        mv.mat_rods = {};
         for (auto jmats : j["material_rods"]) {
             material_slab_payload mslp = jmats;
-            d.mat_rods->push_back(mslp);
+            mv.mat_rods->push_back(mslp);
+        }
+    }
+}
+
+void to_json(nlohmann::ordered_json& j,
+             const detector_homogeneous_material_payload& d) {
+    if (not d.volumes.empty()) {
+        nlohmann::ordered_json jmats;
+        for (const auto& m : d.volumes) {
+            jmats.push_back(m);
+        }
+        j["volumes"] = jmats;
+    }
+}
+
+void from_json(const nlohmann::ordered_json& j,
+               detector_homogeneous_material_payload& d) {
+    if (j.find("volumes") != j.end()) {
+        for (auto jvolume : j["volumes"]) {
+            d.volumes.push_back(jvolume);
         }
     }
 }

--- a/io/include/detray/io/json/json_serializers.hpp
+++ b/io/include/detray/io/json/json_serializers.hpp
@@ -10,4 +10,5 @@
 #include "detray/io/json/json_algebra_io.hpp"
 #include "detray/io/json/json_geometry_io.hpp"
 #include "detray/io/json/json_grids_io.hpp"
+#include "detray/io/json/json_header_io.hpp"
 #include "detray/io/json/json_material_io.hpp"

--- a/tests/common/include/tests/common/test_toy_detector.hpp
+++ b/tests/common/include/tests/common/test_toy_detector.hpp
@@ -73,7 +73,7 @@ inline bool test_toy_detector(const detector<toy_metadata<>>& toy_det,
     auto& sf_finders = toy_det.surface_store();
     auto& transforms = toy_det.transform_store();
     auto& masks = toy_det.mask_store();
-    // auto& materials = toy_det.material_store();
+    auto& materials = toy_det.material_store();
 
     // Materials
     auto portal_mat =
@@ -88,6 +88,7 @@ inline bool test_toy_detector(const detector<toy_metadata<>>& toy_det,
     const bool has_grids =
         (sf_finders.size<sf_finder_ids::e_cylinder2_grid>() != 0u) ||
         (sf_finders.size<sf_finder_ids::e_disc_grid>() != 0u);
+    const bool has_material = (materials.size<material_ids::e_slab>() != 0);
 
     // Check number of geomtery objects
     EXPECT_EQ(volumes.size(), 20u);
@@ -102,7 +103,9 @@ inline bool test_toy_detector(const detector<toy_metadata<>>& toy_det,
         EXPECT_EQ(sf_finders.size<sf_finder_ids::e_cylinder2_grid>(), 4);
         EXPECT_EQ(sf_finders.size<sf_finder_ids::e_disc_grid>(), 6);
     }
-    // EXPECT_EQ(materials.size<material_ids::e_slab>(), 3244u);
+    if (has_material) {
+        EXPECT_EQ(materials.size<material_ids::e_slab>(), 3244u);
+    }
 
     /** Test the links of a volume.
      *
@@ -138,7 +141,7 @@ inline bool test_toy_detector(const detector<toy_metadata<>>& toy_det,
         [&](const dindex vol_index, decltype(surfaces.begin())&& sf_itr,
             const darray<dindex, 2>& range, dindex trf_index,
             mask_link_t&& mask_link, material_link_t&& material_index,
-            const material_slab<scalar>& /*mat*/,
+            const material_slab<scalar>& mat,
             const dvector<dindex>&& volume_links) {
             for (dindex pti = range[0]; pti < range[1]; ++pti) {
                 EXPECT_EQ(sf_itr->volume(), vol_index);
@@ -148,14 +151,16 @@ inline bool test_toy_detector(const detector<toy_metadata<>>& toy_det,
                 // transforms in the transform store
                 EXPECT_EQ(sf_itr->transform(), trf_index + vol_index + 1);
                 EXPECT_EQ(sf_itr->mask(), mask_link);
-                // EXPECT_EQ(sf_itr->material(), material_index);
                 const auto volume_link =
                     masks.template visit<volume_link_getter>(sf_itr->mask());
                 EXPECT_EQ(volume_link, volume_links[pti - range[0]]);
-                /*EXPECT_EQ(
-                    materials
-                        .get<material_ids::e_slab>()[sf_itr->material().index()],
-                    mat);*/
+                if (has_material) {
+                    EXPECT_EQ(sf_itr->material(), material_index);
+                    EXPECT_EQ(
+                        materials.get<
+                            material_ids::e_slab>()[sf_itr->material().index()],
+                        mat);
+                }
 
                 ++sf_itr;
                 ++trf_index;
@@ -177,7 +182,7 @@ inline bool test_toy_detector(const detector<toy_metadata<>>& toy_det,
         [&](const dindex vol_index, decltype(surfaces.begin())&& sf_itr,
             const darray<dindex, 2>& range, dindex trf_index,
             mask_link_t&& mask_index, material_link_t&& material_index,
-            const material_slab<scalar>& /*mat*/,
+            const material_slab<scalar>& mat,
             const dvector<dindex>&& volume_links) {
             for (dindex pti = range[0]; pti < range[1]; ++pti) {
                 EXPECT_EQ(sf_itr->volume(), vol_index);
@@ -188,14 +193,17 @@ inline bool test_toy_detector(const detector<toy_metadata<>>& toy_det,
                 // transforms in the transform store
                 EXPECT_EQ(sf_itr->transform(), trf_index + vol_index + 1);
                 EXPECT_EQ(sf_itr->mask(), mask_index);
-                // EXPECT_EQ(sf_itr->material(), material_index);
                 const auto volume_link =
                     masks.template visit<volume_link_getter>(sf_itr->mask());
                 EXPECT_EQ(volume_link, volume_links[0]);
-                /*EXPECT_EQ(
-                    materials
-                        .get<material_ids::e_slab>()[sf_itr->material().index()],
-                    mat);*/
+                if (has_material) {
+                    EXPECT_EQ(sf_itr->material(), material_index);
+                    EXPECT_EQ(
+                        materials.get<
+                            material_ids::e_slab>()[sf_itr->material().index()],
+                        mat);
+                }
+
                 ++sf_itr;
                 ++trf_index;
                 ++mask_index;

--- a/tests/unit_tests/cpu/materials.cpp
+++ b/tests/unit_tests/cpu/materials.cpp
@@ -31,14 +31,19 @@ using transform3 = test::transform3;
 using vector3 = test::vector3;
 using intersection_t = intersection2D<surface_descriptor<>, transform3>;
 
+namespace {
+
 constexpr scalar tol{1e-7f};
+constexpr auto max_val{std::numeric_limits<scalar>::max()};
+
+}  // anonymous namespace
 
 // This tests the material functionalities
 GTEST_TEST(detray_materials, material) {
     // vacuum
     constexpr vacuum<scalar> vac;
-    EXPECT_TRUE(std::isinf(vac.X0()));
-    EXPECT_TRUE(std::isinf(vac.L0()));
+    EXPECT_EQ(vac.X0(), max_val);
+    EXPECT_EQ(vac.L0(), max_val);
     EXPECT_EQ(vac.Ar(), scalar{0});
     EXPECT_EQ(vac.Z(), scalar{0});
     EXPECT_EQ(vac.molar_density(), scalar{0});

--- a/tests/unit_tests/io/io_json_detector_reader.cpp
+++ b/tests/unit_tests/io/io_json_detector_reader.cpp
@@ -8,6 +8,8 @@
 // Project include(s)
 #include "detray/definitions/algebra.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
+#include "detray/io/common/detector_reader.hpp"
+#include "detray/io/common/detector_writer.hpp"
 #include "detray/io/json/json_reader.hpp"
 #include "detray/io/json/json_writer.hpp"
 #include "tests/common/test_toy_detector.hpp"
@@ -37,19 +39,22 @@ TEST(io, json_toy_geometry) {
     auto file_name = geo_writer.write(
         toy_det, names, std::ios_base::out | std::ios_base::trunc);
 
-    // Read the detector back in
-    detector_t det{host_mr};
+    // Empty volume name map to be filled
     typename detector_t::name_map volume_name_map = {{0u, "toy_detector"}};
 
+    // Read the detector back in
+    detector_builder<toy_metadata<>, volume_builder> toy_builder;
     json_geometry_reader<detector_t> geo_reader;
-    geo_reader.read(det, volume_name_map, file_name);
+    geo_reader.read(toy_builder, volume_name_map, file_name);
+    auto det = toy_builder.build(host_mr);
 
     EXPECT_TRUE(test_toy_detector(det, volume_name_map));
 
     // Read the toy detector into the default detector type
-    detector<> comp_det{host_mr};
+    detector_builder<> comp_builder;
     json_geometry_reader<detector<>> comp_geo_reader;
-    comp_geo_reader.read(comp_det, volume_name_map, file_name);
+    comp_geo_reader.read(comp_builder, volume_name_map, file_name);
+    auto comp_det = comp_builder.build(host_mr);
 
     using mask_id = detector<>::masks::id;
     const auto& masks = comp_det.mask_store();
@@ -67,4 +72,29 @@ TEST(io, json_toy_geometry) {
     EXPECT_EQ(masks.template size<mask_id::e_portal_ring2>(), 52u);
     EXPECT_EQ(masks.template size<mask_id::e_straw_wire>(), 0u);
     EXPECT_EQ(masks.template size<mask_id::e_cell_wire>(), 0u);
+}
+
+/// Test the reading and writing of a toy detector geometry
+TEST(io, json_toy_detector_reader) {
+
+    using detector_t = detector<toy_metadata<>>;
+
+    // Toy detector
+    vecmem::host_memory_resource host_mr;
+    const auto [toy_det, toy_names] = create_toy_geometry(host_mr);
+
+    auto writer_cfg = io::detector_writer_config{}
+                          .format(io::format::json)
+                          .replace_files(true);
+    io::write_detector(toy_det, toy_names, writer_cfg);
+
+    // Read the detector back in
+    io::detector_reader_config reader_cfg{};
+    reader_cfg.add_file("toy_detector_geometry.json")
+        .add_file("toy_detector_homogeneous_material.json");
+
+    const auto [det, names] =
+        io::read_detector<detector_t>(host_mr, reader_cfg);
+
+    EXPECT_TRUE(test_toy_detector(det, names));
 }

--- a/tests/unit_tests/io/io_json_payload.cpp
+++ b/tests/unit_tests/io/io_json_payload.cpp
@@ -14,6 +14,26 @@
 // GTest include(s)
 #include <gtest/gtest.h>
 
+/// This tests the json io for the general file header information
+TEST(io, json_header_payload) {
+
+    detray::header_payload<bool> h;
+    h.common.version = "v0.0.1";
+    h.common.detector = "test_detector";
+    h.common.tag = "test_file";
+    h.common.date = "01.01.2023";
+
+    nlohmann::ordered_json j;
+    j["header"] = h;
+
+    detray::header_payload<bool> ph = j["header"];
+
+    EXPECT_EQ(h.common.version, ph.common.version);
+    EXPECT_EQ(h.common.detector, ph.common.detector);
+    EXPECT_EQ(h.common.tag, ph.common.tag);
+    EXPECT_EQ(h.common.date, ph.common.date);
+}
+
 /// This tests the json io for a single index link
 TEST(io, single_link_payload) {
     detray::single_link_payload sl;

--- a/tutorials/src/cpu/detector/detector_to_dot.cpp
+++ b/tutorials/src/cpu/detector/detector_to_dot.cpp
@@ -9,7 +9,7 @@
 #include "detray/core/detector.hpp"
 #include "detray/detectors/toy_metadata.hpp"
 #include "detray/geometry/volume_graph.hpp"
-#include "detray/io/json/json_reader.hpp"
+#include "detray/io/common/detector_reader.hpp"
 
 // Example linear algebra plugin: std::array
 #include "detray/tutorial/types.hpp"
@@ -27,9 +27,9 @@
 int main(int argc, char** argv) {
 
     // Input data file
-    std::string file_name;
+    auto reader_cfg = detray::io::detector_reader_config{};
     if (argc == 2) {
-        file_name = argv[1];
+        reader_cfg.add_file(argv[1]);
     } else {
         throw std::runtime_error("Please specify an input file name!");
     }
@@ -37,18 +37,14 @@ int main(int argc, char** argv) {
     // Read a toy detector
     using detector_t = detray::detector<detray::toy_metadata<>>;
 
-    // Empty volume name map (won't be filled by the reader, yet)
-    typename detector_t::name_map volume_name_map = {{0u, "toy_detector"}};
-
     // Create an empty detector to be filled
     vecmem::host_memory_resource host_mr;
-    detector_t det{host_mr};
 
-    // Read the json geometry file
-    detray::json_geometry_reader<detector_t> geo_reader;
-    geo_reader.read(det, volume_name_map, file_name);
+    // Read the detector in
+    const auto [det, names] =
+        detray::io::read_detector<detector_t>(host_mr, reader_cfg);
 
-    // The detector now contains a geometry!
+    // Display the detector volume graph
     detray::volume_graph graph(det);
     std::cout << graph.to_dot_string() << std::endl;
 }

--- a/tutorials/src/cpu/detector/read_detector_from_file.cpp
+++ b/tutorials/src/cpu/detector/read_detector_from_file.cpp
@@ -9,7 +9,7 @@
 #include "detray/core/detector.hpp"
 #include "detray/detectors/toy_metadata.hpp"
 #include "detray/geometry/volume_graph.hpp"
-#include "detray/io/json/json_reader.hpp"
+#include "detray/io/common/detector_reader.hpp"
 
 // Example linear algebra plugin: std::array
 #include "detray/tutorial/types.hpp"
@@ -27,9 +27,9 @@
 int main(int argc, char** argv) {
 
     // Input data file
-    std::string file_name;
+    auto reader_cfg = detray::io::detector_reader_config{};
     if (argc == 2) {
-        file_name = argv[1];
+        reader_cfg.add_file(argv[1]);
     } else {
         throw std::runtime_error("Please specify an input file name!");
     }
@@ -37,20 +37,16 @@ int main(int argc, char** argv) {
     // Read a toy detector
     using detector_t = detray::detector<detray::toy_metadata<>>;
 
-    // Empty volume name map (won't be filled by the reader, yet)
-    typename detector_t::name_map volume_name_map;
-
     // Create an empty detector to be filled
     vecmem::host_memory_resource host_mr;
-    detector_t det{host_mr};
 
-    // Read the json geometry file
-    detray::json_geometry_reader<detector_t> geo_reader;
-    geo_reader.read(det, volume_name_map, file_name);
+    // Read the json files
+    const auto [det, names] =
+        detray::io::read_detector<detector_t>(host_mr, reader_cfg);
 
-    // The detector now contains a geometry!
+    // Print the detector volume graph
     detray::volume_graph graph(det);
     std::cout << "\nRead " << det.volumes().size() << " volumes from file "
-              << file_name << ":\n\n"
+              << reader_cfg.files()[0u] << ":\n\n"
               << graph.to_string() << std::endl;
 }


### PR DESCRIPTION
Adds the material reader and connects it to the geometry reader by providing
the read_detector function, which corresponds to the write_detector function.
Since the detector builder works volume-by-volume, and the material building 
functionality is decorated onto the individual volume builders, the material
io payloads had to be adapted to be read/written by volume, too.

In order to know which reader to register for a given file, the file header has
to be inspected. The header now contains a common part, that is e.g. used to 
check if the file version is compatible with the running detray version, as well
as a subheader that is specific to every file. Currently the subheaders contain
some statistics about the file contant that can be used in the future to validate     
the data or help prepare the reader infrastructure (e.g. reserving memory)