### PR TITLE
Test Fix(es), main branch (2023.10.31.)

### DIFF
--- a/tests/unit_tests/io/CMakeLists.txt
+++ b/tests/unit_tests/io/CMakeLists.txt
@@ -4,14 +4,30 @@
 #
 # Mozilla Public License Version 2.0
 
-# Set up the core tests.
+# Helper function for running a test in a specific directory.
+function( _run_test_in_dir test dir )
+   # Make the directory.
+   file( MAKE_DIRECTORY "${dir}" )
+   # Run the test in that directory.
+   set_tests_properties( "detray_test_${test}" PROPERTIES
+      WORKING_DIRECTORY "${dir}" )
+endfunction()
+
+# Set up the I/O tests. Running the reader and writer tests in separate
+# directories, so that they would not interfere with each other.
 detray_add_test( io
    "io_json_payload.cpp"
    LINK_LIBRARIES GTest::gtest_main detray::core_array detray::io_array )
+
 detray_add_test( io_writer
    "io_json_detector_writer.cpp"
    LINK_LIBRARIES GTest::gtest_main vecmem::core detray::core_array detray::io_array detray::utils_array )
+_run_test_in_dir( io_writer
+   "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/io_writer_test_rundir" )
+
 detray_add_test( io_reader
     "io_json_detector_reader.cpp"
     LINK_LIBRARIES GTest::gtest_main vecmem::core detray::core_array
     detray::io_array detray::test detray_tests_common detray::utils_array)
+_run_test_in_dir( io_reader
+   "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/io_reader_test_rundir" )


### PR DESCRIPTION
Made the I/O reader and writer tests run in different directories, to stop them from interfering with each other.

As discussed [on Mattermost](https://mattermost.web.cern.ch/acts/pl/iwbwb6xfajr9fdgrnt1i8ptyjy), the recent CI failures are because of
  - https://github.com/acts-project/detray/blob/main/tests/unit_tests/io/io_json_detector_reader.cpp and;
  - https://github.com/acts-project/detray/blob/main/tests/unit_tests/io/io_json_detector_writer.cpp

using the same filenames during their execution. Allowing them to overwrite each others' files. Or even just making them fail with the following:

```
[bash][atspot01]:build > ./bin/detray_test_io_reader 
Running main() from /home/krasznaa/ATLAS/projects/detray/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from io
[ RUN      ] io.json_telescope_detector_reader
WARNING: No entries in volume finder
Detector check: OK
[       OK ] io.json_telescope_detector_reader (1 ms)
[ RUN      ] io.json_toy_geometry
WARNING: No material in detector
WARNING: acceleration data structures store has empty collection no. 1
WARNING: acceleration data structures store has empty collection no. 2
WARNING: No entries in volume finder
WARNING: mask store has empty collection no. 2
WARNING: mask store has empty collection no. 3
WARNING: mask store has empty collection no. 6
WARNING: mask store has empty collection no. 7
WARNING: No material in detector
WARNING: acceleration data structures store has empty collection no. 1
WARNING: acceleration data structures store has empty collection no. 2
WARNING: acceleration data structures store has empty collection no. 3
WARNING: acceleration data structures store has empty collection no. 4
WARNING: No entries in volume finder
[       OK ] io.json_toy_geometry (130 ms)
[ RUN      ] io.json_toy_detector_reader
WARNING: No entries in volume finder
Detector check: OK
WARNING: No entries in volume finder
[       OK ] io.json_toy_detector_reader (241 ms)
[ RUN      ] io.json_wire_chamber_reader
WARNING: mask store has empty collection no. 0
WARNING: mask store has empty collection no. 1
WARNING: mask store has empty collection no. 2
WARNING: mask store has empty collection no. 3
WARNING: mask store has empty collection no. 6
WARNING: acceleration data structures store has empty collection no. 1
WARNING: acceleration data structures store has empty collection no. 3
WARNING: acceleration data structures store has empty collection no. 4
WARNING: No entries in volume finder
Detector check: OK
[       OK ] io.json_wire_chamber_reader (127 ms)
[----------] 4 tests from io (501 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (501 ms total)
[  PASSED  ] 4 tests.
[bash][atspot01]:build > ./bin/detray_test_io_writer 
Running main() from /home/krasznaa/ATLAS/projects/detray/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from io
[ RUN      ] io.json_telescope_geometry_writer
[       OK ] io.json_telescope_geometry_writer (0 ms)
[ RUN      ] io.json_telescope_material_writer
[       OK ] io.json_telescope_material_writer (0 ms)
[ RUN      ] io.json_toy_grid_writer
[       OK ] io.json_toy_grid_writer (9 ms)
[ RUN      ] io.json_toy_detector_writer
[       OK ] io.json_toy_detector_writer (58 ms)
[ RUN      ] io.json_wire_chamber_writer
[       OK ] io.json_wire_chamber_writer (35 ms)
[----------] 5 tests from io (104 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (104 ms total)
[  PASSED  ] 5 tests.
[bash][atspot01]:build > ./bin/detray_test_io_reader 
Running main() from /home/krasznaa/ATLAS/projects/detray/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from io
[ RUN      ] io.json_telescope_detector_reader
WARNING: No entries in volume finder
Detector check: OK
In line 45:
                                1.0
                                0.0
/home/krasznaa/ATLAS/projects/detray/detray/tests/unit_tests/io/io_json_detector_reader.cpp:123: Failure
Value of: compare_files("telescope_detector_geometry.json", "telescope_detector_geometry_2.json")
  Actual: false
Expected: true

[  FAILED  ] io.json_telescope_detector_reader (3 ms)
[ RUN      ] io.json_toy_geometry
WARNING: No material in detector
WARNING: acceleration data structures store has empty collection no. 1
WARNING: acceleration data structures store has empty collection no. 2
WARNING: No entries in volume finder
WARNING: mask store has empty collection no. 2
WARNING: mask store has empty collection no. 3
WARNING: mask store has empty collection no. 6
WARNING: mask store has empty collection no. 7
WARNING: No material in detector
WARNING: acceleration data structures store has empty collection no. 1
WARNING: acceleration data structures store has empty collection no. 2
WARNING: acceleration data structures store has empty collection no. 3
WARNING: acceleration data structures store has empty collection no. 4
WARNING: No entries in volume finder
[       OK ] io.json_toy_geometry (134 ms)
[ RUN      ] io.json_toy_detector_reader
WARNING: No entries in volume finder
Detector check: OK
WARNING: No entries in volume finder
[       OK ] io.json_toy_detector_reader (228 ms)
[ RUN      ] io.json_wire_chamber_reader
WARNING: mask store has empty collection no. 0
WARNING: mask store has empty collection no. 1
WARNING: mask store has empty collection no. 2
WARNING: mask store has empty collection no. 3
WARNING: mask store has empty collection no. 6
WARNING: acceleration data structures store has empty collection no. 1
WARNING: acceleration data structures store has empty collection no. 3
WARNING: acceleration data structures store has empty collection no. 4
WARNING: No entries in volume finder
Detector check: OK
[       OK ] io.json_wire_chamber_reader (126 ms)
[----------] 4 tests from io (493 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (493 ms total)
[  PASSED  ] 3 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] io.json_telescope_detector_reader

 1 FAILED TEST
[bash][atspot01]:build >
```

Yepp, the "reader" -> "writer" -> "reader" order in the same directory also always fails. :frowning: But this PR is not fixing that, it just makes sure that the tests would always run separate from each other. Only necessitating that repeated runs of the same executable would be successful.