### PR TITLE
fix: cmake list

### DIFF
--- a/extern/actsvg/CMakeLists.txt
+++ b/extern/actsvg/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -24,6 +24,9 @@ mark_as_advanced( DETRAY_ACTSVG_GIT_REPOSITORY DETRAY_ACTSVG_GIT_TAG )
 FetchContent_Declare( actsvg
    GIT_REPOSITORY "${DETRAY_ACTSVG_GIT_REPOSITORY}"
    GIT_TAG "${DETRAY_ACTSVG_GIT_TAG}" )
+
+# Make sure the web plugin of ACTSVG is built
+set(ACTSVG_BUILD_WEB ON CACHE BOOL "Build the web plugin of ACTSVG")
 
 # Now set up its build.
 FetchContent_MakeAvailable( actsvg )


### PR DESCRIPTION
The CMake list for extern/actsvg missed the `actsvg::web` module to be built.