### PR TITLE
ref: rename surface store

### DIFF
--- a/core/include/detray/core/detector_metadata.hpp
+++ b/core/include/detray/core/detector_metadata.hpp
@@ -124,7 +124,7 @@ struct default_metadata {
 
     /// Give your mask types a name (needs to be consecutive and has to match
     /// the types position in the mask store!)
-    enum class mask_ids {
+    enum class mask_ids : std::uint8_t {
         e_rectangle2 = 0,
         e_portal_rectangle2 = 0,
         e_trapezoid2 = 1,
@@ -163,7 +163,7 @@ unbounded_cell, unmasked_plane*/>;
     /// Give your material types a name (needs to be consecutive and has to
     /// match the types position in the mask store!)
     /// @TODO: Add the material grid types for every surface shape
-    enum class material_ids {
+    enum class material_ids : std::uint8_t {
         e_slab = 0,
         e_rod = 1,
         // ... material map types
@@ -180,7 +180,7 @@ unbounded_cell, unmasked_plane*/>;
     using transform_link = typename transform_store<>::link_type;
     using mask_link = typename mask_store<>::single_link;
     using material_link = typename material_store<>::single_link;
-    using source_link = dindex;
+    using source_link = std::uint64_t;
     /// Surface type used for sensitives, passives and portals
     using surface_type =
         surface_descriptor<mask_link, material_link, transform_link, nav_link,
@@ -189,7 +189,7 @@ unbounded_cell, unmasked_plane*/>;
     /// How to index the constituent objects (surfaces) in a volume
     /// If they share the same index value here, they will be added into the
     /// same acceleration data structure (brute force is always at 0)
-    enum geo_objects : std::size_t {
+    enum geo_objects : std::uint8_t {
         e_portal = 0,     // Brute force search
         e_sensitive = 1,  // Grid accelerated search (can be different types)
         e_passive = 0,    // Brute force search
@@ -198,7 +198,7 @@ unbounded_cell, unmasked_plane*/>;
     };
 
     /// Acceleration data structures
-    enum class sf_finder_ids {
+    enum class accel_ids : std::uint8_t {
         e_brute_force = 0,     // test all surfaces in a volume (brute force)
         e_disc_grid = 1,       // e.g. endcap layers
         e_cylinder2_grid = 2,  // e.g. barrel layers
@@ -213,13 +213,13 @@ unbounded_cell, unmasked_plane*/>;
     /// How a volume links to the accelration data structures
     /// In this case: One link for portals/passives and one sensitive surfaces
     using object_link_type =
-        dmulti_index<dtyped_index<sf_finder_ids, dindex>, geo_objects::e_size>;
+        dmulti_index<dtyped_index<accel_ids, dindex>, geo_objects::e_size>;
 
     /// How to store the acceleration data structures
     template <template <typename...> class tuple_t = dtuple,
               typename container_t = host_container_types>
-    using surface_finder_store =
-        multi_store<sf_finder_ids, empty_context, tuple_t,
+    using accelerator_store =
+        multi_store<accel_ids, empty_context, tuple_t,
                     brute_force_collection<surface_type, container_t>,
                     grid_collection<disc_sf_grid<surface_type, container_t>>,
                     grid_collection<

--- a/core/include/detray/geometry/detail/surface_descriptor.hpp
+++ b/core/include/detray/geometry/detail/surface_descriptor.hpp
@@ -31,7 +31,8 @@ namespace detray {
 template <typename mask_link_t = dtyped_index<dindex, dindex>,
           typename material_link_t = dtyped_index<dindex, dindex>,
           typename transform_link_t = dindex,
-          typename navigation_link_t = dindex, typename source_link_t = dindex>
+          typename navigation_link_t = dindex,
+          typename source_link_t = std::uint64_t>
 class surface_descriptor {
 
     public:
@@ -79,7 +80,7 @@ class surface_descriptor {
                                  const mask_link &mask,
                                  const material_link &material,
                                  const dindex volume, const source_link &src,
-                                 surface_id sf_id)
+                                 const surface_id sf_id)
         : _mask(mask), _material(material), _trf(trf), _src(src) {
         m_barcode = geometry::barcode{}.set_volume(volume).set_id(sf_id);
     }

--- a/core/include/detray/geometry/detail/volume_descriptor.hpp
+++ b/core/include/detray/geometry/detail/volume_descriptor.hpp
@@ -77,19 +77,19 @@ class volume_descriptor {
 
     /// @returns link to all acceleration data structures - const access
     DETRAY_HOST_DEVICE constexpr auto full_link() const -> const link_type & {
-        return m_sf_finder_links;
+        return m_accel_links;
     }
 
     /// @returns acc data structure link for a specific type of object - const
     template <ID obj_id>
     DETRAY_HOST_DEVICE constexpr auto link() const -> const link_t & {
-        return detail::get<obj_id>(m_sf_finder_links);
+        return detail::get<obj_id>(m_accel_links);
     }
 
     /// Set surface finder link from @param link
     template <ID obj_id>
     DETRAY_HOST constexpr auto set_link(const link_t link) -> void {
-        detail::get<obj_id>(m_sf_finder_links) = link;
+        detail::get<obj_id>(m_accel_links) = link;
     }
 
     /// Set surface finder link from @param id and @param index of the
@@ -99,7 +99,7 @@ class volume_descriptor {
     DETRAY_HOST constexpr auto set_link(const typename link_t::id_type id,
                                         const typename link_t::index_type index)
         -> void {
-        detail::get<obj_id>(m_sf_finder_links) = link_t{id, index};
+        detail::get<obj_id>(m_accel_links) = link_t{id, index};
     }
 
     /// Equality operator
@@ -108,7 +108,7 @@ class volume_descriptor {
     DETRAY_HOST_DEVICE
     constexpr auto operator==(const volume_descriptor &rhs) const -> bool {
         return (m_id == rhs.m_id && m_index == rhs.m_index &&
-                m_sf_finder_links == rhs.m_sf_finder_links);
+                m_accel_links == rhs.m_accel_links);
     }
 
     private:
@@ -122,7 +122,7 @@ class volume_descriptor {
     dindex m_transform{dindex_invalid};
 
     /// Links for every object type to an acceleration data structure
-    link_type m_sf_finder_links{};
+    link_type m_accel_links{};
 };
 
 }  // namespace detray

--- a/core/include/detray/geometry/detail/volume_kernels.hpp
+++ b/core/include/detray/geometry/detail/volume_kernels.hpp
@@ -19,10 +19,9 @@ struct surface_getter {
 
     /// Call operator that forwards the neighborhood search call in a volume
     /// to a surface finder data structure
-    template <typename sf_finder_group_t, typename sf_finder_index_t,
-              typename... Args>
-    DETRAY_HOST_DEVICE inline void operator()(const sf_finder_group_t &group,
-                                              const sf_finder_index_t index,
+    template <typename accel_group_t, typename accel_index_t, typename... Args>
+    DETRAY_HOST_DEVICE inline void operator()(const accel_group_t &group,
+                                              const accel_index_t index,
                                               Args &&... args) const {
 
         // Run over the surfaces in a single acceleration data structure
@@ -38,10 +37,10 @@ struct neighborhood_getter {
 
     /// Call operator that forwards the neighborhood search call in a volume
     /// to a surface finder data structure
-    template <typename sf_finder_group_t, typename sf_finder_index_t,
+    template <typename accel_group_t, typename accel_index_t,
               typename detector_t, typename track_t, typename... Args>
     DETRAY_HOST_DEVICE inline void operator()(
-        const sf_finder_group_t &group, const sf_finder_index_t index,
+        const accel_group_t &group, const accel_index_t index,
         const detector_t &det, const typename detector_t::volume_type &volume,
         const track_t &track, Args &&... args) const {
 

--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -132,7 +132,7 @@ class detector_volume {
         unsigned int n = 0u) const -> unsigned int {
         // Get the index of the surface collection with type index 'I'
         constexpr auto sf_col_id{
-            static_cast<typename detector_t::sf_finders::id>(I)};
+            static_cast<typename detector_t::accel::id>(I)};
         const auto &link{
             m_desc
                 .template link<static_cast<typename descr_t::object_id>(I)>()};
@@ -141,7 +141,7 @@ class detector_volume {
         // number of candidates that we can expect from it
         if (not link.is_invalid()) {
             const unsigned int n_max{
-                m_detector.surface_store()
+                m_detector.accelerator_store()
                     .template get<sf_col_id>()[detail::get<1>(link)]
                     .n_max_candidates()};
             // @todo: Remove when local navigation becomes available !!!!
@@ -245,7 +245,7 @@ class detector_volume {
         if (not link.is_invalid()) {
             // Run over the surfaces in a single acceleration data structure
             // and apply the functor to the resulting neighborhood
-            m_detector.surface_store().template visit<functor_t>(
+            m_detector.accelerator_store().template visit<functor_t>(
                 link, std::forward<Args>(args)...);
         }
         // Check the next surface type

--- a/core/include/detray/geometry/volume_graph.hpp
+++ b/core/include/detray/geometry/volume_graph.hpp
@@ -56,7 +56,6 @@ class volume_graph {
     public:
     using geo_obj_ids = typename detector_t::geo_obj_ids;
     using volume_container_t = vector_t<typename detector_t::volume_type>;
-    using surface_container_t = typename detector_t::surface_container;
     using mask_container_t = typename detector_t::mask_container;
 
     /// @brief Builds a graph node from the detector collections on the fly.

--- a/core/include/detray/tools/cuboid_portal_generator.hpp
+++ b/core/include/detray/tools/cuboid_portal_generator.hpp
@@ -79,7 +79,7 @@ class cuboid_portal_generator final
     /// @param ctx the geometry context (not needed for portals).
     DETRAY_HOST
     auto operator()(typename detector_t::volume_type &volume,
-                    typename detector_t::surface_container_t &surfaces,
+                    typename detector_t::surface_container &surfaces,
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {}) const

--- a/core/include/detray/tools/grid_builder.hpp
+++ b/core/include/detray/tools/grid_builder.hpp
@@ -108,8 +108,8 @@ class grid_builder final : public volume_decorator<detector_t> {
         // Take the surfaces that should be filled into the grid out of the
         // brute force finder
         const auto vol_idx{vol_ptr->index()};
-        constexpr auto bf_id{detector_t::sf_finders::id::e_brute_force};
-        auto &bf_search = det.surface_store().template get<bf_id>();
+        constexpr auto bf_id{detector_t::accel::id::e_brute_force};
+        auto &bf_search = det.accelerator_store().template get<bf_id>();
 
         // Grid has not been filled previously, fill it automatically
         if (m_grid.size() == 0u) {
@@ -169,11 +169,11 @@ class grid_builder final : public volume_decorator<detector_t> {
         }
 
         // Add the grid to the detector and link it to its volume
-        constexpr auto gid{detector_t::sf_finders::template get_id<grid_t>()};
-        det.surface_store().template push_back<gid>(m_grid);
+        constexpr auto gid{detector_t::accel::template get_id<grid_t>()};
+        det.accelerator_store().template push_back<gid>(m_grid);
         vol_ptr->template set_link<
             detector_t::volume_type::object_id::e_sensitive>(
-            gid, det.surface_store().template size<gid>() - 1);
+            gid, det.accelerator_store().template size<gid>() - 1);
 
         return vol_ptr;
     }

--- a/core/include/detray/tools/material_factory.hpp
+++ b/core/include/detray/tools/material_factory.hpp
@@ -187,7 +187,7 @@ class material_factory final : public factory_decorator<detector_t> {
     /// @param material material store of the volume builder that the new
     ///                 materials get added to.
     DETRAY_HOST
-    auto operator()(typename detector_t::surface_container_t &surfaces,
+    auto operator()(typename detector_t::surface_container &surfaces,
                     typename detector_t::material_container &materials) {
 
         // This builder is only called on a homogeneous material description

--- a/core/include/detray/tools/surface_factory.hpp
+++ b/core/include/detray/tools/surface_factory.hpp
@@ -88,13 +88,14 @@ class surface_factory : public surface_factory_interface<detector_t> {
     DETRAY_HOST
     void push_back(surface_data_t &&sf_data) override {
 
-        auto [type, vlink, index, bounds, trf] = sf_data.get_data();
+        auto [type, vlink, index, source, bounds, trf] = sf_data.get_data();
 
         assert(bounds.size() == mask_shape_t::boundaries::e_size);
 
         m_types.push_back(type);
         m_volume_link.push_back(vlink);
         m_indices.push_back(index);
+        m_sources.push_back(source);
         m_bounds.push_back(std::move(bounds));
         m_transforms.push_back(trf);
     }
@@ -108,6 +109,7 @@ class surface_factory : public surface_factory_interface<detector_t> {
 
         m_volume_link.reserve(n_surfaces);
         m_indices.reserve(n_surfaces);
+        m_sources.reserve(n_surfaces);
         m_bounds.reserve(n_surfaces);
         m_transforms.reserve(n_surfaces);
 
@@ -123,6 +125,7 @@ class surface_factory : public surface_factory_interface<detector_t> {
         m_types.clear();
         m_volume_link.clear();
         m_indices.clear();
+        m_sources.clear();
         m_bounds.clear();
         m_transforms.clear();
     }
@@ -139,7 +142,7 @@ class surface_factory : public surface_factory_interface<detector_t> {
     DETRAY_HOST
     auto operator()([[maybe_unused]] typename detector_t::volume_type &volume,
                     [[maybe_unused]]
-                    typename detector_t::surface_container_t &surfaces,
+                    typename detector_t::surface_container &surfaces,
                     [[maybe_unused]]
                     typename detector_t::transform_container &transforms,
                     [[maybe_unused]] typename detector_t::mask_container &masks,
@@ -209,7 +212,7 @@ class surface_factory : public surface_factory_interface<detector_t> {
                 this->insert_in_container(
                     surfaces,
                     {trf_idx, mask_link, material_link, volume.index(),
-                     dindex_invalid, m_types[idx]},
+                     m_sources[idx], m_types[idx]},
                     sf_idx);
             }
         }
@@ -225,6 +228,7 @@ class surface_factory : public surface_factory_interface<detector_t> {
         assert(m_bounds.size() == m_types.size());
         assert(m_bounds.size() == m_volume_link.size());
         assert(m_bounds.size() == m_indices.size());
+        assert(m_bounds.size() == m_sources.size());
         assert(m_bounds.size() == m_transforms.size());
     }
 
@@ -235,6 +239,8 @@ class surface_factory : public surface_factory_interface<detector_t> {
     /// Indices of surfaces for the placement in container
     /// (counted as "volume-local": 0 to n_sf_in_volume)
     std::vector<dindex> m_indices{};
+    /// Source links of surfaces
+    std::vector<std::uint64_t> m_sources{};
     /// Mask boundaries of surfaces
     std::vector<std::vector<scalar_t>> m_bounds{};
     /// Transforms of surfaces

--- a/core/include/detray/tools/surface_factory_interface.hpp
+++ b/core/include/detray/tools/surface_factory_interface.hpp
@@ -43,10 +43,12 @@ class surface_data {
         const surface_id type, const typename detector_t::transform3 &trf,
         navigation_link volume_link,
         const std::vector<typename detector_t::scalar_type> &mask_boundaries,
-        const dindex idx = dindex_invalid)
+        const dindex idx = dindex_invalid,
+        const std::uint64_t source = detail::invalid_value<std::uint64_t>())
         : m_type{type},
           m_volume_link{volume_link},
           m_index{idx},
+          m_source{source},
           m_boundaries{mask_boundaries},
           m_transform{trf} {}
 
@@ -54,9 +56,10 @@ class surface_data {
     DETRAY_HOST
     auto get_data()
         -> std::tuple<surface_id &, navigation_link &, dindex &,
+                      std::uint64_t &,
                       std::vector<typename detector_t::scalar_type> &,
                       typename detector_t::transform3 &> {
-        return std::tie(m_type, m_volume_link, m_index, m_boundaries,
+        return std::tie(m_type, m_volume_link, m_index, m_source, m_boundaries,
                         m_transform);
     }
 
@@ -68,8 +71,9 @@ class surface_data {
     /// The position of the surface in the detector containers, used to match
     /// the surface to e.g. its material
     dindex m_index;
-    // Simple tuple of all mask types in the detector. Only one entry is filled
-    // with the mask that corresponds to this specific surface.
+    /// Source link (ACTS geoID)
+    std::uint64_t m_source;
+    /// Vector of mask boundary values
     std::vector<typename detector_t::scalar_type> m_boundaries;
     /// The surface placement
     typename detector_t::transform3 m_transform;
@@ -109,7 +113,7 @@ class surface_factory_interface {
     DETRAY_HOST
     virtual auto operator()(
         typename detector_t::volume_type &volume,
-        typename detector_t::surface_container_t &surfaces,
+        typename detector_t::surface_container &surfaces,
         typename detector_t::transform_container &transforms,
         typename detector_t::mask_container &masks,
         typename detector_t::geometry_context ctx = {}) const
@@ -178,7 +182,7 @@ class factory_decorator : public surface_factory_interface<detector_t> {
 
     DETRAY_HOST
     auto operator()(typename detector_t::volume_type &volume,
-                    typename detector_t::surface_container_t &surfaces,
+                    typename detector_t::surface_container &surfaces,
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {}) const

--- a/core/include/detray/tools/volume_builder.hpp
+++ b/core/include/detray/tools/volume_builder.hpp
@@ -47,7 +47,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
         // force method that will at least contain the portals
         m_volume
             .template set_link<static_cast<typename volume_type::object_id>(0)>(
-                detector_t::sf_finders::id::e_default, 0);
+                detector_t::accel::id::e_default, 0);
     };
 
     /// Adds the @param name of the volume to a @param name_map
@@ -129,7 +129,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
 
     protected:
     /// @returns Access to the surface descriptor data
-    typename detector_t::surface_container_t& surfaces() override {
+    typename detector_t::surface_container& surfaces() override {
         return m_surfaces;
     }
 
@@ -176,10 +176,10 @@ class volume_builder : public volume_builder_interface<detector_t> {
         // surfaces are filled into the default brute_force accelerator.
         // For the other accelerators (grid etc.) there need to be dedicated
         // builders
-        constexpr auto default_acc_id{detector_t::sf_finders::id::e_default};
+        constexpr auto default_acc_id{detector_t::accel::id::e_default};
         m_volume.template set_link<surface_id>(
             default_acc_id,
-            det.surface_store().template size<default_acc_id>() - 1u);
+            det.accelerator_store().template size<default_acc_id>() - 1u);
 
         // Append masks
         det.append_masks(std::move(m_masks));
@@ -195,7 +195,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
 
     /// Data of conatined surfaces
     /// @{
-    typename detector_t::surface_container_t m_surfaces{};
+    typename detector_t::surface_container m_surfaces{};
     typename detector_t::transform_container m_transforms{};
     typename detector_t::mask_container m_masks{};
     /// @}

--- a/core/include/detray/tools/volume_builder_interface.hpp
+++ b/core/include/detray/tools/volume_builder_interface.hpp
@@ -82,7 +82,7 @@ class volume_builder_interface {
     protected:
     /// Access to builder data
     /// @{
-    virtual typename detector_t::surface_container_t &surfaces() = 0;
+    virtual typename detector_t::surface_container &surfaces() = 0;
     virtual typename detector_t::transform_container &transforms() = 0;
     virtual typename detector_t::mask_container &masks() = 0;
     /// @}
@@ -153,7 +153,7 @@ class volume_decorator : public volume_builder_interface<detector_t> {
     /// @}
 
     protected:
-    typename detector_t::surface_container_t &surfaces() override {
+    typename detector_t::surface_container &surfaces() override {
         return m_builder->surfaces();
     }
     typename detector_t::transform_container &transforms() override {

--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -166,8 +166,8 @@ inline void check_empty(const detector_t &det) {
 
     // Check for empty acceleration data structure collections (e.g. grids)
     detail::report_empty(
-        det.surface_store(), "acceleration data structures store",
-        std::make_index_sequence<detector_t::sf_finders::n_types>{});
+        det.accelerator_store(), "acceleration data structures store",
+        std::make_index_sequence<detector_t::accel::n_types>{});
 
     // Check volume search data structure
     if (not find_volumes(det.volume_search_grid())) {

--- a/io/include/detray/io/common/geometry_writer.hpp
+++ b/io/include/detray/io/common/geometry_writer.hpp
@@ -119,7 +119,7 @@ class geometry_writer : public writer_interface<detector_t> {
         sf_data.transform = serialize(sf.transform({}));
         sf_data.mask = sf.template visit_mask<get_mask_payload>();
         sf_data.material = sf.template visit_material<get_material_payload>();
-        sf_data.source = base_type::serialize(sf.source());
+        sf_data.source = sf.source();
 
         return sf_data;
     }
@@ -157,8 +157,8 @@ class geometry_writer : public writer_interface<detector_t> {
         for (unsigned int i = 1u; i < link.size(); ++i) {
             const auto& l = link[i];
             if (not l.is_invalid()) {
-                const auto aclp =
-                    det.surface_store().template visit<get_acc_link_payload>(l);
+                const auto aclp = det.accelerator_store()
+                                      .template visit<get_acc_link_payload>(l);
                 vol_data.acc_links->push_back(aclp);
             }
         }

--- a/io/include/detray/io/common/grid_reader.hpp
+++ b/io/include/detray/io/common/grid_reader.hpp
@@ -295,7 +295,7 @@ class grid_reader : public reader_interface<detector_t> {
 
         // The compiler will instantiate this function for all possible types of
         // grids: Only proceed, if the grid type is known by the detector
-        if constexpr (detector_t::sf_finders::template is_defined<grid_t>()) {
+        if constexpr (detector_t::accel::template is_defined<grid_t>()) {
 
             // Decorate the current volume builder with the grid
             using grid_builder_t =

--- a/io/include/detray/io/common/grid_writer.hpp
+++ b/io/include/detray/io/common/grid_writer.hpp
@@ -57,7 +57,7 @@ class grid_writer : public writer_interface<detector_t> {
 
         header_data.sub_header.emplace();
         auto& grid_sub_header = header_data.sub_header.value();
-        grid_sub_header.n_grids = get_n_grids(det.surface_store());
+        grid_sub_header.n_grids = get_n_grids(det.accelerator_store());
 
         return header_data;
     }
@@ -85,7 +85,7 @@ class grid_writer : public writer_interface<detector_t> {
                 }
 
                 // If the accelerator is a grid, insert the payload
-                det.surface_store().template visit<get_grid_payload>(
+                det.accelerator_store().template visit<get_grid_payload>(
                     acc_link, vol_desc.index(), grids_data);
             }
         }
@@ -206,10 +206,10 @@ class grid_writer : public writer_interface<detector_t> {
     /// Retrieve number of overall grids in detector
     template <std::size_t I = 0u>
     static std::size_t get_n_grids(
-        const typename detector_t::surface_container& store,
+        const typename detector_t::accelerator_container& store,
         std::size_t n = 0u) {
 
-        using store_t = typename detector_t::surface_container;
+        using store_t = typename detector_t::accelerator_container;
         constexpr auto coll_id{store_t::value_types::to_id(I)};
         using accel_t = typename store_t::template get_type<coll_id>;
 

--- a/io/include/detray/io/common/payloads.hpp
+++ b/io/include/detray/io/common/payloads.hpp
@@ -89,7 +89,7 @@ struct surface_payload {
     transform_payload transform{};
     mask_payload mask{};
     std::optional<material_link_payload> material;
-    single_link_payload source{};
+    std::uint64_t source{};
     // Write the surface barcode as an additional information
     std::uint64_t barcode{std::numeric_limits<std::uint64_t>::max()};
     detray::surface_id type{detray::surface_id::e_sensitive};

--- a/tests/unit_tests/cpu/core_detector.cpp
+++ b/tests/unit_tests/cpu/core_detector.cpp
@@ -46,7 +46,7 @@ void prefill_detector(detector_t& d,
     detray::empty_context empty_ctx{};
     vecmem::memory_resource* host_mr = d.resource();
     typename detector_t::transform_container trfs(*host_mr);
-    typename detector_t::surface_container_t surfaces{};
+    typename detector_t::surface_container surfaces{};
     typename detector_t::mask_container masks(*host_mr);
     typename detector_t::material_container materials(*host_mr);
 
@@ -138,7 +138,7 @@ GTEST_TEST(detray_core, detector) {
     using detector_t = detector<>;
     using mask_id = typename detector_t::masks::id;
     using material_id = typename detector_t::materials::id;
-    using finder_id = typename detector_t::sf_finders::id;
+    using finder_id = typename detector_t::accel::id;
 
     vecmem::host_memory_resource host_mr;
     detector_t d(host_mr);
@@ -159,14 +159,16 @@ GTEST_TEST(detray_core, detector) {
     EXPECT_TRUE(d.mask_store().template empty<mask_id::e_cell_wire>());
     EXPECT_TRUE(d.material_store().template empty<material_id::e_slab>());
     EXPECT_TRUE(d.material_store().template empty<material_id::e_rod>());
-    EXPECT_TRUE(d.surface_store().template empty<finder_id::e_brute_force>());
-    EXPECT_TRUE(d.surface_store().template empty<finder_id::e_disc_grid>());
     EXPECT_TRUE(
-        d.surface_store().template empty<finder_id::e_cylinder2_grid>());
-    EXPECT_TRUE(d.surface_store().template empty<finder_id::e_irr_disc_grid>());
+        d.accelerator_store().template empty<finder_id::e_brute_force>());
+    EXPECT_TRUE(d.accelerator_store().template empty<finder_id::e_disc_grid>());
     EXPECT_TRUE(
-        d.surface_store().template empty<finder_id::e_irr_cylinder2_grid>());
-    EXPECT_TRUE(d.surface_store().template empty<finder_id::e_default>());
+        d.accelerator_store().template empty<finder_id::e_cylinder2_grid>());
+    EXPECT_TRUE(
+        d.accelerator_store().template empty<finder_id::e_irr_disc_grid>());
+    EXPECT_TRUE(d.accelerator_store()
+                    .template empty<finder_id::e_irr_cylinder2_grid>());
+    EXPECT_TRUE(d.accelerator_store().template empty<finder_id::e_default>());
 
     // Add some geometrical data
     prefill_detector(d, geo_ctx);
@@ -187,15 +189,18 @@ GTEST_TEST(detray_core, detector) {
     EXPECT_EQ(d.mask_store().template size<mask_id::e_cell_wire>(), 0u);
     EXPECT_EQ(d.material_store().template size<material_id::e_slab>(), 2u);
     EXPECT_EQ(d.material_store().template size<material_id::e_rod>(), 1u);
-    EXPECT_EQ(d.surface_store().template size<finder_id::e_brute_force>(), 1u);
-    EXPECT_EQ(d.surface_store().template size<finder_id::e_disc_grid>(), 0u);
-    EXPECT_EQ(d.surface_store().template size<finder_id::e_cylinder2_grid>(),
-              0u);
-    EXPECT_EQ(d.surface_store().template size<finder_id::e_irr_disc_grid>(),
+    EXPECT_EQ(d.accelerator_store().template size<finder_id::e_brute_force>(),
+              1u);
+    EXPECT_EQ(d.accelerator_store().template size<finder_id::e_disc_grid>(),
               0u);
     EXPECT_EQ(
-        d.surface_store().template size<finder_id::e_irr_cylinder2_grid>(), 0u);
-    EXPECT_EQ(d.surface_store().template size<finder_id::e_default>(), 1u);
+        d.accelerator_store().template size<finder_id::e_cylinder2_grid>(), 0u);
+    EXPECT_EQ(d.accelerator_store().template size<finder_id::e_irr_disc_grid>(),
+              0u);
+    EXPECT_EQ(
+        d.accelerator_store().template size<finder_id::e_irr_cylinder2_grid>(),
+        0u);
+    EXPECT_EQ(d.accelerator_store().template size<finder_id::e_default>(), 1u);
 }
 
 /// This tests the functionality of a surface factory
@@ -398,7 +403,7 @@ GTEST_TEST(detray_tools, detector_volume_construction) {
     using transform3 = typename detector_t::transform3;
     using geo_obj_id = typename detector_t::geo_obj_ids;
     using mask_id = typename detector_t::masks::id;
-    using sf_finder_id = typename detector_t::sf_finders::id;
+    using accel_id = typename detector_t::accel::id;
 
     // Surface factories
     using portal_cylinder_factory =
@@ -557,7 +562,7 @@ GTEST_TEST(detray_tools, detector_volume_construction) {
     EXPECT_TRUE(d.transform_store()[first_trf] == trf);
 
     // Check the acceleration data structure link
-    dtyped_index<sf_finder_id, dindex> acc_link{sf_finder_id::e_default, 1u};
+    dtyped_index<accel_id, dindex> acc_link{accel_id::e_default, 1u};
     ASSERT_TRUE(vol.full_link().size() == geo_obj_id::e_size);
     EXPECT_EQ(vol.link<geo_obj_id::e_portal>(), acc_link);
     EXPECT_EQ(vol.link<geo_obj_id::e_passive>(), acc_link);

--- a/tests/unit_tests/cpu/geometry_volume.cpp
+++ b/tests/unit_tests/cpu/geometry_volume.cpp
@@ -25,7 +25,7 @@ enum geo_objects : unsigned int {
 };
 
 // surface finder ids for testing
-enum sf_finder_ids : unsigned int {
+enum accel_ids : unsigned int {
     e_default = 0,
     e_grid = 1,
 };
@@ -36,23 +36,22 @@ enum sf_finder_ids : unsigned int {
 GTEST_TEST(detray_geometry, detector_volume) {
     using namespace detray;
 
-    using sf_finder_link_t = dtyped_index<sf_finder_ids, dindex>;
-    using volume_t = volume_descriptor<geo_objects, sf_finder_link_t>;
+    using accel_link_t = dtyped_index<accel_ids, dindex>;
+    using volume_t = volume_descriptor<geo_objects, accel_link_t>;
 
     // Check construction, setters and getters
     volume_t v1(volume_id::e_cylinder);
     v1.set_index(12345u);
-    v1.template set_link<geo_objects::e_portal>({sf_finder_ids::e_default, 1u});
-    v1.template set_link<geo_objects::e_sensitive>(
-        {sf_finder_ids::e_grid, 12u});
+    v1.template set_link<geo_objects::e_portal>({accel_ids::e_default, 1u});
+    v1.template set_link<geo_objects::e_sensitive>({accel_ids::e_grid, 12u});
 
     ASSERT_TRUE(v1.id() == volume_id::e_cylinder);
     ASSERT_TRUE(v1.index() == 12345u);
     ASSERT_TRUE(v1.template link<geo_objects::e_portal>().id() ==
-                sf_finder_ids::e_default);
+                accel_ids::e_default);
     ASSERT_TRUE(v1.template link<geo_objects::e_portal>().index() == 1u);
     ASSERT_TRUE(v1.template link<geo_objects::e_sensitive>().id() ==
-                sf_finder_ids::e_grid);
+                accel_ids::e_grid);
     ASSERT_TRUE(v1.template link<geo_objects::e_sensitive>().index() == 12u);
 
     // Check copy constructor
@@ -60,9 +59,9 @@ GTEST_TEST(detray_geometry, detector_volume) {
     ASSERT_EQ(v2.id(), volume_id::e_cylinder);
     ASSERT_EQ(v2.index(), 12345u);
     ASSERT_TRUE(v2.template link<geo_objects::e_portal>().id() ==
-                sf_finder_ids::e_default);
+                accel_ids::e_default);
     ASSERT_TRUE(v2.template link<geo_objects::e_portal>().index() == 1u);
     ASSERT_TRUE(v2.template link<geo_objects::e_sensitive>().id() ==
-                sf_finder_ids::e_grid);
+                accel_ids::e_grid);
     ASSERT_TRUE(v2.template link<geo_objects::e_sensitive>().index() == 12u);
 }

--- a/tests/unit_tests/cpu/grid_grid_builder.cpp
+++ b/tests/unit_tests/cpu/grid_grid_builder.cpp
@@ -156,7 +156,7 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
 
     using transform3 = typename detector_t::transform3;
     using geo_obj_id = typename detector_t::geo_obj_ids;
-    using acc_ids = typename detector_t::sf_finders::id;
+    using acc_ids = typename detector_t::accel::id;
     using mask_id = typename detector_t::masks::id;
 
     // cylinder grid type of the toy detector
@@ -278,8 +278,8 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
 
     // check the portals in the detector
     const auto& bf_finder =
-        d.surface_store()
-            .template get<detector_t::sf_finders::id::e_brute_force>()[0];
+        d.accelerator_store()
+            .template get<detector_t::accel::id::e_brute_force>()[0];
     for (const auto& sf : bf_finder.all()) {
         EXPECT_TRUE((sf.id() == surface_id::e_portal) or
                     (sf.id() == surface_id::e_passive));
@@ -288,8 +288,8 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
 
     // check the sensitive surfaces in the grid
     const auto& cyl_grid =
-        d.surface_store()
-            .template get<detector_t::sf_finders::id::e_cylinder2_grid>()[0];
+        d.accelerator_store()
+            .template get<detector_t::accel::id::e_cylinder2_grid>()[0];
     dindex trf_idx{3u};
     for (const auto& sf : cyl_grid.all()) {
         EXPECT_TRUE(sf.is_sensitive());

--- a/tests/unit_tests/device/cuda/detector_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/detector_cuda_kernel.cu
@@ -69,9 +69,9 @@ __global__ void detector_test_kernel(
     }
 
     // print output test for surface finder
-    /*auto& sf_finder_device = det_device.sf_finders_store();
-    for (unsigned int i_s = 0u; i_s < sf_finder_device.size(); i_s++) {
-        auto& grid = sf_finder_device[i_s];
+    /*auto& accel_device = det_device.accelerator_store();
+    for (unsigned int i_s = 0u; i_s < accel_device.size(); i_s++) {
+        auto& grid = accel_device[i_s];
         for (unsigned int i = 0u; i < grid.axis_p0().bins(); i++) {
             for (unsigned int j = 0u; j < grid.axis_p1().bins(); j++) {
                 const auto& bin = grid.bin(i, j);

--- a/tutorials/include/detray/tutorial/detector_metadata.hpp
+++ b/tutorials/include/detray/tutorial/detector_metadata.hpp
@@ -68,7 +68,7 @@ struct my_metadata {
     /// How to index the constituent objects in a volume
     /// If they share the same index value here, they will be added into the
     /// same acceleration data structure in every respective volume
-    enum geo_objects : std::size_t {
+    enum geo_objects : std::uint8_t {
         e_surface = 0u,  //< This detector keeps all surfaces in the same
                          //  acceleration data structure (id 0)
         e_size = 1u
@@ -88,7 +88,7 @@ struct my_metadata {
     /// good idea to have the most common types in the first tuple entries, in
     /// order to minimize the depth of the 'unrolling' before a mask is found
     /// in the tuple
-    enum class mask_ids {
+    enum class mask_ids : std::uint8_t {
         e_square2 = 0,
         e_trapezoid2 = 1,
         e_portal_rectangle2 = 2
@@ -104,7 +104,7 @@ struct my_metadata {
                             trapezoid, rectangle>;
 
     /// Similar to the mask store, there is a material store, which
-    enum class material_ids {
+    enum class material_ids : std::uint8_t {
         e_slab = 0,
         e_none = 1,
     };
@@ -122,14 +122,14 @@ struct my_metadata {
     using transform_link = typename transform_store<>::link_type;
     using mask_link = typename mask_store<>::single_link;
     using material_link = typename material_store<>::single_link;
-    using source_link = dindex;
+    using source_link = std::uint64_t;
     using surface_type =
         surface_descriptor<mask_link, material_link, transform_link, nav_link,
                            source_link>;
 
     /// The acceleration data structures live in another tuple that needs to
     /// indexed correctly
-    enum class sf_finder_ids {
+    enum class accel_ids : std::uint8_t {
         e_brute_force = 0,  //< test all surfaces in a volume (brute force)
         e_default = e_brute_force,
     };
@@ -140,8 +140,8 @@ struct my_metadata {
     /// ( @c empty_context )
     template <template <typename...> class tuple_t = dtuple,
               typename container_t = host_container_types>
-    using surface_finder_store =
-        multi_store<sf_finder_ids, empty_context, tuple_t,
+    using accelerator_store =
+        multi_store<accel_ids, empty_context, tuple_t,
                     brute_force_collection<surface_type, container_t>>;
 
     /// Data structure that allows to find the current detector volume from a

--- a/tutorials/include/detray/tutorial/square_surface_generator.hpp
+++ b/tutorials/include/detray/tutorial/square_surface_generator.hpp
@@ -60,7 +60,7 @@ class square_surface_generator final
     /// @param ctx the geometry context.
     DETRAY_HOST
     auto operator()(typename detector_t::volume_type &volume,
-                    typename detector_t::surface_container_t &surfaces,
+                    typename detector_t::surface_container &surfaces,
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {}) const

--- a/tutorials/src/device/cuda/detector_construction.cpp
+++ b/tutorials/src/device/cuda/detector_construction.cpp
@@ -74,6 +74,9 @@ int main() {
     auto vol_buff = detray::get_buffer(det_host.volumes(), dev_mr, cuda_cpy,
                                        detray::copy::sync,
                                        vecmem::data::buffer_type::fixed_size);
+    auto sf_buff = detray::get_buffer(det_host.surface_lookup(), dev_mr,
+                                      cuda_cpy, detray::copy::sync,
+                                      vecmem::data::buffer_type::fixed_size);
     // Use resizable buffer and asynchronous copy for alignment
     auto trf_buff = detray::get_buffer(det_host.transform_store(), dev_mr,
                                        cuda_cpy, detray::copy::async,
@@ -84,20 +87,17 @@ int main() {
     auto mat_buff = detray::get_buffer(det_host.material_store(), dev_mr,
                                        cuda_cpy, detray::copy::sync,
                                        vecmem::data::buffer_type::fixed_size);
-    auto sf_buff = detray::get_buffer(det_host.surface_store(), dev_mr,
-                                      cuda_cpy, detray::copy::sync,
-                                      vecmem::data::buffer_type::fixed_size);
-    auto sf_lkp_buff = detray::get_buffer(
-        det_host.surface_lookup(), dev_mr, cuda_cpy, detray::copy::sync,
-        vecmem::data::buffer_type::fixed_size);
+    auto acc_buff = detray::get_buffer(det_host.accelerator_store(), dev_mr,
+                                       cuda_cpy, detray::copy::sync,
+                                       vecmem::data::buffer_type::fixed_size);
     auto vgrid_buff = detray::get_buffer(det_host.volume_search_grid(), dev_mr,
                                          cuda_cpy, detray::copy::sync,
                                          vecmem::data::buffer_type::fixed_size);
 
     // Assemble the detector buffer
     auto det_custom_buff = typename decltype(det_host)::buffer_type(
-        std::move(vol_buff), std::move(trf_buff), std::move(msk_buff),
-        std::move(mat_buff), std::move(sf_buff), std::move(sf_lkp_buff),
+        std::move(vol_buff), std::move(sf_buff), std::move(trf_buff),
+        std::move(msk_buff), std::move(mat_buff), std::move(acc_buff),
         std::move(vgrid_buff));
 
     std::cout << "\nCustom buffer setup:" << std::endl;

--- a/tutorials/src/device/cuda/detector_construction.cu
+++ b/tutorials/src/device/cuda/detector_construction.cu
@@ -34,11 +34,11 @@ __global__ void print_kernel(
     printf("Number of portal cylinders: %d\n",
            det.mask_store().get<mask_id::e_portal_cylinder2>().size());
     printf("Number of portal collections: %d\n",
-           det.surface_store().get<acc_id::e_brute_force>().size());
+           det.accelerator_store().get<acc_id::e_brute_force>().size());
     printf("Number of disc grids: %d\n",
-           det.surface_store().get<acc_id::e_disc_grid>().size());
+           det.accelerator_store().get<acc_id::e_disc_grid>().size());
     printf("Number of cylinder grids: %d\n",
-           det.surface_store().get<acc_id::e_cylinder2_grid>().size());
+           det.accelerator_store().get<acc_id::e_cylinder2_grid>().size());
 }
 
 void print(typename detray::tutorial::detector_host_t::view_type det_data) {

--- a/tutorials/src/device/cuda/detector_construction.hpp
+++ b/tutorials/src/device/cuda/detector_construction.hpp
@@ -21,7 +21,7 @@ using detector_device_t =
     detector<detray::toy_metadata, device_container_types>;
 
 using mask_id = typename detector_host_t::masks::id;
-using acc_id = typename detector_host_t::sf_finders::id;
+using acc_id = typename detector_host_t::accel::id;
 
 /// Detector construction tutorial function (prints some detector statistics)
 void print(typename detector_host_t::view_type det_data);

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -460,12 +460,12 @@ inline auto create_telescope_detector(
 
     // The telescope detector has only one volume with default placement
     auto &vol = det.new_volume(volume_id::e_cuboid,
-                               {detector_t::sf_finders::id::e_default, 0u});
+                               {detector_t::accel::id::e_default, 0u});
     vol.set_transform(det.transform_store().size());
     det.transform_store().emplace_back();
 
     // Add module surfaces to volume
-    typename detector_t::surface_container_t surfaces(&resource);
+    typename detector_t::surface_container surfaces(&resource);
     typename detector_t::mask_container masks(resource);
     typename detector_t::material_container materials(resource);
     typename detector_t::transform_container transforms(resource);

--- a/utils/include/detray/detectors/create_toy_geometry.hpp
+++ b/utils/include/detray/detectors/create_toy_geometry.hpp
@@ -179,7 +179,7 @@ template <
     std::enable_if_t<
         std::is_invocable_v<factory_t, typename detector_t::geometry_context &,
                             typename detector_t::volume_type &,
-                            typename detector_t::surface_container_t &,
+                            typename detector_t::surface_container &,
                             typename detector_t::mask_container &,
                             typename detector_t::material_container &,
                             typename detector_t::transform_container &>,
@@ -192,10 +192,10 @@ inline void add_cylinder_grid(const typename detector_t::geometry_context &ctx,
     using geo_obj_ids = typename detector_t::geo_obj_ids;
 
     constexpr auto cyl_id = detector_t::masks::id::e_portal_cylinder2;
-    constexpr auto grid_id = detector_t::sf_finders::id::e_cylinder2_grid;
+    constexpr auto grid_id = detector_t::accel::id::e_cylinder2_grid;
 
     using cyl_grid_t =
-        typename detector_t::surface_container::template get_type<grid_id>;
+        typename detector_t::accelerator_container::template get_type<grid_id>;
     auto gbuilder =
         grid_builder<detector_t, cyl_grid_t, detray::detail::fill_by_pos>{
             nullptr};
@@ -217,7 +217,7 @@ inline void add_cylinder_grid(const typename detector_t::geometry_context &ctx,
     const cyl_mask_t cyl_mask{mask_values, 0u};
 
     // Create the sensitive surfaces
-    typename detector_t::surface_container_t surfaces(&resource);
+    typename detector_t::surface_container surfaces(&resource);
     typename detector_t::mask_container masks(resource);
     typename detector_t::material_container materials(resource);
     typename detector_t::transform_container transforms(resource);
@@ -253,9 +253,9 @@ inline void add_cylinder_grid(const typename detector_t::geometry_context &ctx,
                        det.transform_store(), det.mask_store(), ctx);
     assert(gbuilder.get().all().size() == surfaces.size());
 
-    det.surface_store().template push_back<grid_id>(gbuilder.get());
+    det.accelerator_store().template push_back<grid_id>(gbuilder.get());
     vol.template set_link<geo_obj_ids::e_sensitive>(
-        grid_id, det.surface_store().template size<grid_id>() - 1u);
+        grid_id, det.accelerator_store().template size<grid_id>() - 1u);
 }
 
 /// Helper function that creates a surface grid of trapezoidal endcap modules.
@@ -270,7 +270,7 @@ template <
     std::enable_if_t<
         std::is_invocable_v<factory_t, typename detector_t::geometry_context &,
                             typename detector_t::volume_type &,
-                            typename detector_t::surface_container_t &,
+                            typename detector_t::surface_container &,
                             typename detector_t::mask_container &,
                             typename detector_t::material_container &,
                             typename detector_t::transform_container &>,
@@ -283,10 +283,10 @@ inline void add_disc_grid(const typename detector_t::geometry_context &ctx,
     using geo_obj_ids = typename detector_t::geo_obj_ids;
 
     constexpr auto disc_id = detector_t::masks::id::e_portal_ring2;
-    constexpr auto grid_id = detector_t::sf_finders::id::e_disc_grid;
+    constexpr auto grid_id = detector_t::accel::id::e_disc_grid;
 
     using disc_grid_t =
-        typename detector_t::surface_container::template get_type<grid_id>;
+        typename detector_t::accelerator_container::template get_type<grid_id>;
     auto gbuilder =
         grid_builder<detector_t, disc_grid_t, detray::detail::fill_by_pos>{
             nullptr};
@@ -297,7 +297,7 @@ inline void add_disc_grid(const typename detector_t::geometry_context &ctx,
         det.mask_store().template get<disc_id>().at(portal_mask_idx);
 
     // Create the sensitive surfaces
-    typename detector_t::surface_container_t surfaces(&resource);
+    typename detector_t::surface_container surfaces(&resource);
     typename detector_t::mask_container masks(resource);
     typename detector_t::material_container materials(resource);
     typename detector_t::transform_container transforms(resource);
@@ -333,9 +333,9 @@ inline void add_disc_grid(const typename detector_t::geometry_context &ctx,
                        det.transform_store(), det.mask_store(), ctx);
     assert(gbuilder.get().all().size() == surfaces.size());
 
-    det.surface_store().template push_back<grid_id>(gbuilder.get());
+    det.accelerator_store().template push_back<grid_id>(gbuilder.get());
     vol.template set_link<geo_obj_ids::e_sensitive>(
-        grid_id, det.surface_store().template size<grid_id>() - 1u);
+        grid_id, det.accelerator_store().template size<grid_id>() - 1u);
 }
 
 /** Helper method for positioning of modules in an endcap ring
@@ -541,7 +541,7 @@ inline void add_beampipe(
                                     : edc_lay_sizes[n_edc_layers - 1u].second};
     scalar min_z{-max_z};
 
-    typename detector_t::surface_container_t surfaces(&resource);
+    typename detector_t::surface_container surfaces(&resource);
     typename detector_t::mask_container masks(resource);
     typename detector_t::material_container materials(resource);
     typename detector_t::transform_container transforms(resource);
@@ -553,9 +553,9 @@ inline void add_beampipe(
     det.transform_store().emplace_back(ctx);
 
     beampipe.template set_link<object_id::e_portal>(
-        detector_t::sf_finders::id::e_default, 0u);
+        detector_t::accel::id::e_default, 0u);
     beampipe.template set_link<object_id::e_passive>(
-        detector_t::sf_finders::id::e_default, 0u);
+        detector_t::accel::id::e_default, 0u);
 
     // This is the beampipe surface
     dindex volume_link{beampipe_idx};
@@ -657,14 +657,14 @@ inline void add_endcap_barrel_connection(
     const scalar edc_disc_z{side < 0 ? min_z : max_z};
     const scalar brl_disc_z{side < 0 ? max_z : min_z};
 
-    typename detector_t::surface_container_t surfaces(&resource);
+    typename detector_t::surface_container surfaces(&resource);
     typename detector_t::mask_container masks(resource);
     typename detector_t::material_container materials(resource);
     typename detector_t::transform_container transforms(resource);
 
-    auto &connector_gap = det.new_volume(volume_id::e_cylinder,
-                                         {detector_t::sf_finders::id::e_default,
-                                          detail::invalid_value<dindex>()});
+    auto &connector_gap = det.new_volume(
+        volume_id::e_cylinder,
+        {detector_t::accel::id::e_default, detail::invalid_value<dindex>()});
     dindex connector_gap_idx{det.volumes().back().index()};
     names[connector_gap_idx + 1u] =
         "connector_gap_" + std::to_string(connector_gap_idx);
@@ -982,7 +982,7 @@ inline auto create_toy_geometry(vecmem::memory_resource &resource,
 
         void operator()(const typename detector_t::geometry_context &ctx,
                         typename detector_t::volume_type &volume,
-                        typename detector_t::surface_container_t &surfaces,
+                        typename detector_t::surface_container &surfaces,
                         typename detector_t::mask_container &masks,
                         typename detector_t::material_container &materials,
                         typename detector_t::transform_container &transforms) {
@@ -997,7 +997,7 @@ inline auto create_toy_geometry(vecmem::memory_resource &resource,
 
         void operator()(const typename detector_t::geometry_context &ctx,
                         typename detector_t::volume_type &volume,
-                        typename detector_t::surface_container_t &surfaces,
+                        typename detector_t::surface_container &surfaces,
                         typename detector_t::mask_container &masks,
                         typename detector_t::material_container &materials,
                         typename detector_t::transform_container &transforms) {

--- a/utils/include/detray/detectors/create_wire_chamber.hpp
+++ b/utils/include/detray/detectors/create_wire_chamber.hpp
@@ -130,7 +130,7 @@ inline auto create_wire_chamber(vecmem::memory_resource &resource,
         auto mask_volume_link{static_cast<nav_link_t>(volume_idx)};
 
         // Containers per volume
-        typename detector_t::surface_container_t surfaces(&resource);
+        typename detector_t::surface_container surfaces(&resource);
         typename detector_t::mask_container masks(resource);
         typename detector_t::material_container materials(resource);
         typename detector_t::transform_container transforms(resource);
@@ -212,10 +212,11 @@ inline auto create_wire_chamber(vecmem::memory_resource &resource,
         // Get relevant ids
         using geo_obj_ids = typename detector_t::geo_obj_ids;
         constexpr auto cyl_id = detector_t::masks::id::e_portal_cylinder2;
-        constexpr auto grid_id = detector_t::sf_finders::id::e_cylinder2_grid;
+        constexpr auto grid_id = detector_t::accel::id::e_cylinder2_grid;
 
         using cyl_grid_t =
-            typename detector_t::surface_container::template get_type<grid_id>;
+            typename detector_t::accelerator_container::template get_type<
+                grid_id>;
         auto gbuilder =
             grid_builder<detector_t, cyl_grid_t, detray::detail::fill_by_pos>{
                 nullptr};
@@ -241,9 +242,9 @@ inline auto create_wire_chamber(vecmem::memory_resource &resource,
         gbuilder.fill_grid(detector_volume{det, vol}, det.surface_lookup(),
                            det.transform_store(), det.mask_store(), ctx0);
 
-        det.surface_store().template push_back<grid_id>(gbuilder.get());
+        det.accelerator_store().template push_back<grid_id>(gbuilder.get());
         vol.template set_link<geo_obj_ids::e_sensitive>(
-            grid_id, det.surface_store().template size<grid_id>() - 1u);
+            grid_id, det.accelerator_store().template size<grid_id>() - 1u);
 
         // Add volume grid
         // TODO: Fill it

--- a/utils/include/detray/detectors/detector_helper.hpp
+++ b/utils/include/detray/detectors/detector_helper.hpp
@@ -169,13 +169,13 @@ struct detector_helper {
         const scalar_t upper_z{std::max(lay_neg_z, lay_pos_z)};
 
         // Add module surfaces to volume
-        typename detector_t::surface_container_t surfaces(&resource);
+        typename detector_t::surface_container surfaces(&resource);
         typename detector_t::mask_container masks(resource);
         typename detector_t::material_container materials(resource);
         typename detector_t::transform_container transforms(resource);
 
         auto &cyl_volume = det.new_volume(
-            volume_id::e_cylinder, {detector_t::sf_finders::id::e_default, 0u});
+            volume_id::e_cylinder, {detector_t::accel::id::e_default, 0u});
 
         // volume placement
         cyl_volume.set_transform(det.transform_store().size());

--- a/utils/include/detray/detectors/itk_metadata.hpp
+++ b/utils/include/detray/detectors/itk_metadata.hpp
@@ -69,7 +69,7 @@ struct itk_metadata {
     /// good idea to have the most common types in the first tuple entries, in
     /// order to minimize the depth of the 'unrolling' before a mask is found
     /// in the tuple
-    enum class mask_ids {
+    enum class mask_ids : std::uint8_t {
         e_rectangle2 = 0,
         e_annulus2 = 1,
         e_portal_cylinder2 = 2,
@@ -86,7 +86,7 @@ struct itk_metadata {
                             rectangle, annulus, cylinder_portal, disc_portal>;
 
     /// Similar to the mask store, there is a material store, which
-    enum class material_ids {
+    enum class material_ids : std::uint8_t {
         e_slab = 0,
         e_none = 1,
     };
@@ -104,7 +104,7 @@ struct itk_metadata {
     using transform_link = typename transform_store<>::link_type;
     using mask_link = typename mask_store<>::single_link;
     using material_link = typename material_store<>::single_link;
-    using source_link = dindex;
+    using source_link = std::uint64_t;
     /// Surface type used for sensitives, passives and portals
     using surface_type =
         surface_descriptor<mask_link, material_link, transform_link, nav_link,
@@ -113,7 +113,7 @@ struct itk_metadata {
     /// How to index the constituent objects in a volume
     /// If they share the same index value here, they will be added into the
     /// same acceleration data structure in every respective volume
-    enum geo_objects : unsigned int {
+    enum geo_objects : std::uint8_t {
         e_surface = 0u,  //< This detector keeps all surfaces in the same
         e_portal = 0u,   //  acceleration data structure (id 0)
         e_passive = 0u,
@@ -122,7 +122,7 @@ struct itk_metadata {
 
     /// The acceleration data structures live in another tuple that needs to be
     /// indexed correctly:
-    enum class sf_finder_ids {
+    enum class accel_ids : std::uint8_t {
         e_brute_force = 0,  //< test all surfaces in a volume (brute force)
         e_default = e_brute_force,
     };
@@ -130,7 +130,7 @@ struct itk_metadata {
     /// How a volume finds its constituent objects in the detector containers
     /// In this case: One range for sensitive/passive surfaces, one for portals
     using object_link_type =
-        dmulti_index<dtyped_index<sf_finder_ids, dindex>, geo_objects::e_size>;
+        dmulti_index<dtyped_index<accel_ids, dindex>, geo_objects::e_size>;
 
     /// The tuple store that hold the acceleration data structures for all
     /// volumes. Every collection of accelerationdata structures defines its
@@ -138,8 +138,8 @@ struct itk_metadata {
     /// ( @c empty_context )
     template <template <typename...> class tuple_t = dtuple,
               typename container_t = host_container_types>
-    using surface_finder_store =
-        multi_store<sf_finder_ids, empty_context, tuple_t,
+    using accelerator_store =
+        multi_store<accel_ids, empty_context, tuple_t,
                     brute_force_collection<surface_type, container_t>>;
 
     /// Data structure that allows to find the current detector volume from a

--- a/utils/include/detray/detectors/telescope_metadata.hpp
+++ b/utils/include/detray/detectors/telescope_metadata.hpp
@@ -45,7 +45,7 @@ struct telescope_metadata {
 
     /// Rectangles are always needed as portals (but the yhave the same type as
     /// module rectangles). Only one additional mask shape is allowed
-    enum class mask_ids {
+    enum class mask_ids : std::uint8_t {
         e_rectangle2 = 0,
         e_portal_rectangle2 = 0,
         e_annulus2 = 1,
@@ -78,7 +78,7 @@ struct telescope_metadata {
                             rectangle, mask<mask_shape_t, nav_link>>>;
 
     /// Material type ids
-    enum class material_ids {
+    enum class material_ids : std::uint8_t {
         e_slab = 0,
         e_rod = 0,
         e_none = 1,
@@ -99,14 +99,14 @@ struct telescope_metadata {
     using transform_link = typename transform_store<>::link_type;
     using mask_link = typename mask_store<>::single_link;
     using material_link = typename material_store<>::single_link;
-    using source_link = dindex;
+    using source_link = std::uint64_t;
     /// Surface type used for sensitives, passives and portals
     using surface_type =
         surface_descriptor<mask_link, material_link, transform_link, nav_link,
                            source_link>;
 
     /// No grids/other acceleration data structure, everything is brute forced
-    enum geo_objects : std::size_t {
+    enum geo_objects : std::uint8_t {
         e_sensitive = 0,
         e_portal = 0,
         e_size = 1,
@@ -114,20 +114,20 @@ struct telescope_metadata {
     };
 
     /// Acceleration data structures
-    enum class sf_finder_ids {
+    enum class accel_ids {
         e_brute_force = 0,  // test all surfaces in a volume (brute force)
         e_default = e_brute_force,
     };
 
     /// One link for all surfaces (in the brute force method)
     using object_link_type =
-        dmulti_index<dtyped_index<sf_finder_ids, dindex>, geo_objects::e_size>;
+        dmulti_index<dtyped_index<accel_ids, dindex>, geo_objects::e_size>;
 
     /// How to store the brute force search data structure
     template <template <typename...> class tuple_t = dtuple,
               typename container_t = host_container_types>
-    using surface_finder_store =
-        multi_store<sf_finder_ids, empty_context, tuple_t,
+    using accelerator_store =
+        multi_store<accel_ids, empty_context, tuple_t,
                     brute_force_collection<surface_type, container_t>>;
 
     /// Volume search (only one volume exists)

--- a/utils/include/detray/detectors/toy_metadata.hpp
+++ b/utils/include/detray/detectors/toy_metadata.hpp
@@ -67,7 +67,7 @@ struct toy_metadata {
                                          vector_t, geometry_context>;
 
     /// Mask type ids
-    enum class mask_ids {
+    enum class mask_ids : std::uint8_t {
         e_rectangle2 = 0,
         e_trapezoid2 = 1,
         e_portal_cylinder2 = 2,
@@ -83,7 +83,7 @@ struct toy_metadata {
                             rectangle, trapezoid, cylinder_portal, disc_portal>;
 
     /// Material type ids
-    enum class material_ids {
+    enum class material_ids : std::uint8_t {
         e_slab = 0,
         e_none = 1,
     };
@@ -98,14 +98,14 @@ struct toy_metadata {
     using transform_link = typename transform_store<>::link_type;
     using mask_link = typename mask_store<>::single_link;
     using material_link = typename material_store<>::single_link;
-    using source_link = dindex;
+    using source_link = std::uint64_t;
     /// Surface type used for sensitives, passives and portals
     using surface_type =
         surface_descriptor<mask_link, material_link, transform_link, nav_link,
                            source_link>;
 
     /// Portals and passives in the brute froce search, sensitives in the grids
-    enum geo_objects : std::size_t {
+    enum geo_objects : std::uint8_t {
         e_sensitive = 1,
         e_portal = 0,
         e_passive = 0,
@@ -114,7 +114,7 @@ struct toy_metadata {
     };
 
     /// Acceleration data structures
-    enum class sf_finder_ids {
+    enum class accel_ids : std::uint8_t {
         e_brute_force = 0,     // test all surfaces in a volume (brute force)
         e_disc_grid = 1,       // endcap
         e_cylinder2_grid = 2,  // barrel
@@ -123,13 +123,13 @@ struct toy_metadata {
 
     /// One link for portals/passives and one sensitive surfaces
     using object_link_type =
-        dmulti_index<dtyped_index<sf_finder_ids, dindex>, geo_objects::e_size>;
+        dmulti_index<dtyped_index<accel_ids, dindex>, geo_objects::e_size>;
 
     /// How to store the acceleration data structures
     template <template <typename...> class tuple_t = dtuple,
               typename container_t = host_container_types>
-    using surface_finder_store = multi_store<
-        sf_finder_ids, empty_context, tuple_t,
+    using accelerator_store = multi_store<
+        accel_ids, empty_context, tuple_t,
         brute_force_collection<surface_type, container_t>,
         grid_collection<disc_sf_grid<surface_type, container_t>>,
         grid_collection<cylinder_sf_grid<surface_type, container_t>>>;


### PR DESCRIPTION
After the merging of the surface acceleration structures with the surface vector did not work, this PR restores the naming of the data stores. Also correctly passes the source links on to the surfaces in the geometry IO and restricts the type ids to 8bits 