### PR TITLE
Add a volume material

### DIFF
--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -112,7 +112,7 @@ class detector {
 
     /// Volume type
     using geo_obj_ids = typename metadata::geo_objects;
-    using volume_type = volume_descriptor<geo_obj_ids, accel_link>;
+    using volume_type = volume_descriptor<geo_obj_ids, scalar_type, accel_link>;
     using volume_container = vector_type<volume_type>;
 
     /// Volume finder definition: Make volume index available from track

--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -13,6 +13,7 @@
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/geometry/detail/volume_kernels.hpp"
+#include "detray/materials/material.hpp"
 
 // System include(s)
 #include <iostream>
@@ -36,6 +37,9 @@ namespace detray {
 /// @TODO: Add access to the volume placement transform and volume center
 template <typename detector_t>  // @TODO: This needs a concept
 class detector_volume {
+
+    /// Scalar type
+    using scalar_type = typename detector_t::scalar_type;
 
     /// Volume descriptor type
     using descr_t = typename detector_t::volume_type;
@@ -94,6 +98,12 @@ class detector_volume {
     DETRAY_HOST_DEVICE
     constexpr auto center() const -> typename detector_t::point3 {
         return transform().translation();
+    }
+
+    /// @returns the material of the volume
+    DETRAY_HOST_DEVICE
+    constexpr auto material() const -> material<scalar_type> {
+        return m_desc.material();
     }
 
     /// Apply a functor to all surfaces in the volume.

--- a/core/include/detray/materials/interaction.hpp
+++ b/core/include/detray/materials/interaction.hpp
@@ -23,14 +23,14 @@ struct interaction {
     using relativistic_quantities =
         detail::relativistic_quantities<scalar_type>;
 
-    template <typename material_t>
     DETRAY_HOST_DEVICE scalar_type compute_energy_loss_bethe(
-        const scalar_type path_segment, const material_t& mat,
-        const int /*pdg*/, const scalar_type m, const scalar_type qOverP,
+        const scalar_type path_segment,
+        const detray::material<scalar_type>& mat, const int /*pdg*/,
+        const scalar_type m, const scalar_type qOverP,
         const scalar_type q) const {
 
-        const scalar_t I{mat.get_material().mean_excitation_energy()};
-        const scalar_t Ne{mat.get_material().molar_electron_density()};
+        const scalar_t I{mat.mean_excitation_energy()};
+        const scalar_t Ne{mat.molar_electron_density()};
         const relativistic_quantities rq(m, qOverP, q);
         const scalar_t eps{rq.compute_epsilon(Ne, path_segment)};
 
@@ -38,7 +38,7 @@ struct interaction {
             return 0.f;
         }
 
-        const scalar_t dhalf{rq.compute_delta_half(mat.get_material())};
+        const scalar_t dhalf{rq.compute_delta_half(mat)};
         const scalar_t u{rq.compute_mass_term(constant<scalar_t>::m_e)};
         const scalar_t wmax{rq.compute_WMax(m)};
         // uses RPP2018 eq. 33.5 scaled from mass stopping power to linear
@@ -51,14 +51,13 @@ struct interaction {
         return eps * running;
     }
 
-    template <typename material_t>
     DETRAY_HOST_DEVICE scalar_type compute_energy_loss_landau(
-        const scalar_type path_segment, const material_t& mat,
+        const scalar_type path_segment, const material<scalar_type>& mat,
         const int /*pdg*/, const scalar_type m, const scalar_type qOverP,
         const scalar_type q) const {
 
-        const scalar_t I{mat.get_material().mean_excitation_energy()};
-        const scalar_t Ne{mat.get_material().molar_electron_density()};
+        const scalar_t I{mat.mean_excitation_energy()};
+        const scalar_t Ne{mat.molar_electron_density()};
         const relativistic_quantities rq(m, qOverP, q);
         const scalar_t eps{rq.compute_epsilon(Ne, path_segment)};
 
@@ -66,7 +65,7 @@ struct interaction {
             return 0.f;
         }
 
-        const scalar_t dhalf{rq.compute_delta_half(mat.get_material())};
+        const scalar_t dhalf{rq.compute_delta_half(mat)};
         const scalar_t t{rq.compute_mass_term(constant<scalar_t>::m_e)};
         // uses RPP2018 eq. 33.11
         const scalar_t running{math_ns::log(t / I) + math_ns::log(eps / I) +
@@ -74,22 +73,20 @@ struct interaction {
         return eps * running;
     }
 
-    template <typename material_t>
     DETRAY_HOST_DEVICE scalar_type compute_energy_loss_landau_fwhm(
-        const scalar_type path_segment, const material_t& mat,
+        const scalar_type path_segment, const material<scalar_type>& mat,
         const int /*pdg*/, const scalar_type m, const scalar_type qOverP,
         const scalar_type q) const {
-        const auto Ne = mat.get_material().molar_electron_density();
+        const auto Ne = mat.molar_electron_density();
         const relativistic_quantities rq(m, qOverP, q);
 
         // the Landau-Vavilov fwhm is 4*eps (see RPP2018 fig. 33.7)
         return 4.f * rq.compute_epsilon(Ne, path_segment);
     }
 
-    template <typename material_t>
     DETRAY_HOST_DEVICE scalar_type compute_energy_loss_landau_sigma(
-        const scalar_type path_segment, const material_t& mat, const int pdg,
-        const scalar_type m, const scalar_type qOverP,
+        const scalar_type path_segment, const material<scalar_type>& mat,
+        const int pdg, const scalar_type m, const scalar_type qOverP,
         const scalar_type q) const {
 
         const scalar_t fwhm{compute_energy_loss_landau_fwhm(path_segment, mat,

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -88,14 +88,16 @@ struct pointwise_material_interactor : actor {
             // Energy Loss
             if (s.do_energy_loss) {
                 s.e_loss = interaction_type().compute_energy_loss_bethe(
-                    path_segment, mat, s.pdg, s.mass, qop, charge);
+                    path_segment, mat.get_material(), s.pdg, s.mass, qop,
+                    charge);
             }
 
             // @todo: include the radiative loss (Bremsstrahlung)
             if (s.do_energy_loss && s.do_covariance_transport) {
                 s.sigma_qop =
                     interaction_type().compute_energy_loss_landau_sigma_QOverP(
-                        path_segment, mat, s.pdg, s.mass, qop, charge);
+                        path_segment, mat.get_material(), s.pdg, s.mass, qop,
+                        charge);
             }
 
             // Covariance update

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -128,9 +128,10 @@ class base_stepper {
         /// Current step size
         scalar _step_size{0.};
 
-        /// TODO: Use options?
-        /// hypothetical mass of particle (assume pion by default)
-        /// scalar _mass = 139.57018 * unit<scalar_type>::MeV;
+        /// The particle mass
+        scalar_type _mass{105.7f * unit<scalar_type>::MeV};
+        /// The particle pdg
+        int _pdg = 13;  // default muon
 
         /// Set new step constraint
         template <step::constraint type = step::constraint::e_actor>

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -82,11 +82,7 @@ class rk_stepper final
             vector3 k2{0.f, 0.f, 0.f};
             vector3 k3{0.f, 0.f, 0.f};
             vector3 k4{0.f, 0.f, 0.f};
-            scalar k_qop1{0.f};
-            scalar k_qop2{0.f};
-            scalar k_qop3{0.f};
             scalar k_qop4{0.f};
-            // array_t<scalar, 4> k_qop{0.f, 0.f, 0.f, 0.f};
         } _step_data;
 
         /// Magnetic field view

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -10,6 +10,9 @@
 // Project include(s).
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/materials/interaction.hpp"
+#include "detray/materials/material.hpp"
+#include "detray/materials/predefined_materials.hpp"
 #include "detray/propagator/base_stepper.hpp"
 #include "detray/propagator/navigation_policies.hpp"
 #include "detray/tracks/tracks.hpp"
@@ -79,11 +82,22 @@ class rk_stepper final
             vector3 k2{0.f, 0.f, 0.f};
             vector3 k3{0.f, 0.f, 0.f};
             vector3 k4{0.f, 0.f, 0.f};
-            array_t<scalar, 4> k_qop{0.f, 0.f, 0.f, 0.f};
+            scalar k_qop1{0.f};
+            scalar k_qop2{0.f};
+            scalar k_qop3{0.f};
+            scalar k_qop4{0.f};
+            // array_t<scalar, 4> k_qop{0.f, 0.f, 0.f, 0.f};
         } _step_data;
 
         /// Magnetic field view
         const magnetic_field_t _magnetic_field;
+
+        /// Material that track is passing through. Usually a volume material
+        detray::material<scalar> _mat = detray::vacuum<scalar>();
+
+        /// Use mean energy loss (Bethe)
+        /// if false, most probable energy loss (Landau) will be used
+        bool _use_mean_loss = true;
 
         /// Set the local error tolerenace
         DETRAY_HOST_DEVICE
@@ -97,10 +111,15 @@ class rk_stepper final
         DETRAY_HOST_DEVICE
         inline void advance_jacobian();
 
+        /// evaulate qop for a given step size and material
+        DETRAY_HOST_DEVICE
+        inline scalar evaluate_qop(const scalar h);
+
         /// evaulate k_n for runge kutta stepping
         DETRAY_HOST_DEVICE
         inline vector3 evaluate_k(const vector3& b_field, const int i,
-                                  const scalar h, const vector3& k_prev);
+                                  const scalar h, const vector3& k_prev,
+                                  const scalar k_qop);
 
         DETRAY_HOST_DEVICE
         inline vector3 dtds() const { return this->_step_data.k4; }

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -226,9 +226,8 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
     sd.b_first[1] = bvec[1];
     sd.b_first[2] = bvec[2];
 
-    sd.k_qop1 = stepping().qop();
     sd.k1 = stepping.evaluate_k(sd.b_first, 0, 0.f, vector3{0.f, 0.f, 0.f},
-                                sd.k_qop1);
+                                stepping().qop());
 
     const auto try_rk4 = [&](const scalar& h) -> bool {
         // State the square and half of the step size
@@ -242,12 +241,11 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
         sd.b_middle[1] = bvec1[1];
         sd.b_middle[2] = bvec1[2];
 
-        sd.k_qop2 = stepping.evaluate_qop(half_h);
-        sd.k2 = stepping.evaluate_k(sd.b_middle, 1, half_h, sd.k1, sd.k_qop2);
+        const scalar k_qop2 = stepping.evaluate_qop(half_h);
+        sd.k2 = stepping.evaluate_k(sd.b_middle, 1, half_h, sd.k1, k_qop2);
 
         // Third Runge-Kutta point
-        sd.k_qop3 = sd.k_qop2;
-        sd.k3 = stepping.evaluate_k(sd.b_middle, 2, half_h, sd.k2, sd.k_qop3);
+        sd.k3 = stepping.evaluate_k(sd.b_middle, 2, half_h, sd.k2, k_qop2);
 
         // Last Runge-Kutta point
         const vector3 pos2 = pos + h * dir + h2 * 0.5f * sd.k3;

--- a/tests/unit_tests/cpu/energy_loss.cpp
+++ b/tests/unit_tests/cpu/energy_loss.cpp
@@ -57,7 +57,8 @@ TEST_P(EnergyLossBetheValidation, bethe_energy_loss) {
 
     // Bethe Stopping power in MeV * cm^2 / g
     const scalar dEdx{
-        I.compute_energy_loss_bethe(path_segment, slab, pdg, m, qOverP, -1.f) /
+        I.compute_energy_loss_bethe(path_segment, slab.get_material(), pdg, m,
+                                    qOverP, -1.f) /
         path_segment / slab.get_material().mass_density() /
         (unit<scalar>::MeV * unit<scalar>::cm2 / unit<scalar>::g)};
 
@@ -195,16 +196,18 @@ TEST_P(EnergyLossLandauValidation, landau_energy_loss) {
     const scalar qOverP{q / p};
 
     // Landau Energy loss in MeV
-    const scalar Landau_MeV{
-        I.compute_energy_loss_landau(path_segment, slab, pdg, m, qOverP, q) /
-        unit<scalar>::MeV};
+    const scalar Landau_MeV{I.compute_energy_loss_landau(path_segment,
+                                                         slab.get_material(),
+                                                         pdg, m, qOverP, q) /
+                            unit<scalar>::MeV};
 
     // Check if difference is within 5% error
     EXPECT_TRUE(std::abs(std::get<2>(GetParam()) - Landau_MeV) / Landau_MeV <
                 0.05f);
 
     // Landau Energy loss Fluctuation
-    const scalar fwhm_MeV{I.compute_energy_loss_landau_fwhm(path_segment, slab,
+    const scalar fwhm_MeV{I.compute_energy_loss_landau_fwhm(path_segment,
+                                                            slab.get_material(),
                                                             pdg, m, qOverP, q) /
                           unit<scalar>::MeV};
 
@@ -266,16 +269,16 @@ TEST_P(LandauDistributionValidation, landau_distribution) {
     const scalar qOverP{q / p};
 
     // Bethe energy loss
-    const scalar dE{
-        I.compute_energy_loss_bethe(path_segment, slab, pdg, m, qOverP, q)};
+    const scalar dE{I.compute_energy_loss_bethe(
+        path_segment, slab.get_material(), pdg, m, qOverP, q)};
 
     // Landau Energy loss
-    const scalar mpv{
-        I.compute_energy_loss_landau(path_segment, slab, pdg, m, qOverP, q)};
+    const scalar mpv{I.compute_energy_loss_landau(
+        path_segment, slab.get_material(), pdg, m, qOverP, q)};
 
     // Landau Energy loss Sigma
-    const scalar sigma{I.compute_energy_loss_landau_sigma(path_segment, slab,
-                                                          pdg, m, qOverP, q)};
+    const scalar sigma{I.compute_energy_loss_landau_sigma(
+        path_segment, slab.get_material(), pdg, m, qOverP, q)};
 
     // Landau Sampling
     landau_distribution<scalar> landau;

--- a/tests/unit_tests/cpu/geometry_volume.cpp
+++ b/tests/unit_tests/cpu/geometry_volume.cpp
@@ -37,7 +37,7 @@ GTEST_TEST(detray_geometry, detector_volume) {
     using namespace detray;
 
     using accel_link_t = dtyped_index<accel_ids, dindex>;
-    using volume_t = volume_descriptor<geo_objects, accel_link_t>;
+    using volume_t = volume_descriptor<geo_objects, scalar, accel_link_t>;
 
     // Check construction, setters and getters
     volume_t v1(volume_id::e_cylinder);

--- a/tests/unit_tests/cpu/tools_stepper.cpp
+++ b/tests/unit_tests/cpu/tools_stepper.cpp
@@ -38,12 +38,28 @@ namespace {
 
 constexpr scalar tol{1e-3f};
 
+struct dummy_descriptor {
+    inline auto material() -> detray::material<scalar> {
+        return vacuum<scalar>();
+    }
+};
+
+struct dummy_detector {
+
+    inline auto volume_by_index(const int /*idx*/) {
+        return dummy_descriptor();
+    }
+};
+
 // dummy navigation struct
 struct nav_state {
     scalar operator()() const { return _step_size; }
     inline auto current_object() const -> dindex { return dindex_invalid; }
     inline auto tolerance() const -> scalar { return tol; }
-
+    inline auto detector() const -> dummy_detector * {
+        return new dummy_detector();
+    }
+    inline auto volume() -> int { return 0; }
     inline void set_full_trust() {}
     inline void set_high_trust() {}
     inline void set_fair_trust() {}

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -63,6 +63,8 @@ struct tel_det_config {
     std::vector<scalar> m_positions{};
     /// Material for the test surfaces
     material<scalar> m_material = silicon_tml<scalar>();
+    /// Material for volume
+    material<scalar> m_volume_material = vacuum<scalar>();
     /// Thickness of the material
     scalar m_thickness{80.f * unit<scalar>::um};
     /// Pilot track along which to place the surfaces
@@ -99,6 +101,10 @@ struct tel_det_config {
         m_material = mat;
         return *this;
     }
+    constexpr tel_det_config &volume_material(const material<scalar> &mat) {
+        m_volume_material = mat;
+        return *this;
+    }
     constexpr tel_det_config &mat_thickness(const scalar t) {
         assert(t > 0.f && "Material thickness must be greater than zero");
         m_thickness = t;
@@ -127,6 +133,9 @@ struct tel_det_config {
     const std::vector<scalar> &positions() const { return m_positions; }
     constexpr const material<scalar> &module_material() const {
         return m_material;
+    }
+    constexpr const material<scalar> &volume_material() const {
+        return m_volume_material;
     }
     constexpr scalar mat_thickness() const { return m_thickness; }
     const trajectory_t &pilot_track() const { return m_trajectory; }
@@ -222,6 +231,9 @@ inline auto create_telescope_detector(
 
     // Build and return the detector
     auto det = det_builder.build(resource);
+
+    // Set the volume material
+    det.volumes()[0u].set_material(cfg.volume_material());
 
     if (cfg.do_check()) {
         detray::detail::check_consistency(det);

--- a/utils/include/detray/simulation/random_scatterer.hpp
+++ b/utils/include/detray/simulation/random_scatterer.hpp
@@ -95,11 +95,13 @@ struct random_scatterer : actor {
             // Energy Loss
             if (s.do_energy_loss) {
                 s.e_loss_mpv = interaction_type().compute_energy_loss_landau(
-                    path_segment, mat, s.pdg, s.mass, qop, charge);
+                    path_segment, mat.get_material(), s.pdg, s.mass, qop,
+                    charge);
 
                 s.e_loss_sigma =
                     interaction_type().compute_energy_loss_landau_sigma(
-                        path_segment, mat, s.pdg, s.mass, qop, charge);
+                        path_segment, mat.get_material(), s.pdg, s.mass, qop,
+                        charge);
             }
 
             // Scattering angle


### PR DESCRIPTION
This PR adds a volume material in the volume descriptor and integrate it with Runge Kutta stepper for continuous energy loss.
I am not sure if we really need to link it to the material store because we might not need any grid structure in a volume. At least I don't see any use cases.
Futhermore, it is just a raw material, neither rod nor slab so doesn't go well material store.

Anyway this doesn't perturb any existing codes nor degrading performance as the default volume material is vacuum.
