### PR TITLE
ref: Add rk stepper policy and a few fixes

### DIFF
--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -26,13 +26,25 @@ enum class id {
     e_rk = 1,
 };
 
+/// A void inpector that does nothing.
+///
+/// Inspectors can be plugged in to understand the current stepper state.
+struct void_inspector {
+    template <typename state_t>
+    DETRAY_HOST_DEVICE constexpr void operator()(const state_t & /*ignored*/,
+                                                 const char * /*ignored*/) {}
+};
+
 }  // namespace stepping
 
 /// Base stepper implementation
-template <typename transform3_t, typename constraint_t, typename policy_t>
+template <typename transform3_t, typename constraint_t, typename policy_t,
+          typename inspector_t = stepping::void_inspector>
 class base_stepper {
 
     public:
+    using inspector_type = inspector_t;
+
     using transform3_type = transform3_t;
     using free_track_parameters_type = free_track_parameters<transform3_t>;
     using bound_track_parameters_type = bound_track_parameters<transform3_t>;
@@ -118,6 +130,9 @@ class base_stepper {
         // Navigation policy state
         typename policy_t::state _policy_state = {};
 
+        /// The inspector type of the stepping
+        inspector_type _inspector;
+
         /// Track path length
         scalar _path_length{0.};
 
@@ -175,6 +190,19 @@ class base_stepper {
         /// @returns this states remaining path length.
         DETRAY_HOST_DEVICE
         inline scalar path_length() const { return _path_length; }
+
+        /// @returns the stepping inspector
+        DETRAY_HOST
+        inline constexpr auto &inspector() { return _inspector; }
+
+        /// Call the stepping inspector
+        DETRAY_HOST_DEVICE
+        inline void run_inspector([[maybe_unused]] const char *message) {
+            if constexpr (not std::is_same_v<inspector_t,
+                                             stepping::void_inspector>) {
+                _inspector(*this, message);
+            }
+        }
     };
 };
 

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -19,12 +19,15 @@ namespace detray {
 
 /// Straight line stepper implementation
 template <typename transform3_t, typename constraint_t = unconstrained_step,
-          typename policy_t = stepper_default_policy>
+          typename policy_t = stepper_default_policy,
+          typename inspector_t = stepping::void_inspector>
 class line_stepper final
-    : public base_stepper<transform3_t, constraint_t, policy_t> {
+    : public base_stepper<transform3_t, constraint_t, policy_t, inspector_t> {
 
     public:
-    using base_type = base_stepper<transform3_t, constraint_t, policy_t>;
+    using base_type =
+        base_stepper<transform3_t, constraint_t, policy_t, inspector_t>;
+    using inspector_type = inspector_t;
     using transform3_type = transform3_t;
     using policy_type = policy_t;
     using free_track_parameters_type =
@@ -107,6 +110,9 @@ class line_stepper final
         if (std::abs(step_size) >
             std::abs(
                 stepping.constraints().template size<>(stepping.direction()))) {
+            // Run inspection before step size is cut
+            stepping.run_inspector("Before constraint: ");
+
             stepping.set_step_size(
                 stepping.constraints().template size<>(stepping.direction()));
         } else {
@@ -121,6 +127,9 @@ class line_stepper final
 
         // Call navigation update policy
         policy_t{}(stepping.policy_state(), propagation);
+
+        // Run inspection if needed
+        stepping.run_inspector("Step complete: ");
 
         return true;
     }

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -94,13 +94,18 @@ class geometry_reader : public reader_interface<detector_t> {
                                     ? pt_factories
                                     : sf_factories};
 
+                // @TODO use portal cylinders until intersectors are fixed
+                auto shape_id{mask_data.shape == mask_shape::cylinder2
+                                  ? mask_shape::portal_cylinder2
+                                  : mask_data.shape};
+
                 // Check if a fitting factory already exists. If not, add it
                 // dynamically
-                const auto key{mask_data.shape};
+                const auto key{shape_id};
                 if (auto search = factories.find(key);
                     search == factories.end()) {
-                    factories[key] = std::move(
-                        init_factory<mask_shape::n_shapes>(mask_data.shape));
+                    factories[key] =
+                        std::move(init_factory<mask_shape::n_shapes>(shape_id));
                 }
 
                 // Add the data to the factory

--- a/io/include/detray/io/common/payloads.hpp
+++ b/io/include/detray/io/common/payloads.hpp
@@ -205,7 +205,7 @@ struct detector_grids_payload {
 /// @brief A payload for a detector geometry
 struct detector_payload {
     std::vector<volume_payload> volumes = {};
-    grid_payload<std::size_t> volume_grid;
+    std::optional<grid_payload<std::size_t>> volume_grid;
 };
 
 }  // namespace detray

--- a/io/include/detray/io/json/json_geometry_io.hpp
+++ b/io/include/detray/io/json/json_geometry_io.hpp
@@ -134,7 +134,9 @@ inline void to_json(nlohmann::ordered_json& j, const detector_payload& d) {
             jvolumes.push_back(v);
         }
         j["volumes"] = jvolumes;
-        j["volume_grid"] = d.volume_grid;
+        if (d.volume_grid.has_value()) {
+            j["volume_grid"] = d.volume_grid.value();
+        }
     }
 }
 
@@ -143,8 +145,11 @@ inline void from_json(const nlohmann::ordered_json& j, detector_payload& d) {
         for (auto jvolume : j["volumes"]) {
             d.volumes.push_back(jvolume);
         }
-        d.volume_grid = j["volume_grid"];
     }
+    // @TODO Put back once volume grids can be read
+    /*if (j.find("volume_grid") != j.end()) {
+        d.volume_grid = j["volume_grid"];
+    }*/
 }
 
 }  // namespace detray

