### PR TITLE
Add a Simple Drift Chamber

### DIFF
--- a/tests/unit_tests/cpu/CMakeLists.txt
+++ b/tests/unit_tests/cpu/CMakeLists.txt
@@ -57,6 +57,7 @@ macro( detray_add_cpu_test algebra )
       "sf_finder_brute_force.cpp"
       "test_core.cpp"
       "test_telescope_detector.cpp"
+      "test_wire_chamber.cpp"
       "test_toy_geometry.cpp"
       "tools_bounding_volume.cpp"
       "tools_cuboid_intersector.cpp"

--- a/tests/unit_tests/cpu/check_geometry_navigation.cpp
+++ b/tests/unit_tests/cpu/check_geometry_navigation.cpp
@@ -12,6 +12,7 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
+#include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/intersection/detail/trajectories.hpp"
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/line_stepper.hpp"
@@ -27,13 +28,12 @@
 using namespace detray;
 using namespace navigation;
 
-using transform3_t = test::transform3;
 using ray_type = detail::ray<transform3_t>;
 using free_track_parameters_type = free_track_parameters<transform3_t>;
 
 /// This test runs intersection with all portals of the toy detector with a ray
 /// and then compares the intersection trace with a straight line navigation.
-GTEST_TEST(detray_propagator, straight_line_navigation) {
+GTEST_TEST(toy_geometry, straight_line_navigation) {
 
     // Detector configuration
     constexpr std::size_t n_brl_layers{4u};
@@ -121,7 +121,7 @@ GTEST_TEST(detray_propagator, straight_line_navigation) {
 
 /// Check the Runge-Kutta based navigation against a helix trajectory as ground
 /// truth
-GTEST_TEST(detray_propagator, helix_navigation) {
+GTEST_TEST(toy_geometry, helix_navigation) {
     using namespace navigation;
 
     // Detector configuration
@@ -230,6 +230,202 @@ GTEST_TEST(detray_propagator, helix_navigation) {
                 << " on track: " << n_tracks << "/"
                 << trk_state_generator.size();
         }
+        ++n_tracks;
+    }
+}
+
+// @TODO: Create common check function for all detectors
+GTEST_TEST(wire_chamber, straight_line_navigation) {
+
+    // Detector configuration
+    vecmem::host_memory_resource host_mr;
+    auto [det, names] = create_wire_chamber(host_mr, wire_chamber_config{});
+
+    // Straight line navigation
+    using detector_t = decltype(det);
+    using intersection_t =
+        intersection2D<typename detector_t::surface_type, transform3_t>;
+    using object_tracer_t =
+        object_tracer<intersection_t, dvector, status::e_on_module,
+                      status::e_on_portal>;
+    using inspector_t = aggregate_inspector<object_tracer_t, print_inspector>;
+    using navigator_t = navigator<detector_t, inspector_t, intersection_t>;
+    using stepper_t =
+        line_stepper<transform3_t, unconstrained_step, always_init>;
+    using propagator_t = propagator<stepper_t, navigator_t, actor_chain<>>;
+
+    // Propagator
+    propagator_t prop(stepper_t{}, navigator_t{});
+
+    constexpr std::size_t theta_steps{20u};
+    constexpr std::size_t phi_steps{20u};
+
+    const point3 ori{0.f, 0.f, 0.f};
+
+    // Iterate through uniformly distributed momentum directions
+    for (const auto ray :
+         uniform_track_generator<ray_type>(theta_steps, phi_steps, ori)) {
+
+        // Shoot ray through the detector and record all surfaces it encounters
+        const auto intersection_trace = particle_gun::shoot_particle(
+            det, ray, 15.f * unit<typename detector_t::scalar_type>::um);
+
+        // Now follow that ray with a track and check, if we find the same
+        // volumes and distances along the way
+        free_track_parameters_type track(ray.pos(), 0.f, ray.dir(), -1.f);
+        propagator_t::state propagation(track, det);
+
+        // Retrieve navigation information
+        auto &inspector = propagation._navigation.inspector();
+        auto &obj_tracer = inspector.template get<object_tracer_t>();
+        auto &debug_printer = inspector.template get<print_inspector>();
+
+        ASSERT_TRUE(prop.propagate(propagation)) << debug_printer.to_string();
+
+        // Compare intersection records
+        EXPECT_EQ(obj_tracer.object_trace.size(), intersection_trace.size());
+
+        std::stringstream debug_stream;
+        for (std::size_t intr_idx = 0u; intr_idx < intersection_trace.size();
+             ++intr_idx) {
+            debug_stream << "-------Intersection trace\n"
+                         << "ray gun: " << intersection_trace[intr_idx].second
+                         << ", vol id: " << intersection_trace[intr_idx].first
+                         << std::endl;
+            debug_stream << "navig.:  " << obj_tracer[intr_idx] << std::endl;
+        }
+
+        // Check every single recorded intersection
+        for (std::size_t i = 0u; i < obj_tracer.object_trace.size(); ++i) {
+            if (obj_tracer[i].sf_desc.barcode() !=
+                intersection_trace[i].second.sf_desc.barcode()) {
+                // Intersection record at portal bound might be flipped
+                // (the portals overlap completely)
+                if (obj_tracer[i].sf_desc.barcode() ==
+                        intersection_trace[i + 1u].second.sf_desc.barcode() and
+                    obj_tracer[i + 1u].sf_desc.barcode() ==
+                        intersection_trace[i].second.sf_desc.barcode()) {
+                    // Have already checked the next record
+                    ++i;
+                    continue;
+                }
+            }
+            ASSERT_EQ(obj_tracer[i].sf_desc.barcode(),
+                      intersection_trace[i].second.sf_desc.barcode())
+                << debug_printer.to_string() << debug_stream.str();
+        }
+    }
+}
+
+// @TODO: Create common check function for all detectors
+GTEST_TEST(wire_chamber, helix_navigation) {
+
+    using namespace navigation;
+
+    // Detector configuration
+    vecmem::host_memory_resource host_mr;
+
+    using b_field_t = detector<default_metadata>::bfield_type;
+
+    const vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                    2.f * unit<scalar>::T};
+
+    auto [det, names] = create_wire_chamber(host_mr, wire_chamber_config{});
+
+    // Runge-Kutta based navigation
+    using detector_t = decltype(det);
+    using intersection_t =
+        intersection2D<typename detector_t::surface_type, transform3_t>;
+    using object_tracer_t =
+        object_tracer<intersection_t, dvector, status::e_on_module,
+                      status::e_on_portal>;
+    using inspector_t = aggregate_inspector<object_tracer_t, print_inspector>;
+    using navigator_t = navigator<detector_t, inspector_t, intersection_t>;
+    using constraints_t = unconstrained_step;
+    using stepper_t =
+        rk_stepper<b_field_t::view_t, transform3_t, constraints_t>;
+    using propagator_t = propagator<stepper_t, navigator_t, actor_chain<>>;
+
+    // Propagator
+    propagator_t prop(stepper_t{}, navigator_t{});
+
+    constexpr std::size_t theta_steps{3u};
+    constexpr std::size_t phi_steps{10u};
+
+    // det.volume_by_pos(ori).index();
+    const point3 ori{0.f, 0.f, 0.f};
+    const scalar p_mag{10.f * unit<scalar>::GeV};
+
+    // Overstepping
+    constexpr scalar overstep_tol{-10.f * unit<scalar>::um};
+
+    // Iterate through uniformly distributed momentum directions
+    std::size_t n_tracks{0u};
+    auto trk_state_generator =
+        uniform_track_generator<free_track_parameters_type>(
+            theta_steps, phi_steps, ori, p_mag);
+
+    for (auto track : trk_state_generator) {
+
+        // Prepare for overstepping in the presence of b fields
+        track.set_overstep_tolerance(overstep_tol);
+
+        // Get ground truth helix from track
+        detail::helix helix(track, &B);
+
+        // Shoot ray through the detector and record all surfaces it encounters
+        const auto intersection_trace = particle_gun::shoot_particle(
+            det, helix, 15.f * unit<typename detector_t::scalar_type>::um);
+
+        // Now follow that helix with the same track and check, if we find
+        // the same volumes and distances along the way
+        propagator_t::state propagation(track, det.get_bfield(), det);
+
+        // Retrieve navigation information
+        auto &inspector = propagation._navigation.inspector();
+        auto &obj_tracer = inspector.template get<object_tracer_t>();
+        auto &debug_printer = inspector.template get<print_inspector>();
+
+        ASSERT_TRUE(prop.propagate(propagation)) << debug_printer.to_string();
+
+        std::stringstream debug_stream;
+        std::size_t n_inters_nav{obj_tracer.object_trace.size()};
+        std::size_t max_entries{
+            std::max(n_inters_nav, intersection_trace.size())};
+        for (std::size_t intr_idx = 0u; intr_idx < max_entries; ++intr_idx) {
+            debug_stream << "-------Intersection trace\n"
+                         << "helix gun: " << intersection_trace[intr_idx].second
+                         << ", vol id: " << intersection_trace[intr_idx].first
+                         << std::endl;
+            debug_stream << "navig.:  " << obj_tracer[intr_idx] << std::endl;
+        }
+
+        // Compare intersection records
+        ASSERT_EQ(n_inters_nav, intersection_trace.size())
+            << debug_printer.to_string() << debug_stream.str();
+
+        // Check every single recorded intersection
+        for (std::size_t i = 0u; i < max_entries; ++i) {
+            if (obj_tracer[i].sf_desc.barcode() !=
+                intersection_trace[i].second.sf_desc.barcode()) {
+                // Intersection record at portal bound might be flipped
+                // (the portals overlap completely)
+                if (obj_tracer[i].sf_desc.barcode() ==
+                        intersection_trace[i + 1u].second.sf_desc.barcode() and
+                    obj_tracer[i + 1u].sf_desc.barcode() ==
+                        intersection_trace[i].second.sf_desc.barcode()) {
+                    // Have already checked the next record
+                    ++i;
+                    continue;
+                }
+            }
+            ASSERT_EQ(obj_tracer[i].sf_desc.barcode(),
+                      intersection_trace[i].second.sf_desc.barcode())
+                << " intersection: " << i << "/" << n_inters_nav
+                << " on track: " << n_tracks << "/"
+                << trk_state_generator.size();
+        }
+
         ++n_tracks;
     }
 }

--- a/tests/unit_tests/cpu/test_wire_chamber.cpp
+++ b/tests/unit_tests/cpu/test_wire_chamber.cpp
@@ -1,0 +1,29 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "detray/detectors/create_wire_chamber.hpp"
+#include "detray/utils/consistency_checker.hpp"
+
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// GTest include.
+#include <gtest/gtest.h>
+
+using namespace detray;
+
+GTEST_TEST(detray_detectors, wire_chamber) {
+
+    vecmem::host_memory_resource host_mr;
+
+    auto [wire_det, names] =
+        create_wire_chamber(host_mr, wire_chamber_config{});
+
+    // Check general consistency of the detector
+    detail::check_consistency(wire_det);
+}

--- a/tests/unit_tests/cpu/tools_navigator.cpp
+++ b/tests/unit_tests/cpu/tools_navigator.cpp
@@ -8,6 +8,7 @@
 // Project include(s)
 #include "detray/definitions/indexing.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
+#include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/propagator/line_stepper.hpp"
 #include "detray/propagator/navigator.hpp"
 #include "detray/test/types.hpp"
@@ -105,7 +106,7 @@ inline void check_step(navigator_t &nav, stepper_t &stepper,
 }  // namespace detray
 
 /// This tests the construction and general methods of the navigator
-GTEST_TEST(detray_propagator, navigator) {
+GTEST_TEST(detray_navigator, toy_geometry) {
     using namespace detray;
     using namespace detray::navigation;
     using transform3 = test::transform3;
@@ -256,6 +257,159 @@ GTEST_TEST(detray_propagator, navigator) {
             ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
         } else {
             ASSERT_TRUE(nav.update(propagation));
+        }
+    }
+
+    // Leave for debugging
+    // std::cout << navigation.inspector().to_string() << std::endl;
+    ASSERT_TRUE(navigation.is_complete()) << navigation.inspector().to_string();
+}
+
+GTEST_TEST(detray_navigator, wire_chamber) {
+
+    using namespace detray;
+    using namespace detray::navigation;
+    using transform3 = test::transform3;
+
+    vecmem::host_memory_resource host_mr;
+
+    /// Tolerance for tests
+    constexpr double tol{0.01};
+
+    constexpr std::size_t n_layers{10};
+    auto [wire_det, names] =
+        create_wire_chamber(host_mr, wire_chamber_config{});
+    using detector_t = decltype(wire_det);
+    using inspector_t = navigation::print_inspector;
+    using navigator_t = navigator<detector_t, inspector_t>;
+    using constraint_t = constrained_step<>;
+    using stepper_t = line_stepper<transform3, constraint_t>;
+
+    // test track
+    point3 pos{0.f, 0.f, 0.f};
+    vector3 mom{1.f, 0.f, 0.f};
+    free_track_parameters<transform3> traj(pos, 0.f, mom, -1.f);
+
+    stepper_t stepper;
+    navigator_t nav;
+
+    prop_state<stepper_t::state, navigator_t::state> propagation{
+        stepper_t::state{traj}, navigator_t::state(wire_det, host_mr)};
+    navigator_t::state &navigation = propagation._navigation;
+    stepper_t::state &stepping = propagation._stepping;
+
+    // Check that the state is unitialized
+    // Default volume is zero
+    ASSERT_EQ(navigation.volume(), 0u);
+    // No surface candidates
+    ASSERT_EQ(navigation.n_candidates(), 0u);
+    // You can not trust the state
+    ASSERT_EQ(navigation.trust_level(), trust_level::e_no_trust);
+    // The status is unkown
+    ASSERT_EQ(navigation.status(), status::e_unknown);
+
+    //
+    // Beam Collison region
+    //
+
+    // Initialize navigation
+    // Test that the navigator has a heartbeat
+    ASSERT_TRUE(nav.init(propagation));
+    // The status is towards portal
+    // One candidates: barrel cylinder portal
+    check_towards_surface<navigator_t>(navigation, 0u, 1u, 0u);
+    // Distance to portal
+    ASSERT_NEAR(navigation(), 500.f * unit<scalar>::mm, tol);
+
+    // Let's make half the step towards the portal
+    stepping.template set_constraint<step::constraint::e_user>(navigation() *
+                                                               0.5f);
+    stepper.step(propagation);
+    // Navigation policy might reduce trust level to fair trust
+    navigation.set_fair_trust();
+    // Release user constraint again
+    stepping.template release_step<step::constraint::e_user>();
+    ASSERT_TRUE(navigation.trust_level() == trust_level::e_fair);
+    // Re-navigate
+    ASSERT_TRUE(nav.update(propagation));
+    // Trust level is restored
+    ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
+    // The status remains: towards surface
+    check_towards_surface<navigator_t>(navigation, 0u, 1u, 0u);
+    // Distance to portal is now halved
+    ASSERT_NEAR(navigation(), 250.f * unit<scalar>::mm, tol);
+
+    // Let's immediately update, nothing should change, as there is full trust
+    ASSERT_TRUE(nav.update(propagation));
+    check_towards_surface<navigator_t>(navigation, 0u, 1u, 0u);
+    ASSERT_NEAR(navigation(), 250.f * unit<scalar>::mm, tol);
+
+    // Step onto portal in volume 0
+    stepper.step(propagation);
+    navigation.set_high_trust();
+    ASSERT_TRUE(navigation.trust_level() == trust_level::e_high);
+    ASSERT_TRUE(nav.update(propagation)) << navigation.inspector().to_string();
+    ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
+
+    //
+    // Wire Layer
+    //
+
+    // Last volume before we leave world
+    dindex last_vol_id = n_layers;
+
+    // maps volume id to the sequence of surfaces that the navigator encounters
+    std::map<dindex, std::vector<dindex>> sf_sequences;
+
+    // layer 1 to 10
+    sf_sequences[1] = {3u, 7u, 4u};
+    sf_sequences[2] = {167u, 171u, 168u};
+    sf_sequences[3] = {337u, 341u, 338u};
+    sf_sequences[4] = {513u, 517u, 514u};
+    sf_sequences[5] = {696u, 700u, 697u};
+    sf_sequences[6] = {885u, 889u, 886u};
+    sf_sequences[7] = {1080u, 1084u, 1081u};
+    sf_sequences[8] = {1281u, 1285u, 1282u};
+    sf_sequences[9] = {1489u, 1493u, 1490u};
+    sf_sequences[10] = {1703u, 1707u, 1704u};
+
+    // Every iteration steps through one wire layer
+    for (const auto &[vol_id, sf_seq] : sf_sequences) {
+
+        // Exclude the portal we are already on
+        std::size_t n_candidates = sf_seq.size() - 1u;
+
+        // We switched to next barrel volume
+        check_volume_switch<navigator_t>(navigation, vol_id);
+
+        // The status is: on adjacent portal in volume, towards next candidate
+        check_on_surface<navigator_t>(navigation, vol_id, n_candidates,
+                                      sf_seq[0], sf_seq[1]);
+
+        // Step through the module surfaces
+        for (std::size_t sf = 1u; sf < sf_seq.size() - 1u; ++sf) {
+            // Count only the currently reachable candidates
+            check_step(nav, stepper, propagation, vol_id, n_candidates - sf,
+                       sf_seq[sf], sf_seq[sf + 1u]);
+        }
+
+        // Step onto the portal in volume
+        stepper.step(propagation);
+        navigation.set_high_trust();
+
+        // Check agianst last volume
+        if (vol_id == last_vol_id) {
+            ASSERT_FALSE(nav.update(propagation));
+            // The status is: exited
+            ASSERT_EQ(navigation.status(), status::e_on_target);
+            // Switch to next volume leads out of the detector world -> exit
+            ASSERT_TRUE(is_invalid_value(navigation.volume()));
+            // We know we went out of the detector
+            ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
+        } else {
+            // ASSERT_TRUE(nav.update(propagation));
+            ASSERT_TRUE(nav.update(propagation))
+                << navigation.inspector().to_string();
         }
     }
 

--- a/utils/include/detray/detectors/create_toy_geometry.hpp
+++ b/utils/include/detray/detectors/create_toy_geometry.hpp
@@ -11,6 +11,7 @@
 #include "detray/core/detector.hpp"
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/detectors/detector_helper.hpp"
 #include "detray/detectors/toy_metadata.hpp"
 #include "detray/geometry/detector_volume.hpp"
 #include "detray/geometry/surface.hpp"
@@ -35,185 +36,10 @@ namespace detray {
 
 namespace {
 
+using transform3_t = __plugin::transform3<detray::scalar>;
 using point3 = __plugin::point3<detray::scalar>;
 using vector3 = __plugin::vector3<detray::scalar>;
 using point2 = __plugin::point2<detray::scalar>;
-
-/** Function that adds a cylinder portal.
- *
- * @tparam cylinder_id default cylinder id
- *
- * @param volume_idx volume the portal should be added to
- * @param ctx geometric context
- * @param surfaces container to add new surface to
- * @param masks container to add new cylinder mask to
- * @param transforms container to add new transform to
- * @param r raius of the cylinder
- * @param lower_z lower extend in z
- * @param upper_z upper extend in z
- * @param volume_link link to next volume for the masks
- */
-template <auto cyl_id, typename context_t, typename surface_container_t,
-          typename mask_container_t, typename material_container_t,
-          typename transform_container_t, typename volume_links>
-inline void add_cylinder_surface(
-    const dindex volume_idx, context_t &ctx, surface_container_t &surfaces,
-    mask_container_t &masks, material_container_t &materials,
-    transform_container_t &transforms, const scalar r, const scalar lower_z,
-    const scalar upper_z, const volume_links volume_link,
-    const material<scalar> &mat, const scalar thickness) {
-    using surface_type = typename surface_container_t::value_type;
-    using mask_link_type = typename surface_type::mask_link;
-    using material_id = typename surface_type::material_id;
-    using material_link_type = typename surface_type::material_link;
-
-    constexpr auto slab_id = material_id::e_slab;
-
-    const scalar min_z{std::min(lower_z, upper_z)};
-    const scalar max_z{std::max(lower_z, upper_z)};
-
-    // translation
-    point3 tsl{0.f, 0.f, 0.f};
-
-    // add transform and masks
-    transforms.emplace_back(ctx, tsl);
-    masks.template emplace_back<cyl_id>(empty_context{}, volume_link, r, min_z,
-                                        max_z);
-
-    // Add material slab
-    materials.template emplace_back<slab_id>(empty_context{}, mat, thickness);
-
-    // add surface
-    mask_link_type mask_link{cyl_id, masks.template size<cyl_id>() - 1u};
-    material_link_type material_link{slab_id,
-                                     materials.template size<slab_id>() - 1u};
-    const surface_id sf_id = (volume_link != volume_idx)
-                                 ? surface_id::e_portal
-                                 : surface_id::e_passive;
-    surfaces.emplace_back(transforms.size(ctx) - 1u, mask_link, material_link,
-                          volume_idx, dindex_invalid, sf_id);
-}
-
-/** Function that adds a disc portal.
- *
- * @tparam disc_id default disc id
- *
- * @param volume_idx volume the portal should be added to
- * @param ctx geometric context
- * @param surfaces container to add new surface to
- * @param masks container to add new cylinder mask to
- * @param transforms container to add new transform to
- * @param min_r lower radius of the disc
- * @param max_r upper radius of the disc
- * @param z z position of the disc
- * @param volume_link link to next volume for the masks
- */
-template <typename context_t, typename surface_container_t,
-          typename mask_container_t, typename material_container_t,
-          typename transform_container_t, typename volume_links>
-inline void add_disc_surface(
-    const dindex volume_idx, context_t &ctx, surface_container_t &surfaces,
-    mask_container_t &masks, material_container_t &materials,
-    transform_container_t &transforms, const scalar inner_r,
-    const scalar outer_r, const scalar z, const volume_links volume_link,
-    const material<scalar> &mat, const scalar thickness) {
-    using surface_type = typename surface_container_t::value_type;
-    using mask_id = typename surface_type::mask_id;
-    using mask_link_type = typename surface_type::mask_link;
-    using material_id = typename surface_type::material_id;
-    using material_link_type = typename surface_type::material_link;
-
-    constexpr auto disc_id = mask_id::e_portal_ring2;
-    constexpr auto slab_id = material_id::e_slab;
-
-    const scalar min_r{std::min(inner_r, outer_r)};
-    const scalar max_r{std::max(inner_r, outer_r)};
-
-    // translation
-    point3 tsl{0.f, 0.f, z};
-
-    // add transform and mask
-    transforms.emplace_back(ctx, tsl);
-    masks.template emplace_back<disc_id>(empty_context{}, volume_link, min_r,
-                                         max_r);
-
-    // Add material slab
-    materials.template emplace_back<slab_id>(empty_context{}, mat, thickness);
-
-    // add surface
-    mask_link_type mask_link{disc_id, masks.template size<disc_id>() - 1u};
-    material_link_type material_link{slab_id,
-                                     materials.template size<slab_id>() - 1u};
-    const surface_id sf_id = (volume_link != volume_idx)
-                                 ? surface_id::e_portal
-                                 : surface_id::e_sensitive;
-    surfaces.emplace_back(transforms.size(ctx) - 1u, mask_link, material_link,
-                          volume_idx, dindex_invalid, sf_id);
-}
-
-/** Function that adds a generic cylinder volume, using a factory for contained
- *  module surfaces.
- *
- * @tparam detector_t the detector type
- * @tparam factory_t type of module factory. Must be callable on containers.
- *
- * @param det detector the volume should be added to
- * @param resource vecmem memory resource for the temporary containers
- * @param ctx geometry context
- * @param lay_inner_r inner radius of volume
- * @param lay_outer_r outer radius of volume
- * @param lay_neg_r lower extend of volume
- * @param lay_pos_r upper extend of volume
- * @param volume_links volume links for the portals of the volume
- * @param module_factory functor that adds module surfaces to volume
- */
-template <typename detector_t>
-void create_cyl_volume(detector_t &det, vecmem::memory_resource &resource,
-                       typename detector_t::geometry_context &ctx,
-                       const scalar lay_inner_r, const scalar lay_outer_r,
-                       const scalar lay_neg_z, const scalar lay_pos_z,
-                       const std::vector<dindex> &volume_links) {
-    // volume bounds
-    const scalar inner_r{std::min(lay_inner_r, lay_outer_r)};
-    const scalar outer_r{std::max(lay_inner_r, lay_outer_r)};
-    const scalar lower_z{std::min(lay_neg_z, lay_pos_z)};
-    const scalar upper_z{std::max(lay_neg_z, lay_pos_z)};
-
-    // Add module surfaces to volume
-    typename detector_t::surface_container_t surfaces(&resource);
-    typename detector_t::mask_container masks(resource);
-    typename detector_t::material_container materials(resource);
-    typename detector_t::transform_container transforms(resource);
-
-    auto &cyl_volume = det.new_volume(
-        volume_id::e_cylinder, {detector_t::sf_finders::id::e_default, 0u});
-
-    // volume placement
-    cyl_volume.set_transform(det.transform_store().size());
-    // translation of the cylinder
-    point3 t{0.f, 0.f, 0.5f * (upper_z + lower_z)};
-    det.transform_store().emplace_back(ctx, t);
-
-    // negative and positive, inner and outer portal surface
-    constexpr auto cyl_id = detector_t::masks::id::e_portal_cylinder2;
-    add_cylinder_surface<cyl_id>(cyl_volume.index(), ctx, surfaces, masks,
-                                 materials, transforms, inner_r, lower_z,
-                                 upper_z, volume_links[0], vacuum<scalar>(),
-                                 0.f * unit<scalar>::mm);
-    add_cylinder_surface<cyl_id>(cyl_volume.index(), ctx, surfaces, masks,
-                                 materials, transforms, outer_r, lower_z,
-                                 upper_z, volume_links[1], vacuum<scalar>(),
-                                 0.f * unit<scalar>::mm);
-    add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
-                     transforms, inner_r, outer_r, lower_z, volume_links[2],
-                     vacuum<scalar>(), 0.f * unit<scalar>::mm);
-    add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
-                     transforms, inner_r, outer_r, upper_z, volume_links[3],
-                     vacuum<scalar>(), 0.f * unit<scalar>::mm);
-
-    det.add_objects_per_volume(ctx, cyl_volume, surfaces, masks, transforms,
-                               materials);
-}
 
 /** Helper function that creates a layer of rectangular barrel modules.
  *
@@ -704,7 +530,7 @@ inline void add_beampipe(
     dindex link = beampipe_idx;
     for (int i = static_cast<int>(vol_sizes.size()) - 1; i >= 0; --i) {
         volume_link = ++link;
-        add_cylinder_surface<cyl_id>(
+        detail::detector_helper<transform3_t>().add_cylinder_surface<cyl_id>(
             beampipe_idx, ctx, surfaces, masks, materials, transforms,
             edc_inner_r, -vol_sizes[static_cast<unsigned int>(i)].second,
             -vol_sizes[static_cast<unsigned int>(i)].first, volume_link,
@@ -713,16 +539,16 @@ inline void add_beampipe(
 
     // barrel portals
     volume_link = n_brl_layers <= 0u ? leaving_world : link + 1u;
-    add_cylinder_surface<cyl_id>(beampipe_idx, ctx, surfaces, masks, materials,
-                                 transforms, edc_inner_r, -brl_half_z,
-                                 brl_half_z, volume_link, vacuum<scalar>(),
-                                 0.f * unit<scalar>::mm);
+    detail::detector_helper<transform3_t>().add_cylinder_surface<cyl_id>(
+        beampipe_idx, ctx, surfaces, masks, materials, transforms, edc_inner_r,
+        -brl_half_z, brl_half_z, volume_link, vacuum<scalar>(),
+        0.f * unit<scalar>::mm);
 
     // positive endcap portals
     link += 7u;
     for (unsigned int i = 0u; i < vol_sizes.size(); ++i) {
         volume_link = ++link;
-        add_cylinder_surface<cyl_id>(
+        detail::detector_helper<transform3_t>().add_cylinder_surface<cyl_id>(
             beampipe_idx, ctx, surfaces, masks, materials, transforms,
             edc_inner_r, vol_sizes[i].second, vol_sizes[i].first, volume_link,
             vacuum<scalar>(), 0.f * unit<scalar>::mm);
@@ -730,18 +556,21 @@ inline void add_beampipe(
 
     // disc portals
     volume_link = leaving_world;
-    add_disc_surface(beampipe_idx, ctx, surfaces, masks, materials, transforms,
-                     beampipe_vol_size.first, beampipe_vol_size.second, min_z,
-                     volume_link, vacuum<scalar>(), 0.f * unit<scalar>::mm);
-    add_disc_surface(beampipe_idx, ctx, surfaces, masks, materials, transforms,
-                     beampipe_vol_size.first, beampipe_vol_size.second, max_z,
-                     volume_link, vacuum<scalar>(), 0.f * unit<scalar>::mm);
+    detail::detector_helper<transform3_t>().add_disc_surface(
+        beampipe_idx, ctx, surfaces, masks, materials, transforms,
+        beampipe_vol_size.first, beampipe_vol_size.second, min_z, volume_link,
+        vacuum<scalar>(), 0.f * unit<scalar>::mm);
+    detail::detector_helper<transform3_t>().add_disc_surface(
+        beampipe_idx, ctx, surfaces, masks, materials, transforms,
+        beampipe_vol_size.first, beampipe_vol_size.second, max_z, volume_link,
+        vacuum<scalar>(), 0.f * unit<scalar>::mm);
 
     // This is the beampipe surface
-    add_cylinder_surface<detector_t::masks::id::e_cylinder2>(
-        beampipe_idx, ctx, surfaces, masks, materials, transforms, beampipe_r,
-        min_z, max_z, beampipe_idx, beryllium_tml<scalar>(),
-        0.8f * unit<scalar>::mm);
+    detail::detector_helper<transform3_t>()
+        .add_cylinder_surface<detector_t::masks::id::e_cylinder2>(
+            beampipe_idx, ctx, surfaces, masks, materials, transforms,
+            beampipe_r, min_z, max_z, beampipe_idx, beryllium_tml<scalar>(),
+            0.8f * unit<scalar>::mm);
 
     det.add_objects_per_volume(ctx, beampipe, surfaces, masks, transforms,
                                materials);
@@ -801,19 +630,20 @@ inline void add_endcap_barrel_connection(
     det.transform_store().emplace_back(ctx, t);
 
     dindex volume_link{beampipe_idx};
-    add_cylinder_surface<cyl_id>(connector_gap_idx, ctx, surfaces, masks,
-                                 materials, transforms, edc_inner_r, min_z,
-                                 max_z, volume_link, vacuum<scalar>(),
-                                 0.f * unit<scalar>::mm);
+    detail::detector_helper<transform3_t>().add_cylinder_surface<cyl_id>(
+        connector_gap_idx, ctx, surfaces, masks, materials, transforms,
+        edc_inner_r, min_z, max_z, volume_link, vacuum<scalar>(),
+        0.f * unit<scalar>::mm);
     volume_link = leaving_world;
-    add_cylinder_surface<cyl_id>(connector_gap_idx, ctx, surfaces, masks,
-                                 materials, transforms, edc_outer_r, min_z,
-                                 max_z, volume_link, vacuum<scalar>(),
-                                 0.f * unit<scalar>::mm);
+    detail::detector_helper<transform3_t>().add_cylinder_surface<cyl_id>(
+        connector_gap_idx, ctx, surfaces, masks, materials, transforms,
+        edc_outer_r, min_z, max_z, volume_link, vacuum<scalar>(),
+        0.f * unit<scalar>::mm);
     volume_link = edc_vol_idx;
-    add_disc_surface(connector_gap_idx, ctx, surfaces, masks, materials,
-                     transforms, edc_inner_r, edc_outer_r, edc_disc_z,
-                     volume_link, vacuum<scalar>(), 0.f * unit<scalar>::mm);
+    detail::detector_helper<transform3_t>().add_disc_surface(
+        connector_gap_idx, ctx, surfaces, masks, materials, transforms,
+        edc_inner_r, edc_outer_r, edc_disc_z, volume_link, vacuum<scalar>(),
+        0.f * unit<scalar>::mm);
 
     // Get vol sizes in z also for gap volumes
     std::vector<std::pair<scalar, scalar>> vol_sizes;
@@ -826,10 +656,10 @@ inline void add_endcap_barrel_connection(
     volume_link = brl_vol_idx;
     for (unsigned int i = 0u; i < 2u * n_brl_layers - 1u; ++i) {
         volume_link = brl_vol_idx++;
-        add_disc_surface(connector_gap_idx, ctx, surfaces, masks, materials,
-                         transforms, vol_sizes[i].first, vol_sizes[i].second,
-                         brl_disc_z, volume_link, vacuum<scalar>(),
-                         0.f * unit<scalar>::mm);
+        detail::detector_helper<transform3_t>().add_disc_surface(
+            connector_gap_idx, ctx, surfaces, masks, materials, transforms,
+            vol_sizes[i].first, vol_sizes[i].second, brl_disc_z, volume_link,
+            vacuum<scalar>(), 0.f * unit<scalar>::mm);
     }
 
     det.add_objects_per_volume(ctx, connector_gap, surfaces, masks, transforms,
@@ -912,20 +742,22 @@ void add_endcap_detector(
         is_gap = !is_gap;
         const scalar sign{static_cast<scalar>(cfg.side)};
         if (is_gap) {
-            create_cyl_volume(det, resource, ctx, cfg.inner_r, cfg.outer_r,
-                              sign * (vol_size_itr + cfg.side * i)->first,
-                              sign * (vol_size_itr + cfg.side * i)->second,
-                              volume_links_vec[static_cast<unsigned int>(i)]);
+            detail::detector_helper<transform3_t>().create_cyl_volume(
+                det, resource, ctx, cfg.inner_r, cfg.outer_r,
+                sign * (vol_size_itr + cfg.side * i)->first,
+                sign * (vol_size_itr + cfg.side * i)->second,
+                volume_links_vec[static_cast<unsigned int>(i)]);
 
             dindex vol_idx = det.volumes().back().index();
             names[vol_idx + 1u] = "gap_" + std::to_string(vol_idx);
 
         } else {
             m_factory.cfg.edc_position = *(pos_itr + cfg.side * i / 2);
-            create_cyl_volume(det, resource, ctx, cfg.inner_r, cfg.outer_r,
-                              sign * (vol_size_itr + cfg.side * i)->first,
-                              sign * (vol_size_itr + cfg.side * i)->second,
-                              volume_links_vec[static_cast<unsigned int>(i)]);
+            detail::detector_helper<transform3_t>().create_cyl_volume(
+                det, resource, ctx, cfg.inner_r, cfg.outer_r,
+                sign * (vol_size_itr + cfg.side * i)->first,
+                sign * (vol_size_itr + cfg.side * i)->second,
+                volume_links_vec[static_cast<unsigned int>(i)]);
 
             dindex vol_idx = det.volumes().back().index();
             names[vol_idx + 1u] = "endcap_" + std::to_string(vol_idx);
@@ -1000,18 +832,18 @@ void add_barrel_detector(
         // Every second layer is a gap volume
         is_gap = !is_gap;
         if (is_gap) {
-            create_cyl_volume(det, resource, ctx, vol_sizes[i].first,
-                              vol_sizes[i].second, -brl_half_z, brl_half_z,
-                              volume_links_vec[i]);
+            detail::detector_helper<transform3_t>().create_cyl_volume(
+                det, resource, ctx, vol_sizes[i].first, vol_sizes[i].second,
+                -brl_half_z, brl_half_z, volume_links_vec[i]);
 
             dindex vol_idx = det.volumes().back().index();
             names[vol_idx + 1u] = "gap_" + std::to_string(vol_idx);
         } else {
             m_factory.cfg.m_binning = m_binning[j];
             m_factory.cfg.layer_r = lay_positions[j];
-            create_cyl_volume(det, resource, ctx, vol_sizes[i].first,
-                              vol_sizes[i].second, -brl_half_z, brl_half_z,
-                              volume_links_vec[i]);
+            detail::detector_helper<transform3_t>().create_cyl_volume(
+                det, resource, ctx, vol_sizes[i].first, vol_sizes[i].second,
+                -brl_half_z, brl_half_z, volume_links_vec[i]);
 
             dindex vol_idx = det.volumes().back().index();
             names[vol_idx + 1u] = "barrel_" + std::to_string(vol_idx);

--- a/utils/include/detray/detectors/create_wire_chamber.hpp
+++ b/utils/include/detray/detectors/create_wire_chamber.hpp
@@ -250,6 +250,25 @@ auto create_wire_chamber(vecmem::memory_resource &resource,
         det.append_masks(std::move(masks));
         det.append_transforms(std::move(transforms));
         det.append_materials(std::move(materials));
+
+        // Add volume grid
+        // TODO: Fill it
+
+        // Dimensions of the volume grid: minr, min phi, minz, maxr, maxphi,
+        // maxz
+        // TODO: Adapt to number of layers
+        mask<cylinder3D> vgrid_dims{0u,     0.f,   -constant<scalar>::pi,
+                                    -600.f, 180.f, constant<scalar>::pi,
+                                    600.f};
+        std::array<std::size_t, 3> n_vgrid_bins{1u, 1u, 1u};
+
+        grid_factory_type<typename detector_t::volume_finder> vgrid_factory{};
+        auto vgrid = vgrid_factory.template new_grid<
+            n_axis::open<n_axis::label::e_r>,
+            n_axis::circular<n_axis::label::e_phi>,
+            n_axis::open<n_axis::label::e_z>, n_axis::irregular<>,
+            n_axis::regular<>, n_axis::irregular<>>(vgrid_dims, n_vgrid_bins);
+        det.set_volume_finder(std::move(vgrid));
     }
 
     return std::make_pair(std::move(det), std::move(name_map));

--- a/utils/include/detray/detectors/create_wire_chamber.hpp
+++ b/utils/include/detray/detectors/create_wire_chamber.hpp
@@ -72,7 +72,7 @@ auto create_wire_chamber(vecmem::memory_resource &resource,
                          const wire_chamber_config &cfg) {
 
     // Detector type
-    using detector_t = detector<>;
+    using detector_t = detector<default_metadata, covfie::field, container_t>;
 
     using nav_link_t = typename detector_t::surface_type::navigation_link;
     using mask_id = typename detector_t::surface_type::mask_id;
@@ -159,7 +159,7 @@ auto create_wire_chamber(vecmem::memory_resource &resource,
         typename detector_t::transform_container transforms(resource);
 
         // Wire center positions
-        detray::dvector<point3> m_centers;
+        detray::dvector<point3> m_centers{};
         for (unsigned int i_w = 0u; i_w < n_wires_per_layer; i_w++) {
             const scalar x =
                 center_layer_rad * std::cos(theta * static_cast<scalar>(i_w));

--- a/utils/include/detray/detectors/create_wire_chamber.hpp
+++ b/utils/include/detray/detectors/create_wire_chamber.hpp
@@ -1,0 +1,258 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/core/detector.hpp"
+#include "detray/core/detector_metadata.hpp"
+#include "detray/definitions/units.hpp"
+#include "detray/detectors/detector_helper.hpp"
+#include "detray/masks/masks.hpp"
+#include "detray/materials/predefined_materials.hpp"
+#include "detray/tools/bounding_volume.hpp"
+#include "detray/tools/grid_builder.hpp"
+#include "detray/utils/axis_rotation.hpp"
+#include "detray/utils/unit_vectors.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/memory_resource.hpp>
+
+// Covfie include(s)
+#include <covfie/core/backend/primitive/constant.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/vector.hpp>
+
+namespace detray {
+
+namespace {
+
+using transform3_t = __plugin::transform3<detray::scalar>;
+using point3 = __plugin::point3<detray::scalar>;
+using vector3 = __plugin::vector3<detray::scalar>;
+using point2 = __plugin::point2<detray::scalar>;
+
+}  // namespace
+
+struct wire_chamber_config {
+
+    /// Number of layers
+    unsigned int m_n_layers{10u};
+
+    /// Field vector for an homogenoues b-field
+    vector3 m_bfield_vec{0.f, 0.f, 2.f * unit<scalar>::T};
+
+    constexpr wire_chamber_config &n_layers(const unsigned int n) {
+        m_n_layers = n;
+        return *this;
+    }
+
+    wire_chamber_config &bfield_vec(const vector3 &field_vec) {
+        m_bfield_vec = field_vec;
+        return *this;
+    }
+
+    wire_chamber_config &bfield_vec(const scalar x, const scalar y,
+                                    const scalar z) {
+        m_bfield_vec = {x, y, z};
+        return *this;
+    }
+
+    constexpr unsigned int n_layers() const { return m_n_layers; }
+    constexpr const vector3 &bfield_vec() const { return m_bfield_vec; }
+
+};  // wire chamber config
+
+template <typename container_t = host_container_types>
+auto create_wire_chamber(vecmem::memory_resource &resource,
+                         const wire_chamber_config &cfg) {
+
+    // Detector type
+    using detector_t = detector<>;
+
+    using nav_link_t = typename detector_t::surface_type::navigation_link;
+    using mask_id = typename detector_t::surface_type::mask_id;
+    using material_id = typename detector_t::surface_type::material_id;
+    using mask_link_type = typename detector_t::surface_type::mask_link;
+    using material_link_type = typename detector_t::surface_type::material_link;
+    constexpr auto wire_id = mask_id::e_cell_wire;
+    constexpr auto rod_id = material_id::e_rod;
+    constexpr auto leaving_world{detail::invalid_value<nav_link_t>()};
+
+    // Detector configurations
+    constexpr scalar cyl_half_z{500.f * unit<scalar>::mm};
+    constexpr scalar inner_cyl_rad{500.f * unit<scalar>::mm};
+    constexpr scalar cell_size = 10.f * unit<scalar>::mm;
+    constexpr scalar stereo_angle = 50.f * unit<scalar>::mrad;
+    const material<scalar> wire_mat = tungsten<scalar>();
+    constexpr scalar wire_rad = 15.f * unit<scalar>::um;
+
+    // B field
+    using const_bfield_bknd_t =
+        covfie::backend::constant<covfie::vector::vector_d<scalar, 3>,
+                                  covfie::vector::vector_d<scalar, 3>>;
+    const auto &B = cfg.bfield_vec();
+    auto bfield = covfie::field<const_bfield_bknd_t>(
+        const_bfield_bknd_t::configuration_t{B[0], B[1], B[2]});
+
+    // Create detector
+    detector_t det(resource, std::move(bfield));
+
+    // Detector and volume names
+    typename detector_t::name_map name_map = {{0u, "wire_chamber"}};
+
+    // geometry context object
+    typename detector_t::geometry_context ctx0{};
+
+    // Beam collision volume
+    detail::detector_helper<transform3_t>().create_cyl_volume(
+        det, resource, ctx0, 0.f, inner_cyl_rad, -cyl_half_z, cyl_half_z,
+        {leaving_world, 1u, leaving_world, leaving_world});
+
+    name_map[1u] = "beam_vol_0";
+
+    // Layer volumes
+    const unsigned int n_layers{cfg.n_layers()};
+    for (unsigned int i_lay = 0; i_lay < n_layers; i_lay++) {
+
+        // Create a volume
+        const scalar inner_layer_rad =
+            inner_cyl_rad + static_cast<scalar>(i_lay) * cell_size * 2.f;
+        const scalar outer_layer_rad =
+            inner_cyl_rad + static_cast<scalar>(i_lay + 1) * cell_size * 2.f;
+
+        if (i_lay < n_layers - 1) {
+            detail::detector_helper<transform3_t>().create_cyl_volume(
+                det, resource, ctx0, inner_layer_rad, outer_layer_rad,
+                -cyl_half_z, cyl_half_z,
+                {i_lay, i_lay + 2, leaving_world, leaving_world});
+        } else {
+            detail::detector_helper<transform3_t>().create_cyl_volume(
+                det, resource, ctx0, inner_layer_rad, outer_layer_rad,
+                -cyl_half_z, cyl_half_z,
+                {i_lay, leaving_world, leaving_world, leaving_world});
+        }
+
+        // Current vol
+        auto &vol = det.volumes().back();
+
+        // Layer configuration
+        const scalar center_layer_rad = inner_layer_rad + cell_size;
+        const scalar theta = 2 * cell_size / center_layer_rad;
+        const unsigned int n_wires_per_layer =
+            static_cast<unsigned int>(2 * constant<scalar>::pi / theta);
+
+        // Get volume ID
+        auto volume_idx = vol.index();
+        name_map[volume_idx + 1u] = "layer_vol_" + std::to_string(volume_idx);
+
+        auto mask_volume_link{static_cast<nav_link_t>(volume_idx)};
+
+        // Containers per volume
+        typename detector_t::surface_container_t surfaces(&resource);
+        typename detector_t::mask_container masks(resource);
+        typename detector_t::material_container materials(resource);
+        typename detector_t::transform_container transforms(resource);
+
+        // Wire center positions
+        detray::dvector<point3> m_centers;
+        for (unsigned int i_w = 0u; i_w < n_wires_per_layer; i_w++) {
+            const scalar x =
+                center_layer_rad * std::cos(theta * static_cast<scalar>(i_w));
+            const scalar y =
+                center_layer_rad * std::sin(theta * static_cast<scalar>(i_w));
+            const scalar z = 0.f;
+
+            m_centers.push_back({x, y, z});
+        }
+
+        for (auto &m_center : m_centers) {
+
+            // Surfaces with the linking into the local containers
+            mask_link_type mask_link = {wire_id,
+                                        masks.template size<wire_id>()};
+            material_link_type material_link{rod_id,
+                                             materials.template size<rod_id>()};
+            const auto trf_index = transforms.size(ctx0);
+            surfaces.emplace_back(trf_index, mask_link, material_link,
+                                  volume_idx, dindex_invalid,
+                                  surface_id::e_sensitive);
+
+            // The wire bounds
+            masks.template emplace_back<wire_id>(
+                empty_context{}, mask_volume_link, cell_size, cyl_half_z);
+            materials.template emplace_back<rod_id>(empty_context{}, wire_mat,
+                                                    wire_rad);
+
+            // Build the transform
+            vector3 z_axis{0.f, 0.f, 1.f};
+            vector3 r_axis = vector::normalize(m_center);
+            const scalar sign = (i_lay % 2 == 0) ? 1 : -1;
+            z_axis = axis_rotation<transform3_t>(r_axis,
+                                                 sign * stereo_angle)(z_axis);
+            vector3 x_axis =
+                unit_vectors<vector3>().make_curvilinear_unit_u(z_axis);
+            transforms.emplace_back(ctx0, m_center, z_axis, x_axis);
+        }
+
+        // Iterate the surfaces and update their links
+        const auto trf_offset{det.transform_store().size(ctx0)};
+        auto sf_offset{det.n_surfaces()};
+
+        for (auto &sf_desc : surfaces) {
+            // Make sure the volume was constructed correctly
+            assert(sf_desc.volume() < det.volumes().size());
+
+            // Update the surface links accroding to number of data in detector
+            const auto sf = surface{det, sf_desc};
+            sf.template visit_mask<detail::mask_index_update>(sf_desc);
+            sf.template visit_material<detail::material_index_update>(sf_desc);
+            sf_desc.update_transform(trf_offset);
+            sf_desc.set_index(sf_offset++);
+
+            // Copy surface descriptor into global lookup
+            det.add_surface_to_lookup(sf_desc);
+        }
+
+        //
+        // Fill Grid
+        //
+
+        // Get relevant ids
+        using geo_obj_ids = typename detector_t::geo_obj_ids;
+        constexpr auto cyl_id = detector_t::masks::id::e_portal_cylinder2;
+        constexpr auto grid_id = detector_t::sf_finders::id::e_cylinder2_grid;
+
+        using cyl_grid_t =
+            typename detector_t::surface_container::template get_type<grid_id>;
+        auto gbuilder =
+            grid_builder<detector_t, cyl_grid_t, detray::detail::fill_by_pos>{};
+
+        // The disc portals are at the end of the portal range by construction
+        auto portal_mask_idx = (det.portals(vol).end() - 3u)->mask().index();
+        const auto &cyl_mask =
+            det.mask_store().template get<cyl_id>().at(portal_mask_idx);
+
+        // Add new grid to the detector
+        gbuilder.init_grid(cyl_mask, {100u, 1u});
+        gbuilder.fill_grid(detector_volume{det, vol}, surfaces, transforms,
+                           masks, ctx0);
+
+        det.surface_store().template push_back<grid_id>(gbuilder.get());
+        vol.template set_link<geo_obj_ids::e_sensitive>(
+            grid_id, det.surface_store().template size<grid_id>() - 1u);
+
+        // Add transforms, masks and material to detector
+        det.append_masks(std::move(masks));
+        det.append_transforms(std::move(transforms));
+        det.append_materials(std::move(materials));
+    }
+
+    return std::make_pair(std::move(det), std::move(name_map));
+}
+
+}  // namespace detray

--- a/utils/include/detray/detectors/detector_helper.hpp
+++ b/utils/include/detray/detectors/detector_helper.hpp
@@ -1,0 +1,214 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include <iostream>
+
+#include "detray/core/detail/data_context.hpp"
+#include "detray/definitions/geometry.hpp"
+#include "detray/definitions/indexing.hpp"
+#include "detray/materials/material.hpp"
+#include "detray/materials/predefined_materials.hpp"
+
+namespace detray::detail {
+
+template <typename algebra_t>
+struct detector_helper {
+
+    using scalar_t = typename algebra_t::scalar_type;
+    using point3 = typename algebra_t::point3;
+
+    /** Function that adds a cylinder portal.
+     *
+     * @tparam cylinder_id default cylinder id
+     *
+     * @param volume_idx volume the portal should be added to
+     * @param ctx geometric context
+     * @param surfaces container to add new surface to
+     * @param masks container to add new cylinder mask to
+     * @param transforms container to add new transform to
+     * @param r raius of the cylinder
+     * @param lower_z lower extend in z
+     * @param upper_z upper extend in z
+     * @param volume_link link to next volume for the masks
+     */
+    template <auto cyl_id, typename context_t, typename surface_container_t,
+              typename mask_container_t, typename material_container_t,
+              typename transform_container_t, typename volume_links>
+    inline void add_cylinder_surface(
+        const dindex volume_idx, context_t &ctx, surface_container_t &surfaces,
+        mask_container_t &masks, material_container_t &materials,
+        transform_container_t &transforms, const scalar_t r,
+        const scalar_t lower_z, const scalar_t upper_z,
+        const volume_links volume_link, const material<scalar_t> &mat,
+        const scalar_t thickness) {
+        using surface_type = typename surface_container_t::value_type;
+        using mask_link_type = typename surface_type::mask_link;
+        using material_id = typename surface_type::material_id;
+        using material_link_type = typename surface_type::material_link;
+
+        constexpr auto slab_id = material_id::e_slab;
+
+        const scalar_t min_z{std::min(lower_z, upper_z)};
+        const scalar_t max_z{std::max(lower_z, upper_z)};
+
+        // translation
+        point3 tsl{0.f, 0.f, 0.f};
+
+        // add transform and masks
+        transforms.emplace_back(ctx, tsl);
+        masks.template emplace_back<cyl_id>(empty_context{}, volume_link, r,
+                                            min_z, max_z);
+
+        // Add material slab
+        materials.template emplace_back<slab_id>(empty_context{}, mat,
+                                                 thickness);
+
+        // add surface
+        mask_link_type mask_link{cyl_id, masks.template size<cyl_id>() - 1u};
+        material_link_type material_link{
+            slab_id, materials.template size<slab_id>() - 1u};
+        const surface_id sf_id = (volume_link != volume_idx)
+                                     ? surface_id::e_portal
+                                     : surface_id::e_passive;
+
+        surfaces.emplace_back(transforms.size(ctx) - 1u, mask_link,
+                              material_link, volume_idx, dindex_invalid, sf_id);
+    }
+
+    /** Function that adds a disc portal.
+     *
+     * @tparam disc_id default disc id
+     *
+     * @param volume_idx volume the portal should be added to
+     * @param ctx geometric context
+     * @param surfaces container to add new surface to
+     * @param masks container to add new cylinder mask to
+     * @param transforms container to add new transform to
+     * @param min_r lower radius of the disc
+     * @param max_r upper radius of the disc
+     * @param z z position of the disc
+     * @param volume_link link to next volume for the masks
+     */
+    template <typename context_t, typename surface_container_t,
+              typename mask_container_t, typename material_container_t,
+              typename transform_container_t, typename volume_links>
+    inline void add_disc_surface(
+        const dindex volume_idx, context_t &ctx, surface_container_t &surfaces,
+        mask_container_t &masks, material_container_t &materials,
+        transform_container_t &transforms, const scalar_t inner_r,
+        const scalar_t outer_r, const scalar_t z,
+        const volume_links volume_link, const material<scalar_t> &mat,
+        const scalar_t thickness) {
+        using surface_type = typename surface_container_t::value_type;
+        using mask_id = typename surface_type::mask_id;
+        using mask_link_type = typename surface_type::mask_link;
+        using material_id = typename surface_type::material_id;
+        using material_link_type = typename surface_type::material_link;
+
+        constexpr auto disc_id = mask_id::e_portal_ring2;
+        constexpr auto slab_id = material_id::e_slab;
+
+        const scalar_t min_r{std::min(inner_r, outer_r)};
+        const scalar_t max_r{std::max(inner_r, outer_r)};
+
+        // translation
+        point3 tsl{0.f, 0.f, z};
+
+        // add transform and mask
+        transforms.emplace_back(ctx, tsl);
+        masks.template emplace_back<disc_id>(empty_context{}, volume_link,
+                                             min_r, max_r);
+
+        // Add material slab
+        materials.template emplace_back<slab_id>(empty_context{}, mat,
+                                                 thickness);
+
+        // add surface
+        mask_link_type mask_link{disc_id, masks.template size<disc_id>() - 1u};
+        material_link_type material_link{
+            slab_id, materials.template size<slab_id>() - 1u};
+        const surface_id sf_id = (volume_link != volume_idx)
+                                     ? surface_id::e_portal
+                                     : surface_id::e_sensitive;
+        surfaces.emplace_back(transforms.size(ctx) - 1u, mask_link,
+                              material_link, volume_idx, dindex_invalid, sf_id);
+    }
+
+    /** Function that adds a generic cylinder volume, using a factory for
+     * contained module surfaces.
+     *
+     * @tparam detector_t the detector type
+     * @tparam factory_t type of module factory. Must be callable on containers.
+     *
+     * @param det detector the volume should be added to
+     * @param resource vecmem memory resource for the temporary containers
+     * @param ctx geometry context
+     * @param lay_inner_r inner radius of volume
+     * @param lay_outer_r outer radius of volume
+     * @param lay_neg_r lower extend of volume
+     * @param lay_pos_r upper extend of volume
+     * @param volume_links volume links for the portals of the volume
+     * @param module_factory functor that adds module surfaces to volume
+     */
+    template <typename detector_t>
+    void create_cyl_volume(detector_t &det, vecmem::memory_resource &resource,
+                           typename detector_t::geometry_context &ctx,
+                           const scalar_t lay_inner_r,
+                           const scalar_t lay_outer_r, const scalar_t lay_neg_z,
+                           const scalar_t lay_pos_z,
+                           const std::vector<dindex> &volume_links) {
+        // volume bounds
+        const scalar_t inner_r{std::min(lay_inner_r, lay_outer_r)};
+        const scalar_t outer_r{std::max(lay_inner_r, lay_outer_r)};
+        const scalar_t lower_z{std::min(lay_neg_z, lay_pos_z)};
+        const scalar_t upper_z{std::max(lay_neg_z, lay_pos_z)};
+
+        // Add module surfaces to volume
+        typename detector_t::surface_container_t surfaces(&resource);
+        typename detector_t::mask_container masks(resource);
+        typename detector_t::material_container materials(resource);
+        typename detector_t::transform_container transforms(resource);
+
+        auto &cyl_volume = det.new_volume(
+            volume_id::e_cylinder, {detector_t::sf_finders::id::e_default, 0u});
+
+        // volume placement
+        cyl_volume.set_transform(det.transform_store().size());
+        // translation of the cylinder
+        point3 t{0.f, 0.f, 0.5f * (upper_z + lower_z)};
+        det.transform_store().emplace_back(ctx, t);
+
+        // negative and positive, inner and outer portal surface
+        constexpr auto cyl_id = detector_t::masks::id::e_portal_cylinder2;
+
+        // If inner radius is 0, skip add the innder cylinder
+        if (inner_r > 0.f) {
+            add_cylinder_surface<cyl_id>(
+                cyl_volume.index(), ctx, surfaces, masks, materials, transforms,
+                inner_r, lower_z, upper_z, volume_links[0], vacuum<scalar_t>(),
+                0.f * unit<scalar_t>::mm);
+        }
+        add_cylinder_surface<cyl_id>(
+            cyl_volume.index(), ctx, surfaces, masks, materials, transforms,
+            outer_r, lower_z, upper_z, volume_links[1], vacuum<scalar_t>(),
+            0.f * unit<scalar_t>::mm);
+        add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
+                         transforms, inner_r, outer_r, lower_z, volume_links[2],
+                         vacuum<scalar_t>(), 0.f * unit<scalar_t>::mm);
+        add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
+                         transforms, inner_r, outer_r, upper_z, volume_links[3],
+                         vacuum<scalar_t>(), 0.f * unit<scalar_t>::mm);
+
+        det.add_objects_per_volume(ctx, cyl_volume, surfaces, masks, transforms,
+                                   materials);
+    }
+};
+
+}  // namespace detray::detail


### PR DESCRIPTION
Very simple drift chamber to test navigation and KF with wires; no physical walls, no gas, no field wires but only the sense wires with alternating stereo angle. 

A test with propagation will follow in the same PR.

Vertex detectors can also be added in the future if there is a need.

### UPDATE

`check_geometry_navigation` does not work well for `float` precision, so I decreased the number of trajectories. 
Please note that the test is passed with 10 x 10 helices with `double` precision - I guess the failure with `float` might be from (1) the precision difference between stepper and particle gun or(and) (2) different tolerance setup in trajectory and mask which it is hard for me to track down..  but not sure yet