### PR TITLE
feat: material maps writer

### DIFF
--- a/core/include/detray/core/detail/multi_store.hpp
+++ b/core/include/detray/core/detail/multi_store.hpp
@@ -14,6 +14,7 @@
 #include "detray/core/detail/tuple_container.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/type_list.hpp"
 #include "detray/utils/type_registry.hpp"
 
 // Vecmem include(s)
@@ -356,6 +357,12 @@ class multi_store {
         return m_tuple_container.template visit<functor_t>(
             static_cast<std::size_t>(detail::get<0>(link)),
             detail::get<1>(link), std::forward<Args>(args)...);
+    }
+
+    /// Print the types that are in the store
+    DETRAY_HOST
+    static constexpr void print() {
+        types::print<types::type_list<detail::get_value_t<Ts>...>>();
     }
 
     /// @return the view on this tuple container - non-const

--- a/io/include/detray/io/common/detector_writer.hpp
+++ b/io/include/detray/io/common/detector_writer.hpp
@@ -97,10 +97,15 @@ detail::detector_component_writers<detector_t> assemble_writer(
                 writers.template add<json_homogeneous_material_writer>();
             }
             // Material maps
-            // ...
+            if constexpr (detail::has_material_grids_v<detector_t>) {
+                writers.template add<json_material_map_writer>();
+            }
         }
-        if (cfg.write_grids()) {
-            writers.template add<json_grid_writer>();
+        // Navigation acceleration structures
+        if constexpr (detail::has_surface_grids_v<detector_t>) {
+            if (cfg.write_grids()) {
+                writers.template add<json_surface_grid_writer>();
+            }
         }
     }
 

