### PR TITLE
ref: Simplify surface factories and add unique payload link

### DIFF
--- a/core/include/detray/surface_finders/brute_force_finder.hpp
+++ b/core/include/detray/surface_finders/brute_force_finder.hpp
@@ -119,6 +119,12 @@ class brute_force_collection {
         : m_offsets(detail::get<0>(view.m_view)),
           m_surfaces(detail::get<1>(view.m_view)) {}
 
+    /// @returns access to the volume offsets - const
+    DETRAY_HOST const auto& offsets() const { return m_offsets; }
+
+    /// @returns access to the volume offsets
+    DETRAY_HOST auto& offsets() { return m_offsets; }
+
     /// @returns number of surface collections (at least on per volume) - const
     DETRAY_HOST_DEVICE
     constexpr auto size() const noexcept -> size_type {
@@ -131,12 +137,6 @@ class brute_force_collection {
     constexpr auto empty() const noexcept -> bool {
         return size() == size_type{0};
     }
-
-    /// @returns access to the volume offsets - const
-    DETRAY_HOST const auto& offsets() const { return m_offsets; }
-
-    /// @returns access to the volume offsets
-    DETRAY_HOST auto& offsets() { return m_offsets; }
 
     /// @return access to the surface container - const.
     DETRAY_HOST_DEVICE

--- a/core/include/detray/tools/cuboid_portal_generator.hpp
+++ b/core/include/detray/tools/cuboid_portal_generator.hpp
@@ -54,12 +54,6 @@ class cuboid_portal_generator final
     DETRAY_HOST
     cuboid_portal_generator(const scalar_t env) : m_envelope{env} {}
 
-    /// @returns the id for the surface type (portal surfaces)
-    DETRAY_HOST
-    auto surface_type() const -> surface_id override {
-        return surface_id::e_portal;
-    }
-
     /// @returns the number of rectangle portals this factory will produce
     DETRAY_HOST
     auto size() const -> dindex override { return 6u; }

--- a/core/include/detray/tools/detector_builder.hpp
+++ b/core/include/detray/tools/detector_builder.hpp
@@ -29,9 +29,10 @@ namespace detray {
 /// @brief Provides functionality to build a detray detector volume by volume
 ///
 /// @tparam metadata the type definitions for the detector
+/// @tparam bfield_bknd_t the type of magnetic field to be used
 /// @tparam volume_builder_t the basic volume builder to be used for the
 ///                          geometry data
-/// @tparam volume_data_t the data structure that hold the volume builders
+/// @tparam volume_data_t the data structure that holds the volume builders
 template <typename metadata = default_metadata,
           typename bfield_bknd_t = bfield::const_bknd_t,
           template <typename> class volume_builder_t = volume_builder,
@@ -96,7 +97,6 @@ class detector_builder {
     }
 
     /// Assembles the detector, without a magnetic field
-    // TODO: Remove, won't work for non-constant bfields
     DETRAY_HOST
     void set_bfield(typename detector_type::bfield_type&& field) {
         m_bfield = std::forward<typename detector_type::bfield_type>(field);

--- a/core/include/detray/tools/material_builder.hpp
+++ b/core/include/detray/tools/material_builder.hpp
@@ -40,52 +40,16 @@ class material_builder final : public volume_decorator<detector_t> {
     /// present in the factory, otherwise only add material)
     /// @{
     DETRAY_HOST
-    void add_portals(
-        std::shared_ptr<surface_factory_interface<detector_t>> pt_factory,
-        typename detector_t::geometry_context ctx = {}) override {
-
-        // If the factory also holds surface data, call base volume builder
-        volume_decorator<detector_t>::add_portals(pt_factory, ctx);
-
-        // Add material
-        auto mat_factory =
-            std::dynamic_pointer_cast<material_factory<detector_t>>(pt_factory);
-        if (mat_factory) {
-            (*mat_factory)(this->surfaces(), m_materials);
-        } else {
-            throw std::runtime_error("Not a material factory");
-        }
-    }
-
-    DETRAY_HOST
-    void add_sensitives(
+    void add_surfaces(
         std::shared_ptr<surface_factory_interface<detector_t>> sf_factory,
         typename detector_t::geometry_context ctx = {}) override {
 
         // If the factory also holds surface data, call base volume builder
-        volume_decorator<detector_t>::add_sensitives(sf_factory, ctx);
+        volume_decorator<detector_t>::add_surfaces(sf_factory, ctx);
 
         // Add material
         auto mat_factory =
             std::dynamic_pointer_cast<material_factory<detector_t>>(sf_factory);
-        if (mat_factory) {
-            (*mat_factory)(this->surfaces(), m_materials);
-        } else {
-            throw std::runtime_error("Not a material factory");
-        }
-    }
-
-    DETRAY_HOST
-    void add_passives(
-        std::shared_ptr<surface_factory_interface<detector_t>> ps_factory,
-        typename detector_t::geometry_context ctx = {}) override {
-
-        // If the factory also holds surface data, call base volume builder
-        volume_decorator<detector_t>::add_passives(ps_factory, ctx);
-
-        // Add material
-        auto mat_factory =
-            std::dynamic_pointer_cast<material_factory<detector_t>>(ps_factory);
         if (mat_factory) {
             (*mat_factory)(this->surfaces(), m_materials);
         } else {

--- a/core/include/detray/tools/surface_factory.hpp
+++ b/core/include/detray/tools/surface_factory.hpp
@@ -13,13 +13,15 @@
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/masks/unmasked.hpp"
+#include "detray/materials/material_rod.hpp"
+#include "detray/materials/material_slab.hpp"
 #include "detray/tools/surface_factory_interface.hpp"
 #include "detray/utils/ranges.hpp"
 
 // System include(s)
 #include <algorithm>
 #include <cassert>
-#include <limits>
+#include <exception>
 #include <memory>
 #include <tuple>
 #include <type_traits>
@@ -32,34 +34,20 @@ namespace detray {
 ///
 /// @tparam detector_t the type of detector the volume belongs to.
 /// @tparam mask_shape_t the shape of the surface.
-/// @tparam mask_id the concrete mask id that must be defined in the detector_t.
-/// @tparam sf_id eihter portal, passive or sensitive.
-template <typename detector_t, typename mask_shape_t,
-          typename detector_t::mask_link::id_type mask_id, surface_id sf_id,
-          typename volume_link_t = dindex>
-class surface_factory
-    : public surface_factory_interface<detector_t>,
-      public std::enable_shared_from_this<surface_factory<
-          detector_t, mask_shape_t, mask_id, sf_id, volume_link_t>> {
-    public:
+template <typename detector_t, typename mask_shape_t>
+class surface_factory : public surface_factory_interface<detector_t> {
+
     using scalar_t = typename detector_t::scalar_type;
-    using shape_type = mask_shape_t;
-    using detector_type = detector_t;
+    using volume_link_t = typename detector_t::surface_type::navigation_link;
     // Set individual volume link for portals, but only the mothervolume index
     // for other surfaces.
-    using volume_link_collection =
-        std::conditional_t<sf_id == surface_id::e_portal,
-                           std::vector<volume_link_t>,
-                           detray::views::single<volume_link_t>>;
-    // ensures correct returning of shared pointers without pointless
-    // construction and destructing of surface factories
-    using smart_ptr_handler = std::enable_shared_from_this<surface_factory<
-        detector_t, mask_shape_t, mask_id, sf_id, volume_link_t>>;
+    using volume_link_collection = std::vector<volume_link_t>;
+
+    public:
+    using detector_type = detector_t;
 
     /// shorthad for a colleciton of surface data that can be read by a surface
     /// factory
-    // using surface_data_t = std::unique_ptr<
-    //     surface_data_interface<detector_t, mask_shape_t, volume_link_t>>;
     using surface_data_t = surface_data<detector_t>;
     using sf_data_collection = std::vector<surface_data_t>;
 
@@ -67,22 +55,22 @@ class surface_factory
     DETRAY_HOST
     surface_factory() = default;
 
-    /// @returns the id for the surface type the factory handles (e.g. portals)
-    DETRAY_HOST
-    auto surface_type() const -> surface_id override { return sf_id; }
-
     /// @returns the current number of surfaces that will be built by this
     /// factory
     DETRAY_HOST
     auto size() const -> dindex override {
         check();
-        return static_cast<dindex>(m_components.size());
+        return static_cast<dindex>(m_bounds.size());
     }
+
+    /// @returns the surface types
+    DETRAY_HOST
+    auto types() const -> const std::vector<surface_id> & { return m_types; }
 
     /// @returns the mask boundaries currently held by the factory
     DETRAY_HOST
-    auto components() const -> const std::vector<std::vector<scalar_t>> & {
-        return m_components;
+    auto bounds() const -> const std::vector<std::vector<scalar_t>> & {
+        return m_bounds;
     }
 
     /// @returns the transforms currently held by the factory
@@ -100,63 +88,43 @@ class surface_factory
     DETRAY_HOST
     void push_back(surface_data_t &&sf_data) override {
 
-        auto [vlink, bounds, trf, index] = sf_data.get_data();
+        auto [type, vlink, index, bounds, trf] = sf_data.get_data();
 
         assert(bounds.size() == mask_shape_t::boundaries::e_size);
 
-        if constexpr (sf_id != surface_id::e_portal) {
-            if (size() == 0u) {
-                *m_volume_link = vlink;
-            } else {
-                assert(*m_volume_link == vlink);
-            }
-        } else {
-            m_volume_link.push_back(vlink);
-        }
-
+        m_types.push_back(type);
+        m_volume_link.push_back(vlink);
         m_indices.push_back(index);
+        m_bounds.push_back(std::move(bounds));
         m_transforms.push_back(trf);
-        m_components.push_back(std::move(bounds));
     }
 
     /// Add all necessary compontents to the factory from bundled surface
     /// data in @param surface_data .
     DETRAY_HOST
-    auto push_back(sf_data_collection &&surface_data)
-        -> void /*std::shared_ptr<surface_factory<detector_t, mask_shape_t,
-                   mask_id, sf_id, volume_link_t>>*/
-        override {
+    auto push_back(sf_data_collection &&surface_data) -> void override {
         const auto n_surfaces{
             static_cast<dindex>(size() + surface_data.size())};
 
+        m_volume_link.reserve(n_surfaces);
         m_indices.reserve(n_surfaces);
+        m_bounds.reserve(n_surfaces);
         m_transforms.reserve(n_surfaces);
-        m_components.reserve(n_surfaces);
-
-        if constexpr (sf_id == surface_id::e_portal) {
-            m_volume_link.reserve(n_surfaces);
-        }
 
         // Get per-surface data into detector level container layout
         for (auto &sf_data : surface_data) {
             push_back(std::move(sf_data));
         }
-
-        // return smart_ptr_handler::shared_from_this();
     }
 
     /// Clear old data
     DETRAY_HOST
     auto clear() -> void override {
+        m_types.clear();
+        m_volume_link.clear();
         m_indices.clear();
-        m_components.clear();
+        m_bounds.clear();
         m_transforms.clear();
-        // cannot clear the single-view
-        if constexpr (sf_id == surface_id::e_portal) {
-            m_volume_link.clear();
-        } else {
-            *m_volume_link = volume_link_t{};
-        }
     }
 
     /// Generate the surfaces and add them to given data collections.
@@ -166,19 +134,18 @@ class surface_factory
     /// @param transforms the transforms of the surfaces.
     /// @param masks the masks of the surfaces (all of the same shape).
     /// @param ctx the geometry context.
+    ///
+    /// @returns index range of inserted surfaces in @param surfaces container
     DETRAY_HOST
-    auto operator()(typename detector_t::volume_type &volume,
+    auto operator()([[maybe_unused]] typename detector_t::volume_type &volume,
+                    [[maybe_unused]]
                     typename detector_t::surface_container_t &surfaces,
+                    [[maybe_unused]]
                     typename detector_t::transform_container &transforms,
-                    typename detector_t::mask_container &masks,
+                    [[maybe_unused]] typename detector_t::mask_container &masks,
+                    [[maybe_unused]]
                     typename detector_t::geometry_context ctx = {}) const
         -> dindex_range override {
-        using surface_t = typename detector_t::surface_type;
-        using mask_link_t = typename surface_t::mask_link;
-        using material_link_t = typename surface_t::material_link;
-
-        // The material will be added in a later step
-        constexpr auto no_material = surface_t::material_id::e_none;
         // In case the surfaces container is prefilled with other surfaces
         const dindex surfaces_offset = static_cast<dindex>(surfaces.size());
 
@@ -187,78 +154,91 @@ class surface_factory
             return {surfaces_offset, surfaces_offset};
         }
 
-        for (const auto [idx, comp] : detray::views::enumerate(m_components)) {
+        constexpr auto mask_id{detector_t::masks::template get_id<
+            mask<mask_shape_t, volume_link_t>>()};
 
-            // Append the surfaces relative to the current number of surfaces
-            // in the stores
-            const dindex sf_idx{is_invalid_value(m_indices[idx])
-                                    ? dindex_invalid
-                                    : m_indices[idx]};
+        if constexpr (static_cast<std::size_t>(mask_id) >=
+                      detector_t::masks::n_types) {
 
-            // Add transform
-            const dindex trf_idx =
-                insert_in_container(transforms, m_transforms[idx], sf_idx, ctx);
+            throw std::invalid_argument(
+                "ERROR: Cannot match shape type to mask ID: Found " +
+                mask_shape_t::name + " at mask id " +
+                std::to_string(static_cast<std::size_t>(mask_id)));
 
-            if constexpr (std::is_same_v<mask_shape_t, unmasked>) {
-                masks.template emplace_back<mask_id>(
-                    empty_context{}, m_volume_link[idx],
-                    std::numeric_limits<scalar_t>::infinity());
-            } else {
-                masks.template emplace_back<mask_id>(empty_context{}, comp,
-                                                     m_volume_link[idx]);
+        } else {
+
+            using surface_t = typename detector_t::surface_type;
+            using mask_link_t = typename surface_t::mask_link;
+            using material_link_t = typename surface_t::material_link;
+
+            // The material will be added in a later step
+            constexpr auto no_material{surface_t::material_id::e_none};
+
+            for (const auto [idx, bound] : detray::views::enumerate(m_bounds)) {
+
+                // Append the surfaces relative to the current number of
+                // surfaces in the stores
+                const dindex sf_idx{is_invalid_value(m_indices[idx])
+                                        ? dindex_invalid
+                                        : m_indices[idx]};
+
+                // Add transform
+                const dindex trf_idx = this->insert_in_container(
+                    transforms, m_transforms[idx], sf_idx, ctx);
+
+                // Masks are simply appended, since they are distributed onto
+                // multiple containers, their ordering is different from the
+                // surfaces
+                if constexpr (std::is_same_v<mask_shape_t, unmasked>) {
+                    masks.template emplace_back<mask_id>(
+                        empty_context{}, m_volume_link[idx],
+                        detail::invalid_value<scalar_t>());
+                } else {
+                    masks.template emplace_back<mask_id>(empty_context{}, bound,
+                                                         m_volume_link[idx]);
+                }
+
+                // Add surface with all links set (relative to the given
+                // containers)
+                mask_link_t mask_link{mask_id,
+                                      masks.template size<mask_id>() - 1u};
+                // If material is present, it is added in a later step
+                material_link_t material_link{no_material, dindex_invalid};
+
+                // Add the surface descriptor at the position given by 'sf_idx'
+                this->insert_in_container(
+                    surfaces,
+                    {trf_idx, mask_link, material_link, volume.index(),
+                     dindex_invalid, m_types[idx]},
+                    sf_idx);
             }
-
-            // Add surface with all links set (relative to the given containers)
-            mask_link_t mask_link{mask_id, masks.template size<mask_id>() - 1u};
-            material_link_t material_link{no_material, dindex_invalid};
-
-            insert_in_container(surfaces,
-                                {trf_idx, mask_link, material_link,
-                                 volume.index(), dindex_invalid, sf_id},
-                                sf_idx);
         }
 
         return {surfaces_offset, static_cast<dindex>(surfaces.size())};
     }
 
     private:
-    template <typename container_t, typename... Args>
-    DETRAY_HOST dindex insert_in_container(
-        container_t &cont, const typename container_t::value_type value,
-        const dindex idx, Args &&... args) const {
-        if (is_invalid_value(idx)) {
-            cont.push_back(value, std::forward<Args>(args)...);
-
-            return static_cast<dindex>(cont.size() - 1u);
-        } else {
-            if (cont.size() < idx + 1) {
-                cont.resize(idx + 1, std::forward<Args>(args)...);
-            }
-
-            cont.at(idx, std::forward<Args>(args)...) = value;
-
-            return idx;
-        }
-    }
-
-    /// Check that the containers have the same size
+    /// Run internal consistency check of surface data in the builder
     DETRAY_HOST
     void check() const {
         // This should not happend (need same number and ordering of data)
-        assert(m_components.size() == m_transforms.size());
-        assert(m_components.size() == m_indices.size());
-        if constexpr (sf_id == surface_id::e_portal) {
-            assert(m_components.size() == m_volume_link.size());
-        } else {
-            assert(m_volume_link.size() == 1);
-        }
+        assert(m_bounds.size() == m_types.size());
+        assert(m_bounds.size() == m_volume_link.size());
+        assert(m_bounds.size() == m_indices.size());
+        assert(m_bounds.size() == m_transforms.size());
     }
 
-    dindex_range m_range{dindex_invalid, dindex_invalid};
-    std::vector<dindex> m_indices{};
-    std::vector<std::vector<scalar_t>> m_components{};
-    std::vector<typename detector_t::transform3> m_transforms{};
+    /// Types of the surface (portal|sensitive|passive)
+    std::vector<surface_id> m_types{};
+    /// Mask volume link (used for navigation)
     volume_link_collection m_volume_link{};
+    /// Indices of surfaces for the placement in container
+    /// (counted as "volume-local": 0 to n_sf_in_volume)
+    std::vector<dindex> m_indices{};
+    /// Mask boundaries of surfaces
+    std::vector<std::vector<scalar_t>> m_bounds{};
+    /// Transforms of surfaces
+    std::vector<typename detector_t::transform3> m_transforms{};
 };
 
 }  // namespace detray

--- a/core/include/detray/tools/surface_factory_interface.hpp
+++ b/core/include/detray/tools/surface_factory_interface.hpp
@@ -30,25 +30,39 @@ class surface_data {
     public:
     using navigation_link = typename detector_t::surface_type::navigation_link;
 
+    /// Parametrized constructor
+    ///
+    /// @param type the surface type (portal|sensitive|passive)
+    /// @param trf the surface placement transformation
+    /// @param volume_link the mask volume link (used for navigation)
+    /// @param mask_boundaries define the extent of the surface
+    /// @param idx the index of the surface in the global detector lookup, needs
+    ///            to be passed only if a special ordering should be observed
     DETRAY_HOST
     surface_data(
-        const typename detector_t::transform3 &trf, navigation_link volume_link,
+        const surface_id type, const typename detector_t::transform3 &trf,
+        navigation_link volume_link,
         const std::vector<typename detector_t::scalar_type> &mask_boundaries,
         const dindex idx = dindex_invalid)
-        : m_volume_link{volume_link},
+        : m_type{type},
+          m_volume_link{volume_link},
           m_index{idx},
           m_boundaries{mask_boundaries},
           m_transform{trf} {}
 
+    /// Access the contained data through structured binding
     DETRAY_HOST
     auto get_data()
-        -> std::tuple<navigation_link &,
+        -> std::tuple<surface_id &, navigation_link &, dindex &,
                       std::vector<typename detector_t::scalar_type> &,
-                      typename detector_t::transform3 &, dindex &> {
-        return std::tie(m_volume_link, m_boundaries, m_transform, m_index);
+                      typename detector_t::transform3 &> {
+        return std::tie(m_type, m_volume_link, m_index, m_boundaries,
+                        m_transform);
     }
 
     private:
+    /// Surface type
+    surface_id m_type;
     /// The index of the volume that this surface links to
     navigation_link m_volume_link;
     /// The position of the surface in the detector containers, used to match
@@ -77,11 +91,6 @@ class surface_factory_interface {
     DETRAY_HOST
     virtual dindex size() const = 0;
 
-    /// @returns a surface id that corresponds to the surface type
-    /// i.e. portal/sensisitve/passive
-    DETRAY_HOST
-    virtual surface_id surface_type() const = 0;
-
     /// Add data to the factory
     /// @{
     DETRAY_HOST
@@ -105,6 +114,36 @@ class surface_factory_interface {
         typename detector_t::mask_container &masks,
         typename detector_t::geometry_context ctx = {}) const
         -> dindex_range = 0;
+
+    protected:
+    /// Insert a value in a container at a specific index
+    ///
+    /// @param cont the container to be filled
+    /// @param value the value to be put into the container
+    /// @param idx the position where to insert the value
+    /// @param args optional additional parameters for the container access
+    ///
+    /// @returns the position where the value has been copied.
+    template <typename container_t, typename... Args>
+    DETRAY_HOST dindex insert_in_container(
+        container_t &cont, const typename container_t::value_type value,
+        const dindex idx, Args &&... args) const {
+        // If no valid position is given, perform push back
+        if (is_invalid_value(idx)) {
+            cont.push_back(value, std::forward<Args>(args)...);
+
+            return static_cast<dindex>(cont.size() - 1u);
+        } else {
+            // Make sure the container size encompasses the new value
+            if (cont.size() < idx + 1) {
+                cont.resize(idx + 1, std::forward<Args>(args)...);
+            }
+
+            cont.at(idx, std::forward<Args>(args)...) = value;
+
+            return idx;
+        }
+    }
 };
 
 /// @brief Decorator for the surface factories.
@@ -123,11 +162,6 @@ class factory_decorator : public surface_factory_interface<detector_t> {
     /// @{
     DETRAY_HOST
     dindex size() const override { return m_factory->size(); }
-
-    DETRAY_HOST
-    surface_id surface_type() const override {
-        return m_factory->surface_type();
-    }
 
     DETRAY_HOST
     void push_back(surface_data<detector_t> &&data) override {

--- a/core/include/detray/tools/volume_builder.hpp
+++ b/core/include/detray/tools/volume_builder.hpp
@@ -36,43 +36,58 @@ class volume_builder : public volume_builder_interface<detector_t> {
     using volume_type = typename detector_t::volume_type;
     using geo_obj_ids = typename detector_t::geo_obj_ids;
 
+    /// Parametrized Constructor
+    ///
+    /// @param id flags the type of volume geometry (e.g. cylindrical, cuboid)
+    /// @param idx the index of the volume in the detector volume container
     volume_builder(const volume_id id, const dindex idx = dindex_invalid)
         : m_volume{id} {
         m_volume.set_index(idx);
+        // The first surface search data structure in every volume is a brute
+        // force method that will at least contain the portals
         m_volume
             .template set_link<static_cast<typename volume_type::object_id>(0)>(
                 detector_t::sf_finders::id::e_default, 0);
     };
 
-    /// Adds the @param name of the volume to a name map
+    /// Adds the @param name of the volume to a @param name_map
     template <typename name_map>
     DETRAY_HOST void add_name(const name_map& names, std::string&& name) {
         names.at(vol_index()) = std::move(name);
     }
 
+    /// @returns the volume index in the detector volume container
     DETRAY_HOST
     auto vol_index() -> dindex override { return m_volume.index(); }
 
+    /// Access to the volume under construction - const
     DETRAY_HOST
     auto operator()() const -> const
         typename detector_t::volume_type& override {
         return m_volume;
     }
+
+    /// Access to the volume under construction - non-const
     DETRAY_HOST
     auto operator()() -> typename detector_t::volume_type& override {
         return m_volume;
     }
 
+    /// Build the volume with internal surfaces and portals and add it to the
+    /// detector instance @param det
     DETRAY_HOST
     auto build(detector_t& det, typename detector_t::geometry_context ctx = {})
         -> typename detector_t::volume_type* override {
+        // Prepare volume data
         m_volume.set_index(static_cast<dindex>(det.volumes().size()));
 
         m_volume.set_transform(det.transform_store().size());
         det.transform_store().push_back(m_trf);
 
-        add_objects_per_volume(ctx, det);
+        // Add all data from the builder to the detector containers
+        add_to_detector(ctx, det);
 
+        // Reset after the data was added to the detector
         m_surfaces.clear();
         m_transforms.clear(ctx);
         m_masks.clear_all();
@@ -81,17 +96,22 @@ class volume_builder : public volume_builder_interface<detector_t> {
         return &(det.volumes().back());
     }
 
+    /// Adds a placement transform @param trf for the volume
     DETRAY_HOST
     void add_volume_placement(
         const typename detector_t::transform3& trf = {}) override {
         m_trf = trf;
     }
 
+    /// Constructs a placement transform with identity rotation and translation
+    /// @param t for the volume
     DETRAY_HOST
     void add_volume_placement(const typename detector_t::point3& t) override {
         m_trf = typename detector_t::transform3{t};
     }
 
+    /// Constructs a placement transform from axes @param x and @param z
+    /// and the translation @param t for the volume
     DETRAY_HOST
     void add_volume_placement(const typename detector_t::point3& t,
                               const typename detector_t::vector3& x,
@@ -99,45 +119,37 @@ class volume_builder : public volume_builder_interface<detector_t> {
         m_trf = typename detector_t::transform3{t, z, x, true};
     }
 
+    /// Add data for (a) new surface(s) to the builder
     DETRAY_HOST
-    void add_portals(
-        std::shared_ptr<surface_factory_interface<detector_t>> pt_factory,
-        typename detector_t::geometry_context ctx = {}) override {
-        (*pt_factory)(m_volume, m_surfaces, m_transforms, m_masks, ctx);
-    }
-
-    DETRAY_HOST
-    void add_sensitives(
+    void add_surfaces(
         std::shared_ptr<surface_factory_interface<detector_t>> sf_factory,
         typename detector_t::geometry_context ctx = {}) override {
         (*sf_factory)(m_volume, m_surfaces, m_transforms, m_masks, ctx);
     }
 
-    DETRAY_HOST
-    void add_passives(
-        std::shared_ptr<surface_factory_interface<detector_t>> ps_factory,
-        typename detector_t::geometry_context ctx = {}) override {
-        (*ps_factory)(m_volume, m_surfaces, m_transforms, m_masks, ctx);
-    }
-
     protected:
+    /// @returns Access to the surface descriptor data
     typename detector_t::surface_container_t& surfaces() override {
         return m_surfaces;
     }
+
+    /// @returns Access to the surface/volume transform data
     typename detector_t::transform_container& transforms() override {
         return m_transforms;
     }
+
+    /// @returns Access to the surface mask data
     typename detector_t::mask_container& masks() override { return m_masks; }
 
-    /// Add a new full set of detector components (e.g. transforms or volumes)
-    /// according to given geometry_context.
+    /// Adds a new full set of volume components (e.g. transforms or masks)
+    /// to the global detector data stores and updates all links.
     ///
     /// @param ctx is the geometry_context of the call
     /// @param det is the detector instance that the volume should be added to
     ///
     /// @note can throw an exception if input data is inconsistent
     template <geo_obj_ids surface_id = static_cast<geo_obj_ids>(0)>
-    DETRAY_HOST auto add_objects_per_volume(
+    DETRAY_HOST auto add_to_detector(
         const typename detector_t::geometry_context ctx,
         detector_t& det) noexcept(false) -> void {
 
@@ -145,8 +157,8 @@ class volume_builder : public volume_builder_interface<detector_t> {
         const auto trf_offset = det.transform_store().size(ctx);
         det.append_transforms(std::move(m_transforms), ctx);
 
-        // Update mask and transform index of surfaces and set a
-        // unique barcode (index of surface in container)
+        // Update mask and transform index of surfaces and set the
+        // correct index of the surface in container
         auto sf_offset{static_cast<dindex>(det.surface_lookup().size())};
         for (auto& sf_desc : m_surfaces) {
             const auto sf = surface{det, sf_desc};
@@ -176,12 +188,17 @@ class volume_builder : public volume_builder_interface<detector_t> {
         det.volumes().push_back(m_volume);
     }
 
+    /// Volume descriptor of the volume under construction
     typename detector_t::volume_type m_volume{};
+    /// Placement of the volume under construction
     typename detector_t::transform3 m_trf{};
 
+    /// Data of conatined surfaces
+    /// @{
     typename detector_t::surface_container_t m_surfaces{};
     typename detector_t::transform_container m_transforms{};
     typename detector_t::mask_container m_masks{};
+    /// @}
 };
 
 namespace detail {

--- a/core/include/detray/tools/volume_builder_interface.hpp
+++ b/core/include/detray/tools/volume_builder_interface.hpp
@@ -71,28 +71,12 @@ class volume_builder_interface {
         const typename detector_t::vector3 &x,
         const typename detector_t::vector3 &z) = 0;
 
-    /// @brief Add the portals to the volume.
-    /// @returns the index range of the portals in the temporary surface
-    /// container used by the factory ( gets final update in @c build() )
-    DETRAY_HOST
-    virtual void add_portals(
-        std::shared_ptr<surface_factory_interface<detector_t>> pt_factory,
-        typename detector_t::geometry_context ctx = {}) = 0;
-
-    /// @brief Add sensitive surfaces to the volume, if any
+    /// @brief Add surfaces to the volume
     /// @returns the index range of the sensitives in the temporary surface
     /// container used by the factory ( gets final update in @c build() )
     DETRAY_HOST
-    virtual void add_sensitives(
+    virtual void add_surfaces(
         std::shared_ptr<surface_factory_interface<detector_t>> sf_factory,
-        typename detector_t::geometry_context ctx = {}) = 0;
-
-    /// @brief Add passive surfaces to the volume, if any
-    /// @returns the index range of the passives in the temporary surface
-    /// container used by the factory ( gets final update in @c build() )
-    DETRAY_HOST
-    virtual void add_passives(
-        std::shared_ptr<surface_factory_interface<detector_t>> ps_factory,
         typename detector_t::geometry_context ctx = {}) = 0;
 
     protected:
@@ -161,24 +145,10 @@ class volume_decorator : public volume_builder_interface<detector_t> {
     }
 
     DETRAY_HOST
-    void add_portals(
-        std::shared_ptr<surface_factory_interface<detector_t>> pt_factory,
-        typename detector_t::geometry_context ctx = {}) override {
-        return m_builder->add_portals(std::move(pt_factory), ctx);
-    }
-
-    DETRAY_HOST
-    void add_sensitives(
+    void add_surfaces(
         std::shared_ptr<surface_factory_interface<detector_t>> sf_factory,
         typename detector_t::geometry_context ctx = {}) override {
-        return m_builder->add_sensitives(std::move(sf_factory), ctx);
-    }
-
-    DETRAY_HOST
-    void add_passives(
-        std::shared_ptr<surface_factory_interface<detector_t>> ps_factory,
-        typename detector_t::geometry_context ctx = {}) override {
-        return m_builder->add_passives(std::move(ps_factory), ctx);
+        return m_builder->add_surfaces(std::move(sf_factory), ctx);
     }
     /// @}
 

--- a/core/include/detray/utils/type_registry.hpp
+++ b/core/include/detray/utils/type_registry.hpp
@@ -38,8 +38,7 @@ class type_registry {
     /// Get the index for a type. Needs to be unrolled in case of thrust tuple.
     template <typename object_t>
     DETRAY_HOST_DEVICE static constexpr ID get_id() {
-        return unroll_ids<std::remove_reference_t<object_t>,
-                          registered_types...>();
+        return unroll_ids<std::decay_t<object_t>, registered_types...>();
     }
 
     /// Get the index for a type. Use template parameter deduction.

--- a/io/include/detray/io/common/detail/utils.hpp
+++ b/io/include/detray/io/common/detail/utils.hpp
@@ -44,6 +44,6 @@ inline std::string get_detray_version() {
     return "detray - " + std::string(detray::version);
 }
 
-inline static const std::string minimal_io_version{"detray - 0.35.0"};
+inline static const std::string minimal_io_version{"detray - 0.43.0"};
 
 }  // namespace detray::detail

--- a/io/include/detray/io/common/detector_writer.hpp
+++ b/io/include/detray/io/common/detector_writer.hpp
@@ -70,11 +70,11 @@ struct detector_writer_config {
 
 namespace detail {
 
-/// From the detector type @tparam detector_t, inferr the writers that are
-/// needed
+/// From the detector type @tparam detector_t, infer the writers that are needed
 template <class detector_t>
 detail::detector_component_writers<detector_t> assemble_writer(
     const io::detector_writer_config& cfg) {
+
     detail::detector_component_writers<detector_t> writers;
 
     if (cfg.format() == io::format::json) {
@@ -118,6 +118,7 @@ void write_detector(detector_t& det, const typename detector_t::name_map& names,
 
     // Get the writer
     auto writer = detray::detail::assemble_writer<detector_t>(cfg);
+
     writer.write(det, names, mode);
 }
 

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -26,16 +26,11 @@
 
 namespace std {
 
-// Specialize std::hash so this pair can be used as key in e.g. a map
+// Specialize std::hash directly to the shape id type
 template <>
-struct hash<std::pair<detray::surface_id, detray::io::detail::mask_shape>> {
-    auto operator()(
-        std::pair<detray::surface_id, detray::io::detail::mask_shape> p)
-        const noexcept {
-        // Calculate a hash from both numbers and avoid collisions
-        return std::hash<std::size_t>()(static_cast<std::size_t>(p.first)) +
-               1000u *
-                   std::hash<std::size_t>()(static_cast<std::size_t>(p.second));
+struct hash<detray::io::detail::mask_shape> {
+    auto operator()(detray::io::detail::mask_shape m) const noexcept {
+        return std::hash<std::size_t>()(static_cast<std::size_t>(m));
     }
 };
 
@@ -89,45 +84,40 @@ class geometry_reader : public reader_interface<detector_t> {
             vbuilder->add_volume_placement(deserialize(vol_data.transform));
 
             // Prepare the surface factories (one per shape and surface type)
-            std::map<std::pair<surface_id, mask_shape>, sf_factory_ptr_t>
-                sf_factories;
+            std::map<mask_shape, sf_factory_ptr_t> pt_factories, sf_factories;
 
             // Add the surfaces to the factories
             for (const auto& sf_data : vol_data.surfaces) {
 
                 const mask_payload& mask_data = sf_data.mask;
 
+                // Get a reference to the correct factory colleciton
+                auto& factories{sf_data.type == surface_id::e_portal
+                                    ? pt_factories
+                                    : sf_factories};
+
                 // Check if a fitting factory already exists. If not, add it
                 // dynamically
-                const auto key = std::make_pair(sf_data.type, mask_data.shape);
-                if (auto search = sf_factories.find(key);
-                    search == sf_factories.end()) {
-                    sf_factories[key] =
+                const auto key{mask_data.shape};
+                if (auto search = factories.find(key);
+                    search == factories.end()) {
+                    factories[key] =
                         std::move(init_factory<mask_shape::n_shapes>(
                             mask_data.shape, sf_data.type));
                 }
 
                 // Add the data to the factory
-                sf_factories.at(key)->push_back(deserialize(sf_data));
+                factories.at(key)->push_back(deserialize(sf_data));
             }
 
-            // Add the surfaces to the volume
+            // Add the portals to the volume first
             typename detector_t::geometry_context geo_ctx{};
-            for (auto [key, sf_factory_ptr] : sf_factories) {
-                // Sort the surfaces into the volume builder by type
-                switch (sf_factory_ptr->surface_type()) {
-                    case surface_id::e_portal:
-                        vbuilder->add_portals(sf_factory_ptr, geo_ctx);
-                        break;
-                    case surface_id::e_sensitive:
-                        vbuilder->add_sensitives(sf_factory_ptr, geo_ctx);
-                        break;
-                    case surface_id::e_passive:
-                        vbuilder->add_passives(sf_factory_ptr, geo_ctx);
-                        break;
-                    case surface_id::e_unknown:
-                        break;
-                };
+            for (auto [key, pt_factory] : pt_factories) {
+                vbuilder->add_surfaces(pt_factory, geo_ctx);
+            }
+            // Add all other surfaces next
+            for (auto [key, sf_factory] : sf_factories) {
+                vbuilder->add_surfaces(sf_factory, geo_ctx);
             }
         }
 
@@ -174,7 +164,7 @@ class geometry_reader : public reader_interface<detector_t> {
                                      ? *(sf_data.index_in_coll)
                                      : detail::invalid_value<std::size_t>()};
 
-        return {deserialize(sf_data.transform),
+        return {sf_data.type, deserialize(sf_data.transform),
                 static_cast<nav_link_t>(
                     base_type::deserialize(sf_data.mask.volume_link)),
                 std::move(mask_boundaries), static_cast<dindex>(sf_idx)};
@@ -194,31 +184,10 @@ class geometry_reader : public reader_interface<detector_t> {
             // detector
             using mask_info_t = mask_info<I>;
             using shape_t = typename mask_info_t::type;
-            [[maybe_unused]] constexpr auto mask_id{mask_info_t::value};
 
             // Test wether this shape exists in detector
             if constexpr (not std::is_same_v<shape_t, void>) {
-                // Get the correct factory for the type of surface
-                switch (sf_type) {
-                    case surface_id::e_portal:
-                        using pt_factory_t =
-                            surface_factory<detector_t, shape_t, mask_id,
-                                            surface_id::e_portal>;
-                        return std::make_shared<pt_factory_t>();
-                    case surface_id::e_sensitive:
-                        using sf_factory_t =
-                            surface_factory<detector_t, shape_t, mask_id,
-                                            surface_id::e_sensitive>;
-                        return std::make_shared<sf_factory_t>();
-                    case surface_id::e_passive:
-                        using ps_factory_t =
-                            surface_factory<detector_t, shape_t, mask_id,
-                                            surface_id::e_passive>;
-                        return std::make_shared<ps_factory_t>();
-                    case surface_id::e_unknown:
-                        throw std::invalid_argument(
-                            "Unknown surface type in geometry file");
-                };
+                return std::make_shared<surface_factory<detector_t, shape_t>>();
             }
         }
         // Test next shape id

--- a/io/include/detray/io/common/payloads.hpp
+++ b/io/include/detray/io/common/payloads.hpp
@@ -128,9 +128,11 @@ struct material_payload {
 
 /// @brief A payload object for a material slab/rod
 struct material_slab_payload {
-    using type = io::detail::material_type;
+    using mat_type = io::detail::material_type;
 
-    material_link_payload mat_link{};
+    mat_type type{mat_type::unknown};
+    std::optional<std::size_t> index_in_coll;
+    single_link_payload surface{};
     real_io thickness{std::numeric_limits<real_io>::max()};
     material_payload mat{};
 };

--- a/io/include/detray/io/json/json_material_io.hpp
+++ b/io/include/detray/io/json/json_material_io.hpp
@@ -52,16 +52,24 @@ inline void from_json(const nlohmann::ordered_json& j, material_payload& m) {
 }
 
 inline void to_json(nlohmann::ordered_json& j, const material_slab_payload& m) {
-    j["mat_link"] = m.mat_link;
+    j["type"] = m.type;
+    j["surface_idx"] = m.surface;
     j["thickness"] = m.thickness;
     j["material"] = m.mat;
+    if (m.index_in_coll.has_value()) {
+        j["index_in_coll"] = m.index_in_coll.value();
+    }
 }
 
 inline void from_json(const nlohmann::ordered_json& j,
                       material_slab_payload& m) {
-    m.mat_link = j["mat_link"];
+    m.type = j["type"];
+    m.surface = j["surface_idx"];
     m.thickness = j["thickness"];
     m.mat = j["material"];
+    if (j.find("index_in_coll") != j.end()) {
+        m.index_in_coll = j["index_in_coll"];
+    }
 }
 
 inline void to_json(nlohmann::ordered_json& j,
@@ -95,7 +103,7 @@ inline void from_json(const nlohmann::ordered_json& j,
         }
     }
     if (j.find("material_rods") != j.end()) {
-        mv.mat_rods = {};
+        mv.mat_rods.emplace();
         for (auto jmats : j["material_rods"]) {
             material_slab_payload mslp = jmats;
             mv.mat_rods->push_back(mslp);

--- a/io/include/detray/io/json/json_reader.hpp
+++ b/io/include/detray/io/json/json_reader.hpp
@@ -78,10 +78,12 @@ class json_reader final : public common_reader_t<detector_t, Args...> {
         // Read json from file
         io::detail::file_handle file{file_name,
                                      std::ios_base::in | std::ios_base::binary};
+
+        // Reads the data from file and returns the corresponding io payloads
         nlohmann::json in_json;
         *file >> in_json;
 
-        // Reads the data from file and returns the corresponding io payloads
+        // Add the data from the payload to the detray detector builder
         base_reader::deserialize(det_builder, name_map, in_json["data"]);
     }
 };

--- a/tests/unit_tests/cpu/core_detector.cpp
+++ b/tests/unit_tests/cpu/core_detector.cpp
@@ -205,25 +205,27 @@ GTEST_TEST(detray_tools, surface_factory) {
 
     using detector_t = detector<>;
     using transform3 = typename detector_t::transform3;
-    using mask_id = typename detector_t::masks::id;
 
     //
     // check portal cylinder
     //
     using portal_cylinder_factory =
-        surface_factory<detector_t, typename default_metadata::cylinder_portal,
-                        mask_id::e_portal_cylinder2, surface_id::e_portal>;
+        surface_factory<detector_t,
+                        typename default_metadata::cylinder_portal::shape>;
 
     auto pt_cyl_factory = std::make_shared<portal_cylinder_factory>();
 
     typename portal_cylinder_factory::sf_data_collection cyl_sf_data;
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, -1000.f}), 0u,
+    cyl_sf_data.emplace_back(surface_id::e_portal,
+                             transform3(point3{0.f, 0.f, -1000.f}), 0u,
                              std::vector<scalar>{10.f, -1000.f, 1500.f});
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, 1000.f}), 2u,
+    cyl_sf_data.emplace_back(surface_id::e_portal,
+                             transform3(point3{0.f, 0.f, 1000.f}), 2u,
                              std::vector<scalar>{20.f, -1500.f, 1000.f});
 
     EXPECT_EQ(pt_cyl_factory->size(), 0u);
-    EXPECT_TRUE(pt_cyl_factory->components().empty());
+    EXPECT_TRUE(pt_cyl_factory->types().empty());
+    EXPECT_TRUE(pt_cyl_factory->bounds().empty());
     EXPECT_TRUE(pt_cyl_factory->transforms().empty());
     EXPECT_TRUE(pt_cyl_factory->volume_links().empty());
 
@@ -232,10 +234,11 @@ GTEST_TEST(detray_tools, surface_factory) {
     cyl_sf_data.clear();
 
     EXPECT_EQ(pt_cyl_factory->size(), 2u);
-    EXPECT_EQ(pt_cyl_factory->components().size(), 2u);
+    EXPECT_EQ(pt_cyl_factory->types().size(), 2u);
+    EXPECT_EQ(pt_cyl_factory->bounds().size(), 2u);
     EXPECT_EQ(pt_cyl_factory->transforms().size(), 2u);
     EXPECT_EQ(pt_cyl_factory->volume_links().size(), 2u);
-    const auto& portal_cyl_comps = pt_cyl_factory->components().front();
+    const auto& portal_cyl_comps = pt_cyl_factory->bounds().front();
     EXPECT_NEAR(portal_cyl_comps[0], 10.f, tol);
     EXPECT_NEAR(portal_cyl_comps[1], -1000.f, tol);
     EXPECT_NEAR(portal_cyl_comps[2], 1500.f, tol);
@@ -247,89 +250,62 @@ GTEST_TEST(detray_tools, surface_factory) {
     // check sensitive cylinder
     //
     using sensitive_cylinder_factory =
-        surface_factory<detector_t, cylinder2D<>, mask_id::e_cylinder2,
-                        surface_id::e_sensitive>;
+        surface_factory<detector_t, cylinder2D<>>;
 
-    auto sens_cyl_factory = std::make_shared<sensitive_cylinder_factory>();
+    auto cyl_factory = std::make_shared<sensitive_cylinder_factory>();
 
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, -50.f}), 1u,
+    cyl_sf_data.emplace_back(surface_id::e_sensitive,
+                             transform3(point3{0.f, 0.f, -50.f}), 1u,
                              std::vector<scalar>{5.f, -900.f, 900.f});
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, 50.f}), 1u,
+    cyl_sf_data.emplace_back(surface_id::e_sensitive,
+                             transform3(point3{0.f, 0.f, 50.f}), 1u,
                              std::vector<scalar>{5.f, -900.f, 900.f});
 
-    EXPECT_EQ(sens_cyl_factory->size(), 0u);
-    EXPECT_TRUE(sens_cyl_factory->components().empty());
-    EXPECT_TRUE(sens_cyl_factory->transforms().empty());
-    // The single view is never empty, only uninitialized
-    EXPECT_FALSE(sens_cyl_factory->volume_links().empty());
+    cyl_sf_data.emplace_back(surface_id::e_passive,
+                             transform3(point3{0.f, 0.f, -20.f}), 1u,
+                             std::vector<scalar>{4.9f, -900.f, 900.f});
+    cyl_sf_data.emplace_back(surface_id::e_passive,
+                             transform3(point3{0.f, 0.f, 20.f}), 1u,
+                             std::vector<scalar>{4.9f, -900.f, 900.f});
 
-    sens_cyl_factory->push_back(std::move(cyl_sf_data));
+    EXPECT_EQ(cyl_factory->size(), 0u);
+    EXPECT_TRUE(cyl_factory->types().empty());
+    EXPECT_TRUE(cyl_factory->bounds().empty());
+    EXPECT_TRUE(cyl_factory->transforms().empty());
+    EXPECT_TRUE(cyl_factory->volume_links().empty());
+
+    cyl_factory->push_back(std::move(cyl_sf_data));
     cyl_sf_data.clear();
 
-    EXPECT_EQ(sens_cyl_factory->size(), 2u);
-    EXPECT_EQ(sens_cyl_factory->components().size(), 2u);
-    EXPECT_EQ(sens_cyl_factory->transforms().size(), 2u);
-    EXPECT_EQ(sens_cyl_factory->volume_links().size(), 1u);
-    const auto& sens_cyl_comps = sens_cyl_factory->components().front();
+    EXPECT_EQ(cyl_factory->size(), 4u);
+    EXPECT_EQ(cyl_factory->types().size(), 4u);
+    EXPECT_EQ(cyl_factory->bounds().size(), 4u);
+    EXPECT_EQ(cyl_factory->transforms().size(), 4u);
+    EXPECT_EQ(cyl_factory->volume_links().size(), 4u);
+    const auto& sens_cyl_comps = cyl_factory->bounds().front();
     EXPECT_NEAR(sens_cyl_comps[0], 5.f, tol);
     EXPECT_NEAR(sens_cyl_comps[1], -900.f, tol);
     EXPECT_NEAR(sens_cyl_comps[2], 900.f, tol);
-    const auto& sens_cyl_vol_links = sens_cyl_factory->volume_links();
+    const auto& sens_cyl_vol_links = cyl_factory->volume_links();
     EXPECT_EQ(sens_cyl_vol_links[0], 1u);
-
-    //
-    // check passive cylinder
-    //
-    using passive_cylinder_factory =
-        surface_factory<detector_t, cylinder2D<>, mask_id::e_cylinder2,
-                        surface_id::e_passive>;
-
-    auto psv_cyl_factory = std::make_shared<passive_cylinder_factory>();
-
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, -20.f}), 1u,
-                             std::vector<scalar>{4.9f, -900.f, 900.f});
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, 20.f}), 1u,
-                             std::vector<scalar>{4.9f, -900.f, 900.f});
-
-    EXPECT_EQ(psv_cyl_factory->size(), 0u);
-    EXPECT_TRUE(psv_cyl_factory->components().empty());
-    EXPECT_TRUE(psv_cyl_factory->transforms().empty());
-    // The single view is never empty, only uninitialized
-    EXPECT_FALSE(psv_cyl_factory->volume_links().empty());
-
-    psv_cyl_factory->push_back(std::move(cyl_sf_data));
-    cyl_sf_data.clear();
-
-    EXPECT_EQ(psv_cyl_factory->size(), 2u);
-    EXPECT_EQ(psv_cyl_factory->components().size(), 2u);
-    EXPECT_EQ(psv_cyl_factory->transforms().size(), 2u);
-    EXPECT_EQ(psv_cyl_factory->volume_links().size(), 1u);
-    const auto& psv_cyl_comps = psv_cyl_factory->components().front();
-    EXPECT_NEAR(psv_cyl_comps[0], 4.9f, tol);
-    EXPECT_NEAR(psv_cyl_comps[1], -900.f, tol);
-    EXPECT_NEAR(psv_cyl_comps[2], 900.f, tol);
-    const auto& psv_cyl_vol_links = psv_cyl_factory->volume_links();
-    EXPECT_EQ(psv_cyl_vol_links[0], 1u);
 
     //
     // check the other mask types for this detector
     //
 
     // annulus
-    using annulus_factory =
-        surface_factory<detector_t, annulus2D<>, mask_id::e_annulus2,
-                        surface_id::e_sensitive>;
+    using annulus_factory = surface_factory<detector_t, annulus2D<>>;
 
     auto ann_factory = std::make_shared<annulus_factory>();
 
     typename annulus_factory::sf_data_collection ann_sf_data;
     ann_sf_data.emplace_back(
-        transform3(point3{0.f, 0.f, 0.f}), 1u,
+        surface_id::e_sensitive, transform3(point3{0.f, 0.f, 0.f}), 1u,
         std::vector<scalar>{300.f, 350.f, -0.1f, 0.1f, 0.5f, 0.6f, 1.4f});
     ann_factory->push_back(std::move(ann_sf_data));
     ann_sf_data.clear();
 
-    const auto& ann_comps = ann_factory->components().front();
+    const auto& ann_comps = ann_factory->bounds().front();
     EXPECT_NEAR(ann_comps[0], 300.f, tol);
     EXPECT_NEAR(ann_comps[1], 350.f, tol);
     EXPECT_NEAR(ann_comps[2], -0.1f, tol);
@@ -339,52 +315,50 @@ GTEST_TEST(detray_tools, surface_factory) {
     EXPECT_NEAR(ann_comps[6], 1.4f, tol);
 
     // rectangles
-    using rectangle_factory =
-        surface_factory<detector_t, rectangle2D<>, mask_id::e_rectangle2,
-                        surface_id::e_sensitive>;
+    using rectangle_factory = surface_factory<detector_t, rectangle2D<>>;
 
     auto rect_factory = std::make_shared<rectangle_factory>();
 
     typename rectangle_factory::sf_data_collection rect_sf_data;
-    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, 0.f}), 1u,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, 0.f}), 1u,
                               std::vector<scalar>{10.f, 8.f});
     rect_factory->push_back(std::move(rect_sf_data));
     rect_sf_data.clear();
 
-    const auto& rectgl_comps = rect_factory->components().front();
+    const auto& rectgl_comps = rect_factory->bounds().front();
     EXPECT_NEAR(rectgl_comps[0], 10.f, tol);
     EXPECT_NEAR(rectgl_comps[1], 8.f, tol);
 
     // ring
-    using ring_factory = surface_factory<detector_t, ring2D<>, mask_id::e_ring2,
-                                         surface_id::e_passive>;
+    using disc_factory = surface_factory<detector_t, ring2D<>>;
 
-    auto rng_factory = std::make_shared<ring_factory>();
+    auto sf_disc_factory = std::make_shared<disc_factory>();
 
-    typename ring_factory::sf_data_collection ring_sf_data;
-    ring_sf_data.emplace_back(transform3(point3{0.f, 0.f, 0.f}), 1u,
+    typename disc_factory::sf_data_collection disc_sf_data;
+    disc_sf_data.emplace_back(surface_id::e_passive,
+                              transform3(point3{0.f, 0.f, 0.f}), 1u,
                               std::vector<scalar>{0.f, 5.f});
-    rng_factory->push_back(std::move(ring_sf_data));
-    ring_sf_data.clear();
+    sf_disc_factory->push_back(std::move(disc_sf_data));
+    disc_sf_data.clear();
 
-    const auto& ring_comps = rng_factory->components().front();
+    const auto& ring_comps = sf_disc_factory->bounds().front();
     EXPECT_NEAR(ring_comps[0], 0.f, tol);
     EXPECT_NEAR(ring_comps[1], 5.f, tol);
 
     // trapezoid
-    using trapezoid_factory =
-        surface_factory<detector_t, trapezoid2D<>, mask_id::e_trapezoid2,
-                        surface_id::e_sensitive>;
+    using trapezoid_factory = surface_factory<detector_t, trapezoid2D<>>;
 
     auto trpz_factory = std::make_shared<trapezoid_factory>();
 
     typename trapezoid_factory::sf_data_collection trpz_sf_data;
-    trpz_sf_data.emplace_back(transform3(point3{0.f, 0.f, 0.f}), 1u,
+    trpz_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, 0.f}), 1u,
                               std::vector<scalar>{1.f, 3.f, 2.f, 0.25f});
     trpz_factory->push_back(std::move(trpz_sf_data));
     trpz_sf_data.clear();
 
-    const auto& trpz_comps = trpz_factory->components().front();
+    const auto& trpz_comps = trpz_factory->bounds().front();
     EXPECT_NEAR(trpz_comps[0], 1.f, tol);
     EXPECT_NEAR(trpz_comps[1], 3.f, tol);
     EXPECT_NEAR(trpz_comps[2], 2.f, tol);
@@ -426,29 +400,15 @@ GTEST_TEST(detray_tools, detector_volume_construction) {
     using mask_id = typename detector_t::masks::id;
     using sf_finder_id = typename detector_t::sf_finders::id;
 
-    // portal factories
+    // Surface factories
     using portal_cylinder_factory =
-        surface_factory<detector_t, typename default_metadata::cylinder_portal,
-                        mask_id::e_portal_cylinder2, surface_id::e_portal>;
-    using portal_disc_factory =
-        surface_factory<detector_t, ring2D<>, mask_id::e_portal_ring2,
-                        surface_id::e_portal>;
-
-    // sensitive/passive surface factories
-    using annulus_factory =
-        surface_factory<detector_t, annulus2D<>, mask_id::e_annulus2,
-                        surface_id::e_sensitive>;
-    using cylinder_factory =
-        surface_factory<detector_t, cylinder2D<>, mask_id::e_cylinder2,
-                        surface_id::e_passive>;
-    using rectangle_factory =
-        surface_factory<detector_t, rectangle2D<>, mask_id::e_rectangle2,
-                        surface_id::e_sensitive>;
-    using ring_factory = surface_factory<detector_t, ring2D<>, mask_id::e_ring2,
-                                         surface_id::e_passive>;
-    using trapezoid_factory =
-        surface_factory<detector_t, trapezoid2D<>, mask_id::e_trapezoid2,
-                        surface_id::e_sensitive>;
+        surface_factory<detector_t,
+                        typename default_metadata::cylinder_portal::shape>;
+    using annulus_factory = surface_factory<detector_t, annulus2D<>>;
+    using cylinder_factory = surface_factory<detector_t, cylinder2D<>>;
+    using rectangle_factory = surface_factory<detector_t, rectangle2D<>>;
+    using disc_factory = surface_factory<detector_t, ring2D<>>;
+    using trapezoid_factory = surface_factory<detector_t, trapezoid2D<>>;
 
     // detector
     vecmem::host_memory_resource host_mr;
@@ -479,90 +439,104 @@ GTEST_TEST(detray_tools, detector_volume_construction) {
     typename portal_cylinder_factory::sf_data_collection cyl_sf_data;
     // Creates two cylinders at radius 0mm and 10mm with an extent in z
     // of -5mm to 5mm and linking to volumes 0 and 2, respectively.
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, 0.f}), 0u,
+    cyl_sf_data.emplace_back(surface_id::e_portal,
+                             transform3(point3{0.f, 0.f, 0.f}), 0u,
                              std::vector<scalar>{10.f, -1500.f, 1500.f});
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, 0.f}), 2u,
+    cyl_sf_data.emplace_back(surface_id::e_portal,
+                             transform3(point3{0.f, 0.f, 0.f}), 2u,
                              std::vector<scalar>{20.f, -1500.f, 1500.f});
     pt_cyl_factory->push_back(std::move(cyl_sf_data));
 
-    auto pt_disc_factory = std::make_shared<portal_disc_factory>();
-    typename portal_disc_factory::sf_data_collection ring_sf_data;
+    auto pt_disc_factory = std::make_shared<disc_factory>();
+    typename disc_factory::sf_data_collection disc_sf_data;
     // Creates two discs with a radius of 10mm, linking to volumes 3 and 4
-    ring_sf_data.emplace_back(transform3(point3{0.f, 0.f, -1500.f}), 3u,
+    disc_sf_data.emplace_back(surface_id::e_portal,
+                              transform3(point3{0.f, 0.f, -1500.f}), 3u,
                               std::vector<scalar>{0.f, 10.f});
-    ring_sf_data.emplace_back(transform3(point3{0.f, 0.f, 1500.f}), 4u,
+    disc_sf_data.emplace_back(surface_id::e_portal,
+                              transform3(point3{0.f, 0.f, 1500.f}), 4u,
                               std::vector<scalar>{0.f, 10.f});
-    pt_disc_factory->push_back(std::move(ring_sf_data));
+    pt_disc_factory->push_back(std::move(disc_sf_data));
 
     // sensitive surfaces
     auto ann_factory = std::make_shared<annulus_factory>();
     typename annulus_factory::sf_data_collection ann_sf_data;
     ann_sf_data.emplace_back(
-        transform3(point3{0.f, 0.f, 1000.f}), vol_idx,
+        surface_id::e_sensitive, transform3(point3{0.f, 0.f, 1000.f}), vol_idx,
         std::vector<scalar>{300.f, 350.f, -0.1f, 0.1f, 0.5f, 0.6f, 1.4f});
     ann_sf_data.emplace_back(
-        transform3(point3{0.f, 0.f, 1000.f}), vol_idx,
+        surface_id::e_sensitive, transform3(point3{0.f, 0.f, 1000.f}), vol_idx,
         std::vector<scalar>{350.f, 400.f, -0.1f, 0.1f, 0.5f, 0.6f, 1.4f});
     ann_factory->push_back(std::move(ann_sf_data));
 
     auto rect_factory = std::make_shared<rectangle_factory>();
     typename rectangle_factory::sf_data_collection rect_sf_data;
-    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, -10.f}), vol_idx,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, -10.f}), vol_idx,
                               std::vector<scalar>{10.f, 8.f});
-    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, -20.f}), vol_idx,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, -20.f}), vol_idx,
                               std::vector<scalar>{10.f, 8.f});
-    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, -30.f}), vol_idx,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, -30.f}), vol_idx,
                               std::vector<scalar>{10.f, 8.f});
     rect_factory->push_back(std::move(rect_sf_data));
 
     auto trpz_factory = std::make_shared<trapezoid_factory>();
     typename trapezoid_factory::sf_data_collection trpz_sf_data;
-    trpz_sf_data.emplace_back(transform3(point3{0.f, 0.f, 1000.f}), vol_idx,
+    trpz_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, 1000.f}), vol_idx,
                               std::vector<scalar>{1.f, 3.f, 2.f, 0.25f});
     trpz_factory->push_back(std::move(trpz_sf_data));
 
     // passive surfaces
     auto cyl_factory = std::make_shared<cylinder_factory>();
     cyl_sf_data.clear();
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, 0.f}), vol_idx,
+    cyl_sf_data.emplace_back(surface_id::e_passive,
+                             transform3(point3{0.f, 0.f, 0.f}), vol_idx,
                              std::vector<scalar>{5.f, -1300.f, 1300.f});
     cyl_factory->push_back(std::move(cyl_sf_data));
 
-    auto rng_factory = std::make_shared<ring_factory>();
-    ring_sf_data.clear();
-    ring_sf_data.emplace_back(transform3(point3{0.f, 0.f, -1300.f}), vol_idx,
+    auto sf_disc_factory = std::make_shared<disc_factory>();
+    disc_sf_data.clear();
+    disc_sf_data.emplace_back(surface_id::e_passive,
+                              transform3(point3{0.f, 0.f, -1300.f}), vol_idx,
                               std::vector<scalar>{0.f, 5.f});
-    ring_sf_data.emplace_back(transform3(point3{0.f, 0.f, 1300.f}), vol_idx,
+    disc_sf_data.emplace_back(surface_id::e_passive,
+                              transform3(point3{0.f, 0.f, 1300.f}), vol_idx,
                               std::vector<scalar>{0.f, 5.f});
-    rng_factory->push_back(std::move(ring_sf_data));
+    sf_disc_factory->push_back(std::move(disc_sf_data));
 
     //
     // Fill everything into volume
     //
-    vbuilder.add_portals(pt_cyl_factory, geo_ctx);
-    vbuilder.add_portals(pt_disc_factory, geo_ctx);
+    vbuilder.add_surfaces(pt_cyl_factory, geo_ctx);
+    vbuilder.add_surfaces(pt_disc_factory, geo_ctx);
 
-    vbuilder.add_sensitives(ann_factory, geo_ctx);
-    vbuilder.add_sensitives(rect_factory, geo_ctx);
-    vbuilder.add_sensitives(trpz_factory, geo_ctx);
+    vbuilder.add_surfaces(ann_factory, geo_ctx);
+    vbuilder.add_surfaces(rect_factory, geo_ctx);
+    vbuilder.add_surfaces(trpz_factory, geo_ctx);
 
-    vbuilder.add_passives(cyl_factory, geo_ctx);
-    vbuilder.add_passives(rng_factory, geo_ctx);
+    vbuilder.add_surfaces(cyl_factory, geo_ctx);
+    vbuilder.add_surfaces(sf_disc_factory, geo_ctx);
 
     // try adding something extra later...
     rect_factory->clear();
     rect_sf_data.clear();
-    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, 10.f}), vol_idx,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, 10.f}), vol_idx,
                               std::vector<scalar>{10.f, 8.f});
-    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, 20.f}), vol_idx,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, 20.f}), vol_idx,
                               std::vector<scalar>{10.f, 8.f});
     rect_factory->push_back(std::move(rect_sf_data));
     rect_sf_data.clear();