--- a/tests/common/include/tests/common/tools/particle_gun.hpp
+++ b/tests/common/include/tests/common/tools/particle_gun.hpp
@@ -85,6 +85,20 @@ struct particle_gun {
         std::stable_sort(intersection_record.begin(), intersection_record.end(),
                          sort_path);
 
+        // Make sure the intersection record terminates at world portals
+        auto is_world_exit = [](const std::pair<dindex, intersection_t> &r) {
+            return r.second.volume_link ==
+                   detray::detail::invalid_value<decltype(
+                       r.second.volume_link)>();
+        };
+
+        if (auto it = std::find_if(intersection_record.begin(),
+                                   intersection_record.end(), is_world_exit);
+            it != intersection_record.end()) {
+            auto n{static_cast<std::size_t>(it - intersection_record.begin())};
+            intersection_record.resize(n + 1u);
+        }
+
         return intersection_record;
     }
 };

--- a/tests/unit_tests/cpu/tools_propagator.cpp
+++ b/tests/unit_tests/cpu/tools_propagator.cpp
@@ -145,10 +145,16 @@ class PropagatorWithRkStepper
           std::tuple<scalar, scalar, __plugin::vector3<scalar>>> {
 
     public:
+    using generator_t =
+        uniform_track_generator<free_track_parameters<transform3>>;
+
     /// Set the test environment up
     virtual void SetUp() {
         overstep_tol = std::get<0>(GetParam());
         step_constr = std::get<1>(GetParam());
+
+        trk_gen_cfg.phi_steps(50u).theta_steps(50u);
+        trk_gen_cfg.p_tot(10.f * unit<scalar>::GeV);
     }
 
     /// Clean up
@@ -160,9 +166,7 @@ class PropagatorWithRkStepper
     toy_det_config toy_cfg{4u, 7u};
 
     /// Track generator configuration
-    unsigned int theta_steps{50u};
-    unsigned int phi_steps{50u};
-    scalar mom{10.f * unit<scalar>::GeV};
+    generator_t::configuration trk_gen_cfg{};
 
     /// Stepper configuration
     scalar overstep_tol, step_constr;
@@ -181,7 +185,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
     using navigator_t = navigator<detector_t /*, navigation::print_inspector*/>;
     using track_t = free_track_parameters<transform3>;
     using constraints_t = constrained_step<>;
-    using policy_t = stepper_default_policy;
+    using policy_t = stepper_rk_policy;
     using stepper_t =
         rk_stepper<bfield_t::view_t, transform3, constraints_t, policy_t>;
     // Include helix actor to check track position/covariance
@@ -202,8 +206,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
     propagator_t p(stepper_t{}, navigator_t{});
 
     // Iterate through uniformly distributed momentum directions
-    for (auto track :
-         uniform_track_generator<track_t>(phi_steps, theta_steps, mom)) {
+    for (auto track : generator_t{trk_gen_cfg}) {
         // Generate second track state used for propagation with pathlimit
         track_t lim_track(track);
 
@@ -283,7 +286,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
     using navigator_t = navigator<detector_t /*, navigation::print_inspector*/>;
     using track_t = free_track_parameters<transform3>;
     using constraints_t = constrained_step<>;
-    using policy_t = stepper_default_policy;
+    using policy_t = stepper_rk_policy;
     using stepper_t =
         rk_stepper<bfield_t::view_t, transform3, constraints_t, policy_t>;
     // Include helix actor to check track position/covariance
@@ -303,8 +306,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
     propagator_t p(stepper_t{}, navigator_t{});
 
     // Iterate through uniformly distributed momentum directions
-    for (auto track :
-         uniform_track_generator<track_t>(phi_steps, theta_steps, mom)) {
+    for (auto track : generator_t{trk_gen_cfg}) {
         // Genrate second track state used for propagation with pathlimit
         track_t lim_track(track);
 
@@ -369,21 +371,21 @@ INSTANTIATE_TEST_SUITE_P(
 // non-z-aligned B-fields
 INSTANTIATE_TEST_SUITE_P(PropagationValidation2, PropagatorWithRkStepper,
                          ::testing::Values(std::make_tuple(
-                             -10.f * unit<scalar>::um, 5.f * unit<scalar>::mm,
+                             -800.f * unit<scalar>::um, 40.f * unit<scalar>::mm,
                              __plugin::vector3<scalar>{
                                  0.f * unit<scalar>::T, 1.f * unit<scalar>::T,
                                  1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(PropagationValidation3, PropagatorWithRkStepper,
                          ::testing::Values(std::make_tuple(
-                             -10.f * unit<scalar>::um, 5.f * unit<scalar>::mm,
+                             -800.f * unit<scalar>::um, 40.f * unit<scalar>::mm,
                              __plugin::vector3<scalar>{
                                  1.f * unit<scalar>::T, 0.f * unit<scalar>::T,
                                  1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(PropagationValidation4, PropagatorWithRkStepper,
                          ::testing::Values(std::make_tuple(
-                             -10.f * unit<scalar>::um, 5.f * unit<scalar>::mm,
+                             -800.f * unit<scalar>::um, 35.f * unit<scalar>::mm,
                              __plugin::vector3<scalar>{
                                  1.f * unit<scalar>::T, 1.f * unit<scalar>::T,
                                  1.f * unit<scalar>::T})));

--- a/tests/unit_tests/cpu/tools_track_generators.cpp
+++ b/tests/unit_tests/cpu/tools_track_generators.cpp
@@ -59,7 +59,10 @@ GTEST_TEST(detray_simulation, uniform_track_generator) {
 
     // Now run the track generator and compare
     std::size_t n_tracks{0u};
-    for (const auto track : generator_t(phi_steps, theta_steps)) {
+    generator_t::configuration trk_gen_cfg{};
+    trk_gen_cfg.phi_steps(phi_steps).theta_steps(theta_steps);
+
+    for (const auto track : generator_t(trk_gen_cfg)) {
         vector3& expected = momenta[n_tracks];
         vector3 result = track.mom();
 

--- a/tests/validation/include/detray/validation/detail/svg_display.hpp
+++ b/tests/validation/include/detray/validation/detail/svg_display.hpp
@@ -118,16 +118,18 @@ inline void svg_display(
         gctx, il, intersections_truth, traj, traj_name, intersections, xy);
 
     const auto [vol_xy_svg, _] = il.draw_volumes(volumes, xy, gctx);
-    detray::svgtools::write_svg(path / (outfile + "_" + vol_xy_svg._id),
-                                {xy_axis, vol_xy_svg, svg_traj});
+    detray::svgtools::write_svg(
+        path / (outfile + "_" + vol_xy_svg._id + "_" + traj_name),
+        {xy_axis, vol_xy_svg, svg_traj});
 
     // zr - view
     svg_traj = draw_intersection_and_traj_svg(
         gctx, il, intersections_truth, traj, traj_name, intersections, zr);
 
     const auto vol_zr_svg = il.draw_detector(zr, gctx);
-    detray::svgtools::write_svg(path / (outfile + "_" + vol_zr_svg._id),
-                                {zr_axis, vol_zr_svg, svg_traj});
+    detray::svgtools::write_svg(
+        path / (outfile + "_" + vol_zr_svg._id + "_" + traj_name),
+        {zr_axis, vol_zr_svg, svg_traj});
 
     std::cout << "INFO: Wrote debugging data in: " << path << "\n" << std::endl;
 }

--- a/tests/validation/src/detector_display.cpp
+++ b/tests/validation/src/detector_display.cpp
@@ -74,6 +74,8 @@ int main(int argc, char** argv) {
 
     // Configs to be filled
     detray::io::detector_reader_config reader_cfg{};
+    // Also display incorrect geometries for debugging
+    reader_cfg.do_check(false);
 
     // Help message
     if (vm.count("help")) {

--- a/tests/validation/src/detector_validation.cpp
+++ b/tests/validation/src/detector_validation.cpp
@@ -59,8 +59,10 @@ int main(int argc, char **argv) {
         "min, max range of theta values for particle gun")(
         "origin", po::value<std::vector<scalar_t>>()->multitoken(),
         "coordintates for particle gun origin position")(
-        "p_mag", po::value<scalar_t>()->default_value(10.f),
-        "absolute momentum of the test particle [GeV]")(
+        "p_tot", po::value<scalar_t>()->default_value(10.f),
+        "total momentum of the test particle [GeV]")(
+        "p_T", po::value<scalar_t>()->default_value(10.f),
+        "transverse momentum of the test particle [GeV]")(
         "overstep_tol", po::value<scalar_t>()->default_value(-100.f),
         "overstepping tolerance [um] NOTE: Must be negative!");
 
@@ -79,6 +81,7 @@ int main(int argc, char **argv) {
 
     // Configs to be filled
     detray::io::detector_reader_config reader_cfg{};
+    reader_cfg.do_check(false);  // < Don't run consistency check twice
     detray::consistency_check<detector_t>::config con_chk_cfg{};
     detray::ray_scan<detector_t>::config ray_scan_cfg{};
     detray::helix_scan<detector_t>::config hel_scan_cfg{};
@@ -147,10 +150,14 @@ int main(int argc, char **argv) {
                 "Particle gun origin needs three arguments");
         }
     }
-    if (vm.count("p_mag")) {
-        const scalar_t p_mag{vm["p_mag"].as<scalar_t>()};
+    if (vm.count("p_tot")) {
+        const scalar_t p_mag{vm["p_tot"].as<scalar_t>()};
 
-        hel_nav_cfg.track_generator().p_mag(p_mag * unit<scalar_t>::GeV);
+        hel_nav_cfg.track_generator().p_tot(p_mag * unit<scalar_t>::GeV);
+    } else if (vm.count("p_T")) {
+        const scalar_t p_T{vm["p_T"].as<scalar_t>()};
+
+        hel_nav_cfg.track_generator().p_T(p_T * unit<scalar_t>::GeV);
     }
 
     // Navigation

--- a/tests/validation/src/telescope_detector_validation.cpp
+++ b/tests/validation/src/telescope_detector_validation.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
     helix_scan<tel_detector_t>::config cfg_hel_scan{};
     cfg_hel_scan.name("telescope_detector_helix_scan");
     cfg_hel_scan.overstepping_tolerance(-100.f * unit<scalar_t>::um);
-    cfg_hel_scan.track_generator().p_mag(10.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar_t>::GeV);
     cfg_hel_scan.track_generator().origin({0.f, 0.f, -0.05f});
     cfg_hel_scan.track_generator().theta_steps(100u).phi_steps(100u);
     cfg_hel_scan.track_generator().theta_range(constant<scalar_t>::pi_4,

--- a/tests/validation/src/toy_detector_validation.cpp
+++ b/tests/validation/src/toy_detector_validation.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
     helix_scan<toy_detector_t>::config cfg_hel_scan{};
     cfg_hel_scan.name("toy_detector_helix_scan");
     cfg_hel_scan.overstepping_tolerance(-100.f * unit<scalar_t>::um);
-    cfg_hel_scan.track_generator().p_mag(10.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar_t>::GeV);
     cfg_hel_scan.track_generator().theta_steps(100u).phi_steps(100u);
     detray::detail::register_checks<detray::helix_scan>(toy_det, toy_names,
                                                         cfg_hel_scan);

--- a/tests/validation/src/wire_chamber_validation.cpp
+++ b/tests/validation/src/wire_chamber_validation.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
     helix_scan<wire_chamber_t>::config cfg_hel_scan{};
     cfg_hel_scan.name("wire_chamber_helix_scan");
     cfg_hel_scan.overstepping_tolerance(-100.f * unit<scalar_t>::um);
-    cfg_hel_scan.track_generator().p_mag(10.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar_t>::GeV);
     cfg_hel_scan.track_generator().theta_steps(100u).phi_steps(100u);
     detray::detail::register_checks<detray::helix_scan>(det, names,
                                                         cfg_hel_scan);


### PR DESCRIPTION
This PR adds a RK stepper specific navigation policy that kicks in when the stepper adjusts the step size, anticipating that this means the track direction changed considerably from a straight line. It also adds a stepper print inspector, so that information about when and how the step size gets adjusted becomes available.

Further fixes include:
- enable the navigator to make a volume switch when its hits a portal and the cache is not exhausted. This is needed for backward navigation or when the track bends back into the detector
- enable the track state generators to generate p_T instead of total momentum
- stop recording truth intersections with the particle gun after the track is outside of the detector
- make the volume grid IO optional
- swap the cylinder type in the geometry IO until issue #451 is resolved
- count the failures on the helix validation instead of aborting the test