### PR TITLE
Fix a bug in axis binning

### DIFF
--- a/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
@@ -276,7 +276,7 @@ struct irregular {
         detray::detail::call_reserve(edges, nbins());
 
         edges.insert(
-            edges->end(),
+            edges.end(),
             m_bin_edges->begin() +
                 static_cast<index_type>(detray::detail::get<0>(*m_edges_range)),
             m_bin_edges->begin() + static_cast<index_type>(

--- a/tests/unit_tests/io/io_json_detector_reader.cpp
+++ b/tests/unit_tests/io/io_json_detector_reader.cpp
@@ -8,6 +8,7 @@
 // Project include(s)
 #include "detray/definitions/algebra.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
+#include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/io/common/detector_reader.hpp"
 #include "detray/io/common/detector_writer.hpp"
 #include "detray/io/json/json_reader.hpp"
@@ -100,4 +101,30 @@ TEST(io, json_toy_detector_reader) {
         io::read_detector<detector_t>(host_mr, reader_cfg);
 
     EXPECT_TRUE(test_toy_detector(det, names));
+}
+
+/// Test the reading and writing of a wire chamber
+TEST(io, json_wire_chamber_reader) {
+
+    using detector_t = detector<default_metadata>;
+
+    // Wire chamber
+    vecmem::host_memory_resource host_mr;
+    auto [wire_det, wire_names] =
+        create_wire_chamber(host_mr, wire_chamber_config{});
+
+    auto writer_cfg = io::detector_writer_config{}
+                          .format(io::format::json)
+                          .replace_files(true);
+    io::write_detector(wire_det, wire_names, writer_cfg);
+
+    // Read the detector back in
+    io::detector_reader_config reader_cfg{};
+    reader_cfg.add_file("wire_chamber_geometry.json")
+        .add_file("wire_chamber_homogeneous_material.json");
+
+    const auto [det, names] =
+        io::read_detector<detector_t>(host_mr, reader_cfg);
+
+    EXPECT_EQ(det.volumes().size(), 11u);
 }

--- a/tests/unit_tests/io/io_json_detector_writer.cpp
+++ b/tests/unit_tests/io/io_json_detector_writer.cpp
@@ -10,6 +10,7 @@
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/create_telescope_detector.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
+#include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/io/common/detector_writer.hpp"
 #include "detray/io/json/json_writer.hpp"
 
@@ -91,6 +92,19 @@ TEST(io, json_toy_detector_writer) {
     // Toy detector
     vecmem::host_memory_resource host_mr;
     auto [det, names] = create_toy_geometry(host_mr);
+
+    auto writer_cfg = io::detector_writer_config{}
+                          .format(io::format::json)
+                          .replace_files(true);
+    io::write_detector(det, names, writer_cfg);
+}
+
+/// Test the writing of the entire wire chamber to json
+TEST(io, json_wire_chamber_writer) {
+
+    // Wire chamber
+    vecmem::host_memory_resource host_mr;
+    auto [det, names] = create_wire_chamber(host_mr, wire_chamber_config{});
 
     auto writer_cfg = io::detector_writer_config{}
                           .format(io::format::json)


### PR DESCRIPTION
Fix a bug in axis binning which causes the compilation failure in detector I/O with `default_metadata`  