### PR TITLE
Cover all azimuthal angle of wire chamber

### DIFF
--- a/tests/unit_tests/cpu/tools_navigator.cpp
+++ b/tests/unit_tests/cpu/tools_navigator.cpp
@@ -289,7 +289,7 @@ GTEST_TEST(detray_navigator, wire_chamber) {
 
     // test track
     point3 pos{0.f, 0.f, 0.f};
-    vector3 mom{1.f, 0.f, 0.f};
+    vector3 mom{0.f, 1.f, 0.f};
     free_track_parameters<transform3> traj(pos, 0.f, mom, -1.f);
 
     stepper_t stepper;
@@ -364,16 +364,16 @@ GTEST_TEST(detray_navigator, wire_chamber) {
     std::map<dindex, std::vector<dindex>> sf_sequences;
 
     // layer 1 to 10
-    sf_sequences[1] = {3u, 7u, 4u};
-    sf_sequences[2] = {167u, 171u, 168u};
-    sf_sequences[3] = {337u, 341u, 338u};
-    sf_sequences[4] = {513u, 517u, 514u};
-    sf_sequences[5] = {696u, 700u, 697u};
-    sf_sequences[6] = {885u, 889u, 886u};
-    sf_sequences[7] = {1080u, 1084u, 1081u};
-    sf_sequences[8] = {1281u, 1285u, 1282u};
-    sf_sequences[9] = {1489u, 1493u, 1490u};
-    sf_sequences[10] = {1703u, 1707u, 1704u};
+    sf_sequences[1] = {3u, 47u, 4u};
+    sf_sequences[2] = {168u, 214u, 169u};
+    sf_sequences[3] = {339u, 386u, 340u};
+    sf_sequences[4] = {516u, 565u, 517u};
+    sf_sequences[5] = {700u, 750u, 701u};
+    sf_sequences[6] = {890u, 942u, 891u};
+    sf_sequences[7] = {1086u, 1139u, 1087u};
+    sf_sequences[8] = {1288u, 1343u, 1289u};
+    sf_sequences[9] = {1497u, 1554u, 1498u};
+    sf_sequences[10] = {1712u, 1770u, 1713u};
 
     // Every iteration steps through one wire layer
     for (const auto &[vol_id, sf_seq] : sf_sequences) {

--- a/utils/include/detray/detectors/create_wire_chamber.hpp
+++ b/utils/include/detray/detectors/create_wire_chamber.hpp
@@ -151,9 +151,7 @@ auto create_wire_chamber(vecmem::memory_resource &resource,
 
         // Layer configuration
         const scalar center_layer_rad = inner_layer_rad + cell_size;
-        const scalar theta = 2 * cell_size / center_layer_rad;
-        const unsigned int n_wires_per_layer =
-            static_cast<unsigned int>(2 * constant<scalar>::pi / theta);
+        const scalar delta = 2 * cell_size / center_layer_rad;
 
         // Get volume ID
         auto volume_idx = vol.index();
@@ -169,14 +167,19 @@ auto create_wire_chamber(vecmem::memory_resource &resource,
 
         // Wire center positions
         detray::dvector<point3> m_centers{};
-        for (unsigned int i_w = 0u; i_w < n_wires_per_layer; i_w++) {
-            const scalar x =
-                center_layer_rad * std::cos(theta * static_cast<scalar>(i_w));
-            const scalar y =
-                center_layer_rad * std::sin(theta * static_cast<scalar>(i_w));
+
+        unsigned int n_wires_per_layer{0u};
+        scalar theta{0.f};
+        while (theta <= 2.f * constant<scalar>::pi) {
+
+            const scalar x = center_layer_rad * std::cos(theta);
+            const scalar y = center_layer_rad * std::sin(theta);
             const scalar z = 0.f;
 
             m_centers.push_back({x, y, z});
+
+            n_wires_per_layer++;
+            theta += delta;
         }
 
         for (auto &m_center : m_centers) {


### PR DESCRIPTION
In the current wire chamber, there are small gaps between the azimuthal angle of last wire and 2 * pi. The PR makes the geometry cover full of [0, 2pi].  It seems one wire is added for every layer