### PR TITLE
feat: implement plotting of ray scan positions in python

### DIFF
--- a/tests/unit_tests/io/io_json_detector_reader.cpp
+++ b/tests/unit_tests/io/io_json_detector_reader.cpp
@@ -87,7 +87,7 @@ TEST(io, json_telescope_detector_reader) {
     tel_det_config<rectangle2D<>> tel_cfg{rec2};
     tel_cfg.positions(positions);
 
-    // Wire chamber
+    // Telescope detector
     vecmem::host_memory_resource host_mr;
     auto [telescope_det, telescope_names] =
         create_telescope_detector(host_mr, tel_cfg);

--- a/tests/validation/python/plot_helpers.py
+++ b/tests/validation/python/plot_helpers.py
@@ -1,0 +1,30 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+from collections import namedtuple
+
+#-------------------------------------------------------------------------------
+# Common helpers for plotting measurement data
+#-------------------------------------------------------------------------------
+
+""" Filter the data in a data frame by a given prescription """
+def filter_data(data, filter = lambda df: [], variables = []):
+    dataColl = []
+
+    # Get global data
+    if len(filter(data)) == 0:
+        for var in variables:
+            dataColl.append(data[var].to_numpy())
+
+    # Filtered data
+    else:
+        filtered = data.loc[filter]
+        for var in variables:
+            dataColl.append(filtered[var].to_numpy())
+
+    return tuple(dataColl)
+
+#-------------------------------------------------------------------------------

--- a/tests/validation/python/plot_material_scan.py
+++ b/tests/validation/python/plot_material_scan.py
@@ -4,6 +4,8 @@
 #
 # Mozilla Public License Version 2.0
 
+from pyplot_factory import get_legend_options
+
 # python includes
 import numpy as np
 import math
@@ -29,7 +31,7 @@ def get_n_bins(df):
 
 
 """ Plot the material thickenss vs phi and eta in units of X_0 """
-def X0_vs_eta_phi(df, detector, plotFactory, format = "svg"):
+def X0_vs_eta_phi(df, detector, plotFactory,  out_format =  "pdf"):
 
     # Histogram bin edges
     xBinning, yBinning = get_n_bins(df)
@@ -39,34 +41,32 @@ def X0_vs_eta_phi(df, detector, plotFactory, format = "svg"):
                             x      = df["eta"],
                             y      = df["phi"],
                             z      = df['mat_tX0'],
-                            title  = r'\textbf{Material Scan - thickness / }$\mathbf{X_0}$',
                             label  = detector,
-                            xLabel = r'$\mathbf{\eta}$',
-                            yLabel = r'$\mathbf{\phi}\,\mathrm{[rad]}$',
+                            xLabel = r'$\eta$',
+                            yLabel = r'$\phi\,\mathrm{[rad]}$',
                             zLabel = r'thickness / $X_0$',
                             xBins = xBinning, yBins = yBinning,
                             showStats = False)
 
-    plotFactory.write_plot(hist_data, "t_X0_map", format)
+    plotFactory.write_plot(hist_data, "t_X0_map",  out_format)
 
     # Plot path length through material of the respective ray in units of X_0
     hist_data = plotFactory.hist2D(
                             x      = df["eta"],
                             y      = df["phi"],
                             z      = df['mat_sX0'],
-                            title  = r'\textbf{Material Scan - path length / }$\mathbf{X_0}$',
                             label  = detector,
-                            xLabel = r'$\mathbf{\eta}$',
-                            yLabel = r'$\mathbf{\phi}\,\mathrm{[rad]}$',
+                            xLabel = r'$\eta$',
+                            yLabel = r'$\phi\,\mathrm{[rad]}$',
                             zLabel = r'path length / $X_0$',
                             xBins = xBinning, yBins = yBinning,
                             showStats = False)
 
-    plotFactory.write_plot(hist_data, "s_X0_map", format)
+    plotFactory.write_plot(hist_data, "s_X0_map",  out_format)
 
 
 """ Plot the material thickenss vs phi and eta in units of L_0 """
-def L0_vs_eta_phi(df, detector, plotFactory, format = "svg"):
+def L0_vs_eta_phi(df, detector, plotFactory,  out_format =  "pdf"):
 
     # Histogram bin edges
     xBinning, yBinning = get_n_bins(df)