-    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, 30.f}), vol_idx,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, 30.f}), vol_idx,
                               std::vector<scalar>{10.f, 8.f});
     rect_factory->push_back(std::move(rect_sf_data));
 
-    vbuilder.add_sensitives(rect_factory, geo_ctx);
+    vbuilder.add_surfaces(rect_factory, geo_ctx);
 
     //
     // Adds all surfaces to the detector
@@ -698,9 +672,7 @@ GTEST_TEST(detray_tools, detector_builder) {
     using mask_id = typename detector_t::masks::id;
 
     // Surface factories
-    using trapezoid_factory =
-        surface_factory<detector_t, trapezoid2D<>, mask_id::e_trapezoid2,
-                        surface_id::e_sensitive>;
+    using trapezoid_factory = surface_factory<detector_t, trapezoid2D<>>;
 
     // detector builder
     auto geo_ctx = typename detector_t::geometry_context{};
@@ -724,15 +696,18 @@ GTEST_TEST(detray_tools, detector_builder) {
 
     auto trpz_factory = std::make_shared<trapezoid_factory>();
     typename trapezoid_factory::sf_data_collection trpz_sf_data;
-    trpz_sf_data.emplace_back(transform3(point3{0.f, 0.f, 1000.f}), vol_idx,
+    trpz_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, 1000.f}), vol_idx,
                               std::vector<scalar>{1.f, 3.f, 2.f, 0.25f});
