### PR TITLE
Use field gradients in covariance transport

### DIFF
--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -46,6 +46,10 @@ class rk_stepper final
     using bound_track_parameters_type =
         typename base_type::bound_track_parameters_type;
     using magnetic_field_type = magnetic_field_t;
+    using size_type = typename matrix_operator::size_ty;
+    template <size_type ROWS, size_type COLS>
+    using matrix_type =
+        typename matrix_operator::template matrix_type<ROWS, COLS>;
 
     DETRAY_HOST_DEVICE
     rk_stepper() {}
@@ -82,6 +86,8 @@ class rk_stepper final
             vector3 k2{0.f, 0.f, 0.f};
             vector3 k3{0.f, 0.f, 0.f};
             vector3 k4{0.f, 0.f, 0.f};
+            // @NOTE: k_qop2 = k_qop3
+            scalar k_qop2{0.f};
             scalar k_qop4{0.f};
         } _step_data;
 
@@ -94,6 +100,9 @@ class rk_stepper final
         /// Use mean energy loss (Bethe)
         /// if false, most probable energy loss (Landau) will be used
         bool _use_mean_loss = true;
+
+        /// Use b field gradient in error propagation
+        bool _use_field_gradient = false;
 
         /// Set the local error tolerenace
         DETRAY_HOST_DEVICE
@@ -116,6 +125,9 @@ class rk_stepper final
         inline vector3 evaluate_k(const vector3& b_field, const int i,
                                   const scalar h, const vector3& k_prev,
                                   const scalar k_qop);
+
+        DETRAY_HOST_DEVICE
+        inline matrix_type<3, 3> evaluate_field_gradient(const vector3& pos);
 
         DETRAY_HOST_DEVICE
         inline vector3 dtds() const { return this->_step_data.k4; }

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -140,9 +140,9 @@ void detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
         auto dGdR = matrix_operator().template identity<3, 3>();
 
         const vector3 pos1 = track.pos();
-        const vector3 pos2 = pos1 + half_h * dir2;
-        const vector3 pos3 = pos1 + half_h * dir3;
-        const vector3 pos4 = pos1 + h * dir4;
+        const vector3 pos2 = pos1 + half_h * dir1;
+        const vector3 pos3 = pos1 + half_h * dir2;
+        const vector3 pos4 = pos1 + h * dir3;
 
         const matrix_type<3, 3> field_gradient1 = evaluate_field_gradient(pos1);
         const matrix_type<3, 3> field_gradient2 = evaluate_field_gradient(pos2);
@@ -257,7 +257,7 @@ auto detray::rk_stepper<
 
     matrix_type<3, 3> dBdr = matrix_operator().template zero<3, 3>();
 
-    const scalar h = 0.001f;
+    const scalar h = 1e-4f;
 
     for (unsigned int i = 0; i < 3; i++) {
 

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -152,7 +152,7 @@ void detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
         // dk{n}dR = d(qop_n * t_n X B_n)/dR
         //         = qop_n * [ d(t_n)/dR (X) B_n - d(B_n)/dR (X) t_n ]
         matrix_type<3, 3> dk1dR =
-            qop1 * mat_helper().column_wise_cross(field_gradient1, dir1);
+            -1.f * qop1 * mat_helper().column_wise_cross(field_gradient1, dir1);
         matrix_type<3, 3> dk2dR = qop2 * half_h * dk1dR;
         dk2dR = mat_helper().column_wise_cross(dk2dR, sd.b_middle) -
                 qop2 * mat_helper().column_wise_cross(field_gradient2, dir2);

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -250,9 +250,9 @@ auto detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
 template <typename magnetic_field_t, typename transform3_t,
           typename constraint_t, typename policy_t, typename inspector_t,
           template <typename, std::size_t> class array_t>
-auto detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
-                        array_t>::state::evaluate_field_gradient(const vector3&
-                                                                     pos)
+auto detray::rk_stepper<
+    magnetic_field_t, transform3_t, constraint_t, policy_t, inspector_t,
+    array_t>::state::evaluate_field_gradient(const vector3& pos)
     -> matrix_type<3, 3> {
 
     matrix_type<3, 3> dBdr = matrix_operator().template zero<3, 3>();
@@ -290,7 +290,7 @@ auto detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
 }
 
 template <typename magnetic_field_t, typename transform3_t,
-          typename constraint_t, typename policy_t,
+          typename constraint_t, typename policy_t, typename inspector_t,
           template <typename, std::size_t> class array_t>
 template <typename propagation_state_t>
 bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -153,13 +153,13 @@ void detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
         //         = qop_n * [ d(t_n)/dR (X) B_n - d(B_n)/dR (X) t_n ]
         matrix_type<3, 3> dk1dR =
             qop1 * mat_helper().column_wise_cross(field_gradient1, dir1);
-        dk2dR = qop2 * half_h * dk1dR;
+        matrix_type<3, 3> dk2dR = qop2 * half_h * dk1dR;
         dk2dR = mat_helper().column_wise_cross(dk2dR, sd.b_middle) -
                 qop2 * mat_helper().column_wise_cross(field_gradient2, dir2);
-        dk3dR = qop3 * half_h * dk2dR;
+        matrix_type<3, 3> dk3dR = qop3 * half_h * dk2dR;
         dk3dR = mat_helper().column_wise_cross(dk3dR, sd.b_middle) -
                 qop3 * mat_helper().column_wise_cross(field_gradient3, dir3);
-        dk4dR = qop4 * h * dk3dR;
+        matrix_type<3, 3> dk4dR = qop4 * h * dk3dR;
         dk4dR = mat_helper().column_wise_cross(dk4dR, sd.b_last) -
                 qop4 * mat_helper().column_wise_cross(field_gradient4, dir4);
 


### PR DESCRIPTION
Just an implentation of field gradient component in rk stepper covariance transport.

Equation (18) of http://cds.cern.ch/record/1114177/files/ATL-SOFT-PUB-2009-002.pdf

The improvment will be tested in #610 

-------------------------------------------------------
Update

Below graph shows the relative difference beween jacobian evaluated by detray::propagator and numerical differentiation. Jacobian is defined as derivative of bound parameter at the final surface with respect to the bound parameter at the initial surface.

Geometry setting: two rectangle surfaces (telescope geometry) which went thru random rotation, tilt, and spacing.
Track setting: 10 GeV particles in random direction
Field setting: inhomogenenous bfield in detray data directory. Bfield setup was hacked to use field interpolation
RK tolerance = 10^-10

Triangle: With bfield gradient
Diamond: Without bfield gradient
![image](https://github.com/acts-project/detray/assets/63090140/cd739935-49c4-45c7-b7ea-d02bb60b667d)

Improvement in most jacobian elements was observed, which is good