@@ -76,93 +76,95 @@ def L0_vs_eta_phi(df, detector, plotFactory, format = "svg"):
                             x      = df["eta"],
                             y      = df["phi"],
                             z      = df['mat_tL0'],
-                            title  = r'\textbf{Material Scan - thickness /} $\mathbf{\Lambda_0}$',
                             label  = detector,
-                            xLabel = r'$\mathbf{\eta}$',
-                            yLabel = r'$\mathbf{\phi}\,\mathrm{[rad]}$',
+                            xLabel = r'$\eta$',
+                            yLabel = r'$\phi\,\mathrm{[rad]}$',
                             zLabel = r'thickness / $\Lambda_0$',
                             xBins = xBinning, yBins = yBinning,
                             showStats = False)
 
-    plotFactory.write_plot(hist_data, "t_L0_map", format)
+    plotFactory.write_plot(hist_data, "t_L0_map",  out_format)
 
     # Plot path length through material of the respective ray in units of L_0
     hist_data = plotFactory.hist2D(
                             x      = df["eta"],
                             y      = df["phi"],
                             z      = df['mat_sL0'],
-                            title  = r'\textbf{Material Scan - path length /} $\mathbf{\Lambda_0}$',
                             label  = detector,
-                            xLabel = r'$\mathbf{\eta}$',
-                            yLabel = r'$\mathbf{\phi}\,\mathrm{[rad]}$',
+                            xLabel = r'$\eta$',
+                            yLabel = r'$\phi\,\mathrm{[rad]}$',
                             zLabel = r'path length / $\Lambda_0$',
                             xBins = xBinning, yBins = yBinning,
                             showStats = False)
 
-    plotFactory.write_plot(hist_data, "s_L0_map", format)
+    plotFactory.write_plot(hist_data, "s_L0_map",  out_format)
 
 
 """ Plot the material thickness in units of X_0 vs eta """
-def X0_vs_eta(df, detector, plotFactory, format = "svg"):
+def X0_vs_eta(df, detector, plotFactory,  out_format =  "pdf"):
 
     # Histogram bin edges
     xBinning, _ = get_n_bins(df)
+    lgd_ops = get_legend_options()
+    lgd_ops._replace(loc = 'upper center')
 
     hist_data = plotFactory.hist1D(
                             x      = df['eta'],
                             w      = df['mat_tX0'],
                             normalize = False,
-                            title  = r'\textbf{Material Scan - thickness / }$\mathbf{X_0}$',
                             label  = rf'{detector}',
-                            xLabel = r'$\mathbf{\eta}$',
+                            xLabel = r'$\eta$',
                             yLabel = r'thickness / $X_0$',
                             bins = xBinning,
-                            showStats = False)
+                            showStats = False,
+                            lgd_ops = lgd_ops)
 
-    plotFactory.write_plot(hist_data, "t_X0", format)
+    plotFactory.write_plot(hist_data, "t_X0",  out_format)
 
     hist_data = plotFactory.hist1D(
                             x      = df['eta'],
                             w      = df['mat_sX0'],
                             normalize = False,
-                            title  = r'\textbf{Material Scan - path length / }$\mathbf{X_0}$',
                             label  = rf'{detector}',
-                            xLabel = r'$\mathbf{\eta}$',
+                            xLabel = r'$\eta$',
                             yLabel = r'path length / $X_0$',
                             bins = xBinning,
-                            showStats = False)
+                            showStats = False,
+                            lgd_ops = lgd_ops)
 
-    plotFactory.write_plot(hist_data, "s_X0", format)
+    plotFactory.write_plot(hist_data, "s_X0",  out_format)
 
 
 """ Plot the material thickness in units of L_0 vs eta """
-def L0_vs_eta(df, detector, plotFactory, format = "svg"):
+def L0_vs_eta(df, detector, plotFactory,  out_format =  "pdf"):
 
     # Histogram bin edges
     xBinning, _ = get_n_bins(df)
+    lgd_ops = get_legend_options()
+    lgd_ops._replace(loc = 'upper center')
 
     hist_data = plotFactory.hist1D(
                             x      = df['eta'],
                             w      = df['mat_tL0'],
                             normalize = False,
-                            title  = r'\textbf{Material Scan - thickness / }$\mathbf{\Lambda_0}$',
                             label  = rf'{detector}',
-                            xLabel = r'$\mathbf{\eta}$',
+                            xLabel = r'$\eta$',
                             yLabel = r'thickness / $\Lambda_0$',
                             bins = xBinning,
-                            showStats = False)
+                            showStats = False,
+                            lgd_ops = lgd_ops)
 