-    trpz_sf_data.emplace_back(transform3(point3{0.f, 0.f, 1100.f}), vol_idx,
+    trpz_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, 1100.f}), vol_idx,
                               std::vector<scalar>{1.f, 3.f, 2.f, 0.25f});
-    trpz_sf_data.emplace_back(transform3(point3{0.f, 0.f, 1200.f}), vol_idx,
+    trpz_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, 1200.f}), vol_idx,
                               std::vector<scalar>{1.f, 3.f, 2.f, 0.25f});
     trpz_factory->push_back(std::move(trpz_sf_data));
 
-    vbuilder->add_sensitives(trpz_factory, geo_ctx);
+    vbuilder->add_surfaces(trpz_factory, geo_ctx);
 
     //
     // second volume builder
@@ -748,7 +723,7 @@ GTEST_TEST(detray_tools, detector_builder) {
     auto portal_generator =
         std::make_shared<cuboid_portal_generator<detector_t>>(env);
 
-    vbuilder2->add_portals(portal_generator);
+    vbuilder2->add_surfaces(portal_generator);
 
     // initial checks
     EXPECT_EQ(vbuilder2->vol_index(), 1u);

--- a/tests/unit_tests/cpu/grid_grid_builder.cpp
+++ b/tests/unit_tests/cpu/grid_grid_builder.cpp
@@ -12,6 +12,7 @@
 #include "detray/definitions/bfield_backends.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/detectors/toy_metadata.hpp"
+#include "detray/intersection/cylinder_portal_intersector.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/surface_finders/grid/populator.hpp"
 #include "detray/surface_finders/grid/serializer.hpp"
@@ -36,7 +37,7 @@ using vector3 = test::vector3;
 
 test::transform3 Identity{};
 
-using test_detector_t = detector<toy_metadata>;
+using detector_t = detector<toy_metadata>;
 
 }  // anonymous namespace
 
