### PR TITLE
Use d(qop)/ds in jacobian calculation

### DIFF
--- a/core/include/detray/coordinates/coordinate_base.hpp
+++ b/core/include/detray/coordinates/coordinate_base.hpp
@@ -223,7 +223,7 @@ struct coordinate_base {
 
     DETRAY_HOST_DEVICE inline free_matrix path_correction(
         const vector3& pos, const vector3& dir, const vector3& dtds,
-        const transform3_t& trf3) const {
+        const scalar dqopds, const transform3_t& trf3) const {
 
         free_to_path_matrix path_derivative =
             Derived<transform3_t>().path_derivative(trf3, pos, dir, dtds);
@@ -236,6 +236,7 @@ struct coordinate_base {
         matrix_operator().element(derivative, e_free_dir0, 0u) = dtds[0];
         matrix_operator().element(derivative, e_free_dir1, 0u) = dtds[1];
         matrix_operator().element(derivative, e_free_dir2, 0u) = dtds[2];
+        matrix_operator().element(derivative, e_free_qoverp, 0u) = dqopds;
 
         return derivative * path_derivative;
     }

--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -213,10 +213,10 @@ struct surface_kernels {
         DETRAY_HOST_DEVICE inline free_matrix operator()(
             const mask_group_t& mask_group, const index_t& index,
             const transform3& trf3, const vector3& pos, const vector3& dir,
-            const vector3& dtds) const {
+            const vector3& dtds, const scalar dqopds) const {
 
-            return mask_group[index].local_frame().path_correction(pos, dir,
-                                                                   dtds, trf3);
+            return mask_group[index].local_frame().path_correction(
+                pos, dir, dtds, dqopds, trf3);
         }
     };
 

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -260,10 +260,10 @@ class surface {
     /// @returns the path correction term
     DETRAY_HOST_DEVICE
     constexpr auto path_correction(const context &ctx, const vector3 &pos,
-                                   const vector3 &dir,
-                                   const vector3 &dtds) const {
-        return visit_mask<typename kernels::path_correction>(transform(ctx),
-                                                             pos, dir, dtds);
+                                   const vector3 &dir, const vector3 &dtds,
+                                   const scalar dqopds) const {
+        return visit_mask<typename kernels::path_correction>(
+            transform(ctx), pos, dir, dtds, dqopds);
     }
 
     /// @returns the vertices in local frame with @param n_seg the number of

--- a/core/include/detray/materials/detail/relativistic_quantities.hpp
+++ b/core/include/detray/materials/detail/relativistic_quantities.hpp
@@ -101,8 +101,7 @@ struct relativistic_quantities {
     ///
     ///     (K/2) * (Z/A) * rho * (q²/beta²)
     ///
-    /// where (Z/A)*rho is the electron density in the material and x is the
-    /// traversed length (thickness) of the material.
+    /// where (Z/A)*rho is the electron density in the material.
     DETRAY_HOST_DEVICE inline scalar_type compute_epsilon_per_length(
         const scalar_type molarElectronDensity) const {
         return 0.5f * K * molarElectronDensity * m_q2OverBeta2;

--- a/core/include/detray/materials/detail/relativistic_quantities.hpp
+++ b/core/include/detray/materials/detail/relativistic_quantities.hpp
@@ -96,18 +96,30 @@ struct relativistic_quantities {
         return -2.f * (a * b - 2.f + m_beta2) / (qOverP * (a * b + 2.f));
     }
 
-    /// Compute epsilon energy pre-factor for RPP2018 eq. 33.11.
+    /// Compute epsilon per length where epsilon is defined at RPP2023
+    /// eq. 34.12. Defined as
+    ///
+    ///     (K/2) * (Z/A) * rho * (q²/beta²)
+    ///
+    /// where (Z/A)*rho is the electron density in the material and x is the
+    /// traversed length (thickness) of the material.
+    DETRAY_HOST_DEVICE inline scalar_type compute_epsilon_per_length(
+        const scalar_type molarElectronDensity) const {
+        return 0.5f * K * molarElectronDensity * m_q2OverBeta2;
+    }
+
+    /// Compute epsilon energy pre-factor for RPP2023 eq. 34.12.
     ///
     /// Defined as
     ///
-    ///     (K/2) * (Z/A)*rho * x * (q²/beta²)
+    ///     (K/2) * (Z/A) * rho * x * (q²/beta²)
     ///
     /// where (Z/A)*rho is the electron density in the material and x is the
     /// traversed length (thickness) of the material.
     DETRAY_HOST_DEVICE inline scalar_type compute_epsilon(
         const scalar_type molarElectronDensity,
         const scalar_type thickness) const {
-        return 0.5f * K * molarElectronDensity * thickness * m_q2OverBeta2;
+        return compute_epsilon_per_length(molarElectronDensity) * thickness;
     }
 
     /// Compute epsilon logarithmic derivative w/ respect to q/p.

--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -86,7 +86,8 @@ struct parameter_transporter : actor {
 
             // Path correction factor
             free_matrix path_correction = local_coordinate.path_correction(
-                stepping().pos(), stepping().dir(), stepping.dtds(), trf3);
+                stepping().pos(), stepping().dir(), stepping.dtds(),
+                stepping.dqopds(), trf3);
 
             const free_matrix correction_term =
                 matrix_operator()

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -84,6 +84,9 @@ class line_stepper final
 
         DETRAY_HOST_DEVICE
         inline vector3 dtds() const { return vector3{0.f, 0.f, 0.f}; }
+
+        DETRAY_HOST_DEVICE
+        inline scalar dqopds() const { return 0.f; }
     };
 
     /// Take a step, regulared by a constrained step

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -132,8 +132,13 @@ class rk_stepper final
         DETRAY_HOST_DEVICE
         inline matrix_type<3, 3> evaluate_field_gradient(const vector3& pos);
 
+        /// Evaluate dtds, where t is unit tangentional direction
         DETRAY_HOST_DEVICE
         inline vector3 dtds() const { return this->_step_data.k4; }
+
+        /// Evaulate d(qop)/ds
+        DETRAY_HOST_DEVICE
+        inline scalar dqopds() const;
 
         /// Call the stepping inspector
         template <typename... Args>

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -132,7 +132,7 @@ class rk_stepper final
         DETRAY_HOST_DEVICE
         inline matrix_type<3, 3> evaluate_field_gradient(const vector3& pos);
 
-        /// Evaluate dtds, where t is unit tangentional direction
+        /// Evaluate dtds, where t is the unit tangential direction
         DETRAY_HOST_DEVICE
         inline vector3 dtds() const { return this->_step_data.k4; }
 

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -292,6 +292,37 @@ auto detray::rk_stepper<
 template <typename magnetic_field_t, typename transform3_t,
           typename constraint_t, typename policy_t, typename inspector_t,
           template <typename, std::size_t> class array_t>
+auto detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
+                        inspector_t, array_t>::state::dqopds() const -> scalar {
+
+    const auto& mat = this->_mat;
+    const auto& pdg = this->_pdg;
+
+    // d(qop)ds is zero for empty space
+    if (mat == detray::vacuum<scalar>()) {
+        return 0.f;
+    }
+
+    const scalar qop = this->_step_data.k_qop4;
+    const scalar q = this->_track.charge();
+    const scalar p = q / qop;
+    const scalar mass = this->_mass;
+    const scalar E = std::sqrt(p * p + mass * mass);
+
+    // Compute stopping power
+    const scalar stopping_power =
+        interaction<scalar>().compute_stopping_power(mat, pdg, mass, qop, q);
+
+    // Assert that a momentum is a positive value
+    assert(p >= 0.f);
+
+    // d(qop)ds, which is equal to (qop) * E * (-dE/ds) / p^2
+    return qop * E * stopping_power / (p * p);
+}
+
+template <typename magnetic_field_t, typename transform3_t,
+          typename constraint_t, typename policy_t, typename inspector_t,
+          template <typename, std::size_t> class array_t>
 template <typename propagation_state_t>
 bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
                         inspector_t, array_t>::step(propagation_state_t&

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -296,7 +296,7 @@ auto detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
                         inspector_t, array_t>::state::dqopds() const -> scalar {
 
     const auto& mat = this->_mat;
-    const auto& pdg = this->_pdg;
+    const auto pdg = this->_pdg;
 
     // d(qop)ds is zero for empty space
     if (mat == detray::vacuum<scalar>()) {

--- a/tests/unit_tests/cpu/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/covariance_transport.cpp
@@ -210,6 +210,9 @@ class HelixCovarianceTransportValidation : public ::testing::Test {
         // d^2r/ds^2, or dt/ds at the destination surface
         const vector3 dtds = hlx.qop() * vector::cross(t, B);
 
+        // d(qop)/ds, which is zero in this test
+        const scalar dqopds = 0.f;
+
         // Free track at the destination surface
         free_track_parameters<transform3> free_trk_1;
         free_trk_1.set_pos(r);
@@ -218,7 +221,7 @@ class HelixCovarianceTransportValidation : public ::testing::Test {
 
         // Path correction
         const free_matrix path_correction =
-            destination_frame.path_correction(r, t, dtds, trf_1);
+            destination_frame.path_correction(r, t, dtds, dqopds, trf_1);
 
         // Correction term for the path variation
         const free_matrix correction_term =


### PR DESCRIPTION
Based on #612 

For an extra precision when there is a non-vacuum volume material.
Without this term, d(qop)/dloc0, d(qop)/dloc1, d(qop)/dphi, d(qop)/dtheta is always zero. 