### PR TITLE
feat: grid search

### DIFF
--- a/core/include/detray/definitions/indexing.hpp
+++ b/core/include/detray/definitions/indexing.hpp
@@ -24,8 +24,9 @@ inline constexpr dindex dindex_invalid = detail::invalid_value<dindex>();
 using dindex_range = darray<dindex, 2>;
 using dindex_sequence = dvector<dindex>;
 
-DETRAY_HOST
-inline std::ostream& operator<<(std::ostream& os, const dindex_range& r) {
+template <typename I>
+DETRAY_HOST inline std::ostream& operator<<(std::ostream& os,
+                                            const darray<I, 2>& r) {
 
     bool writeSeparator = false;
     for (auto i = 0u; i < r.size(); ++i) {

--- a/core/include/detray/surface_finders/grid/axis.hpp
+++ b/core/include/detray/surface_finders/grid/axis.hpp
@@ -105,22 +105,33 @@ struct single_axis {
 
     /// Given a value on the axis, find the correct bin.
     ///
+    /// @note This includes bin index wrapping for circular axis.
+    ///
     /// @param v is the value for the bin search
     ///
     /// @returns the bin index.
     DETRAY_HOST_DEVICE
     inline dindex bin(const scalar_type v) const {
-        return m_bounds.map(m_binning.bin(v), m_binning.nbins());
+        int b{m_bounds.map(m_binning.bin(v), m_binning.nbins())};
+
+        if constexpr (bounds_type::type == n_axis::bounds::e_circular) {
+            b = m_bounds.wrap(b, m_binning.nbins());
+        }
+
+        return static_cast<dindex>(b);
     }
 
     /// Given a value on the axis and a neighborhood, find the correct bin range
+    ///
+    /// @note (!) The circular axis index wrap-around happens in a separate
+    ///           step so that index sequences are well defined
     ///
     /// @param v is the value for the bin search
     /// @param nhood is the neighborhood range (in #bins or value interval)
     ///
     /// @returns a dindex_range around the bin index.
     template <typename neighbor_t>
-    DETRAY_HOST_DEVICE dindex_range
+    DETRAY_HOST_DEVICE bin_range
     range(const scalar_type v, const array_type<neighbor_t, 2> &nhood) const {
         return m_bounds.map(m_binning.range(v, nhood), m_binning.nbins());
     }

--- a/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
@@ -20,6 +20,10 @@
 
 namespace detray::n_axis {
 
+/// @brief Helper to tie two bin indices to a range.
+/// @note Cannot use dindex_range for signed integer bin indices.
+using bin_range = std::array<int, 2>;
+
 /// @brief A regular binning scheme.
 ///
 /// The binning on the input parameter space is regular and therefore only needs
@@ -80,13 +84,15 @@ struct regular {
 
     /// Access function to a range with binned neighborhood
     ///
+    /// @note This is an inclusive range
+    ///
     /// @param v is the value for the bin search
     /// @param nhood is the neighborhood bin index range (# neighboring bins)
     ///
     /// @returns the corresponding range of bin indices
     DETRAY_HOST_DEVICE
-    array_type<int, 2> range(const scalar_t v,
-                             const array_type<dindex, 2> &nhood) const {
+    bin_range range(const scalar_t v,
+                    const array_type<dindex, 2> &nhood) const {
         const int ibin{bin(v)};
         const int ibinmin{ibin - static_cast<int>(nhood[0])};
         const int ibinmax{ibin + static_cast<int>(nhood[1])};
@@ -96,13 +102,15 @@ struct regular {
 
     /// Access function to a range with scalar neighborhood
     ///
+    /// @note This is an inclusive range
+    ///
     /// @param v is the value for the bin search
     /// @param nhood is the neighborhood value range (range on axis values)
     ///
     /// @returns the corresponding range of bin indices
     DETRAY_HOST_DEVICE
-    array_type<int, 2> range(const scalar_t v,
-                             const array_type<scalar_t, 2> &nhood) const {
+    bin_range range(const scalar_t v,
+                    const array_type<scalar_t, 2> &nhood) const {
         return {bin(v - nhood[0]), bin(v + nhood[1])};
     }
 
@@ -229,13 +237,15 @@ struct irregular {
 
     /// Access function to a range with binned neighborhood
     ///
+    /// @note This is an inclusive range
+    ///
     /// @param v is the value for the bin search
     /// @param nhood is the neighborhood range (# neighboring bins)
     ///
     /// @returns the corresponding range of bin indices
     DETRAY_HOST_DEVICE
-    array_type<int, 2> range(const scalar_t v,
-                             const array_type<dindex, 2> &nhood) const {
+    bin_range range(const scalar_t v,
+                    const array_type<dindex, 2> &nhood) const {
         const int ibin{bin(v)};
         const int ibinmin{ibin - static_cast<int>(nhood[0])};
         const int ibinmax{ibin + static_cast<int>(nhood[1])};
@@ -250,11 +260,9 @@ struct irregular {
     ///
     /// @returns the corresponding range of bin indices
     DETRAY_HOST_DEVICE
-    array_type<int, 2> range(const scalar_t v,
-                             const array_type<scalar_t, 2> &nhood) const {
-        const int nbin{bin(v - nhood[0])};
-        const int pbin{bin(v + nhood[1])};
-        return {nbin, pbin};
+    bin_range range(const scalar_t v,
+                    const array_type<scalar_t, 2> &nhood) const {
+        return {bin(v - nhood[0]), bin(v + nhood[1])};
     }
 
     /// @return the bin edges for a given @param ibin

--- a/core/include/detray/surface_finders/grid/detail/axis_helpers.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_helpers.hpp
@@ -17,12 +17,16 @@
 namespace detray::n_axis {
 
 /// @brief Multi-bin: contains bin indices from multiple axes
-template <std::size_t DIM>
-struct multi_bin : public dmulti_index<dindex, DIM> {};
+template <std::size_t DIM, typename index_t = dindex>
+struct multi_bin : public dmulti_index<index_t, DIM> {};
+
+/// @brief Helper to tie two bin indices to a range.
+/// @note Cannot use dindex_range for signed integer bin indices.
+using bin_range = std::array<int, 2>;
 
 /// @brief Multi-bin-range: contains bin index ranges from multiple axes
 template <std::size_t DIM>
-struct multi_bin_range : public dmulti_index<dindex_range, DIM> {};
+struct multi_bin_range : public dmulti_index<bin_range, DIM> {};
 
 namespace detail {
 

--- a/core/include/detray/surface_finders/grid/detail/bin_view.hpp
+++ b/core/include/detray/surface_finders/grid/detail/bin_view.hpp
@@ -1,0 +1,192 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/containers.hpp"
+#include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/ranges.hpp"
+
+// System include(s)
+#include <utility>
+
+namespace detray::n_axis::detail {
+
+template <typename G, typename I>
+struct bin_iterator;
+
+/// @returns the local bin indexer for the given @param search_window.
+/// (cartesian product of the bin index ranges on the respective axes)
+template <std::size_t... I>
+DETRAY_HOST_DEVICE inline auto get_bin_indexer(
+    const n_axis::multi_bin_range<sizeof...(I)> &search_window,
+    std::index_sequence<I...>) {
+
+    return detray::views::cartesian_product{
+        detray::views::iota{detray::detail::get<I>(search_window)}...};
+}
+
+/// @brief Range adaptor that fetches grid bins according to a search window.
+template <typename grid_t>
+struct bin_view : public detray::ranges::view_interface<bin_view<grid_t>> {
+
+    /// Cartesian product view over the local bin index sequences
+    using bin_indexer_t = decltype(
+        get_bin_indexer(std::declval<n_axis::multi_bin_range<grid_t::Dim>>(),
+                        std::declval<std::make_index_sequence<grid_t::Dim>>()));
+
+    using iterator_t =
+        bin_iterator<grid_t, detray::ranges::iterator_t<bin_indexer_t>>;
+    using value_t = typename std::iterator_traits<iterator_t>::value_type;
+
+    /// Default constructor
+    constexpr bin_view() = default;
+
+    /// Construct from a @param search_window of local bin index ranges and an
+    /// underlying @param grid
+    DETRAY_HOST_DEVICE constexpr explicit bin_view(
+        const grid_t &grid, n_axis::multi_bin_range<grid_t::Dim> &search_window)
+        : m_grid{grid},
+          m_bin_indexer{get_bin_indexer(
+              search_window,
+              std::make_integer_sequence<std::size_t, grid_t::Dim>{})} {}
+
+    /// Copy constructor
+    DETRAY_HOST_DEVICE
+    constexpr bin_view(const bin_view &other)
+        : m_grid{other.m_grid}, m_bin_indexer{other.m_bin_indexer} {}
+
+    /// Default destructor
+    ~bin_view() = default;
+
+    /// Copy assignment operator
+    DETRAY_HOST_DEVICE
+    bin_view &operator=(const bin_view &other) {
+        m_grid = other.m_grid;
+        m_bin_indexer = other.m_bin_indexer;
+        return *this;
+    }
+
+    /// @returns start position: first local bin index
+    DETRAY_HOST_DEVICE
+    constexpr auto begin() const -> iterator_t {
+        return {m_grid, detray::ranges::begin(m_bin_indexer)};
+    }
+
+    /// @returns sentinel of the range: last local bin index
+    DETRAY_HOST_DEVICE
+    constexpr auto end() const -> iterator_t {
+        return {m_grid, detray::ranges::end(m_bin_indexer)};
+    }
+
+    /// @returns number of all bins in the search area
+    DETRAY_HOST_DEVICE
+    constexpr auto size() const noexcept -> std::size_t {
+        return m_bin_indexer.size();
+    }
+
+    private:
+    /// The underlying grid that holds the bins
+    const grid_t &m_grid;
+    /// How to index the bins in the search window (produces local indices)
+    bin_indexer_t m_bin_indexer;
+};
+
+/// @brief Iterate through the bin search area.
+template <typename grid_t, typename bin_indexer_t>
+struct bin_iterator {
+
+    using difference_type = std::ptrdiff_t;
+    using value_type = typename grid_t::bin_type;
+    using pointer = value_type *;
+    using reference = value_type &;
+    using iterator_category = detray::ranges::bidirectional_iterator_tag;
+
+    /// Default constructor required by LegacyIterator trait
+    constexpr bin_iterator() = default;
+
+    /// Construct from a bin indexing prescription @param bin_indexer and a
+    /// @param grid
+    DETRAY_HOST_DEVICE
+    constexpr bin_iterator(const grid_t &grid, bin_indexer_t &&bin_indexer)
+        : m_grid(grid), m_bin_indexer(std::move(bin_indexer)) {}
+
+    /// @returns true if it points to the same local bin.
+    DETRAY_HOST_DEVICE constexpr bool operator==(
+        const bin_iterator &rhs) const {
+        return (m_bin_indexer == rhs.m_bin_indexer);
+    }
+
+    /// @returns false if it points to the same local bin.
+    DETRAY_HOST_DEVICE constexpr bool operator!=(
+        const bin_iterator &rhs) const {
+        return (m_bin_indexer != rhs.m_bin_indexer);
+    }
+
+    /// Increment to find next local bin index.
+    DETRAY_HOST_DEVICE auto operator++() -> bin_iterator & {
+        ++m_bin_indexer;
+        return *this;
+    }
+
+    /// Decrement to find previous local bin index.
+    DETRAY_HOST_DEVICE auto operator--() -> bin_iterator & {
+        --m_bin_indexer;
+        return *this;
+    }
+
+    /// @returns the bin that corresponds to the current local bin index - const
+    DETRAY_HOST_DEVICE
+    constexpr decltype(auto) operator*() const {
+        // Get the correct local bin index
+        auto lbin = n_axis::multi_bin<grid_t::Dim>{};
+        map_circular(*m_bin_indexer, lbin,
+                     std::make_integer_sequence<std::size_t, grid_t::Dim>{});
+        // Transform to global bin index
+        const dindex gbin{m_grid.serializer()(m_grid.axes(), lbin)};
+        // Fetch the bin
+        return (*(m_grid.data().bin_data()))[gbin + m_grid.data().offset()];
+    }
+
+    private:
+    /// The iota range that is generated for circular axes does not map to their
+    /// local bin index range, yet
+    template <typename... Idx_t, std::size_t... I>
+    DETRAY_HOST_DEVICE constexpr void map_circular(
+        std::tuple<Idx_t...> index_tuple, n_axis::multi_bin<grid_t::Dim> &mbin,
+        std::index_sequence<I...>) const {
+        // Run the mapping for every axis in the grid
+        (map_circular(m_grid.template get_axis<I>(), index_tuple, mbin), ...);
+    }
+
+    /// Map the local bin index for the phi axis to a periodic range and fill
+    /// the local bin @param mbin
+    template <typename axis_t, typename... Idx_t>
+    DETRAY_HOST_DEVICE constexpr void map_circular(
+        const axis_t &ax, std::tuple<Idx_t...> index_tuple,
+        n_axis::multi_bin<grid_t::Dim> &mbin) const {
+
+        constexpr auto loc_idx{
+            static_cast<std::size_t>(axis_t::bounds_type::label)};
+
+        if constexpr (axis_t::bounds_type::type == n_axis::bounds::e_circular) {
+            mbin[loc_idx] = static_cast<dindex>(n_axis::circular<>{}.wrap(
+                std::get<loc_idx>(index_tuple), ax.nbins()));
+        } else {
+            // All other axes start with a range that is already mapped
+            mbin[loc_idx] = static_cast<dindex>(std::get<loc_idx>(index_tuple));
+        }
+    }
+
+    /// Grid
+    const grid_t &m_grid;
+    /// Bin indexing (cartesian product over local bin index ranges)
+    bin_indexer_t m_bin_indexer;
+};
+
+}  // namespace detray::n_axis::detail

--- a/core/include/detray/surface_finders/grid/detail/serializer_impl.hpp
+++ b/core/include/detray/surface_finders/grid/detail/serializer_impl.hpp
@@ -41,7 +41,7 @@ struct simple_serializer<1> {
     DETRAY_HOST_DEVICE auto operator()(multi_axis_t & /*axes*/,
                                        dindex gbin) const
         -> n_axis::multi_bin<1> {
-        return {{gbin}};
+        return {gbin};
     }
 };
 
@@ -81,7 +81,7 @@ struct simple_serializer<2> {
         dindex bin0{gbin % nbins_axis0};
         dindex bin1{static_cast<dindex>(gbin / nbins_axis0)};
 
-        return {{bin0, bin1}};
+        return {bin0, bin1};
     }
 };
 
@@ -127,7 +127,7 @@ struct simple_serializer<3> {
         dindex bin0{gbin % nbins_axis0};
         dindex bin1{static_cast<dindex>(gbin / (nbins_axis0)) % nbins_axis1};
         dindex bin2{static_cast<dindex>(gbin / (nbins_axis0 * nbins_axis1))};
-        return {{bin0, bin1, bin2}};
+        return {bin0, bin1, bin2};
     }
 };
 

--- a/core/include/detray/tools/bin_association.hpp
+++ b/core/include/detray/tools/bin_association.hpp
@@ -232,7 +232,7 @@ static inline void bin_association(const context_t & /*context*/,
 
                             // Register if associated
                             if (associated) {
-                                grid.populate({{bin_0, bin_1}}, sf);
+                                grid.populate({bin_0, bin_1}, sf);
                                 break;
                             }
                         }

--- a/core/include/detray/utils/ranges.hpp
+++ b/core/include/detray/utils/ranges.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/utils/ranges/cartesian_product.hpp"
 #include "detray/utils/ranges/empty.hpp"
 #include "detray/utils/ranges/enumerate.hpp"
 #include "detray/utils/ranges/iota.hpp"

--- a/core/include/detray/utils/ranges/cartesian_product.hpp
+++ b/core/include/detray/utils/ranges/cartesian_product.hpp
@@ -1,0 +1,233 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/qualifiers.hpp"
+#include "detray/utils/ranges/ranges.hpp"
+#include "detray/utils/tuple.hpp"
+
+// System include(s)
+#include <tuple>  // < needed for structured binding of iterator values
+
+namespace detray::ranges {
+
+namespace detail {
+
+template <typename... T>
+struct cartesian_product_iterator;
+
+}
+
+/// @brief Range adaptor that generates a cartesian product from the given input
+/// ranges
+///
+/// @see https://en.cppreference.com/w/cpp/ranges/cartesian_product_view
+/// @see
+/// https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/std/ranges
+template <typename... range_ts>
+struct cartesian_product_view : public detray::ranges::view_interface<
+                                    cartesian_product_view<range_ts...>> {
+
+    using iterator_coll_t =
+        detray::tuple<detray::ranges::iterator_t<range_ts>...>;
+    using iterator_t = detray::ranges::detail::cartesian_product_iterator<
+        detray::ranges::iterator_t<range_ts>...>;
+    using value_type = std::tuple<typename std::iterator_traits<
+        detray::ranges::iterator_t<range_ts>>::value_type &...>;
+
+    /// Default constructor
+    constexpr cartesian_product_view() = default;
+
+    /// Construct from a pack of @param ranges.
+    template <typename... ranges_t>
+    DETRAY_HOST_DEVICE constexpr explicit cartesian_product_view(
+        ranges_t &&...ranges)
+        : m_begins{detray::ranges::begin(std::forward<ranges_t>(ranges))...},
+          m_ends{detray::ranges::end(std::forward<ranges_t>(ranges))...} {}
+
+    /// Copy constructor
+    DETRAY_HOST_DEVICE
+    constexpr cartesian_product_view(const cartesian_product_view &other)
+        : m_begins{other.m_begins}, m_ends{other.m_ends} {}
+
+    /// Default destructor
+    ~cartesian_product_view() = default;
+
+    /// Copy assignment operator
+    DETRAY_HOST_DEVICE
+    cartesian_product_view &operator=(const cartesian_product_view &other) {
+        m_begins = other.m_begins;
+        m_ends = other.m_ends;
+        return *this;
+    }
+
+    /// @return start position of range - const
+    DETRAY_HOST_DEVICE
+    constexpr auto begin() const -> iterator_t { return {m_begins, m_ends}; }
+
+    /// @return sentinel of the range - const
+    DETRAY_HOST_DEVICE
+    constexpr auto end() const -> iterator_t { return {m_ends, m_ends}; }
+
+    /// @returns a pointer to the beginning of the data of the first underlying
+    /// range - const
+    DETRAY_HOST_DEVICE
+    constexpr auto data() const { return &(*(detray::get<0>(m_begins()))); }
+
+    /// @returns a pointer to the beginning of the data of the first underlying
+    /// range - non-const
+    DETRAY_HOST_DEVICE
+    constexpr auto data() { return &(*(detray::get<0>(m_begins()))); }
+
+    /// @returns product of the number elements of all ranges in the view
+    template <std::size_t I = sizeof...(range_ts) - 1u>
+    DETRAY_HOST_DEVICE constexpr auto size(std::size_t s = 1u) const noexcept
+        -> std::size_t {
+
+        const auto begin = detray::get<I>(m_begins);
+        const auto end = detray::get<I>(m_ends);
+
+        s *= static_cast<std::size_t>(detray::ranges::distance(begin, end));
+
+        if constexpr (I > 0u) {
+            return size<I - 1u>(s);
+        } else {
+            return s;
+        }
+    }
+
+    private:
+    /// Start and end position of the subranges
+    iterator_coll_t m_begins{}, m_ends{};
+};
+
+namespace views {
+
+/// @brief interface type to construct a @c cartesian_product_view with CTAD
+template <typename... range_ts>
+struct cartesian_product : public ranges::cartesian_product_view<range_ts...> {
+
+    using base_type = ranges::cartesian_product_view<range_ts...>;
+
+    constexpr cartesian_product() = default;
+
+    template <typename... ranges_t>
+    DETRAY_HOST_DEVICE constexpr explicit cartesian_product(
+        ranges_t &&...ranges)
+        : base_type(std::forward<ranges_t>(ranges)...) {}
+};
+
+// deduction guides
+
+template <typename... ranges_ts>
+DETRAY_HOST_DEVICE cartesian_product(ranges_ts &&...ranges)
+    ->cartesian_product<ranges_ts...>;
+
+}  // namespace views
+
+namespace detail {
+
+/// @brief Iterator implementation for the cartesian product view
+template <typename... iterator_ts>
+struct cartesian_product_iterator {
+
+    using difference_type = std::ptrdiff_t;
+    using value_type =
+        std::tuple<typename std::iterator_traits<iterator_ts>::value_type...>;
+    using pointer = value_type *;
+    using reference = value_type &;
+    using iterator_category = detray::ranges::input_iterator_tag;
+
+    /// Default constructor required by LegacyIterator trait
+    constexpr cartesian_product_iterator() = default;
+
+    /// Construct from a collection of @param begin and @param end positions
+    DETRAY_HOST_DEVICE
+    constexpr cartesian_product_iterator(
+        const detray::tuple<iterator_ts...> &begins,
+        const detray::tuple<iterator_ts...> &ends)
+        : m_begins(&begins), m_ends(&ends), m_itrs(begins) {}
+
+    /// Copy assignment operator
+    DETRAY_HOST_DEVICE
+    cartesian_product_iterator &operator=(
+        const cartesian_product_iterator &other) {
+        m_begins = other.m_begins;
+        m_ends = other.m_ends;
+        return *this;
+    }
+
+    /// @returns true if the last range iterators are equal.
+    DETRAY_HOST_DEVICE constexpr bool operator==(
+        const cartesian_product_iterator &rhs) const {
+        return (detray::get<0>(m_itrs) == detray::get<0>(rhs.m_itrs));
+    }
+
+    /// @returns true if the last range iterators are not equal
+    /// @note (if the outermost range (pos 0 in the pack) goes to its end
+    /// position, the iteration stops).
+    DETRAY_HOST_DEVICE constexpr bool operator!=(
+        const cartesian_product_iterator &rhs) const {
+        return (detray::get<0>(m_itrs) != detray::get<0>(rhs.m_itrs));
+    }
+
+    /// Increment iterators.
+    DETRAY_HOST_DEVICE constexpr auto operator++()
+        -> cartesian_product_iterator & {
+        unroll_increment();
+        return *this;
+    }
+
+    /// @returns the structured binding of all current iterator values - const
+    DETRAY_HOST_DEVICE
+    constexpr auto operator*() const {
+        return unroll_values(
+            std::make_integer_sequence<std::size_t, sizeof...(iterator_ts)>{});
+    }
+
+    /// @returns the structured binding of all current iterator values.
+    DETRAY_HOST_DEVICE
+    constexpr auto operator*() {
+        return unroll_values(
+            std::make_integer_sequence<std::size_t, sizeof...(iterator_ts)>{});
+    }
+
+    private:
+    /// Unroll the increment over all iterators and, for the inner iterators,
+    /// reset to start a new iteration
+    /// @see
+    /// https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/std/ranges
+    template <std::size_t I = sizeof...(iterator_ts) - 1u>
+    DETRAY_HOST_DEVICE constexpr void unroll_increment() {
+        auto &itr = detray::get<I>(m_itrs);
+        ++itr;
+        if constexpr (I > 0u) {
+            if (itr == detray::get<I>(*m_ends)) {
+                itr = detray::get<I>(*m_begins);
+                unroll_increment<I - 1>();
+            }
+        }
+    }
+
+    /// Pack the return values
+    /// @note uses @c std::tuple for structured binding
+    template <std::size_t... I>
+    DETRAY_HOST_DEVICE constexpr auto unroll_values(std::index_sequence<I...>) {
+        return std::tie(*detray::get<I>(m_itrs)...);
+    }
+
+    /// Global range collection of begin and end iterators
+    const detray::tuple<iterator_ts...> *m_begins{nullptr}, *m_ends{nullptr};
+    /// Current iterator states
+    detray::tuple<iterator_ts...> m_itrs;
+};
+
+}  // namespace detail
+
+}  // namespace detray::ranges

--- a/core/include/detray/utils/ranges/pick.hpp
+++ b/core/include/detray/utils/ranges/pick.hpp
@@ -158,8 +158,7 @@ class pick_view : public detray::ranges::view_interface<
     public:
     using iterator_t = iterator;
 
-    /// Default constructor (only works if @c imrementable_t is default
-    /// constructible)
+    /// Default constructor
     pick_view() = default;
 
     /// Construct from a @param range that will be enumerated beginning at 0

--- a/core/include/detray/utils/ranges/static_join.hpp
+++ b/core/include/detray/utils/ranges/static_join.hpp
@@ -238,7 +238,7 @@ struct static_join_iterator {
             // Iterator has reached last valid position in this range during the
             // previous decrement. Now go to the end of the previous range
             --m_idx;
-            m_iter = (*m_ends)[m_idx] - 1;
+            m_iter = detray::ranges::prev((*m_ends)[m_idx]);
         }
         return *this;
     }

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/volume.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/volume.hpp
@@ -23,7 +23,6 @@
 
 // System include(s)
 #include <map>
-#include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -87,16 +86,10 @@ auto volume(const typename detector_t::geometry_context& context,
                 p_volume._v_surfaces.emplace_back(svgtools::conversion::surface(
                     context, sf, style._surface_style));
 
-            std::stringstream sf_info, msk_info, mat_info;
-            sf_info << "* index " << sf.index();
-            msk_info << "* " << sf.shape_name() << ": " << desc.mask().index();
-            mat_info << "* mat.: " << static_cast<int>(desc.material().id())
-                     << ", " << desc.material().index();
+            std::string sf_info{"* index " + std::to_string(sf.index())};
 
-            p_surface._aux_info["module_info"] = {sf_info.str(), msk_info.str(),
-                                                  mat_info.str()};
-            p_surface._aux_info["grid_info"] = {sf_info.str(), msk_info.str(),
-                                                mat_info.str()};
+            p_surface._aux_info["module_info"] = {sf_info};
+            p_surface._aux_info["grid_info"] = {sf_info};
 
             // Put the sensitive surfaces in the module/grid sheets
             if (sf.is_sensitive()) {

--- a/tests/unit_tests/core/utils_ranges.cpp
+++ b/tests/unit_tests/core/utils_ranges.cpp
@@ -200,8 +200,8 @@ TEST(utils, ranges_iota_single) {
     static_assert(std::is_copy_assignable_v<decltype(seq)>);
     static_assert(detray::ranges::range_v<decltype(seq)>);
     static_assert(detray::ranges::view<decltype(seq)>);
-    static_assert(detray::ranges::input_range_v<decltype(seq)>);
-    static_assert(not detray::ranges::forward_range_v<decltype(seq)>);
+    static_assert(detray::ranges::bidirectional_range_v<decltype(seq)>);
+    static_assert(not detray::ranges::random_access_range_v<decltype(seq)>);
 
     // Test prerequisits for LagacyIterator
     static_assert(
@@ -230,8 +230,8 @@ TEST(utils, ranges_iota_interval) {
     static_assert(detray::ranges::range_v<decltype(seq)>);
     static_assert(detray::ranges::view<decltype(seq)>);
     static_assert(std::is_copy_assignable_v<decltype(seq)>);
-    static_assert(detray::ranges::input_range_v<decltype(seq)>);
-    static_assert(not detray::ranges::forward_range_v<decltype(seq)>);
+    static_assert(detray::ranges::bidirectional_range_v<decltype(seq)>);
+    static_assert(not detray::ranges::random_access_range_v<decltype(seq)>);
 
     // Test prerequisits for LagacyIterator
     static_assert(
@@ -255,9 +255,9 @@ TEST(utils, ranges_iota_interval) {
 // Unittest for the generation of a cartesian product from a range of intervals
 TEST(utils, ranges_cartesian_product) {
 
-    auto seq1 = detray::views::iota(dindex_range{2u, 7u});
-    auto seq2 = detray::views::iota(dindex_range{1u, 10u});
-    auto seq3 = detray::views::iota(dindex_range{3u, 4u});
+    const auto seq1 = detray::views::iota(dindex_range{2u, 7u});
+    const auto seq2 = detray::views::iota(dindex_range{1u, 10u});
+    const auto seq3 = detray::views::iota(dindex_range{3u, 4u});
 
     detray::views::cartesian_product cp{std::move(seq1), std::move(seq2),
                                         std::move(seq3)};
@@ -266,8 +266,8 @@ TEST(utils, ranges_cartesian_product) {
     static_assert(detray::ranges::range_v<decltype(cp)>);
     static_assert(detray::ranges::view<decltype(cp)>);
     static_assert(std::is_copy_assignable_v<decltype(cp)>);
-    static_assert(detray::ranges::input_range_v<decltype(cp)>);
-    static_assert(not detray::ranges::forward_range_v<decltype(cp)>);
+    static_assert(detray::ranges::bidirectional_range_v<decltype(cp)>);
+    static_assert(not detray::ranges::random_access_range_v<decltype(cp)>);
 
     // Test prerequisits for LagacyIterator
     static_assert(
@@ -288,7 +288,8 @@ TEST(utils, ranges_cartesian_product) {
         }
     }
 
-    for (std::size_t r = 0; const auto [i, j, k] : cp) {
+    std::size_t r{0u};
+    for (const auto [i, j, k] : cp) {
         const auto [l, m, n] = result[r];
         ++r;
         ASSERT_EQ(i, l);
@@ -315,8 +316,8 @@ TEST(utils, ranges_enumerate) {
     static_assert(detray::ranges::random_access_range_v<decltype(enumerator)>);
 
     // Test prerequisits for LagacyIterator
-    static_assert(std::is_copy_constructible_v<
-                  typename decltype(enumerator)::iterator_t>);
+    static_assert(std::is_copy_constructible_v<typename decltype(
+                      enumerator)::iterator_t>);
     static_assert(
         std::is_copy_assignable_v<typename decltype(enumerator)::iterator_t>);
     static_assert(
@@ -540,8 +541,8 @@ TEST(utils, ranges_subrange_iota) {
     auto iota_sr = detray::ranges::subrange(detray::views::iota(seq), interval);
 
     // Check iterator category
-    static_assert(detray::ranges::input_range_v<decltype(iota_sr)>);
-    static_assert(not detray::ranges::forward_range_v<decltype(iota_sr)>);
+    static_assert(detray::ranges::bidirectional_range_v<decltype(iota_sr)>);
+    static_assert(not detray::ranges::random_access_range_v<decltype(iota_sr)>);
 
     std::size_t i{4u};
     for (const auto v : iota_sr) {
@@ -595,10 +596,11 @@ TEST(utils, ranges_pick_joined_sequence) {
     auto selected = detray::views::pick(seq, indices);
 
     // Check iterator category
-    static_assert(detray::ranges::input_range_v<decltype(indices)>);
-    static_assert(not detray::ranges::forward_range_v<decltype(indices)>);
-    static_assert(detray::ranges::input_range_v<decltype(selected)>);
-    static_assert(not detray::ranges::forward_range_v<decltype(selected)>);
+    static_assert(detray::ranges::bidirectional_range_v<decltype(indices)>);
+    static_assert(not detray::ranges::random_access_range_v<decltype(indices)>);
+    static_assert(detray::ranges::bidirectional_range_v<decltype(selected)>);
+    static_assert(
+        not detray::ranges::random_access_range_v<decltype(selected)>);
 
     // Test inherited member functions
     const auto [i, v] = selected[2];

--- a/tests/unit_tests/core/utils_ranges.cpp
+++ b/tests/unit_tests/core/utils_ranges.cpp
@@ -5,8 +5,6 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
 // detray test
 #include "tests/common/test_defs.hpp"
 
@@ -18,6 +16,9 @@
 #include "vecmem/containers/device_vector.hpp"
 #include "vecmem/containers/jagged_device_vector.hpp"
 #include "vecmem/containers/jagged_vector.hpp"
+
+// GTest include(s)
+#include <gtest/gtest.h>
 
 // System include(s)
 #include <forward_list>
@@ -251,6 +252,51 @@ TEST(utils, ranges_iota_interval) {
     ASSERT_EQ(check, reference);
 }
 
+// Unittest for the generation of a cartesian product from a range of intervals
+TEST(utils, ranges_cartesian_product) {
+
+    auto seq1 = detray::views::iota(dindex_range{2u, 7u});
+    auto seq2 = detray::views::iota(dindex_range{1u, 10u});
+    auto seq3 = detray::views::iota(dindex_range{3u, 4u});
+
+    detray::views::cartesian_product cp{std::move(seq1), std::move(seq2),
+                                        std::move(seq3)};
+
+    // General tests
+    static_assert(detray::ranges::range_v<decltype(cp)>);
+    static_assert(detray::ranges::view<decltype(cp)>);
+    static_assert(std::is_copy_assignable_v<decltype(cp)>);
+    static_assert(detray::ranges::input_range_v<decltype(cp)>);
+    static_assert(not detray::ranges::forward_range_v<decltype(cp)>);
+
+    // Test prerequisits for LagacyIterator
+    static_assert(
+        std::is_copy_constructible_v<typename decltype(cp)::iterator_t>);
+    static_assert(std::is_copy_assignable_v<typename decltype(cp)::iterator_t>);
+    static_assert(std::is_destructible_v<typename decltype(cp)::iterator_t>);
+
+    // Test size
+    ASSERT_EQ(cp.size(), seq1.size() * seq2.size() * seq3.size());
+
+    // Generate truth
+    std::vector<std::tuple<dindex, dindex, dindex>> result;
+    for (auto i : seq1) {
+        for (auto j : seq2) {
+            for (auto k : seq3) {
+                result.emplace_back(i, j, k);
+            }
+        }
+    }
+
+    for (std::size_t r = 0; const auto [i, j, k] : cp) {
+        const auto [l, m, n] = result[r];
+        ++r;
+        ASSERT_EQ(i, l);
+        ASSERT_EQ(j, m);
+        ASSERT_EQ(k, n);
+    }
+}
+
 // Unittest for the convenience enumeration of a range
 TEST(utils, ranges_enumerate) {
 
@@ -269,8 +315,8 @@ TEST(utils, ranges_enumerate) {
     static_assert(detray::ranges::random_access_range_v<decltype(enumerator)>);
 
     // Test prerequisits for LagacyIterator
-    static_assert(std::is_copy_constructible_v<typename decltype(
-                      enumerator)::iterator_t>);
+    static_assert(std::is_copy_constructible_v<
+                  typename decltype(enumerator)::iterator_t>);
     static_assert(
         std::is_copy_assignable_v<typename decltype(enumerator)::iterator_t>);
     static_assert(

--- a/tests/unit_tests/cpu/grid_axis.cpp
+++ b/tests/unit_tests/cpu/grid_axis.cpp
@@ -49,7 +49,7 @@ GTEST_TEST(detray_grid, open_regular_axis) {
     // second entry is the number of bins (10): Lower and upper bin edges of
     // the max and min bin are -3 and 7 => stepsize is (7 - (-3)) / 10 = 1
     // ... -3, -2, -1,  0,  1,  2,  3,  4,  5,  6,  7 ...
-    //  [0]  [1] [2] [3] [4] [5] [6] [7] [8] [9] [10] [11]
+    //   [0] [1] [2] [3] [4] [5] [6] [7] [8] [9] [10] [11]
     const dindex_range edge_range = {2u, 10u};
 
     // An open regular x-axis
@@ -66,11 +66,11 @@ GTEST_TEST(detray_grid, open_regular_axis) {
     EXPECT_NEAR(or_axis.span()[1], 7.f, tol);
     // Axis bin access
     // Axis is open: Every value smaller than -3 is mapped into bin 0:
-    // which is (inf, -3)
+    // which is (-inf, -3]
     EXPECT_EQ(or_axis.bin(-4.f), 0u);
     EXPECT_EQ(or_axis.bin(2.5f), 6u);
     // Axis is open: Every value greater than 7 is mapped into bin 11:
-    // which is (7, inf)
+    // which is [7, inf)
     EXPECT_EQ(or_axis.bin(8.f), 11u);
 
     // Axis range access - binned (symmetric & asymmetric)
@@ -80,19 +80,19 @@ GTEST_TEST(detray_grid, open_regular_axis) {
     const darray<dindex, 2> nhood44i = {4u, 4u};
     const darray<dindex, 2> nhood55i = {5u, 5u};
 
-    dindex_range expected_range = {6u, 6u};
+    n_axis::bin_range expected_range = {6u, 7u};
     EXPECT_EQ(or_axis.range(2.5f, nhood00i), expected_range);
-    expected_range = {6u, 7u};
+    expected_range = {6u, 8u};
     EXPECT_EQ(or_axis.range(2.5f, nhood01i), expected_range);
-    expected_range = {5u, 7u};
+    expected_range = {5u, 8u};
     EXPECT_EQ(or_axis.range(2.5f, nhood11i), expected_range);
-    expected_range = {2u, 10u};
+    expected_range = {2u, 11u};
     EXPECT_EQ(or_axis.range(2.5f, nhood44i), expected_range);
-    expected_range = {1u, 11u};
+    expected_range = {1u, 12u};
     EXPECT_EQ(or_axis.range(2.5f, nhood55i), expected_range);
-    expected_range = {1u, 9u};
+    expected_range = {1u, 10u};
     EXPECT_EQ(or_axis.range(1.5f, nhood44i), expected_range);
-    expected_range = {4u, 11u};
+    expected_range = {4u, 12u};
     EXPECT_EQ(or_axis.range(5.5f, nhood55i), expected_range);
 
     // Axis range access - scalar (symmteric & asymmetric)
@@ -101,12 +101,12 @@ GTEST_TEST(detray_grid, open_regular_axis) {
     const darray<scalar, 2> nhood11s = {1.f, 1.f};
     const darray<scalar, 2> nhoodAlls = {10.f, 10.f};
 
-    expected_range = {6u, 6u};
+    expected_range = {6u, 7u};
     EXPECT_EQ(or_axis.range(2.5f, nhood00s), expected_range);
     EXPECT_EQ(or_axis.range(2.5f, nhood_tol), expected_range);
-    expected_range = {5u, 7u};
+    expected_range = {5u, 8u};
     EXPECT_EQ(or_axis.range(2.5f, nhood11s), expected_range);
-    expected_range = {0u, 11u};
+    expected_range = {0u, 12u};
     EXPECT_EQ(or_axis.range(2.5f, nhoodAlls), expected_range);
 }
 
@@ -149,19 +149,19 @@ GTEST_TEST(detray_grid, closed_regular_axis) {
     const darray<dindex, 2> nhood44i = {4u, 4u};
     const darray<dindex, 2> nhood55i = {5u, 5u};
 
-    dindex_range expected_range = {5u, 5u};
+    n_axis::bin_range expected_range = {5u, 6u};
     EXPECT_EQ(cr_axis.range(2.5f, nhood00i), expected_range);
-    expected_range = {5u, 6u};
+    expected_range = {5u, 7u};
     EXPECT_EQ(cr_axis.range(2.5f, nhood01i), expected_range);
-    expected_range = {4u, 6u};
+    expected_range = {4u, 7u};
     EXPECT_EQ(cr_axis.range(2.5f, nhood11i), expected_range);
-    expected_range = {1u, 9u};
+    expected_range = {1u, 10u};
     EXPECT_EQ(cr_axis.range(2.5f, nhood44i), expected_range);
-    expected_range = {0u, 9u};
+    expected_range = {0u, 10u};
     EXPECT_EQ(cr_axis.range(2.5f, nhood55i), expected_range);
-    expected_range = {0u, 8u};
+    expected_range = {0u, 9u};
     EXPECT_EQ(cr_axis.range(1.5f, nhood44i), expected_range);
-    expected_range = {3u, 9u};
+    expected_range = {3u, 10u};
     EXPECT_EQ(cr_axis.range(5.5f, nhood55i), expected_range);
 
     // Axis range access - scalar (symmteric & asymmetric)
@@ -170,12 +170,12 @@ GTEST_TEST(detray_grid, closed_regular_axis) {
     const darray<scalar, 2> nhood11s = {1.f, 1.f};
     const darray<scalar, 2> nhoodAlls = {10.f, 10.f};
 
-    expected_range = {5u, 5u};
+    expected_range = {5u, 6u};
     EXPECT_EQ(cr_axis.range(2.5f, nhood00s), expected_range);
     EXPECT_EQ(cr_axis.range(2.5f, nhood_tol), expected_range);
-    expected_range = {4u, 6u};
+    expected_range = {4u, 7u};
     EXPECT_EQ(cr_axis.range(2.5f, nhood11s), expected_range);
-    expected_range = {0u, 9u};
+    expected_range = {0u, 10u};
     EXPECT_EQ(cr_axis.range(2.5f, nhoodAlls), expected_range);
 }
 
@@ -224,17 +224,21 @@ GTEST_TEST(detray_grid, circular_regular_axis) {
     const darray<dindex, 2> nhood11i = {1u, 1u};
     const darray<dindex, 2> nhood22i = {2u, 2u};
 
-    dindex_range expected_range = {0u, 0u};
-    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood00i),
+    n_axis::bin_range expected_range = {0u, 1u};
+    EXPECT_EQ(circ_bounds.wrap(
+                  cr_axis.range(constant<scalar>::pi + tol, nhood00i), 36u),
               expected_range);
-    expected_range = {0u, 1u};
-    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood01i),
+    expected_range = {0u, 2u};
+    EXPECT_EQ(circ_bounds.wrap(
+                  cr_axis.range(constant<scalar>::pi + tol, nhood01i), 36u),
               expected_range);
-    expected_range = {35u, 1u};
-    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood11i),
+    expected_range = {35u, 2u};
+    EXPECT_EQ(circ_bounds.wrap(
+                  cr_axis.range(constant<scalar>::pi + tol, nhood11i), 36u),
               expected_range);
-    expected_range = {34u, 2u};
-    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood22i),
+    expected_range = {34u, 3u};
+    EXPECT_EQ(circ_bounds.wrap(
+                  cr_axis.range(constant<scalar>::pi + tol, nhood22i), 36u),
               expected_range);
 
     // Axis range access - scalar (symmetric & asymmteric)
@@ -243,13 +247,16 @@ GTEST_TEST(detray_grid, circular_regular_axis) {
     const scalar bin_step{cr_axis.bin_width()};
     const darray<scalar, 2> nhood22s = {2.f * bin_step, 2.f * bin_step};
 
-    expected_range = {0u, 0u};
-    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood00s),
+    expected_range = {0u, 1u};
+    EXPECT_EQ(circ_bounds.wrap(
+                  cr_axis.range(constant<scalar>::pi + tol, nhood00s), 36u),
               expected_range);
-    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood_tol),
+    EXPECT_EQ(circ_bounds.wrap(
+                  cr_axis.range(constant<scalar>::pi + tol, nhood_tol), 36u),
               expected_range);
-    expected_range = {34u, 2u};
-    EXPECT_EQ(cr_axis.range(constant<scalar>::pi + tol, nhood22s),
+    expected_range = {34u, 3u};
+    EXPECT_EQ(circ_bounds.wrap(
+                  cr_axis.range(constant<scalar>::pi + tol, nhood22s), 36u),
               expected_range);
 }
 
@@ -290,15 +297,15 @@ GTEST_TEST(detray_grid, closed_irregular_axis) {
     const darray<dindex, 2> nhood11i = {1u, 1u};
     const darray<dindex, 2> nhood22i = {2u, 2u};
 
-    dindex_range expected_range = {2u, 2u};
+    n_axis::bin_range expected_range = {2u, 3u};
     EXPECT_EQ(cir_axis.range(3.f, nhood00i), expected_range);
-    expected_range = {1u, 3u};
+    expected_range = {1u, 4u};
     EXPECT_EQ(cir_axis.range(3.f, nhood11i), expected_range);
-    expected_range = {2u, 3u};
+    expected_range = {2u, 4u};
     EXPECT_EQ(cir_axis.range(3.f, nhood01i), expected_range);
-    expected_range = {0u, 1u};
+    expected_range = {0u, 2u};
     EXPECT_EQ(cir_axis.range(0.f, nhood11i), expected_range);
-    expected_range = {2u, 5u};
+    expected_range = {2u, 6u};
     EXPECT_EQ(cir_axis.range(10.f, nhood22i), expected_range);
 
     // Axis range access - scalar
@@ -306,11 +313,11 @@ GTEST_TEST(detray_grid, closed_irregular_axis) {
     const darray<scalar, 2> nhood10s = {1.5f, 0.2f};
     const darray<scalar, 2> nhood11s = {4.f, 5.5f};
 
-    expected_range = {2u, 2u};
+    expected_range = {2u, 3u};
     EXPECT_EQ(cir_axis.range(3.f, nhood00s), expected_range);
-    expected_range = {1u, 2u};
+    expected_range = {1u, 3u};
     EXPECT_EQ(cir_axis.range(3.f, nhood10s), expected_range);
-    expected_range = {0u, 4u};
+    expected_range = {0u, 5u};
     EXPECT_EQ(cir_axis.range(3.f, nhood11s), expected_range);
 }
 
@@ -361,18 +368,18 @@ GTEST_TEST(detray_grid, multi_axis) {
     const darray<dindex, 2> nhood01i = {0u, 1u};
     const darray<dindex, 2> nhood22i = {2u, 2u};
 
-    dmulti_index<dindex_range, 3> expected_ranges{};
-    expected_ranges[0] = {11u, 11u};
-    expected_ranges[1] = {21u, 21};
-    expected_ranges[2] = {5u, 5u};
-    EXPECT_EQ(axes.bin_ranges(p3, nhood00i), expected_ranges);
+    n_axis::multi_bin_range<3> expected_ranges{};
     expected_ranges[0] = {11u, 12u};
     expected_ranges[1] = {21u, 22u};
     expected_ranges[2] = {5u, 6u};
+    EXPECT_EQ(axes.bin_ranges(p3, nhood00i), expected_ranges);
+    expected_ranges[0] = {11u, 13u};
+    expected_ranges[1] = {21u, 23u};
+    expected_ranges[2] = {5u, 7u};
     EXPECT_EQ(axes.bin_ranges(p3, nhood01i), expected_ranges);
-    expected_ranges[0] = {9u, 13u};
-    expected_ranges[1] = {19u, 23u};
-    expected_ranges[2] = {3u, 7u};
+    expected_ranges[0] = {9u, 14u};
+    expected_ranges[1] = {19u, 24u};
+    expected_ranges[2] = {3u, 8u};
     EXPECT_EQ(axes.bin_ranges(p3, nhood22i), expected_ranges);
 
     // Axis range access - scalar
@@ -380,17 +387,17 @@ GTEST_TEST(detray_grid, multi_axis) {
     const darray<scalar, 2> nhood10s = {1.5f, 0.2f};
     const darray<scalar, 2> nhood11s = {4.f, 5.5f};
 
-    expected_ranges[0] = {11u, 11u};
-    expected_ranges[1] = {21u, 21u};
-    expected_ranges[2] = {5u, 5u};
+    expected_ranges[0] = {11u, 12u};
+    expected_ranges[1] = {21u, 22u};
+    expected_ranges[2] = {5u, 6u};
     EXPECT_EQ(axes.bin_ranges(p3, nhood00s), expected_ranges);
-    expected_ranges[0] = {9u, 11u};
-    expected_ranges[1] = {19u, 21u};
-    expected_ranges[2] = {4u, 5u};
+    expected_ranges[0] = {9u, 12u};
+    expected_ranges[1] = {19u, 22u};
+    expected_ranges[2] = {4u, 6u};
     EXPECT_EQ(axes.bin_ranges(p3, nhood10s), expected_ranges);
-    expected_ranges[0] = {7u, 16u};
-    expected_ranges[1] = {17u, 26u};
-    expected_ranges[2] = {3u, 7u};
+    expected_ranges[0] = {7u, 17u};
+    expected_ranges[1] = {17u, 27u};
+    expected_ranges[2] = {3u, 8u};
     EXPECT_EQ(axes.bin_ranges(p3, nhood11s), expected_ranges);
 
     // Owning multi axis test

--- a/tests/unit_tests/cpu/grid_grid_collection.cpp
+++ b/tests/unit_tests/cpu/grid_grid_collection.cpp
@@ -122,8 +122,8 @@ GTEST_TEST(detray_grid, grid_collection) {
     auto flat_bin_view = single_grid.all();
     EXPECT_EQ(seq.size(), 24u);
     EXPECT_EQ(flat_bin_view.size(), 24u);
-    EXPECT_TRUE(std::equal(flat_bin_view.begin(), flat_bin_view.end(),
-                           seq.begin(), seq.end()));
+    EXPECT_TRUE(
+        std::equal(flat_bin_view.begin(), flat_bin_view.end(), seq.begin()));
 
     auto grid_coll_view = get_data(grid_coll);
     static_assert(std::is_same_v<decltype(grid_coll_view),

--- a/tests/unit_tests/cpu/grid_serializer.cpp
+++ b/tests/unit_tests/cpu/grid_serializer.cpp
@@ -53,23 +53,23 @@ GTEST_TEST(detray_grid, serializer2D) {
     simple_serializer<2> serializer{};
 
     // Serializing
-    multi_bin<2> mbin{{0u, 0u}};
+    multi_bin<2> mbin{0u, 0u};
     EXPECT_EQ(serializer(axes, mbin), 0u);
-    mbin = {{5u, 0u}};
+    mbin = {5u, 0u};
     EXPECT_EQ(serializer(axes, mbin), 5u);
-    mbin = {{0u, 1u}};
+    mbin = {0u, 1u};
     EXPECT_EQ(serializer(axes, mbin), 6u);
-    mbin = {{5u, 2u}};
+    mbin = {5u, 2u};
     EXPECT_EQ(serializer(axes, mbin), 17u);
 
     // Deserialize
-    multi_bin<2> expected_mbin{{0u, 0u}};
+    multi_bin<2> expected_mbin{0u, 0u};
     EXPECT_EQ(serializer(axes, 0u), expected_mbin);
-    expected_mbin = {{5u, 0u}};
+    expected_mbin = {5u, 0u};
     EXPECT_EQ(serializer(axes, 5u), expected_mbin);
-    expected_mbin = {{0u, 1u}};
+    expected_mbin = {0u, 1u};
     EXPECT_EQ(serializer(axes, 6u), expected_mbin);
-    expected_mbin = {{5u, 2u}};
+    expected_mbin = {5u, 2u};
     EXPECT_EQ(serializer(axes, 17u), expected_mbin);
 }
 
@@ -85,22 +85,22 @@ GTEST_TEST(detray_grid, serializer3D) {
     simple_serializer<3> serializer{};
 
     // Serializing
-    multi_bin<3> mbin{{0u, 0u, 0u}};
+    multi_bin<3> mbin{0u, 0u, 0u};
     EXPECT_EQ(serializer(axes, mbin), 0u);
-    mbin = {{2u, 1u, 0u}};
+    mbin = {2u, 1u, 0u};
     EXPECT_EQ(serializer(axes, mbin), 6u);
-    mbin = {{3u, 0u, 1u}};
+    mbin = {3u, 0u, 1u};
     EXPECT_EQ(serializer(axes, mbin), 11u);
-    mbin = {{1u, 1u, 1u}};
+    mbin = {1u, 1u, 1u};
     EXPECT_EQ(serializer(axes, mbin), 13u);
 
     // Deserialize
-    multi_bin<3> expected_mbin{{0u, 0u, 0u}};
+    multi_bin<3> expected_mbin{0u, 0u, 0u};
     EXPECT_EQ(serializer(axes, 0u), expected_mbin);
-    expected_mbin = {{2u, 1u, 0u}};
+    expected_mbin = {2u, 1u, 0u};
     EXPECT_EQ(serializer(axes, 6u), expected_mbin);
-    expected_mbin = {{3u, 0u, 1u}};
+    expected_mbin = {3u, 0u, 1u};
     EXPECT_EQ(serializer(axes, 11u), expected_mbin);
-    expected_mbin = {{1u, 1u, 1u}};
+    expected_mbin = {1u, 1u, 1u};
     EXPECT_EQ(serializer(axes, 13u), expected_mbin);
 }

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.cu
@@ -89,6 +89,39 @@ void test_iota(const darray<dindex, 2> range,
 }
 
 //
+// cartesian product
+//
+__global__ void cartesian_product_kernel(
+    const darray<dindex, 2> range1, const darray<dindex, 2> range2,
+    const darray<dindex, 2> range3,
+    vecmem::data::vector_view<std::tuple<dindex, dindex, dindex>> check_data) {
+
+    vecmem::device_vector<std::tuple<dindex, dindex, dindex>> check(check_data);
+
+    auto seq1 = detray::views::iota(range1);
+    auto seq2 = detray::views::iota(range2);
+    auto seq3 = detray::views::iota(range3);
+
+    for (const auto [i, j, k] : detray::views::cartesian_product(
+             std::move(seq1), std::move(seq2), std::move(seq3))) {
+        check.emplace_back(i, j, k);
+    }
+}
+
+void test_cartesian_product(
+    const darray<dindex, 2> range1, const darray<dindex, 2> range2,
+    const darray<dindex, 2> range3,
+    vecmem::data::vector_view<std::tuple<dindex, dindex, dindex>> check_data) {
+
+    // run the kernel
+    cartesian_product_kernel<<<1, 1>>>(range1, range2, range3, check_data);
+
+    // cuda error check
+    DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());
+    DETRAY_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+}
+
+//
 // enumerate
 //
 __global__ void enumerate_kernel(

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda_kernel.hpp
@@ -34,6 +34,12 @@ void test_pointer(const dindex value, dindex& check);
 void test_iota(const darray<dindex, 2> range,
                vecmem::data::vector_view<dindex> check_data);
 
+/// Test @c detray::views::cartesian_product
+void test_cartesian_product(
+    const darray<dindex, 2> range1, const darray<dindex, 2> range2,
+    const darray<dindex, 2> range3,
+    vecmem::data::vector_view<std::tuple<dindex, dindex, dindex>> check_data);
+
 /// Test @c detray::views::enumerate
 void test_enumerate(vecmem::data::vector_view<uint_holder> seq_data,
                     vecmem::data::vector_view<dindex> check_idx_data,

--- a/tests/validation/src/detector_display.cpp
+++ b/tests/validation/src/detector_display.cpp
@@ -113,7 +113,7 @@ int main(int argc, char** argv) {
         }
     } else {
         // default
-        window = {2u, 2u};
+        window = {1u, 1u};
     }
 
     // Read the detector geometry


### PR DESCRIPTION
Implement the neighborhood lookup on the grids using in-place iteration (no memory allocations for a result vector):
- lookup of the index ranges on the axes that correspond to the search position plus a search window around it
- generate an index sequence for every local bin axis range
- in order to index every bin in the search area, calculate the cartesian product of all of the index sequences
- map the cartesian product to global bin indices
- fetch the bin, which is itself a range
- join all of the bin ranges into a single iteration

Except for the first and the last step, everything else is handled by the new ```bin_view``` class, which can also be used in other contexts than local navigation to iterate through the bins in a neighborhood of a grid.

For the phi axes, which have periodic boundary conditions for their bin indices, the wrapping has been separated from the mapping of the search window on the axis range, so that the generation of the index sequence is well defined. The resulting bin index sequence is mapped onto the periodic boundary conditions in a dedicated step during the bin view iteration.