### PR TITLE
ref: Use proto detector and proto volumes in svgtools illustrator

### DIFF
--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -324,6 +324,12 @@ class detector {
         return _surfaces[bcd.index()];
     }
 
+    /// @returns a surface using its index - const
+    DETRAY_HOST_DEVICE
+    constexpr auto surface(dindex sf_idx) const -> const surface_type & {
+        return _surfaces[sf_idx];
+    }
+
     /// @returns the overall number of surfaces in the detector
     DETRAY_HOST_DEVICE
     constexpr auto n_surfaces() const -> dindex {

--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -47,6 +47,16 @@ struct surface_kernels {
         }
     };
 
+    /// A functor to retrieve the masks shape name
+    struct get_shape_name {
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST inline std::string operator()(const mask_group_t&,
+                                                  const index_t&) const {
+
+            return mask_group_t::value_type::shape::name;
+        }
+    };
+
     /// A functor to run the mask self check. Puts error messages into @param os
     struct mask_self_check {
         template <typename mask_group_t, typename index_t>

--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -58,7 +58,7 @@ class detector_volume {
     /// Constructor from detector @param det and volume index @param vol_idx in
     /// that detector.
     constexpr detector_volume(const detector_t &det, const dindex vol_idx)
-        : detector_volume(det, det.volume_by_index(vol_idx)) {}
+        : detector_volume(det, det.volumes()[vol_idx]) {}
 
     /// Equality operator
     ///

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -64,6 +64,11 @@ class surface {
     constexpr surface(const detector_t &det, const geometry::barcode bcd)
         : surface(det, det.surface(bcd)) {}
 
+    /// Constructor from detector @param det and surface index @param sf_idx
+    DETRAY_HOST_DEVICE
+    constexpr surface(const detector_t &det, const dindex sf_idx)
+        : surface(det, det.surface(sf_idx)) {}
+
     /// Conversion to surface interface around constant detector type
     template <typename detector_type = detector_t,
               std::enable_if_t<!std::is_const_v<detector_type>, bool> = true>
@@ -131,6 +136,12 @@ class surface {
     DETRAY_HOST_DEVICE
     constexpr auto volume_link() const {
         return visit_mask<typename kernels::get_volume_link>();
+    }
+
+    /// @returns the mask shape name
+    DETRAY_HOST
+    std::string shape_name() const {
+        return visit_mask<typename kernels::get_shape_name>();
     }
 
     /// @returns the coordinate transform matrix of the surface

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/detector.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/detector.hpp
@@ -1,0 +1,46 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/geometry/detector_volume.hpp"
+#include "detray/plugins/svgtools/conversion/volume.hpp"
+
+// Actsvg include(s)
+#include "actsvg/proto/detector.hpp"
+
+namespace detray::svgtools::conversion {
+
+/// @brief Generates the proto detector object
+///
+/// @param context The geometry context.
+/// @param detector The detector object.
+/// @param hide_portals whether to display portals.
+/// @param hide_passives whether to display passive surfaces.
+///
+/// @returns An actsvg proto volume representing the volume.
+template <typename point3_container_t, typename detector_t, typename view_t>
+auto detector(const typename detector_t::geometry_context& context,
+              const detector_t& detector, const view_t& view,
+              bool hide_portals = false, bool hide_passives = false,
+              bool hide_grids = false) {
+
+    actsvg::proto::detector<point3_container_t> p_detector;
+
+    for (const auto& vol_desc : detector.volumes()) {
+
+        p_detector._volumes.push_back(
+            svgtools::conversion::volume<point3_container_t>(
+                context, detector, detector_volume{detector, vol_desc}, view,
+                hide_portals, hide_passives, hide_grids));
+    }
+
+    return p_detector;
+}
+
+}  // namespace detray::svgtools::conversion

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/information_section.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/information_section.hpp
@@ -41,7 +41,8 @@ inline auto information_section(
     const detray::surface<detector_t>& d_surface) {
     svgtools::meta::proto::information_section<point3_t> is;
     is._title = d_surface.is_portal() ? "Portal" : "Surface";
-    const auto position = d_surface.center(context);
+    const auto position =
+        d_surface.transform(context).point_to_global(d_surface.centroid());
     is._info = {"Idx: " + std::to_string(d_surface.index()),
                 point_to_string(position)};
     is._position = svgtools::conversion::point<point3_t>(position);

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/portal.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/portal.hpp
@@ -23,17 +23,22 @@ namespace detray::svgtools::conversion {
 template <typename point3_container_t, typename detector_t>
 auto portal(const typename detector_t::geometry_context& context,
             const detector_t& detector,
-            const detray::surface<detector_t>& d_portal) {
+            const detray::surface<detector_t>& d_portal,
+            bool hide_links = false) {
     assert(d_portal.is_portal());
+
     using p_portal_t = actsvg::proto::portal<point3_container_t>;
+
     p_portal_t p_portal;
-    if (svgtools::utils::is_not_world_portal(d_portal)) {
+    p_portal._name = "portal_" + std::to_string(d_portal.index());
+    if (!hide_links && svgtools::utils::is_not_world_portal(d_portal)) {
         p_portal._volume_links = {
             svgtools::conversion::link<point3_container_t>(context, detector,
                                                            d_portal)};
     }
     p_portal._surface =
         svgtools::conversion::surface<point3_container_t>(context, d_portal);
+
     return p_portal;
 }
 

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
@@ -205,8 +205,14 @@ struct surface_converter {
 template <typename point3_container_t, typename detector_t>
 auto surface(const typename detector_t::geometry_context& context,
              const detray::surface<detector_t>& d_surface) {
-    return d_surface.template visit_mask<surface_converter<point3_container_t>>(
-        d_surface.transform(context));
+
+    auto p_surface =
+        d_surface.template visit_mask<surface_converter<point3_container_t>>(
+            d_surface.transform(context));
+
+    p_surface._name = "surface_" + std::to_string(d_surface.index());
+
+    return p_surface;
 }
 
 }  // namespace detray::svgtools::conversion

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/volume.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/volume.hpp
@@ -9,70 +9,63 @@
 
 // Project include(s)
 #include "detray/geometry/detector_volume.hpp"
+#include "detray/geometry/surface.hpp"
+#include "detray/plugins/svgtools/conversion/grid.hpp"
 #include "detray/plugins/svgtools/conversion/portal.hpp"
 #include "detray/plugins/svgtools/conversion/surface.hpp"
 #include "detray/plugins/svgtools/utils/volume_utils.hpp"
 
 // Actsvg include(s)
-#include "actsvg/proto/portal.hpp"
-#include "actsvg/proto/surface.hpp"
 #include "actsvg/proto/volume.hpp"
-
-// System include(s)
-#include <vector>
 
 namespace detray::svgtools::conversion {
 
-/// @brief Calculates the proto volume of a collection of detray surfaces.
+/// @brief Generates the proto volume of a detray volume.
 ///
-/// @param context The context.
-/// @param d_surfaces The detray surfaces.
+/// @param context The geometry context.
+/// @param detector The detractor the volume belongs to.
+/// @param d_volume The detray volume.
+/// @param hide_portals whether to display the volumes portals.
+/// @param hide_passives whether to display the contained passive surfaces.
 ///
 /// @returns An actsvg proto volume representing the volume.
-template <typename point3_container_t, typename detector_t>
+template <typename point3_container_t, typename detector_t, typename view_t>
 auto volume(const typename detector_t::geometry_context& context,
             const detector_t& detector,
-            const std::vector<detray::surface<detector_t>>& d_surfaces) {
-    using p_volume_t = actsvg::proto::volume<point3_container_t>;
-    using p_portal_t = actsvg::proto::portal<point3_container_t>;
-    using p_surface_t = actsvg::proto::surface<point3_container_t>;
-    p_volume_t p_volume;
-    std::vector<p_surface_t> surfaces;
-    std::vector<p_portal_t> portals;
-    for (const auto& item : d_surfaces) {
-        if (item.is_portal()) {
-            auto portal = svgtools::conversion::portal<point3_container_t>(
-                context, detector, item);
-            portals.push_back(portal);
-        } else {
-            auto surface = svgtools::conversion::surface<point3_container_t>(
-                context, item);
-            surfaces.push_back(surface);
+            const detray::detector_volume<detector_t>& d_volume,
+            const view_t& view, bool hide_portals = false,
+            bool hide_passives = false, bool hide_grids = false) {
+
+    actsvg::proto::volume<point3_container_t> p_volume;
+    p_volume._index = d_volume.index();
+
+    for (const auto& desc :
+         svgtools::utils::surface_lookup(detector, d_volume)) {
+
+        const auto sf = detray::surface{detector, desc};
+
+        if (sf.is_portal()) {
+            if (!hide_portals) {
+                auto portal = svgtools::conversion::portal<point3_container_t>(
+                    context, detector, sf, false);
+                p_volume._portals.push_back(portal);
+            }
+        } else if (!(sf.is_passive() && hide_passives)) {
+            auto surface =
+                svgtools::conversion::surface<point3_container_t>(context, sf);
+            p_volume._v_surfaces.push_back(surface);
         }
     }
-    p_volume._v_surfaces = surfaces;
-    p_volume._portals = portals;
-    return p_volume;
-}
 
-/// @brief Calculates the proto volume of a detray volume.
-///
-/// @param context The context.
-/// @param d_volume The detray volume.
-///
-/// @returns An actsvg proto volume representing the volume.
-template <typename point3_container_t, typename detector_t>
-auto volume(const typename detector_t::geometry_context& context,
-            const detector_t& detector,
-            const detray::detector_volume<detector_t>& d_volume) {
-    std::vector<detray::surface<detector_t>> surfaces{};
-    const auto descriptors =
-        svgtools::utils::surface_lookup(detector, d_volume);
-    for (const auto& desc : descriptors) {
-        surfaces.push_back(detray::surface{detector, desc});
+    // Convert grid, if present
+    if (!hide_grids) {
+        if (auto p_grid_ptr = svgtools::conversion::grid<actsvg::scalar>(
+                detector, p_volume._index, view)) {
+            p_volume._surface_grid = *p_grid_ptr;
+        }
     }
-    return svgtools::conversion::volume<point3_container_t>(context, detector,
-                                                            surfaces);
+
+    return p_volume;
 }
 
 }  // namespace detray::svgtools::conversion

--- a/plugins/svgtools/include/detray/plugins/svgtools/styling/colors.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/styling/colors.hpp
@@ -1,0 +1,112 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Actsvg include(s)
+#include "actsvg/core/style.hpp"
+
+// System include(s)
+#include <array>
+#include <vector>
+
+namespace detray::svgtools::styling::colors {
+
+/// @brief Picks a random element in the container.
+template <typename container_t>
+auto pick_random(container_t container) {
+    const auto idx = static_cast<std::size_t>(std::rand()) % container.size();
+    return container[idx];
+}
+
+// Black
+constexpr std::array black{0, 0, 0};
+constexpr std::array dark_grey{171, 171, 171};
+constexpr std::array mortar{89, 89, 89};
+constexpr std::array suva_grey{137, 137, 137};
+constexpr std::array very_light_grey{207, 207, 207};
+
+// Red tones
+constexpr std::array red{255, 0, 0};
+constexpr std::array cardinal{167, 51, 63};
+constexpr std::array madder{165, 28, 48};
+constexpr std::array auburn{167, 51, 63};
+constexpr std::array burgundy{116, 18, 29};
+constexpr std::array chocolate_cosmos{88, 12, 31};
+constexpr std::array macaroni_and_cheese{255, 188, 121};
+constexpr std::array pumpkin{255, 128, 14};
+constexpr std::array tenne{200, 82, 0};
+
+// Blue tones
+constexpr std::array blue{0, 0, 255};
+constexpr std::array celestial_blue{62, 146, 204};
+constexpr std::array cerulean{0, 107, 164};
+constexpr std::array lapis_lazulli{42, 98, 143};
+constexpr std::array picton_blue{95, 158, 209};
+constexpr std::array prussian_blue1{19, 41, 61};
+constexpr std::array prussian_blue2{22, 50, 79};
+constexpr std::array indigo_dye{24, 67, 90};
+constexpr std::array sail{162, 200, 236};
+
+// Green tones
+constexpr std::array green{0, 255, 0};
+constexpr std::array celadon{190, 230, 206};
+constexpr std::array aquamarine1{188, 255, 219};
+constexpr std::array aquamarine2{141, 255, 205};
+constexpr std::array emerald{104, 216, 155};
+constexpr std::array shamrock_green{79, 157, 105};
+
+std::vector<actsvg::style::color> black_theme(const actsvg::scalar opacity) {
+    return {{black, opacity}};
+}
+
+std::vector<actsvg::style::color> red_theme(const actsvg::scalar opacity) {
+    return {{cardinal, opacity},
+            {madder, opacity},
+            {auburn, opacity},
+            {burgundy, opacity},
+            {chocolate_cosmos, opacity}};
+}
+
+std::vector<actsvg::style::color> blue_theme(const actsvg::scalar opacity) {
+    return {{celestial_blue, opacity},
+            {lapis_lazulli, opacity},
+            {prussian_blue1, opacity},
+            {prussian_blue2, opacity},
+            {indigo_dye, opacity}};
+}
+
+std::vector<actsvg::style::color> green_theme(const actsvg::scalar opacity) {
+    return {{emerald, opacity},
+            {shamrock_green, opacity},
+            {celadon, opacity},
+            {aquamarine1, opacity},
+            {aquamarine2, opacity}};
+}
+
+// Same color circle that is used in matplot plugin
+struct tableau_colorblind10 {
+    static std::vector<actsvg::style::color> grey_tones(
+        const actsvg::scalar opacity) {
+        return {{dark_grey, opacity},
+                {mortar, opacity},
+                {suva_grey, opacity},
+                {very_light_grey, opacity}};
+    }
+    static std::vector<actsvg::style::color> blue_tones(
+        const actsvg::scalar opacity) {
+        return {{cerulean, opacity}, {picton_blue, opacity}, {sail, opacity}};
+    }
+    static std::vector<actsvg::style::color> red_tones(
+        const actsvg::scalar opacity) {
+        return {{tenne, opacity},
+                {pumpkin, opacity},
+                {macaroni_and_cheese, opacity}};
+    }
+};
+
+}  // namespace detray::svgtools::styling::colors

--- a/plugins/svgtools/include/detray/plugins/svgtools/styling/styling.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/styling/styling.hpp
@@ -7,12 +7,20 @@
 
 #pragma once
 
+// Project include(s)
+#include "detray/plugins/svgtools/meta/proto/intersection.hpp"
+#include "detray/plugins/svgtools/meta/proto/landmark.hpp"
+#include "detray/plugins/svgtools/meta/proto/trajectory.hpp"
+#include "detray/plugins/svgtools/styling/colors.hpp"
+
 // Actsvg include(s)
 #include "actsvg/core.hpp"
 #include "actsvg/core/style.hpp"
+#include "actsvg/proto/grid.hpp"
+#include "actsvg/proto/portal.hpp"
+#include "actsvg/proto/surface.hpp"
+#include "actsvg/proto/volume.hpp"
 #include "actsvg/styles/defaults.hpp"
-#include "detray/plugins/svgtools/meta/proto/intersection.hpp"
-#include "detray/plugins/svgtools/meta/proto/landmark.hpp"
 
 // System include(s)
 #include <cstdlib>
@@ -20,191 +28,173 @@
 
 namespace detray::svgtools::styling {
 
-namespace colors {
+/// Style applied to an actsvg proto surface
+struct surface_style {
 
-/// @brief Picks a random element in the container.
-template <typename container_t>
-auto pick_random(container_t container) {
-    const auto idx = static_cast<std::size_t>(std::rand()) % container.size();
-    return container[idx];
-}
+    surface_style(actsvg::style::color fill_color =
+                      colors::tableau_colorblind10::red_tones(0.4f).front(),
+                  actsvg::scalar stroke_width = 0.4f)
+        : _fill_color{fill_color}, _stroke_width{stroke_width} {
 
-// Black
-constexpr std::array black{0, 0, 0};
-constexpr std::array dark_grey{171, 171, 171};
-constexpr std::array mortar{89, 89, 89};
-constexpr std::array suva_grey{137, 137, 137};
-constexpr std::array very_light_grey{207, 207, 207};
-
-// Red tones
-constexpr std::array red{255, 0, 0};
-constexpr std::array cardinal{167, 51, 63};
-constexpr std::array madder{165, 28, 48};
-constexpr std::array auburn{167, 51, 63};
-constexpr std::array burgundy{116, 18, 29};
-constexpr std::array chocolate_cosmos{88, 12, 31};
-constexpr std::array macaroni_and_cheese{255, 188, 121};
-constexpr std::array pumpkin{255, 128, 14};
-constexpr std::array tenne{200, 82, 0};
-
-// Blue tones
-constexpr std::array blue{0, 0, 255};
-constexpr std::array celestial_blue{62, 146, 204};
-constexpr std::array cerulean{0, 107, 164};
-constexpr std::array lapis_lazulli{42, 98, 143};
-constexpr std::array picton_blue{95, 158, 209};
-constexpr std::array prussian_blue1{19, 41, 61};
-constexpr std::array prussian_blue2{22, 50, 79};
-constexpr std::array indigo_dye{24, 67, 90};
-constexpr std::array sail{162, 200, 236};
-
-// Green tones
-constexpr std::array green{0, 255, 0};
-constexpr std::array celadon{190, 230, 206};
-constexpr std::array aquamarine1{188, 255, 219};
-constexpr std::array aquamarine2{141, 255, 205};
-constexpr std::array emerald{104, 216, 155};
-constexpr std::array shamrock_green{79, 157, 105};
-
-std::vector<actsvg::style::color> black_theme(const actsvg::scalar opacity) {
-    return {{black, opacity}};
-}
-
-std::vector<actsvg::style::color> red_theme(const actsvg::scalar opacity) {
-    return {{cardinal, opacity},
-            {madder, opacity},
-            {auburn, opacity},
-            {burgundy, opacity},
-            {chocolate_cosmos, opacity}};
-}
-
-std::vector<actsvg::style::color> blue_theme(const actsvg::scalar opacity) {
-    return {{celestial_blue, opacity},
-            {lapis_lazulli, opacity},
-            {prussian_blue1, opacity},
-            {prussian_blue2, opacity},
-            {indigo_dye, opacity}};
-}
-
-std::vector<actsvg::style::color> green_theme(const actsvg::scalar opacity) {
-    return {{emerald, opacity},
-            {shamrock_green, opacity},
-            {celadon, opacity},
-            {aquamarine1, opacity},
-            {aquamarine2, opacity}};
-}
-
-// Same color circle that is used in matplot plugin
-struct tableau_colorblind10 {
-    static std::vector<actsvg::style::color> grey_tones(
-        const actsvg::scalar opacity) {
-        return {{dark_grey, opacity},
-                {mortar, opacity},
-                {suva_grey, opacity},
-                {very_light_grey, opacity}};
+        _stroke_color = fill_color;
+        _highlight_rgb = colors::macaroni_and_cheese;
+        _highlights = {};
+        _highlight_stroke_rgb = _highlight_rgb;
+        _highlight_stroke_width = stroke_width;
+        _font_size = 14u;
+        _n_segments = 72u;
     }
-    static std::vector<actsvg::style::color> blue_tones(
-        const actsvg::scalar opacity) {
-        return {{cerulean, opacity}, {picton_blue, opacity}, {sail, opacity}};
-    }
-    static std::vector<actsvg::style::color> red_tones(
-        const actsvg::scalar opacity) {
-        return {{tenne, opacity},
-                {pumpkin, opacity},
-                {macaroni_and_cheese, opacity}};
-    }
+    // Fill color
+    actsvg::style::color _fill_color;
+
+    // Stroke
+    actsvg::scalar _stroke_width;
+    actsvg::style::color _stroke_color;
+
+    // Highlights
+    std::array<int, 3> _highlight_rgb;
+    std::vector<std::string> _highlights;
+    std::array<int, 3> _highlight_stroke_rgb;
+    actsvg::scalar _highlight_stroke_width;
+
+    unsigned int _font_size;
+    // Granularity of vertex approximation of arcs
+    unsigned int _n_segments;
 };
 
-}  // namespace colors
+/// Style applied to an actsvg proto portal link
+struct link_style {
+    actsvg::scalar _marker_size;
+};
 
+/// Style applied to an actsvg proto portal
+struct portal_style {
+    surface_style _surface_style;
+    link_style _link_style;
+};
+
+/// Style applied to an actsvg proto grid
 struct grid_style {
     actsvg::style::color _stroke_color;
     actsvg::scalar _stroke_width;
 };
 
+/// Style applied to an actsvg proto volume
+struct volume_style {
+    surface_style _surface_style;
+    portal_style _portal_style;
+    grid_style _grid_style;
+};
+
+/// Style applied to an actsvg proto detector
+struct detector_style {
+    volume_style _volume_style;
+    grid_style _grid_style;
+};
+
+/// Style applied to a proto landmark
 struct landmark_style {
-    std::vector<actsvg::style::color> _fill_colors;
+    actsvg::style::color _fill_color;
     actsvg::scalar _stroke_width;
     actsvg::scalar _marker_size;
     std::string _marker_type;
 };
 
+/// Style applied to a proto trajectory
 struct trajectory_style {
-    std::vector<actsvg::style::color> _fill_colors;
+    // Give different tracks different colors
+    actsvg::style::color _fill_color;
     actsvg::scalar _stroke_width;
 };
 
-struct surface_style {
-    std::vector<actsvg::style::color> _fill_colors;
-    actsvg::scalar _stroke_width;
-};
-
-struct link_style {
-    actsvg::scalar _marker_size;
-};
-
-struct portal_style {
-    surface_style _surface_style;
-    link_style _link_style;
-    bool _hide_links;
-};
-
-struct volume_style {
-    surface_style _surface_style;
-    portal_style _portal_style;
-};
-
+/// Global styling options
 struct style {
-    volume_style _volume_style;
-    landmark_style _intersection_style;
+    detector_style _detector_style;
     trajectory_style _trajectory_style;
-    grid_style _grid_style;
     landmark_style _landmark_style;
-    bool _do_random_coloring = true;
+    landmark_style _intersection_style;
 };
 
-const surface_style surface_style1{colors::blue_theme(0.5f), 3.f};
-const surface_style surface_style2{colors::red_theme(0.5f), 3.f};
-const surface_style surface_style3{
-    colors::tableau_colorblind10::grey_tones(0.8f), 1.f};
-const surface_style surface_style4{
-    colors::tableau_colorblind10::blue_tones(0.3f), 1.5f};
-const surface_style surface_style5{
-    colors::tableau_colorblind10::red_tones(0.4f), 1.f};
+/// The default styling
+namespace svg_default {
 
-const link_style link_style1{1.2f};
+// Surface styles
+const styling::surface_style surface_style{colors::blue_theme(0.5f).front(),
+                                           3.f};
+const styling::surface_style surface_style_portal{
+    colors::red_theme(0.5f).front(), 3.f};
 
-const portal_style portal_style1{surface_style2, link_style1, false};
-const portal_style portal_style2{surface_style4, link_style1, false};
+// Portal style
+const styling::link_style link_style{1.2f};
+const styling::portal_style portal_style{surface_style_portal, link_style};
 
-const volume_style volume_style1{surface_style1, portal_style1};
-const volume_style volume_style2{surface_style5, portal_style2};
+// Volume style
+const styling::grid_style grid_style{colors::red_theme(1.f).front(), 1.f};
+const styling::volume_style volume_style{surface_style, portal_style,
+                                         grid_style};
 
-const landmark_style landmark_style1{colors::black_theme(1.f), 0.8f, 5.f, "x"};
-const landmark_style landmark_style2{colors::black_theme(1.f), 0.8f, 3.f, "o"};
+// Detector style
+const styling::detector_style detector_style{volume_style, grid_style};
 
-const grid_style grid_style1{colors::red_theme(1.f)[0], 1.f};
-const grid_style grid_style2{colors::tableau_colorblind10::blue_tones(1.f)[2],
-                             1.2f};
+// Intersection points and track state style
+const styling::landmark_style intersection_style{
+    colors::black_theme(1.f).front(), 0.8f, 5.f, "x"};
+const styling::landmark_style landmark_style{colors::green_theme(1.f).front(),
+                                             0.8f, 3.f, "o"};
 
-const trajectory_style trajectory_style1{colors::green_theme(1.f), 1.f};
+// Trajectory style
+const styling::trajectory_style trajectory_style{
+    colors::green_theme(1.f).front(), 1.f};
 
-const style style1{volume_style1, landmark_style1, trajectory_style1,
-                   grid_style1, landmark_style2};
-const style tableau_colorblind{volume_style2,     landmark_style1,
-                               trajectory_style1, grid_style2,
-                               landmark_style2,   false};
+// Full style
+const styling::style style{detector_style, trajectory_style, landmark_style,
+                           intersection_style};
+}  // namespace svg_default
+
+/// Styling that matches data plotting
+namespace tableau_colorblind {
+
+// Surface styles
+const styling::surface_style surface_style_passive{
+    colors::tableau_colorblind10::grey_tones(0.8f).front(), 1.f};
+const styling::surface_style surface_style_portal{
+    colors::tableau_colorblind10::blue_tones(0.2f).front(), 1.5f};
+const styling::surface_style surface_style_sensitive{
+    colors::tableau_colorblind10::red_tones(0.3f).front(), 1.f};
+
+// Portal style
+const styling::portal_style portal_style{surface_style_portal,
+                                         svg_default::link_style};
+
+// Volume style
+const styling::grid_style grid_style{
+    colors::tableau_colorblind10::blue_tones(1.f)[2], 1.f};
+const styling::volume_style volume_style{surface_style_sensitive, portal_style,
+                                         grid_style};
+
+// Detector style
+const styling::detector_style detector_style{volume_style, grid_style};
+
+// Full style
+const styling::style style{detector_style, svg_default::trajectory_style,
+                           svg_default::landmark_style,
+                           svg_default::intersection_style};
+}  // namespace tableau_colorblind
 
 /// @brief Sets the style of the proto surface.
 template <typename point3_container_t>
 void apply_style(actsvg::proto::surface<point3_container_t>& p_surface,
-                 const surface_style& styling, bool do_random_coloring = true) {
-    auto fill_color = do_random_coloring
-                          ? colors::pick_random(styling._fill_colors)
-                          : styling._fill_colors.front();
-    p_surface._fill = actsvg::style::fill(fill_color);
+                 const surface_style& styling) {
+    // Fill color
+    p_surface._fill = actsvg::style::fill(styling._fill_color);
+    p_surface._fill._fc._hl_rgb = styling._highlight_rgb;
+    p_surface._fill._fc._highlight = styling._highlights;
+
+    // Stroke
     p_surface._stroke =
-        actsvg::style::stroke(fill_color, styling._stroke_width);
+        actsvg::style::stroke(styling._stroke_color, styling._stroke_width);
+    p_surface._stroke._sc._hl_rgb = styling._highlight_stroke_rgb;
+    p_surface._stroke._hl_width = styling._highlight_stroke_width;
 }
 
 /// @brief Sets the style of the proto link.
@@ -218,17 +208,10 @@ void apply_style(
 /// @brief Sets the style of the proto portal.
 template <typename point3_container_t>
 void apply_style(actsvg::proto::portal<point3_container_t>& p_portal,
-                 const portal_style& styling, bool do_random_coloring = true) {
-    auto fill_color =
-        do_random_coloring
-            ? colors::pick_random(styling._surface_style._fill_colors)
-            : styling._surface_style._fill_colors.front();
-    p_portal._surface._fill = actsvg::style::fill(fill_color);
-    p_portal._surface._stroke =
-        actsvg::style::stroke(fill_color, styling._surface_style._stroke_width);
-    if (styling._hide_links) {
-        p_portal._volume_links = {};
-    }
+                 const portal_style& styling) {
+
+    apply_style(p_portal._surface, styling._surface_style);
+
     for (auto& volume_link : p_portal._volume_links) {
         apply_style<point3_container_t>(volume_link, styling._link_style);
     }
@@ -238,30 +221,40 @@ void apply_style(actsvg::proto::portal<point3_container_t>& p_portal,
 void apply_style(actsvg::proto::grid& p_grid, const grid_style& styling) {
     p_grid._stroke._sc = styling._stroke_color;
     p_grid._stroke._width = styling._stroke_width;
+    // Use dashed lines for the grid
+    p_grid._stroke._dasharray = {4};
 }
 
 /// @brief Sets the style of the proto volume.
 template <typename point3_container_t>
 void apply_style(actsvg::proto::volume<point3_container_t>& p_volume,
-                 const volume_style& styling, bool do_random_coloring) {
+                 const volume_style& styling) {
     for (auto& p_surface : p_volume._v_surfaces) {
-        apply_style(p_surface, styling._surface_style, do_random_coloring);
+        apply_style(p_surface, styling._surface_style);
     }
     for (auto& p_portals : p_volume._portals) {
-        apply_style(p_portals, styling._portal_style, do_random_coloring);
+        apply_style(p_portals, styling._portal_style);
+    }
+    apply_style(p_volume._surface_grid, styling._grid_style);
+}
+
+/// @brief Sets the style of the proto volume.
+template <typename point3_container_t>
+void apply_style(actsvg::proto::detector<point3_container_t>& p_detector,
+                 const detector_style& styling) {
+    for (auto& p_volume : p_detector._volumes) {
+        apply_style(p_volume, styling._volume_style);
     }
 }
 
 /// @brief Sets the style of the proto landmark.
 template <typename point3_t>
 void apply_style(meta::proto::landmark<point3_t>& p_landmark,
-                 const landmark_style& styling, bool do_random_coloring) {
-    auto fill_color = do_random_coloring
-                          ? colors::pick_random(styling._fill_colors)
-                          : styling._fill_colors.front();
-    const auto fill = actsvg::style::fill(fill_color);
+                 const landmark_style& styling) {
+
+    const auto fill = actsvg::style::fill(styling._fill_color);
     const auto stroke =
-        actsvg::style::stroke(fill_color, styling._stroke_width);
+        actsvg::style::stroke(styling._fill_color, styling._stroke_width);
 
     const auto marker = actsvg::style::marker{
         styling._marker_type, styling._marker_size, fill, stroke};
@@ -271,12 +264,12 @@ void apply_style(meta::proto::landmark<point3_t>& p_landmark,
 /// @brief Sets the style of the proto intersection record.
 template <typename point3_t>
 void apply_style(meta::proto::intersection<point3_t>& p_intersection,
-                 const landmark_style& styling, bool do_random_coloring) {
-    auto fill_color = do_random_coloring
-                          ? colors::pick_random(styling._fill_colors)
-                          : styling._fill_colors.front();
+                 const landmark_style& styling) {
+
     const auto stroke =
-        actsvg::style::stroke(fill_color, styling._stroke_width);
+        actsvg::style::stroke(styling._fill_color, styling._stroke_width);
+
+    auto fill_color = styling._fill_color;
     fill_color._opacity *= 0.5f;
     const auto fill = actsvg::style::fill(fill_color);
 
@@ -291,18 +284,9 @@ void apply_style(meta::proto::intersection<point3_t>& p_intersection,
 /// @brief Sets the style of the proto trajectory.
 template <typename point3_t>
 void apply_style(meta::proto::trajectory<point3_t>& p_trajectory,
-                 const trajectory_style& styling, bool do_random_coloring) {
-    auto fill_color = do_random_coloring
-                          ? colors::pick_random(styling._fill_colors)
-                          : styling._fill_colors.front();
+                 const trajectory_style& styling) {
     p_trajectory._stroke =
-        actsvg::style::stroke(fill_color, styling._stroke_width);
-}
-
-template <typename style1_t, typename style2_t>
-auto copy_fill_colors(style1_t target, const style2_t& reference) {
-    target._fill_colors = reference._fill_colors;
-    return target;
+        actsvg::style::stroke(styling._fill_color, styling._stroke_width);
 }
 
 }  // namespace detray::svgtools::styling

--- a/tests/unit_tests/svgtools/detectors.cpp
+++ b/tests/unit_tests/svgtools/detectors.cpp
@@ -44,12 +44,12 @@ int main(int, char**) {
     il.show_info(true);
 
     // Get the svg of the toy detetector in x-y view.
-    const auto svg_xy = il.draw_detector("detector_xy", xy);
+    const auto svg_xy = il.draw_detector(xy);
     // Write the svg of toy detector.
     detray::svgtools::write_svg("test_svgtools_detector_xy", {xy_axis, svg_xy});
 
     // Get the svg of the toy detetector in z-r view.
-    const auto svg_zr = il.draw_detector("detector_zr", zr);
+    const auto svg_zr = il.draw_detector(zr);
     // Write the svg of toy detector in z-r view
     detray::svgtools::write_svg("test_svgtools_detector_zr", {zr_axis, svg_zr});
 }

--- a/tests/unit_tests/svgtools/grids.cpp
+++ b/tests/unit_tests/svgtools/grids.cpp
@@ -39,16 +39,10 @@ int main(int, char**) {
         10UL, 11UL, 12UL, 13UL, 14UL, 15UL, 16UL, 17UL, 18UL, 19UL};
 
     for (const auto i : indices) {
-        std::string name = "volume" + std::to_string(i) + "_grid";
-        // Draw the grid for volume i.
-        if (auto grid_svg_ptr = il.draw_grid(name, i, view)) {
-            // Draw volume i.
-            const auto volume_svg = il.draw_volume("volume", i, view);
-            // Write volume i and its grid
-            // (the grid is last in the list since we want it to be displayed on
-            // top of the volume).
-            detray::svgtools::write_svg(name + ".svg",
-                                        {volume_svg, *grid_svg_ptr});
-        }
+        // Draw volume i.
+        il.hide_grids(false);
+        const auto volume_svg = il.draw_volume(i, view);
+        // Write volume i and its grid
+        detray::svgtools::write_svg(volume_svg._id, volume_svg);
     }
 }

--- a/tests/unit_tests/svgtools/groups.cpp
+++ b/tests/unit_tests/svgtools/groups.cpp
@@ -44,25 +44,23 @@ int main(int, char**) {
     const std::array surface_group_indices{1UL, 100UL, 10UL, 200UL};
 
     const auto svg_surface_group_xy =
-        il.draw_surfaces("my_surface_group1_xy", surface_group_indices, xy);
+        il.draw_surfaces(surface_group_indices, xy);
     detray::svgtools::write_svg("test_svgtools_surface_group_xy",
                                 {axes, svg_surface_group_xy});
 
     const auto svg_surface_group_zr =
-        il.draw_surfaces("my_surface_group1_zr", surface_group_indices, zr);
+        il.draw_surfaces(surface_group_indices, zr);
     detray::svgtools::write_svg("test_svgtools_surface_group_zr.svg",
                                 {axes, svg_surface_group_zr});
 
     // Visualisation of a group of volumes.
     const std::array volume_group_indices{3UL, 5UL};
 
-    const auto svg_volume_group_xy =
-        il.draw_volumes("my_volume_group1_xy", volume_group_indices, xy);
+    const auto svg_volume_group_xy = il.draw_volumes(volume_group_indices, xy);
     detray::svgtools::write_svg("test_svgtools_volume_group_xy",
                                 {axes, svg_volume_group_xy});
 
-    const auto svg_volume_group_zr =
-        il.draw_volumes("my_volume_group1_zr", volume_group_indices, zr);
+    const auto svg_volume_group_zr = il.draw_volumes(volume_group_indices, zr);
     detray::svgtools::write_svg("test_svgtools_volume_group_zr",
                                 {axes, svg_volume_group_zr});
 

--- a/tests/unit_tests/svgtools/intersections.cpp
+++ b/tests/unit_tests/svgtools/intersections.cpp
@@ -52,7 +52,7 @@ int main(int, char**) {
     const detray::svgtools::illustrator il{det, names};
 
     // Drawing the detector.
-    const auto svg_det = il.draw_detector("detector", view);
+    const auto svg_det = il.draw_detector(view);
 
     // Creating the rays.
     using generator_t =

--- a/tests/unit_tests/svgtools/surfaces.cpp
+++ b/tests/unit_tests/svgtools/surfaces.cpp
@@ -50,9 +50,9 @@ int main(int, char**) {
     for (std::size_t i : indices) {
         std::string name = "test_svgtools_surface" + std::to_string(i);
         // Visualization of surface/portal i:
-        const auto svg_xy = il.draw_surface(name, i, xy);
+        const auto svg_xy = il.draw_surface(i, xy);
         detray::svgtools::write_svg(name + "_xy", {axes, svg_xy});
-        const auto svg_zr = il.draw_surface(name, i, zr);
+        const auto svg_zr = il.draw_surface(i, zr);
         detray::svgtools::write_svg(name + "_zr", {axes, svg_zr});
     }
 }

--- a/tests/unit_tests/svgtools/trajectories.cpp
+++ b/tests/unit_tests/svgtools/trajectories.cpp
@@ -51,7 +51,7 @@ int main(int, char**) {
 
     // Show the relevant volumes in the detector.
     const auto svg_volumes =
-        il.draw_volumes("detector", std::vector{7UL, 9UL, 11UL, 13UL}, view);
+        il.draw_volumes(std::vector{7UL, 9UL, 11UL, 13UL}, view);
 
     // Creating a ray.
     using transform3_t = typename detector_t::transform3;

--- a/tests/unit_tests/svgtools/volumes.cpp
+++ b/tests/unit_tests/svgtools/volumes.cpp
@@ -42,7 +42,9 @@ int main(int, char**) {
     const auto [det, names] = detray::create_toy_geometry(host_mr);
 
     // Creating the svg generator for the detector.
-    const detray::svgtools::illustrator il{det, names};
+    detray::svgtools::illustrator il{det, names};
+    // Only test volume conversion here
+    il.hide_grids(true);
 
     // Indexes of the volumes in the detector to be visualized.
     std::array indices{0UL,  1UL,  2UL,  3UL,  4UL,  5UL,  6UL,
@@ -52,9 +54,9 @@ int main(int, char**) {
     for (std::size_t i : indices) {
         std::string name = "test_svgtools_volume" + std::to_string(i);
         // Visualization of volume i:
-        const auto svg_xy = il.draw_volume(name, i, xy);
+        const auto svg_xy = il.draw_volume(i, xy);
         detray::svgtools::write_svg(name + "_xy", {axes, svg_xy});
-        const auto svg_zr = il.draw_volume(name, i, zr);
+        const auto svg_zr = il.draw_volume(i, zr);
         detray::svgtools::write_svg(name + "_zr", {axes, svg_zr});
     }
 }

--- a/tests/unit_tests/svgtools/web.cpp
+++ b/tests/unit_tests/svgtools/web.cpp
@@ -60,17 +60,8 @@ int main(int, char**) {
 
     // Draw the volumes and include them in the svg vector.
     for (std::size_t i : indices) {
-        std::string name = "Volume_" + std::to_string(i);
-        const auto svg = il.draw_volume(name, i, view);
+        const auto svg = il.draw_volume(i, view);
         svgs.push_back(svg);
-    }
-
-    // Draw the grids and include them in the svg vector.
-    for (const auto i : indices) {
-        std::string name = "Grid_" + std::to_string(i);
-        if (auto svg_ptr = il.draw_grid(name, i, view)) {
-            svgs.push_back(*svg_ptr);
-        }
     }
 
     // Draw some example trajectories and include them in the svg vector (along

--- a/tests/validation/include/detray/validation/detail/svg_display.hpp
+++ b/tests/validation/include/detray/validation/detail/svg_display.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/io/common/detail/utils.hpp"
 #include "detray/plugins/svgtools/illustrator.hpp"
 #include "detray/plugins/svgtools/styling/styling.hpp"
 #include "detray/plugins/svgtools/writer.hpp"
@@ -98,13 +99,7 @@ inline void svg_display(
     }
 
     // General options
-    auto path = std::filesystem::path(outdir);
-    if (not std::filesystem::exists(path)) {
-        std::error_code err;
-        if (!std::filesystem::create_directories(path, err)) {
-            throw std::runtime_error(err.message());
-        }
-    }
+    auto path = detray::detail::create_path(outdir);
 
     actsvg::style::stroke stroke_black = actsvg::style::stroke();
 
@@ -122,18 +117,16 @@ inline void svg_display(
     auto svg_traj = draw_intersection_and_traj_svg(
         gctx, il, intersections_truth, traj, traj_name, intersections, xy);
 
-    std::string name_xy = outfile + "_xy";
-    const auto vol_xy_svg = il.draw_volumes(name_xy, volumes, xy, gctx);
-    detray::svgtools::write_svg(path / name_xy,
+    const auto vol_xy_svg = il.draw_volumes(volumes, xy, gctx);
+    detray::svgtools::write_svg(path / (outfile + "_" + vol_xy_svg._id),
                                 {xy_axis, vol_xy_svg, svg_traj});
 
     // zr - view
     svg_traj = draw_intersection_and_traj_svg(
         gctx, il, intersections_truth, traj, traj_name, intersections, zr);
 
-    std::string name_zr = outfile + "_zr";
-    const auto vol_zr_svg = il.draw_detector(name_zr, zr, gctx);
-    detray::svgtools::write_svg(path / name_zr,
+    const auto vol_zr_svg = il.draw_detector(zr, gctx);
+    detray::svgtools::write_svg(path / (outfile + "_" + vol_zr_svg._id),
                                 {zr_axis, vol_zr_svg, svg_traj});
 
     std::cout << "INFO: Wrote debugging data in: " << path << "\n" << std::endl;

--- a/tests/validation/include/detray/validation/detector_helix_scan.hpp
+++ b/tests/validation/include/detray/validation/detector_helix_scan.hpp
@@ -46,7 +46,7 @@ class helix_scan : public test::fixture_base<> {
         trk_gen_config_t m_trk_gen_cfg{};
         // Visualization style to be applied to the svgs
         detray::svgtools::styling::style m_style =
-            detray::svgtools::styling::tableau_colorblind;
+            detray::svgtools::styling::tableau_colorblind::style;
 
         /// Getters
         /// @{

--- a/tests/validation/include/detray/validation/detector_ray_scan.hpp
+++ b/tests/validation/include/detray/validation/detector_ray_scan.hpp
@@ -81,7 +81,7 @@ class ray_scan : public test::fixture_base<> {
         trk_gen_config_t m_trk_gen_cfg{};
         // Visualization style to be applied to the svgs
         detray::svgtools::styling::style m_style =
-            detray::svgtools::styling::tableau_colorblind;
+            detray::svgtools::styling::tableau_colorblind::style;
 
         /// Getters
         /// @{

--- a/tests/validation/include/detray/validation/helix_navigation.hpp
+++ b/tests/validation/include/detray/validation/helix_navigation.hpp
@@ -51,7 +51,7 @@ class helix_navigation : public test::fixture_base<> {
         trk_gen_config_t m_trk_gen_cfg{};
         // Visualization style to be applied to the svgs
         detray::svgtools::styling::style m_style =
-            detray::svgtools::styling::tableau_colorblind;
+            detray::svgtools::styling::tableau_colorblind::style;
 
         /// Getters
         /// @{

--- a/tests/validation/include/detray/validation/straight_line_navigation.hpp
+++ b/tests/validation/include/detray/validation/straight_line_navigation.hpp
@@ -51,7 +51,7 @@ class straight_line_navigation : public test::fixture_base<> {
         trk_gen_config_t m_trk_gen_cfg{};
         // Visualization style to be applied to the svgs
         detray::svgtools::styling::style m_style =
-            detray::svgtools::styling::tableau_colorblind;
+            detray::svgtools::styling::tableau_colorblind::style;
 
         /// Getters
         /// @{


### PR DESCRIPTION
This uses the actsvg proto classes for the detector and detector volumes as a prerequisite to transforming layer volumes into sheets. Also streamlines the styling and svg id naming a bit.