### PR TITLE
bug: fixed trapezoid flipping

### DIFF
--- a/utils/include/detray/detectors/create_toy_geometry.hpp
+++ b/utils/include/detray/detectors/create_toy_geometry.hpp
@@ -453,7 +453,8 @@ void create_endcap_modules(context_t &ctx, volume_type &vol,
             // the module transform from the position
             scalar m_phi{algebra::getter::phi(m_position)};
             // the center position of the modules
-            point3 m_center{static_cast<scalar>(cfg.side) * m_position};
+            point3 m_center{m_position};
+            m_center[2] *= static_cast<scalar>(cfg.side);
             // the rotation matrix of the module
             vector3 m_local_y{math_ns::cos(m_phi), std::sin(m_phi), 0.f};
             // take different axis to have the same readout direction


### PR DESCRIPTION
Fixed a bug where trapezoids in the toy detector would be flipped incorrectly (see image). The side with the smaller length now faces towards the center.

**Before**
![selected surfaces (xy)](https://github.com/acts-project/detray/assets/92879080/84f1b640-a079-4e56-a0ae-046b09b4dd45)

**After**
![selected surfaces (xy)](https://github.com/acts-project/detray/assets/92879080/379a2575-a164-4ff0-867d-71ce413de0dc)
