### PR TITLE
feat: json schemas for data files

### DIFF
--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -127,6 +127,12 @@ class surface {
         return barcode().id() == surface_id::e_passive;
     }
 
+    /// @returns the mask volume link
+    DETRAY_HOST_DEVICE
+    constexpr auto volume_link() const {
+        return visit_mask<typename kernels::get_volume_link>();
+    }
+
     /// @returns the coordinate transform matrix of the surface
     DETRAY_HOST_DEVICE
     constexpr auto transform(const context &ctx) const -> const transform3 & {

--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -50,8 +50,16 @@ struct surface_checker {
         }
 
         if (sf.volume() != vol_idx) {
-            err_stream << "Incorrect volume index on surface: " << sf;
+            err_stream << "ERROR: Incorrect volume index on surface: " << sf;
 
+            throw std::invalid_argument(err_stream.str());
+        }
+
+        // Does the mask link to an existing volume?
+        if (!is_invalid_value(sf.volume_link()) &&
+            (sf.volume_link() >= det.volumes().size())) {
+            err_stream << "ERROR: Incorrect volume link to non-existent volume "
+                       << sf.volume_link();
             throw std::invalid_argument(err_stream.str());
         }
 
@@ -59,9 +67,9 @@ struct surface_checker {
         // lookup
         const auto sf_from_lkp = surface{det, det.surface(sf.barcode())};
         if (not(sf_from_lkp == sf)) {
-            err_stream << "Surfaces in volume and detector lookups differ:\n"
-                       << "In volume acceleration data structure: " << sf
-                       << "\nIn detector surface lookup: " << sf_from_lkp;
+            err_stream << "ERROR: Surfaces in volume and detector lookups "
+                       << "differ:\n In volume acceleration data structure: "
+                       << sf << "\nIn detector surface lookup: " << sf_from_lkp;
 
             throw std::runtime_error(err_stream.str());
         }

--- a/io/include/detray/io/common/payloads.hpp
+++ b/io/include/detray/io/common/payloads.hpp
@@ -91,7 +91,8 @@ struct surface_payload {
     std::optional<material_link_payload> material;
     std::uint64_t source{};
     // Write the surface barcode as an additional information
-    std::uint64_t barcode{std::numeric_limits<std::uint64_t>::max()};
+    std::optional<std::uint64_t> barcode{
+        detail::invalid_value<std::uint64_t>()};
     detray::surface_id type{detray::surface_id::e_sensitive};
 };
 

--- a/io/include/detray/io/json/json_geometry_io.hpp
+++ b/io/include/detray/io/json/json_geometry_io.hpp
@@ -59,7 +59,9 @@ inline void from_json(const nlohmann::ordered_json& j, mask_payload& m) {
 }
 
 inline void to_json(nlohmann::ordered_json& j, const surface_payload& s) {
-    j["barcode"] = s.barcode;
+    if (s.barcode.has_value()) {
+        j["barcode"] = s.barcode.value();
+    }
     j["type"] = static_cast<unsigned int>(s.type);
     j["source"] = s.source;
     j["transform"] = s.transform;
@@ -73,7 +75,9 @@ inline void to_json(nlohmann::ordered_json& j, const surface_payload& s) {
 }
 
 inline void from_json(const nlohmann::ordered_json& j, surface_payload& s) {
-    s.barcode = j["barcode"];
+    if (j.find("barcode") != j.end()) {
+        s.barcode = j["barcode"];
+    }
     s.type = static_cast<detray::surface_id>(j["type"]);
     s.source = j["source"];
     s.transform = j["transform"];
@@ -115,7 +119,7 @@ inline void from_json(const nlohmann::ordered_json& j, volume_payload& v) {
         v.surfaces.push_back(s);
     }
     if (j.find("acc_links") != j.end()) {
-        v.acc_links = {};
+        v.acc_links.emplace();
         for (auto jl : j["acc_links"]) {
             acc_links_payload al = jl;
             v.acc_links->push_back(al);

--- a/tests/validation/python/json_schemas/geometry.py
+++ b/tests/validation/python/json_schemas/geometry.py
@@ -1,0 +1,269 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+""" Schema of a geometry file """
+geometry_schema = {
+    "type" : "object",
+    "properties" : {
+        "header" : {
+            "type" : "object",
+            "description": "File header section with important IO metadata",
+            "properties": {
+                "common" : {
+                    "type" : "object",
+                    "description": "General metadata",
+                    "properties": {
+                        "version": {
+                            "type" : "string",
+                            "description": "detray version this file was created with",
+                        },
+                        "detector": {
+                            "type" : "string",
+                            "description": "Name of the detector",
+                        },
+                        "date": {
+                            "type" : "string",
+                            "description": "Time stamp (file creation)",
+                        },
+                        "tag": {
+                            "type" : "string",
+                            "description": "Type of data",
+                            "enum": ["geometry"]
+                        }
+                    },
+                    "required": ["version", "detector", "tag"]
+                },
+                "volume_count" : {
+                    "type" : "integer",
+                    "description": "Number of volumes in the detector",
+                    "minimum": 0,
+                },
+                "surface_count" : {
+                    "type" : "integer",
+                    "description": "Number of surfaces in the detector",
+                    "minimum": 0,
+                },
+            },
+            "required": ["common"]
+        },
+        "data" : {
+            "type" : "object",
+            "description": "Geometry data section (volume-by-volume)",
+            "properties" : {
+                "volumes" : {
+                    "type" : "array",
+                    "minitems" : 1,
+                    "items" : {
+                        "type" : "object",
+                        "description": "Data of a single volume",
+                        "properties" : {
+                            "name": {
+                                "type" : "string",
+                                "description": "The volume name"
+                            },
+                            "index": {
+                                "type" : "integer",
+                                "description": "The volume index",
+                                "minimum": 0
+                            },
+                            "type": {
+                                "type" : "integer",
+                                "description": "The volume type id (e.g. cylinder)",
+                                "minimum": 0,
+                                "maximum": 4,
+                            },
+                            "transform": {
+                                "type" : "object",
+                                "description": "Data of the volume placement matrix",
+                                "properties" : {
+                                    "translation": {
+                                        "type" : "array",
+                                        "description": "Translation vector",
+                                        "minitems" : 3,
+                                        "maxItems": 3,
+                                        "items": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "rotation": {
+                                        "type" : "array",
+                                        "description": "Rotation matrix",
+                                        "minitems" : 9,
+                                        "maxItems": 9,
+                                        "items": {
+                                            "type": "number"
+                                        }
+                                    }
+                                },
+                                "required": ["translation", "rotation"]
+                            },
+                            "acc_links": {
+                                "type" : "array",
+                                "description": "Typed indices for the acceleration structures",
+                                "minitems" : 0,
+                                "maxItems": 5,
+                                "uniqueItems": True,
+                                "items": {
+                                    "type": "object",
+                                    "properties" : {
+                                        "type" : {
+                                            "type" : "integer",
+                                            "description" : "Type ID of the acceleration structure",
+                                            "minimum": 1,
+                                            "maximum": 5
+                                        },
+                                        "index" : {
+                                            "type" : "integer",
+                                            "description" : "Global index of the acceleration structure",
+                                            "minimum": 0,
+                                        }
+                                    },
+                                    "required": ["type", "index"]
+                                }
+                            },
+                            "surfaces" : {
+                                "type" : "array",
+                                "description": "The contained surfaces",
+                                "minitems" : 1,
+                                "uniqueItems": True,
+                                "items" : {
+                                    "type" : "object",
+                                    "properties" : {
+                                        "barcode": {
+                                            "type" : "integer",
+                                            "description" : "detray internal surface hash",
+                                            "minimum": 0,
+                                        },
+                                        "type": {
+                                            "type" : "integer",
+                                            "description" : "Surface type (portal: 0, sensitive: 1, passive: 2)",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        "source": {
+                                            "type" : "integer",
+                                            "description" : "bits that link the detray surface to its source",
+                                            "minimum": 0,
+                                        },
+                                        "index_in_coll": {
+                                            "type" : "integer",
+                                            "description" : "Volume-local sorting index",
+                                            "minimum": 0
+                                        },
+                                        "transform": {
+                                            "type" : "object",
+                                            "description": "Data of the surface placement matrix",
+                                            "properties" : {
+                                                "translation": {
+                                                    "type" : "array",
+                                                    "description": "Translation vector",
+                                                    "minitems" : 3,
+                                                    "maxItems": 3,
+                                                    "items": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                "rotation": {
+                                                    "type" : "array",
+                                                    "description": "Rotation matrix",
+                                                    "minitems" : 9,
+                                                    "maxItems": 9,
+                                                    "items": {
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            },
+                                            "required": ["translation", "rotation"]
+                                        },
+                                        "mask" : {
+                                            "type" : "object",
+                                            "description" : "Surface mask data",
+                                            "properties" : {
+                                                "shape": {
+                                                    "type" : "integer",
+                                                    "description" : "Shape ID",
+                                                    "minimum": 0,
+                                                    "maximum": 12
+                                                },
+                                                "volume_link": {
+                                                    "type" : "integer",
+                                                    "description" : "Navigation link",
+                                                    "minimum": 0,
+                                                },
+                                                "boundaries": {
+                                                    "type" : "array",
+                                                    "description" : "Mask boundary values",
+                                                    "minitems" : 1,
+                                                    "maxItems": 7,
+                                                    "items": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                            },
+                                            "required": ["shape", "volume_link", "boundaries"]
+                                        },
+                                        "material" : {
+                                            "type" : "object",
+                                            "description" : "Surface material link",
+                                            "properties" : {
+                                                "type": {
+                                                    "type" : "integer",
+                                                    "description" : "Material type ID",
+                                                    "minimum": 0,
+                                                    "maximum": 10
+                                                },
+                                                "index": {
+                                                    "type" : "integer",
+                                                    "description" : "Index of material instance",
+                                                    "minimum": 0,
+                                                },
+                                            },
+                                            "required": ["type", "index"]
+                                        }
+                                    },
+                                    "required": ["type", "source", "transform", "mask"]
+                                }
+                            }
+                        },
+                        "required": ["name", "index", "type", "transform", "surfaces"]
+                    }
+                },
+                "volume_grid" : {
+                    "type" : "object",
+                    "description" : "Data for the volume grid (temporary placeholder)",
+                    "properties" : {
+                        "volume_link": {
+                            "type" : "integer",
+                            "description" : "Volume link",
+                            "minimum": 0,
+                        },
+                        "acc_link": {
+                            "type" : "object",
+                            "description": "Typed index for the grids",
+                            "properties" : {
+                                "type" : {
+                                    "type" : "integer",
+                                    "description" : "Type ID of the acceleration structure",
+                                },
+                                "index" : {
+                                    "type" : "integer",
+                                    "description" : "Global index of the acceleration structure",
+                                    "minimum": 0,
+                                }
+                            },
+                            "required": ["type", "index"]
+                        },
+                        "axes": { "type": "null" },
+                        "bins": { "type": "null" }
+                    },
+                    "required": ["volume_link", "acc_link", "axes", "bins"]
+                }
+            },
+            "required": ["volumes"]
+        },
+    },
+   "required": ["header", "data"]
+}

--- a/tests/validation/python/json_schemas/homogeneous_material.py
+++ b/tests/validation/python/json_schemas/homogeneous_material.py
@@ -1,0 +1,168 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+""" Schema of a homogeneous material file """
+homogeneous_material_schema = {
+    "type" : "object",
+    "properties" : {
+        "header" : {
+            "type" : "object",
+            "description": "File header section with important IO metadata",
+            "properties": {
+                "common" : {
+                    "type" : "object",
+                    "description": "General metadata",
+                    "properties": {
+                        "version": {
+                            "type" : "string",
+                            "description": "detray version this file was created with",
+                        },
+                        "detector": {
+                            "type" : "string",
+                            "description": "Name of the detector",
+                        },
+                        "date": {
+                            "type" : "string",
+                            "description": "Time stamp (file creation)",
+                        },
+                        "tag": {
+                            "type" : "string",
+                            "description": "Type of data",
+                            "enum": ["homogeneous_material"]
+                        }
+                    },
+                    "required": ["version", "detector", "tag"]
+                },
+                "slab_count" : {
+                    "type" : "integer",
+                    "description": "Number of material slabs in the detector",
+                    "minimum": 0,
+                },
+                "rod_count" : {
+                    "type" : "integer",
+                    "description": "Number of material rods in the detector",
+                    "minimum": 0,
+                },
+            },
+            "required": ["common"]
+        },
+        "data" : {
+            "type" : "object",
+            "description": "Homogeneous material data (volume-by-volume)",
+            "properties" : {
+                "volumes" : {
+                    "type" : "array",
+                    "minitems": 1,
+                    "items" : {
+                        "type" : "object",
+                        "description": "Material data of a single volume",
+                        "properties" : {
+                            "volume_link": {
+                                "type" : "integer",
+                                "description": "The volume index"
+                            },
+                            "material_slabs": {
+                                "type" : "array",
+                                "minitems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "description": "The material slab",
+                                    "properties" : {
+                                        "type": {
+                                            "type" : "integer",
+                                            "description" : "Material type ID",
+                                            "enum" : [9]
+                                        },
+                                        "surface_idx": {
+                                            "type" : "integer",
+                                            "description" : "Volume-local index of the surface the slab belongs to",
+                                            "minimum": 0,
+                                        },
+                                        "thickness": {
+                                            "type" : "number",
+                                            "description" : "Thickness of the slab",
+                                            "minimum": 0,
+                                        },
+                                        "index_in_coll": {
+                                            "type" : "integer",
+                                            "description" : "Volume-local sorting index",
+                                            "minimum": 0
+                                        },
+                                        "material" : {
+                                            "type" : "object",
+                                            "properties" : {
+                                                "params" : {
+                                                    "type" : "array",
+                                                    "description" : "Material parameters",
+                                                    "minitems" : 7,
+                                                    "maxItems": 7,
+                                                    "items": {
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            },
+                                            "required": ["params"]
+                                        }
+                                    },
+                                    "required": ["type", "surface_idx", "thickness"]
+                                }
+                            },
+                            "material_rods": {
+                                "type" : "array",
+                                "minitems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "description": "The material rods",
+                                    "properties" : {
+                                        "type": {
+                                            "type" : "integer",
+                                            "description" : "Material type ID",
+                                            "enum" : [10]
+                                        },
+                                        "surface_idx": {
+                                            "type" : "integer",
+                                            "description" : "Volume-local index of the surface the slab belongs to",
+                                            "minimum": 0,
+                                        },
+                                        "thickness": {
+                                            "type" : "number",
+                                            "description" : "Radius of the rod",
+                                            "minimum": 0,
+                                        },
+                                        "index_in_coll": {
+                                            "type" : "integer",
+                                            "description" : "Volume-local sorting index",
+                                            "minimum": 0
+                                        },
+                                        "material" : {
+                                            "type" : "object",
+                                            "properties" : {
+                                                "params" : {
+                                                    "type" : "array",
+                                                    "description" : "Material parameters",
+                                                    "minitems" : 7,
+                                                    "maxItems": 7,
+                                                    "items": {
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            },
+                                            "required": ["params"]
+                                        }
+                                    },
+                                    "required": ["type", "surface_idx", "thickness"]
+                                }
+                            },
+                        },
+                        "required": ["volume_link", "material_slabs"]
+                    }
+                }
+            },
+            "required": ["volumes"]
+        },
+    },
+   "required": ["header", "data"]
+}

--- a/tests/validation/python/json_schemas/surface_grids.py
+++ b/tests/validation/python/json_schemas/surface_grids.py
@@ -1,0 +1,161 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+""" Schema of a srface grid file """
+surface_grid_schema = {
+    "type" : "object",
+    "properties" : {
+        "header" : {
+            "type" : "object",
+            "description": "File header section with important IO metadata",
+            "properties": {
+                "common" : {
+                    "type" : "object",
+                    "description": "General metadata",
+                    "properties": {
+                        "version": {
+                            "type" : "string",
+                            "description": "detray version this file was created with",
+                        },
+                        "detector": {
+                            "type" : "string",
+                            "description": "Name of the detector",
+                        },
+                        "date": {
+                            "type" : "string",
+                            "description": "Time stamp (file creation)",
+                        },
+                        "tag": {
+                            "type" : "string",
+                            "description": "Type of data",
+                            "enum": ["surface_grids"]
+                        }
+                    },
+                    "required": ["version", "detector", "tag"]
+                },
+                "grid_count" : {
+                    "type" : "integer",
+                    "description": "Number of grids in the detector",
+                    "minimum": 0,
+                },
+            },
+            "required": ["common"]
+        },
+        "data" : {
+            "type" : "object",
+            "description": "Grid data section (volume-by-volume)",
+            "properties" : {
+                "grids" : {
+                    "type" : "array",
+                    "minitems" : 1,
+                    "items" : {
+                        "type" : "object",
+                        "description": "Grid data of a single volume",
+                        "properties" : {
+                            "volume_link": {
+                                "type" : "integer",
+                                "description" : "Volume link",
+                                "minimum": 0,
+                            },
+                            "acc_link": {
+                                "type" : "object",
+                                "description": "Typed index for the grid",
+                                "properties" : {
+                                    "type" : {
+                                        "type" : "integer",
+                                        "description" : "Type ID of the acceleration structure",
+                                    },
+                                    "index" : {
+                                        "type" : "integer",
+                                        "description" : "Global index of the acceleration structure",
+                                        "minimum": 0,
+                                    }
+                                },
+                                "required": ["type", "index"]
+                            },
+                            "axes": {
+                                "type" : "array",
+                                "descriptrion" : "The axes of the grid",
+                                "minitems" : 1,
+                                "uniqueItems": True,
+                                "items" : {
+                                    "type" : "object",
+                                    "properties" : {
+                                        "label": {
+                                            "type" : "integer",
+                                            "description" : "Label ID of the axis",
+                                            "minimum": 0,
+                                            "maximum": 2,
+                                        },
+                                        "bounds": {
+                                            "type" : "integer",
+                                            "description" : "Type ID of the bounds",
+                                            "minimum": 0,
+                                            "maximum": 2,
+                                        },
+                                        "binning": {
+                                            "type" : "integer",
+                                            "description" : "Type ID of the binning",
+                                            "minimum": 0,
+                                            "maximum": 1,
+                                        },
+                                        "bins": {
+                                            "type" : "integer",
+                                            "description" : "Number of bins",
+                                            "minimum": 1,
+                                        },
+                                        "edges": {
+                                            "type" : "array",
+                                            "description" : "Bin edges (min, max for regular binning)",
+                                            "minitems" : 2,
+                                            "uniqueItems": True,
+                                            "items" : { "type" : "number" }
+                                        },
+                                    },
+                                    "required": ["label", "bounds", "binning", "bins", "edges"]
+                                }
+                            },
+                            "bins": {
+                                "type": "array",
+                                "description" : "The bin content",
+                                "minitems" : 1,
+                                "uniqueItems": True,
+                                "items" : {
+                                    "type" : "object",
+                                    "description" : "A single bin",
+                                    "properties" : {
+                                        "loc_index" : {
+                                            "type" : "array",
+                                            "description" : "Local bin indices",
+                                            "minitems" : 1,
+                                            "maxitems" : 3,
+                                            "items" : {
+                                                "type" : "integer",
+                                                "minimum": 0,
+                                            }
+                                        },
+                                        "content" : {
+                                            "type" : "array",
+                                            "description" : "Global surface indices",
+                                            "items" : {
+                                                "type" : "integer",
+                                                "minimum": 0,
+                                            }
+                                        }
+                                    },
+                                    "required": ["loc_index", "content"]
+                                }
+                            }
+                        },
+                        "required": ["volume_link", "acc_link"]
+                    }
+                }
+            },
+            "required": ["grids"]
+        },
+    },
+   "required": ["header", "data"]
+}

--- a/tests/validation/python/run_file_checker.py
+++ b/tests/validation/python/run_file_checker.py
@@ -1,0 +1,78 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+import argparse
+import json
+import os
+import sys
+from jsonschema import validate
+
+from json_schemas.geometry import geometry_schema
+from json_schemas.homogeneous_material import homogeneous_material_schema
+from json_schemas.surface_grids import surface_grid_schema
+
+def __main__():
+#----------------------------------------------------------------arg parsing
+
+    parser = argparse.ArgumentParser(description = "Detray File Validation")
+
+    parser.add_argument("--geometry_file",
+                        help=("Input geometry json file."),
+                        default = "", type=str)
+    parser.add_argument("--homogeneous_material_file",
+                        help=("Input homogeneous material json file."),
+                        default = "", type=str)
+    parser.add_argument("--grid_file",
+                        help=("Surface grid json file."),
+                        default = "", type=str)
+
+    args = parser.parse_args()
+
+    # Check input json files
+    filename_dict = {}
+
+    geo_file = args.geometry_file
+    if not geo_file == "":
+        if not os.path.isfile(geo_file):
+            print(f"Geometry file does not exist! ({geo_file})")
+            sys.exit(1)
+        else:
+            filename_dict[geo_file] = geometry_schema
+
+    mat_file = args.homogeneous_material_file
+    if not mat_file == "":
+        if not os.path.isfile(mat_file):
+            print(f"Homogeneous material file does not exist! ({mat_file})")
+            sys.exit(1)
+        else:
+            filename_dict[mat_file] = homogeneous_material_schema
+
+    grid_file = args.grid_file
+    if not grid_file == "":
+        if not os.path.isfile(grid_file):
+            print(f"Surface grid file does not exist! ({grid_file})")
+            sys.exit(1)
+        else:
+            filename_dict[grid_file] = surface_grid_schema
+
+#------------------------------------------------------------------------run
+
+    for filename, schema in filename_dict.items():
+        with open(filename) as file:
+            try:
+                input_json = json.load(file)
+            except json.decoder.JSONDecodeError:
+                print(f"Invalid json file: {filename}")
+            else:
+                validate(instance=input_json, schema=schema)
+                print(f"{filename}: OK")
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    __main__()
+
+#-------------------------------------------------------------------------------


### PR DESCRIPTION
Add schemas for the json data files and provide an executable to read an check json files:

```
python tests/validation/python/run_file_checking.py --geometry_file filename
```

Implemented: geometry, homogeneous material, surface grids

Edit: Also added a few fixes in the payloads and the detector checker