@@ -126,11 +127,11 @@ GTEST_TEST(detray_tools, grid_builder) {
     // cylinder grid type of the toy detector
     using cyl_grid_t =
         grid<coordinate_axes<cylinder2D<>::axes<>, false, host_container_types>,
-             test_detector_t::surface_type, simple_serializer,
-             regular_attacher<1>>;
+             detector_t::surface_type, simple_serializer, regular_attacher<1>>;
 
-    auto gbuilder = grid_builder<test_detector_t, cyl_grid_t,
-                                 detray::detail::bin_associator>{nullptr};
+    auto gbuilder =
+        grid_builder<detector_t, cyl_grid_t, detray::detail::bin_associator>{
+            nullptr};
 
     // The cylinder portals are at the end of the surface range by construction
     const auto cyl_mask = mask<cylinder2D<>>{0u, 10.f, -500.f, 500.f};
@@ -154,43 +155,34 @@ GTEST_TEST(detray_tools, grid_builder) {
 /// Integration test: grid builder as volume builder decorator
 GTEST_TEST(detray_tools, decorator_grid_builder) {
 
-    using transform3 = typename test_detector_t::transform3;
-    using geo_obj_id = typename test_detector_t::geo_obj_ids;
-    using acc_ids = typename test_detector_t::sf_finders::id;
-    using mask_id = typename test_detector_t::masks::id;
+    using transform3 = typename detector_t::transform3;
+    using geo_obj_id = typename detector_t::geo_obj_ids;
+    using acc_ids = typename detector_t::sf_finders::id;
+    using mask_id = typename detector_t::masks::id;
 
     // cylinder grid type of the toy detector
     using cyl_grid_t =
         grid<coordinate_axes<cylinder2D<>::axes<>, false, host_container_types>,
-             test_detector_t::surface_type, simple_serializer,
-             regular_attacher<1>>;
+             detector_t::surface_type, simple_serializer, regular_attacher<1>>;
 
-    using portal_cylinder_factory_t =
-        surface_factory<test_detector_t, cylinder2D<>,
-                        mask_id::e_portal_cylinder2, surface_id::e_portal>;
-    using rectangle_factory =
-        surface_factory<test_detector_t, rectangle2D<>, mask_id::e_rectangle2,
-                        surface_id::e_sensitive>;
-    using trapezoid_factory =
-        surface_factory<test_detector_t, trapezoid2D<>, mask_id::e_trapezoid2,
-                        surface_id::e_sensitive>;
-    using cylinder_factory =
-        surface_factory<test_detector_t, cylinder2D<>, mask_id::e_cylinder2,
-                        surface_id::e_passive>;
+    using pt_cylinder_t = cylinder2D<false, cylinder_portal_intersector>;
+    using pt_cylinder_factory_t = surface_factory<detector_t, pt_cylinder_t>;
+    using rectangle_factory = surface_factory<detector_t, rectangle2D<>>;
+    using trapezoid_factory = surface_factory<detector_t, trapezoid2D<>>;
+    using cylinder_factory = surface_factory<detector_t, pt_cylinder_t>;
 
     vecmem::host_memory_resource host_mr;
-    test_detector_t d(host_mr);
-    auto geo_ctx = typename test_detector_t::geometry_context{};
+    detector_t d(host_mr);
+    auto geo_ctx = typename detector_t::geometry_context{};
     const auto vol_idx{
-        static_cast<typename test_detector_t::surface_type::navigation_link>(
+        static_cast<typename detector_t::surface_type::navigation_link>(
             d.volumes().size())};
 
-    auto vbuilder = std::make_unique<volume_builder<test_detector_t>>(
-        volume_id::e_cylinder);
-    auto gbuilder =
-        grid_builder<test_detector_t, cyl_grid_t>{std::move(vbuilder)};
+    auto vbuilder =
+        std::make_unique<volume_builder<detector_t>>(volume_id::e_cylinder);
+    auto gbuilder = grid_builder<detector_t, cyl_grid_t>{std::move(vbuilder)};
     // passive surfaces are added to the grid
-    // gbuilder.set_add_passives();
+    // gbuilder.set_add_surfaces();
 
     // The cylinder portals are at the end of the surface range by construction
     const auto cyl_mask = mask<cylinder2D<>>{0u, 10.f, -500.f, 500.f};
@@ -202,12 +194,14 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
     EXPECT_TRUE(d.volumes().size() == 0);
 
     // Add some portals first
-    auto pt_cyl_factory = std::make_shared<portal_cylinder_factory_t>();
+    auto pt_cyl_factory = std::make_shared<pt_cylinder_factory_t>();
 
-    typename portal_cylinder_factory_t::sf_data_collection cyl_sf_data;
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, 0.f}), 0u,
+    typename pt_cylinder_factory_t::sf_data_collection cyl_sf_data;
+    cyl_sf_data.emplace_back(surface_id::e_portal,
+                             transform3(point3{0.f, 0.f, 0.f}), 0u,
                              std::vector<scalar>{10.f, -1500.f, 1500.f});
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, 0.f}), 2u,
+    cyl_sf_data.emplace_back(surface_id::e_portal,
+                             transform3(point3{0.f, 0.f, 0.f}), 2u,
                              std::vector<scalar>{20.f, -1500.f, 1500.f});
     pt_cyl_factory->push_back(std::move(cyl_sf_data));
 
