### PR TITLE
fix: for ITk reading and drawing

### DIFF
--- a/core/include/detray/core/detector_metadata.hpp
+++ b/core/include/detray/core/detector_metadata.hpp
@@ -101,7 +101,7 @@ struct default_metadata {
     template <typename grid_shape_t, typename bin_entry_t, typename container_t>
     using surface_grid_t =
         grid<coordinate_axes<grid_shape_t, false, container_t>, bin_entry_t,
-             simple_serializer, regular_attacher<9>>;
+             simple_serializer, regular_attacher<100>>;
 
     // 2D cylindrical grid for the barrel layers
     template <typename bin_entry_t, typename container_t>

--- a/core/include/detray/intersection/intersection.hpp
+++ b/core/include/detray/intersection/intersection.hpp
@@ -92,7 +92,7 @@ struct intersection2D {
     DETRAY_HOST_DEVICE
     bool operator==(const intersection2D &rhs) const {
         return std::abs(path - rhs.path) <
-               std::numeric_limits<scalar_type>::epsilon();
+               std::numeric_limits<float>::epsilon();
     }
 
     /// Transform to a string for output debugging

--- a/core/include/detray/masks/annulus2D.hpp
+++ b/core/include/detray/masks/annulus2D.hpp
@@ -302,8 +302,8 @@ class annulus2D {
         scalar_t max_r = bounds[e_max_r];
         scalar_t min_phi = bounds[e_average_phi] + bounds[e_min_phi_rel];
         scalar_t max_phi = bounds[e_average_phi] + bounds[e_max_phi_rel];
-        scalar_t origin_x = -bounds[e_shift_x];
-        scalar_t origin_y = -bounds[e_shift_y];
+        scalar_t origin_x = bounds[e_shift_x];
+        scalar_t origin_y = bounds[e_shift_y];
 
         point2_t origin_m = {origin_x, origin_y};
 

--- a/core/include/detray/tools/volume_builder_interface.hpp
+++ b/core/include/detray/tools/volume_builder_interface.hpp
@@ -40,6 +40,14 @@ class volume_builder_interface {
     DETRAY_HOST
     virtual auto vol_index() -> dindex = 0;
 
+    /// Toggles whether sensitive surfaces are added to the brute force method
+    DETRAY_HOST
+    virtual void has_accel(bool toggle) = 0;
+
+    /// @returns whether sensitive surfaces are added to the brute force method
+    DETRAY_HOST
+    virtual bool has_accel() const = 0;
+
     /// @returns reading access to the volume
     DETRAY_HOST
     virtual auto operator()() const -> const
@@ -118,6 +126,12 @@ class volume_decorator : public volume_builder_interface<detector_t> {
 
     DETRAY_HOST
     auto vol_index() -> dindex override { return m_builder->vol_index(); }
+
+    DETRAY_HOST
+    void has_accel(bool toggle) override { m_builder->has_accel(toggle); };
+
+    DETRAY_HOST
+    bool has_accel() const override { return m_builder->has_accel(); }
 
     DETRAY_HOST
     auto build(detector_t &det,

--- a/io/include/detray/io/common/detector_reader.hpp
+++ b/io/include/detray/io/common/detector_reader.hpp
@@ -132,7 +132,7 @@ namespace io {
 /// @param cfg the detector reader configuration
 ///
 /// @returns a complete detector object + a map that contains the volume names
-template <class detector_t, std::size_t CAP = 9u, std::size_t DIM = 2u,
+template <class detector_t, std::size_t CAP = 100u, std::size_t DIM = 2u,
           template <typename> class volume_builder_t = volume_builder>
 auto read_detector(vecmem::memory_resource& resc,
                    const detector_reader_config& cfg) noexcept(false) {

--- a/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
@@ -280,8 +280,8 @@ class illustrator {
                                                _style._eta_lines_style);
 
                 // Hardcoded until we find a way to scale axes automatically
-                p_eta_lines._r = 200.f;
-                p_eta_lines._z = 2000.f;
+                p_eta_lines._r = 1100.f;
+                p_eta_lines._z = 3100.f;
 
                 det_svg.add_object(svgtools::meta::display::eta_lines(
                     "eta_lines_", p_eta_lines));

--- a/tests/unit_tests/cpu/grid_grid_builder.cpp
+++ b/tests/unit_tests/cpu/grid_grid_builder.cpp
@@ -177,8 +177,8 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
         static_cast<typename detector_t::surface_type::navigation_link>(
             d.volumes().size())};
 
-    auto vbuilder =
-        std::make_unique<volume_builder<detector_t>>(volume_id::e_cylinder);
+    auto vbuilder = std::make_unique<volume_builder<detector_t>>(
+        volume_id::e_cylinder, vol_idx);
     auto gbuilder = grid_builder<detector_t, cyl_grid_t>{std::move(vbuilder)};
     // passive surfaces are added to the grid
     // gbuilder.set_add_surfaces();

--- a/tests/validation/include/detray/validation/detail/svg_display.hpp
+++ b/tests/validation/include/detray/validation/detail/svg_display.hpp
@@ -104,10 +104,10 @@ inline void svg_display(
     actsvg::style::stroke stroke_black = actsvg::style::stroke();
 
     // x-y axis.
-    auto xy_axis = actsvg::draw::x_y_axes("axes", {-250, 250}, {-250, 250},
+    auto xy_axis = actsvg::draw::x_y_axes("axes", {-1100, 1100}, {-1100, 1100},
                                           stroke_black, "x", "y");
     // z-r axis.
-    auto zr_axis = actsvg::draw::x_y_axes("axes", {-1500, 1500}, {-5, 250},
+    auto zr_axis = actsvg::draw::x_y_axes("axes", {-3100, 3100}, {-5, 1100},
                                           stroke_black, "z", "r");
     // Creating the views.
     const actsvg::views::x_y xy;

--- a/tests/validation/src/detector_display.cpp
+++ b/tests/validation/src/detector_display.cpp
@@ -134,10 +134,10 @@ int main(int argc, char** argv) {
     actsvg::style::stroke stroke_black = actsvg::style::stroke();
 
     // x-y axis.
-    auto xy_axis = actsvg::draw::x_y_axes("axes", {-250, 250}, {-250, 250},
+    auto xy_axis = actsvg::draw::x_y_axes("axes", {-1100, 1100}, {-1100, 1100},
                                           stroke_black, "x", "y");
     // z-r axis.
-    auto zr_axis = actsvg::draw::x_y_axes("axes", {-2000, 2000}, {-5, 250},
+    auto zr_axis = actsvg::draw::x_y_axes("axes", {-3100, 3100}, {-5, 1100},
                                           stroke_black, "z", "r");
 
     // Creating the views.


### PR DESCRIPTION
Increase the grid bin capacity to fit all candidates and fix vertex generation sign bug. Additionally, it restructures the grid building a little, so that the contract with the volume builder is that a boolean needs to be set when a builder for an acceleration structure is present. This allows for better reasoning on how and when to fill the brute force navigation method with surfaces