### PR TITLE
feat: material scanner

### DIFF
--- a/core/include/detray/materials/interaction.hpp
+++ b/core/include/detray/materials/interaction.hpp
@@ -12,7 +12,6 @@
 #include "detray/definitions/pdg_particle.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
-#include "detray/intersection/intersection.hpp"
 #include "detray/materials/detail/relativistic_quantities.hpp"
 
 namespace detray {

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -9,7 +9,6 @@
 
 // Project include(s)
 #include "detray/definitions/qualifiers.hpp"
-#include "detray/intersection/intersection.hpp"
 #include "detray/materials/material.hpp"
 #include "detray/materials/predefined_materials.hpp"
 
@@ -52,9 +51,13 @@ struct material_rod : public detail::homogeneous_material_tag {
     DETRAY_HOST_DEVICE
     constexpr const material_type& get_material() const { return m_material; }
 
-    /// Return the radius
+    /// @returns the radius
     DETRAY_HOST_DEVICE
     constexpr scalar_type radius() const { return m_radius; }
+
+    /// @returns the radius (alias function to keep interfaces homogeneous)
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type thickness() const { return m_radius; }
 
     /// @returns the path segment through the material
     ///

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -9,7 +9,6 @@
 
 // Project include(s)
 #include "detray/definitions/qualifiers.hpp"
-#include "detray/intersection/intersection.hpp"
 #include "detray/materials/material.hpp"
 #include "detray/materials/predefined_materials.hpp"
 

--- a/tests/validation/CMakeLists.txt
+++ b/tests/validation/CMakeLists.txt
@@ -3,6 +3,7 @@
 # (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
 include( CMakeFindDependencyMacro )
 
 find_dependency( Boost COMPONENTS program_options )

--- a/tests/validation/include/detray/validation/detector_material_scan.hpp
+++ b/tests/validation/include/detray/validation/detector_material_scan.hpp
@@ -1,0 +1,182 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/intersection/detail/trajectories.hpp"
+#include "detray/io/common/detail/file_handle.hpp"
+#include "detray/simulation/event_generator/track_generators.hpp"
+#include "detray/test/types.hpp"
+#include "tests/common/test_base/fixture_base.hpp"
+#include "tests/common/tools/particle_gun.hpp"
+
+// System include(s)
+#include <ios>
+#include <iostream>
+#include <string>
+
+namespace detray {
+
+/// @brief Test class that runs the material ray scan on a given detector.
+///
+/// @note The lifetime of the detector needs to be guaranteed.
+template <typename detector_t>
+class material_scan : public test::fixture_base<> {
+
+    using transform3_t = typename detector_t::transform3;
+    using scalar_t = typename detector_t::scalar_type;
+    using ray_t = detail::ray<transform3_t>;
+
+    public:
+    using fixture_type = test::fixture_base<>;
+
+    struct config : public fixture_type::configuration {
+        using trk_gen_config_t =
+            typename uniform_track_generator<ray_t>::configuration;
+
+        std::string m_name{"material_scan"};
+        trk_gen_config_t m_trk_gen_cfg{};
+
+        /// Getters
+        /// @{
+        const std::string &name() const { return m_name; }
+        trk_gen_config_t &track_generator() { return m_trk_gen_cfg; }
+        const trk_gen_config_t &track_generator() const {
+            return m_trk_gen_cfg;
+        }
+        /// @}
+
+        /// Setters
+        /// @{
+        config &name(const std::string n) {
+            m_name = n;
+            return *this;
+        }
+        /// @}
+    };
+
+    template <typename config_t>
+    explicit material_scan(const detector_t &det,
+                           const typename detector_t::name_map &names,
+                           const config_t &cfg = {})
+        : m_det{det}, m_names{names} {
+        m_cfg.name(cfg.name());
+        m_cfg.track_generator() = cfg.track_generator();
+    }
+
+    /// Run the ray scan
+    void TestBody() override {
+
+        std::size_t n_tracks{0u};
+        auto ray_generator =
+            uniform_track_generator<ray_t>(m_cfg.track_generator());
+
+        // Csv output file
+        std::string file_name{m_cfg.name() + "_" + m_names.at(0)};
+        detray::io::detail::file_handle outfile{
+            file_name, ".csv",
+            std::ios::out | std::ios::binary | std::ios::trunc};
+        *outfile << "eta,phi,mat_sX0,mat_sL0,mat_tX0,mat_tL0" << std::endl;
+
+        std::cout << "INFO: Running material scan on: " << m_names.at(0)
+                  << "\n(" << ray_generator.size() << " rays) ...\n"
+                  << std::endl;
+
+        scalar_t eta{}, phi{}, mat_sX0{}, mat_sL0{}, mat_tX0{}, mat_tL0{};
+        for (const auto ray : ray_generator) {
+
+            // Record all intersections and surfaces along the ray
+            const auto intersection_record =
+                particle_gun::shoot_particle(m_det, ray);
+
+            if (intersection_record.empty()) {
+                std::cout << "ERROR: Intersection trace empty for ray "
+                          << n_tracks << "/" << ray_generator.size() << ": "
+                          << ray << std::endl;
+                break;
+            }
+
+            eta = getter::eta(ray.dir());
+            phi = getter::phi(ray.dir());
+            // Total accumulated path length in X0 and L0, respectively
+            mat_sX0 = 0.f;
+            mat_sL0 = 0.f;
+            // Total accumulated material thickness in X0 and L0, respectively
+            mat_tX0 = 0.f;
+            mat_tL0 = 0.f;
+
+            // Record material for this ray
+            for (const auto &record : intersection_record) {
+
+                const auto sf = surface{m_det, record.second.sf_desc};
+
+                const auto [seg, t, mx0, ml0] =
+                    sf.template visit_material<get_material_params>(
+                        record.second.cos_incidence_angle,
+                        record.second.local[0]);
+
+                if (mx0 > 0.f) {
+                    mat_sX0 += seg / mx0;
+                    mat_tX0 += t / mx0;
+                } else {
+                    std::cout << "WARNING: Encountered invalid X_0: " << mx0
+                              << "\nOn surface: " << sf << std::endl;
+                }
+                if (ml0 > 0.f) {
+                    mat_sL0 += seg / ml0;
+                    mat_tL0 += t / ml0;
+                } else {
+                    std::cout << "WARNING: Encountered invalid L_0: " << ml0
+                              << "\nOn surface: " << sf << std::endl;
+                }
+            }
+
+            if (mat_sX0 == 0.f or mat_sL0 == 0.f or mat_tX0 == 0.f or
+                mat_tL0 == 0.f) {
+                std::cout << "WARNING: No material recorded for ray "
+                          << n_tracks << "/" << ray_generator.size() << ": "
+                          << ray << std::endl;
+            }
+
+            *outfile << eta << "," << phi << "," << mat_sX0 << "," << mat_sL0
+                     << "," << mat_tX0 << "," << mat_tL0 << std::endl;
+
+            ++n_tracks;
+        }
+    }
+
+    private:
+    /// @brief Functor to retrieve the material parameters of a given
+    /// intersection
+    struct get_material_params {
+        template <typename mat_group_t, typename index_t>
+        inline auto operator()(const mat_group_t &mat_group,
+                               const index_t &index,
+                               const scalar_t cos_inc_angle,
+                               const scalar_t approach) const {
+
+            const auto slab = mat_group[index];
+
+            const scalar_t seg{slab.path_segment(cos_inc_angle, approach)};
+            const scalar_t t{slab.thickness()};
+            const scalar_t mat_X0{slab.get_material().X0()};
+            const scalar_t mat_L0{slab.get_material().L0()};
+
+            return std::tuple(seg, t, mat_X0, mat_L0);
+        }
+    };
+
+    /// The configuration of this test
+    config m_cfg;
+    /// The detector to be checked
+    const detector_t &m_det;
+    /// Volume names
+    const typename detector_t::name_map &m_names;
+};
+
+}  // namespace detray

--- a/tests/validation/python/plot_material_scan.py
+++ b/tests/validation/python/plot_material_scan.py
@@ -1,0 +1,168 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# python includes
+import numpy as np
+import math
+import matplotlib.pyplot as plt
+
+
+""" Calculate edges of bins to plot the mateiral data """
+def get_n_bins(df):
+    # Find the number of ray directions
+    row_count = df.groupby(df['eta']).count()
+    yBins = row_count['phi'].max()
+    xBins = int(len(df['eta']) / yBins)
+    assert len(df['eta']) == xBins * yBins, "Could not infer the number of rays correctly"
+
+    # Get the axis spacing
+    x_range = np.max(df['eta']) - np.min(df['eta'])
+    xBinning = np.linspace(np.min(df['eta']) - 0.5 * x_range/xBins, np.max(df['eta']) + 0.5 * x_range/xBins, xBins + 1)
+
+    y_range = np.max(df['phi']) - np.min(df['phi'])
+    yBinning = np.linspace(np.min(df['phi']) - 0.5 * y_range/yBins, np.max(df['phi']) + 0.5 * y_range/yBins, yBins + 1)
+
+    return xBinning, yBinning
+
+
+""" Plot the material thickenss vs phi and eta in units of X_0 """
+def X0_vs_eta_phi(df, detector, plotFactory, format = "svg"):
+
+    # Histogram bin edges
+    xBinning, yBinning = get_n_bins(df)
+
+    # Plot the thickness of every material slab in units of X_0
+    hist_data = plotFactory.hist2D(
+                            x      = df["eta"],
+                            y      = df["phi"],
+                            z      = df['mat_tX0'],
+                            title  = r'\textbf{Material Scan - thickness / }$\mathbf{X_0}$',
+                            label  = detector,
+                            xLabel = r'$\mathbf{\eta}$',
+                            yLabel = r'$\mathbf{\phi}\,\mathrm{[rad]}$',
+                            zLabel = r'thickness / $X_0$',
+                            xBins = xBinning, yBins = yBinning,
+                            showStats = False)
+
+    plotFactory.write_plot(hist_data, "t_X0_map", format)
+
+    # Plot path length through material of the respective ray in units of X_0
+    hist_data = plotFactory.hist2D(
+                            x      = df["eta"],
+                            y      = df["phi"],
+                            z      = df['mat_sX0'],
+                            title  = r'\textbf{Material Scan - path length / }$\mathbf{X_0}$',
+                            label  = detector,
+                            xLabel = r'$\mathbf{\eta}$',
+                            yLabel = r'$\mathbf{\phi}\,\mathrm{[rad]}$',
+                            zLabel = r'path length / $X_0$',
+                            xBins = xBinning, yBins = yBinning,
+                            showStats = False)
+
+    plotFactory.write_plot(hist_data, "s_X0_map", format)
+
+
+""" Plot the material thickenss vs phi and eta in units of L_0 """
+def L0_vs_eta_phi(df, detector, plotFactory, format = "svg"):
+
+    # Histogram bin edges
+    xBinning, yBinning = get_n_bins(df)
+
+    # Plot the thickness of every material slab in units of L_0
+    hist_data = plotFactory.hist2D(
+                            x      = df["eta"],
+                            y      = df["phi"],
+                            z      = df['mat_tL0'],
+                            title  = r'\textbf{Material Scan - thickness /} $\mathbf{\Lambda_0}$',
+                            label  = detector,
+                            xLabel = r'$\mathbf{\eta}$',
+                            yLabel = r'$\mathbf{\phi}\,\mathrm{[rad]}$',
+                            zLabel = r'thickness / $\Lambda_0$',
+                            xBins = xBinning, yBins = yBinning,
+                            showStats = False)
+
+    plotFactory.write_plot(hist_data, "t_L0_map", format)
+
+    # Plot path length through material of the respective ray in units of L_0
+    hist_data = plotFactory.hist2D(
+                            x      = df["eta"],
+                            y      = df["phi"],
+                            z      = df['mat_sL0'],
+                            title  = r'\textbf{Material Scan - path length /} $\mathbf{\Lambda_0}$',
+                            label  = detector,
+                            xLabel = r'$\mathbf{\eta}$',
+                            yLabel = r'$\mathbf{\phi}\,\mathrm{[rad]}$',
+                            zLabel = r'path length / $\Lambda_0$',
+                            xBins = xBinning, yBins = yBinning,
+                            showStats = False)
+
+    plotFactory.write_plot(hist_data, "s_L0_map", format)
+
+
+""" Plot the material thickness in units of X_0 vs eta """
+def X0_vs_eta(df, detector, plotFactory, format = "svg"):
+
+    # Histogram bin edges
+    xBinning, _ = get_n_bins(df)
+
+    hist_data = plotFactory.hist1D(
+                            x      = df['eta'],
+                            w      = df['mat_tX0'],
+                            normalize = False,
+                            title  = r'\textbf{Material Scan - thickness / }$\mathbf{X_0}$',
+                            label  = rf'{detector}',
+                            xLabel = r'$\mathbf{\eta}$',
+                            yLabel = r'thickness / $X_0$',
+                            bins = xBinning,
+                            showStats = False)
+
+    plotFactory.write_plot(hist_data, "t_X0", format)
+
+    hist_data = plotFactory.hist1D(
+                            x      = df['eta'],
+                            w      = df['mat_sX0'],
+                            normalize = False,
+                            title  = r'\textbf{Material Scan - path length / }$\mathbf{X_0}$',
+                            label  = rf'{detector}',
+                            xLabel = r'$\mathbf{\eta}$',
+                            yLabel = r'path length / $X_0$',
+                            bins = xBinning,
+                            showStats = False)
+
+    plotFactory.write_plot(hist_data, "s_X0", format)
+
+
+""" Plot the material thickness in units of L_0 vs eta """
+def L0_vs_eta(df, detector, plotFactory, format = "svg"):
+
+    # Histogram bin edges
+    xBinning, _ = get_n_bins(df)
+
+    hist_data = plotFactory.hist1D(
+                            x      = df['eta'],
+                            w      = df['mat_tL0'],
+                            normalize = False,
+                            title  = r'\textbf{Material Scan - thickness / }$\mathbf{\Lambda_0}$',
+                            label  = rf'{detector}',
+                            xLabel = r'$\mathbf{\eta}$',
+                            yLabel = r'thickness / $\Lambda_0$',
+                            bins = xBinning,
+                            showStats = False)
+
+    plotFactory.write_plot(hist_data, "t_L0", format)
+
+    hist_data = plotFactory.hist1D(
+                            x      = df['eta'],
+                            w      = df['mat_sL0'],
+                            normalize = False,
+                            title  = r'\textbf{Material Scan - path length / }$\mathbf{\Lambda_0}$',
+                            label  = rf'{detector}',
+                            xLabel = r'$\mathbf{\eta}$',
+                            yLabel = r'path length / $\Lambda_0$',
+                            bins = xBinning,
+                            showStats = False)
+
+    plotFactory.write_plot(hist_data, "s_L0", format)

--- a/tests/validation/python/pyplot_factory.py
+++ b/tests/validation/python/pyplot_factory.py
@@ -1,0 +1,228 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# -*- coding: utf-8 -*-
+
+# python includes
+from collections import namedtuple
+import math
+import numpy as np
+
+# python based plotting
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+
+#-------------------------------------------------------------------------------
+# Global identifiers
+#-------------------------------------------------------------------------------
+
+""" Pass plotting data between functions """
+plt_data  = namedtuple('plt_data', 'fig ax lgd data bins mu rms errors')
+
+#-------------------------------------------------------------------------------
+# Data Plotting
+#-------------------------------------------------------------------------------
+
+"""
+Plotter interface that uses pyplot/matplotlib.
+"""
+class pyplot_factory():
+
+    def __init__(self, outDir, logger, atlas_badge = ""):
+        self.name = 'Pyplot',
+        self.outputPrefix = outDir
+        self.logger = logger
+        self.atlas_badge = atlas_badge
+        self.badge_scale = 1.1
+
+
+    """ Add legend to a plot. Labbels must be defined. """
+    def add_legend(self, ax):
+        return ax.legend(loc="upper right")
+
+
+    """
+    Create a histogram from given input data. The normalization is achieved by 
+    dividing the bin count by the total number of observations. The error is 
+    calculated as the square root of the bin content.
+    """
+    def hist1D(self, x, w = None,
+               xLabel = 'x', yLabel = '', title = "",  label = "",
+               xMin   = None, xMax  = None, bins = 1,
+               color  = 'tab:blue', alpha = 0.75,
+               setLog    = False,
+               normalize = False,
+               showError = False,
+               showStats = True):
+
+        # Create fresh plot
+        fig = plt.figure(figsize = (8, 6))
+        ax = fig.add_subplot(1, 1, 1)
+
+        # Do calculations on data in the range of the histogram
+        if not xMin is None and not xMax is None:
+            x = x[np.where(x >= xMin)]
+            x = x[np.where(x <= xMax)]
+        else:
+            xMin = np.min(x)
+            xMax = np.max(x)
+
+        # Nothing left to do
+        if len(x) == 0:
+            self.logger.debug(rf" create hist: empty data {label}")
+            return plt_data(fig, ax, None, None, None, None, None, None)
+
+        # Histogram normalization
+        scale = 1./len(x) if normalize else 1.
+
+        # Fill data
+        data, bins, hist = ax.hist(x, weights = w,
+                                   range = (xMin, xMax),
+                                   bins = bins,
+                                   label=f"{label}  ({len(x)} entries)",
+                                   histtype  ='stepfilled',
+                                   density = normalize,
+                                   facecolor = mcolors.to_rgba(color, alpha),
+                                   edgecolor = color)
+
+        # Add some additional information
+        if showStats:
+            mean = np.mean(x, axis=0)
+            rms  = np.sqrt(np.mean(np.square(x)))
+
+            # Create empty plot with blank marker containing the extra label
+            newline = '\n'
+            ax.plot([], [], ' ', label= rf'mean = {mean:.2e}'
+                                        rf'{newline}RMS  = {rms:.2e}')
+        else:
+            mean = None
+            rms = None
+
+        # Refine plot
+        ax.set_title(title)
+        ax.set_xlabel(xLabel)
+        ax.set_ylabel(yLabel)
+        ax.grid(True, alpha = 0.25)
+
+        # Add legend
+        lgd = self.add_legend(ax)
+
+        # Calculate the bin error
+        binCenters = 0.5 * (bins[1:] + bins[:-1])
+        errors     = np.sqrt(scale * data)
+        if showError:
+            ax.errorbar(binCenters, data,
+                        yerr      = errors,
+                        fmt       = '.',
+                        linestyle = '',
+                        color     = color)
+
+        # Plot log scale
+        if setLog:
+            ax.set_yscale('log')
+
+        return plt_data(fig, ax, lgd, data, bins, mean, rms, errors)
+
+
+    """
+    Create a 2D histogram from given input data. If z values are given they will
+    be used as weights per bin.
+    """
+    def hist2D(self, x, y, z = None,
+                xLabel = 'x', yLabel = 'y', zLabel = '', title = "", label = "",
+                xMin   = None, xMax  = None, xBins = 1,
+                yMin   = None, yMax  = None, yBins = 1,
+                color  = 'tab:blue', alpha = 0.75,
+                setLog    = False,
+                showError = False,
+                showStats = True):
+
+        # Create fresh plot
+        fig = plt.figure(figsize = (8, 6))
+        ax = fig.add_subplot(1, 1, 1)
+
+        # Do calculations on data in the range of the histogram
+        if not xMin is None and not xMax is None:
+            x = x[np.where(x >= xMin)]
+            x = x[np.where(x <= xMax)]
+        else:
+            xMin = np.min(x)
+            xMax = np.max(x)
+
+        if not yMin is None and not yMax is None:
+            y = y[np.where(y >= yMin)]
+            y = y[np.where(y <= yMax)]
+        else:
+            yMin = np.min(y)
+            yMax = np.max(y)
+
+        # Nothing left to do
+        if len(x) == 0 or len(y) == 0:
+            self.logger.debug(rf" create hist: empty data {label}")
+            return plt_data(fig, ax, None, None, None, None, None, None)
+
+        # Fill data
+        data, xbins, ybins, hist = ax.hist2d(
+                                    x, y, weights = z,
+                                    range = [(xMin, xMax), (yMin, yMax)],
+                                    bins = (xBins, yBins),
+                                    label=f"{label}  ({len(x)*len(y)} entries)",
+                                    facecolor = mcolors.to_rgba(color, alpha),
+                                    edgecolor = None)
+
+        # Add some additional information
+        if showStats:
+            xMean = np.mean(x, axis=0)
+            xRms  = np.sqrt(np.mean(np.square(x)))
+            yMean = np.mean(y, axis=0)
+            yRms  = np.sqrt(np.mean(np.square(y)))
+
+            # Create empty plot with blank marker containing the extra label
+            newline = '\n'
+            ax.plot([], [], ' ', label= rf'xMean = {xMean:.2e}'
+                                        rf'{newline}xRMS  = {xRms:.2e}'
+                                        rf'yMean = {yMean:.2e}'
+                                        rf'{newline}yRMS  = {yRms:.2e}')
+
+        # Refine plot
+        ax.set_title(title)
+        ax.set_xlabel(xLabel)
+        ax.set_ylabel(yLabel)
+
+        # Add the colorbar
+        fig.colorbar(hist, label = zLabel)
+
+        return plt_data(fig, ax, None, data, None, None, None, None)
+
+
+    """ Safe a plot to disk """
+    def write_plot(self, plot_data, name = "plot", file_format = "svg",
+                   outPrefix = ""):
+        if (outPrefix == ""):
+            fileName = self.outputPrefix + name + "." + file_format
+        else:
+            fileName = outPrefix + name + "." + file_format
+
+        plot_data.fig.savefig(fileName, dpi=150)
+        plt.close(plot_data.fig)
+
+
+    """ Safe a plot as svg """
+    def write_svg(self, plot_data, name, outPrefix = ""):
+
+        self.write_plot(plot_data, name, ".svg", outPrefix)
+
+
+    """ Safe a plot as pdf """
+    def write_pdf(self, plot_data, name, outPrefix = ""):
+
+        self.write_plot(plot_data, name, ".pdf", outPrefix)
+
+
+    """ Safe a plot as png """
+    def write_png(self, plot_data, name, outPrefix = ""):
+
+        self.write_plot(plot_data, name, ".png", outPrefix)

--- a/tests/validation/python/run_material_validation.py
+++ b/tests/validation/python/run_material_validation.py
@@ -1,0 +1,120 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+import plot_material_scan
+from pyplot_factory import pyplot_factory
+
+# python includes
+import argparse
+import logging
+import numpy as np
+import pandas as pd
+import os
+import sys
+from datetime import datetime
+import matplotlib.pyplot as plt
+
+
+plt.rc('text', usetex=True)
+plt.rc('text.latex', preamble=r'\usepackage{amsmath}')
+
+
+def __main__():
+
+#----------------------------------------------------------------arg parsing
+
+    parser = argparse.ArgumentParser(description = "Detray Material Validation")
+    parser.add_argument("--debug", "-d",
+                        help=("Enables debug output"), 
+                        action="store_true")
+    parser.add_argument("--logfile",
+                        help=("Write log in file"), 
+                        default = "", type=str)
+    parser.add_argument("--input", "-i",
+                        help=("Input material scan data file."),
+                        default = "", type=str)
+    parser.add_argument("--outdir", "-o",
+                        help=("Output directory for plots."),
+                        default = "./material_plots/", type=str)
+    parser.add_argument("--output_format", "-of",
+                        help=("Format of the plot files (svg|png|pdf)."),
+                        default = "png", type=str)
+
+    args = parser.parse_args()
+
+#---------------------------------------------------------------------config
+
+    # Check output path
+    if not os.path.isdir(args.outdir):
+        os.mkdir(args.outdir, 0o755)
+    outdir = args.outdir
+
+    # Set log level
+    logLevel = logging.INFO
+    if args.debug:
+        logLevel = logging.DEBUG
+
+    # Check logfile path
+    if args.logfile != "":
+        logDirName  = os.path.dirname(args.logfile)
+
+        if logDirName != "" and not os.path.isdir(logDirName):
+            os.mkdir(logDirName, 0o755)
+
+        if not os.path.isfile(args.logfile):
+            with open(args.logfile, 'x'): pass
+
+        # Write log in logfile
+        logging.basicConfig(filename=args.logfile, 
+                            format=("%(levelname)s (%(module)s):"
+                                    " %(message)s"), level=logLevel)
+    else:
+        # Write log to terminal
+        logging.basicConfig(format=("%(levelname)s (%(module)s):"
+                                    " %(message)s"), level=logLevel)
+
+    logging.info("\n--------------------------------------------------------\n"
+                 "Running material validation "+\
+                 str(datetime.now().strftime("%d/%m/%Y %H:%M"))+\
+                 "\n--------------------------------------------------------\n")
+
+    # Check input data files from material scan
+    if args.input == "":
+        logging.error(f"Please specify an input data file!")
+        sys.exit(1)
+
+    if not os.path.isfile(args.input):
+        logging.error(f"Data file does not exist! ({args.input})")
+        sys.exit(1)
+
+    if not args.output_format in ["svg", "png", "pdf"]:
+        logging.error(f"Unknown output file format: {out_format}")
+        sys.exit(1)
+
+    mat_scan_file = args.input
+    out_format = args.output_format
+
+#----------------------------------------------------------------prepare data
+
+    df = pd.read_csv(mat_scan_file)
+
+    plot_factory = pyplot_factory(outdir + "material_", logging)
+
+#------------------------------------------------------------------------run
+
+    # The histograms are not re-weighted (if the rays are not evenly distributed
+    # the material in some bins might be artificially high)!
+    plot_material_scan.X0_vs_eta_phi(df, "toy detector", plot_factory, out_format)
+    plot_material_scan.L0_vs_eta_phi(df, "toy detector", plot_factory, out_format)
+    plot_material_scan.X0_vs_eta(df, "toy detector", plot_factory, out_format)
+    plot_material_scan.L0_vs_eta(df, "toy detector", plot_factory, out_format)
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    __main__()
+
+#------------------------------------------------------------------------------- 

--- a/tests/validation/src/CMakeLists.txt
+++ b/tests/validation/src/CMakeLists.txt
@@ -10,6 +10,11 @@ detray_add_executable(detector_validation
                       LINK_LIBRARIES GTest::gtest GTest::gtest_main 
                       detray_validation)
 
+detray_add_executable(material_validation
+                      "material_validation.cpp"
+                      LINK_LIBRARIES GTest::gtest GTest::gtest_main 
+                      detray_validation)
+
 # Build the CI tests
 detray_add_test(telescope_detector
                 "telescope_detector_validation.cpp"

--- a/tests/validation/src/material_validation.cpp
+++ b/tests/validation/src/material_validation.cpp
@@ -1,0 +1,116 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/core/detector.hpp"
+#include "detray/definitions/units.hpp"
+#include "detray/io/common/detector_reader.hpp"
+#include "detray/validation/detail/register_checks.hpp"
+#include "detray/validation/detector_material_scan.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// GTest include(s)
+#include <gtest/gtest.h>
+
+// Boost
+#include <boost/program_options.hpp>
+
+// System include(s)
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace po = boost::program_options;
+using namespace detray;
+
+int main(int argc, char **argv) {
+
+    // Use the most general type to be able to read in all detector files
+    using detector_t = detray::detector<>;
+    using scalar_t = detector_t::scalar_type;
+
+    // Filter out the google test flags
+    ::testing::InitGoogleTest(&argc, argv);
+
+    // Options parsing
+    po::options_description desc("\ndetray validation options");
+
+    desc.add_options()("help", "produce help message")(
+        "geometry_file", po::value<std::string>(), "geometry input file")(
+        "material_file", po::value<std::string>(), "material input file")(
+        "bfield_file", po::value<std::string>(),
+        "magnetic field map input file")(
+        "phi_steps", po::value<std::size_t>()->default_value(50u),
+        "# phi steps for particle gun")(
+        "eta_steps", po::value<std::size_t>()->default_value(50u),
+        "# eta steps for particle gun");
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    // Help message
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Configs to be filled
+    detray::io::detector_reader_config reader_cfg{};
+    detray::material_scan<detector_t>::config mat_scan_cfg{};
+    mat_scan_cfg.track_generator().uniform_eta(true);
+
+    // Input files
+    if (vm.count("geometry_file")) {
+        reader_cfg.add_file(vm["geometry_file"].as<std::string>());
+    } else {
+        std::stringstream err_stream{};
+        err_stream << "Please specify a geometry input file!\n\n" << desc;
+
+        throw std::invalid_argument(err_stream.str());
+    }
+    if (vm.count("material_file")) {
+        reader_cfg.add_file(vm["material_file"].as<std::string>());
+    } else {
+        std::stringstream err_stream{};
+        err_stream << "Please specify a material input file!\n\n" << desc;
+
+        throw std::invalid_argument(err_stream.str());
+    }
+    if (vm.count("bfield_file")) {
+        reader_cfg.add_file(vm["bfield_file"].as<std::string>());
+    } else {
+        reader_cfg.bfield_vec(0.f, 0.f, 2.f * unit<scalar_t>::T);
+    }
+
+    // Particle gun
+    if (vm.count("phi_steps")) {
+        const std::size_t phi_steps{vm["phi_steps"].as<std::size_t>()};
+
+        mat_scan_cfg.track_generator().phi_steps(phi_steps);
+    }
+    if (vm.count("eta_steps")) {
+        const std::size_t eta_steps{vm["eta_steps"].as<std::size_t>()};
+
+        mat_scan_cfg.track_generator().eta_steps(eta_steps);
+        mat_scan_cfg.track_generator().eta_range(-4.f, 4.f);
+    }
+
+    vecmem::host_memory_resource host_mr;
+
+    const auto [det, names] =
+        detray::io::read_detector<detector_t>(host_mr, reader_cfg);
+
+    // Print the detector's material as recorded by a ray scan
+    detray::detail::register_checks<detray::material_scan>(det, names,
+                                                           mat_scan_cfg);
+
+    // Run the checks
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Add material scan and corresponding plotting tools. The material scanner is added to the validations suite and can shoot rays in uniform eta steps through a detector and record the total encountered material for each ray. The material is recorded either per radiation or interaction length and as total thickness of the material vs. ray path length through the material.

In a second tool (implemented in python), the resulting material budget can be plotted automatically, either as 2D eta-phi map or as a histogram against eta. The plotting functionality has been abstracted into a `plot_factory` to be reusable in other workflows.

The chain can be run with the following commands:
```
> ./bin/detray_material_validation --geometry_file toy_detector_geometry.json --material_file toy_detector_homogeneous_material.json --phi_steps 500 --eta_steps 500
```
and the plotting:
```
> python3 ../tests/validation/python/run_material_validation.py --input material_scan_toy_detector.csv --output_format pdf
```
Help messages are also available