@@ -215,33 +209,38 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
     auto rect_factory = std::make_shared<rectangle_factory>();
 
     typename rectangle_factory::sf_data_collection rect_sf_data;
-    rect_sf_data.emplace_back(transform3(point3{7.07f, 7.07f, -500.f}), vol_idx,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{7.07f, 7.07f, -500.f}), vol_idx,
                               std::vector<scalar>{10.f, 8.f});
-    rect_sf_data.emplace_back(transform3(point3{7.07f, 7.07f, -250.f}), vol_idx,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{7.07f, 7.07f, -250.f}), vol_idx,
                               std::vector<scalar>{10.f, 8.f});
-    rect_sf_data.emplace_back(transform3(point3{7.07f, 7.07f, 100.f}), vol_idx,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{7.07f, 7.07f, 100.f}), vol_idx,
                               std::vector<scalar>{10.f, 8.f});
     rect_factory->push_back(std::move(rect_sf_data));
 
     auto trpz_factory = std::make_shared<trapezoid_factory>();
 
     typename trapezoid_factory::sf_data_collection trpz_sf_data;
-    trpz_sf_data.emplace_back(transform3(point3{7.07f, 7.07f, 600.f}), vol_idx,
+    trpz_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{7.07f, 7.07f, 600.f}), vol_idx,
                               std::vector<scalar>{1.f, 3.f, 2.f, 0.25f});
     trpz_factory->push_back(std::move(trpz_sf_data));
 
     auto cyl_factory = std::make_shared<cylinder_factory>();
 
     cyl_sf_data.clear();
