### PR TITLE
feat: material maps

### DIFF
--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -99,7 +99,7 @@ class detector {
 
     /// Forward mask types that are present in this detector
     using material_container =
-        typename metadata::template material_store<tuple_type, vector_type>;
+        typename metadata::template material_store<tuple_type, container_t>;
     using materials = typename material_container::value_types;
     using material_link = typename material_container::single_link;
 

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -333,7 +333,8 @@ class surface {
         }
         // Only check, if there is material in the detector
         if (not m_detector.material_store().all_empty()) {
-            if (is_invalid_value(m_desc.material())) {
+            if (m_desc.material().id() != detector_t::materials::id::e_none and
+                m_desc.material().is_invalid_index()) {
                 os << "ERROR: Surface does not have valid material:\n"
                    << *this << std::endl;
                 return false;

--- a/core/include/detray/materials/material_map.hpp
+++ b/core/include/detray/materials/material_map.hpp
@@ -1,0 +1,30 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Detray include(s)
+#include "detray/definitions/containers.hpp"
+#include "detray/materials/material_slab.hpp"
+#include "detray/surface_finders/grid/grid.hpp"
+#include "detray/tools/grid_factory.hpp"
+
+namespace detray {
+
+/// Definition of binned material
+template <typename axes_shape, typename scalar_t,
+          typename container_t = host_container_types, bool owning = false>
+using material_map = grid<coordinate_axes<axes_shape, owning, container_t>,
+                          material_slab<scalar_t>, simple_serializer, replacer>;
+
+/// How to build material maps of various shapes
+// TODO: Move to material_map_builder once available
+template <typename scalar_t = detray::scalar>
+using material_map_factory =
+    grid_factory<material_slab<scalar_t>, simple_serializer, replacer>;
+
+}  // namespace detray

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -8,9 +8,14 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/materials/material.hpp"
 #include "detray/materials/predefined_materials.hpp"
+
+// System include(s)
+#include <limits>
+#include <ostream>
 
 namespace detray {
 
@@ -66,14 +71,14 @@ struct material_rod : public detail::homogeneous_material_tag {
     DETRAY_HOST_DEVICE constexpr scalar_type path_segment(
         const scalar_type cos_inc_angle, const scalar_type approach) const {
         // Assume that is.local[0] is radial distance of line intersector
-        if (std::abs(approach) > m_radius) {
+        if (math_ns::abs(approach) > m_radius) {
             return 0.f;
         }
 
         const scalar_type sin_inc_angle_2{1.f - cos_inc_angle * cos_inc_angle};
 
-        return 2.f * std::sqrt((m_radius * m_radius - approach * approach) /
-                               sin_inc_angle_2);
+        return 2.f * math_ns::sqrt((m_radius * m_radius - approach * approach) /
+                                   sin_inc_angle_2);
     }
 
     /// @returns the path segment through the material in X0
@@ -92,6 +97,16 @@ struct material_rod : public detail::homogeneous_material_tag {
     DETRAY_HOST_DEVICE constexpr scalar_type path_segment_in_L0(
         const scalar_type cos_inc_angle, const scalar_type approach) const {
         return this->path_segment(cos_inc_angle, approach) / m_material.L0();
+    }
+
+    /// @returns a string stream that prints the material details
+    DETRAY_HOST
+    friend std::ostream& operator<<(std::ostream& os, const material_rod& mat) {
+        os << "rod: ";
+        os << mat.get_material().to_string();
+        os << " | radius: " << mat.radius() << "mm";
+
+        return os;
     }
 
     private:

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -14,6 +14,7 @@
 
 // System include(s)
 #include <limits>
+#include <ostream>
 
 namespace detray {
 
@@ -90,6 +91,17 @@ struct material_slab : public detail::homogeneous_material_tag {
     DETRAY_HOST_DEVICE constexpr scalar_type path_segment_in_L0(
         const scalar_type cos_inc_angle, const scalar_type = 0.f) const {
         return m_thickness_in_L0 / cos_inc_angle;
+    }
+
+    /// @returns a string stream that prints the material details
+    DETRAY_HOST
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const material_slab& mat) {
+        os << "slab: ";
+        os << mat.get_material().to_string();
+        os << " | thickness: " << mat.thickness() << "mm";
+
+        return os;
     }
 
     private:

--- a/core/include/detray/propagator/navigator.hpp
+++ b/core/include/detray/propagator/navigator.hpp
@@ -344,6 +344,14 @@ class navigator {
             return m_status == navigation::status::e_on_portal;
         }
 
+        /// Helper method to check the track has encountered material
+        DETRAY_HOST_DEVICE
+        inline auto encountered_material() const -> bool {
+            return (is_on_module() or is_on_portal()) and
+                   (current()->sf_desc.material().id() !=
+                    detector_t::materials::id::e_none);
+        }
+
         /// Helper method to check if a kernel is exhausted - const
         DETRAY_HOST_DEVICE
         inline auto is_exhausted() const -> bool {

--- a/core/include/detray/surface_finders/brute_force_finder.hpp
+++ b/core/include/detray/surface_finders/brute_force_finder.hpp
@@ -75,6 +75,9 @@ class brute_force_collection {
         /// @returns an iterator over all surfaces in the data structure
         DETRAY_HOST_DEVICE constexpr auto all() const { return *this; }
 
+        /// @returns an iterator over all surfaces in the data structure
+        DETRAY_HOST_DEVICE auto all() { return *this; }
+
         /// @return the maximum number of surface candidates during a
         /// neighborhood lookup
         DETRAY_HOST_DEVICE constexpr auto n_max_candidates() const
@@ -149,6 +152,12 @@ class brute_force_collection {
     /// Create brute force surface finder from surface container - const
     DETRAY_HOST_DEVICE
     auto operator[](const size_type i) const -> value_type {
+        return {m_surfaces, dindex_range{m_offsets[i], m_offsets[i + 1u]}};
+    }
+
+    /// Create brute force surface finder from surface container - const
+    DETRAY_HOST_DEVICE
+    auto operator[](const size_type i) -> value_type {
         return {m_surfaces, dindex_range{m_offsets[i], m_offsets[i + 1u]}};
     }
 

--- a/core/include/detray/surface_finders/grid/grid.hpp
+++ b/core/include/detray/surface_finders/grid/grid.hpp
@@ -284,11 +284,21 @@ class grid {
 
     /// Find the value of a single bin - const
     ///
-    /// @param p is point in the local frame
+    /// @param p is point in the local (bound) frame
     ///
     /// @return the iterable view of the bin content
-    DETRAY_HOST_DEVICE auto search(
-        const typename local_frame_type::point3 &p) const {
+    template <typename point_t>
+    DETRAY_HOST_DEVICE auto search(const point_t &p) const {
+        return bin(m_axes.bins(p));
+    }
+
+    /// Find the value of a single bin
+    ///
+    /// @param p is point in the local (bound) frame
+    ///
+    /// @return the iterable view of the bin content
+    template <typename point_t>
+    DETRAY_HOST_DEVICE auto search(const point_t &p) {
         return bin(m_axes.bins(p));
     }
 

--- a/core/include/detray/surface_finders/grid/grid_collection.hpp
+++ b/core/include/detray/surface_finders/grid/grid_collection.hpp
@@ -115,9 +115,47 @@ class grid_collection<
         return static_cast<dindex>(m_offsets.size());
     }
 
+    /// @returns an iterator that points to the first grid
+    /// @note Not implemented!
+    DETRAY_HOST_DEVICE
+    constexpr auto begin() noexcept -> bool { return true; }
+
+    /// @returns an iterator that points to the coll. end
+    /// @note Not implemented!
+    DETRAY_HOST_DEVICE
+    constexpr auto end() noexcept -> bool { return false; }
+
     /// @returns the number of grids in the collection - const
     DETRAY_HOST_DEVICE
     constexpr auto empty() const noexcept -> bool { return m_offsets.empty(); }
+
+    /// @brief Resize the underlying containers
+    /// @note Not defined! The amount of memory can differ for every grid
+    DETRAY_HOST_DEVICE
+    constexpr void resize(std::size_t) noexcept { /*Not defined*/
+    }
+
+    /// @brief Reserve memory
+    /// @note Not defined! The amount of memory can differ for every grid
+    DETRAY_HOST_DEVICE
+    constexpr void reserve(std::size_t) noexcept { /*Not defined*/
+    }
+
+    /// Removes all data from the grid collection containers
+    DETRAY_HOST_DEVICE
+    constexpr void clear() noexcept {
+        m_offsets.clear();
+        m_bins.clear();
+        m_axes_data.clear();
+        m_bin_edges.clear();
+    }
+
+    /// Insert a number of grids
+    /// @note Not defined! There is no grid iterator implementation
+    template <typename... Args>
+    DETRAY_HOST_DEVICE constexpr void insert(Args &&...) noexcept {
+        /*Not defined*/
+    }
 
     /// @returns the offsets for the grids in the bin storage - const
     DETRAY_HOST_DEVICE

--- a/core/include/detray/tools/material_builder.hpp
+++ b/core/include/detray/tools/material_builder.hpp
@@ -62,8 +62,6 @@ class material_builder final : public volume_decorator<detector_t> {
     DETRAY_HOST
     auto build(detector_t &det, typename detector_t::geometry_context ctx = {})
         -> typename detector_t::volume_type * override {
-        // This builder is only called on a homogeneous material description
-        using mat_types = typename detector_t::material_container::value_types;
 
         const auto &material = det.material_store();
 
@@ -74,7 +72,8 @@ class material_builder final : public volume_decorator<detector_t> {
                 sf.update_material(
                     material.template size<material_id::e_slab>());
             }
-            if constexpr (mat_types::n_types == 2u) {
+            if constexpr (detector_t::materials::template is_defined<
+                              material_rod<scalar_type>>()) {
                 if (sf.material().id() == material_id::e_rod) {
                     sf.update_material(
                         material.template size<material_id::e_rod>());

--- a/core/include/detray/tools/material_factory.hpp
+++ b/core/include/detray/tools/material_factory.hpp
@@ -190,8 +190,6 @@ class material_factory final : public factory_decorator<detector_t> {
     auto operator()(typename detector_t::surface_container &surfaces,
                     typename detector_t::material_container &materials) {
 
-        // This builder is only called on a homogeneous material description
-        using mat_types = typename detector_t::material_container::value_types;
         using link_t = typename detector_t::surface_type::material_link;
 
         if (m_materials.empty()) {
@@ -231,7 +229,8 @@ class material_factory final : public factory_decorator<detector_t> {
                 mat_idx = this->insert_in_container(mat_coll, mat_slab,
                                                     m_links[sf_idx].second);
             }
-            if constexpr (mat_types::n_types == 2u) {
+            if constexpr (detector_t::materials::template is_defined<
+                              material_rod<scalar_type>>()) {
                 if (m_links.at(sf_idx).first == material_id::e_rod) {
                     auto &mat_coll =
                         materials.template get<material_id::e_rod>();

--- a/core/include/detray/tools/volume_builder.hpp
+++ b/core/include/detray/tools/volume_builder.hpp
@@ -11,6 +11,8 @@
 #include "detray/definitions/geometry.hpp"
 #include "detray/geometry/surface.hpp"
 #include "detray/tools/volume_builder_interface.hpp"
+// @TODO: Remove once material map writing becomes available
+#include "detray/surface_finders/accelerator_grid.hpp"
 
 // System include(s)
 #include <memory>
@@ -219,10 +221,13 @@ struct mask_index_update {
 struct material_index_update {
 
     template <typename group_t, typename index_t, typename surface_t>
-    DETRAY_HOST inline void operator()(const group_t& group,
-                                       const index_t& /*index*/,
-                                       surface_t& sf) const {
-        sf.update_material(static_cast<dindex>(group.size()));
+    DETRAY_HOST inline void operator()(
+        [[maybe_unused]] const group_t& group,
+        [[maybe_unused]] const index_t& /*index*/,
+        [[maybe_unused]] surface_t& sf) const {
+        if constexpr (!detail::is_grid_v<typename group_t::value_type>) {
+            sf.update_material(static_cast<dindex>(group.size()));
+        }
     }
 };
 

--- a/io/include/detray/io/common/detector_writer.hpp
+++ b/io/include/detray/io/common/detector_writer.hpp
@@ -93,7 +93,7 @@ detail::detector_component_writers<detector_t> assemble_writer(
         // Find other writers, depending on the detector type
         if (cfg.write_material()) {
             // Simple material
-            if constexpr (detail::is_homogeneous_material_v<detector_t>) {
+            if constexpr (detail::has_homogeneous_material_v<detector_t>) {
                 writers.template add<json_homogeneous_material_writer>();
             }
             // Material maps
@@ -119,7 +119,7 @@ namespace io {
 /// using @param names to name the components
 template <class detector_t>
 void write_detector(detector_t& det, const typename detector_t::name_map& names,
-                    const detector_writer_config& cfg) {
+                    detector_writer_config& cfg) {
     // How to open the file
     const std::ios_base::openmode out_mode{std::ios_base::out |
                                            std::ios_base::binary};
@@ -127,6 +127,10 @@ void write_detector(detector_t& det, const typename detector_t::name_map& names,
         cfg.replace_files() ? (out_mode | std::ios_base::trunc) : out_mode;
 
     const auto file_path = detray::detail::create_path(cfg.path());
+
+    if (det.material_store().all_empty()) {
+        cfg.write_material(false);
+    }
 
     // Get the writer
     auto writer = detray::detail::assemble_writer<detector_t>(cfg);

--- a/io/include/detray/io/common/homogeneous_material_reader.hpp
+++ b/io/include/detray/io/common/homogeneous_material_reader.hpp
@@ -50,7 +50,7 @@ class homogeneous_material_reader : public reader_interface<detector_t> {
             det_builder,
         typename detector_t::name_map& /*name_map*/,
         const detector_homogeneous_material_payload& det_mat_data) {
-        using mat_types = typename detector_t::material_container::value_types;
+
         using material_id = typename detector_t::materials::id;
 
         // Deserialize the material volume by volume
@@ -72,7 +72,7 @@ class homogeneous_material_reader : public reader_interface<detector_t> {
                 mat_factory->add_material(material_id::e_slab,
                                           deserialize(slab_data), sf_link);
             }
-            if constexpr (mat_types::n_types == 2u) {
+            if constexpr (detail::has_material_rods_v<detector_t>) {
                 if (mv_data.mat_rods.has_value()) {
                     for (const auto& rod_data : *(mv_data.mat_rods)) {
                         assert(rod_data.type == io::detail::material_type::rod);

--- a/tests/common/include/tests/common/test_toy_detector.hpp
+++ b/tests/common/include/tests/common/test_toy_detector.hpp
@@ -83,8 +83,8 @@ inline bool test_toy_detector(
     auto& materials = toy_det.material_store();
 
     // Materials
-    auto portal_mat =
-        material_slab<scalar>(vacuum<scalar>(), 0.f * unit<scalar>::mm);
+    auto portal_mat = material_slab<scalar>(toy_det_config{}.mapped_material(),
+                                            1.5f * unit<scalar>::mm);
     auto beampipe_mat =
         material_slab<scalar>(beryllium_tml<scalar>(), 0.8f * unit<scalar>::mm);
     auto pixel_mat =
@@ -97,6 +97,8 @@ inline bool test_toy_detector(
         (accel.template size<accel_ids::e_disc_grid>() != 0u);
     const bool has_material =
         (materials.template size<material_ids::e_slab>() != 0);
+    const bool has_material_maps =
+        (materials.template size<material_ids::e_disc2_map>() != 0);
 
     // Check number of geomtery objects
     EXPECT_EQ(volumes.size(), 20u);
@@ -111,8 +113,13 @@ inline bool test_toy_detector(
         EXPECT_EQ(accel.template size<accel_ids::e_cylinder2_grid>(), 4);
         EXPECT_EQ(accel.template size<accel_ids::e_disc_grid>(), 6);
     }
-    if (has_material) {
+    if (has_material and !has_material_maps) {
         EXPECT_EQ(materials.template size<material_ids::e_slab>(), 3244u);
+    } else if (has_material and has_material_maps) {
+        EXPECT_EQ(materials.template size<material_ids::e_slab>(), 3141u);
+        EXPECT_EQ(materials.template size<material_ids::e_cylinder2_map>(),
+                  51u);
+        EXPECT_EQ(materials.template size<material_ids::e_disc2_map>(), 52u);
     }
 
     /** Test the links of a volume.
@@ -162,7 +169,7 @@ inline bool test_toy_detector(
                 const auto volume_link =
                     masks.template visit<volume_link_getter>(sf_itr->mask());
                 EXPECT_EQ(volume_link, volume_links[pti - range[0]]);
-                if (has_material) {
+                if (has_material and !has_material_maps) {
                     EXPECT_EQ(sf_itr->material(), material_index);
                     EXPECT_EQ(
                         materials.template get<
@@ -204,12 +211,13 @@ inline bool test_toy_detector(
                 const auto volume_link =
                     masks.template visit<volume_link_getter>(sf_itr->mask());
                 EXPECT_EQ(volume_link, volume_links[0]);
-                if (has_material) {
+                if (has_material and !has_material_maps) {
                     EXPECT_EQ(sf_itr->material(), material_index);
                     EXPECT_EQ(
                         materials.template get<
                             material_ids::e_slab>()[sf_itr->material().index()],
-                        mat);
+                        mat)
+                        << sf_itr->material();
                 }
 
                 ++sf_itr;

--- a/tests/unit_tests/cpu/CMakeLists.txt
+++ b/tests/unit_tests/cpu/CMakeLists.txt
@@ -47,6 +47,7 @@ macro( detray_add_cpu_test algebra )
       "masks_unbounded.cpp"
       "masks_unmasked.cpp"
       "material_interaction.cpp"
+      "material_maps.cpp"
       "materials.cpp"
       "scattering.cpp"
       "sf_finder_brute_force.cpp"

--- a/tests/unit_tests/cpu/material_maps.cpp
+++ b/tests/unit_tests/cpu/material_maps.cpp
@@ -1,0 +1,237 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Detray include(s)
+#include "detray/definitions/indexing.hpp"
+#include "detray/masks/masks.hpp"
+#include "detray/materials/material_map.hpp"
+
+// GTest include(s)
+#include <gtest/gtest.h>
+
+using namespace detray;
+using namespace detray::n_axis;
+
+using material_t = typename material_map_factory<scalar>::value_type;
+
+namespace {
+
+material_map_factory<scalar> mat_map_factory{};
+
+}  // anonymous namespace
+
+/// Unittest: Test the construction of an annulus shaped material map
+GTEST_TEST(detray_material, annulus_map) {
+
+    constexpr scalar minR{7.2f * unit<scalar>::mm};
+    constexpr scalar maxR{12.0f * unit<scalar>::mm};
+    constexpr scalar minPhi{0.74195f};
+    constexpr scalar maxPhi{1.33970f};
+
+    mask<annulus2D<>> ann2{0u, minR, maxR, minPhi, maxPhi, 0.f, -2.f, 2.f};
+
+    auto annulus_map = mat_map_factory.new_grid(ann2, {10u, 20u});
+
+    EXPECT_EQ(annulus_map.Dim, 2u);
+    EXPECT_EQ(annulus_map.nbins(), 200u);
+
+    auto r_axis = annulus_map.get_axis<label::e_r>();
+    EXPECT_EQ(r_axis.nbins(), 10u);
+    EXPECT_EQ(r_axis.min(), minR);
+    EXPECT_EQ(r_axis.max(), maxR);
+
+    auto phi_axis = annulus_map.get_axis<label::e_phi>();
+    EXPECT_EQ(phi_axis.nbins(), 20u);
+    EXPECT_EQ(phi_axis.min(), -minPhi);
+    EXPECT_EQ(phi_axis.max(), maxPhi);
+
+    // Add some material entries
+    scalar thickness = 2.f * unit<scalar>::mm;
+    for (dindex gbin = 0; gbin < annulus_map.nbins(); ++gbin) {
+        annulus_map.populate(gbin,
+                             material_t(silicon_tml<scalar>{}, thickness));
+        thickness += 1.f * unit<scalar>::mm;
+    }
+
+    EXPECT_EQ(annulus_map.at(0, 0),
+              material_t(silicon_tml<scalar>{}, 2.f * unit<scalar>::mm));
+    EXPECT_EQ(annulus_map.at(1, 0),
+              material_t(silicon_tml<scalar>{}, 3.f * unit<scalar>::mm));
+    EXPECT_EQ(annulus_map.at(22, 0),
+              material_t(silicon_tml<scalar>{}, 24.f * unit<scalar>::mm));
+    EXPECT_EQ(annulus_map.at(199, 0),
+              material_t(silicon_tml<scalar>{}, 201.f * unit<scalar>::mm));
+    EXPECT_FALSE(annulus_map.at(199, 0) ==
+                 material_t(gold<scalar>{}, 201.f * unit<scalar>::mm));
+}
+
+/// Unittest: Test the construction of a cylindrical material map
+GTEST_TEST(detray_material, cylinder_map) {
+
+    constexpr scalar r{3.f * unit<scalar>::mm};
+    constexpr scalar hz{4.f * unit<scalar>::mm};
+
+    mask<cylinder2D<>> cyl{0u, r, -hz, hz};
+
+    auto cylinder_map = mat_map_factory.new_grid(cyl, {10u, 20u});
+
+    EXPECT_EQ(cylinder_map.Dim, 2u);
+    EXPECT_EQ(cylinder_map.nbins(), 200u);
+
+    auto rphi_axis = cylinder_map.get_axis<label::e_rphi>();
+    EXPECT_EQ(rphi_axis.nbins(), 10u);
+    EXPECT_EQ(rphi_axis.min(), -constant<scalar>::pi * r);
+    EXPECT_EQ(rphi_axis.max(), constant<scalar>::pi * r);
+
+    auto z_axis = cylinder_map.get_axis<label::e_cyl_z>();
+    EXPECT_EQ(z_axis.nbins(), 20u);
+    EXPECT_EQ(z_axis.min(), -hz);
+    EXPECT_EQ(z_axis.max(), hz);
+
+    scalar thickness = 2.f * unit<scalar>::mm;
+    for (dindex gbin = 0; gbin < cylinder_map.nbins(); ++gbin) {
+        cylinder_map.populate(gbin, material_t(vacuum<scalar>{}, thickness));
+        thickness += 1.f * unit<scalar>::mm;
+    }
+
+    EXPECT_EQ(cylinder_map.at(0, 0),
+              material_t(vacuum<scalar>{}, 2.f * unit<scalar>::mm));
+    EXPECT_EQ(cylinder_map.at(1, 0),
+              material_t(vacuum<scalar>{}, 3.f * unit<scalar>::mm));
+    EXPECT_EQ(cylinder_map.at(22, 0),
+              material_t(vacuum<scalar>{}, 24.f * unit<scalar>::mm));
+    EXPECT_EQ(cylinder_map.at(199, 0),
+              material_t(vacuum<scalar>{}, 201.f * unit<scalar>::mm));
+    EXPECT_FALSE(cylinder_map.at(199, 0) ==
+                 material_t(gold<scalar>{}, 201.f * unit<scalar>::mm));
+}
+
+/// Unittest: Test the construction of a rectangular material map
+GTEST_TEST(detray_material, rectangle_map) {
+
+    constexpr scalar hx{1.f * unit<scalar>::mm};
+    constexpr scalar hy{9.3f * unit<scalar>::mm};
+
+    mask<rectangle2D<>> r2{0u, hx, hy};
+
+    auto rectangle_map = mat_map_factory.new_grid(r2, {10u, 20u});
+
+    EXPECT_EQ(rectangle_map.Dim, 2u);
+    EXPECT_EQ(rectangle_map.nbins(), 200u);
+
+    auto x_axis = rectangle_map.get_axis<label::e_x>();
+    EXPECT_EQ(x_axis.nbins(), 10u);
+    EXPECT_EQ(x_axis.min(), -hx);
+    EXPECT_EQ(x_axis.max(), hx);
+
+    auto y_axis = rectangle_map.get_axis<label::e_y>();
+    EXPECT_EQ(y_axis.nbins(), 20u);
+    EXPECT_EQ(y_axis.min(), -hy);
+    EXPECT_EQ(y_axis.max(), hy);
+
+    scalar thickness = 2.f * unit<scalar>::mm;
+    for (dindex gbin = 0; gbin < rectangle_map.nbins(); ++gbin) {
+        rectangle_map.populate(gbin,
+                               material_t(oxygen_gas<scalar>{}, thickness));
+        thickness += 1.f * unit<scalar>::mm;
+    }
+
+    EXPECT_EQ(rectangle_map.at(0, 0),
+              material_t(oxygen_gas<scalar>{}, 2.f * unit<scalar>::mm));
+    EXPECT_EQ(rectangle_map.at(1, 0),
+              material_t(oxygen_gas<scalar>{}, 3.f * unit<scalar>::mm));
+    EXPECT_EQ(rectangle_map.at(22, 0),
+              material_t(oxygen_gas<scalar>{}, 24.f * unit<scalar>::mm));
+    EXPECT_EQ(rectangle_map.at(199, 0),
+              material_t(oxygen_gas<scalar>{}, 201.f * unit<scalar>::mm));
+    EXPECT_FALSE(rectangle_map.at(199, 0) ==
+                 material_t(gold<scalar>{}, 201.f * unit<scalar>::mm));
+}
+
+/// Unittest: Test the construction of a ring shaped material map
+GTEST_TEST(detray_material, disc_map) {
+
+    constexpr scalar inner_r{0.f * unit<scalar>::mm};
+    constexpr scalar outer_r{3.5f * unit<scalar>::mm};
+
+    mask<ring2D<>> r2{0u, inner_r, outer_r};
+
+    auto disc_map = mat_map_factory.new_grid(r2, {10u, 20u});
+
+    EXPECT_EQ(disc_map.Dim, 2u);
+    EXPECT_EQ(disc_map.nbins(), 200u);
+
+    auto r_axis = disc_map.get_axis<label::e_r>();
+    EXPECT_EQ(r_axis.nbins(), 10u);
+    EXPECT_EQ(r_axis.min(), inner_r);
+    EXPECT_EQ(r_axis.max(), outer_r);
+
+    auto phi_axis = disc_map.get_axis<label::e_phi>();
+    EXPECT_EQ(phi_axis.nbins(), 20u);
+    EXPECT_EQ(phi_axis.min(), -constant<scalar>::pi);
+    EXPECT_EQ(phi_axis.max(), constant<scalar>::pi);
+
+    scalar thickness = 2.f * unit<scalar>::mm;
+    for (dindex gbin = 0; gbin < disc_map.nbins(); ++gbin) {
+        disc_map.populate(gbin, material_t(aluminium<scalar>{}, thickness));
+        thickness += 1.f * unit<scalar>::mm;
+    }
+
+    EXPECT_EQ(disc_map.at(0, 0),
+              material_t(aluminium<scalar>{}, 2.f * unit<scalar>::mm));
+    EXPECT_EQ(disc_map.at(1, 0),
+              material_t(aluminium<scalar>{}, 3.f * unit<scalar>::mm));
+    EXPECT_EQ(disc_map.at(22, 0),
+              material_t(aluminium<scalar>{}, 24.f * unit<scalar>::mm));
+    EXPECT_EQ(disc_map.at(199, 0),
+              material_t(aluminium<scalar>{}, 201.f * unit<scalar>::mm));
+    EXPECT_FALSE(disc_map.at(199, 0) ==
+                 material_t(gold<scalar>{}, 201.f * unit<scalar>::mm));
+}
+
+/// Unittest: Test the construction of a trapezoid material map
+GTEST_TEST(detray_material, trapezoid_map) {
+
+    constexpr scalar hx_miny{1.f * unit<scalar>::mm};
+    constexpr scalar hx_maxy{3.f * unit<scalar>::mm};
+    constexpr scalar hy{2.f * unit<scalar>::mm};
+    constexpr scalar divisor{1.f / (2.f * hy)};
+
+    mask<trapezoid2D<>> t2{0u, hx_miny, hx_maxy, hy, divisor};
+
+    auto trapezoid_map = mat_map_factory.new_grid(t2, {10u, 20u});
+
+    EXPECT_EQ(trapezoid_map.Dim, 2u);
+    EXPECT_EQ(trapezoid_map.nbins(), 200u);
+
+    auto x_axis = trapezoid_map.get_axis<label::e_x>();
+    EXPECT_EQ(x_axis.nbins(), 10u);
+    EXPECT_EQ(x_axis.min(), -hx_maxy);
+    EXPECT_EQ(x_axis.max(), hx_maxy);
+
+    auto y_axis = trapezoid_map.get_axis<label::e_y>();
+    EXPECT_EQ(y_axis.nbins(), 20u);
+    EXPECT_EQ(y_axis.min(), -hy);
+    EXPECT_EQ(y_axis.max(), hy);
+
+    scalar thickness = 2.f * unit<scalar>::mm;
+    for (dindex gbin = 0; gbin < trapezoid_map.nbins(); ++gbin) {
+        trapezoid_map.populate(gbin, material_t(gold<scalar>{}, thickness));
+        thickness += 1.f * unit<scalar>::mm;
+    }
+
+    EXPECT_EQ(trapezoid_map.at(0, 0),
+              material_t(gold<scalar>{}, 2.f * unit<scalar>::mm));
+    EXPECT_EQ(trapezoid_map.at(1, 0),
+              material_t(gold<scalar>{}, 3.f * unit<scalar>::mm));
+    EXPECT_EQ(trapezoid_map.at(22, 0),
+              material_t(gold<scalar>{}, 24.f * unit<scalar>::mm));
+    EXPECT_EQ(trapezoid_map.at(199, 0),
+              material_t(gold<scalar>{}, 201.f * unit<scalar>::mm));
+    EXPECT_FALSE(trapezoid_map.at(199, 0) ==
+                 material_t(aluminium<scalar>{}, 201.f * unit<scalar>::mm));
+}

--- a/tests/unit_tests/cpu/test_toy_geometry.cpp
+++ b/tests/unit_tests/cpu/test_toy_geometry.cpp
@@ -23,7 +23,14 @@ GTEST_TEST(detray_detectors, toy_geometry) {
 
     vecmem::host_memory_resource host_mr;
 
-    const auto [toy_det, names] = create_toy_geometry(host_mr);
+    toy_det_config toy_cfg{};
+    toy_cfg.use_material_maps(false);
+    const auto [toy_det, names] = create_toy_geometry(host_mr, toy_cfg);
 
     EXPECT_TRUE(test_toy_detector(toy_det, names));
+
+    toy_cfg.use_material_maps(true);
+    const auto [toy_det2, names2] = create_toy_geometry(host_mr, toy_cfg);
+
+    EXPECT_TRUE(test_toy_detector(toy_det2, names2));
 }

--- a/tests/unit_tests/cpu/tools_particle_gun.cpp
+++ b/tests/unit_tests/cpu/tools_particle_gun.cpp
@@ -36,9 +36,7 @@ GTEST_TEST(detray_tools, particle_gun) {
 
     // Build the geometry
     vecmem::host_memory_resource host_mr;
-    toy_det_config toy_cfg{};
-
-    auto [toy_det, names] = create_toy_geometry(host_mr, toy_cfg);
+    auto [toy_det, names] = create_toy_geometry(host_mr);
 
     unsigned int theta_steps{50u};
     unsigned int phi_steps{50u};

--- a/tests/unit_tests/cpu/tools_propagator.cpp
+++ b/tests/unit_tests/cpu/tools_propagator.cpp
@@ -119,7 +119,9 @@ struct helix_inspector : actor {
 GTEST_TEST(detray_propagator, propagator_line_stepper) {
 
     vecmem::host_memory_resource host_mr;
-    const auto [d, names] = create_toy_geometry(host_mr);
+    toy_det_config toy_cfg{};
+    toy_cfg.use_material_maps(false);
+    const auto [d, names] = create_toy_geometry(host_mr, toy_cfg);
 
     using navigator_t = navigator<decltype(d), navigation::print_inspector>;
     using stepper_t = line_stepper<transform3>;
@@ -190,7 +192,8 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
                     parameter_resetter<transform3>>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
-    // Build detector and magnetic field
+    // Build detector
+    toy_cfg.use_material_maps(false);
     const auto [det, names] = create_toy_geometry(host_mr, toy_cfg);
 
     const bfield_t bfield = bfield::create_const_field(std::get<2>(GetParam()));
@@ -292,6 +295,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     // Build detector and magnetic field
+    toy_cfg.use_material_maps(false);
     const auto [det, names] = create_toy_geometry(host_mr, toy_cfg);
     const bfield_t bfield = bfield::create_inhom_field();
 

--- a/tests/unit_tests/io/io_json_detector_reader.cpp
+++ b/tests/unit_tests/io/io_json_detector_reader.cpp
@@ -138,7 +138,9 @@ TEST(io, json_toy_geometry) {
 
     // Toy detector
     vecmem::host_memory_resource host_mr;
-    auto [toy_det, names] = create_toy_geometry(host_mr);
+    toy_det_config toy_cfg{};
+    toy_cfg.use_material_maps(false);
+    auto [toy_det, names] = create_toy_geometry(host_mr, toy_cfg);
 
     // Write the detector
     json_geometry_writer<detector_t> geo_writer;
@@ -190,6 +192,7 @@ TEST(io, json_toy_detector_reader) {
     // Toy detector
     vecmem::host_memory_resource host_mr;
     toy_det_config toy_cfg{};
+    toy_cfg.use_material_maps(false);
     const auto [toy_det, toy_names] = create_toy_geometry(host_mr, toy_cfg);
 
     auto writer_cfg = io::detector_writer_config{}
@@ -234,8 +237,9 @@ TEST(io, json_wire_chamber_reader) {
 
     // Wire chamber
     vecmem::host_memory_resource host_mr;
-    auto [wire_det, wire_names] =
-        create_wire_chamber(host_mr, wire_chamber_config{});
+    wire_chamber_config wire_cfg{};
+    wire_cfg.use_material_maps(false);
+    auto [wire_det, wire_names] = create_wire_chamber(host_mr, wire_cfg);
 
     auto writer_cfg = io::detector_writer_config{}
                           .format(io::format::json)

--- a/tutorials/include/detray/tutorial/detector_metadata.hpp
+++ b/tutorials/include/detray/tutorial/detector_metadata.hpp
@@ -112,9 +112,10 @@ struct my_metadata {
     /// How to store and link materials. The material does not make use of
     /// conditions data ( @c empty_context )
     template <template <typename...> class tuple_t = dtuple,
-              template <typename...> class vector_t = dvector>
-    using material_store = regular_multi_store<material_ids, empty_context,
-                                               tuple_t, vector_t, slab>;
+              typename container_t = host_container_types>
+    using material_store =
+        multi_store<material_ids, empty_context, tuple_t,
+                    typename container_t::template vector_type<slab>>;
 
     /// Surface descriptor type used for sensitives, passives and portals
     /// It holds the indices to the surface data in the detector data stores

--- a/utils/include/detray/detectors/detector_helper.hpp
+++ b/utils/include/detray/detectors/detector_helper.hpp
@@ -11,10 +11,46 @@
 #include "detray/core/detail/data_context.hpp"
 #include "detray/definitions/geometry.hpp"
 #include "detray/definitions/indexing.hpp"
-#include "detray/materials/material.hpp"
-#include "detray/materials/predefined_materials.hpp"
+#include "detray/materials/material_map.hpp"
+#include "detray/materials/material_slab.hpp"
 
 namespace detray::detail {
+
+/// Generate material along z bins for a cylinder material grid
+inline std::vector<material_slab<scalar>> generate_cyl_mat(
+    const std::array<scalar, 2u> &bounds, const std::size_t nbins,
+    material<scalar> mat, const scalar t) {
+    std::vector<material_slab<scalar>> ts;
+    ts.reserve(nbins);
+
+    scalar z{bounds[0]};
+    const scalar z_step{(bounds[1] - bounds[0]) /
+                        static_cast<scalar>(nbins - 1u)};
+    for (std::size_t n = 0u; n < nbins; ++n) {
+        ts.emplace_back(mat, static_cast<scalar>(0.00001f * z * z) + t);
+        z += z_step;
+    }
+
+    return ts;
+}
+
+/// Generate material along r bins for a disc material grid
+inline std::vector<material_slab<scalar>> generate_disc_mat(
+    const std::array<scalar, 2u> &bounds, const std::size_t nbins,
+    material<scalar> mat, const scalar t) {
+    std::vector<material_slab<scalar>> ts;
+    ts.reserve(nbins);
+
+    scalar r{bounds[0]};
+    const scalar r_step{(bounds[1] - bounds[0]) /
+                        static_cast<scalar>(nbins - 1u)};
+    for (std::size_t n = 0u; n < nbins; ++n) {
+        ts.emplace_back(mat, static_cast<scalar>(0.01f * r) + t);
+        r += r_step;
+    }
+
+    return ts;
+}
 
 template <typename algebra_t>
 struct detector_helper {
@@ -37,21 +73,19 @@ struct detector_helper {
      * @param volume_link link to next volume for the masks
      */
     template <auto cyl_id, typename context_t, typename surface_container_t,
-              typename mask_container_t, typename material_container_t,
-              typename transform_container_t, typename volume_links>
-    inline void add_cylinder_surface(
-        const dindex volume_idx, context_t &ctx, surface_container_t &surfaces,
-        mask_container_t &masks, material_container_t &materials,
-        transform_container_t &transforms, const scalar_t r,
-        const scalar_t lower_z, const scalar_t upper_z,
-        const volume_links volume_link, const material<scalar_t> &mat,
-        const scalar_t thickness) {
+              typename mask_container_t, typename transform_container_t,
+              typename volume_links>
+    inline auto add_cylinder_surface(const dindex volume_idx, context_t &ctx,
+                                     surface_container_t &surfaces,
+                                     mask_container_t &masks,
+                                     transform_container_t &transforms,
+                                     const scalar_t r, const scalar_t lower_z,
+                                     const scalar_t upper_z,
+                                     const volume_links volume_link) const {
         using surface_type = typename surface_container_t::value_type;
         using mask_link_type = typename surface_type::mask_link;
         using material_id = typename surface_type::material_id;
         using material_link_type = typename surface_type::material_link;
-
-        constexpr auto slab_id = material_id::e_slab;
 
         const scalar_t min_z{std::min(lower_z, upper_z)};
         const scalar_t max_z{std::max(lower_z, upper_z)};
@@ -61,23 +95,21 @@ struct detector_helper {
 
         // add transform and masks
         transforms.emplace_back(ctx, tsl);
-        masks.template emplace_back<cyl_id>(empty_context{}, volume_link, r,
-                                            min_z, max_z);
-
-        // Add material slab
-        materials.template emplace_back<slab_id>(empty_context{}, mat,
-                                                 thickness);
+        auto &mask_ref = masks.template emplace_back<cyl_id>(
+            empty_context{}, volume_link, r, min_z, max_z);
 
         // add surface
         mask_link_type mask_link{cyl_id, masks.template size<cyl_id>() - 1u};
-        material_link_type material_link{
-            slab_id, materials.template size<slab_id>() - 1u};
+        material_link_type material_link{material_id::e_none, dindex_invalid};
         const surface_id sf_id = (volume_link != volume_idx)
                                      ? surface_id::e_portal
                                      : surface_id::e_passive;
 
-        surfaces.emplace_back(transforms.size(ctx) - 1u, mask_link,
-                              material_link, volume_idx, dindex_invalid, sf_id);
+        auto &sf_ref = surfaces.emplace_back(transforms.size(ctx) - 1u,
+                                             mask_link, material_link,
+                                             volume_idx, dindex_invalid, sf_id);
+
+        return std::tie(sf_ref, mask_ref);
     }
 
     /** Function that adds a disc portal.
@@ -89,21 +121,21 @@ struct detector_helper {
      * @param surfaces container to add new surface to
      * @param masks container to add new cylinder mask to
      * @param transforms container to add new transform to
-     * @param min_r lower radius of the disc
-     * @param max_r upper radius of the disc
+     * @param inner_r lower radius of the disc
+     * @param outer_r upper radius of the disc
      * @param z z position of the disc
      * @param volume_link link to next volume for the masks
      */
     template <typename context_t, typename surface_container_t,
-              typename mask_container_t, typename material_container_t,
-              typename transform_container_t, typename volume_links>
-    inline void add_disc_surface(
-        const dindex volume_idx, context_t &ctx, surface_container_t &surfaces,
-        mask_container_t &masks, material_container_t &materials,
-        transform_container_t &transforms, const scalar_t inner_r,
-        const scalar_t outer_r, const scalar_t z,
-        const volume_links volume_link, const material<scalar_t> &mat,
-        const scalar_t thickness) {
+              typename mask_container_t, typename transform_container_t,
+              typename volume_links>
+    inline auto add_disc_surface(const dindex volume_idx, context_t &ctx,
+                                 surface_container_t &surfaces,
+                                 mask_container_t &masks,
+                                 transform_container_t &transforms,
+                                 const scalar_t inner_r, const scalar_t outer_r,
+                                 const scalar_t z,
+                                 const volume_links volume_link) const {
         using surface_type = typename surface_container_t::value_type;
         using mask_id = typename surface_type::mask_id;
         using mask_link_type = typename surface_type::mask_link;
@@ -111,7 +143,6 @@ struct detector_helper {
         using material_link_type = typename surface_type::material_link;
 
         constexpr auto disc_id = mask_id::e_portal_ring2;
-        constexpr auto slab_id = material_id::e_slab;
 
         const scalar_t min_r{std::min(inner_r, outer_r)};
         const scalar_t max_r{std::max(inner_r, outer_r)};
@@ -121,22 +152,20 @@ struct detector_helper {
 
         // add transform and mask
         transforms.emplace_back(ctx, tsl);
-        masks.template emplace_back<disc_id>(empty_context{}, volume_link,
-                                             min_r, max_r);
-
-        // Add material slab
-        materials.template emplace_back<slab_id>(empty_context{}, mat,
-                                                 thickness);
+        auto &mask_ref = masks.template emplace_back<disc_id>(
+            empty_context{}, volume_link, min_r, max_r);
 
         // add surface
         mask_link_type mask_link{disc_id, masks.template size<disc_id>() - 1u};
-        material_link_type material_link{
-            slab_id, materials.template size<slab_id>() - 1u};
+        material_link_type material_link{material_id::e_none, dindex_invalid};
         const surface_id sf_id = (volume_link != volume_idx)
                                      ? surface_id::e_portal
                                      : surface_id::e_sensitive;
-        surfaces.emplace_back(transforms.size(ctx) - 1u, mask_link,
-                              material_link, volume_idx, dindex_invalid, sf_id);
+        auto &sf_ref = surfaces.emplace_back(transforms.size(ctx) - 1u,
+                                             mask_link, material_link,
+                                             volume_idx, dindex_invalid, sf_id);
+
+        return std::tie(sf_ref, mask_ref);
     }
 
     /** Function that adds a generic cylinder volume, using a factory for
@@ -145,6 +174,7 @@ struct detector_helper {
      * @tparam detector_t the detector type
      * @tparam factory_t type of module factory. Must be callable on containers.
      *
+     * @param cfg detector building configuration
      * @param det detector the volume should be added to
      * @param resource vecmem memory resource for the temporary containers
      * @param ctx geometry context
@@ -153,15 +183,15 @@ struct detector_helper {
      * @param lay_neg_r lower extend of volume
      * @param lay_pos_r upper extend of volume
      * @param volume_links volume links for the portals of the volume
-     * @param module_factory functor that adds module surfaces to volume
      */
-    template <typename detector_t>
-    void create_cyl_volume(detector_t &det, vecmem::memory_resource &resource,
+    template <typename config_t, typename detector_t>
+    void create_cyl_volume(const config_t &cfg, detector_t &det,
+                           vecmem::memory_resource &resource,
                            typename detector_t::geometry_context &ctx,
                            const scalar_t lay_inner_r,
                            const scalar_t lay_outer_r, const scalar_t lay_neg_z,
                            const scalar_t lay_pos_z,
-                           const std::vector<dindex> &volume_links) {
+                           const std::vector<dindex> &volume_links) const {
         // volume bounds
         const scalar_t inner_r{std::min(lay_inner_r, lay_outer_r)};
         const scalar_t outer_r{std::max(lay_inner_r, lay_outer_r)};
@@ -186,26 +216,93 @@ struct detector_helper {
         // negative and positive, inner and outer portal surface
         constexpr auto cyl_id = detector_t::masks::id::e_portal_cylinder2;
 
-        // If inner radius is 0, skip add the innder cylinder
+        auto &material_coll =
+            cfg.use_material_maps() ? det.material_store() : materials;
+
+        // If inner radius is 0, skip adding the inner cylinder
         if (inner_r > 0.f) {
-            add_cylinder_surface<cyl_id>(
-                cyl_volume.index(), ctx, surfaces, masks, materials, transforms,
-                inner_r, lower_z, upper_z, volume_links[0], vacuum<scalar_t>(),
-                0.f * unit<scalar_t>::mm);
+            auto [inner_cyl, inner_cyl_mask] = add_cylinder_surface<cyl_id>(
+                cyl_volume.index(), ctx, surfaces, masks, transforms, inner_r,
+                lower_z, upper_z, volume_links[0]);
+            create_material(cfg, inner_cyl, inner_cyl_mask, material_coll);
         }
-        add_cylinder_surface<cyl_id>(
-            cyl_volume.index(), ctx, surfaces, masks, materials, transforms,
-            outer_r, lower_z, upper_z, volume_links[1], vacuum<scalar_t>(),
-            0.f * unit<scalar_t>::mm);
-        add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
-                         transforms, inner_r, outer_r, lower_z, volume_links[2],
-                         vacuum<scalar_t>(), 0.f * unit<scalar_t>::mm);
-        add_disc_surface(cyl_volume.index(), ctx, surfaces, masks, materials,
-                         transforms, inner_r, outer_r, upper_z, volume_links[3],
-                         vacuum<scalar_t>(), 0.f * unit<scalar_t>::mm);
+
+        auto [outer_cyl, outer_cyl_mask] = add_cylinder_surface<cyl_id>(
+            cyl_volume.index(), ctx, surfaces, masks, transforms, outer_r,
+            lower_z, upper_z, volume_links[1]);
+        create_material(cfg, outer_cyl, outer_cyl_mask, material_coll);
+
+        auto [neg_disc, neg_disc_mask] = add_disc_surface(
+            cyl_volume.index(), ctx, surfaces, masks, transforms, inner_r,
+            outer_r, lower_z, volume_links[2]);
+        create_material(cfg, neg_disc, neg_disc_mask, material_coll);
+
+        auto [pos_disc, pos_disc_mask] = add_disc_surface(
+            cyl_volume.index(), ctx, surfaces, masks, transforms, inner_r,
+            outer_r, upper_z, volume_links[3]);
+        create_material(cfg, pos_disc, pos_disc_mask, material_coll);
 
         det.add_objects_per_volume(ctx, cyl_volume, surfaces, masks, transforms,
                                    materials);
+    }
+
+    template <typename config_t, typename surface_desc_t, typename mask_t,
+              typename material_container_t>
+    inline void create_material(const config_t &cfg, surface_desc_t &sf,
+                                const mask_t &sf_mask,
+                                material_container_t &materials) const {
+        using material_id = typename surface_desc_t::material_id;
+        using material_link_type = typename surface_desc_t::material_link;
+
+        if (cfg.use_material_maps()) {
+            material_map_factory<scalar_t> mat_map_factory{};
+
+            constexpr auto is_disc_map{
+                std::is_same_v<typename mask_t::shape, ring2D<>>};
+
+            // Scale material thickness either over r- or z-bins
+            const std::size_t bins =
+                is_disc_map ? cfg.disc_map_bins()[0] : cfg.cyl_map_bins()[1];
+
+            const auto &bounds = sf_mask.values();
+            const auto mat{
+                is_disc_map
+                    ? cfg.edc_mat_generator()({bounds[ring2D<>::e_inner_r],
+                                               bounds[ring2D<>::e_outer_r]},
+                                              bins, cfg.mapped_material(),
+                                              cfg.thickness())
+                    : cfg.barrel_mat_generator()(
+                          {bounds[cylinder2D<>::e_n_half_z],
+                           bounds[cylinder2D<>::e_p_half_z]},
+                          bins, cfg.mapped_material(), cfg.thickness())};
+
+            auto material_map = mat_map_factory.template new_grid<>(
+                sf_mask,
+                is_disc_map ? cfg.disc_map_bins() : cfg.cyl_map_bins());
+
+            const auto n_bins_per_axis{material_map.axes().nbins()};
+            for (dindex bin0 = 0u; bin0 < n_bins_per_axis[0]; ++bin0) {
+                for (dindex bin1 = 0u; bin1 < n_bins_per_axis[1]; ++bin1) {
+                    material_map.populate(n_axis::multi_bin<2>{bin0, bin1},
+                                          mat[is_disc_map ? bin0 : bin1]);
+                }
+            }
+
+            constexpr auto map_id{is_disc_map ? material_id::e_disc2_map
+                                              : material_id::e_cylinder2_map};
+
+            materials.template push_back<map_id>(material_map);
+
+            sf.material() = material_link_type{
+                map_id, materials.template size<map_id>() - 1u};
+        } else {
+            materials.template emplace_back<material_id::e_slab>(
+                {}, cfg.mapped_material(), cfg.thickness());
+
+            sf.material() = material_link_type{
+                material_id::e_slab,
+                materials.template size<material_id::e_slab>() - 1u};
+        }
     }
 };
 

--- a/utils/include/detray/detectors/telescope_metadata.hpp
+++ b/utils/include/detray/detectors/telescope_metadata.hpp
@@ -86,14 +86,14 @@ struct telescope_metadata {
 
     /// How to store materials
     template <template <typename...> class tuple_t = dtuple,
-              template <typename...> class vector_t = dvector>
+              typename container_t = host_container_types>
     using material_store = std::conditional_t<
         std::is_same_v<mask<mask_shape_t, nav_link>, cell_wire> |
             std::is_same_v<mask<mask_shape_t, nav_link>, straw_wire>,
-        regular_multi_store<material_ids, empty_context, tuple_t, vector_t,
-                            slab, rod>,
-        regular_multi_store<material_ids, empty_context, tuple_t, vector_t,
-                            slab>>;
+        regular_multi_store<material_ids, empty_context, tuple_t,
+                            container_t::template vector_type, slab, rod>,
+        regular_multi_store<material_ids, empty_context, tuple_t,
+                            container_t::template vector_type, slab>>;
 
     /// How to link to the entries in the data stores
     using transform_link = typename transform_store<>::link_type;


### PR DESCRIPTION
Add material grids as material maps and add the relevant types to the
detector metadata. The material maps of different shapes are tested
in a dedicated unittest.
    
Material maps are added to the toy detector and wire chamber via
the detector helper. The material is a silicon and aluminium mixture
that is mapped in configurable binning onto the disc and cylinder
portals.