### PR TITLE
Add measurement dimension surface function

### DIFF
--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -57,6 +57,17 @@ struct surface_kernels {
         }
     };
 
+    /// A functor get the measurement dimension
+    struct meas_dim {
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline unsigned int operator()(
+            const mask_group_t& /*mask_group*/,
+            const index_t& /*index*/) const {
+
+            return mask_group_t::value_type::shape::meas_dim;
+        }
+    };
+
     /// A functor get the surface normal at a given local/bound position
     struct normal {
         template <typename mask_group_t, typename index_t>

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -139,6 +139,12 @@ class surface {
         return transform(ctx).translation();
     }
 
+    /// @returns the measurement dimesntion of surface
+    DETRAY_HOST_DEVICE
+    constexpr auto meas_dim() const -> unsigned int {
+        return visit_mask<typename kernels::meas_dim>();
+    }
+
     /// @returns the surface normal in global coordinates at a given bound/local
     /// position @param p
     template <typename point_t = point2,

--- a/tests/unit_tests/cpu/geometry_surface.cpp
+++ b/tests/unit_tests/cpu/geometry_surface.cpp
@@ -147,4 +147,7 @@ GTEST_TEST(detray_geometry, surface) {
     ASSERT_NEAR(global2[1], glob_pos[1], tol);
     // The bound transform assumes the point is on surface
     ASSERT_NEAR(global2[2], disc_translation[2], tol);
+
+    // WARNING: This should be 0u for portal
+    ASSERT_EQ(disc.meas_dim(), 2u);
 }


### PR DESCRIPTION
PR adds measurement dimension surface function

It's not a serious issue but portal/passive surface types are supposed to be defined with zero measurement dimension
(i.e. defined disc_portal as `ring2D<plane_intersector, 0u>`)