-    cyl_sf_data.emplace_back(transform3(point3{0.f, 0.f, 0.f}), vol_idx,
+    cyl_sf_data.emplace_back(surface_id::e_passive,
+                             transform3(point3{0.f, 0.f, 0.f}), vol_idx,
                              std::vector<scalar>{5.f, -1300.f, 1300.f});
     cyl_factory->push_back(std::move(cyl_sf_data));
 
     // senstivies should end up in the grid, portals in the volume
-    gbuilder.add_portals(pt_cyl_factory, geo_ctx);
-    gbuilder.add_sensitives(rect_factory, geo_ctx);
-    gbuilder.add_sensitives(trpz_factory, geo_ctx);
-    gbuilder.add_passives(cyl_factory, geo_ctx);
+    gbuilder.add_surfaces(pt_cyl_factory, geo_ctx);
+    gbuilder.add_surfaces(rect_factory, geo_ctx);
+    gbuilder.add_surfaces(trpz_factory, geo_ctx);
+    gbuilder.add_surfaces(cyl_factory, geo_ctx);
 
     const auto& cyl_axis_z = gbuilder.get().template get_axis<label::e_cyl_z>();
     EXPECT_EQ(cyl_axis_z.label(), label::e_cyl_z);
@@ -270,6 +269,7 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
     EXPECT_EQ(vol.template link<geo_obj_id::e_passive>(),
               sf_range[geo_obj_id::e_passive]);
 
+    // Only the portals should be in the detector's surface container now
     EXPECT_EQ(d.surface_lookup().size(), 7u);
     EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_cylinder2>(), 3u);
     EXPECT_EQ(d.mask_store().template size<mask_id::e_portal_ring2>(), 0u);