-    plotFactory.write_plot(hist_data, "t_L0", format)
+    plotFactory.write_plot(hist_data, "t_L0",  out_format)
 
     hist_data = plotFactory.hist1D(
                             x      = df['eta'],
                             w      = df['mat_sL0'],
                             normalize = False,
-                            title  = r'\textbf{Material Scan - path length / }$\mathbf{\Lambda_0}$',
                             label  = rf'{detector}',
-                            xLabel = r'$\mathbf{\eta}$',
+                            xLabel = r'$\eta$',
                             yLabel = r'path length / $\Lambda_0$',
                             bins = xBinning,
-                            showStats = False)
+                            showStats = False,
+                            lgd_ops = lgd_ops)
 
-    plotFactory.write_plot(hist_data, "s_L0", format)
+    plotFactory.write_plot(hist_data, "s_L0",  out_format)

--- a/tests/validation/python/plot_ray_scan.py
+++ b/tests/validation/python/plot_ray_scan.py
@@ -1,0 +1,147 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+import plot_helpers
+from pyplot_factory import legend_options
+
+# python includes
+import numpy as np
+
+""" Plot the intersection points of the detector with the rays - xy view """
+def intersection_points_xy(opts, df, detector, scan_type, plotFactory,  out_format = "png"):
+
+    n_rays = np.max(df['index']) + 1
+    tracks = "rays" if scan_type == "ray" else "helices"
+
+    # Reduce data to the requested z-range (50mm tolerance)
+    min_z = opts.z_range[0]
+    max_z = opts.z_range[1]
+    assert min_z < max_z, "xy plotting range: min z must be smaller that max z"
+    sensitive_range = lambda data: ((data['z'] > min_z) & (data['z'] < max_z) & (data['type'] == 1))
+    portal_range = lambda data: ((data['z'] > min_z) & (data['z'] < max_z) & (data['type'] == 0))
+    passive_range = lambda data: ((data['z'] > min_z) & (data['z'] < max_z) & (data['type'] == 2))
+
+    senstive_x, senstive_y = plot_helpers.filter_data(
+                                                data      = df,
+                                                filter    = sensitive_range,
+                                                variables = ['x', 'y'])
+
+    # Plot the xy coordinates of the filtered intersections points
+    lgd_ops = legend_options('upper center', 4, 0.4, 0.005)
+    hist_data = plotFactory.scatter(
+                            figsize = (8, 8),
+                            x       = senstive_x,
+                            y       = senstive_y,
+                            xLabel  = r'$x\,\mathrm{[mm]}$',
+                            yLabel  = r'$y\,\mathrm{[mm]}$',
+                            label   = "sensitives",
+                            color   = 'C5',
+                            showStats = lambda x, y: f"{n_rays} {tracks}",
+                            lgd_ops = lgd_ops)
+
+    # Portal surfaces
+    if not opts.hide_portals:
+        portal_x, portal_y = plot_helpers.filter_data(
+                                                data      = df,
+                                                filter    = portal_range,
+                                                variables = ['x', 'y'])
+
+        plotFactory.highlight_region(hist_data, portal_x, portal_y, 'C0',      \
+                                     "portals")
+
+    # Passive surfaces
+    if not opts.hide_passives:
+        passive_x, passive_y = plot_helpers.filter_data(
+                                                data      = df,
+                                                filter    = passive_range,
+                                                variables = ['x', 'y'])
+
+        plotFactory.highlight_region(hist_data, passive_x, passive_y, 'C2',    \
+                                     "passives")
+
+    # Refine legend
+    hist_data.lgd.legendHandles[0].set_visible(False)
+    for handle in hist_data.lgd.legendHandles[1:]:
+        handle.set_sizes([40])
+
+    # For this plot, move the legend ouside
+    hist_data.lgd.set_bbox_to_anchor((0.5, 1.11))
+
+    # Adjust spacing in box
+    for vpack in hist_data.lgd._legend_handle_box.get_children()[:1]:
+        for hpack in vpack.get_children():
+            hpack.get_children()[0].set_width(0)
+
+    detector_name = detector.replace(' ', '_')
+    plotFactory.write_plot(hist_data, f"{detector_name}_{scan_type}_scan_xy",  out_format)
+
+
+""" Plot the intersection points of the detector with the rays - rz view """
+def intersection_points_rz(opts, df, detector, scan_type, plotFactory,  out_format = "png"):
+
+    n_rays = np.max(df['index']) + 1
+    tracks =  "rays" if scan_type == "ray" else "helices"
+
+    # Reduce data to the requested z-range
+    sensitive_range = lambda data: (data['type'] == 1)
+    portal_range = lambda data: (data['type'] == 0)
+    passive_range = lambda data: (data['type'] == 2)
+
+    sensitive_x, sensitive_y, sensitive_z = plot_helpers.filter_data(
+                                                data      = df,
+                                                filter    = sensitive_range,
+                                                variables = ['x', 'y', 'z'])
+
+    # Plot the xy coordinates of the filtered intersections points
+    lgd_ops = legend_options('upper center', 4, 0.8, 0.005)
+    hist_data = plotFactory.scatter(
+                            figsize = (12, 6),
+                            x      = sensitive_z,
+                            y      = np.hypot(sensitive_x, sensitive_y),
+                            xLabel = r'$z\,\mathrm{[mm]}$',
+                            yLabel = r'$r\,\mathrm{[mm]}$',
+                            label  = "sensitives",
+                            color  = 'C5',
+                            showStats = lambda x, y: f"{n_rays} {tracks}",
+                            lgd_ops = lgd_ops)
+
+    # Portal surfaces
+    if not opts.hide_portals:
+        portal_x, portal_y, portal_z = plot_helpers.filter_data(
+                                                    data      = df,
+                                                    filter    = portal_range,
+                                                    variables = ['x', 'y', 'z'])
+
+        plotFactory.highlight_region(hist_data, portal_z,                      \
+                                     np.hypot(portal_x, portal_y),             \
+                                     'C0', "portals")
+
+    # Passive surfaces
+    if not opts.hide_passives:
+        passive_x, passive_y, passive_z = plot_helpers.filter_data(
+                                                    data      = df,
+                                                    filter    = passive_range,
+                                                    variables = ['x', 'y', 'z'])
+
+        plotFactory.highlight_region(hist_data, passive_z,                     \
+                                    np.hypot(passive_x, passive_y),            \
+                                    'C2', "passives")
+
+    # Refine legend
+    hist_data.lgd.legendHandles[0].set_visible(False)
+    for handle in hist_data.lgd.legendHandles[1:]:
+        handle.set_sizes([40])
+
+    # For this plot, move the legend ouside
+    hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+
+    # Adjust spacing in box
+    for vpack in hist_data.lgd._legend_handle_box.get_children()[:1]:
+        for hpack in vpack.get_children():
+            hpack.get_children()[0].set_width(0)
+
+    detector_name = detector.replace(' ', '_')
+    plotFactory.write_plot(hist_data, f"{detector_name}_{scan_type}_scan_rz",  out_format)

