### PR TITLE
Avoid multiple definitions

### DIFF
--- a/io/include/detray/io/common/detail/file_handle.hpp
+++ b/io/include/detray/io/common/detail/file_handle.hpp
@@ -100,12 +100,9 @@ class file_handle final {
     std::fstream m_stream;
 
     /// How many files have been created? Maximum: 65'536
-    static std::size_t n_files;
-    static std::size_t n_open_files;
+    std::size_t n_files{0};
+    std::size_t n_open_files{0};
 };
-
-std::size_t file_handle::n_files{0u};
-std::size_t file_handle::n_open_files{0u};
 
 }  // namespace detail
 

--- a/io/include/detray/io/common/detail/file_handle.hpp
+++ b/io/include/detray/io/common/detail/file_handle.hpp
@@ -100,8 +100,8 @@ class file_handle final {
     std::fstream m_stream;
 
     /// How many files have been created? Maximum: 65'536
-    std::size_t n_files{0};
-    std::size_t n_open_files{0};
+    inline static std::size_t n_files{0u};
+    inline static std::size_t n_open_files{0u};
 };
 
 }  // namespace detail

--- a/io/include/detray/io/json/json_algebra_io.hpp
+++ b/io/include/detray/io/json/json_algebra_io.hpp
@@ -15,12 +15,12 @@
 /// JSON I/O extension
 namespace detray {
 
-void to_json(nlohmann::ordered_json& j, const transform_payload& t) {
+inline void to_json(nlohmann::ordered_json& j, const transform_payload& t) {
     j["translation"] = t.tr;
     j["rotation"] = t.rot;
 }
 
-void from_json(const nlohmann::ordered_json& j, transform_payload& t) {
+inline void from_json(const nlohmann::ordered_json& j, transform_payload& t) {
     t.tr = j["translation"];
     t.rot = j["rotation"];
 }

--- a/io/include/detray/io/json/json_common_io.hpp
+++ b/io/include/detray/io/json/json_common_io.hpp
@@ -13,49 +13,53 @@
 
 namespace detray {
 
-void to_json(nlohmann::ordered_json& j, const common_header_payload& h) {
+inline void to_json(nlohmann::ordered_json& j, const common_header_payload& h) {
     j["version"] = h.version;
     j["detector"] = h.detector;
     j["date"] = h.date;
     j["tag"] = h.tag;
 }
 
-void from_json(const nlohmann::ordered_json& j, common_header_payload& h) {
+inline void from_json(const nlohmann::ordered_json& j,
+                      common_header_payload& h) {
     h.version = j["version"];
     h.detector = j["detector"];
     h.date = j["date"];
     h.tag = j["tag"];
 }
 
-void to_json(nlohmann::ordered_json& j, const header_payload<bool>& h) {
+inline void to_json(nlohmann::ordered_json& j, const header_payload<bool>& h) {
     j["common"] = h.common;
     // Do write the optional subheader here, but in the dedicated serializers
 }
 
-void from_json(const nlohmann::ordered_json& j, header_payload<bool>& h) {
+inline void from_json(const nlohmann::ordered_json& j,
+                      header_payload<bool>& h) {
     h.common = j["common"];
     // Do not look at the optional subheader here
 }
 
 /// Data links IO
 /// @{
-void to_json(nlohmann::ordered_json& j, const single_link_payload& so) {
+inline void to_json(nlohmann::ordered_json& j, const single_link_payload& so) {
     j = so.link;
 }
 
-void from_json(const nlohmann::ordered_json& j, single_link_payload& so) {
+inline void from_json(const nlohmann::ordered_json& j,
+                      single_link_payload& so) {
     so.link = j;
 }
 
 template <typename type_id>
-void to_json(nlohmann::ordered_json& j, const typed_link_payload<type_id>& m) {
+inline void to_json(nlohmann::ordered_json& j,
+                    const typed_link_payload<type_id>& m) {
     j["type"] = static_cast<unsigned int>(m.type);
     j["index"] = m.index;
 }
 
 template <typename type_id>
-void from_json(const nlohmann::ordered_json& j,
-               typed_link_payload<type_id>& m) {
+inline void from_json(const nlohmann::ordered_json& j,
+                      typed_link_payload<type_id>& m) {
     m.type = static_cast<type_id>(j["type"]);
     m.index = j["index"];
 }

--- a/io/include/detray/io/json/json_geometry_io.hpp
+++ b/io/include/detray/io/json/json_geometry_io.hpp
@@ -24,7 +24,7 @@
 /// JSON I/O extension
 namespace detray {
 
-void to_json(nlohmann::ordered_json& j, const geo_header_payload& h) {
+inline void to_json(nlohmann::ordered_json& j, const geo_header_payload& h) {
     j["common"] = h.common;
 
     if (h.sub_header.has_value()) {
@@ -34,7 +34,7 @@ void to_json(nlohmann::ordered_json& j, const geo_header_payload& h) {
     }
 }
 
-void from_json(const nlohmann::ordered_json& j, geo_header_payload& h) {
+inline void from_json(const nlohmann::ordered_json& j, geo_header_payload& h) {
     h.common = j["common"];
 
     if (j.find("volume_count") != j.end() and
@@ -46,19 +46,19 @@ void from_json(const nlohmann::ordered_json& j, geo_header_payload& h) {
     }
 }
 
-void to_json(nlohmann::ordered_json& j, const mask_payload& m) {
+inline void to_json(nlohmann::ordered_json& j, const mask_payload& m) {
     j["shape"] = static_cast<unsigned int>(m.shape);
     j["volume_link"] = m.volume_link;
     j["boundaries"] = m.boundaries;
 }
 
-void from_json(const nlohmann::ordered_json& j, mask_payload& m) {
+inline void from_json(const nlohmann::ordered_json& j, mask_payload& m) {
     m.shape = static_cast<mask_payload::mask_shape>(j["shape"]);
     m.volume_link = j["volume_link"];
     m.boundaries = j["boundaries"].get<std::vector<real_io>>();
 }
 
-void to_json(nlohmann::ordered_json& j, const surface_payload& s) {
+inline void to_json(nlohmann::ordered_json& j, const surface_payload& s) {
     j["barcode"] = s.barcode;
     j["type"] = static_cast<unsigned int>(s.type);
     j["source"] = s.source;
@@ -69,7 +69,7 @@ void to_json(nlohmann::ordered_json& j, const surface_payload& s) {
     }
 }
 
-void from_json(const nlohmann::ordered_json& j, surface_payload& s) {
+inline void from_json(const nlohmann::ordered_json& j, surface_payload& s) {
     s.barcode = j["barcode"];
     s.type = static_cast<detray::surface_id>(j["type"]);
     s.source = j["source"];
@@ -80,7 +80,7 @@ void from_json(const nlohmann::ordered_json& j, surface_payload& s) {
     }
 }
 
-void to_json(nlohmann::ordered_json& j, const volume_payload& v) {
+inline void to_json(nlohmann::ordered_json& j, const volume_payload& v) {
     j["name"] = v.name;
     j["index"] = v.index;
     j["type"] = v.type;
@@ -99,7 +99,7 @@ void to_json(nlohmann::ordered_json& j, const volume_payload& v) {
     }
 }
 
-void from_json(const nlohmann::ordered_json& j, volume_payload& v) {
+inline void from_json(const nlohmann::ordered_json& j, volume_payload& v) {
     v.name = j["name"];
     v.index = j["index"];
     v.type = j["type"];
@@ -117,7 +117,7 @@ void from_json(const nlohmann::ordered_json& j, volume_payload& v) {
     }
 }
 
-void to_json(nlohmann::ordered_json& j, const detector_payload& d) {
+inline void to_json(nlohmann::ordered_json& j, const detector_payload& d) {
     if (not d.volumes.empty()) {
         nlohmann::ordered_json jvolumes;
         for (const auto& v : d.volumes) {
@@ -128,7 +128,7 @@ void to_json(nlohmann::ordered_json& j, const detector_payload& d) {
     }
 }
 
-void from_json(const nlohmann::ordered_json& j, detector_payload& d) {
+inline void from_json(const nlohmann::ordered_json& j, detector_payload& d) {
     if (j.find("volumes") != j.end()) {
         for (auto jvolume : j["volumes"]) {
             d.volumes.push_back(jvolume);

--- a/io/include/detray/io/json/json_grids_io.hpp
+++ b/io/include/detray/io/json/json_grids_io.hpp
@@ -21,7 +21,7 @@
 
 namespace detray {
 
-void to_json(nlohmann::ordered_json& j, const grid_header_payload& h) {
+inline void to_json(nlohmann::ordered_json& j, const grid_header_payload& h) {
     j["common"] = h.common;
 
     if (h.sub_header.has_value()) {
@@ -30,7 +30,7 @@ void to_json(nlohmann::ordered_json& j, const grid_header_payload& h) {
     }
 }
 
-void from_json(const nlohmann::ordered_json& j, grid_header_payload& h) {
+inline void from_json(const nlohmann::ordered_json& j, grid_header_payload& h) {
     h.common = j["common"];
 
     if (j.find("grid_count") != j.end()) {
@@ -40,7 +40,7 @@ void from_json(const nlohmann::ordered_json& j, grid_header_payload& h) {
     }
 }
 
-void to_json(nlohmann::ordered_json& j, const axis_payload& a) {
+inline void to_json(nlohmann::ordered_json& j, const axis_payload& a) {
     j["label"] = static_cast<unsigned int>(a.label);
     j["bounds"] = static_cast<unsigned int>(a.bounds);
     j["binning"] = static_cast<unsigned int>(a.binning);
@@ -48,7 +48,7 @@ void to_json(nlohmann::ordered_json& j, const axis_payload& a) {
     j["edges"] = a.edges;
 }
 
-void from_json(const nlohmann::ordered_json& j, axis_payload& a) {
+inline void from_json(const nlohmann::ordered_json& j, axis_payload& a) {
     a.binning = static_cast<n_axis::binning>(j["binning"]);
     a.bounds = static_cast<n_axis::bounds>(j["bounds"]);
     a.label = static_cast<n_axis::label>(j["label"]);
@@ -56,17 +56,17 @@ void from_json(const nlohmann::ordered_json& j, axis_payload& a) {
     a.edges = j["edges"].get<std::vector<real_io>>();
 }
 
-void to_json(nlohmann::ordered_json& j, const grid_bin_payload& g) {
+inline void to_json(nlohmann::ordered_json& j, const grid_bin_payload& g) {
     j["loc_index"] = g.loc_index;
     j["content"] = g.content;
 }
 
-void from_json(const nlohmann::ordered_json& j, grid_bin_payload& g) {
+inline void from_json(const nlohmann::ordered_json& j, grid_bin_payload& g) {
     g.loc_index = j["loc_index"].get<std::vector<unsigned int>>();
     g.content = j["content"].get<std::vector<std::size_t>>();
 }
 
-void to_json(nlohmann::ordered_json& j, const grid_payload& g) {
+inline void to_json(nlohmann::ordered_json& j, const grid_payload& g) {
     j["volume_link"] = g.volume_link;
     j["acc_link"] = g.acc_link;
 
@@ -87,7 +87,7 @@ void to_json(nlohmann::ordered_json& j, const grid_payload& g) {
     }
 }
 
-void from_json(const nlohmann::ordered_json& j, grid_payload& g) {
+inline void from_json(const nlohmann::ordered_json& j, grid_payload& g) {
     g.volume_link = j["volume_link"];
     g.acc_link = j["acc_link"];
 
@@ -109,7 +109,8 @@ void from_json(const nlohmann::ordered_json& j, grid_payload& g) {
     }
 }
 
-void to_json(nlohmann::ordered_json& j, const detector_grids_payload& d) {
+inline void to_json(nlohmann::ordered_json& j,
+                    const detector_grids_payload& d) {
     if (not d.grids.empty()) {
         nlohmann::ordered_json jgrids;
         for (const auto& gr : d.grids) {
@@ -119,7 +120,8 @@ void to_json(nlohmann::ordered_json& j, const detector_grids_payload& d) {
     }
 }
 
-void from_json(const nlohmann::ordered_json& j, detector_grids_payload& d) {
+inline void from_json(const nlohmann::ordered_json& j,
+                      detector_grids_payload& d) {
     if (j.find("grids") != j.end()) {
         for (auto jgrid : j["grids"]) {
             grid_payload grp = jgrid;

--- a/io/include/detray/io/json/json_material_io.hpp
+++ b/io/include/detray/io/json/json_material_io.hpp
@@ -20,8 +20,8 @@
 /// JSON I/O extension
 namespace detray {
 
-void to_json(nlohmann::ordered_json& j,
-             const homogeneous_material_header_payload& h) {
+inline void to_json(nlohmann::ordered_json& j,
+                    const homogeneous_material_header_payload& h) {
     j["common"] = h.common;
 
     if (h.sub_header.has_value()) {
@@ -31,8 +31,8 @@ void to_json(nlohmann::ordered_json& j,
     }
 }
 
-void from_json(const nlohmann::ordered_json& j,
-               homogeneous_material_header_payload& h) {
+inline void from_json(const nlohmann::ordered_json& j,
+                      homogeneous_material_header_payload& h) {
     h.common = j["common"];
 
     if (j.find("slab_count") != j.end() and j.find("rod_count") != j.end()) {
@@ -43,27 +43,29 @@ void from_json(const nlohmann::ordered_json& j,
     }
 }
 
-void to_json(nlohmann::ordered_json& j, const material_payload& m) {
+inline void to_json(nlohmann::ordered_json& j, const material_payload& m) {
     j["params"] = m.params;
 }
 
-void from_json(const nlohmann::ordered_json& j, material_payload& m) {
+inline void from_json(const nlohmann::ordered_json& j, material_payload& m) {
     m.params = j["params"].get<std::array<real_io, 7>>();
 }
 
-void to_json(nlohmann::ordered_json& j, const material_slab_payload& m) {
+inline void to_json(nlohmann::ordered_json& j, const material_slab_payload& m) {
     j["mat_link"] = m.mat_link;
     j["thickness"] = m.thickness;
     j["material"] = m.mat;
 }
 
-void from_json(const nlohmann::ordered_json& j, material_slab_payload& m) {
+inline void from_json(const nlohmann::ordered_json& j,
+                      material_slab_payload& m) {
     m.mat_link = j["mat_link"];
     m.thickness = j["thickness"];
     m.mat = j["material"];
 }
 
-void to_json(nlohmann::ordered_json& j, const material_volume_payload& mv) {
+inline void to_json(nlohmann::ordered_json& j,
+                    const material_volume_payload& mv) {
     j["volume_link"] = mv.volume_link;
 
     if (not mv.mat_slabs.empty()) {
@@ -82,7 +84,8 @@ void to_json(nlohmann::ordered_json& j, const material_volume_payload& mv) {
     }
 }
 
-void from_json(const nlohmann::ordered_json& j, material_volume_payload& mv) {
+inline void from_json(const nlohmann::ordered_json& j,
+                      material_volume_payload& mv) {
     mv.volume_link = j["volume_link"];
 
     if (j.find("material_slabs") != j.end()) {
@@ -100,8 +103,8 @@ void from_json(const nlohmann::ordered_json& j, material_volume_payload& mv) {
     }
 }
 
-void to_json(nlohmann::ordered_json& j,
-             const detector_homogeneous_material_payload& d) {
+inline void to_json(nlohmann::ordered_json& j,
+                    const detector_homogeneous_material_payload& d) {
     if (not d.volumes.empty()) {
         nlohmann::ordered_json jmats;
         for (const auto& m : d.volumes) {
@@ -111,8 +114,8 @@ void to_json(nlohmann::ordered_json& j,
     }
 }
 
-void from_json(const nlohmann::ordered_json& j,
-               detector_homogeneous_material_payload& d) {
+inline void from_json(const nlohmann::ordered_json& j,
+                      detector_homogeneous_material_payload& d) {
     if (j.find("volumes") != j.end()) {
         for (auto jvolume : j["volumes"]) {
             d.volumes.push_back(jvolume);

--- a/io/include/detray/io/json/json_reader.hpp
+++ b/io/include/detray/io/json/json_reader.hpp
@@ -24,7 +24,7 @@
 namespace detray {
 
 /// @brief Function that reads the common header part of a file
-common_header_payload read_json_header(const std::string& file_name) {
+inline common_header_payload read_json_header(const std::string& file_name) {
 
     // Read json file
     io::detail::file_handle file{file_name,


### PR DESCRIPTION
Removing the global variables and Add `inline` attributes to global functions to avoid multiple definitino