### PR TITLE
ref: grid payloads cleanup

### DIFF
--- a/io/include/detray/io/common/detail/definitions.hpp
+++ b/io/include/detray/io/common/detail/definitions.hpp
@@ -19,6 +19,8 @@
 #include "detray/masks/ring2D.hpp"
 #include "detray/masks/single3D.hpp"
 #include "detray/masks/trapezoid2D.hpp"
+#include "detray/materials/material_rod.hpp"
+#include "detray/materials/material_slab.hpp"
 #include "detray/utils/type_registry.hpp"
 
 namespace detray {
@@ -84,6 +86,26 @@ enum class material_type : unsigned int {
     rod = 10u,
     unknown = 11u
 };
+
+/// Infer the IO material id from the material type
+template <typename material_t>
+constexpr material_type get_material_id() {
+    using scalar_t = typename material_t::scalar_type;
+
+    /// Register the material types to the @c material_type enum
+    using mat_registry =
+        type_registry<material_type, annulus2D<>, cuboid3D<>, cylinder2D<>,
+                      cylinder3D, rectangle2D<>, ring2D<>, trapezoid2D<>,
+                      line<true>, line<false>, material_slab<scalar_t>,
+                      material_rod<scalar_t>>;
+
+    // Find the correct material IO id;
+    if constexpr (mat_registry::is_defined(material_t{})) {
+        return mat_registry::get_id(material_t{});
+    } else {
+        return material_type::unknown;
+    }
+}
 
 /// Enumerate the different acceleration data structures
 enum class acc_type : unsigned int {

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -135,11 +135,6 @@ class geometry_reader : public reader_interface<detector_t> {
         det_builder.template set_volume_finder();
     }
 
-    /// @returns a link from its io payload @param link_data
-    static dindex deserialize(const single_link_payload& link_data) {
-        return static_cast<dindex>(link_data.link);
-    }
-
     /// @returns a surface transform from its io payload @param trf_data
     static typename detector_t::transform3 deserialize(
         const transform_payload& trf_data) {
@@ -177,7 +172,8 @@ class geometry_reader : public reader_interface<detector_t> {
                   std::back_inserter(mask_boundaries));
 
         return {deserialize(sf_data.transform),
-                static_cast<nav_link_t>(deserialize(sf_data.mask.volume_link)),
+                static_cast<nav_link_t>(
+                    base_type::deserialize(sf_data.mask.volume_link)),
                 std::move(mask_boundaries)};
     }
 

--- a/io/include/detray/io/common/geometry_writer.hpp
+++ b/io/include/detray/io/common/geometry_writer.hpp
@@ -15,8 +15,6 @@
 #include "detray/io/common/io_interface.hpp"
 #include "detray/io/common/payloads.hpp"
 #include "detray/masks/masks.hpp"
-#include "detray/materials/material_rod.hpp"
-#include "detray/materials/material_slab.hpp"
 
 // System include(s)
 #include <algorithm>
@@ -76,14 +74,6 @@ class geometry_writer : public writer_interface<detector_t> {
         return det_data;
     }
 
-    /// Serialize a link @param idx into its io payload
-    static single_link_payload serialize(const std::size_t idx) {
-        single_link_payload link_data;
-        link_data.link = idx;
-
-        return link_data;
-    }
-
     /// Serialize a surface transform @param trf into its io payload
     static transform_payload serialize(
         const typename detector_t::transform3& trf) {
@@ -109,36 +99,13 @@ class geometry_writer : public writer_interface<detector_t> {
 
         mask_data.shape = io::detail::get_shape_id<typename mask_t::shape>();
 
-        mask_data.volume_link = serialize(m.volume_link());
+        mask_data.volume_link = base_type::serialize(m.volume_link());
 
         mask_data.boundaries.resize(mask_t::boundaries::e_size);
         std::copy(std::cbegin(m.values()), std::cend(m.values()),
                   std::begin(mask_data.boundaries));
 
         return mask_data;
-    }
-
-    /// Serialize a surface material link @param m into its io payload
-    template <class material_t>
-    static material_link_payload serialize(const std::size_t idx) {
-        using scalar_t = typename material_t::scalar_type;
-        using type_id = material_link_payload::material_type;
-
-        material_link_payload mat_data;
-
-        // Find the correct material type index (use name for simplicity)
-        if constexpr (std::is_same_v<material_t, material_slab<scalar_t>>) {
-            mat_data.type = type_id::slab;
-        } else if constexpr (std::is_same_v<material_t,
-                                            material_rod<scalar_t>>) {
-            mat_data.type = type_id::rod;
-        } else {
-            mat_data.type = type_id::unknown;
-        }
-
-        mat_data.index = idx;
-
-        return mat_data;
     }
 
     /// Serialize a detector surface @param sf into its io payload
@@ -150,19 +117,9 @@ class geometry_writer : public writer_interface<detector_t> {
         sf_data.transform = serialize(sf.transform({}));
         sf_data.mask = sf.template visit_mask<get_mask_payload>();
         sf_data.material = sf.template visit_material<get_material_payload>();
-        sf_data.source = serialize(sf.source());
+        sf_data.source = base_type::serialize(sf.source());
 
         return sf_data;
-    }
-
-    /// Serialize a link @param idx into its io payload
-    static acc_links_payload serialize(const acc_links_payload::acc_type id,
-                                       const std::size_t idx) {
-        acc_links_payload link_data;
-        link_data.type = id;
-        link_data.index = idx;
-
-        return link_data;
     }
 
     /// Serialize a detector portal @param sf into its io payload
@@ -171,7 +128,7 @@ class geometry_writer : public writer_interface<detector_t> {
         const std::string& name) {
         volume_payload vol_data;
 
-        vol_data.index = serialize(vol_desc.index());
+        vol_data.index = base_type::serialize(vol_desc.index());
         vol_data.name = name;
         vol_data.transform =
             serialize(det.transform_store()[vol_desc.transform()]);
@@ -218,8 +175,11 @@ class geometry_writer : public writer_interface<detector_t> {
         template <typename material_group_t, typename index_t>
         inline auto operator()(const material_group_t&,
                                const index_t& index) const {
-            return geometry_writer<detector_t>::template serialize<
-                typename material_group_t::value_type>(index);
+            using material_t = typename material_group_t::value_type;
+
+            // Find the correct material type index
+            return base_type::serialize(
+                io::detail::get_material_id<material_t>(), index);
         }
     };
 
@@ -231,16 +191,14 @@ class geometry_writer : public writer_interface<detector_t> {
 
             using accel_t = typename acc_group_t::value_type;
 
-            if constexpr (detail::is_grid_v<accel_t>) {
-                constexpr auto id{io::detail::get_grid_id<accel_t>()};
+            auto id{acc_links_payload::type_id::unknown};
 
-                return geometry_writer<detector_t>::serialize(id, index);
-            } else {
-                // This functor is only called for accelerator data structures
-                // that are not 'brute force'
-                return geometry_writer<detector_t>::serialize(
-                    acc_links_payload::acc_type::unknown, index);
+            // Only serialize grids
+            if constexpr (detail::is_grid_v<accel_t>) {
+                id = io::detail::get_grid_id<accel_t>();
             }
+
+            return base_type::serialize(id, index);
         }
     };
 };

--- a/io/include/detray/io/common/homogeneous_material_reader.hpp
+++ b/io/include/detray/io/common/homogeneous_material_reader.hpp
@@ -24,7 +24,7 @@
 
 namespace detray {
 
-/// @brief Abstract base class for tracking geometry readers
+/// @brief Abstract base class for a homogeneous material reader.
 template <class detector_t>
 class homogeneous_material_reader : public reader_interface<detector_t> {
 
@@ -57,7 +57,7 @@ class homogeneous_material_reader : public reader_interface<detector_t> {
         for (const auto& mv_data : det_mat_data.volumes) {
             // Decorate the current volume builder with material
             auto vm_builder = det_builder.template decorate<material_builder>(
-                static_cast<dindex>(mv_data.index));
+                base_type::deserialize(mv_data.volume_link));
 
             // Add the material data to the factory
             auto mat_factory = std::make_shared<material_factory<detector_t>>();

--- a/io/include/detray/io/common/io_interface.hpp
+++ b/io/include/detray/io/common/io_interface.hpp
@@ -41,6 +41,11 @@ class reader_interface {
         typename detector_t::name_map&, const std::string&) = 0;
 
     protected:
+    /// @returns a link from its io payload @param link_data
+    static dindex deserialize(const single_link_payload& link_data) {
+        return static_cast<dindex>(link_data.link);
+    }
+
     /// Extension that matches the file format of the respective reader
     std::string m_file_extension;
 };
@@ -79,6 +84,27 @@ class writer_interface {
         header_data.date = detail::get_current_date();
 
         return header_data;
+    }
+
+    /// Serialize a link @param idx into its io payload
+    static single_link_payload serialize(const std::size_t idx) {
+        single_link_payload link_data;
+        link_data.link = idx;
+
+        return link_data;
+    }
+
+    /// Serialize a typed link with a type id @param id and and index
+    /// @param idx into its io payload
+    template <typename type_id>
+    static typed_link_payload<type_id> serialize(const type_id id,
+                                                 const std::size_t idx) {
+        typed_link_payload<type_id> link_data;
+
+        link_data.type = id;
+        link_data.index = idx;
+
+        return link_data;
     }
 
     /// Extension that matches the file format of the respective writer

--- a/io/include/detray/io/common/payloads.hpp
+++ b/io/include/detray/io/common/payloads.hpp
@@ -26,19 +26,28 @@ namespace detray {
 
 /// @brief a payload for common information
 struct common_header_payload {
-    std::string version, detector, tag, date;
+    std::string version{}, detector{}, tag{}, date{};
 };
 
 /// @brief a payload for common and extra information
 template <typename sub_header_payload_t = bool>
 struct header_payload {
-    common_header_payload common;
+    common_header_payload common{};
     std::optional<sub_header_payload_t> sub_header;
 };
 
 /// @brief A payload for a single object link
 struct single_link_payload {
-    std::size_t link;
+    std::size_t link{std::numeric_limits<std::size_t>::max()};
+};
+
+/// @brief A payload for a typed object link
+template <typename type_id_t>
+struct typed_link_payload {
+    using type_id = type_id_t;
+
+    type_id type{type_id::unknown};
+    std::size_t index{std::numeric_limits<std::size_t>::max()};
 };
 
 /// Geometry payloads
@@ -46,62 +55,55 @@ struct single_link_payload {
 
 /// @brief a payload for the geometry specific part of the file header
 struct geo_sub_header_payload {
-    std::size_t n_volumes, n_surfaces;
+    std::size_t n_volumes{0ul}, n_surfaces{0ul};
 };
 
 /// @brief a payload for the geometry file header
 using geo_header_payload = header_payload<geo_sub_header_payload>;
 
+/// @brief A payload object to link a surface to its material
+using material_link_payload = typed_link_payload<io::detail::material_type>;
+
+/// @brief A payload object to link a volume to its acceleration data structures
+using acc_links_payload = typed_link_payload<io::detail::acc_type>;
+
 /// @brief A payload for an affine transformation in homogeneous coordinates
 struct transform_payload {
-    std::array<real_io, 3u> tr;
+    std::array<real_io, 3u> tr{};
     // Column major
-    std::array<real_io, 9u> rot;
+    std::array<real_io, 9u> rot{};
 };
 
 /// @brief A payload object for surface masks
 struct mask_payload {
     using mask_shape = io::detail::mask_shape;
-    mask_shape shape = mask_shape::unknown;
-    single_link_payload volume_link;
-    std::vector<real_io> boundaries;
-};
 
-/// @brief A payload object to link a surface to its material
-struct material_link_payload {
-    using material_type = io::detail::material_type;
-    material_type type = material_type::unknown;
-    std::size_t index;
+    mask_shape shape{mask_shape::unknown};
+    single_link_payload volume_link{};
+    std::vector<real_io> boundaries{};
 };
 
 /// @brief  A payload for surfaces
 struct surface_payload {
-    transform_payload transform;
-    mask_payload mask;
+    transform_payload transform{};
+    mask_payload mask{};
     std::optional<material_link_payload> material;
-    single_link_payload source;
+    single_link_payload source{};
     // Write the surface barcode as an additional information
-    std::uint64_t barcode;
-    detray::surface_id type = detray::surface_id::e_sensitive;
-};
-
-/// @brief A payload object to link a volume to its acceleration data structures
-struct acc_links_payload {
-    using acc_type = io::detail::acc_type;
-    acc_type type;
-    std::size_t index;
+    std::uint64_t barcode{std::numeric_limits<std::uint64_t>::max()};
+    detray::surface_id type{detray::surface_id::e_sensitive};
 };
 
 /// @brief A payload for volumes
 struct volume_payload {
-    std::string name = "";
-    detray::volume_id type = detray::volume_id::e_cylinder;
-    transform_payload transform;
-    std::vector<surface_payload> surfaces;
+    std::string name{};
+    detray::volume_id type{detray::volume_id::e_cylinder};
+    transform_payload transform{};
+    std::vector<surface_payload> surfaces{};
     // Index of the volume in the detector volume container
-    single_link_payload index;
+    single_link_payload index{};
     // Optional accelerator data structures
-    std::optional<std::vector<acc_links_payload>> acc_links;
+    std::optional<std::vector<acc_links_payload>> acc_links{};
 };
 
 /// @}
@@ -111,7 +113,7 @@ struct volume_payload {
 
 /// @brief a payload for the material specific part of the file header
 struct homogeneous_material_sub_header_payload {
-    std::size_t n_slabs, n_rods;
+    std::size_t n_slabs{0ul}, n_rods{0ul};
 };
 
 /// @brief a payload for the homogeneous material file header
@@ -120,28 +122,28 @@ using homogeneous_material_header_payload =
 
 /// @brief A payload object for a material parametrization
 struct material_payload {
-    std::array<real_io, 7u> params;
+    std::array<real_io, 7u> params{};
 };
 
 /// @brief A payload object for a material slab/rod
 struct material_slab_payload {
-    using material_type = io::detail::material_type;
-    material_type type = material_type::unknown;
-    std::size_t index;
-    real_io thickness;
-    material_payload mat;
+    using type = io::detail::material_type;
+
+    material_link_payload mat_link{};
+    real_io thickness{std::numeric_limits<real_io>::max()};
+    material_payload mat{};
 };
 
 /// @brief A payload object for the material contained in a volume
 struct material_volume_payload {
-    std::size_t index;
-    std::vector<material_slab_payload> mat_slabs = {};
+    single_link_payload volume_link{};
+    std::vector<material_slab_payload> mat_slabs{};
     std::optional<std::vector<material_slab_payload>> mat_rods;
 };
 
 /// @brief A payload for the homogeneous material description of a detector
 struct detector_homogeneous_material_payload {
-    std::vector<material_volume_payload> volumes = {};
+    std::vector<material_volume_payload> volumes{};
 };
 
 /// @}
@@ -149,49 +151,41 @@ struct detector_homogeneous_material_payload {
 /// Payloads for a uniform grid
 /// @{
 
-/// @brief a payload for the simple grid file header
-struct grid_header_payload {
-    std::string version, detector, tag, date;
-    std::size_t n_grids;
+/// @brief a payload for the grid specific part of the file header
+struct grid_sub_header_payload {
+    std::size_t n_grids{0u};
 };
+
+/// @brief a payload for the grid file header
+using grid_header_payload = header_payload<grid_sub_header_payload>;
 
 /// @brief axis definition and bin edges
 struct axis_payload {
     /// axis lookup type
-    n_axis::binning binning = n_axis::binning::e_regular;
-    n_axis::bounds bounds = n_axis::bounds::e_closed;
-    n_axis::label label = n_axis::label::e_r;
+    n_axis::binning binning{n_axis::binning::e_regular};
+    n_axis::bounds bounds{n_axis::bounds::e_closed};
+    n_axis::label label{n_axis::label::e_r};
 
-    std::size_t bins = 0u;
-    std::vector<real_io> edges = {};
+    std::size_t bins{0u};
+    std::vector<real_io> edges{};
 };
 
 /// @brief A payload for a grid bin
 struct grid_bin_payload {
-    std::vector<unsigned int> loc_index = {};
-    std::vector<std::size_t> content = {};
+    std::vector<unsigned int> loc_index{};
+    std::vector<std::size_t> content{};
 };
 
 /// @brief A payload for a grid definition
 struct grid_payload {
     using grid_type = io::detail::acc_type;
-    grid_type type = grid_type::unknown;
-    std::size_t index;
 
-    std::vector<axis_payload> axes = {};
-    std::vector<grid_bin_payload> bins = {};
-};
+    single_link_payload volume_link{};
+    acc_links_payload acc_link{};
 
-/// @brief A payload for objects within a grid
-struct grid_objects_payload {
-    grid_payload grid;
+    std::vector<axis_payload> axes{};
+    std::vector<grid_bin_payload> bins{};
     std::optional<transform_payload> transform;
-};
-
-/// @brief navigation links definition
-struct links_payload {
-    std::vector<single_link_payload> single_links;
-    std::optional<grid_objects_payload> grid_links;
 };
 
 /// @brief A payload for the grid collections of a detector
@@ -204,7 +198,7 @@ struct detector_grids_payload {
 /// @brief A payload for a detector geometry
 struct detector_payload {
     std::vector<volume_payload> volumes = {};
-    grid_objects_payload volume_grid;
+    grid_payload volume_grid;
 };
 
 }  // namespace detray

--- a/io/include/detray/io/json/json_common_io.hpp
+++ b/io/include/detray/io/json/json_common_io.hpp
@@ -37,4 +37,28 @@ void from_json(const nlohmann::ordered_json& j, header_payload<bool>& h) {
     // Do not look at the optional subheader here
 }
 
+/// Data links IO
+/// @{
+void to_json(nlohmann::ordered_json& j, const single_link_payload& so) {
+    j = so.link;
+}
+
+void from_json(const nlohmann::ordered_json& j, single_link_payload& so) {
+    so.link = j;
+}
+
+template <typename type_id>
+void to_json(nlohmann::ordered_json& j, const typed_link_payload<type_id>& m) {
+    j["type"] = static_cast<unsigned int>(m.type);
+    j["index"] = m.index;
+}
+
+template <typename type_id>
+void from_json(const nlohmann::ordered_json& j,
+               typed_link_payload<type_id>& m) {
+    m.type = static_cast<type_id>(j["type"]);
+    m.index = j["index"];
+}
+/// @}
+
 }  // namespace detray

--- a/io/include/detray/io/json/json_geometry_io.hpp
+++ b/io/include/detray/io/json/json_geometry_io.hpp
@@ -11,7 +11,8 @@
 #include "detray/io/common/payloads.hpp"
 #include "detray/io/json/json.hpp"
 #include "detray/io/json/json_algebra_io.hpp"
-#include "detray/io/json/json_header_io.hpp"
+#include "detray/io/json/json_common_io.hpp"
+#include "detray/io/json/json_grids_io.hpp"
 
 // System include(s)
 #include <array>
@@ -45,14 +46,6 @@ void from_json(const nlohmann::ordered_json& j, geo_header_payload& h) {
     }
 }
 
-void to_json(nlohmann::ordered_json& j, const single_link_payload& so) {
-    j = so.link;
-}
-
-void from_json(const nlohmann::ordered_json& j, single_link_payload& so) {
-    so.link = j;
-}
-
 void to_json(nlohmann::ordered_json& j, const mask_payload& m) {
     j["shape"] = static_cast<unsigned int>(m.shape);
     j["volume_link"] = m.volume_link;
@@ -63,16 +56,6 @@ void from_json(const nlohmann::ordered_json& j, mask_payload& m) {
     m.shape = static_cast<mask_payload::mask_shape>(j["shape"]);
     m.volume_link = j["volume_link"];
     m.boundaries = j["boundaries"].get<std::vector<real_io>>();
-}
-
-void to_json(nlohmann::ordered_json& j, const material_link_payload& m) {
-    j["type"] = static_cast<unsigned int>(m.type);
-    j["index"] = m.index;
-}
-
-void from_json(const nlohmann::ordered_json& j, material_link_payload& m) {
-    m.type = static_cast<material_link_payload::material_type>(j["type"]);
-    m.index = j["index"];
 }
 
 void to_json(nlohmann::ordered_json& j, const surface_payload& s) {
@@ -95,16 +78,6 @@ void from_json(const nlohmann::ordered_json& j, surface_payload& s) {
     if (j.find("material") != j.end()) {
         s.material = j["material"];
     }
-}
-
-void to_json(nlohmann::ordered_json& j, const acc_links_payload& al) {
-    j["type"] = static_cast<unsigned int>(al.type);
-    j["index"] = al.index;
-}
-
-void from_json(const nlohmann::ordered_json& j, acc_links_payload& al) {
-    al.type = static_cast<acc_links_payload::acc_type>(j["type"]);
-    al.index = j["index"];
 }
 
 void to_json(nlohmann::ordered_json& j, const volume_payload& v) {
@@ -141,6 +114,26 @@ void from_json(const nlohmann::ordered_json& j, volume_payload& v) {
             acc_links_payload al = jl;
             v.acc_links->push_back(al);
         }
+    }
+}
+
+void to_json(nlohmann::ordered_json& j, const detector_payload& d) {
+    if (not d.volumes.empty()) {
+        nlohmann::ordered_json jvolumes;
+        for (const auto& v : d.volumes) {
+            jvolumes.push_back(v);
+        }
+        j["volumes"] = jvolumes;
+        j["volume_grid"] = d.volume_grid;
+    }
+}
+
+void from_json(const nlohmann::ordered_json& j, detector_payload& d) {
+    if (j.find("volumes") != j.end()) {
+        for (auto jvolume : j["volumes"]) {
+            d.volumes.push_back(jvolume);
+        }
+        d.volume_grid = j["volume_grid"];
     }
 }
 

--- a/io/include/detray/io/json/json_material_io.hpp
+++ b/io/include/detray/io/json/json_material_io.hpp
@@ -10,7 +10,7 @@
 // Project include(s)
 #include "detray/io/common/payloads.hpp"
 #include "detray/io/json/json.hpp"
-#include "detray/io/json/json_header_io.hpp"
+#include "detray/io/json/json_common_io.hpp"
 
 // System include(s)
 #include <array>
@@ -52,21 +52,19 @@ void from_json(const nlohmann::ordered_json& j, material_payload& m) {
 }
 
 void to_json(nlohmann::ordered_json& j, const material_slab_payload& m) {
-    j["type"] = material_slab_payload::material_type::slab;
-    j["index"] = m.index;
+    j["mat_link"] = m.mat_link;
     j["thickness"] = m.thickness;
     j["material"] = m.mat;
 }
 
 void from_json(const nlohmann::ordered_json& j, material_slab_payload& m) {
-    m.type = material_slab_payload::material_type::slab;
-    m.index = j["index"];
+    m.mat_link = j["mat_link"];
     m.thickness = j["thickness"];
     m.mat = j["material"];
 }
 
 void to_json(nlohmann::ordered_json& j, const material_volume_payload& mv) {
-    j["index"] = mv.index;
+    j["volume_link"] = mv.volume_link;
 
     if (not mv.mat_slabs.empty()) {
         nlohmann::ordered_json jmats;
@@ -85,7 +83,7 @@ void to_json(nlohmann::ordered_json& j, const material_volume_payload& mv) {
 }
 
 void from_json(const nlohmann::ordered_json& j, material_volume_payload& mv) {
-    mv.index = j["index"];
+    mv.volume_link = j["volume_link"];
 
     if (j.find("material_slabs") != j.end()) {
         for (auto jmats : j["material_slabs"]) {

--- a/io/include/detray/io/json/json_serializers.hpp
+++ b/io/include/detray/io/json/json_serializers.hpp
@@ -10,5 +10,4 @@
 #include "detray/io/json/json_algebra_io.hpp"
 #include "detray/io/json/json_geometry_io.hpp"
 #include "detray/io/json/json_grids_io.hpp"
-#include "detray/io/json/json_header_io.hpp"
 #include "detray/io/json/json_material_io.hpp"

--- a/tests/unit_tests/io/io_json_payload.cpp
+++ b/tests/unit_tests/io/io_json_payload.cpp
@@ -137,8 +137,8 @@ TEST(io, json_grid_payload) {
         detray::n_axis::label::e_r, 2u, std::vector<detray::real_io>{0.f, 2.f}};
 
     detray::grid_payload g;
-    g.type = detray::grid_payload::grid_type::polar2_grid;
-    g.index = 12u;
+    g.acc_link = {detray::grid_payload::grid_type::polar2_grid, 12u};
+    g.volume_link = {2u};
     g.axes = {a0, a1};
     g.bins = bins;
 
@@ -147,104 +147,10 @@ TEST(io, json_grid_payload) {
 
     detray::grid_payload pg = j["grid"];
 
-    EXPECT_EQ(g.type, pg.type);
-    EXPECT_EQ(g.index, pg.index);
+    EXPECT_EQ(g.acc_link.type, pg.acc_link.type);
+    EXPECT_EQ(g.acc_link.index, pg.acc_link.index);
     EXPECT_EQ(g.axes.size(), pg.axes.size());
     EXPECT_EQ(g.bins.size(), pg.bins.size());
-}
-
-/// This tests the json io for a surface search grid
-TEST(io, grid_objects_payload) {
-    detray::grid_objects_payload go;
-
-    std::vector<detray::grid_bin_payload> bins = {
-        {{0u, 1u}, {0u, 2u}}, {{1u, 1u}, {1u, 2u}}, {{2u, 1u}, {2u, 2u}}};
-
-    detray::axis_payload a0{
-        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_circular,
-        detray::n_axis::label::e_phi, 3u,
-        std::vector<detray::real_io>{-detray::constant<detray::real_io>::pi,
-                                     detray::constant<detray::real_io>::pi}};
-
-    detray::axis_payload a1{
-        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_closed,
-        detray::n_axis::label::e_r, 2u, std::vector<detray::real_io>{0.f, 2.f}};
-
-    detray::grid_payload g;
-    g.type = detray::grid_payload::grid_type::polar2_grid;
-    g.index = 12u;
-    g.axes = {a0, a1};
-    g.bins = bins;
-
-    go.grid = g;
-
-    nlohmann::ordered_json j;
-    j["links"] = go;
-    detray::grid_objects_payload pgo = j["links"];
-
-    EXPECT_EQ(go.grid.axes.size(), pgo.grid.axes.size());
-    EXPECT_EQ(go.grid.bins.size(), pgo.grid.bins.size());
-
-    detray::transform_payload p;
-    p.tr = {100.f, 200.f, 300.f};
-    p.rot = {1.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f};
-
-    detray::grid_objects_payload got;
-    got.transform = p;
-
-    got.grid = g;
-
-    j["links_t"] = got;
-    detray::grid_objects_payload pgot = j["links_t"];
-
-    EXPECT_EQ(got.grid.axes.size(), pgot.grid.axes.size());
-    EXPECT_EQ(got.grid.bins.size(), pgot.grid.bins.size());
-    EXPECT_EQ(got.transform.value().tr, pgot.transform.value().tr);
-    EXPECT_EQ(got.transform.value().rot, pgot.transform.value().rot);
-}
-
-/// This tests the json io for a surface search grid, including links
-TEST(io, json_links_payload) {
-
-    std::vector<detray::grid_bin_payload> bins = {
-        {{0u, 1u}, {0u, 2u}}, {{1u, 1u}, {1u, 2u}}, {{2u, 1u}, {2u, 2u}}};
-
-    detray::axis_payload a0{
-        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_circular,
-        detray::n_axis::label::e_phi, 3u,
-        std::vector<detray::real_io>{-detray::constant<detray::real_io>::pi,
-                                     detray::constant<detray::real_io>::pi}};
-
-    detray::axis_payload a1{
-        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_closed,
-        detray::n_axis::label::e_r, 2u, std::vector<detray::real_io>{0.f, 2.f}};
-
-    detray::grid_payload g;
-    g.type = detray::grid_payload::grid_type::polar2_grid;
-    g.index = 12u;
-    g.axes = {a0, a1};
-    g.bins = bins;
-
-    detray::grid_objects_payload go;
-    go.grid = g;
-
-    detray::single_link_payload sl;
-    sl.link = 3u;
-
-    detray::links_payload l;
-    l.grid_links = go;
-    l.single_links = {sl};
-
-    nlohmann::ordered_json j;
-    j["links"] = l;
-
-    detray::links_payload pl = j["links"];
-
-    EXPECT_EQ(l.single_links.size(), pl.single_links.size());
-    EXPECT_EQ(l.grid_links.value().grid.axes.size(),
-              pl.grid_links.value().grid.axes.size());
-    EXPECT_EQ(l.grid_links.value().grid.bins.size(),
-              pl.grid_links.value().grid.bins.size());
 }
 
 /// This tests the json io for a surface mask
@@ -272,7 +178,7 @@ TEST(io, json_mask_payload) {
 TEST(io, json_material_link_payload) {
 
     detray::material_link_payload m;
-    m.type = detray::material_link_payload::material_type::slab;
+    m.type = detray::material_link_payload::type_id::slab;
     m.index = 2u;
 
     nlohmann::ordered_json j;
@@ -301,7 +207,7 @@ TEST(io, json_surface_payload) {
     m.boundaries = {10.f, 20.f, 34.f, 1.4f};
 
     detray::material_link_payload mat;
-    mat.type = detray::material_link_payload::material_type::slab;
+    mat.type = detray::material_link_payload::type_id::slab;
     mat.index = 2u;
 
     s.transform = t;
@@ -331,7 +237,7 @@ TEST(io, json_surface_payload) {
 TEST(io, acc_links_payload) {
 
     detray::acc_links_payload l;
-    l.type = detray::acc_links_payload::acc_type::cylinder2_grid;
+    l.type = detray::acc_links_payload::type_id::cylinder2_grid;
     l.index = 2u;
 
     nlohmann::ordered_json j;
@@ -355,7 +261,7 @@ TEST(io, json_volume_payload) {
     sl.link = 1u;
 
     detray::acc_links_payload al;
-    al.type = detray::acc_links_payload::acc_type::cylinder2_grid;
+    al.type = detray::acc_links_payload::type_id::cylinder2_grid;
     al.index = 2u;
 
     detray::surface_payload s;
@@ -366,7 +272,7 @@ TEST(io, json_volume_payload) {
     m.boundaries = {10.f, 20.f, 34.f, 1.4f};
 
     detray::material_link_payload mat;
-    mat.type = detray::material_link_payload::material_type::slab;
+    mat.type = detray::material_link_payload::type_id::slab;
     mat.index = 2u;
 
     s.transform = t;
@@ -401,8 +307,7 @@ TEST(io, json_volume_payload) {
 TEST(io, json_material_slab_payload) {
 
     detray::material_slab_payload m;
-    m.type = detray::material_slab_payload::material_type::slab;
-    m.index = 21u;
+    m.mat_link = {detray::material_slab_payload::type::slab, 21u};
     m.thickness = 1.2f;
     m.mat.params = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f};
 
@@ -411,8 +316,8 @@ TEST(io, json_material_slab_payload) {
 
     detray::material_slab_payload pm = j["material"];
 
-    EXPECT_EQ(m.type, pm.type);
-    EXPECT_EQ(m.index, pm.index);
+    EXPECT_EQ(m.mat_link.type, pm.mat_link.type);
+    EXPECT_EQ(m.mat_link.index, pm.mat_link.index);
     EXPECT_EQ(m.thickness, pm.thickness);
     EXPECT_EQ(m.mat.params, pm.mat.params);
 }


### PR DESCRIPTION
Cleans up the IO payloads (in particular the payloads for the links are put into a single place) and switches the grid writer to write the payloads by volume, which will be needed in order to fill the grid builders. Also removes some old payloads from the grids