### PR TITLE
External Updates, main branch (2023.10.09.)

### DIFF
--- a/extern/covfie/CMakeLists.txt
+++ b/extern/covfie/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,7 +18,7 @@ message( STATUS "Fetching covfie as part of the Detray project" )
 
 # Declare where to get covfie from.
 set( DETRAY_COVFIE_SOURCE
-   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.8.0.tar.gz;URL_MD5;b29a452aa529ee1b170650a15c591ce8"
+   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.8.1.tar.gz;URL_MD5;0b4dc9624533d1ed4ea7a763da47f07e"
    CACHE STRING "Source for covfie, when built as part of this project" )
 mark_as_advanced( DETRAY_COVFIE_SOURCE )
 FetchContent_Declare( covfie ${DETRAY_COVFIE_SOURCE} )

--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,7 +18,7 @@ message( STATUS "Building GoogleTest as part of the Detray project" )
 
 # Declare where to get GoogleTest from.
 set( DETRAY_GOOGLETEST_SOURCE
-   "URL;https://github.com/google/googletest/archive/release-1.11.0.tar.gz;URL_MD5;e8a8df240b6938bb6384155d4c37d937"
+   "URL;https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz;URL_MD5;c8340a482851ef6a3fe618a082304cfc"
    CACHE STRING "Source for GoogleTest, when built as part of this project" )
 mark_as_advanced( DETRAY_GOOGLETEST_SOURCE )
 FetchContent_Declare( GoogleTest ${DETRAY_GOOGLETEST_SOURCE} )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the Detray project" )
 
 # Declare where to get VecMem from.
 set( DETRAY_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.24.0.tar.gz;URL_MD5;f6936ea57921d7e5110606c7a9e9a371"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v0.27.0.tar.gz;URL_MD5;cd1520efbd46d5d09ac5727452939ede"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( DETRAY_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${DETRAY_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated some externals for (better) Windows/CMake compatibility.
  - The updated VecMem version provides SYCL support on Windows with CMake 3.27+;
  - The updated GoogleTest version avoids a warning with CMake 3.27+;
  - The updated Covfie version removes GCC specific hardcodes that prevented a build on Windows.

This is all in a prelude for things to come... 👻