### PR TITLE
Always initialize the step data of rk stepper

### DIFF
--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -71,9 +71,14 @@ class rk_stepper final
 
         /// stepping data required for RKN4
         struct {
-            vector3 b_first, b_middle, b_last;
-            vector3 k1, k2, k3, k4;
-            array_t<scalar, 4> k_qop;
+            vector3 b_first{0.f, 0.f, 0.f};
+            vector3 b_middle{0.f, 0.f, 0.f};
+            vector3 b_last{0.f, 0.f, 0.f};
+            vector3 k1{0.f, 0.f, 0.f};
+            vector3 k2{0.f, 0.f, 0.f};
+            vector3 k3{0.f, 0.f, 0.f};
+            vector3 k4{0.f, 0.f, 0.f};
+            array_t<scalar, 4> k_qop{0.f, 0.f, 0.f, 0.f};
         } _step_data;
 
         /// Magnetic field view


### PR DESCRIPTION
I found that uninitialized `k4` of step data (return of `dtds()`) causes non-deterministic result in CPU CKF.

Technically this happens when `parameter_transport` uses `dtds()` during the first actor run of propagator, which doesn't have any step data information. 
TBH, initial `k4` value should be initialized as (dtds = q/p * dir * B(r0)) rather than `(0,0,0)` but let's do this later (I;ve already spent too much energy to debug this...)




