### PR TITLE
Normalize direction of helix

### DIFF
--- a/core/include/detray/intersection/detail/trajectories.hpp
+++ b/core/include/detray/intersection/detail/trajectories.hpp
@@ -239,7 +239,7 @@ class helix {
         ret = ret + math_ns::cos(_K * s) * _t0;
         ret = ret + _alpha * math_ns::sin(_K * s) * _n0;
 
-        return ret;
+        return vector::normalize(ret);
     }
 
     DETRAY_HOST_DEVICE


### PR DESCRIPTION
To make sure that the direction of helix is always normalized (A part of #610)