@@ -280,7 +280,7 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
     // check the portals in the detector
     const auto& bf_finder =
         d.surface_store()
-            .template get<test_detector_t::sf_finders::id::e_brute_force>()[0];
+            .template get<detector_t::sf_finders::id::e_brute_force>()[0];
     for (const auto& sf : bf_finder.all()) {
         EXPECT_TRUE((sf.id() == surface_id::e_portal) or
                     (sf.id() == surface_id::e_passive));
@@ -290,8 +290,7 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
     // check the sensitive surfaces in the grid
     const auto& cyl_grid =
         d.surface_store()
-            .template get<
-                test_detector_t::sf_finders::id::e_cylinder2_grid>()[0];
+            .template get<detector_t::sf_finders::id::e_cylinder2_grid>()[0];
     dindex trf_idx{3u};
     for (const auto& sf : cyl_grid.all()) {
         EXPECT_TRUE(sf.is_sensitive());

--- a/tests/unit_tests/cpu/tools_material_builder.cpp
+++ b/tests/unit_tests/cpu/tools_material_builder.cpp
@@ -42,13 +42,10 @@ constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
 TEST(detray_tools, material_builder) {
 
     using transform3 = typename detector_t::transform3;
-    using mask_id = typename detector_t::masks::id;
     using material_id = typename detector_t::materials::id;
 
     // Build rectangle surfaces with material slabs
-    using rectangle_factory =
-        surface_factory<detector_t, rectangle2D<>, mask_id::e_rectangle2,
-                        surface_id::e_sensitive>;
+    using rectangle_factory = surface_factory<detector_t, rectangle2D<>>;
     auto mat_factory = std::make_unique<material_factory<detector_t>>(
         std::make_unique<rectangle_factory>());
 
@@ -64,16 +61,19 @@ TEST(detray_tools, material_builder) {
     EXPECT_TRUE(mat_factory->thickness().empty());
 
     // Add material for a few rectangle surfaces
-    mat_factory->push_back({transform3(point3{0.f, 0.f, -1.f}), 1u,
+    mat_factory->push_back({surface_id::e_sensitive,
+                            transform3(point3{0.f, 0.f, -1.f}), 1u,
                             std::vector<scalar>{10.f, 8.f}});
     mat_factory->add_material(material_id::e_slab,
                               {1.f * unit<scalar>::mm, silicon<scalar>()});
-    mat_factory->push_back({transform3(point3{0.f, 0.f, 1.f}), 1u,
+    mat_factory->push_back({surface_id::e_sensitive,
+                            transform3(point3{0.f, 0.f, 1.f}), 1u,
                             std::vector<scalar>{20.f, 16.f}});
     mat_factory->add_material(material_id::e_slab,
                               {10.f * unit<scalar>::mm, tungsten<scalar>()});
     // Pass the parameters for 'gold'
-    mat_factory->push_back({transform3(point3{0.f, 0.f, 1.f}), 1u,
+    mat_factory->push_back({surface_id::e_sensitive,
+                            transform3(point3{0.f, 0.f, 1.f}), 1u,
                             std::vector<scalar>{20.f, 16.f}});
     mat_factory->add_material(
         material_id::e_rod,
@@ -101,18 +101,11 @@ GTEST_TEST(detray_tools, decorator_material_builder) {
     using mask_id = typename detector_t::masks::id;
     using material_id = typename detector_t::materials::id;
 
-    using portal_cylinder_factory_t =
-        surface_factory<detector_t, cylinder2D<>, mask_id::e_portal_cylinder2,
-                        surface_id::e_portal>;
-    using rectangle_factory =
-        surface_factory<detector_t, rectangle2D<>, mask_id::e_rectangle2,
-                        surface_id::e_sensitive>;
-    using trapezoid_factory =
-        surface_factory<detector_t, trapezoid2D<>, mask_id::e_trapezoid2,
-                        surface_id::e_sensitive>;
-    using cylinder_factory =
-        surface_factory<detector_t, cylinder2D<>, mask_id::e_cylinder2,
-                        surface_id::e_passive>;
+    using pt_cylinder_t = cylinder2D<false, cylinder_portal_intersector>;
+    using pt_cylinder_factory_t = surface_factory<detector_t, pt_cylinder_t>;
+    using rectangle_factory = surface_factory<detector_t, rectangle2D<>>;
+    using trapezoid_factory = surface_factory<detector_t, trapezoid2D<>>;
+    using cylinder_factory = surface_factory<detector_t, cylinder2D<>>;
 
     using mat_factory_t = material_factory<detector_t>;
 
@@ -127,33 +120,40 @@ GTEST_TEST(detray_tools, decorator_material_builder) {
     EXPECT_TRUE(d.volumes().size() == 0);
 
     // Add some portals first
-    auto pt_cyl_factory = std::make_unique<portal_cylinder_factory_t>();
+    auto pt_cyl_factory = std::make_unique<pt_cylinder_factory_t>();
 
-    pt_cyl_factory->push_back({transform3(point3{0.f, 0.f, 0.f}), 1u,
+    pt_cyl_factory->push_back({surface_id::e_portal,
+                               transform3(point3{0.f, 0.f, 0.f}), 1u,
                                std::vector<scalar>{10.f, -1500.f, 1500.f}});
-    pt_cyl_factory->push_back({transform3(point3{0.f, 0.f, 0.f}), 2u,
+    pt_cyl_factory->push_back({surface_id::e_portal,
+                               transform3(point3{0.f, 0.f, 0.f}), 2u,
                                std::vector<scalar>{20.f, -1500.f, 1500.f}});
 
     // Then some passive and sensitive surfaces
     auto rect_factory = std::make_unique<rectangle_factory>();
 
     typename rectangle_factory::sf_data_collection rect_sf_data;
-    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, -10.f}), 0u,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, -10.f}), 0u,
                               std::vector<scalar>{10.f, 8.f});
-    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, -20.f}), 0u,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, -20.f}), 0u,
                               std::vector<scalar>{10.f, 8.f});
-    rect_sf_data.emplace_back(transform3(point3{0.f, 0.f, -30.f}), 0u,
+    rect_sf_data.emplace_back(surface_id::e_sensitive,
+                              transform3(point3{0.f, 0.f, -30.f}), 0u,
                               std::vector<scalar>{10.f, 8.f});
     rect_factory->push_back(std::move(rect_sf_data));
 
     auto trpz_factory = std::make_unique<trapezoid_factory>();
 
-    trpz_factory->push_back({transform3(point3{0.f, 0.f, 1000.f}), 0u,
+    trpz_factory->push_back({surface_id::e_sensitive,
+                             transform3(point3{0.f, 0.f, 1000.f}), 0u,
                              std::vector<scalar>{1.f, 3.f, 2.f, 0.25f}});
 
     auto cyl_factory = std::make_unique<cylinder_factory>();
 
-    cyl_factory->push_back({transform3(point3{0.f, 0.f, 0.f}), 0u,
+    cyl_factory->push_back({surface_id::e_passive,
+                            transform3(point3{0.f, 0.f, 0.f}), 0u,
                             std::vector<scalar>{5.f, -1300.f, 1300.f}});
 
     // Now add the material for each surface
@@ -184,10 +184,10 @@ GTEST_TEST(detray_tools, decorator_material_builder) {
         material_id::e_slab, {1.5f * unit<scalar>::mm, tungsten<scalar>()});
 
     // Add surfaces and material to detector
-    mat_builder.add_portals(mat_pt_cyl_factory, geo_ctx);
-    mat_builder.add_sensitives(mat_rect_factory, geo_ctx);
-    mat_builder.add_sensitives(mat_trpz_factory, geo_ctx);
-    mat_builder.add_passives(mat_cyl_factory, geo_ctx);
+    mat_builder.add_surfaces(mat_pt_cyl_factory, geo_ctx);
+    mat_builder.add_surfaces(mat_rect_factory, geo_ctx);
+    mat_builder.add_surfaces(mat_trpz_factory, geo_ctx);
+    mat_builder.add_surfaces(mat_cyl_factory, geo_ctx);
 
     // Add the volume to the detector
     mat_builder.build(d);
@@ -266,7 +266,7 @@ GTEST_TEST(detray_tools, detector_builder_with_material) {
     mat_portal_factory->add_material(
         material_id::e_slab, {6.f * unit<scalar>::mm, silicon<scalar>()});
 
-    mv_builder->add_portals(mat_portal_factory);
+    mv_builder->add_surfaces(mat_portal_factory);
 
     //
     // build the detector

--- a/tests/unit_tests/io/io_json_detector_reader.cpp
+++ b/tests/unit_tests/io/io_json_detector_reader.cpp
@@ -7,6 +7,7 @@
 
 // Project include(s)
 #include "detray/definitions/algebra.hpp"
+#include "detray/detectors/create_telescope_detector.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
 #include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/io/common/detector_reader.hpp"
@@ -23,9 +24,112 @@
 #include <gtest/gtest.h>
 
 // System include(s)
+#include <filesystem>
 #include <ios>
 
 using namespace detray;
+
+namespace {
+
+/// Compare two files with names @param file_name1 and @param file_name2 for
+/// equality, while skipping the first @param skip lines (header part)
+bool compare_files(const std::string& file_name1, const std::string& file_name2,
+                   std::size_t skip = 15u) {
+    auto file1 = io::detail::file_handle(
+        file_name1, std::ios_base::in | std::ios_base::binary);
+    auto file2 = io::detail::file_handle(
+        file_name2, std::ios_base::in | std::ios_base::binary);
+
+    std::string line1, line2;
+
+    // Check files line by line
+    std::size_t i{1u};
+    while (std::getline(*file1, line1)) {
+        if (std::getline(*file2, line2)) {
+            if (skip < i and line1 != line2) {
+                std::cout << "In line " << i << ":" << std::endl
+                          << line1 << std::endl
+                          << line2 << std::endl;
+                return false;
+            }
+        } else {
+            std::cout << "Could not read next line from file 2:" << std::endl
+                      << "In line " << i << ":" << std::endl
+                      << line1 << std::endl;
+            return false;
+        }
+        ++i;
+    }
+
+    // Are there more lines in file2 than file1?
+    if (std::getline(*file2, line2)) {
+        std::cout << "Could not read next line from file 1:" << std::endl
+                  << "In line " << i << ":" << std::endl
+                  << line2 << std::endl;
+        return false;
+    }
+
+    // Passed
+    return true;
+}
+
+}  // anonymous namespace
+
+/// Test the reading and writing of a telescope detector
+TEST(io, json_telescope_detector_reader) {
+
+    mask<rectangle2D<>> rec2{0u, 100.f, 100.f};
+
+    // Surface positions
+    std::vector<scalar> positions = {1.f,   50.f,  100.f, 150.f, 200.f, 250.f,
+                                     300.f, 350.f, 400.f, 450.f, 500.f};
+
+    tel_det_config<rectangle2D<>> tel_cfg{rec2};
+    tel_cfg.positions(positions);
+
+    // Wire chamber
+    vecmem::host_memory_resource host_mr;
+    auto [telescope_det, telescope_names] =
+        create_telescope_detector(host_mr, tel_cfg);
+
+    using detector_t = decltype(telescope_det);
+
+    auto writer_cfg = io::detector_writer_config{}
+                          .format(io::format::json)
+                          .write_grids(false)
+                          .replace_files(true);
+    io::write_detector(telescope_det, telescope_names, writer_cfg);
+
+    // Read the detector back in
+    io::detector_reader_config reader_cfg{};
+    reader_cfg.do_check(true)
+        .add_file("telescope_detector_geometry.json")
+        .add_file("telescope_detector_homogeneous_material.json");
+
+    const auto [det, names] =
+        io::read_detector<detector_t>(host_mr, reader_cfg);
+
+    const auto mat_store = det.material_store();
+    const auto slabs = mat_store.get<detector_t::materials::id::e_slab>();
+
+    EXPECT_EQ(det.volumes().size(), 1u);
+    EXPECT_EQ(slabs.size(), positions.size() + 6u);
+
+    // Write the result to a different set of files
+    writer_cfg.replace_files(false);
+    io::write_detector(det, names, writer_cfg);
+
+    // Not equal due to missing data deduplication in IO
+    /*EXPECT_TRUE(compare_files("telescope_detector_geometry.json",
+     * "telescope_detector_geometry_2.json"));*/
+    EXPECT_TRUE(
+        compare_files("telescope_detector_homogeneous_material.json",
+                      "telescope_detector_homogeneous_material_2.json"));
+
+    // Remove files
+    std::filesystem::remove("telescope_detector_geometry_2.json");
+    std::filesystem::remove("telescope_detector_homogeneous_material_2.json");
+}
 
 /// Test the reading and writing of a toy detector geometry
 TEST(io, json_toy_geometry) {
@@ -96,7 +200,8 @@ TEST(io, json_toy_detector_reader) {
 
     // Read the detector back in
     io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file("toy_detector_geometry.json")
+    reader_cfg.do_check(true)
+        .add_file("toy_detector_geometry.json")
         .add_file("toy_detector_homogeneous_material.json")
         .add_file("toy_detector_surface_grids.json")
         .add_file(toy_cfg.bfield_file());
@@ -104,11 +209,24 @@ TEST(io, json_toy_detector_reader) {
     const auto [det, names] =
         io::read_detector<detector_t, 1u>(host_mr, reader_cfg);
 
+    EXPECT_TRUE(test_toy_detector(det, names));
+
     // Write the result to a different set of files
     writer_cfg.replace_files(false);
     io::write_detector(det, names, writer_cfg);
 
-    EXPECT_TRUE(test_toy_detector(det, names));
+    // Compare writing round-trip
+    EXPECT_TRUE(compare_files("toy_detector_geometry.json",
+                              "toy_detector_geometry_2.json"));
+    EXPECT_TRUE(compare_files("toy_detector_homogeneous_material.json",
+                              "toy_detector_homogeneous_material_2.json"));
+    EXPECT_TRUE(compare_files("toy_detector_surface_grids.json",
+                              "toy_detector_surface_grids_2.json"));
+
+    // Remove files
+    std::filesystem::remove("toy_detector_geometry_2.json");
+    std::filesystem::remove("toy_detector_homogeneous_material_2.json");
+    std::filesystem::remove("toy_detector_surface_grids_2.json");
 }
 
 /// Test the reading and writing of a wire chamber
@@ -128,7 +246,8 @@ TEST(io, json_wire_chamber_reader) {
 
     // Read the detector back in
     io::detector_reader_config reader_cfg{};
-    reader_cfg.add_file("wire_chamber_geometry.json")
+    reader_cfg.do_check(true)
+        .add_file("wire_chamber_geometry.json")
         .add_file("wire_chamber_homogeneous_material.json")
         .add_file("wire_chamber_surface_grids.json");
 
@@ -136,4 +255,21 @@ TEST(io, json_wire_chamber_reader) {
         io::read_detector<detector_t>(host_mr, reader_cfg);
 
     EXPECT_EQ(det.volumes().size(), 11u);
+
+    // Write the result to a different set of files
+    writer_cfg.replace_files(false);
+    io::write_detector(det, names, writer_cfg);
+
+    // Compare writing round-trip
+    EXPECT_TRUE(compare_files("wire_chamber_geometry.json",
+                              "wire_chamber_geometry_2.json"));
+    EXPECT_TRUE(compare_files("wire_chamber_homogeneous_material.json",
+                              "wire_chamber_homogeneous_material_2.json"));
+    EXPECT_TRUE(compare_files("wire_chamber_surface_grids.json",
+                              "wire_chamber_surface_grids_2.json"));
+
+    // Remove files
+    std::filesystem::remove("wire_chamber_geometry_2.json");
+    std::filesystem::remove("wire_chamber_homogeneous_material_2.json");
+    std::filesystem::remove("wire_chamber_surface_grids_2.json");
 }

--- a/tests/unit_tests/io/io_json_payload.cpp
+++ b/tests/unit_tests/io/io_json_payload.cpp
@@ -307,7 +307,9 @@ TEST(io, json_volume_payload) {
 TEST(io, json_material_slab_payload) {
 
     detray::material_slab_payload m;
-    m.mat_link = {detray::material_slab_payload::type::slab, 21u};
+    m.type = detray::material_slab_payload::mat_type::slab;
+    m.index_in_coll = 21u;
+    m.surface.link = 5u;
     m.thickness = 1.2f;
     m.mat.params = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f};
 
@@ -316,8 +318,9 @@ TEST(io, json_material_slab_payload) {
 
     detray::material_slab_payload pm = j["material"];
 
-    EXPECT_EQ(m.mat_link.type, pm.mat_link.type);
-    EXPECT_EQ(m.mat_link.index, pm.mat_link.index);
+    EXPECT_EQ(m.type, pm.type);
+    EXPECT_EQ(m.index_in_coll, pm.index_in_coll);
+    EXPECT_EQ(m.surface.link, pm.surface.link);
     EXPECT_EQ(m.thickness, pm.thickness);
     EXPECT_EQ(m.mat.params, pm.mat.params);
 }

--- a/tutorials/include/detray/tutorial/square_surface_generator.hpp
+++ b/tutorials/include/detray/tutorial/square_surface_generator.hpp
@@ -38,12 +38,6 @@ class square_surface_generator final
     square_surface_generator(std::size_t n, scalar_t hl)
         : m_n_squares{static_cast<dindex>(n)}, m_half_length{hl} {}
 
-    /// @returns the id for the surface type (sensitive surfaces)
-    DETRAY_HOST
-    auto surface_type() const -> surface_id override {
-        return surface_id::e_sensitive;
-    }
-
     /// @returns the number of surfaces this factory will produce
     DETRAY_HOST
     auto size() const -> dindex override { return m_n_squares; }
@@ -105,7 +99,7 @@ class square_surface_generator final
                 detail::invalid_value<typename material_link_t::index_type>()};
             surfaces.emplace_back(transforms.size(ctx) - 1u, mask_link,
                                   material_link, volume.index(), dindex_invalid,
-                                  surface_type());
+                                  surface_id::e_sensitive);
         }
 
         return {surfaces_offset, static_cast<dindex>(surfaces.size())};

--- a/tutorials/src/cpu/detector/do_it_yourself_detector.cpp
+++ b/tutorials/src/cpu/detector/do_it_yourself_detector.cpp
@@ -47,9 +47,7 @@ int main() {
 
     // Fill some squares into the volume
     using square_factory_t =
-        detray::surface_factory<detector_t, detray::tutorial::square2D<>,
-                                detector_t::masks::id::e_square2,
-                                detray::surface_id::e_sensitive>;
+        detray::surface_factory<detector_t, detray::tutorial::square2D<>>;
     auto sq_factory = std::make_shared<square_factory_t>();
 
     // Add a square that is 20x20mm large, links back to its mother volume (0)
@@ -58,7 +56,8 @@ int main() {
         1.f * detray::unit<detray::scalar>::mm,
         2.f * detray::unit<detray::scalar>::mm,
         3.f * detray::unit<detray::scalar>::mm};
-    sq_factory->push_back({detray::tutorial::transform3{translation},
+    sq_factory->push_back({detray::surface_id::e_sensitive,
+                           detray::tutorial::transform3{translation},
                            0u,
                            {20.f * detray::unit<detray::scalar>::mm}});
 
@@ -73,9 +72,9 @@ int main() {
         std::make_shared<detray::cuboid_portal_generator<detector_t>>(env);
 
     // Add surfaces to volume and add the volume to the detector
-    vbuilder.add_sensitives(sq_factory);
-    vbuilder.add_sensitives(sq_generator);
-    vbuilder.add_portals(portal_generator);
+    vbuilder.add_surfaces(sq_factory);
+    vbuilder.add_surfaces(sq_generator);
+    vbuilder.add_surfaces(portal_generator);
 
     vbuilder.build(det);
 

--- a/tutorials/src/cpu/detector/read_detector_from_file.cpp
+++ b/tutorials/src/cpu/detector/read_detector_from_file.cpp
@@ -34,8 +34,8 @@ int main(int argc, char** argv) {
         throw std::runtime_error("Please specify an input file name!");
     }
 
-    // Read a toy detector with constant bfield (default)
-    using detector_t = detray::detector<detray::toy_metadata>;
+    // Read a toy detector
+    using detector_t = detray::detector<>;
 
     // Create an empty detector to be filled
     vecmem::host_memory_resource host_mr;

--- a/tutorials/src/cpu/detector/track_geometry_changes.cpp
+++ b/tutorials/src/cpu/detector/track_geometry_changes.cpp
@@ -44,9 +44,9 @@ int main() {
     auto geo_checker = detray::hash_tree(adj_mat);
 
     if (geo_checker.root() == root_hash) {
-        std::cout << "Geometry are links consistent" << std::endl;
+        std::cout << "Geometry links are consistent" << std::endl;
     } else {
-        std::cerr << "\nGeometry are linking has changed! Please check:\n"
+        std::cerr << "\nGeometry linking has changed! Please check:\n"
                   << graph.to_string() << std::endl;
     }
 }

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -84,6 +84,7 @@ struct tel_det_config {
         return *this;
     }
     constexpr tel_det_config &positions(const std::vector<scalar> &dists) {
+        m_positions.clear();
         std::copy_if(dists.begin(), dists.end(),
                      std::back_inserter(m_positions),
                      [](scalar d) { return (d >= 0.f); });


### PR DESCRIPTION
Various fixes and refactoring:
- Remove some template arguments from the surface factories and pass information as runtime parameters instead.
- Collaps the various ways to add surfaces to one `add_surfaces` method
- Improved comments
- Similar to the `surface_factory`, explicitly preserve ordering of material data by adding indices to the payloads and direct placing in the container. Can alternatively also be passed without explicit ordering (if surface index is invalid)
- clear the placement vector in the telescope creation to add surface only once
- correctly initialize material rod vector in IO, so that wire chamber can be built correctly
- Added a write-read-write round trip with file comparison for all inbuilt detectors