### PR TITLE
Thrust Warning Suppression, main branch (2023.10.30.)

### DIFF
--- a/extern/thrust/CMakeLists.txt
+++ b/extern/thrust/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -29,3 +29,11 @@ set( THRUST_ENABLE_INSTALL_RULES TRUE CACHE BOOL
 
 # Get it into the current directory.
 FetchContent_MakeAvailable( Thrust )
+
+# Treat the Thrust headers as "system headers", to avoid getting warnings from
+# them. But not for CUDA, as that would make it pick up CUB from the CUDA
+# installation. Breaking the build.
+get_target_property( _incDirs _Thrust_Thrust INTERFACE_INCLUDE_DIRECTORIES )
+target_include_directories( _Thrust_Thrust SYSTEM
+   INTERFACE $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${_incDirs}> )
+unset( _incDirs )


### PR DESCRIPTION
While testing the build of the project on macOS with Xcode 15.0.1 (`Apple clang version 15.0.0`), I came across the following warnings/errors:

```
[ 80%] Building CXX object tests/unit_tests/core/CMakeFiles/detray_test_core.dir/thrust_tuple.cpp.o
In file included from /Users/krasznaa/ATLAS/projects/detray/detray/tests/unit_tests/core/thrust_tuple.cpp:9:
In file included from /Users/krasznaa/ATLAS/projects/detray/build/_deps/thrust-src/thrust/tuple.h:34:
In file included from /Users/krasznaa/ATLAS/projects/detray/build/_deps/thrust-src/thrust/detail/tuple.inl:19:
/Users/krasznaa/ATLAS/projects/detray/build/_deps/thrust-src/thrust/detail/type_traits.h:147:10: error: builtin __has_trivial_constructor is deprecated; use __is_trivially_constructible instead [-Werror,-Wdeprecated-builtins]
      || __has_trivial_constructor(T)
         ^
/Users/krasznaa/ATLAS/projects/detray/build/_deps/thrust-src/thrust/detail/type_traits.h:163:10: error: builtin __has_trivial_copy is deprecated; use __is_trivially_copyable instead [-Werror,-Wdeprecated-builtins]
      || __has_trivial_copy(T)
         ^
In file included from /Users/krasznaa/ATLAS/projects/detray/detray/tests/unit_tests/core/thrust_tuple.cpp:9:
In file included from /Users/krasznaa/ATLAS/projects/detray/build/_deps/thrust-src/thrust/tuple.h:34:
In file included from /Users/krasznaa/ATLAS/projects/detray/build/_deps/thrust-src/thrust/detail/tuple.inl:19:
In file included from /Users/krasznaa/ATLAS/projects/detray/build/_deps/thrust-src/thrust/detail/type_traits.h:734:
/Users/krasznaa/ATLAS/projects/detray/build/_deps/thrust-src/thrust/detail/type_traits/has_trivial_assign.h:45:10: error: builtin __has_trivial_assign is deprecated; use __is_trivially_assignable instead [-Werror,-Wdeprecated-builtins]
      || __has_trivial_assign(T)
         ^
3 errors generated.
```

This, slightly more fine-tuned update than I'd like (meaning that our code should really not have to know that Thrust calls its relevant internal library `_Thrust_Thrust`...), silences those warnings.