--- a/tests/validation/src/detector_validation.cpp
+++ b/tests/validation/src/detector_validation.cpp
@@ -43,24 +43,31 @@ int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
 
     // Options parsing
-    po::options_description desc("\ndetray validation options");
+    po::options_description desc("\ndetray detector validation options");
 
     desc.add_options()("help", "produce help message")(
         "write_volume_graph", "writes the volume graph to file")(
-        "write_ray_scan", "writes the ray scan intersections to file")(
+        "write_scan_data", "writes the ray/helix scan intersections to file")(
         "geometry_file", po::value<std::string>(), "geometry input file")(
         "material_file", po::value<std::string>(), "material input file")(
         "phi_steps", po::value<std::size_t>()->default_value(50u),
         "# phi steps for particle gun")(
         "theta_steps", po::value<std::size_t>()->default_value(50u),
         "# theta steps for particle gun")(
+        "theta_range", po::value<std::vector<scalar_t>>()->multitoken(),
+        "min, max range of theta values for particle gun")(
+        "origin", po::value<std::vector<scalar_t>>()->multitoken(),
+        "coordintates for particle gun origin position")(
         "p_mag", po::value<scalar_t>()->default_value(10.f),
         "absolute momentum of the test particle [GeV]")(
         "overstep_tol", po::value<scalar_t>()->default_value(-100.f),
         "overstepping tolerance [um] NOTE: Must be negative!");
 
     po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::store(parse_command_line(argc, argv, desc,
+                                 po::command_line_style::unix_style ^
+                                     po::command_line_style::allow_short),
+              vm);
     po::notify(vm);
 
     // Help message
