### PR TITLE
feat: regular eta steps for uniform track generator

### DIFF
--- a/core/include/detray/propagator/navigator.hpp
+++ b/core/include/detray/propagator/navigator.hpp
@@ -126,7 +126,7 @@ class navigator {
 
             sf.template visit_mask<intersection_initialize>(
                 candidates, detail::ray(track), sf_descr, det.transform_store(),
-                tol);
+                sf.is_portal() ? 0.f : tol);
         }
     };
 
@@ -740,7 +740,8 @@ class navigator {
 
         // Check whether this candidate is reachable by the track
         return sf.template visit_mask<intersection_update>(
-            detail::ray(track), candidate, det->transform_store(), tol);
+            detail::ray(track), candidate, det->transform_store(),
+            sf.is_portal() ? 0.f : tol);
     }
 
     /// Helper to evict all unreachable/invalid candidates from the cache:

--- a/tests/benchmarks/cpu/intersect_all.cpp
+++ b/tests/benchmarks/cpu/intersect_all.cpp
@@ -29,11 +29,14 @@
 // Use the detray:: namespace implicitly.
 using namespace detray;
 
+using trk_generator_t =
+    uniform_track_generator<free_track_parameters<test::transform3>>;
+
+constexpr unsigned int theta_steps{100u};
+constexpr unsigned int phi_steps{100u};
+
 // This test runs intersection with all surfaces of the TrackML detector
 void BM_INTERSECT_ALL(benchmark::State &state) {
-
-    static const unsigned int theta_steps{100u};
-    static const unsigned int phi_steps{100u};
 
     // Detector configuration
     vecmem::host_memory_resource host_mr;
@@ -48,18 +51,22 @@ void BM_INTERSECT_ALL(benchmark::State &state) {
 
     std::size_t hits{0u};
     std::size_t missed{0u};
+    std::size_t n_surfaces{0u};
+    test::point3 origin{0.f, 0.f, 0.f};
+    std::vector<intersection2D<typename detector_t::surface_type,
+                               typename detector_t::transform3>>
+        intersections{};
+
+    // Iterate through uniformly distributed momentum directions
+    auto trk_generator = trk_generator_t{};
+    trk_generator.config()
+        .theta_steps(theta_steps)
+        .phi_steps(phi_steps)
+        .origin(origin);
 
     for (auto _ : state) {
-        test::point3 pos{0.f, 0.f, 0.f};
-        std::vector<intersection2D<typename detector_t::surface_type,
-                                   typename detector_t::transform3>>
-            intersections{};
-        std::size_t n_surfaces{0u};
 
-        // Iterate through uniformly distributed momentum directions
-        for (const auto track :
-             uniform_track_generator<free_track_parameters<test::transform3>>(
-                 theta_steps, phi_steps, pos)) {
+        for (const auto track : trk_generator) {
 
             // Loop over all surfaces in detector
             for (const auto &sf_desc : d.surface_lookup()) {

--- a/tests/benchmarks/cpu/intersect_surfaces.cpp
+++ b/tests/benchmarks/cpu/intersect_surfaces.cpp
@@ -26,6 +26,8 @@
 // Use the detray:: namespace implicitly.
 using namespace detray;
 
+using ray_generator_t = uniform_track_generator<detail::ray<test::transform3>>;
+
 static const unsigned int theta_steps = 1000u;
 static const unsigned int phi_steps = 1000u;
 
@@ -41,16 +43,17 @@ void BM_INTERSECT_PLANES(benchmark::State &state) {
     auto planes = test::planes_along_direction(
         dists, vector::normalize(test::vector3{1.f, 1.f, 1.f}));
     constexpr mask<rectangle2D<>> rect{0u, 10.f, 20.f};
-    test::point3 ori = {0.f, 0.f, 0.f};
+
+    // Iterate through uniformly distributed momentum directions
+    auto ray_generator = ray_generator_t{};
+    ray_generator.config().theta_steps(theta_steps).phi_steps(phi_steps);
 
     for (auto _ : state) {
         benchmark::DoNotOptimize(sfhit);
         benchmark::DoNotOptimize(sfmiss);
 
         // Iterate through uniformly distributed momentum directions
-        for (const auto ray :
-             uniform_track_generator<detail::ray<test::transform3>>(
-                 theta_steps, phi_steps, ori, 1.f)) {
+        for (const auto ray : ray_generator) {
 
             for (const auto &plane : planes) {
                 auto pi = rect.intersector<intersection2D<
@@ -115,16 +118,16 @@ void BM_INTERSECT_CYLINDERS(benchmark::State &state) {
     plane_surface plane(test::transform3(), mask_link, material_link, 0u, false,
                         surface_id::e_sensitive);
 
-    const test::point3 ori = {0.f, 0.f, 0.f};
+    // Iterate through uniformly distributed momentum directions
+    auto ray_generator = ray_generator_t{};
+    ray_generator.config().theta_steps(theta_steps).phi_steps(phi_steps);
 
     for (auto _ : state) {
         benchmark::DoNotOptimize(sfhit);
         benchmark::DoNotOptimize(sfmiss);
 
         // Iterate through uniformly distributed momentum directions
-        for (const auto ray :
-             uniform_track_generator<detail::ray<test::transform3>>(
-                 theta_steps, phi_steps, ori, 1.f)) {
+        for (const auto ray : ray_generator) {
 
             for (const auto &cylinder : cylinders) {
                 auto ci = cylinder.intersector<intersection_t>();
@@ -170,16 +173,16 @@ void BM_INTERSECT_PORTAL_CYLINDERS(benchmark::State &state) {
     plane_surface plane(test::transform3(), mask_link, material_link, 0u, false,
                         surface_id::e_sensitive);
 
-    const test::point3 ori = {0.f, 0.f, 0.f};
+    // Iterate through uniformly distributed momentum directions
+    auto ray_generator = ray_generator_t{};
+    ray_generator.config().theta_steps(theta_steps).phi_steps(phi_steps);
 
     for (auto _ : state) {
         benchmark::DoNotOptimize(sfhit);
         benchmark::DoNotOptimize(sfmiss);
 
         // Iterate through uniformly distributed momentum directions
-        for (const auto ray :
-             uniform_track_generator<detail::ray<test::transform3>>(
-                 theta_steps, phi_steps, ori, 1.f)) {
+        for (const auto ray : ray_generator) {
 
             for (const auto &cylinder : cylinders) {
                 auto cpi = cylinder.intersector<intersection_t>();
@@ -222,14 +225,14 @@ void BM_INTERSECT_CONCETRIC_CYLINDERS(benchmark::State &state) {
     plane_surface plane(test::transform3(), mask_link, material_link, 0u, false,
                         surface_id::e_sensitive);
 
-    const test::point3 ori = {0.f, 0.f, 0.f};
+    // Iterate through uniformly distributed momentum directions
+    auto ray_generator = ray_generator_t{};
+    ray_generator.config().theta_steps(theta_steps).phi_steps(phi_steps);
 
     for (auto _ : state) {
 
         // Iterate through uniformly distributed momentum directions
-        for (const auto ray :
-             uniform_track_generator<detail::ray<test::transform3>>(
-                 theta_steps, phi_steps, ori, 1.f)) {
+        for (const auto ray : ray_generator) {
 
             for (const auto &cylinder : cylinders) {
                 auto cci = cylinder.intersector<intersection_t>();

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -31,13 +31,12 @@ toy_det_config toy_cfg{4u, 7u};
 
 void fill_tracks(vecmem::vector<free_track_parameters<transform3>> &tracks,
                  const std::size_t theta_steps, const std::size_t phi_steps) {
-    // Set origin position of tracks
-    const point3 ori{0.f, 0.f, 0.f};
+    // Set momentum of tracks
     const scalar mom_mag{10.f * unit<scalar>::GeV};
 
     // Iterate through uniformly distributed momentum directions
     for (auto traj : uniform_track_generator<free_track_parameters<transform3>>(
-             theta_steps, phi_steps, ori, mom_mag)) {
+             phi_steps, theta_steps, mom_mag)) {
         tracks.push_back(traj);
     }
 }

--- a/tests/common/include/tests/common/test_base/propagator_test.hpp
+++ b/tests/common/include/tests/common/test_base/propagator_test.hpp
@@ -139,14 +139,11 @@ inline vecmem::vector<track_t> generate_tracks(
     // Track collection
     vecmem::vector<track_t> tracks(mr);
 
-    // Set origin position of tracks
-    const point3 ori{0.f, 0.f, 0.f};
+    // Set momentum of tracks
     const scalar p_mag{10.f * unit<scalar>::GeV};
 
     // Iterate through uniformly distributed momentum directions
-    for (auto track : uniform_track_generator<track_t>(
-             ts, ps, ori, p_mag, {0.01f, constant<scalar>::pi},
-             {-constant<scalar>::pi, constant<scalar>::pi})) {
+    for (auto track : uniform_track_generator<track_t>(ps, ts, p_mag)) {
         track.set_overstep_tolerance(overstep_tolerance);
 
         // Put it into vector of trajectories

--- a/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
@@ -66,7 +66,7 @@ struct helix_cylinder_intersector
         // Guard against inifinite loops
         constexpr std::size_t max_n_tries{1000u};
         // Tolerance for convergence
-        constexpr scalar_type tol{1e-4f};
+        constexpr scalar_type tol{1e-3f};
 
         // Get the surface placement
         const auto &sm = trf.matrix();
@@ -128,10 +128,12 @@ struct helix_cylinder_intersector
                 const vector3 crp = vector::cross(h.pos(s) - sc, sz);
                 const scalar_type denom{
                     2.f * vector::dot(crp, vector::cross(h.dir(s), sz))};
+
                 // No intersection can be found if dividing by zero
                 if (denom == 0.f) {
                     return ret;
                 }
+
                 // x_n+1 = x_n - f(s) / f'(s)
                 s_prev = s;
                 s -= (vector::dot(crp, crp) - r * r) / denom;
@@ -148,16 +150,6 @@ struct helix_cylinder_intersector
             const auto p3 = h.pos(s);
             is.local = mask.to_local_frame(trf, p3);
             is.status = mask.is_inside(is.local, mask_tolerance);
-
-            // Perform the r-check for Newton solution even if it is not
-            // required by the mask's shape
-            const bool r_check =
-                std::abs(r - is.local[2]) <
-                mask_tolerance +
-                    5.f * std::numeric_limits<scalar_type>::epsilon();
-            if (not r_check) {
-                is.status = intersection::status::e_outside;
-            }
 
             // Compute some additional information if the intersection is valid
             if (is.status == intersection::status::e_inside) {

--- a/tests/common/include/tests/common/tools/particle_gun.hpp
+++ b/tests/common/include/tests/common/tools/particle_gun.hpp
@@ -63,7 +63,8 @@ struct particle_gun {
             // Retrieve candidate(s) from the surface
             const auto sf = surface{detector, sf_desc};
             sf.template visit_mask<intersection_kernel_t>(
-                intersections, traj, sf_desc, tf_store, mask_tolerance);
+                intersections, traj, sf_desc, tf_store,
+                sf.is_portal() ? 0.f : mask_tolerance);
 
             // Candidate is invalid if it lies in the opposite direction
             for (auto &sfi : intersections) {

--- a/tests/unit_tests/cpu/tools_particle_gun.cpp
+++ b/tests/unit_tests/cpu/tools_particle_gun.cpp
@@ -43,7 +43,6 @@ GTEST_TEST(detray_tools, particle_gun) {
 
     unsigned int theta_steps{50u};
     unsigned int phi_steps{50u};
-    const point3 ori{0.f, 0.f, 0.f};
 
     // Record ray tracing
     using detector_t = decltype(toy_det);
@@ -52,8 +51,8 @@ GTEST_TEST(detray_tools, particle_gun) {
     std::vector<std::vector<std::pair<dindex, intersection_t>>> expected;
     //  Iterate through uniformly distributed momentum directions with ray
     for (const auto test_ray :
-         uniform_track_generator<detail::ray<transform3_type>>(
-             theta_steps, phi_steps, ori)) {
+         uniform_track_generator<detail::ray<transform3_type>>(phi_steps,
+                                                               theta_steps)) {
 
         // Record all intersections and objects along the ray
         const auto intersection_record =
@@ -66,7 +65,7 @@ GTEST_TEST(detray_tools, particle_gun) {
     std::size_t n_tracks{0u};
     for (const auto track :
          uniform_track_generator<free_track_parameters<transform3_type>>(
-             theta_steps, phi_steps, ori)) {
+             phi_steps, theta_steps)) {
         const detail::helix test_helix(track, &B);
 
         // Record all intersections and objects along the ray

--- a/tests/unit_tests/cpu/tools_propagator.cpp
+++ b/tests/unit_tests/cpu/tools_propagator.cpp
@@ -160,7 +160,6 @@ class PropagatorWithRkStepper
     /// Track generator configuration
     unsigned int theta_steps{50u};
     unsigned int phi_steps{50u};
-    point3 ori{0.f, 0.f, 0.f};
     scalar mom{10.f * unit<scalar>::GeV};
 
     /// Stepper configuration
@@ -200,7 +199,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
 
     // Iterate through uniformly distributed momentum directions
     for (auto track :
-         uniform_track_generator<track_t>(theta_steps, phi_steps, ori, mom)) {
+         uniform_track_generator<track_t>(phi_steps, theta_steps, mom)) {
         // Generate second track state used for propagation with pathlimit
         track_t lim_track(track);
 
@@ -241,7 +240,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
         // Propagate the entire detector
         ASSERT_TRUE(p.propagate(state, actor_states))
             << print_insp_state.to_string() << std::endl;
-        // << state._navigation.inspector().to_string() << std::endl;
+        //  << state._navigation.inspector().to_string() << std::endl;
 
         // Propagate with path limit
         ASSERT_NEAR(pathlimit_aborter_state.path_limit(), path_limit, tol);
@@ -299,7 +298,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
 
     // Iterate through uniformly distributed momentum directions
     for (auto track :
-         uniform_track_generator<track_t>(theta_steps, phi_steps, ori, mom)) {
+         uniform_track_generator<track_t>(phi_steps, theta_steps, mom)) {
         // Genrate second track state used for propagation with pathlimit
         track_t lim_track(track);
 

--- a/tests/unit_tests/cpu/tools_stepper.cpp
+++ b/tests/unit_tests/cpu/tools_stepper.cpp
@@ -166,7 +166,6 @@ GTEST_TEST(detray_propagator, rk_stepper) {
     constexpr scalar stepsize_constr{0.5f * unit<scalar>::mm};
 
     // Track generator configuration
-    const point3 ori{0.f, 0.f, 0.f};
     const scalar p_mag{10.f * unit<scalar>::GeV};
     constexpr unsigned int theta_steps = 100u;
     constexpr unsigned int phi_steps = 100u;
@@ -174,7 +173,7 @@ GTEST_TEST(detray_propagator, rk_stepper) {
     // Iterate through uniformly distributed momentum directions
     for (auto track :
          uniform_track_generator<free_track_parameters<transform3>>(
-             theta_steps, phi_steps, ori, p_mag)) {
+             phi_steps, theta_steps, p_mag)) {
         // Generate track state used for propagation with constrained step size
         free_track_parameters c_track(track);
 
@@ -241,7 +240,7 @@ GTEST_TEST(detray_propagator, rk_stepper) {
         ASSERT_NEAR(crk_state.path_length(), 0.f, tol);
 
         const point3 backward_relative_error{1.f / (2.f * path_length) *
-                                             (rk_state().pos() - ori)};
+                                             (rk_state().pos())};
         // Make sure that relative error is smaller than the tolerance
         EXPECT_NEAR(getter::norm(backward_relative_error), 0.f, tol);
 
@@ -271,7 +270,6 @@ TEST(detray_propagator, rk_stepper_inhomogeneous_bfield) {
     constexpr scalar stepsize_constr{0.5f * unit<scalar>::mm};
 
     // Track generator configuration
-    const point3 ori{0.f, 0.f, 0.f};
     const scalar p_mag{10.f * unit<scalar>::GeV};
     constexpr unsigned int theta_steps = 100u;
     constexpr unsigned int phi_steps = 100u;
@@ -279,7 +277,7 @@ TEST(detray_propagator, rk_stepper_inhomogeneous_bfield) {
     // Iterate through uniformly distributed momentum directions
     for (auto track :
          uniform_track_generator<free_track_parameters<transform3>>(
-             theta_steps, phi_steps, ori, p_mag)) {
+             phi_steps, theta_steps, p_mag)) {
         // Generate track state used for propagation with constrained step size
         free_track_parameters c_track(track);
 
@@ -328,7 +326,7 @@ TEST(detray_propagator, rk_stepper_inhomogeneous_bfield) {
         ASSERT_NEAR(crk_state.path_length(), 0.f, tol);
 
         const point3 backward_relative_error{1.f / (2.f * path_length) *
-                                             (rk_state().pos() - ori)};
+                                             (rk_state().pos())};
         // Make sure that relative error is smaller than the tolerance
         EXPECT_NEAR(getter::norm(backward_relative_error), 0.f, tol);
 

--- a/tests/unit_tests/cpu/tools_track_generators.cpp
+++ b/tests/unit_tests/cpu/tools_track_generators.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -20,21 +20,25 @@ using point3 = test::point3;
 using transform3 = test::transform3;
 
 GTEST_TEST(detray_simulation, uniform_track_generator) {
+    using generator_t =
+        uniform_track_generator<free_track_parameters<transform3>>;
 
     constexpr const scalar tol{1e-5f};
+    constexpr const scalar epsilon{generator_t::configuration::epsilon};
 
     constexpr std::size_t phi_steps{50u};
     constexpr std::size_t theta_steps{50u};
 
     std::array<vector3, phi_steps * theta_steps> momenta{};
 
-    // Loops of theta values ]0,pi[
+    // Loop over theta values ]0,pi[
     for (std::size_t itheta{0u}; itheta < theta_steps; ++itheta) {
-        const scalar theta{0.01f + static_cast<scalar>(itheta) *
-                                       (constant<scalar>::pi - 0.01f) /
-                                       static_cast<scalar>(theta_steps)};
+        const scalar theta{epsilon +
+                           static_cast<scalar>(itheta) *
+                               (constant<scalar>::pi - 2.f * epsilon) /
+                               static_cast<scalar>(theta_steps - 1u)};
 
-        // Loops of phi values [-pi, pi]
+        // Loop over phi values [-pi, pi]
         for (std::size_t iphi{0u}; iphi < phi_steps; ++iphi) {
             // The direction
             const scalar phi{-constant<scalar>::pi +
@@ -55,10 +59,8 @@ GTEST_TEST(detray_simulation, uniform_track_generator) {
 
     // Now run the track generator and compare
     std::size_t n_tracks{0u};
-    for (const auto track :
-         uniform_track_generator<free_track_parameters<transform3>>(
-             theta_steps, phi_steps)) {
-        vector3 &expected = momenta[n_tracks];
+    for (const auto track : generator_t(phi_steps, theta_steps)) {
+        vector3& expected = momenta[n_tracks];
         vector3 result = track.mom();
 
         // Compare with for loop
@@ -74,9 +76,8 @@ GTEST_TEST(detray_simulation, uniform_track_generator) {
 
     // Generate rays
     n_tracks = 0u;
-    for (const auto r : uniform_track_generator<detail::ray<transform3>>(
-             theta_steps, phi_steps)) {
-        vector3 &expected = momenta[n_tracks];
+    for (const auto r : generator_t(phi_steps, theta_steps)) {
+        vector3& expected = momenta[n_tracks];
         vector3 result = r.dir();
 
         // Compare with for loop
@@ -94,11 +95,9 @@ GTEST_TEST(detray_simulation, uniform_track_generator) {
     const vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
                     2.f * unit<scalar>::T};
     n_tracks = 0u;
-    for (const auto track :
-         uniform_track_generator<free_track_parameters<transform3>>(
-             theta_steps, phi_steps)) {
+    for (const auto track : generator_t(phi_steps, theta_steps)) {
         detail::helix<transform3> helix_traj(track, &B);
-        vector3 &expected = momenta[n_tracks];
+        vector3& expected = momenta[n_tracks];
         vector3 result = helix_traj.dir(0.f);
 
         // Compare with for loop
@@ -113,19 +112,77 @@ GTEST_TEST(detray_simulation, uniform_track_generator) {
     ASSERT_EQ(momenta.size(), n_tracks);
 }
 
-GTEST_TEST(detray_simulation, uniform_track_generator_with_range) {
+GTEST_TEST(detray_simulation, uniform_track_generator_eta) {
+    using generator_t =
+        uniform_track_generator<free_track_parameters<transform3>>;
 
     constexpr const scalar tol{1e-5f};
 
-    constexpr std::size_t theta_steps{2u};
-    constexpr std::size_t phi_steps{4u};
+    constexpr std::size_t phi_steps{50u};
+    constexpr std::size_t eta_steps{50u};
+
+    std::array<vector3, phi_steps * eta_steps> momenta{};
+
+    // Loop over eta values [-5, 5]
+    for (std::size_t ieta{0u}; ieta < eta_steps; ++ieta) {
+        const scalar eta{-5.f + static_cast<scalar>(ieta) * (10.f) /
+                                    static_cast<scalar>(eta_steps - 1u)};
+        const scalar theta{2.f * std::atan(std::exp(-eta))};
+
+        // Loop over phi values [-pi, pi]
+        for (std::size_t iphi{0u}; iphi < phi_steps; ++iphi) {
+            // The direction
+            const scalar phi{-constant<scalar>::pi +
+                             static_cast<scalar>(iphi) *
+                                 (2.f * constant<scalar>::pi) /
+                                 static_cast<scalar>(phi_steps)};
+
+            // intialize a track
+            vector3 mom{std::cos(phi) * std::sin(theta),
+                        std::sin(phi) * std::sin(theta), std::cos(theta)};
+            vector::normalize(mom);
+            free_track_parameters<transform3> traj({0.f, 0.f, 0.f}, 0.f, mom,
+                                                   -1.f);
+
+            momenta[ieta * phi_steps + iphi] = traj.mom();
+        }
+    }
+
+    // Now run the track generator and compare
+    std::size_t n_tracks{0u};
+
+    auto trk_generator = generator_t{};
+    trk_generator.config().phi_steps(phi_steps).eta_steps(eta_steps);
+
+    for (const auto track : trk_generator) {
+        vector3& expected = momenta[n_tracks];
+        vector3 result = track.mom();
+
+        // Compare with for loop
+        EXPECT_NEAR(getter::norm(expected - result), 0.f, tol)
+            << "Expected\tResult: \n"
+            << expected[0] << "\t" << result[0] << "\n"
+            << expected[1] << "\t" << result[1] << "\n"
+            << expected[2] << "\t" << result[2] << std::endl;
+
+        ++n_tracks;
+    }
+    ASSERT_EQ(momenta.size(), n_tracks);
+}
+
+GTEST_TEST(detray_simulation, uniform_track_generator_with_range) {
+    using generator_t =
+        uniform_track_generator<free_track_parameters<transform3>>;
+
+    constexpr const scalar tol{1e-5f};
 
     std::vector<std::array<scalar, 2>> theta_phi;
 
-    for (const auto track :
-         uniform_track_generator<free_track_parameters<transform3>>(
-             theta_steps, phi_steps, {0.f, 0.f, 0.f}, 1.f * unit<scalar>::GeV,
-             {1.f, 2.f}, {-2.f, 2.f})) {
+    auto trk_gen_cfg = generator_t::configuration{};
+    trk_gen_cfg.phi_range(-2.f, 2.f).phi_steps(4u);
+    trk_gen_cfg.theta_range(1.f, 2.f).theta_steps(2u);
+
+    for (const auto track : generator_t{trk_gen_cfg}) {
         const auto dir = track.dir();
         theta_phi.push_back({getter::theta(dir), getter::phi(dir)});
     }
@@ -139,13 +196,13 @@ GTEST_TEST(detray_simulation, uniform_track_generator_with_range) {
     EXPECT_NEAR(theta_phi[2][1], 0.f, tol);
     EXPECT_NEAR(theta_phi[3][0], 1.f, tol);
     EXPECT_NEAR(theta_phi[3][1], 1.f, tol);
-    EXPECT_NEAR(theta_phi[4][0], 1.5f, tol);
+    EXPECT_NEAR(theta_phi[4][0], 2.f, tol);
     EXPECT_NEAR(theta_phi[4][1], -2.f, tol);
-    EXPECT_NEAR(theta_phi[5][0], 1.5f, tol);
+    EXPECT_NEAR(theta_phi[5][0], 2.f, tol);
     EXPECT_NEAR(theta_phi[5][1], -1.f, tol);
-    EXPECT_NEAR(theta_phi[6][0], 1.5f, tol);
+    EXPECT_NEAR(theta_phi[6][0], 2.f, tol);
     EXPECT_NEAR(theta_phi[6][1], 0.f, tol);
-    EXPECT_NEAR(theta_phi[7][0], 1.5f, tol);
+    EXPECT_NEAR(theta_phi[7][0], 2.f, tol);
     EXPECT_NEAR(theta_phi[7][1], 1.f, tol);
 }
 
@@ -156,6 +213,9 @@ GTEST_TEST(detray_simulation, random_track_generator_uniform) {
     using uniform_gen_t =
         random_numbers<scalar, std::uniform_real_distribution<scalar>,
                        std::seed_seq>;
+    using trk_generator_t =
+        random_track_generator<free_track_parameters<transform3>,
+                               uniform_gen_t>;
 
     // Tolerance depends on sample size
     constexpr scalar tol{0.05f};
@@ -165,14 +225,13 @@ GTEST_TEST(detray_simulation, random_track_generator_uniform) {
     constexpr std::size_t n_gen_tracks{10000u};
 
     // Other params
-    point3 ori = {0.f, 0.f, 0.f};
-    point3 ori_stddev = {0.1f * unit<scalar>::mm, 0.f * unit<scalar>::mm,
-                         0.2f * unit<scalar>::mm};
-    std::array<scalar, 2> mom_range = {1.f * unit<scalar>::GeV,
-                                       2.f * unit<scalar>::GeV};
-    std::array<scalar, 2> theta_range = {0.01f, constant<scalar>::pi};
-    std::array<scalar, 2> phi_range = {-0.9f * constant<scalar>::pi,
-                                       0.8f * constant<scalar>::pi};
+    trk_generator_t::configuration trk_gen_cfg{};
+    trk_gen_cfg.n_tracks(n_gen_tracks);
+    trk_gen_cfg.phi_range(-0.9f * constant<scalar>::pi,
+                          0.8f * constant<scalar>::pi);
+    trk_gen_cfg.mom_range(1.f * unit<scalar>::GeV, 2.f * unit<scalar>::GeV);
+    trk_gen_cfg.origin_stddev({0.1f * unit<scalar>::mm, 0.f * unit<scalar>::mm,
+                               0.2f * unit<scalar>::mm});
 
     // Catch the results
     std::array<scalar, n_gen_tracks> x{};
@@ -182,11 +241,7 @@ GTEST_TEST(detray_simulation, random_track_generator_uniform) {
     std::array<scalar, n_gen_tracks> phi{};
     std::array<scalar, n_gen_tracks> theta{};
 
-    for (const auto track :
-         random_track_generator<free_track_parameters<transform3>,
-                                uniform_gen_t>(n_gen_tracks, ori, ori_stddev,
-                                               mom_range, theta_range,
-                                               phi_range)) {
+    for (const auto track : trk_generator_t{trk_gen_cfg}) {
         const auto pos = track.pos();
         x[n_tracks] = pos[0];
         y[n_tracks] = pos[1];
@@ -201,6 +256,11 @@ GTEST_TEST(detray_simulation, random_track_generator_uniform) {
     ASSERT_EQ(n_gen_tracks, n_tracks);
 
     // Check uniform distrubution
+    const auto& ori = trk_gen_cfg.origin();
+    const auto& ori_stddev = trk_gen_cfg.origin_stddev();
+    const auto& phi_range = trk_gen_cfg.phi_range();
+    const auto& theta_range = trk_gen_cfg.theta_range();
+    const auto& mom_range = trk_gen_cfg.mom_range();
 
     // Mean
     EXPECT_NEAR(statistics::mean(x), ori[0], tol);
@@ -232,6 +292,8 @@ GTEST_TEST(detray_simulation, random_track_generator_normal) {
     // Use deterministic random number generator for testing
     using normal_gen_t =
         random_numbers<scalar, std::normal_distribution<scalar>, std::seed_seq>;
+    using trk_generator_t =
+        random_track_generator<free_track_parameters<transform3>, normal_gen_t>;
 
     // Tolerance depends on sample size
     constexpr scalar tol{0.05f};
@@ -241,14 +303,14 @@ GTEST_TEST(detray_simulation, random_track_generator_normal) {
     constexpr std::size_t n_gen_tracks{10000u};
 
     // Other params
-    point3 ori = {0.f, 0.f, 0.f};
-    point3 ori_stddev = {0.1f * unit<scalar>::mm, 0.5f * unit<scalar>::mm,
-                         0.3f * unit<scalar>::mm};
-    std::array<scalar, 2> mom_range = {1.f * unit<scalar>::GeV,
-                                       2.f * unit<scalar>::GeV};
-    std::array<scalar, 2> theta_range = {0.01f, constant<scalar>::pi};
-    std::array<scalar, 2> phi_range = {-0.9f * constant<scalar>::pi,
-                                       0.8f * constant<scalar>::pi};
+    trk_generator_t::configuration trk_gen_cfg{};
+    trk_gen_cfg.n_tracks(n_gen_tracks);
+    trk_gen_cfg.phi_range(-0.9f * constant<scalar>::pi,
+                          0.8f * constant<scalar>::pi);
+    trk_gen_cfg.mom_range(1.f * unit<scalar>::GeV, 2.f * unit<scalar>::GeV);
+    trk_gen_cfg.origin({0.f, 0.f, 0.f});
+    trk_gen_cfg.origin_stddev({0.1f * unit<scalar>::mm, 0.5f * unit<scalar>::mm,
+                               0.3f * unit<scalar>::mm});
 
     // Catch the results
     std::array<scalar, n_gen_tracks> x{};
@@ -258,11 +320,7 @@ GTEST_TEST(detray_simulation, random_track_generator_normal) {
     std::array<scalar, n_gen_tracks> phi{};
     std::array<scalar, n_gen_tracks> theta{};
 
-    for (const auto track :
-         random_track_generator<free_track_parameters<transform3>,
-                                normal_gen_t>(n_gen_tracks, ori, ori_stddev,
-                                              mom_range, theta_range,
-                                              phi_range)) {
+    for (const auto track : trk_generator_t{trk_gen_cfg}) {
         const auto pos = track.pos();
         x[n_tracks] = pos[0];
         y[n_tracks] = pos[1];
@@ -277,6 +335,11 @@ GTEST_TEST(detray_simulation, random_track_generator_normal) {
     ASSERT_EQ(n_gen_tracks, n_tracks);
 
     // check gaussian distribution - values are clamped to phi/theta range
+    const auto& ori = trk_gen_cfg.origin();
+    const auto& ori_stddev = trk_gen_cfg.origin_stddev();
+    const auto& phi_range = trk_gen_cfg.phi_range();
+    const auto& theta_range = trk_gen_cfg.theta_range();
+    const auto& mom_range = trk_gen_cfg.mom_range();
 
     // Mean
     EXPECT_NEAR(statistics::mean(x), ori[0], tol);

--- a/tests/unit_tests/device/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda.cpp
@@ -32,15 +32,13 @@ TEST(navigator_cuda, navigator) {
     vecmem::vector<free_track_parameters<transform3>> tracks_host(&mng_mr);
     vecmem::vector<free_track_parameters<transform3>> tracks_device(&mng_mr);
 
-    // Set origin position of tracks
-    const point3 ori{0.f, 0.f, 0.f};
+    // Magnitude of total momentum of tracks
     const scalar p_mag{10.f * unit<scalar>::GeV};
 
     // Iterate through uniformly distributed momentum directions
     for (auto track :
          uniform_track_generator<free_track_parameters<transform3>>(
-             theta_steps, phi_steps, ori, p_mag, {0.01f, constant<scalar>::pi},
-             {-constant<scalar>::pi, constant<scalar>::pi})) {
+             phi_steps, theta_steps, p_mag)) {
         track.set_overstep_tolerance(overstep_tolerance);
 
         tracks_host.push_back(track);

--- a/tests/unit_tests/svgtools/intersections.cpp
+++ b/tests/unit_tests/svgtools/intersections.cpp
@@ -48,15 +48,14 @@ int main(int, char**) {
     const auto svg_det = il.draw_detector("detector", context, view);
 
     // Creating the rays.
-    unsigned int theta_steps{10u};
-    unsigned int phi_steps{10u};
-    const typename detector_t::point3 ori{0.f, 0.f, 100.f};
+    using generator_t =
+        detray::uniform_track_generator<detray::detail::ray<transform3_t>>;
+    auto trk_gen_cfg = generator_t::configuration{};
+    trk_gen_cfg.origin({0.f, 0.f, 100.f}).phi_steps(10u).theta_steps(10u);
 
     std::size_t index = 0;
     // Iterate through uniformly distributed momentum directions with ray
-    for (const auto test_ray :
-         detray::uniform_track_generator<detray::detail::ray<transform3_t>>(
-             theta_steps, phi_steps, ori)) {
+    for (const auto test_ray : generator_t{trk_gen_cfg}) {
 
         // Record all intersections and objects along the ray
         const auto intersection_record =

--- a/tests/validation/include/detray/validation/detail/navigation_check_helper.hpp
+++ b/tests/validation/include/detray/validation/detail/navigation_check_helper.hpp
@@ -84,7 +84,7 @@ bool compare_traces(const inters_trace_t &intersection_trace,
     // Do a final check on the trace sizes
     const bool is_size{n_inters_nav == intersection_trace.size()};
     EXPECT_TRUE(is_size) << "ERROR: Intersection traces found different number "
-                            "of surfaces! Please check the last elements"
+                            "of surfaces! Please check the last elements\n"
                          << debug_stream.str();
     if (not is_size) {
         return false;

--- a/tests/validation/src/toy_detector_validation.cpp
+++ b/tests/validation/src/toy_detector_validation.cpp
@@ -61,10 +61,7 @@ int main(int argc, char **argv) {
     cfg_hel_scan.name("toy_detector_helix_scan");
     cfg_hel_scan.overstepping_tolerance(-100.f * unit<scalar_t>::um);
     cfg_hel_scan.track_generator().p_mag(10.f * unit<scalar_t>::GeV);
-    // Fails in single precision for more helices (unless is configured with
-    // only three edc layers)
-    // cfg_hel_scan.track_generator().theta_steps(100u).phi_steps(100u);
-    cfg_hel_scan.track_generator().theta_steps(30u).phi_steps(30u);
+    cfg_hel_scan.track_generator().theta_steps(100u).phi_steps(100u);
     detray::detail::register_checks<detray::helix_scan>(toy_det, toy_names,
                                                         cfg_hel_scan);
 
@@ -84,7 +81,7 @@ int main(int argc, char **argv) {
     // TODO: Fails due to mask tolerances for more helices, regardless of edc
     // configuration/precision
     // cfg_hel_nav.track_generator().theta_steps(100u).phi_steps(100u);
-    cfg_hel_nav.track_generator().theta_steps(30u).phi_steps(30u);
+    cfg_hel_nav.track_generator().theta_steps(50u).phi_steps(50u);
 
     detail::register_checks<helix_navigation>(toy_det, toy_names, cfg_hel_nav);
 

--- a/tests/validation/src/wire_chamber_validation.cpp
+++ b/tests/validation/src/wire_chamber_validation.cpp
@@ -60,9 +60,7 @@ int main(int argc, char **argv) {
     cfg_hel_scan.name("wire_chamber_helix_scan");
     cfg_hel_scan.overstepping_tolerance(-100.f * unit<scalar_t>::um);
     cfg_hel_scan.track_generator().p_mag(10.f * unit<scalar_t>::GeV);
-    // Fails in single precision for more helices
-    // cfg_hel_scan.track_generator().theta_steps(100u).phi_steps(100u);
-    cfg_hel_scan.track_generator().theta_steps(3u).phi_steps(10u);
+    cfg_hel_scan.track_generator().theta_steps(100u).phi_steps(100u);
     detray::detail::register_checks<detray::helix_scan>(det, names,
                                                         cfg_hel_scan);
 
@@ -80,7 +78,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.track_generator() = cfg_hel_scan.track_generator();
     // TODO: Fails for more helices
     // cfg_hel_nav.track_generator().theta_steps(100u).phi_steps(100u);
-    cfg_hel_nav.track_generator().theta_steps(3u).phi_steps(10u);
+    cfg_hel_nav.track_generator().theta_steps(25u).phi_steps(25u);
 
     detail::register_checks<helix_navigation>(det, names, cfg_hel_nav);
 

--- a/tutorials/src/cpu/detector/detector_ray_scan.cpp
+++ b/tutorials/src/cpu/detector/detector_ray_scan.cpp
@@ -56,13 +56,9 @@ int main() {
     // Index of the volume that the ray origin lies in
     detray::dindex start_index{0u};
 
-    // Number of rays in theta and phi
-    unsigned int theta_steps{100u};
-    unsigned int phi_steps{100u};
-    // Origin of the rays
-    const detray::tutorial::point3 origin{0.f, 0.f, 0.f};
-    auto ray_generator =
-        detray::uniform_track_generator<ray_t>(theta_steps, phi_steps, origin);
+    // Generate a number of rays
+    auto ray_generator = detray::uniform_track_generator<ray_t>{};
+    ray_generator.config().theta_steps(100u).phi_steps(100u);
 
     // Run the check
     std::cout << "\nScanning detector (" << ray_generator.size()

--- a/tutorials/src/cpu/propagation/navigation_inspection.cpp
+++ b/tutorials/src/cpu/propagation/navigation_inspection.cpp
@@ -75,11 +75,10 @@ int main() {
     using ray_type = detray::detail::ray<detray::tutorial::transform3>;
     constexpr std::size_t theta_steps{1};
     constexpr std::size_t phi_steps{1};
-    const detray::tutorial::point3 origin{0.f, 0.f, 0.f};
 
     // Iterate through uniformly distributed momentum directions
-    for (const auto ray : detray::uniform_track_generator<ray_type>(
-             theta_steps, phi_steps, origin)) {
+    for (const auto ray :
+         detray::uniform_track_generator<ray_type>(phi_steps, theta_steps)) {
 
         // Shoot ray through the detector and record all surface intersections
         const auto intersection_trace =

--- a/tutorials/src/device/cuda/propagation.cpp
+++ b/tutorials/src/device/cuda/propagation.cpp
@@ -42,8 +42,7 @@ int main() {
     // Track directions to be generated
     constexpr unsigned int theta_steps{10u};
     constexpr unsigned int phi_steps{10u};
-    // Set origin and direction of tracks
-    const detray::tutorial::point3 origin{0.f, 0.f, 0.f};
+    // Set momentum of tracks
     const detray::scalar p_mag{10.f * detray::unit<detray::scalar>::GeV};
     // How much can the navigator overshoot on a given surface?
     constexpr detray::scalar overstep_tolerance{
@@ -52,7 +51,7 @@ int main() {
     // Genrate the tracks
     for (auto track : detray::uniform_track_generator<
              detray::free_track_parameters<detray::tutorial::transform3>>(
-             theta_steps, phi_steps, origin, p_mag)) {
+             phi_steps, theta_steps, p_mag)) {
         // Set the oversetpping tolerance for every track
         track.set_overstep_tolerance(overstep_tolerance);
         // Put it into vector of tracks


### PR DESCRIPTION
Enable regular steps in eta for ```uniform_track_generator``` (this is needed for the material scans). The stepping for theta/eta has been adjusted, so that it becomes symmetric for positive and negative eta. Theta and eta ranges are inclusive, but clamped to (0, pi) and [-0.001 * num_max, 0.001 * num_max], respectively.

In order to facilitate the more complex configuration, the config structs of the track generators are used in more places and the possibility to pass complicated configurations to the parametrized constructors has been limited to the most common case.

Edit: Due to some failures in the helix scan tests because of the altered track directions, I set the mask tolerance for portals to zero and reduced the convergence tolerance for the Newton cylinder intersector (it fails to find some portals otherwise)