### PR TITLE
ref: Add centroid approximation for (annulus) shape

### DIFF
--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -79,6 +79,16 @@ struct surface_kernels {
         }
     };
 
+    /// A functor get the mask centroid in local cartesian coordinates
+    struct centroid {
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline point3 operator()(
+            const mask_group_t& mask_group, const index_t& index) const {
+
+            return mask_group[index].centroid();
+        }
+    };
+
     /// A functor to perform global to local bound transformation
     struct global_to_bound {
         template <typename mask_group_t, typename index_t>

--- a/core/include/detray/masks/annulus2D.hpp
+++ b/core/include/detray/masks/annulus2D.hpp
@@ -264,6 +264,27 @@ class annulus2D {
         return corner_pos;
     }
 
+    /// @returns the shapes centroid in local cartesian coordinates
+    /// @note the caluculated centroid position is only an approximation
+    /// (centroid of the four corner points)!
+    template <typename algebra_t,
+              template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST_DEVICE typename algebra_t::point3 centroid(
+        const bounds_t<scalar_t, kDIM> &bounds) const {
+
+        // Strip polar system
+        const auto crns = corners(bounds);
+
+        // Coordinates of the centroid position in strip system
+        const scalar_t r{0.25f * (crns[0] + crns[2] + crns[4] + crns[6])};
+        const scalar_t phi{bounds[e_average_phi]};
+
+        return r * typename algebra_t::point3{math_ns::cos(phi),
+                                              math_ns::sin(phi), 0.f};
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values for the stereo annulus

--- a/core/include/detray/masks/cuboid3D.hpp
+++ b/core/include/detray/masks/cuboid3D.hpp
@@ -128,6 +128,20 @@ class cuboid3D {
         return o_bounds;
     }
 
+    /// @returns the shapes centroid in local cartesian coordinates
+    template <typename algebra_t,
+              template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST_DEVICE typename algebra_t::point3 centroid(
+        const bounds_t<scalar_t, kDIM> &bounds) const {
+
+        return 0.5f *
+               typename algebra_t::point3{bounds[e_min_x] + bounds[e_max_x],
+                                          bounds[e_min_y] + bounds[e_max_y],
+                                          bounds[e_min_z] + bounds[e_max_z]};
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values for the cuboid

--- a/core/include/detray/masks/cylinder2D.hpp
+++ b/core/include/detray/masks/cylinder2D.hpp
@@ -131,6 +131,17 @@ class cylinder2D {
                 xy_bound,  xy_bound,  bounds[e_p_half_z] + env};
     }
 
+    /// @returns the shapes centroid in local cartesian coordinates
+    template <typename algebra_t,
+              template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST_DEVICE typename algebra_t::point3 centroid(
+        const bounds_t<scalar_t, kDIM> &bounds) const {
+
+        return {0.f, 0.f, 0.5f * (bounds[e_n_half_z] + bounds[e_p_half_z])};
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values for the cylinder

--- a/core/include/detray/masks/cylinder3D.hpp
+++ b/core/include/detray/masks/cylinder3D.hpp
@@ -124,6 +124,19 @@ class cylinder3D {
                 r_bound,  r_bound,  bounds[e_max_z] + env};
     }
 
+    /// @returns the shapes centroid in local cartesian coordinates
+    template <typename algebra_t,
+              template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST_DEVICE typename algebra_t::point3 centroid(
+        const bounds_t<scalar_t, kDIM> &bounds) const {
+
+        return 0.5f * typename algebra_t::point3{
+                          0.f, (bounds[e_min_phi] + bounds[e_max_phi]),
+                          (bounds[e_min_z] + bounds[e_max_z])};
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values for the cylinder

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -151,6 +151,17 @@ class line {
         return {-xy_bound, -xy_bound, -z_bound, xy_bound, xy_bound, z_bound};
     }
 
+    /// @returns the shapes centroid in local cartesian coordinates
+    template <typename algebra_t,
+              template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST_DEVICE typename algebra_t::point3 centroid(
+        const bounds_t<scalar_t, kDIM> &) const {
+
+        return {0.f, 0.f, 0.f};
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values for the line

--- a/core/include/detray/masks/masks.hpp
+++ b/core/include/detray/masks/masks.hpp
@@ -189,6 +189,11 @@ class mask {
     DETRAY_HOST_DEVICE
     auto volume_link() -> links_type& { return _volume_link; }
 
+    /// @returns the masks centroid in local cartesian coordinates
+    DETRAY_HOST_DEVICE auto centroid() const {
+        return _shape.template centroid<algebra_t>(_values);
+    }
+
     /// @brief Lower and upper point for minimum axis aligned bounding box.
     ///
     /// Computes the min and max vertices in a local 3 dim cartesian frame.

--- a/core/include/detray/masks/rectangle2D.hpp
+++ b/core/include/detray/masks/rectangle2D.hpp
@@ -116,6 +116,17 @@ class rectangle2D {
         return {-x_bound, -y_bound, -env, x_bound, y_bound, env};
     }
 
+    /// @returns the shapes centroid in local cartesian coordinates
+    template <typename algebra_t,
+              template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST_DEVICE typename algebra_t::point3 centroid(
+        const bounds_t<scalar_t, kDIM> &) const {
+
+        return {0.f, 0.f, 0.f};
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values for the stereo annulus

--- a/core/include/detray/masks/ring2D.hpp
+++ b/core/include/detray/masks/ring2D.hpp
@@ -117,6 +117,17 @@ class ring2D {
         return {-r_bound, -r_bound, -env, r_bound, r_bound, env};
     }
 
+    /// @returns the shapes centroid in local cartesian coordinates
+    template <typename algebra_t,
+              template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST_DEVICE typename algebra_t::point3 centroid(
+        const bounds_t<scalar_t, kDIM> &) const {
+
+        return {0.f, 0.f, 0.f};
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values for the stereo annulus

--- a/core/include/detray/masks/single3D.hpp
+++ b/core/include/detray/masks/single3D.hpp
@@ -117,6 +117,22 @@ class single3D {
         return o_bounds;
     }
 
+    /// @returns the shapes centroid in local cartesian coordinates
+    template <typename algebra_t,
+              template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST_DEVICE auto centroid(
+        const bounds_t<scalar_t, kDIM> &bounds) const {
+
+        using point3_t = typename algebra_t::point3;
+
+        point3_t centr{0.f, 0.f, 0.f};
+        centr[kCheckIndex] = 0.5f * (bounds[e_lower] + bounds[e_upper]);
+
+        return centr;
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values for the single value

--- a/core/include/detray/masks/trapezoid2D.hpp
+++ b/core/include/detray/masks/trapezoid2D.hpp
@@ -130,6 +130,24 @@ class trapezoid2D {
         return {-x_bound, -y_bound, -env, x_bound, y_bound, env};
     }
 
+    /// @returns the shapes centroid in local cartesian coordinates
+    template <typename algebra_t,
+              template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST_DEVICE typename algebra_t::point3 centroid(
+        const bounds_t<scalar_t, kDIM> &bounds) const {
+
+        const scalar_t h_2{bounds[e_half_length_2]};
+        const scalar_t a_2{bounds[e_half_length_1]};
+        const scalar_t b_2{bounds[e_half_length_0]};
+
+        const scalar_t y{2.f * h_2 * (2.f * a_2 + b_2) * 1.f /
+                         (3.f * (a_2 + b_2))};
+
+        return {0.f, y - h_2, 0.f};
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values for the trapezoid

--- a/core/include/detray/masks/unbounded.hpp
+++ b/core/include/detray/masks/unbounded.hpp
@@ -79,6 +79,16 @@ class unbounded {
         return shape{}.template local_min_bounds<algebra_t>(bounds, env);
     }
 
+    /// @returns the shapes centroid in local cartesian coordinates
+    template <
+        typename algebra_t, template <typename, std::size_t> class bounds_t,
+        typename scalar_t, std::size_t kDIM,
+        typename std::enable_if_t<kDIM == boundaries::e_size, bool> = true>
+    DETRAY_HOST_DEVICE auto centroid(
+        const bounds_t<scalar_t, kDIM>& bounds) const {
+        return shape{}.template centroid<algebra_t>(bounds);
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values for the underlying shape

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -94,6 +94,16 @@ class unmasked {
         return {-inf, -inf, -inf, inf, inf, inf};
     }
 
+    /// @returns the shapes centroid in global cartesian coordinates
+    template <typename algebra_t,
+              template <typename, std::size_t> class bounds_t,
+              typename scalar_t, std::size_t kDIM,
+              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    DETRAY_HOST_DEVICE typename algebra_t::point3 centroid(
+        const bounds_t<scalar_t, kDIM>&) const {
+        return {0.f, 0.f, 0.f};
+    }
+
     /// Generate vertices in local cartesian frame
     ///
     /// @param bounds the boundary values

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
@@ -146,8 +146,8 @@ auto inline surface(const transform_t& transform, const mask<annulus2D<>>& m) {
 
     auto ri = static_cast<scalar_t>(m[shape_t::e_min_r]);
     auto ro = static_cast<scalar_t>(m[shape_t::e_max_r]);
-    auto center =
-        svgtools::conversion::point<point3_t>(transform.translation());
+    auto center = svgtools::conversion::point<point3_t>(
+        transform.point_to_global(m.centroid()));
 
     p_surface._type = p_surface_t::type::e_annulus;
     p_surface._radii = {ri, ro};

--- a/plugins/svgtools/include/detray/plugins/svgtools/utils/surface_kernels.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/utils/surface_kernels.hpp
@@ -94,7 +94,7 @@ struct link_start_getter {
     template <typename mask_t, typename transform_t>
     auto inline link_start(const mask_t& mask,
                            const transform_t& transform) const {
-        return mask.global_min_bounds_center(transform);
+        return transform.point_to_global(mask.centroid());
     }
 
     // Calculates the (optimal) link starting point for rings.
@@ -134,7 +134,7 @@ struct link_start_getter {
         // Polar coordinate system.
         const typename mask_t::local_frame_type frame{};
 
-        const auto true_center = mask.global_min_bounds_center(transform);
+        const auto true_center = transform.point_to_global(mask.centroid());
         const auto rel_point =
             frame.local_to_global(transform, point3_t{r, phi, z}) -
             transform.translation();

--- a/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_cylinder_intersector.hpp
@@ -47,17 +47,18 @@ struct helix_cylinder_intersector
     /// Operator function to find intersections between helix and cylinder mask
     ///
     /// @tparam mask_t is the input mask type
-    /// @tparam surface_t is the input transform type
+    /// @tparam surface_desc_t is the input transform type
     ///
     /// @param h is the input helix trajectory
+    /// @param sf_desc is the surface descriptor
     /// @param mask is the input mask
     /// @param trf is the transform
     /// @param mask_tolerance is the tolerance for mask edges
     ///
     /// @return the intersection
-    template <typename mask_t, typename surface_t>
+    template <typename mask_t, typename surface_desc_t>
     DETRAY_HOST_DEVICE inline std::array<intersection_t, 2> operator()(
-        const helix_type &h, const surface_t &sf, const mask_t &mask,
+        const helix_type &h, const surface_desc_t &sf_desc, const mask_t &mask,
         const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
 
@@ -153,7 +154,7 @@ struct helix_cylinder_intersector
 
             // Compute some additional information if the intersection is valid
             if (is.status == intersection::status::e_inside) {
-                is.sf_desc = sf;
+                is.sf_desc = sf_desc;
                 is.direction = std::signbit(s)
                                    ? intersection::direction::e_opposite
                                    : intersection::direction::e_along;

--- a/tests/common/include/tests/common/tools/intersectors/helix_intersection_kernel.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_intersection_kernel.hpp
@@ -25,30 +25,30 @@ struct helix_intersection_initialize {
     /// @tparam mask_group_t is the input mask group type found by variadic
     /// unrolling
     /// @tparam traj_t is the input trajectory type (e.g. ray or helix)
-    /// @tparam surface_t is the input surface type
+    /// @tparam surface_desc_t is the input surface descriptor type
     /// @tparam transform_container_t is the input transform store type
     ///
     /// @param mask_group is the input mask group
     /// @param traj is the input trajectory
-    /// @param surface is the input surface
+    /// @param sf_desc is the surface descriptor
     /// @param contextual_transforms is the input transform container
     /// @param mask_tolerance is the tolerance for mask size
     ///
     /// @return the intersection
     template <typename mask_group_t, typename mask_range_t,
-              typename is_container_t, typename traj_t, typename surface_t,
+              typename is_container_t, typename traj_t, typename surface_desc_t,
               typename transform_container_t>
     DETRAY_HOST_DEVICE inline void operator()(
         const mask_group_t &mask_group, const mask_range_t &mask_range,
         is_container_t &is_container, const traj_t &traj,
-        const surface_t &surface,
+        const surface_desc_t &sf_desc,
         const transform_container_t &contextual_transforms,
         const scalar mask_tolerance = 0.f) const {
 
         using intersection_t = typename is_container_t::value_type;
         using mask_t = typename mask_group_t::value_type;
 
-        const auto &ctf = contextual_transforms[surface.transform()];
+        const auto &ctf = contextual_transforms[sf_desc.transform()];
 
         // Run over the masks that belong to the surface
         for (const auto &mask :
@@ -56,7 +56,7 @@ struct helix_intersection_initialize {
 
             if (place_in_collection(
                     helix_intersector<intersection_t, mask_t>()(
-                        traj, surface, mask, ctf, mask_tolerance),
+                        traj, sf_desc, mask, ctf, mask_tolerance),
                     is_container)) {
                 return;
             };

--- a/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_line_intersector.hpp
@@ -40,18 +40,18 @@ struct helix_line_intersector {
     /// Operator function to find intersections between helix and line mask
     ///
     /// @tparam mask_t is the input mask type
-    /// @tparam transform_t is the input transform type
+    /// @tparam surface_desc_t is the input surface descriptor type
     ///
     /// @param h is the input helix trajectory
-    /// @param sf is the input surface
+    /// @param sf_desc is the surface descriptor
     /// @param mask is the input mask
     /// @param trf is the transform
     /// @param mask_tolerance is the tolerance for mask edges
     ///
     /// @return the intersection
-    template <typename mask_t, typename surface_t>
+    template <typename mask_t, typename surface_desc_t>
     DETRAY_HOST_DEVICE inline intersection_t operator()(
-        const helix_type &h, const surface_t &sf, const mask_t &mask,
+        const helix_type &h, const surface_desc_t &sf_desc, const mask_t &mask,
         const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
 
@@ -153,7 +153,7 @@ struct helix_line_intersector {
 
         // Compute some additional information if the intersection is valid
         if (sfi.status == intersection::status::e_inside) {
-            sfi.sf_desc = sf;
+            sfi.sf_desc = sf_desc;
             sfi.direction = std::signbit(s)
                                 ? intersection::direction::e_opposite
                                 : intersection::direction::e_along;

--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -40,18 +40,19 @@ struct helix_plane_intersector {
     /// Operator function to find intersections between helix and planar mask
     ///
     /// @tparam mask_t is the input mask type
-    /// @tparam transform_t is the input transform type
+    /// @tparam surface_desc_t is the input surface descriptor type
     ///
     /// @param h is the input helix trajectory
+    /// @param sf_desc is the surface descriptor
     /// @param mask is the input mask
     /// @param trf is the transform
     /// @param mask_tolerance is the tolerance for mask edges
     /// @param overstep_tolerance is the tolerance for track overstepping
     ///
     /// @return the intersection
-    template <typename mask_t, typename surface_t>
+    template <typename mask_t, typename surface_desc_t>
     DETRAY_HOST_DEVICE inline intersection_t operator()(
-        const helix_type &h, const surface_t &sf, const mask_t &mask,
+        const helix_type &h, const surface_desc_t &sf_desc, const mask_t &mask,
         const transform3_type &trf,
         const scalar_type mask_tolerance = 0.f) const {
 
@@ -70,7 +71,8 @@ struct helix_plane_intersector {
         const point3 st = getter::vector<3>(sm, 0u, 3u);
 
         // Starting point on the helix for the Newton iteration
-        scalar_type s{getter::norm(st - h.pos(0.f))};
+        scalar_type s{
+            getter::norm(trf.point_to_global(mask.centroid()) - h.pos(0.f))};
         scalar_type s_prev{0.f};
 
         // f(s) = sn * (h.pos(s) - st) == 0
@@ -100,7 +102,7 @@ struct helix_plane_intersector {
 
         // Compute some additional information if the intersection is valid
         if (sfi.status == intersection::status::e_inside) {
-            sfi.sf_desc = sf;
+            sfi.sf_desc = sf_desc;
             sfi.direction = std::signbit(s)
                                 ? intersection::direction::e_opposite
                                 : intersection::direction::e_along;

--- a/tests/common/include/tests/common/tools/particle_gun.hpp
+++ b/tests/common/include/tests/common/tools/particle_gun.hpp
@@ -55,7 +55,7 @@ struct particle_gun {
                                intersection_initialize>;
 
         // Loop over all surfaces in the detector
-        const auto &tf_store = detector.transform_store();
+        const auto &trf_store = detector.transform_store();
 
         std::vector<intersection_t> intersections{};
 
@@ -63,7 +63,7 @@ struct particle_gun {
             // Retrieve candidate(s) from the surface
             const auto sf = surface{detector, sf_desc};
             sf.template visit_mask<intersection_kernel_t>(
-                intersections, traj, sf_desc, tf_store,
+                intersections, traj, sf_desc, trf_store,
                 sf.is_portal() ? 0.f : mask_tolerance);
 
             // Candidate is invalid if it lies in the opposite direction

--- a/tests/unit_tests/cpu/geometry_surface.cpp
+++ b/tests/unit_tests/cpu/geometry_surface.cpp
@@ -137,7 +137,7 @@ GTEST_TEST(detray_geometry, surface) {
 
     // Roundtrip
     const point3_t global = disc.local_to_global(ctx, local, {});
-    const point3_t global2 = disc.local_to_global(ctx, bound, {});
+    const point3_t global2 = disc.bound_to_global(ctx, bound, {});
 
     ASSERT_NEAR(glob_pos[0], global[0], tol);
     ASSERT_NEAR(glob_pos[1], global[1], tol);

--- a/tests/unit_tests/cpu/masks_annulus2D.cpp
+++ b/tests/unit_tests/cpu/masks_annulus2D.cpp
@@ -5,16 +5,16 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// Project include(s)
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/test/types.hpp"
-#include "detray/tracks/bound_track_parameters.hpp"
+
+// GTest include
+#include <gtest/gtest.h>
 
 using namespace detray;
 using point3_t = test::point3;
-using transform3_t = test::transform3;
 
 constexpr scalar tol{1e-5f};
 
@@ -101,4 +101,10 @@ GTEST_TEST(detray_masks, annulus2D) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], 10.50652f + envelope, tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], 10.89317f + envelope, tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], envelope, tol);
+
+    // TODO: Check against visiualization
+    /*const auto centroid = ann2.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);*/
 }

--- a/tests/unit_tests/cpu/masks_cylinder.cpp
+++ b/tests/unit_tests/cpu/masks_cylinder.cpp
@@ -5,16 +5,16 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// Project include(s)
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/test/types.hpp"
-#include "detray/tracks/bound_track_parameters.hpp"
+
+// GTest include
+#include <gtest/gtest.h>
 
 using namespace detray;
 using point3_t = test::point3;
-using transform3_t = test::transform3;
 
 constexpr scalar tol{1e-7f};
 
@@ -41,9 +41,6 @@ GTEST_TEST(detray_masks, cylinder2D) {
     // Move outside point inside using a tolerance
     ASSERT_TRUE(c.is_inside(p2_out, 0.6f) == intersection::status::e_inside);
 
-    // Dummy bound track parameter
-    bound_track_parameters<transform3_t> bound_params;
-
     // Check bounding box
     constexpr scalar envelope{0.01f};
     const auto loc_bounds = c.local_min_bounds(envelope);
@@ -53,6 +50,11 @@ GTEST_TEST(detray_masks, cylinder2D) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], (r + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], (r + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], (hz + envelope), tol);
+
+    const auto centroid = c.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }
 
 /// This tests the basic functionality of a 3D cylinder
@@ -91,4 +93,9 @@ GTEST_TEST(detray_masks, cylinder3D) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], (r + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], (r + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], (hz + envelope), tol);
+
+    const auto centroid = c.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }

--- a/tests/unit_tests/cpu/masks_line.cpp
+++ b/tests/unit_tests/cpu/masks_line.cpp
@@ -5,16 +5,16 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// Project include(s)
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/test/types.hpp"
-#include "detray/tracks/bound_track_parameters.hpp"
+
+// GTest include
+#include <gtest/gtest.h>
 
 using namespace detray;
 using point3_t = test::point3;
-using transform3_t = test::transform3;
 
 namespace {
 
@@ -45,11 +45,6 @@ GTEST_TEST(detray_masks, line_radial_cross_sect) {
     ASSERT_TRUE(ln.is_inside(ln_out1) == intersection::status::e_outside);
     ASSERT_TRUE(ln.is_inside(ln_out2) == intersection::status::e_outside);
 
-    // Dummy bound track parameter
-    bound_track_parameters<transform3_t> bound_params;
-    auto& bound_vec = bound_params.vector();
-    getter::element(bound_vec, e_bound_loc0, 0u) = 1.f;
-
     // Check bounding box
     constexpr scalar envelope{0.01f};
     const auto loc_bounds = ln.local_min_bounds(envelope);
@@ -59,6 +54,11 @@ GTEST_TEST(detray_masks, line_radial_cross_sect) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], (cell_size + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], (cell_size + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], (hz + envelope), tol);
+
+    const auto centroid = ln.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }
 
 /// This tests the basic functionality of a line with a square cross section
@@ -83,11 +83,6 @@ GTEST_TEST(detray_masks, line_square_cross_sect) {
     ASSERT_TRUE(ln.is_inside(ln_out1) == intersection::status::e_outside);
     ASSERT_TRUE(ln.is_inside(ln_out2) == intersection::status::e_outside);
 
-    // Dummy bound track parameter
-    bound_track_parameters<transform3_t> bound_params;
-    auto& bound_vec = bound_params.vector();
-    getter::element(bound_vec, e_bound_loc0, 0u) = -1.f;
-
     // Check bounding box
     constexpr scalar envelope{0.01f};
     const auto loc_bounds = ln.local_min_bounds(envelope);
@@ -97,4 +92,9 @@ GTEST_TEST(detray_masks, line_square_cross_sect) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], (cell_size + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], (cell_size + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], (hz + envelope), tol);
+
+    const auto centroid = ln.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }

--- a/tests/unit_tests/cpu/masks_rectangle2D.cpp
+++ b/tests/unit_tests/cpu/masks_rectangle2D.cpp
@@ -5,16 +5,16 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// Project include(s)
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/test/types.hpp"
-#include "detray/tracks/bound_track_parameters.hpp"
+
+// GTest include
+#include <gtest/gtest.h>
 
 using namespace detray;
 using point3_t = test::point3;
-using transform3_t = test::transform3;
 
 constexpr scalar tol{1e-7f};
 
@@ -41,9 +41,6 @@ GTEST_TEST(detray_masks, rectangle2D) {
     // Move outside point inside using a tolerance
     ASSERT_TRUE(r2.is_inside(p2_out, 1.f) == intersection::status::e_inside);
 
-    // Dummy bound track parameter
-    bound_track_parameters<transform3_t> bound_params;
-
     // Check bounding box
     constexpr scalar envelope{0.01f};
     const auto loc_bounds = r2.local_min_bounds(envelope);
@@ -53,6 +50,11 @@ GTEST_TEST(detray_masks, rectangle2D) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], (hx + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], (hy + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], envelope, tol);
+
+    const auto centroid = r2.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }
 
 /// This tests the basic functionality of a cuboid3D

--- a/tests/unit_tests/cpu/masks_ring2D.cpp
+++ b/tests/unit_tests/cpu/masks_ring2D.cpp
@@ -5,16 +5,16 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// Project include(s)
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/test/types.hpp"
-#include "detray/tracks/bound_track_parameters.hpp"
+
+// GTest include
+#include <gtest/gtest.h>
 
 using namespace detray;
 using point3_t = test::point3;
-using transform3_t = test::transform3;
 
 constexpr scalar tol{1e-7f};
 
@@ -41,9 +41,6 @@ GTEST_TEST(detray_masks, ring2D) {
     ASSERT_TRUE(r2.is_inside(p2_pl_out, 1.2f) ==
                 intersection::status::e_inside);
 
-    // Dummy bound track parameter
-    bound_track_parameters<transform3_t> bound_params;
-
     // Check bounding box
     constexpr scalar envelope{0.01f};
     const auto loc_bounds = r2.local_min_bounds(envelope);
@@ -53,4 +50,9 @@ GTEST_TEST(detray_masks, ring2D) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], (outer_r + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], (outer_r + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], envelope, tol);
+
+    const auto centroid = r2.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }

--- a/tests/unit_tests/cpu/masks_single3D.cpp
+++ b/tests/unit_tests/cpu/masks_single3D.cpp
@@ -5,16 +5,16 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// Project include(s)
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/test/types.hpp"
-#include "detray/tracks/bound_track_parameters.hpp"
+
+// GTest include
+#include <gtest/gtest.h>
 
 using namespace detray;
 using point3_t = test::point3;
-using transform3_t = test::transform3;
 
 constexpr scalar tol{1e-7f};
 
@@ -47,6 +47,11 @@ GTEST_TEST(detray_masks, single3_0) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], (h0 + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], envelope, tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], envelope, tol);
+
+    const auto centroid = m1_0.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }
 
 /// This tests the basic functionality of a single value mask (index 1)
@@ -69,9 +74,6 @@ GTEST_TEST(detray_masks, single3_1) {
     // Move outside point inside using a tolerance - take t1 not t1
     ASSERT_TRUE(m1_1.is_inside(p3_out, 0.6f) == intersection::status::e_inside);
 
-    // Dummy bound track parameter
-    bound_track_parameters<transform3_t> bound_params;
-
     // Check bounding box
     constexpr scalar envelope{0.01f};
     const auto loc_bounds = m1_1.local_min_bounds(envelope);
@@ -81,6 +83,11 @@ GTEST_TEST(detray_masks, single3_1) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], envelope, tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], (h1 + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], envelope, tol);
+
+    const auto centroid = m1_1.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }
 
 /// This tests the basic functionality of a single value mask (index 2)
@@ -103,9 +110,6 @@ GTEST_TEST(detray_masks, single3_2) {
     // Move outside point inside using a tolerance - take t1 not t1
     ASSERT_TRUE(m1_2.is_inside(p3_out, 6.1f) == intersection::status::e_inside);
 
-    // Dummy bound track parameter
-    bound_track_parameters<transform3_t> bound_params;
-
     // Check bounding box
     constexpr scalar envelope{0.01f};
     const auto loc_bounds = m1_2.local_min_bounds(envelope);
@@ -115,4 +119,9 @@ GTEST_TEST(detray_masks, single3_2) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], envelope, tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], envelope, tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], (h2 + envelope), tol);
+
+    const auto centroid = m1_2.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }

--- a/tests/unit_tests/cpu/masks_trapezoid2D.cpp
+++ b/tests/unit_tests/cpu/masks_trapezoid2D.cpp
@@ -5,16 +5,16 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// Project include(s)
 #include "detray/definitions/units.hpp"
 #include "detray/masks/masks.hpp"
 #include "detray/test/types.hpp"
-#include "detray/tracks/bound_track_parameters.hpp"
+
+// GTest include
+#include <gtest/gtest.h>
 
 using namespace detray;
 using point3_t = test::point3;
-using transform3_t = test::transform3;
 
 constexpr scalar tol{1e-7f};
 
@@ -44,9 +44,6 @@ GTEST_TEST(detray_masks, trapezoid2D) {
     // Move outside point inside using a tolerance
     ASSERT_TRUE(t2.is_inside(p2_out, 1.) == intersection::status::e_inside);
 
-    // Dummy bound track parameter
-    bound_track_parameters<transform3_t> bound_params;
-
     // Check bounding box
     constexpr scalar envelope{0.01f};
     const auto loc_bounds = t2.local_min_bounds(envelope);
@@ -56,4 +53,9 @@ GTEST_TEST(detray_masks, trapezoid2D) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], (hx_maxy + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], (hy + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], envelope, tol);
+
+    const auto centroid = t2.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 1.f / 3.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }

--- a/tests/unit_tests/cpu/masks_unbounded.cpp
+++ b/tests/unit_tests/cpu/masks_unbounded.cpp
@@ -10,7 +10,6 @@
 #include "detray/masks/masks.hpp"
 #include "detray/masks/unbounded.hpp"
 #include "detray/test/types.hpp"
-#include "detray/tracks/bound_track_parameters.hpp"
 
 // GTest include(s)
 #include <gtest/gtest.h>
@@ -56,9 +55,6 @@ GTEST_TEST(detray_masks, unbounded) {
     typename mask<unbounded_t>::point3_t p2 = {0.5f, -9.f, 0.f};
     ASSERT_TRUE(u.is_inside(p2, 0.f) == intersection::status::e_inside);
 
-    // Dummy bound track parameter
-    bound_track_parameters<transform3_t> bound_params;
-
     // Check bounding box
     constexpr scalar envelope{0.01f};
     const auto loc_bounds = u.local_min_bounds(envelope);
@@ -68,4 +64,9 @@ GTEST_TEST(detray_masks, unbounded) {
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_x], (h + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_y], (h + envelope), tol);
     ASSERT_NEAR(loc_bounds[cuboid3D<>::e_max_z], envelope, tol);
+
+    const auto centroid = u.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }

--- a/tests/unit_tests/cpu/masks_unmasked.cpp
+++ b/tests/unit_tests/cpu/masks_unmasked.cpp
@@ -5,16 +5,18 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
+// Project include(s)
 #include "detray/masks/masks.hpp"
 #include "detray/masks/unmasked.hpp"
 #include "detray/test/types.hpp"