@@ -82,10 +89,9 @@ int main(int argc, char **argv) {
         con_chk_cfg.write_graph(true);
         throw std::invalid_argument("Writing of voume graph not implemented");
     }
-    if (vm.count("write_ray_scan")) {
+    if (vm.count("write_scan_data")) {
         ray_scan_cfg.write_intersections(true);
         hel_scan_cfg.write_intersections(true);
-        throw std::invalid_argument("Writing of ray scan not implemented");
     }
 
     // Input files
@@ -106,11 +112,36 @@ int main(int argc, char **argv) {
         const std::size_t phi_steps{vm["phi_steps"].as<std::size_t>()};
 
         ray_scan_cfg.track_generator().phi_steps(phi_steps);
+        hel_nav_cfg.track_generator().phi_steps(phi_steps);
     }
     if (vm.count("theta_steps")) {
         const std::size_t theta_steps{vm["theta_steps"].as<std::size_t>()};
 
         ray_scan_cfg.track_generator().theta_steps(theta_steps);
+        hel_nav_cfg.track_generator().theta_steps(theta_steps);
+    }
+    if (vm.count("theta_range")) {
+        const auto theta_range = vm["theta_range"].as<std::vector<scalar_t>>();
+        if (theta_range.size() == 2u) {
+            ray_scan_cfg.track_generator().theta_range(theta_range[0],
+                                                       theta_range[1]);
+            hel_nav_cfg.track_generator().theta_range(theta_range[0],
+                                                      theta_range[1]);
+        } else {
+            throw std::invalid_argument("Theta range needs two arguments");
+        }
+    }
+    if (vm.count("origin")) {
+        const auto origin = vm["origin"].as<std::vector<scalar_t>>();
+        if (origin.size() == 3u) {
+            ray_scan_cfg.track_generator().origin(
+                {origin[0], origin[1], origin[2]});
+            hel_nav_cfg.track_generator().origin(
+                {origin[0], origin[1], origin[2]});
+        } else {
+            throw std::invalid_argument(
+                "Particle gun origin needs three arguments");
+        }
     }
     if (vm.count("p_mag")) {
         const scalar_t p_mag{vm["p_mag"].as<scalar_t>()};
@@ -140,22 +171,21 @@ int main(int argc, char **argv) {
                                                                con_chk_cfg);
 
     // Navigation link consistency, discovered by ray intersection
+    ray_scan_cfg.name("ray_scan_" + names.at(0));
     detray::detail::register_checks<detray::ray_scan>(det, names, ray_scan_cfg);
 
     // Navigation link consistency, discovered by helix intersection
-    // Full number of helices only works in double precision
-    // hel_nav_cfg.track_generator().phi_steps(100u).theta_steps(100u);
-    hel_scan_cfg.track_generator().phi_steps(30u).theta_steps(30u);
+    hel_scan_cfg.name("helix_scan_" + names.at(0));
     detray::detail::register_checks<detray::helix_scan>(det, names,
                                                         hel_scan_cfg);
 
     // Comparision of straight line navigation with ray scan
+    str_nav_cfg.name("straight_line_navigation_" + names.at(0));
     detray::detail::register_checks<detray::straight_line_navigation>(
         det, names, str_nav_cfg);
 
     // Comparision of navigation in a constant B-field with helix
-    // For now, run with reduced number of helices, until helix test is fixed
-    hel_nav_cfg.track_generator().phi_steps(30u).theta_steps(30u);
+    hel_nav_cfg.name("helix_navigation_" + names.at(0));
     detray::detail::register_checks<detray::helix_navigation>(det, names,
                                                               hel_nav_cfg);
 


### PR DESCRIPTION
Add functionality to output the positions of the ray surface intersections, as well as python tools to plot them in an xy - and an rz view. The data can both be plotted for the ray and the helix scan, which needs to be turned on by the ```--write_scan_data``` option.