--- a/io/include/detray/io/common/homogeneous_material_writer.hpp
+++ b/io/include/detray/io/common/homogeneous_material_writer.hpp
@@ -22,12 +22,17 @@
 
 namespace detray {
 
+template <typename detector_t>
+class material_map_writer;
+
 /// @brief Abstract base class for simple material description writers
 template <class detector_t>
 class homogeneous_material_writer : public writer_interface<detector_t> {
 
     using base_type = writer_interface<detector_t>;
     using scalar_t = typename detector_t::scalar_type;
+
+    friend class material_map_writer<detector_t>;
 
     protected:
     /// Tag the writer as "homogeneous_material"

--- a/io/include/detray/io/common/material_map_writer.hpp
+++ b/io/include/detray/io/common/material_map_writer.hpp
@@ -1,0 +1,92 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/io/common/detail/grid_writer.hpp"
+#include "detray/io/common/detail/type_traits.hpp"
+#include "detray/io/common/homogeneous_material_writer.hpp"
+#include "detray/io/common/io_interface.hpp"
+#include "detray/io/common/payloads.hpp"
+#include "detray/materials/material_slab.hpp"
+
+// System include(s)
+#include <string>
+
+namespace detray {
+
+/// @brief Abstract base class for material maps writers
+template <class detector_t>
+class material_map_writer
+    : public detail::grid_writer<
+          detector_t, material_slab<typename detector_t::scalar_type>> {
+
+    using scalar_t = typename detector_t::scalar_type;
+    using material_t = material_slab<scalar_t>;
+
+    using base_type =
+        detail::grid_writer<detector_t,
+                            material_slab<typename detector_t::scalar_type>>;
+    using grid_writer_t = base_type;
+    using mat_writer_t = homogeneous_material_writer<detector_t>;
+
+    protected:
+    /// Tag the writer as "material_map"
+    inline static const std::string tag = "material_maps";
+
+    public:
+    /// Same constructors for this class as for base_type
+    using base_type::base_type;
+
+    protected:
+    /// Serialize the header information into its payload
+    static auto write_header(const detector_t& det,
+                             const std::string_view det_name) {
+
+        return grid_writer_t::write_header(tag, det.material_store(), det_name);
+    }
+
+    /// Serialize the material description of a detector @param det into its io
+    /// payload
+    static detector_grids_payload<material_slab_payload> serialize(
+        const detector_t& det, const typename detector_t::name_map&) {
+
+        detector_grids_payload<material_slab_payload> grids_data;
+
+        // How to serialize a material slab in the grid
+        auto mat_serializer = [](const material_t& mat) {
+            return mat_writer_t::serialize(mat, dindex_invalid);
+        };
+
+        for (const auto& vol_desc : det.volumes()) {
+
+            /// Check if a surface has a metrial map
+            for (const auto& sf_desc : det.surface_lookup()) {
+                if (sf_desc.volume() != vol_desc.index()) {
+                    continue;
+                }
+
+                const auto& mat_link = sf_desc.material();
+                // Don't look at empty links
+                if (mat_link.is_invalid() or
+                    mat_link.id() == detector_t::materials::id::e_none) {
+                    continue;
+                }
+
+                // Generate the payload
+                grid_writer_t::serialize(det.material_store(), mat_link,
+                                         sf_desc.index(), grids_data,
+                                         mat_serializer);
+            }
+        }
+
+        return grids_data;
+    }
+};
+
+}  // namespace detray

--- a/io/include/detray/io/common/surface_grid_writer.hpp
+++ b/io/include/detray/io/common/surface_grid_writer.hpp
@@ -1,0 +1,82 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/indexing.hpp"
+#include "detray/io/common/detail/grid_writer.hpp"
+#include "detray/io/common/io_interface.hpp"
+#include "detray/io/common/payloads.hpp"
+
+// System include(s)
+#include <string>
+
+namespace detray {
+
+/// @brief Abstract base class for accelerator grid writers
+template <class detector_t>
+class surface_grid_writer
+    : public detail::grid_writer<detector_t,
+                                 typename detector_t::surface_type> {
+
+    using surface_t = typename detector_t::surface_type;
+    using base_type = detail::grid_writer<detector_t, surface_t>;
+    using grid_writer_t = base_type;
+
+    protected:
+    /// Tag the writer as "surface_grids"
+    inline static const std::string tag = "surface_grids";
+
+    public:
+    /// Same constructors for this class as for base_type
+    using base_type::base_type;
+
+    protected:
+    /// Serialize the header information into its payload
+    static auto write_header(const detector_t& det,
+                             const std::string_view det_name) {
+
+        return grid_writer_t::write_header(tag, det.accelerator_store(),
+                                           det_name);
+    }
+
+    /// Serialize the grid collections of a detector @param det into their io
+    /// payload
+    static detector_grids_payload<std::size_t> serialize(
+        const detector_t& det, const typename detector_t::name_map&) {
+
+        detector_grids_payload<std::size_t> grids_data;
+
+        // How to serialize the surface descriptors in the grid
+        auto sf_serializer = [](const surface_t& sf_desc) {
+            return sf_desc.index();
+        };
+
+        for (const auto& vol_desc : det.volumes()) {
+            // Links to all acceleration data structures in the volume
+            const auto& multi_link = vol_desc.full_link();
+
+            for (dindex i = 0u; i < multi_link.size(); ++i) {
+                const auto& acc_link = multi_link[i];
+                // Don't look at empty links
+                if (acc_link.is_invalid()) {
+                    continue;
+                }
+
+                // Generate the payload
+                grid_writer_t::serialize(det.accelerator_store(), acc_link,
+                                         vol_desc.index(), grids_data,
+                                         sf_serializer);
+            }
+        }
+
+        return grids_data;
+    }
+};
+
+}  // namespace detray

--- a/io/include/detray/io/json/json_writer.hpp
+++ b/io/include/detray/io/json/json_writer.hpp
@@ -10,8 +10,9 @@
 // Project include(s)
 #include "detray/io/common/detail/file_handle.hpp"
 #include "detray/io/common/geometry_writer.hpp"
-#include "detray/io/common/grid_writer.hpp"
 #include "detray/io/common/homogeneous_material_writer.hpp"
+#include "detray/io/common/material_map_writer.hpp"
+#include "detray/io/common/surface_grid_writer.hpp"
 #include "detray/io/json/json.hpp"
 #include "detray/io/json/json_serializers.hpp"
 
@@ -91,9 +92,12 @@ template <typename detector_t>
 using json_homogeneous_material_writer =
     json_writer<detector_t, homogeneous_material_writer>;
 
+/// Write a material map description to file in json format
+template <typename detector_t>
+using json_material_map_writer = json_writer<detector_t, material_map_writer>;
+
 /// Write the detector grid collections to file in json format
-template <typename detector_t,
-          typename value_t = typename detector_t::surface_type>
-using json_grid_writer = json_writer<detector_t, grid_writer, value_t>;
+template <typename detector_t>
+using json_surface_grid_writer = json_writer<detector_t, surface_grid_writer>;
 
 }  // namespace detray

--- a/tests/unit_tests/io/io_json_detector_writer.cpp
+++ b/tests/unit_tests/io/io_json_detector_writer.cpp
@@ -74,6 +74,22 @@ TEST(io, json_telescope_material_writer) {
 }
 
 /// Test the writing of the toy detector grids to json
+TEST(io, json_toy_material_maps_writer) {
+
+    using detector_t = detector<toy_metadata>;
+
+    // Toy detector
+    vecmem::host_memory_resource host_mr;
+    toy_det_config toy_cfg{};
+    toy_cfg.use_material_maps(true);
+    auto [det, names] = create_toy_geometry(host_mr, toy_cfg);
+
+    json_material_map_writer<detector_t> map_writer;
+    map_writer.write(det, names,
+                     std::ios::out | std::ios::binary | std::ios::trunc);
+}
+
+/// Test the writing of the toy detector grids to json
 TEST(io, json_toy_grid_writer) {
 
     using detector_t = detector<toy_metadata>;
@@ -82,7 +98,7 @@ TEST(io, json_toy_grid_writer) {
     vecmem::host_memory_resource host_mr;
     auto [det, names] = create_toy_geometry(host_mr);
 
-    json_grid_writer<detector_t> grid_writer;
+    json_surface_grid_writer<detector_t> grid_writer;
     grid_writer.write(det, names,
                       std::ios::out | std::ios::binary | std::ios::trunc);
 }
@@ -92,7 +108,9 @@ TEST(io, json_toy_detector_writer) {
 
     // Toy detector
     vecmem::host_memory_resource host_mr;
-    auto [det, names] = create_toy_geometry(host_mr);
+    toy_det_config toy_cfg{};
+    toy_cfg.use_material_maps(true);
+    const auto [det, names] = create_toy_geometry(host_mr, toy_cfg);
 
     auto writer_cfg = io::detector_writer_config{}
                           .format(io::format::json)


### PR DESCRIPTION
This implements the material maps writing. It splits the common writer functionality for the grids in a common helper class that is inherited by the `surface_grid_writer` and the new `material_map_writer`. The `material_map_writer` uses the `grid_payload` with a `material_slab_payload` as value type.