-#include "detray/tracks/bound_track_parameters.hpp"
+
+// GTest include
+#include <gtest/gtest.h>
 
 using namespace detray;
 using point3_t = test::point3;
-using transform3_t = test::transform3;
+
+constexpr scalar tol{1e-7f};
 
 /// This tests the basic functionality of an unmasked plane
 GTEST_TEST(detray_masks, unmasked) {
@@ -23,9 +25,6 @@ GTEST_TEST(detray_masks, unmasked) {
     mask<unmasked> u{};
 
     ASSERT_TRUE(u.is_inside(p2, 0.f) == intersection::status::e_inside);
-
-    // Dummy bound track parameter
-    bound_track_parameters<transform3_t> bound_params;
 
     // Check bounding box
     constexpr scalar envelope{0.01f};
@@ -36,4 +35,9 @@ GTEST_TEST(detray_masks, unmasked) {
     ASSERT_TRUE(std::isinf(loc_bounds[cuboid3D<>::e_max_x]));
     ASSERT_TRUE(std::isinf(loc_bounds[cuboid3D<>::e_max_y]));
     ASSERT_TRUE(std::isinf(loc_bounds[cuboid3D<>::e_max_z]));
+
+    const auto centroid = u.centroid();
+    ASSERT_NEAR(centroid[0], 0.f, tol);
+    ASSERT_NEAR(centroid[1], 0.f, tol);
+    ASSERT_NEAR(centroid[2], 0.f, tol);
 }

--- a/tests/unit_tests/svgtools/masks.cpp
+++ b/tests/unit_tests/svgtools/masks.cpp
@@ -39,7 +39,7 @@ int main(int, char**) {
 
     const typename transform_t::vector3 tr{0.f, 150.f, 0.f};
     const typename toy_detector_t::transform3 transform(tr);
-    const actsvg::views::z_phi view{};
+    const actsvg::views::x_y view{};
 
     // Visualize a 2D annulus.
     // e_min_r, e_max_r, e_min_phi_rel, e_max_phi_rel, e_average_phi, e_shift_x,
@@ -90,7 +90,7 @@ int main(int, char**) {
 
     // Visualize a line.
     // e_cross_section, e_half_z
-    detray::mask<detray::line<>> lin2D{0u, 1.f, 100.f};
+    detray::mask<detray::line<>> lin2D{0u, 10.f, 100.f};
     const auto lin2D_proto =
         detray::svgtools::conversion::surface<point3_container>(transform,
                                                                 lin2D);


### PR DESCRIPTION
Move the calculation of the surface center position into the shapes and add an approximation for the annulus shape. Also uses the annulus center now in a few places and does some renaming for clarification in the helix intersectors.