### PR TITLE
Use bfield interpolation rather than NN

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -73,7 +73,7 @@ jobs:
     # Set the path to the test data files
     env:
       DETRAY_DATA_DIRECTORY: ${{ github.workspace }}/data/
-      DETRAY_BFIELD_FILE: ${{ github.workspace }}/data/odd-bfield_v0_8_0.cvf
+      DETRAY_BFIELD_FILE: ${{ github.workspace }}/data/odd-bfield_v0_9_0.cvf
 
     # The build/test steps to execute.
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ build_cuda:
 test_cuda:
   variables:
     DETRAY_DATA_DIRECTORY: src/data/
-    DETRAY_BFIELD_FILE: $CI_PROJECT_DIR/src/data/odd-bfield_v0_8_0.cvf
+    DETRAY_BFIELD_FILE: $CI_PROJECT_DIR/src/data/odd-bfield_v0_9_0.cvf
   stage: test
   tags: [docker-gpu-nvidia]
   image: ghcr.io/acts-project/ubuntu2004_cuda:v30

--- a/data/detray_data_get_files.sh
+++ b/data/detray_data_get_files.sh
@@ -27,7 +27,7 @@ usage() {
 }
 
 # Default script arguments.
-DETRAY_DATA_NAME=${DETRAY_DATA_NAME:-"detray-data-v1"}
+DETRAY_DATA_NAME=${DETRAY_DATA_NAME:-"detray-data-v2"}
 DETRAY_WEB_DIRECTORY=${DETRAY_WEB_DIRECTORY:-"https://acts.web.cern.ch/traccc/data"}
 DETRAY_DATA_DIRECTORY=${DETRAY_DATA_DIRECTORY:-$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)}
 DETRAY_CMAKE_EXECUTABLE=${DETRAY_CMAKE_EXECUTABLE:-cmake}

--- a/extern/covfie/CMakeLists.txt
+++ b/extern/covfie/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Fetching covfie as part of the Detray project" )
 
 # Declare where to get covfie from.
 set( DETRAY_COVFIE_SOURCE
-   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.8.1.tar.gz;URL_MD5;0b4dc9624533d1ed4ea7a763da47f07e"
+   "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.9.0.tar.gz;URL_MD5;b310712c6dd1acc8104c734086f40fc0"
    CACHE STRING "Source for covfie, when built as part of this project" )
 mark_as_advanced( DETRAY_COVFIE_SOURCE )
 FetchContent_Declare( covfie ${DETRAY_COVFIE_SOURCE} )

--- a/tests/unit_tests/device/cuda/propagator_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/propagator_cuda_kernel.hpp
@@ -24,10 +24,10 @@ namespace detray {
 namespace bfield::cuda {
 
 // Inhomogeneous field (cuda)
-using inhom_bknd_t = covfie::backend::affine<
-    covfie::backend::nearest_neighbour<covfie::backend::strided<
-        covfie::vector::ulong3, covfie::backend::cuda_device_array<
-                                    covfie::vector::vector_d<scalar, 3>>>>>;
+using inhom_bknd_t = covfie::backend::affine<covfie::backend::linear<
+    covfie::backend::strided<covfie::vector::vector_d<std::size_t, 3>,
+                             covfie::backend::cuda_device_array<
+                                 covfie::vector::vector_d<scalar, 3>>>>>;
 
 }  // namespace bfield::cuda
 

--- a/tutorials/src/device/cuda/propagation.hpp
+++ b/tutorials/src/device/cuda/propagation.hpp
@@ -31,9 +31,9 @@ namespace detray::tutorial {
 namespace bfield::cuda {
 
 // Inhomogeneous field (cuda)
-using inhom_bknd_t = covfie::backend::affine<
-    covfie::backend::nearest_neighbour<covfie::backend::strided<
-        covfie::vector::ulong3,
+using inhom_bknd_t =
+    covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
+        covfie::vector::vector_d<std::size_t, 3>,
         covfie::backend::cuda_device_array<
             covfie::vector::vector_d<detray::scalar, 3>>>>>;
 

--- a/utils/include/detray/detectors/bfield.hpp
+++ b/utils/include/detray/detectors/bfield.hpp
@@ -15,6 +15,7 @@
 #include <covfie/core/backend/primitive/constant.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
 #include <covfie/core/backend/transformer/linear.hpp>
+#include <covfie/core/backend/transformer/nearest_neighbour.hpp>
 #include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
 #include <covfie/core/vector.hpp>
@@ -32,6 +33,12 @@ using const_field_t = covfie::field<const_bknd_t>;
 using inhom_bknd_t =
     covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
         covfie::vector::vector_d<std::size_t, 3>,
+        covfie::backend::array<covfie::vector::vector_d<detray::scalar, 3>>>>>;
+
+/// Inhomogeneous field with nearest neighbor (host)
+using inhom_bknd_nn_t = covfie::backend::affine<
+    covfie::backend::nearest_neighbour<covfie::backend::strided<
+        covfie::vector::ulong3,
         covfie::backend::array<covfie::vector::vector_d<detray::scalar, 3>>>>>;
 
 using inhom_field_t = covfie::field<inhom_bknd_t>;

--- a/utils/include/detray/detectors/bfield.hpp
+++ b/utils/include/detray/detectors/bfield.hpp
@@ -14,9 +14,10 @@
 // Covfie include(s)
 #include <covfie/core/backend/primitive/constant.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
-#include <covfie/core/backend/transformer/nearest_neighbour.hpp>
+#include <covfie/core/backend/transformer/linear.hpp>
 #include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
+#include <covfie/core/vector.hpp>
 
 namespace detray::bfield {
 
@@ -28,9 +29,9 @@ using const_bknd_t =
 using const_field_t = covfie::field<const_bknd_t>;
 
 /// Inhomogeneous field (host)
-using inhom_bknd_t = covfie::backend::affine<
-    covfie::backend::nearest_neighbour<covfie::backend::strided<
-        covfie::vector::ulong3,
+using inhom_bknd_t =
+    covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
+        covfie::vector::vector_d<std::size_t, 3>,
         covfie::backend::array<covfie::vector::vector_d<detray::scalar, 3>>>>>;
 
 using inhom_field_t = covfie::field<inhom_bknd_t>;


### PR DESCRIPTION
I believe the trilinear interpolation should be used instead of the nearest neighbor (NN) method. The interpolation is what Geant4 and Acts are using with RKN method - If we want to use the NN method, we need to prove that it doesn't harm the performanc first. 

Meanwhile this will require updating the magic io header of the covfie file in `detray/data`