### PR TITLE
ref: Move axes definitions out of shapes and renaming

### DIFF
--- a/core/include/detray/core/detector_metadata.hpp
+++ b/core/include/detray/core/detector_metadata.hpp
@@ -67,28 +67,26 @@ struct default_metadata {
 
     // Disc material grid
     template <typename container_t>
-    using disc_map_t =
-        material_map<ring2D<>::axes<>, detray::scalar, container_t>;
+    using disc_map_t = material_map<ring2D<>, detray::scalar, container_t>;
 
     // Cylindrical material grid
     template <typename container_t>
     using cylinder2_map_t =
-        material_map<cylinder2D<>::axes<>, detray::scalar, container_t>;
+        material_map<cylinder2D<>, detray::scalar, container_t>;
 
     // Rectangular material grid
     template <typename container_t>
     using rectangular_map_t =
-        material_map<rectangle2D<>::axes<>, detray::scalar, container_t>;
+        material_map<rectangle2D<>, detray::scalar, container_t>;
 
     // Cuboid volume material grid
     template <typename container_t>
-    using cuboid_map_t =
-        material_map<cuboid3D<>::axes<>, detray::scalar, container_t>;
+    using cuboid_map_t = material_map<cuboid3D<>, detray::scalar, container_t>;
 
     // Cylindrical volume material grid
     template <typename container_t>
     using cylinder3_map_t =
-        material_map<cylinder3D::axes<>, detray::scalar, container_t>;
+        material_map<cylinder3D, detray::scalar, container_t>;
 
     /// @}
 
@@ -98,48 +96,47 @@ struct default_metadata {
     /// @{
 
     // surface grid definition: bin-content: std::array<surface_type, 9>
-    template <typename grid_shape_t, typename bin_entry_t, typename container_t>
-    using surface_grid_t =
-        grid<coordinate_axes<grid_shape_t, false, container_t>,
-             bins::static_array<bin_entry_t, 50>, simple_serializer>;
+    template <typename axes_t, typename bin_entry_t, typename container_t>
+    using surface_grid_t = grid<axes_t, bins::static_array<bin_entry_t, 50>,
+                                simple_serializer, container_t, false>;
 
     // 2D cylindrical grid for the barrel layers
     template <typename bin_entry_t, typename container_t>
     using cylinder2D_sf_grid =
-        surface_grid_t<cylinder2D<>::axes<>, bin_entry_t, container_t>;
+        surface_grid_t<axes<cylinder2D<>>, bin_entry_t, container_t>;
 
     // disc grid for the endcap layers
     template <typename bin_entry_t, typename container_t>
     using disc_sf_grid =
-        surface_grid_t<ring2D<>::axes<>, bin_entry_t, container_t>;
+        surface_grid_t<axes<ring2D<>>, bin_entry_t, container_t>;
 
     // 3D cylindrical grid for the entire barrel / endcaps
     template <typename bin_entry_t, typename container_t>
     using cylinder3D_sf_grid =
-        surface_grid_t<cylinder3D::axes<>, bin_entry_t, container_t>;
+        surface_grid_t<axes<cylinder3D>, bin_entry_t, container_t>;
 
     // Irregular binning (hopefully not needed)
 
     // cylindrical grid for the barrel layers
     template <typename bin_entry_t, typename container_t>
     using irr_cylinder2D_sf_grid =
-        surface_grid_t<cylinder2D<>::axes<n_axis::bounds::e_closed,
-                                          n_axis::irregular, n_axis::irregular>,
+        surface_grid_t<axes<cylinder2D<>, axis::bounds::e_closed,
+                            axis::irregular, axis::irregular>,
                        bin_entry_t, container_t>;
 
     // disc grid for the endcap layers
     template <typename bin_entry_t, typename container_t>
     using irr_disc_sf_grid =
-        surface_grid_t<ring2D<>::axes<n_axis::bounds::e_closed,
-                                      n_axis::irregular, n_axis::irregular>,
+        surface_grid_t<axes<ring2D<>, axis::bounds::e_closed, axis::irregular,
+                            axis::irregular>,
                        bin_entry_t, container_t>;
 
     // 3D cylindrical grid for the entire barrel
     template <typename bin_entry_t, typename container_t>
-    using irr_cylinder3D_sf_grid = surface_grid_t<
-        cylinder3D::axes<n_axis::bounds::e_closed, n_axis::irregular,
-                         n_axis::irregular, n_axis::irregular>,
-        bin_entry_t, container_t>;
+    using irr_cylinder3D_sf_grid =
+        surface_grid_t<axes<cylinder3D, axis::bounds::e_closed, axis::irregular,
+                            axis::irregular, axis::irregular>,
+                       bin_entry_t, container_t>;
 
     /// @}
 
@@ -277,11 +274,9 @@ container_t>>*/>;
     /// Volume search grid
     template <typename container_t = host_container_types>
     using volume_finder =
-        grid<coordinate_axes<
-                 cylinder3D::axes<n_axis::bounds::e_open, n_axis::irregular,
-                                  n_axis::regular, n_axis::irregular>,
-                 true, container_t>,
-             bins::single<dindex>, simple_serializer>;
+        grid<axes<cylinder3D, axis::bounds::e_open, axis::irregular,
+                  axis::regular, axis::irregular>,
+             bins::single<dindex>, simple_serializer, container_t>;
 };
 
 }  // namespace detray

--- a/core/include/detray/definitions/grid_axis.hpp
+++ b/core/include/detray/definitions/grid_axis.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,7 +10,7 @@
 // System include(s).
 #include <type_traits>
 
-namespace detray::n_axis {
+namespace detray::axis {
 
 /// axis bounds names.
 ///
@@ -47,19 +47,4 @@ enum class binning {
     e_irregular = 1,
 };
 
-/// Determine axis bounds as either 'open' or 'closed' for non-circular axes.
-/// Used in the shape structs.
-/// @{
-template <n_axis::label L>
-struct open;
-
-template <n_axis::label L>
-struct closed;
-
-template <n_axis::bounds s, n_axis::label axis_label>
-using bounds_t =
-    std::conditional_t<s == n_axis::bounds::e_open, n_axis::open<axis_label>,
-                       n_axis::closed<axis_label>>;
-/// @}
-
-}  // namespace detray::n_axis
+}  // namespace detray::axis

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -26,7 +26,7 @@
 
 namespace detray {
 
-namespace axis {
+namespace axis2 {
 /** A regular closed axis.
  *
  * The axis is closed, i.e. each underflow bin is mapped to 0
@@ -611,7 +611,7 @@ struct irregular {
     }
 };
 
-}  // namespace axis
+}  // namespace axis2
 
 /**
  * static implementation of axis data for device

--- a/core/include/detray/masks/annulus2D.hpp
+++ b/core/include/detray/masks/annulus2D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,8 +15,6 @@
 #include "detray/definitions/units.hpp"
 #include "detray/intersection/plane_intersector.hpp"
 #include "detray/masks/detail/vertexing.hpp"
-#include "detray/surface_finders/grid/detail/axis_binning.hpp"
-#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
 #include <limits>
@@ -72,26 +70,8 @@ class annulus2D {
     template <typename intersection_t>
     using intersector_type = intersector_t<intersection_t>;
 
-    /// Behaviour of the two local axes (linear in r, circular in phi)
-    template <
-        n_axis::bounds e_s = n_axis::bounds::e_closed,
-        template <typename, typename> class binning_loc0 = n_axis::regular,
-        template <typename, typename> class binning_loc1 = n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 = n_axis::label::e_r;
-        static constexpr n_axis::label axis_loc1 = n_axis::label::e_phi;
-        static constexpr std::size_t dim{2u};
-
-        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
-                             n_axis::circular<axis_loc1>>;
-
-        /// Local coordinate frame (both for disc and focal system ?)
-        template <typename algebra_t>
-        using coordinate_type = local_frame_type<algebra_t>;
-
-        template <typename C, typename S>
-        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{2u};
 
     /// @returns the stereo angle calculated from the mask @param bounds .
     template <template <typename, std::size_t> class bounds_t,

--- a/core/include/detray/masks/cuboid3D.hpp
+++ b/core/include/detray/masks/cuboid3D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,8 +12,6 @@
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/bounding_box/cuboid_intersector.hpp"
-#include "detray/surface_finders/grid/detail/axis_binning.hpp"
-#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
 #include <cmath>
@@ -51,31 +49,8 @@ class cuboid3D {
     template <typename = void>
     using intersector_type = intersector_t;
 
-    /// Behaviour of the three local axes (linear in x, linear in y,
-    /// linear in z)
-    template <
-        n_axis::bounds e_s = n_axis::bounds::e_closed,
-        template <typename, typename> class binning_loc0 = n_axis::regular,
-        template <typename, typename> class binning_loc1 = n_axis::regular,
-        template <typename, typename> class binning_loc2 = n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 = n_axis::label::e_x;
-        static constexpr n_axis::label axis_loc1 = n_axis::label::e_y;
-        static constexpr n_axis::label axis_loc2 = n_axis::label::e_z;
-        static constexpr std::size_t dim{3u};
-
-        /// How to convert into the local axis system and back
-        template <typename algebra_t>
-        using coordinate_type = local_frame_type<algebra_t>;
-
-        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
-                             n_axis::bounds_t<e_s, axis_loc1>,
-                             n_axis::bounds_t<e_s, axis_loc2>>;
-
-        template <typename C, typename S>
-        using binning =
-            dtuple<binning_loc0<C, S>, binning_loc1<C, S>, binning_loc2<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{3u};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/cylinder2D.hpp
+++ b/core/include/detray/masks/cylinder2D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,8 +13,6 @@
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/cylinder_intersector.hpp"
-#include "detray/surface_finders/grid/detail/axis_binning.hpp"
-#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
 #include <cmath>
@@ -57,26 +55,8 @@ class cylinder2D {
     template <typename intersection_t>
     using intersector_type = intersector_t<intersection_t>;
 
-    /// Behaviour of the two local axes (circular in r_phi, linear in z)
-    template <
-        n_axis::bounds e_s = n_axis::bounds::e_closed,
-        template <typename, typename> class binning_loc0 = n_axis::regular,
-        template <typename, typename> class binning_loc1 = n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 = n_axis::label::e_rphi;
-        static constexpr n_axis::label axis_loc1 = n_axis::label::e_cyl_z;
-        static constexpr std::size_t dim{2u};
-
-        using types = dtuple<n_axis::circular<axis_loc0>,
-                             n_axis::bounds_t<e_s, axis_loc1>>;
-
-        /// How to convert into the local axis system and back
-        template <typename algebra_t>
-        using coordinate_type = cylindrical2<algebra_t>;
-
-        template <typename C, typename S>
-        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{2u};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/cylinder3D.hpp
+++ b/core/include/detray/masks/cylinder3D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,8 +12,6 @@
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/cylinder_intersector.hpp"
-#include "detray/surface_finders/grid/detail/axis_binning.hpp"
-#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
 #include <cmath>
@@ -49,31 +47,8 @@ class cylinder3D {
     template <typename intersection_t>
     using intersector_type = void;
 
-    /// Behaviour of the three local axes (linear in r, circular in phi,
-    /// linear in z)
-    template <
-        n_axis::bounds e_s = n_axis::bounds::e_closed,
-        template <typename, typename> class binning_loc0 = n_axis::regular,
-        template <typename, typename> class binning_loc1 = n_axis::regular,
-        template <typename, typename> class binning_loc2 = n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 = n_axis::label::e_r;
-        static constexpr n_axis::label axis_loc1 = n_axis::label::e_phi;
-        static constexpr n_axis::label axis_loc2 = n_axis::label::e_z;
-        static constexpr std::size_t dim{3u};
-
-        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
-                             n_axis::circular<axis_loc1>,
-                             n_axis::bounds_t<e_s, axis_loc2>>;
-
-        /// How to convert into the local axis system and back
-        template <typename algebra_t>
-        using coordinate_type = local_frame_type<algebra_t>;
-
-        template <typename C, typename S>
-        using binning =
-            dtuple<binning_loc0<C, S>, binning_loc1<C, S>, binning_loc2<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{3u};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/line.hpp
+++ b/core/include/detray/masks/line.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,8 +14,6 @@
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/line_intersector.hpp"
-#include "detray/surface_finders/grid/detail/axis_binning.hpp"
-#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
 #include <cmath>
@@ -63,26 +61,8 @@ class line {
     template <typename intersection_t>
     using intersector_type = intersector_t<intersection_t>;
 
-    /// Behaviour of the two local axes (linear in r/x, linear in z)
-    template <
-        n_axis::bounds e_s = n_axis::bounds::e_closed,
-        template <typename, typename> class binning_loc0 = n_axis::regular,
-        template <typename, typename> class binning_loc1 = n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 = n_axis::label::e_r;
-        static constexpr n_axis::label axis_loc1 = n_axis::label::e_z;
-        static constexpr std::size_t dim{2u};
-
-        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
-                             n_axis::bounds_t<e_s, axis_loc1>>;
-
-        /// How to convert into the local axis system and back
-        template <typename algebra_t>
-        using coordinate_type = line2<algebra_t>;
-
-        template <typename C, typename S>
-        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{2u};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/rectangle2D.hpp
+++ b/core/include/detray/masks/rectangle2D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,8 +12,6 @@
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
-#include "detray/surface_finders/grid/detail/axis_binning.hpp"
-#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
 #include <cmath>
@@ -52,26 +50,8 @@ class rectangle2D {
     template <typename intersection_t>
     using intersector_type = intersector_t<intersection_t>;
 
-    /// Behaviour of the two local axes (linear in x, y)
-    template <
-        n_axis::bounds e_s = n_axis::bounds::e_closed,
-        template <typename, typename> class binning_loc0 = n_axis::regular,
-        template <typename, typename> class binning_loc1 = n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 = n_axis::label::e_x;
-        static constexpr n_axis::label axis_loc1 = n_axis::label::e_y;
-        static constexpr std::size_t dim{2u};
-
-        /// How to convert into the local axis system and back
-        template <typename algebra_t>
-        using coordinate_type = local_frame_type<algebra_t>;
-
-        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
-                             n_axis::bounds_t<e_s, axis_loc1>>;
-
-        template <typename C, typename S>
-        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{2u};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/ring2D.hpp
+++ b/core/include/detray/masks/ring2D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,8 +12,6 @@
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
-#include "detray/surface_finders/grid/detail/axis_binning.hpp"
-#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
 #include <cmath>
@@ -53,26 +51,8 @@ class ring2D {
     template <typename intersection_t>
     using intersector_type = intersector_t<intersection_t>;
 
-    /// Behaviour of the two local axes (linear in r, circular in phi)
-    template <
-        n_axis::bounds e_s = n_axis::bounds::e_closed,
-        template <typename, typename> class binning_loc0 = n_axis::regular,
-        template <typename, typename> class binning_loc1 = n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 = n_axis::label::e_r;
-        static constexpr n_axis::label axis_loc1 = n_axis::label::e_phi;
-        static constexpr std::size_t dim{2u};
-
-        /// How to convert into the local axis system and back
-        template <typename algebra_t>
-        using coordinate_type = local_frame_type<algebra_t>;
-
-        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
-                             n_axis::circular<axis_loc1>>;
-
-        template <typename C, typename S>
-        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{2u};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/single3D.hpp
+++ b/core/include/detray/masks/single3D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,8 +13,6 @@
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
-#include "detray/surface_finders/grid/detail/axis_binning.hpp"
-#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
 #include <cmath>
@@ -54,24 +52,8 @@ class single3D {
     template <typename intersection_t>
     using intersector_type = intersector_t<intersection_t>;
 
-    /// Behaviour of the two local axes (linear in single coordinate x, y or z)
-    template <n_axis::bounds e_s = n_axis::bounds::e_closed,
-              template <typename, typename> class binning_loc0 =
-                  n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 =
-            static_cast<n_axis::label>(kCheckIndex);
-        static constexpr std::size_t dim{1u};
-
-        /// How to convert into the local axis system and back
-        template <typename algebra_t>
-        using coordinate_type = local_frame_type<algebra_t>;
-
-        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>>;
-
-        template <typename C, typename S>
-        using binning = dtuple<binning_loc0<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{1u};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/trapezoid2D.hpp
+++ b/core/include/detray/masks/trapezoid2D.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,8 +12,6 @@
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
-#include "detray/surface_finders/grid/detail/axis_binning.hpp"
-#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
 #include <cmath>
@@ -57,26 +55,8 @@ class trapezoid2D {
     template <typename intersection_t>
     using intersector_type = intersector_t<intersection_t>;
 
-    /// Behaviour of the two local axes (linear in x, y)
-    template <
-        n_axis::bounds e_s = n_axis::bounds::e_closed,
-        template <typename, typename> class binning_loc0 = n_axis::regular,
-        template <typename, typename> class binning_loc1 = n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 = n_axis::label::e_x;
-        static constexpr n_axis::label axis_loc1 = n_axis::label::e_y;
-        static constexpr std::size_t dim{2u};
-
-        /// How to convert into the local axis system and back
-        template <typename algebra_t>
-        using coordinate_type = local_frame_type<algebra_t>;
-
-        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
-                             n_axis::bounds_t<e_s, axis_loc1>>;
-
-        template <typename C, typename S>
-        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{2u};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/unbounded.hpp
+++ b/core/include/detray/masks/unbounded.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,6 +39,9 @@ class unbounded {
     template <typename intersection_t>
     using intersector_type =
         typename shape::template intersector_type<intersection_t>;
+
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{shape_t::dim};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/masks/unmasked.hpp
+++ b/core/include/detray/masks/unmasked.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,8 +12,6 @@
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/intersection/plane_intersector.hpp"
-#include "detray/surface_finders/grid/detail/axis_binning.hpp"
-#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 
 // System include(s)
 #include <limits>
@@ -38,26 +36,8 @@ class unmasked {
     template <typename intersection_t>
     using intersector_type = plane_intersector<intersection_t>;
 
-    /// Behaviour of the two local axes (linear in x, y)
-    template <
-        n_axis::bounds e_s = n_axis::bounds::e_closed,
-        template <typename, typename> class binning_loc0 = n_axis::regular,
-        template <typename, typename> class binning_loc1 = n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 = n_axis::label::e_x;
-        static constexpr n_axis::label axis_loc1 = n_axis::label::e_y;
-        static constexpr std::size_t dim{2u};
-
-        /// How to convert into the local axis system and back
-        template <typename algebra_t>
-        using coordinate_type = local_frame_type<algebra_t>;
-
-        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
-                             n_axis::bounds_t<e_s, axis_loc1>>;
-
-        template <typename C, typename S>
-        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{2u};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/core/include/detray/materials/material_map.hpp
+++ b/core/include/detray/materials/material_map.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 // Detray include(s)
 #include "detray/definitions/containers.hpp"
 #include "detray/materials/material_slab.hpp"
+#include "detray/surface_finders/grid/detail/axis_helpers.hpp"
 #include "detray/surface_finders/grid/detail/grid_bins.hpp"
 #include "detray/surface_finders/grid/grid.hpp"
 #include "detray/surface_finders/grid/serializers.hpp"
@@ -18,11 +19,10 @@
 namespace detray {
 
 /// Definition of binned material
-template <typename axes_shape, typename scalar_t,
+template <typename shape, typename scalar_t,
           typename container_t = host_container_types, bool owning = false>
-using material_map =
-    grid<coordinate_axes<axes_shape, owning, container_t>,
-         bins::single<material_slab<scalar_t>>, simple_serializer>;
+using material_map = grid<axes<shape>, bins::single<material_slab<scalar_t>>,
+                          simple_serializer, container_t, owning>;
 
 /// How to build material maps of various shapes
 // TODO: Move to material_map_builder once available

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -60,6 +60,7 @@ class base_stepper {
 
     public:
     using inspector_type = inspector_t;
+    using policy_type = policy_t;
 
     using transform3_type = transform3_t;
     using free_track_parameters_type = free_track_parameters<transform3_t>;

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -27,16 +27,14 @@ class line_stepper final
     public:
     using base_type =
         base_stepper<transform3_t, constraint_t, policy_t, inspector_t>;
-    using inspector_type = inspector_t;
-    using transform3_type = transform3_t;
-    using policy_type = policy_t;
+
     using free_track_parameters_type =
         typename base_type::free_track_parameters_type;
     using bound_track_parameters_type =
         typename base_type::bound_track_parameters_type;
     using matrix_operator = typename base_type::matrix_operator;
     using size_type = typename matrix_operator::size_ty;
-    using vector3 = typename transform3_type::vector3;
+    using vector3 = typename line_stepper::transform3_type::vector3;
     template <size_type ROWS, size_type COLS>
     using matrix_type =
         typename matrix_operator::template matrix_type<ROWS, COLS>;
@@ -131,7 +129,8 @@ class line_stepper final
         stepping.advance_jacobian();
 
         // Call navigation update policy
-        policy_t{}(stepping.policy_state(), propagation);
+        typename line_stepper::policy_type{}(stepping.policy_state(),
+                                             propagation);
 
         // Run inspection if needed
         stepping.run_inspector(cfg, "Step complete: ");

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -36,9 +36,8 @@ class rk_stepper final
     public:
     using base_type =
         base_stepper<transform3_t, constraint_t, policy_t, inspector_t>;
-    using inspector_type = inspector_t;
+
     using transform3_type = transform3_t;
-    using policy_type = policy_t;
     using scalar_type = typename transform3_type::scalar_type;
     using point3 = typename transform3_type::point3;
     using vector2 = typename transform3_type::point2;

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -17,11 +17,9 @@ template <typename magnetic_field_t, typename transform3_t,
 void detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
                         inspector_t, array_t>::state::advance_track() {
 
-    using scalar_t = typename transform3_t::scalar_type;
-
     const auto& sd = this->_step_data;
-    const scalar_t h{this->_step_size};
-    const scalar_t h_6{h * static_cast<scalar_t>(1. / 6.)};
+    const scalar_type h{this->_step_size};
+    const scalar_type h_6{h * static_cast<scalar_type>(1. / 6.)};
     auto& track = this->_track;
     auto pos = track.pos();
     auto dir = track.dir();
@@ -35,11 +33,11 @@ void detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
     track.set_dir(dir);
 
     auto qop = track.qop();
-    if (!(this->_mat == vacuum<scalar_t>())) {
-        const scalar_t dqopds1 = this->dqopds(qop);
-        const scalar_t dqopds2 = this->dqopds(sd.qop2);
-        const scalar_t dqopds3 = dqopds2;
-        const scalar_t dqopds4 = this->dqopds(sd.qop4);
+    if (!(this->_mat == vacuum<scalar_type>())) {
+        const scalar_type dqopds1 = this->dqopds(qop);
+        const scalar_type dqopds2 = this->dqopds(sd.qop2);
+        const scalar_type dqopds3 = dqopds2;
+        const scalar_type dqopds4 = this->dqopds(sd.qop4);
         qop = qop + h_6 * (dqopds1 + 2.f * (dqopds2 + dqopds3) + dqopds4);
     }
     track.set_qop(qop);
@@ -74,16 +72,14 @@ void detray::rk_stepper<
     /// constant offset does not exist for rectangular matrix dGdu' (due to the
     /// missing Lambda part) and only exists for dFdu' in dlambda/dlambda.
 
-    using scalar_t = typename transform3_t::scalar_type;
-
     const auto& sd = this->_step_data;
-    const scalar_t h{this->_step_size};
+    const scalar_type h{this->_step_size};
     // const auto& mass = this->_mass;
     auto& track = this->_track;
 
     // Half step length
-    const scalar_t half_h{h * 0.5f};
-    const scalar_t h_6{h * static_cast<scalar>(1. / 6.)};
+    const scalar_type half_h{h * 0.5f};
+    const scalar_type h_6{h * static_cast<scalar>(1. / 6.)};
 
     // Direction
     const auto dir1 = track.dir();
@@ -154,33 +150,33 @@ void detray::rk_stepper<
 
     /// (4,4) element (right-bottom) of Eq. 3.12 [JINST 4 P04016]
     if (cfg.use_eloss_gradient) {
-        if (this->_mat == vacuum<scalar_t>()) {
+        if (this->_mat == vacuum<scalar_type>()) {
             getter::element(D, e_free_qoverp, e_free_qoverp) = 1.f;
         } else {
-            const scalar_t q = track.charge();
-            const scalar_t p = q / qop1;
+            const scalar_type q = track.charge();
+            const scalar_type p = q / qop1;
             const auto& mass = this->_mass;
-            const scalar_t p2 = p * p;
-            const scalar_t E2 = p2 + mass * mass;
-            const scalar_t E = math::sqrt(E2);
+            const scalar_type p2 = p * p;
+            const scalar_type E2 = p2 + mass * mass;
+            const scalar_type E = math::sqrt(E2);
 
             // Interaction object
             interaction<scalar> I;
 
             // g: dE/ds = -1 * stopping power
-            const scalar_t g =
+            const scalar_type g =
                 -1.f *
                 I.compute_stopping_power(this->_mat, this->_pdg, mass, qop1, q);
             // dg/d(qop) = -1 * derivation of stopping power
-            const scalar_t dg_dQop =
+            const scalar_type dg_dQop =
                 -1.f *
                 I.derive_stopping_power(this->_mat, this->_pdg, mass, qop1, q);
 
             // d(Qop)/ds = - qop^3 * E * g / q^2
-            const scalar_t dQop_ds =
+            const scalar_type dQop_ds =
                 (-1.f * qop1 * qop1 * qop1 * E * g) / (q * q);
 
-            const scalar_t gradient =
+            const scalar_type gradient =
                 dQop_ds * (1.f / qop1 * (3.f - p2 / E2) + 1.f / g * dg_dQop);
 
             // As the reference of [JINST 4 P04016] said that "The energy loss
@@ -249,39 +245,37 @@ auto detray::rk_stepper<
                                   const detray::stepping::config& cfg) const ->
     typename transform3_t::scalar_type {
 
-    using scalar_t = typename transform3_t::scalar_type;
-
     const auto& track = this->_track;
-    const scalar_t qop = track.qop();
+    const scalar_type qop = track.qop();
 
     if (cfg.use_mean_loss) {
 
         const auto& mat = this->_mat;
-        if (mat == detray::vacuum<scalar_t>()) {
+        if (mat == detray::vacuum<scalar_type>()) {
             return qop;
         }
 
-        const scalar_t mass = this->_mass;
+        const scalar_type mass = this->_mass;
         const auto pdg = this->_pdg;
-        const scalar_t p = track.p();
-        const scalar_t q = track.charge();
+        const scalar_type p = track.p();
+        const scalar_type q = track.charge();
         const auto direction = this->_direction;
 
-        const scalar_t eloss =
-            interaction<scalar_t>().compute_energy_loss_bethe(h, mat, pdg, mass,
-                                                              qop, q);
+        const scalar_type eloss =
+            interaction<scalar_type>().compute_energy_loss_bethe(h, mat, pdg,
+                                                                 mass, qop, q);
 
         // @TODO: Recycle the codes in pointwise_material_interactor.hpp
         // Get new Energy
-        const scalar_t nextE{
+        const scalar_type nextE{
             math::sqrt(mass * mass + p * p) -
-            math::copysign(eloss, static_cast<scalar_t>(direction))};
+            math::copysign(eloss, static_cast<scalar_type>(direction))};
 
         // Put particle at rest if energy loss is too large
-        const scalar_t nextP{
+        const scalar_type nextP{
             (mass < nextE) ? math::sqrt(nextE * nextE - mass * mass) : 0.f};
 
-        constexpr scalar_t inv{detail::invalid_value<scalar_t>()};
+        constexpr scalar_type inv{detail::invalid_value<scalar_type>()};
         return (nextP == 0.f) ? inv : (q != 0.f) ? q / nextP : 1.f / nextP;
     }
     return qop;
@@ -321,8 +315,7 @@ auto detray::rk_stepper<
 
     matrix_type<3, 3> dBdr = matrix_operator().template zero<3, 3>();
 
-    constexpr typename transform3_t::scalar_type delta =
-        1e-1f * unit<scalar>::mm;
+    constexpr auto delta{1e-1f * unit<scalar_type>::mm};
 
     for (unsigned int i = 0; i < 3; i++) {
 
@@ -371,24 +364,23 @@ auto detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
                                                                  qop) const ->
     typename transform3_t::scalar_type {
 
-    using scalar_t = typename transform3_t::scalar_type;
-
     const auto& mat = this->_mat;
     const auto pdg = this->_pdg;
 
     // d(qop)ds is zero for empty space
-    if (mat == detray::vacuum<scalar_t>()) {
+    if (mat == detray::vacuum<scalar_type>()) {
         return 0.f;
     }
 
-    const scalar_t q = this->_track.charge();
-    const scalar_t p = q / qop;
-    const scalar_t mass = this->_mass;
-    const scalar_t E = math::sqrt(p * p + mass * mass);
+    const scalar_type q = this->_track.charge();
+    const scalar_type p = q / qop;
+    const scalar_type mass = this->_mass;
+    const scalar_type E = math::sqrt(p * p + mass * mass);
 
     // Compute stopping power
-    const scalar_t stopping_power =
-        interaction<scalar_t>().compute_stopping_power(mat, pdg, mass, qop, q);
+    const scalar_type stopping_power =
+        interaction<scalar_type>().compute_stopping_power(mat, pdg, mass, qop,
+                                                          q);
 
     // Assert that a momentum is a positive value
     assert(p >= 0.f);
@@ -406,8 +398,6 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
                         array_t>::step(propagation_state_t& propagation,
                                        const detray::stepping::config& cfg) {
 
-    using scalar_t = typename transform3_t::scalar_type;
-
     // Get stepper and navigator states
     state& stepping = propagation._stepping;
     auto& magnetic_field = stepping._magnetic_field;
@@ -418,7 +408,7 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
 
     auto& sd = stepping._step_data;
 
-    scalar_t error_estimate{0.f};
+    scalar_type error_estimate{0.f};
 
     // First Runge-Kutta point
     const vector3 pos = stepping().pos();
@@ -431,10 +421,10 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
     sd.k1 = stepping.evaluate_k(sd.b_first, 0, 0.f, vector3{0.f, 0.f, 0.f},
                                 stepping().qop());
 
-    const auto try_rk4 = [&](const scalar& h) -> bool {
+    const auto try_rk4 = [&](const scalar_type& h) -> bool {
         // State the square and half of the step size
-        const scalar_t h2{h * h};
-        const scalar_t half_h{h * 0.5f};
+        const scalar_type h2{h * h};
+        const scalar_type half_h{h * 0.5f};
 
         // Second Runge-Kutta point
         const vector3 pos1 = pos + half_h * dir + h2 * 0.125f * sd.k1;
@@ -462,7 +452,7 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
         // @Todo
         const vector3 err_vec = h2 * (sd.k1 - sd.k2 - sd.k3 + sd.k4);
         error_estimate =
-            math::max(getter::norm(err_vec), static_cast<scalar_t>(1e-20));
+            math::max(getter::norm(err_vec), static_cast<scalar_type>(1e-20));
 
         return (error_estimate <= cfg.rk_error_tol);
     };
@@ -470,17 +460,17 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
     // Initial step size estimate
     stepping.set_step_size(navigation());
 
-    scalar_t step_size_scaling{1.f};
+    scalar_type step_size_scaling{1.f};
     std::size_t n_step_trials{0u};
 
     // Adjust initial step size to integration error
     while (!try_rk4(stepping._step_size)) {
 
         step_size_scaling = math::min(
-            math::max(0.25f * unit<scalar_t>::mm,
+            math::max(0.25f * unit<scalar_type>::mm,
                       math::sqrt(math::sqrt(
                           (cfg.rk_error_tol / math::abs(error_estimate))))),
-            static_cast<scalar_t>(4));
+            static_cast<scalar_type>(4));
 
         // Only step size reduction is allowed so that we don't overstep
         assert(step_size_scaling <= 1.f);
@@ -532,7 +522,7 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
     stepping.advance_jacobian(cfg);
 
     // Call navigation update policy
-    policy_t{}(stepping.policy_state(), propagation);
+    typename rk_stepper::policy_type{}(stepping.policy_state(), propagation);
 
     // Run final inspection
     stepping.run_inspector(cfg, "Step complete: ");

--- a/core/include/detray/surface_finders/accelerator_grid.hpp
+++ b/core/include/detray/surface_finders/accelerator_grid.hpp
@@ -8,17 +8,8 @@
 #pragma once
 
 // Project include(s)
-#include "detray/surface_finders/grid/axis.hpp"
+#include "detray/surface_finders/grid/detail/axis_helpers.hpp"
 #include "detray/surface_finders/grid/detail/grid_bins.hpp"
 #include "detray/surface_finders/grid/grid.hpp"
 #include "detray/surface_finders/grid/grid_collection.hpp"
 #include "detray/utils/type_traits.hpp"
-
-namespace detray::detail {
-
-template <typename multi_axis_t, typename bin_t,
-          template <std::size_t> class serializer_t>
-struct is_grid<grid<multi_axis_t, bin_t, serializer_t>>
-    : public std::true_type {};
-
-}  // namespace detray::detail

--- a/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_binning.hpp
@@ -18,7 +18,7 @@
 #include <cstddef>
 #include <iterator>
 
-namespace detray::n_axis {
+namespace detray::axis {
 
 /// @brief Helper to tie two bin indices to a range.
 /// @note Cannot use dindex_range for signed integer bin indices.
@@ -303,4 +303,4 @@ struct irregular {
     }
 };
 
-}  // namespace detray::n_axis
+}  // namespace detray::axis

--- a/core/include/detray/surface_finders/grid/detail/axis_bounds.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_bounds.hpp
@@ -14,7 +14,7 @@
 // System include(s).
 #include <cstddef>
 
-namespace detray::n_axis {
+namespace detray::axis {
 
 /// @brief Helper to tie two bin indices to a range.
 /// @note Cannot use dindex_range for signed integer bin indices.
@@ -27,11 +27,11 @@ using bin_range = std::array<int, 2>;
 /// are the overflow bins.
 ///
 /// @tparam axis_label the label of the axis, i.e. x, y, z or r.
-template <n_axis::label axis_label>
+template <axis::label axis_label>
 struct open {
 
-    static constexpr n_axis::label label = axis_label;
-    static constexpr n_axis::bounds type = bounds::e_open;
+    static constexpr axis::label label = axis_label;
+    static constexpr axis::bounds type = bounds::e_open;
 
     /// Map a bin into the axis range
     ///
@@ -94,10 +94,10 @@ struct open {
 /// actual over- or underflow bins (they would be -1 and #bins).
 ///
 /// @tparam axis_label the label of the axis, i.e. x, y, z or r.
-template <n_axis::label axis_label>
+template <axis::label axis_label>
 struct closed {
 
-    static constexpr n_axis::label label = axis_label;
+    static constexpr axis::label label = axis_label;
     static constexpr bounds type = bounds::e_closed;
 
     /// Map a bin into the axis range
@@ -158,10 +158,10 @@ struct closed {
 /// The axis will be periodic, i.e. underflow bins map into #bins - 1 and
 /// overflow bins map into 0: so that [0, #bins - 1], with -1 = #bins - 1 and
 /// #bins = 0.
-template <n_axis::label axis_label = n_axis::label::e_phi>
+template <axis::label axis_label = axis::label::e_phi>
 struct circular {
 
-    static constexpr n_axis::label label = axis_label;
+    static constexpr axis::label label = axis_label;
     static constexpr bounds type = bounds::e_circular;
 
     /// Map a bin into the axis range
@@ -239,4 +239,4 @@ struct circular {
     }
 };
 
-}  // namespace detray::n_axis
+}  // namespace detray::axis

--- a/core/include/detray/surface_finders/grid/detail/axis_helpers.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis_helpers.hpp
@@ -1,0 +1,204 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "detray/coordinates/coordinates.hpp"
+#include "detray/definitions/grid_axis.hpp"
+#include "detray/surface_finders/grid/detail/axis.hpp"
+#include "detray/surface_finders/grid/detail/axis_binning.hpp"
+#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
+#include "detray/utils/type_list.hpp"
+
+// System include(s).
+#include <type_traits>
+
+namespace detray {
+
+namespace axis::detail {
+
+// Forward declarations of helper types
+template <typename, axis::bounds, template <typename, typename> class,
+          template <typename, typename> class,
+          template <typename, typename> class>
+struct get_axes_types;
+
+template <typename, bool, typename, typename, typename = void>
+struct get_coordinate_axes_type;
+
+}  // namespace axis::detail
+
+/// Template parameter for the @c gird: Get a the binning and bounds of grid
+/// axes from geometric shapes
+template <typename shape_t, axis::bounds e_bounds = axis::bounds::e_closed,
+          template <typename, typename> class binning0_t = axis::regular,
+          template <typename, typename> class binning1_t = axis::regular,
+          template <typename, typename> class binning2_t = axis::regular>
+struct axes {
+    static constexpr auto dim{shape_t::dim};
+    using bounds = void;
+    template <typename A>
+    using type = axis::detail::get_axes_types<
+        typename shape_t::template local_frame_type<A>, e_bounds, binning0_t,
+        binning1_t, binning2_t>;
+};
+
+/// Helper trait to resolve the type of a @c multi_axis from a shape
+template <typename axes_t, bool is_owning = true,
+          typename containers = host_container_types,
+          typename algebra_t = __plugin::transform3<detray::scalar>>
+using coordinate_axes = typename axis::detail::get_coordinate_axes_type<
+    axes_t, is_owning, containers, algebra_t>::type;
+
+namespace axis::detail {
+
+/// Determine axis bounds as either 'open' or 'closed' for non-circular axes.
+template <axis::bounds s, axis::label axis_label>
+using bounds_t =
+    std::conditional_t<s == axis::bounds::e_open, axis::open<axis_label>,
+                       axis::closed<axis_label>>;
+
+/// Assemble a @c multi_axis type from a coordinate frame with given bounds and
+/// binnings - unspecified type
+template <typename frame_t, axis::bounds e_bounds,
+          template <typename, typename> class binning0_t,
+          template <typename, typename> class binning1_t,
+          template <typename, typename> class binning2_t>
+struct get_axes_types {};
+
+/// Behaviour of the three local axes (linear in x and y)
+template <typename A, axis::bounds e_bounds,
+          template <typename, typename> class binning0_t,
+          template <typename, typename> class binning1_t,
+          template <typename, typename> class binning2_t>
+struct get_axes_types<cartesian2<A>, e_bounds, binning0_t, binning1_t,
+                      binning2_t> {
+    template <typename algebra_t>
+    using frame = cartesian2<algebra_t>;
+
+    static constexpr auto label0{axis::label::e_x};
+    static constexpr auto label1{axis::label::e_y};
+
+    using bounds = detray::types::list<bounds_t<e_bounds, label0>,
+                                       bounds_t<e_bounds, label1>>;
+    template <typename C, typename S>
+    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>>;
+};
+
+/// Behaviour of the three local axes (linear in x, y, z)
+template <typename A, axis::bounds e_bounds,
+          template <typename, typename> class binning0_t,
+          template <typename, typename> class binning1_t,
+          template <typename, typename> class binning2_t>
+struct get_axes_types<cartesian3<A>, e_bounds, binning0_t, binning1_t,
+                      binning2_t> {
+    template <typename algebra_t>
+    using frame = cartesian3<algebra_t>;
+
+    static constexpr auto label0{axis::label::e_x};
+    static constexpr auto label1{axis::label::e_y};
+    static constexpr auto label2{axis::label::e_z};
+
+    using bounds = detray::types::list<bounds_t<e_bounds, label0>,
+                                       bounds_t<e_bounds, label1>,
+                                       bounds_t<e_bounds, label2>>;
+    template <typename C, typename S>
+    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>,
+                                        binning2_t<C, S>>;
+};
+
+/// Behaviour of the two local axes (linear in r, circular in phi)
+template <typename A, axis::bounds e_bounds,
+          template <typename, typename> class binning0_t,
+          template <typename, typename> class binning1_t,
+          template <typename, typename> class binning2_t>
+struct get_axes_types<polar2<A>, e_bounds, binning0_t, binning1_t, binning2_t> {
+    template <typename algebra_t>
+    using frame = polar2<algebra_t>;
+
+    static constexpr auto label0{axis::label::e_r};
+    static constexpr auto label1{axis::label::e_phi};
+
+    using bounds =
+        detray::types::list<bounds_t<e_bounds, label0>, axis::circular<label1>>;
+    template <typename C, typename S>
+    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>>;
+};
+
+/// Behaviour of the two local axes (circular in r-phi, linear in z)
+template <typename A, axis::bounds e_bounds,
+          template <typename, typename> class binning0_t,
+          template <typename, typename> class binning1_t,
+          template <typename, typename> class binning2_t>
+struct get_axes_types<cylindrical2<A>, e_bounds, binning0_t, binning1_t,
+                      binning2_t> {
+    template <typename algebra_t>
+    using frame = cylindrical2<algebra_t>;
+
+    static constexpr auto label0{axis::label::e_rphi};
+    static constexpr auto label1{axis::label::e_cyl_z};
+
+    using bounds =
+        detray::types::list<axis::circular<label0>, bounds_t<e_bounds, label1>>;
+    template <typename C, typename S>
+    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>>;
+};
+
+/// Behaviour of the two local axes (linear in r, circular in phi, linear in z)
+template <typename A, axis::bounds e_bounds,
+          template <typename, typename> class binning0_t,
+          template <typename, typename> class binning1_t,
+          template <typename, typename> class binning2_t>
+struct get_axes_types<cylindrical3<A>, e_bounds, binning0_t, binning1_t,
+                      binning2_t> {
+    template <typename algebra_t>
+    using frame = cylindrical3<algebra_t>;
+
+    static constexpr auto label0{axis::label::e_r};
+    static constexpr auto label1{axis::label::e_phi};
+    static constexpr auto label2{axis::label::e_z};
+
+    using bounds =
+        detray::types::list<bounds_t<e_bounds, label0>, axis::circular<label1>,
+                            bounds_t<e_bounds, label2>>;
+    template <typename C, typename S>
+    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>,
+                                        binning2_t<C, S>>;
+};
+
+/// @brief Helper type to assemble a multi-axis from shapes
+template <typename axes_t, bool is_owning, typename containers,
+          typename algebra_t, typename>
+struct get_coordinate_axes_type;
+
+/// Construct a @c multi_axis type from a given axes-shape
+template <typename axes_t, bool is_owning, typename containers,
+          typename algebra_t>
+struct get_coordinate_axes_type<
+    axes_t, is_owning, containers, algebra_t,
+    std::enable_if_t<std::is_same_v<typename axes_t::bounds, void>, void>> {
+    using type = typename axis::detail::multi_axis_assembler<
+        is_owning, containers,
+        typename axes_t::template type<algebra_t>::template frame<algebra_t>,
+        typename axes_t::template type<algebra_t>::bounds,
+        typename axes_t::template type<algebra_t>::template binning<
+            containers, typename algebra_t::scalar_type>>::type;
+};
+
+/// Don't do anything if the type is already a @c multi_axis
+template <typename axes_t, bool is_owning, typename containers,
+          typename algebra_t>
+struct get_coordinate_axes_type<
+    axes_t, is_owning, containers, algebra_t,
+    std::enable_if_t<std::is_object_v<typename axes_t::bounds>, void>> {
+    using type = axes_t;
+};
+
+}  // namespace axis::detail
+
+}  // namespace detray

--- a/core/include/detray/surface_finders/grid/detail/simple_serializer.hpp
+++ b/core/include/detray/surface_finders/grid/detail/simple_serializer.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,7 +10,6 @@
 // Project include(s).
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/qualifiers.hpp"
-#include "detray/surface_finders/grid/axis.hpp"
 
 namespace detray {
 
@@ -29,9 +28,9 @@ struct simple_serializer<1> {
 
     /// @returns the axis local bin, which is also the global bin
     template <typename multi_axis_t>
-    DETRAY_HOST_DEVICE auto operator()(multi_axis_t & /*axes*/,
-                                       n_axis::multi_bin<1> mbin) const
-        -> dindex {
+    DETRAY_HOST_DEVICE auto operator()(
+        multi_axis_t & /*axes*/,
+        typename multi_axis_t::loc_bin_index mbin) const -> dindex {
         return mbin[0];
     }
 
@@ -39,8 +38,8 @@ struct simple_serializer<1> {
     template <typename multi_axis_t,
               template <typename, std::size_t> class array_t = darray>
     DETRAY_HOST_DEVICE auto operator()(multi_axis_t & /*axes*/,
-                                       dindex gbin) const
-        -> n_axis::multi_bin<1> {
+                                       dindex gbin) const ->
+        typename multi_axis_t::loc_bin_index {
         return {gbin};
     }
 };
@@ -58,8 +57,8 @@ struct simple_serializer<2> {
     ///
     /// @returns a dindex for the bin data storage
     template <typename multi_axis_t>
-    DETRAY_HOST_DEVICE auto operator()(multi_axis_t &axes,
-                                       n_axis::multi_bin<2> mbin) const
+    DETRAY_HOST_DEVICE auto operator()(
+        multi_axis_t &axes, typename multi_axis_t::loc_bin_index mbin) const
         -> dindex {
         dindex offset{mbin[1] * axes.template get_axis<0>().nbins()};
         return offset + mbin[0];
@@ -74,8 +73,8 @@ struct simple_serializer<2> {
     ///
     /// @return a 2-dimensional multi-bin
     template <typename multi_axis_t>
-    DETRAY_HOST_DEVICE auto operator()(multi_axis_t &axes, dindex gbin) const
-        -> n_axis::multi_bin<2> {
+    DETRAY_HOST_DEVICE auto operator()(multi_axis_t &axes, dindex gbin) const ->
+        typename multi_axis_t::loc_bin_index {
         dindex nbins_axis0 = axes.template get_axis<0>().nbins();
 
         dindex bin0{gbin % nbins_axis0};
@@ -98,8 +97,8 @@ struct simple_serializer<3> {
     ///
     /// @returns a dindex for the bin data storage
     template <typename multi_axis_t>
-    DETRAY_HOST_DEVICE auto operator()(multi_axis_t &axes,
-                                       n_axis::multi_bin<3> mbin) const
+    DETRAY_HOST_DEVICE auto operator()(
+        multi_axis_t &axes, typename multi_axis_t::loc_bin_index mbin) const
         -> dindex {
         dindex nbins_axis0 = axes.template get_axis<0>().nbins();
         dindex nbins_axis1 = axes.template get_axis<1>().nbins();
@@ -119,8 +118,8 @@ struct simple_serializer<3> {
     ///
     /// @return a 3-dimensional multi-bin
     template <typename multi_axis_t>
-    DETRAY_HOST_DEVICE auto operator()(multi_axis_t &axes, dindex gbin) const
-        -> n_axis::multi_bin<3> {
+    DETRAY_HOST_DEVICE auto operator()(multi_axis_t &axes, dindex gbin) const ->
+        typename multi_axis_t::loc_bin_index {
         dindex nbins_axis0 = axes.template get_axis<0>().nbins();
         dindex nbins_axis1 = axes.template get_axis<1>().nbins();
 

--- a/core/include/detray/surface_finders/grid/grid.hpp
+++ b/core/include/detray/surface_finders/grid/grid.hpp
@@ -10,7 +10,8 @@
 // Project include(s).
 #include "detray/core/detail/container_views.hpp"
 #include "detray/definitions/qualifiers.hpp"
-#include "detray/surface_finders/grid/axis.hpp"
+#include "detray/surface_finders/grid/detail/axis.hpp"
+#include "detray/surface_finders/grid/detail/axis_helpers.hpp"
 #include "detray/surface_finders/grid/detail/bin_storage.hpp"
 #include "detray/surface_finders/grid/detail/bin_view.hpp"
 #include "detray/surface_finders/grid/populators.hpp"
@@ -29,18 +30,17 @@ namespace detray {
 
 /// @brief An N-dimensional grid for object storage.
 ///
-/// @tparam multi_axis_t the types of grid axes
+/// @tparam axes_t the types of grid axes
 /// @tparam bin_t type of bin in the (global) bin storage.
 /// @tparam serializer_t how to serialize axis-local bin indices into global bin
 ///                      indices in the grid backend storage and vice versa.
-template <typename multi_axis_t, typename bin_t,
+template <typename axes_t, typename bin_t,
           template <std::size_t> class serializer_t = simple_serializer>
-class grid {
+class grid_impl {
 
     public:
     /// Grid dimension
-    static constexpr unsigned int Dim = multi_axis_t::Dim;
-    static constexpr bool is_owning = multi_axis_t::is_owning;
+    static constexpr unsigned int dim = axes_t::dim;
 
     /// Single value in a bin entry
     using bin_type = bin_t;
@@ -51,16 +51,18 @@ class grid {
 
     /// The type of the multi-axis is tied to the type of the grid: a non-
     /// owning grid holds a non-owning multi-axis member.
-    using axes_type = multi_axis_t;
+    using axes_type = axes_t;
     using glob_bin_index = dindex;
     using loc_bin_index = typename axes_type::loc_bin_index;
     using local_frame_type = typename axes_type::local_frame_type;
     using point_type = typename axes_type::point_type;
     using scalar_type = typename axes_type::scalar_type;
 
+    static constexpr bool is_owning{axes_type::is_owning};
+
     /// How to define a neighborhood for this grid
     template <typename neighbor_t>
-    using neighborhood_type = std::array<neighbor_t, Dim>;
+    using neighborhood_type = std::array<neighbor_t, dim>;
 
     /// Backend storage type for the grid
     using bin_storage =
@@ -80,54 +82,54 @@ class grid {
 
     /// Find the corresponding (non-)owning grid type
     template <bool owning>
-    using type = grid<typename multi_axis_t::template type<owning>, bin_type,
-                      serializer_t>;
+    using type =
+        grid_impl<typename axes_t::template type<owning>, bin_t, serializer_t>;
 
     /// Make grid default constructible: Empty grid with empty axis
-    grid() = default;
+    grid_impl() = default;
 
     /// Create empty grid with empty axes from specific vecmem memory resource
     DETRAY_HOST
-    explicit grid(vecmem::memory_resource &resource)
+    explicit grid_impl(vecmem::memory_resource &resource)
         : m_bins(resource), m_axes(resource) {}
 
     /// Create grid with well defined @param axes and @param bins_data - move
     DETRAY_HOST_DEVICE
-    grid(bin_container_type &&bin_data, axes_type &&axes)
+    grid_impl(bin_container_type &&bin_data, axes_type &&axes)
         : m_bins(std::move(bin_data)), m_axes(std::move(axes)) {}
 
     /// Create grid from container pointers - non-owning (both grid and axes)
     DETRAY_HOST_DEVICE
-    grid(const bin_container_type *bin_data_ptr, const axes_type &axes,
-         const dindex offset = 0)
+    grid_impl(const bin_container_type *bin_data_ptr, const axes_type &axes,
+              const dindex offset = 0)
         : m_bins(*bin_data_ptr, offset, axes.nbins()), m_axes(axes) {}
 
     /// Create grid from container pointers - non-owning (both grid and axes)
     DETRAY_HOST_DEVICE
-    grid(bin_container_type *bin_data_ptr, axes_type &axes,
-         const dindex offset = 0u)
+    grid_impl(bin_container_type *bin_data_ptr, axes_type &axes,
+              const dindex offset = 0u)
         : m_bins(*bin_data_ptr, offset, axes.nbins()), m_axes(axes) {}
 
     /// Create grid from container pointers - non-owning (both grid and axes)
     // TODO: Remove
     DETRAY_HOST_DEVICE
-    grid(const bin_container_type *bin_data_ptr, axes_type &&axes,
-         const dindex offset = 0)
+    grid_impl(const bin_container_type *bin_data_ptr, axes_type &&axes,
+              const dindex offset = 0)
         : m_bins(*(const_cast<bin_container_type *>(bin_data_ptr)), offset,
                  axes.nbins()),
           m_axes(axes) {}
 
     /// Create grid from container pointers - non-owning (both grid and axes)
     DETRAY_HOST_DEVICE
-    grid(bin_container_type *bin_data_ptr, axes_type &&axes,
-         const dindex offset = 0u)
+    grid_impl(bin_container_type *bin_data_ptr, axes_type &&axes,
+              const dindex offset = 0u)
         : m_bins(*bin_data_ptr, offset, axes.nbins()), m_axes(axes) {}
 
     /// Device-side construction from a vecmem based view type
     template <typename grid_view_t,
               typename std::enable_if_t<detail::is_device_view_v<grid_view_t>,
                                         bool> = true>
-    DETRAY_HOST_DEVICE grid(grid_view_t &view)
+    DETRAY_HOST_DEVICE grid_impl(grid_view_t &view)
         : m_bins(detray::detail::get<0>(view.m_view)),
           m_axes(detray::detail::get<1>(view.m_view)) {}
 
@@ -146,7 +148,7 @@ class grid {
     }
 
     /// @returns an axis object, corresponding to the label.
-    template <n_axis::label L>
+    template <axis::label L>
     DETRAY_HOST_DEVICE inline constexpr auto get_axis() const {
         return m_axes.template get_axis<L>();
     }
@@ -169,7 +171,7 @@ class grid {
     }
 
     /// @returns an instance of the grid serializer
-    static constexpr auto serializer() -> serializer_t<Dim> { return {}; }
+    static constexpr auto serializer() -> serializer_t<dim> { return {}; }
 
     /// @returns a local multi-bin index from a global bin index @param gid
     constexpr auto deserialize(const glob_bin_index gid) const
@@ -214,7 +216,7 @@ class grid {
     }
 
     /// @param indices the single indices corresponding to a multi_bin
-    template <typename... I, std::enable_if_t<sizeof...(I) == Dim, bool> = true>
+    template <typename... I, std::enable_if_t<sizeof...(I) == dim, bool> = true>
     DETRAY_HOST_DEVICE decltype(auto) bin(I... indices) const {
         return bin(loc_bin_index{indices...});
     }
@@ -313,7 +315,7 @@ class grid {
 
         // Return iterable over bins in the search window
         auto search_window = axes().bin_ranges(p, win_size);
-        auto search_area = n_axis::detail::bin_view(*this, search_window);
+        auto search_area = axis::detail::bin_view(*this, search_window);
 
         // Join the respective bins to a single iteration
         return detray::views::join(std::move(search_area));
@@ -351,7 +353,7 @@ class grid {
     /// @returns view of a grid, including the grids multi_axis. Also valid if
     /// the value type of the grid is cv qualified (then value_t propagates
     /// quialifiers) - non-const
-    template <bool owner = is_owning, std::enable_if_t<owner, bool> = true>
+    template <bool owning = is_owning, std::enable_if_t<owning, bool> = true>
     DETRAY_HOST auto get_data() -> view_type {
         return view_type{detray::get_data(m_bins), detray::get_data(m_axes)};
     }
@@ -359,7 +361,7 @@ class grid {
     /// @returns view of a grid, including the grids multi_axis. Also valid if
     /// the value type of the grid is cv qualified (then value_t propagates
     /// quialifiers) - const
-    template <bool owner = is_owning, std::enable_if_t<owner, bool> = true>
+    template <bool owning = is_owning, std::enable_if_t<owning, bool> = true>
     DETRAY_HOST auto get_data() const -> const_view_type {
         return const_view_type{detray::get_data(m_bins),
                                detray::get_data(m_axes)};
@@ -371,5 +373,23 @@ class grid {
     /// The axes of the grid
     axes_type m_axes{};
 };
+
+/// Type alias for easier construction
+template <typename axes_t, typename bin_t,
+          template <std::size_t> class serializer_t = simple_serializer,
+          typename containers = host_container_types, bool ownership = true,
+          typename algebra_t = __plugin::transform3<detray::scalar>>
+using grid =
+    grid_impl<coordinate_axes<axes_t, ownership, containers, algebra_t>, bin_t,
+              simple_serializer>;
+
+namespace detail {
+
+template <typename multi_axis_t, typename bin_t,
+          template <std::size_t> class serializer_t>
+struct is_grid<grid_impl<multi_axis_t, bin_t, serializer_t>>
+    : public std::true_type {};
+
+}  // namespace detail
 
 }  // namespace detray

--- a/core/include/detray/tools/bin_association.hpp
+++ b/core/include/detray/tools/bin_association.hpp
@@ -35,7 +35,7 @@ namespace detray {
 ///        taken absolute or relative
 template <typename context_t, typename surface_container_t,
           typename transform_container_t, typename mask_container_t,
-          typename grid_t, std::enable_if_t<grid_t::Dim == 2, bool> = true>
+          typename grid_t, std::enable_if_t<grid_t::dim == 2, bool> = true>
 static inline void bin_association(const context_t & /*context*/,
                                    const surface_container_t &surfaces,
                                    const transform_container_t &transforms,

--- a/core/include/detray/tools/bin_fillers.hpp
+++ b/core/include/detray/tools/bin_fillers.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,7 +8,6 @@
 #pragma once
 
 // Project include(s).
-#include "detray/surface_finders/grid/axis.hpp"
 #include "detray/surface_finders/grid/populators.hpp"
 #include "detray/tools/bin_association.hpp"
 
@@ -30,7 +29,7 @@ struct fill_by_bin {
     template <typename grid_t>
     struct bin_data {
         /// Bin index on the grid axes
-        n_axis::multi_bin<grid_t::Dim> local_bin_idx;
+        typename grid_t::loc_bin_index local_bin_idx;
         /// Single element of the bin content, which can be a collection of grid
         /// values
         typename grid_t::value_type single_element;

--- a/core/include/detray/tools/bounding_volume.hpp
+++ b/core/include/detray/tools/bounding_volume.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,11 +29,10 @@ class axis_aligned_bounding_volume {
     /// @{
     using shape = shape_t;
     using boundaries = typename shape_t::boundaries;
-    using axes = typename shape_t::template axes<>;
     template <typename algebra_t>
     using local_frame = typename shape_t::template local_frame_type<algebra_t>;
 
-    static constexpr std::size_t Dim{axes::Dim};
+    static constexpr std::size_t dim{shape_t::dim};
     /// @}
 
     /// Default constructor builds an infinite box
@@ -78,8 +77,7 @@ class axis_aligned_bounding_volume {
             axis_aligned_bounding_volume<other_shape_t, other_scalar_t>>& aabbs,
         std::size_t box_id, const scalar_t env) {
 
-        using loc_point_t =
-            std::array<scalar_t, other_shape_t::template axes<>::dim>;
+        using loc_point_t = std::array<scalar_t, other_shape_t::dim>;
 
         // Find min/max extent of the local aabb in local coordinates
         constexpr scalar_t inv{detail::invalid_value<scalar_t>()};

--- a/core/include/detray/tools/detector_builder.hpp
+++ b/core/include/detray/tools/detector_builder.hpp
@@ -115,11 +115,11 @@ class detector_builder {
 
             grid_factory_type<vol_finder_t> vgrid_factory{};
             m_vol_finder = vgrid_factory.template new_grid<
-                n_axis::open<n_axis::label::e_r>,
-                n_axis::circular<n_axis::label::e_phi>,
-                n_axis::open<n_axis::label::e_z>, n_axis::irregular<>,
-                n_axis::regular<>, n_axis::irregular<>>(
-                vgrid_dims, n_vgrid_bins, bin_edges);
+                axis::open<axis::label::e_r>,
+                axis::circular<axis::label::e_phi>,
+                axis::open<axis::label::e_z>, axis::irregular<>,
+                axis::regular<>, axis::irregular<>>(vgrid_dims, n_vgrid_bins,
+                                                    bin_edges);
         } else {
             m_vol_finder = vol_finder_t{args...};
         }

--- a/core/include/detray/tools/grid_factory.hpp
+++ b/core/include/detray/tools/grid_factory.hpp
@@ -12,7 +12,8 @@
 #include "detray/definitions/units.hpp"
 #include "detray/intersection/cylinder_portal_intersector.hpp"
 #include "detray/masks/masks.hpp"
-#include "detray/surface_finders/grid/axis.hpp"
+#include "detray/surface_finders/grid/detail/axis.hpp"
+#include "detray/surface_finders/grid/detail/axis_helpers.hpp"
 #include "detray/surface_finders/grid/grid.hpp"
 #include "detray/surface_finders/grid/grid_collection.hpp"
 #include "detray/surface_finders/grid/populators.hpp"
@@ -67,23 +68,32 @@ class grid_factory {
     // annulus 2D
     //
     template <
-        typename r_bounds = n_axis::closed<n_axis::label::e_r>,
-        typename phi_bounds = n_axis::circular<>,
-        typename r_binning = n_axis::regular<host_container_types, scalar_type>,
-        typename phi_binning =
-            n_axis::regular<host_container_types, scalar_type>>
+        typename r_bounds = axis::closed<axis::label::e_r>,
+        typename phi_bounds = axis::circular<>,
+        typename r_binning = axis::regular<host_container_types, scalar_type>,
+        typename phi_binning = axis::regular<host_container_types, scalar_type>,
+        std::enable_if_t<std::is_enum_v<decltype(r_bounds::label)>, bool> =
+            true>
     auto new_grid(const mask<annulus2D<>> &grid_bounds,
                   const std::array<std::size_t, 2UL> n_bins,
                   const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
                       {}}) const {
+
+        static_assert(
+            std::is_same_v<phi_bounds, axis::circular<>>,
+            "Phi axis bounds need to be circular for stereo annulus shape");
+
         // Axes boundaries and local indices
         using boundary = annulus2D<>::boundaries;
-        using axes = annulus2D<>::axes<>;
-        constexpr auto e_r_axis = static_cast<dindex>(axes::axis_loc0);
-        constexpr auto e_phi_axis = static_cast<dindex>(axes::axis_loc1);
+        using axes_t = axes<annulus2D<>>::template type<algebra_t>;
+        using local_frame = typename axes_t::template frame<algebra_t>;
+
+        constexpr auto e_r_axis = static_cast<dindex>(axes_t::label0);
+        constexpr auto e_phi_axis = static_cast<dindex>(axes_t::label1);
+
         auto b_values = grid_bounds.values();
 
-        return new_grid<annulus2D<>>(
+        return new_grid<local_frame>(
             {b_values[boundary::e_min_r], b_values[boundary::e_max_r],
              b_values[boundary::e_average_phi] -
                  b_values[boundary::e_min_phi_rel],
@@ -99,26 +109,30 @@ class grid_factory {
     // cuboid 3D
     //
     template <
-        typename x_bounds = n_axis::closed<n_axis::label::e_x>,
-        typename y_bounds = n_axis::closed<n_axis::label::e_y>,
-        typename z_bounds = n_axis::closed<n_axis::label::e_z>,
-        typename x_binning = n_axis::regular<host_container_types, scalar_type>,
-        typename y_binning = n_axis::regular<host_container_types, scalar_type>,
-        typename z_binning = n_axis::regular<host_container_types, scalar_type>>
+        typename x_bounds = axis::closed<axis::label::e_x>,
+        typename y_bounds = axis::closed<axis::label::e_y>,
+        typename z_bounds = axis::closed<axis::label::e_z>,
+        typename x_binning = axis::regular<host_container_types, scalar_type>,
+        typename y_binning = axis::regular<host_container_types, scalar_type>,
+        typename z_binning = axis::regular<host_container_types, scalar_type>,
+        std::enable_if_t<std::is_enum_v<decltype(x_bounds::label)>, bool> =
+            true>
     auto new_grid(const mask<cuboid3D<>> &grid_bounds,
                   const std::array<std::size_t, 3UL> n_bins,
                   const std::array<std::vector<scalar_type>, 3UL> &bin_edges = {
                       {}}) const {
         // Axes boundaries and local indices
         using boundary = cuboid3D<>::boundaries;
-        using axes = cuboid3D<>::axes<>;
-        constexpr auto e_x_axis = static_cast<dindex>(axes::axis_loc0);
-        constexpr auto e_y_axis = static_cast<dindex>(axes::axis_loc1);
-        constexpr auto e_z_axis = static_cast<dindex>(axes::axis_loc2);
+        using axes_t = axes<cuboid3D<>>::template type<algebra_t>;
+        using local_frame = typename axes_t::template frame<algebra_t>;
+
+        constexpr auto e_x_axis = static_cast<dindex>(axes_t::label0);
+        constexpr auto e_y_axis = static_cast<dindex>(axes_t::label1);
+        constexpr auto e_z_axis = static_cast<dindex>(axes_t::label2);
 
         auto b_values = grid_bounds.values();
 
-        return new_grid<cuboid3D<>>(
+        return new_grid<local_frame>(
             {b_values[boundary::e_min_x], b_values[boundary::e_max_x],
              b_values[boundary::e_min_y], b_values[boundary::e_max_y],
              b_values[boundary::e_min_z], b_values[boundary::e_max_z]},
@@ -132,24 +146,33 @@ class grid_factory {
     // cylinder 2D
     //
     template <
-        typename rphi_bounds = n_axis::circular<n_axis::label::e_rphi>,
-        typename z_bounds = n_axis::closed<n_axis::label::e_cyl_z>,
+        typename rphi_bounds = axis::circular<axis::label::e_rphi>,
+        typename z_bounds = axis::closed<axis::label::e_cyl_z>,
         typename rphi_binning =
-            n_axis::regular<host_container_types, scalar_type>,
-        typename z_binning = n_axis::regular<host_container_types, scalar_type>>
+            axis::regular<host_container_types, scalar_type>,
+        typename z_binning = axis::regular<host_container_types, scalar_type>,
+        std::enable_if_t<std::is_enum_v<decltype(rphi_bounds::label)>, bool> =
+            true>
     auto new_grid(const mask<cylinder2D<>> &grid_bounds,
                   const std::array<std::size_t, 2UL> n_bins,
                   const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
                       {}}) const {
+
+        static_assert(
+            std::is_same_v<rphi_bounds, axis::circular<axis::label::e_rphi>>,
+            "Phi axis bounds need to be circular for cylinder2D shape");
+
         // Axes boundaries and local indices
         using boundary = cylinder2D<>::boundaries;
-        using axes = cylinder2D<>::axes<>;
-        constexpr auto e_rphi_axis = static_cast<dindex>(axes::axis_loc0);
-        constexpr auto e_z_axis = static_cast<dindex>(axes::axis_loc1);
+        using axes_t = axes<cylinder2D<>>::template type<algebra_t>;
+        using local_frame = typename axes_t::template frame<algebra_t>;
+
+        constexpr auto e_rphi_axis = static_cast<dindex>(axes_t::label0);
+        constexpr auto e_z_axis = static_cast<dindex>(axes_t::label1);
 
         auto b_values = grid_bounds.values();
 
-        return new_grid<cylinder2D<>>(
+        return new_grid<local_frame>(
             {-constant<scalar_type>::pi * b_values[boundary::e_r],
              constant<scalar_type>::pi * b_values[boundary::e_r],
              b_values[boundary::e_n_half_z], b_values[boundary::e_p_half_z]},
@@ -163,25 +186,34 @@ class grid_factory {
     // cylinder 2D
     //
     template <
-        typename rphi_bounds = n_axis::circular<n_axis::label::e_rphi>,
-        typename z_bounds = n_axis::closed<n_axis::label::e_cyl_z>,
+        typename rphi_bounds = axis::circular<axis::label::e_rphi>,
+        typename z_bounds = axis::closed<axis::label::e_cyl_z>,
         typename rphi_binning =
-            n_axis::regular<host_container_types, scalar_type>,
-        typename z_binning = n_axis::regular<host_container_types, scalar_type>>
+            axis::regular<host_container_types, scalar_type>,
+        typename z_binning = axis::regular<host_container_types, scalar_type>,
+        std::enable_if_t<std::is_enum_v<decltype(rphi_bounds::label)>, bool> =
+            true>
     auto new_grid(
         const mask<cylinder2D<false, cylinder_portal_intersector>> &grid_bounds,
         const std::array<std::size_t, 2UL> n_bins,
         const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
             {}}) const {
+
+        static_assert(
+            std::is_same_v<rphi_bounds, axis::circular<axis::label::e_rphi>>,
+            "Phi axis bounds need to be circular for cylinder2D portal shape");
+
         // Axes boundaries and local indices
         using boundary = cylinder2D<>::boundaries;
-        using axes = cylinder2D<>::axes<>;
-        constexpr auto e_rphi_axis = static_cast<dindex>(axes::axis_loc0);
-        constexpr auto e_z_axis = static_cast<dindex>(axes::axis_loc1);
+        using axes_t = axes<cylinder2D<>>::template type<algebra_t>;
+        using local_frame = typename axes_t::template frame<algebra_t>;
+
+        constexpr auto e_rphi_axis = static_cast<dindex>(axes_t::label0);
+        constexpr auto e_z_axis = static_cast<dindex>(axes_t::label1);
 
         auto b_values = grid_bounds.values();
 
-        return new_grid<cylinder2D<>>(
+        return new_grid<local_frame>(
             {-constant<scalar_type>::pi * b_values[boundary::e_r],
              constant<scalar_type>::pi * b_values[boundary::e_r],
              b_values[boundary::e_n_half_z], b_values[boundary::e_p_half_z]},
@@ -195,26 +227,35 @@ class grid_factory {
     // cylinder 3D
     //
     template <
-        typename r_bounds = n_axis::closed<n_axis::label::e_r>,
-        typename phi_bounds = n_axis::circular<>,
-        typename z_bounds = n_axis::closed<n_axis::label::e_z>,
-        typename r_binning = n_axis::regular<host_container_types, scalar_type>,
-        typename phi_binning =
-            n_axis::regular<host_container_types, scalar_type>,
-        typename z_binning = n_axis::regular<host_container_types, scalar_type>>
+        typename r_bounds = axis::closed<axis::label::e_r>,
+        typename phi_bounds = axis::circular<>,
+        typename z_bounds = axis::closed<axis::label::e_z>,
+        typename r_binning = axis::regular<host_container_types, scalar_type>,
+        typename phi_binning = axis::regular<host_container_types, scalar_type>,
+        typename z_binning = axis::regular<host_container_types, scalar_type>,
+        std::enable_if_t<std::is_enum_v<decltype(r_bounds::label)>, bool> =
+            true>
     auto new_grid(const mask<cylinder3D> &grid_bounds,
                   const std::array<std::size_t, 3UL> n_bins,
                   const std::array<std::vector<scalar_type>, 3UL> &bin_edges = {
                       {}}) const {
+
+        static_assert(
+            std::is_same_v<phi_bounds, axis::circular<>>,
+            "Phi axis bounds need to be circular for cylinder3D shape");
+
         // Axes boundaries and local indices
         using boundary = cylinder3D::boundaries;
-        using axes = cylinder3D::axes<>;
-        constexpr auto e_r_axis = static_cast<dindex>(axes::axis_loc0);
-        constexpr auto e_phi_axis = static_cast<dindex>(axes::axis_loc1);
-        constexpr auto e_z_axis = static_cast<dindex>(axes::axis_loc2);
+        using axes_t = axes<cylinder3D>::template type<algebra_t>;
+        using local_frame = typename axes_t::template frame<algebra_t>;
+
+        constexpr auto e_r_axis = static_cast<dindex>(axes_t::label0);
+        constexpr auto e_phi_axis = static_cast<dindex>(axes_t::label1);
+        constexpr auto e_z_axis = static_cast<dindex>(axes_t::label2);
+
         auto b_values = grid_bounds.values();
 
-        return new_grid<cylinder3D>(
+        return new_grid<local_frame>(
             {b_values[boundary::e_min_r], b_values[boundary::e_max_r],
              b_values[boundary::e_min_phi], b_values[boundary::e_max_phi],
              -b_values[boundary::e_min_z], b_values[boundary::e_max_z]},
@@ -228,24 +269,31 @@ class grid_factory {
     // polar 2D
     //
     template <
-        typename r_bounds = n_axis::closed<n_axis::label::e_r>,
-        typename phi_bounds = n_axis::circular<>,
-        typename r_binning = n_axis::regular<host_container_types, scalar_type>,
-        typename phi_binning =
-            n_axis::regular<host_container_types, scalar_type>>
+        typename r_bounds = axis::closed<axis::label::e_r>,
+        typename phi_bounds = axis::circular<>,
+        typename r_binning = axis::regular<host_container_types, scalar_type>,
+        typename phi_binning = axis::regular<host_container_types, scalar_type>,
+        std::enable_if_t<std::is_enum_v<decltype(r_bounds::label)>, bool> =
+            true>
     auto new_grid(const mask<ring2D<>> &grid_bounds,
                   const std::array<std::size_t, 2UL> n_bins,
                   const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
                       {}}) const {
+
+        static_assert(std::is_same_v<phi_bounds, axis::circular<>>,
+                      "Phi axis bounds need to be circular for ring shape");
+
         // Axes boundaries and local indices
         using boundary = ring2D<>::boundaries;
-        using axes = ring2D<>::axes<>;
-        constexpr auto e_r_axis = static_cast<dindex>(axes::axis_loc0);
-        constexpr auto e_phi_axis = static_cast<dindex>(axes::axis_loc1);
+        using axes_t = axes<ring2D<>>::template type<algebra_t>;
+        using local_frame = typename axes_t::template frame<algebra_t>;
+
+        constexpr auto e_r_axis = static_cast<dindex>(axes_t::label0);
+        constexpr auto e_phi_axis = static_cast<dindex>(axes_t::label1);
 
         auto b_values = grid_bounds.values();
 
-        return new_grid<ring2D<>>(
+        return new_grid<local_frame>(
             {b_values[boundary::e_inner_r], b_values[boundary::e_outer_r],
              -constant<scalar_type>::pi, constant<scalar_type>::pi},
             {n_bins[e_r_axis], n_bins[e_phi_axis]},
@@ -258,23 +306,27 @@ class grid_factory {
     // rectangle 2D
     //
     template <
-        typename x_bounds = n_axis::closed<n_axis::label::e_x>,
-        typename y_bounds = n_axis::closed<n_axis::label::e_y>,
-        typename x_binning = n_axis::regular<host_container_types, scalar_type>,
-        typename y_binning = n_axis::regular<host_container_types, scalar_type>>
+        typename x_bounds = axis::closed<axis::label::e_x>,
+        typename y_bounds = axis::closed<axis::label::e_y>,
+        typename x_binning = axis::regular<host_container_types, scalar_type>,
+        typename y_binning = axis::regular<host_container_types, scalar_type>,
+        std::enable_if_t<std::is_enum_v<decltype(x_bounds::label)>, bool> =
+            true>
     auto new_grid(const mask<rectangle2D<>> &grid_bounds,
                   const std::array<std::size_t, 2UL> n_bins,
                   const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
                       {}}) const {
         // Axes boundaries and local indices
         using boundary = rectangle2D<>::boundaries;
-        using axes = rectangle2D<>::axes<>;
-        constexpr auto e_x_axis = static_cast<dindex>(axes::axis_loc0);
-        constexpr auto e_y_axis = static_cast<dindex>(axes::axis_loc1);
+        using axes_t = axes<rectangle2D<>>::template type<algebra_t>;
+        using local_frame = typename axes_t::template frame<algebra_t>;
+
+        constexpr auto e_x_axis = static_cast<dindex>(axes_t::label0);
+        constexpr auto e_y_axis = static_cast<dindex>(axes_t::label1);
 
         auto b_values = grid_bounds.values();
 
-        return new_grid<rectangle2D<>>(
+        return new_grid<local_frame>(
             {-b_values[boundary::e_half_x], b_values[boundary::e_half_x],
              -b_values[boundary::e_half_y], b_values[boundary::e_half_y]},
             {n_bins[e_x_axis], n_bins[e_y_axis]},
@@ -287,62 +339,34 @@ class grid_factory {
     // trapezoid 2D
     //
     template <
-        typename x_bounds = n_axis::closed<n_axis::label::e_x>,
-        typename y_bounds = n_axis::closed<n_axis::label::e_y>,
-        typename x_binning = n_axis::regular<host_container_types, scalar_type>,
-        typename y_binning = n_axis::regular<host_container_types, scalar_type>>
+        typename x_bounds = axis::closed<axis::label::e_x>,
+        typename y_bounds = axis::closed<axis::label::e_y>,
+        typename x_binning = axis::regular<host_container_types, scalar_type>,
+        typename y_binning = axis::regular<host_container_types, scalar_type>,
+        std::enable_if_t<std::is_enum_v<decltype(x_bounds::label)>, bool> =
+            true>
     auto new_grid(const mask<trapezoid2D<>> &grid_bounds,
                   const std::array<std::size_t, 2UL> n_bins,
                   const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
                       {}}) const {
         // Axes boundaries and local indices
         using boundary = trapezoid2D<>::boundaries;
-        using axes = trapezoid2D<>::axes<>;
+        using axes_t = axes<trapezoid2D<>>::template type<algebra_t>;
+        using local_frame = typename axes_t::template frame<algebra_t>;
 
-        constexpr auto e_x_axis = static_cast<dindex>(axes::axis_loc0);
-        constexpr auto e_y_axis = static_cast<dindex>(axes::axis_loc1);
+        constexpr auto e_x_axis = static_cast<dindex>(axes_t::label0);
+        constexpr auto e_y_axis = static_cast<dindex>(axes_t::label1);
 
         auto b_values = grid_bounds.values();
 
-        return new_grid<trapezoid2D<>>(
-            {-b_values[boundary::e_half_length_1],
-             b_values[boundary::e_half_length_1],
-             -b_values[boundary::e_half_length_2],
-             b_values[boundary::e_half_length_2]},
-            {n_bins[e_x_axis], n_bins[e_y_axis]},
-            {bin_edges[e_x_axis], bin_edges[e_y_axis]},
-            types::list<x_bounds, y_bounds>{},
-            types::list<x_binning, y_binning>{});
-    }
-
-    /// @brief Create and empty grid with fully initialized axes.
-    ///
-    /// @tparam grid_shape_t the shape of the resulting grid
-    ///         (e.g. cylinder2D).
-    /// @tparam e_bounds the bounds of the regular axes
-    ///         (open vs. closed bounds).
-    /// @tparam binnings the binning types of the axes
-    ///         (regular vs. irregular)
-    ///
-    /// @param spans the span of the axis values for regular axes, otherwise
-    ///              ignored.
-    /// @param n_bins the number of bins for regular axes, otherwise ignored
-    /// @param ax_bin_edges the explicit bin edges for irregular axes
-    ///                     (lower bin edges + the the upper edge of the
-    ///                     last bin), otherwise ignored.
-    template <
-        typename grid_shape_t, typename... bound_ts, typename... binning_ts,
-        std::enable_if_t<std::is_enum_v<typename grid_shape_t::boundaries>,
-                         bool> = true>
-    auto new_grid(const std::vector<scalar_type> spans,
-                  const std::vector<std::size_t> n_bins,
-                  const std::vector<std::vector<scalar_type>> &ax_bin_edges,
-                  const types::list<bound_ts...> &bounds,
-                  const types::list<binning_ts...> &binnings) const {
-
-        return new_grid<
-            typename grid_shape_t::template local_frame_type<algebra_t>>(
-            spans, n_bins, ax_bin_edges, bounds, binnings);
+        return new_grid<local_frame>({-b_values[boundary::e_half_length_1],
+                                      b_values[boundary::e_half_length_1],
+                                      -b_values[boundary::e_half_length_2],
+                                      b_values[boundary::e_half_length_2]},
+                                     {n_bins[e_x_axis], n_bins[e_y_axis]},
+                                     {bin_edges[e_x_axis], bin_edges[e_y_axis]},
+                                     types::list<x_bounds, y_bounds>{},
+                                     types::list<x_binning, y_binning>{});
     }
 
     /// @brief Create and empty grid with fully initialized axes.
@@ -376,17 +400,88 @@ class grid_factory {
 
         // Build the coordinate axes and the grid
         using axes_t =
-            n_axis::multi_axis<is_owning, grid_frame_t,
-                               n_axis::single_axis<bound_ts, binning_ts>...>;
+            axis::multi_axis<is_owning, grid_frame_t,
+                             axis::single_axis<bound_ts, binning_ts>...>;
+        using grid_t = grid<axes_t, bin_t, serializer_t>;
+
+        return new_grid<grid_t>(spans, n_bins, ax_bin_edges);
+    }
+
+    /// Helper to build grid from shape plus binning and bounds types
+    template <
+        typename grid_shape_t, typename... bound_ts, typename... binning_ts,
+        std::enable_if_t<std::is_enum_v<typename grid_shape_t::boundaries>,
+                         bool> = true>
+    auto new_grid(const std::vector<scalar_type> spans,
+                  const std::vector<std::size_t> n_bins,
+                  const std::vector<std::vector<scalar_type>> &ax_bin_edges,
+                  const types::list<bound_ts...> &bounds,
+                  const types::list<binning_ts...> &binnings) const {
+
+        return new_grid<
+            typename grid_shape_t::template local_frame_type<algebra_t>>(
+            spans, n_bins, ax_bin_edges, bounds, binnings);
+    }
+
+    /// Helper overload for grid builder: Build from mask and resolve bounds
+    /// and binnings from concrete grid type
+    template <typename grid_t, typename grid_shape_t,
+              std::enable_if_t<detail::is_grid_v<grid_t>, bool> = true>
+    auto new_grid(const mask<grid_shape_t> &spans,
+                  const std::array<std::size_t, grid_t::dim> &n_bins,
+                  const std::array<std::vector<scalar_type>, grid_t::dim>
+                      &ax_bin_edges) const {
+
+        return new_grid(spans, n_bins, ax_bin_edges,
+                        typename grid_t::axes_type::bounds{},
+                        typename grid_t::axes_type::binnings{});
+    }
+
+    /// Helper overload for grid builder: Build from mask and resolve bounds
+    /// and binnings
+    template <
+        typename grid_shape_t, typename... bound_ts, typename... binning_ts,
+        std::enable_if_t<std::is_enum_v<typename grid_shape_t::boundaries>,
+                         bool> = true>
+    auto new_grid(const mask<grid_shape_t> &spans,
+                  const std::array<std::size_t, grid_shape_t::dim> &n_bins,
+                  const std::array<std::vector<scalar_type>, grid_shape_t::dim>
+                      &ax_bin_edges,
+                  const types::list<bound_ts...> &,
+                  const types::list<binning_ts...> &) const {
+
+        return new_grid<bound_ts..., binning_ts...>(spans, n_bins,
+                                                    ax_bin_edges);
+    }
+
+    /// @brief Create and empty grid with fully initialized axes.
+    ///
+    /// @tparam grid_t the tpye of the resulting grid
+    ///
+    /// @param spans the span of the axis values for regular axes, otherwise
+    ///              ignored.
+    /// @param n_bins the number of bins for regular axes, otherwise ignored
+    /// @param ax_bin_edges the explicit bin edges for irregular axes
+    ///                     (lower bin edges + the the upper edge of the
+    ///                     last bin), otherwise ignored.
+    template <typename grid_t,
+              std::enable_if_t<detail::is_grid_v<grid_t>, bool> = true>
+    auto new_grid(
+        const std::vector<scalar_type> spans,
+        const std::vector<std::size_t> n_bins,
+        const std::vector<std::vector<scalar_type>> &ax_bin_edges) const {
+
+        using owning_grid_t = typename grid_t::template type<true>;
+        using axes_t = typename owning_grid_t::axes_type;
 
         // Prepare data
         vector_type<dindex_range> axes_data{};
         vector_type<scalar_type> bin_edges{};
 
         // Call init for every axis
-        unroll_axis_init<types::list<binning_ts...>>(
+        unroll_axis_init<typename axes_t::binnings>(
             spans, n_bins, ax_bin_edges, axes_data, bin_edges,
-            std::make_index_sequence<axes_t::Dim>{});
+            std::make_index_sequence<axes_t::dim>{});
 
         // Assemble the grid and return it
         axes_t axes(std::move(axes_data), std::move(bin_edges));
@@ -395,7 +490,7 @@ class grid_factory {
         bin_data.resize(axes.nbins_per_axis()[0] * axes.nbins_per_axis()[1],
                         bin_type{});
 
-        return grid_type<axes_t>(std::move(bin_data), std::move(axes));
+        return owning_grid_t(std::move(bin_data), std::move(axes));
     }
 
     private:
@@ -410,7 +505,7 @@ class grid_factory {
                    vector_type<scalar_type> &bin_edges) const {
         if constexpr (std::is_same_v<
                           types::at<binnings, I>,
-                          n_axis::regular<host_container_types, scalar_type>>) {
+                          axis::regular<host_container_types, scalar_type>>) {
             axes_data.push_back({static_cast<dindex>(bin_edges.size()),
                                  static_cast<dindex>(n_bins.at(I))});
             bin_edges.push_back(spans.at(I * 2u));
@@ -456,13 +551,13 @@ auto grid_factory<bin_t, serializer_t, algebra_t>::to_string(
     for (unsigned int i{0u}; i < ax0.nbins(); ++i) {
 
         // Loop over the second dimension
-        if constexpr (grid_t::Dim > 1u) {
+        if constexpr (grid_t::dim > 1u) {
             const auto &ax1 = gr.template get_axis<1>();
             std::cout << "{";
             for (unsigned int j{0u}; j < ax1.nbins(); ++j) {
 
                 // Loop over the third dimension
-                if constexpr (grid_t::Dim > 2) {
+                if constexpr (grid_t::dim > 2) {
                     const auto &ax2 = gr.template get_axis<2>();
                     std::cout << "{";
                     for (unsigned int k{0u}; k < ax2.nbins(); ++k) {

--- a/io/include/detray/io/common/detail/grid_writer.hpp
+++ b/io/include/detray/io/common/detail/grid_writer.hpp
@@ -68,7 +68,7 @@ class grid_writer : public writer_interface<detector_t> {
         grid_data.acc_link = base_type::serialize(type, idx);
 
         // Serialize the multi-axis into single axis payloads
-        const std::array<axis_payload, grid_t::Dim> axes_data =
+        const std::array<axis_payload, grid_t::dim> axes_data =
             serialize(gr.axes());
 
         grid_data.axes.resize(axes_data.size());
@@ -89,7 +89,7 @@ class grid_writer : public writer_interface<detector_t> {
     /// Serialize a multi-axis @param axes into its io payload
     template <bool ownership, typename local_frame_t, typename... axis_ts>
     static auto serialize(
-        const n_axis::multi_axis<ownership, local_frame_t, axis_ts...>& axes) {
+        const axis::multi_axis<ownership, local_frame_t, axis_ts...>& axes) {
 
         // Serialize every single axis and construct array from their payloads
         std::array<axis_payload, sizeof...(axis_ts)> axes_data{
@@ -101,7 +101,7 @@ class grid_writer : public writer_interface<detector_t> {
     /// Serialize a single axis @param axis into its io payload
     template <typename bounds_t, typename binning_t>
     static axis_payload serialize(
-        const n_axis::single_axis<bounds_t, binning_t>& axis) {
+        const axis::single_axis<bounds_t, binning_t>& axis) {
         axis_payload axis_data;
 
         axis_data.binning = axis.binning();
@@ -109,7 +109,7 @@ class grid_writer : public writer_interface<detector_t> {
         axis_data.label = axis.label();
         axis_data.bins = axis.nbins();
 
-        if (axis.binning() == n_axis::binning::e_regular) {
+        if (axis.binning() == axis::binning::e_regular) {
             axis_data.edges = {axis.min(), axis.max()};
         } else {
             const auto& bin_edges = axis.bin_edges();
@@ -124,7 +124,7 @@ class grid_writer : public writer_interface<detector_t> {
     /// Serialize a multi-bin @param mbin into its io payload
     template <typename content_t, std::size_t DIM, typename content_range_t>
     static grid_bin_payload<content_t> serialize(
-        const n_axis::multi_bin<DIM> mbin, const content_range_t& content,
+        const axis::multi_bin<DIM> mbin, const content_range_t& content,
         std::function<content_t(const value_t&)> serializer) {
 
         grid_bin_payload<content_t> bin_data;

--- a/io/include/detray/io/common/detector_reader.hpp
+++ b/io/include/detray/io/common/detector_reader.hpp
@@ -94,15 +94,20 @@ auto assemble_reader(const io::detector_reader_config& cfg) noexcept(false) {
                 readers.template add<json_geometry_reader>(file_name);
 
             } else if (header.tag == "homogeneous_material") {
-                readers.template add<json_homogeneous_material_reader>(
-                    file_name);
+                if constexpr (detail::has_homogeneous_material_v<detector_t>) {
+                    readers.template add<json_homogeneous_material_reader>(
+                        file_name);
+                }
 
             } else if (header.tag == "surface_grids") {
-                using surface_t = typename detector_t::surface_type;
-                readers.template add<json_grid_reader, surface_t,
-                                     std::integral_constant<std::size_t, CAP>,
-                                     std::integral_constant<std::size_t, DIM>>(
-                    file_name);
+                if constexpr (detail::has_surface_grids_v<detector_t>) {
+                    using surface_t = typename detector_t::surface_type;
+                    readers
+                        .template add<json_grid_reader, surface_t,
+                                      std::integral_constant<std::size_t, CAP>,
+                                      std::integral_constant<std::size_t, DIM>>(
+                            file_name);
+                }
             } else {
                 throw std::invalid_argument("Unsupported file tag '" +
                                             header.tag +

--- a/io/include/detray/io/common/payloads.hpp
+++ b/io/include/detray/io/common/payloads.hpp
@@ -166,9 +166,9 @@ using grid_header_payload = header_payload<grid_sub_header_payload>;
 /// @brief axis definition and bin edges
 struct axis_payload {
     /// axis lookup type
-    n_axis::binning binning{n_axis::binning::e_regular};
-    n_axis::bounds bounds{n_axis::bounds::e_closed};
-    n_axis::label label{n_axis::label::e_r};
+    axis::binning binning{axis::binning::e_regular};
+    axis::bounds bounds{axis::bounds::e_closed};
+    axis::label label{axis::label::e_r};
 
     std::size_t bins{0u};
     std::vector<real_io> edges{};

--- a/io/include/detray/io/json/json_grids_io.hpp
+++ b/io/include/detray/io/json/json_grids_io.hpp
@@ -49,9 +49,9 @@ inline void to_json(nlohmann::ordered_json& j, const axis_payload& a) {
 }
 
 inline void from_json(const nlohmann::ordered_json& j, axis_payload& a) {
-    a.binning = static_cast<n_axis::binning>(j["binning"]);
-    a.bounds = static_cast<n_axis::bounds>(j["bounds"]);
-    a.label = static_cast<n_axis::label>(j["label"]);
+    a.binning = static_cast<axis::binning>(j["binning"]);
+    a.bounds = static_cast<axis::bounds>(j["bounds"]);
+    a.label = static_cast<axis::label>(j["label"]);
     a.bins = j["bins"];
     a.edges = j["edges"].get<std::vector<real_io>>();
 }

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
@@ -9,8 +9,8 @@
 
 // Project include(s)
 #include "detray/core/detector.hpp"
+#include "detray/definitions/grid_axis.hpp"
 #include "detray/definitions/units.hpp"
-#include "detray/grids/axis.hpp"
 #include "detray/plugins/svgtools/styling/styling.hpp"
 
 // Actsvg include(s)
@@ -56,7 +56,7 @@ template <
 inline auto grid_type_and_edges(const grid_t& grid, const view_t&) {
 
     using scalar_t = typename grid_t::local_frame_type::scalar_type;
-    using axis_label = detray::n_axis::label;
+    using axis_label = detray::axis::label;
 
     auto edges_rphi = grid.template get_axis<axis_label::e_rphi>().bin_edges();
     auto edges_z = grid.template get_axis<axis_label::e_cyl_z>().bin_edges();
@@ -95,7 +95,7 @@ template <
 inline auto grid_type_and_edges(const grid_t& grid, const view_t&) {
 
     using scalar_t = typename grid_t::local_frame_type::scalar_type;
-    using axis_label = detray::n_axis::label;
+    using axis_label = detray::axis::label;
 
     auto edges_r = grid.template get_axis<axis_label::e_r>().bin_edges();
     auto edges_phi = grid.template get_axis<axis_label::e_phi>().bin_edges();
@@ -152,7 +152,7 @@ struct bin_association_getter {
             using point2_t = typename transform3_t::point2;
 
             // The sheet display only works for 2-dimensional grids
-            if constexpr (accel_t::Dim != 2u) {
+            if constexpr (accel_t::dim != 2u) {
                 return {};
             }
 

--- a/tests/benchmarks/cpu/find_volume.cpp
+++ b/tests/benchmarks/cpu/find_volume.cpp
@@ -38,8 +38,8 @@ void BM_FIND_VOLUMES(benchmark::State &state) {
 
     auto &volume_grid = d.volume_search_grid();
 
-    const auto &axis_r = volume_grid.get_axis<n_axis::label::e_r>();
-    const auto &axis_z = volume_grid.get_axis<n_axis::label::e_z>();
+    const auto &axis_r = volume_grid.get_axis<axis::label::e_r>();
+    const auto &axis_z = volume_grid.get_axis<axis::label::e_z>();
 
     // Get a rough step size from irregular axes
     auto range0 = axis_r.span();

--- a/tests/benchmarks/cpu/grids.cpp
+++ b/tests/benchmarks/cpu/grids.cpp
@@ -31,8 +31,8 @@ namespace {
 auto make_regular_grid(vecmem::memory_resource &mr) {
 
     // Return the grid.
-    return grid2<replace_populator, axis::regular, axis::regular, serializer2>{
-        {25u, 0.f, 25.f, mr}, {60u, 0.f, 60.f, mr}, mr};
+    return grid2<replace_populator, axis2::regular, axis2::regular,
+                 serializer2>{{25u, 0.f, 25.f, mr}, {60u, 0.f, 60.f, mr}, mr};
 }
 
 }  // namespace
@@ -99,7 +99,7 @@ auto make_irregular_grid(vecmem::memory_resource &mr) {
         yboundaries.push_back(i);
     }
 
-    return grid2<replace_populator, axis::irregular, axis::irregular,
+    return grid2<replace_populator, axis2::irregular, axis2::irregular,
                  serializer2>({xboundaries, mr}, {yboundaries, mr}, mr);
 }
 

--- a/tests/common/include/tests/common/tools/test_surfaces.hpp
+++ b/tests/common/include/tests/common/tools/test_surfaces.hpp
@@ -118,9 +118,9 @@ create_endcap_components(scalar inner_r, scalar outer_r, scalar pos_z,
 
     // Declare the inner, outer, ecn, ecp object finder
 
-    using cylinder_grid = grid2<replace_populator, axis::circular,
-                                axis::regular, decltype(serializer)>;
-    using disc_grid = grid2<replace_populator, axis::regular, axis::circular,
+    using cylinder_grid = grid2<replace_populator, axis2::circular,
+                                axis2::regular, decltype(serializer)>;
+    using disc_grid = grid2<replace_populator, axis2::regular, axis2::circular,
                             decltype(serializer)>;
 
     typename cylinder_grid::axis_p0_type rphi_axis_inner = {
@@ -231,9 +231,9 @@ create_barrel_components(scalar r, scalar stagger_r, unsigned int n_phi,
                    (module_ly - overlap_z)};
 
     // Declare the inner, outer, ecn, ecp object finder
-    using cylinder_grid = grid2<replace_populator, axis::circular,
-                                axis::regular, decltype(serializer)>;
-    using disc_grid = grid2<replace_populator, axis::regular, axis::circular,
+    using cylinder_grid = grid2<replace_populator, axis2::circular,
+                                axis2::regular, decltype(serializer)>;
+    using disc_grid = grid2<replace_populator, axis2::regular, axis2::circular,
                             decltype(serializer)>;
 
     typename cylinder_grid::axis_p0_type rphi_axis_inner = {
@@ -244,7 +244,7 @@ create_barrel_components(scalar r, scalar stagger_r, unsigned int n_phi,
     typename cylinder_grid::axis_p0_type rphi_axis_outer = {
         n_phi, -volume_outer_r * (constant<scalar>::pi + 0.5f * step_phi),
         volume_outer_r * (constant<scalar>::pi - 0.5f * step_phi), host_mr};
-    // axis::regular<> z_axis_outer = {n_z, -0.5f * length_z, 0.5f * length_z};
+    // axis2::regular<> z_axis_outer = {n_z, -0.5f * length_z, 0.5f * length_z};
     typename disc_grid::axis_p0_type r_axis_ecn = {1, volume_inner_r,
                                                    volume_outer_r, host_mr};
     typename disc_grid::axis_p1_type phi_axis_ecn = {

--- a/tests/unit_tests/core/grids_axis.cpp
+++ b/tests/unit_tests/core/grids_axis.cpp
@@ -24,7 +24,7 @@ using namespace detray;
 TEST(grids, regular_closed_axis) {
     vecmem::host_memory_resource resource;
 
-    axis::regular<> ten_bins{10u, -3.f, 7.f, resource};
+    axis2::regular<> ten_bins{10u, -3.f, 7.f, resource};
     // N bins
     EXPECT_EQ(ten_bins.bins(), 10u);
     // Axis bin access
@@ -93,7 +93,7 @@ TEST(grids, regular_circular_axis) {
     scalar half_module{constant<scalar>::pi / 72.f};
     scalar phi_min = -constant<scalar>::pi + half_module;
     scalar phi_max = constant<scalar>::pi - half_module;
-    axis::circular<> full_pi = {36u, phi_min, phi_max, resource};
+    axis2::circular<> full_pi = {36u, phi_min, phi_max, resource};
     // N bins
     EXPECT_EQ(full_pi.bins(), 36u);
     // Axis bin access
@@ -157,7 +157,7 @@ TEST(grids, regular_circular_axis) {
 TEST(grids, irregular_closed_axis) {
     vecmem::host_memory_resource resource;
 
-    axis::irregular<> nonreg({-3.f, 1.f, 2.f, 4.f, 8.f, 12.f}, resource);
+    axis2::irregular<> nonreg({-3.f, 1.f, 2.f, 4.f, 8.f, 12.f}, resource);
 
     // Axis bin access
     //

--- a/tests/unit_tests/core/grids_grid2.cpp
+++ b/tests/unit_tests/core/grids_grid2.cpp
@@ -28,7 +28,7 @@ TEST(grids, grid2_replace_populator) {
 
     serializer2 serializer;
 
-    using grid2r = grid2<replace_populator, axis::regular, axis::regular,
+    using grid2r = grid2<replace_populator, axis2::regular, axis2::regular,
                          decltype(serializer)>;
     typename grid2r::axis_p0_type xaxis{10u, -5.f, 5.f, host_mr};
     typename grid2r::axis_p1_type yaxis{10u, -5.f, 5.f, host_mr};
@@ -80,7 +80,7 @@ TEST(grids, grid2_replace_populator) {
               156u, 157u, 163u, 164u, 165u, 166u, 167u};
     EXPECT_EQ(test, expect);
 
-    using grid2cc = grid2<replace_populator, axis::circular, axis::regular,
+    using grid2cc = grid2<replace_populator, axis2::circular, axis2::regular,
                           decltype(serializer)>;
 
     typename grid2cc::axis_p0_type circular{4u, -2.f, 2.f, host_mr};
@@ -108,7 +108,7 @@ TEST(grids, grid2_complete_populator) {
 
     serializer2 serializer;
 
-    using grid2r = grid2<complete_populator, axis::regular, axis::regular,
+    using grid2r = grid2<complete_populator, axis2::regular, axis2::regular,
                          decltype(serializer), dvector, djagged_vector, darray,
                          dtuple, dindex, false, 3>;
 
@@ -183,7 +183,7 @@ TEST(grids, grid2_attach_populator) {
 
     serializer2 serializer;
 
-    using grid2r = grid2<attach_populator, axis::regular, axis::regular,
+    using grid2r = grid2<attach_populator, axis2::regular, axis2::regular,
                          decltype(serializer)>;
     typename grid2r::axis_p0_type xaxis{2u, -1.f, 1.f, host_mr};
     typename grid2r::axis_p1_type yaxis{2u, -1.f, 1.f, host_mr};
@@ -237,7 +237,7 @@ TEST(grids, grid2_shift) {
 
     serializer2 serializer;
 
-    using grid2r = grid2<replace_populator, axis::regular, axis::regular,
+    using grid2r = grid2<replace_populator, axis2::regular, axis2::regular,
                          decltype(serializer)>;
 
     typename grid2r::axis_p0_type xaxis{10u, -5.f, 5.f, host_mr};
@@ -259,7 +259,7 @@ TEST(grids, grid2_irregular_replace) {
     replace_populator<> replacer;
     serializer2 serializer;
 
-    using grid2ir = grid2<replace_populator, axis::irregular, axis::irregular,
+    using grid2ir = grid2<replace_populator, axis2::irregular, axis2::irregular,
                           decltype(serializer)>;
 
     typename grid2ir::axis_p0_type xaxis{

--- a/tests/unit_tests/core/grids_serializer.cpp
+++ b/tests/unit_tests/core/grids_serializer.cpp
@@ -24,8 +24,8 @@ using namespace detray;
 TEST(grids, serialize_deserialize) {
     vecmem::host_memory_resource resource;
 
-    axis::regular<> r6{6u, -3.f, 7.f, resource};
-    axis::circular<> c12{12u, -3.f, 3.f, resource};
+    axis2::regular<> r6{6u, -3.f, 7.f, resource};
+    axis2::circular<> c12{12u, -3.f, 3.f, resource};
 
     serializer2 ser2;
 

--- a/tests/unit_tests/core/utils_local_object_finder.cpp
+++ b/tests/unit_tests/core/utils_local_object_finder.cpp
@@ -31,7 +31,7 @@ TEST(utils, local_object_finder) {
 
     test::point2<detray::scalar> p2 = {-4.5f, -4.5f};
 
-    using grid2r = grid2<replace_populator, axis::regular, axis::regular,
+    using grid2r = grid2<replace_populator, axis2::regular, axis2::regular,
                          decltype(serializer)>;
 
     typename grid2r::axis_p0_type xaxis{10u, -5.f, 5.f, host_mr};

--- a/tests/unit_tests/cpu/grid_axis.cpp
+++ b/tests/unit_tests/cpu/grid_axis.cpp
@@ -1,27 +1,26 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
-#include <gtest/gtest.h>
-
-#include <limits>
-
-// detray test
-#include <vecmem/containers/device_vector.hpp>
-#include <vecmem/containers/vector.hpp>
-#include <vecmem/memory/host_memory_resource.hpp>
-
 // detray core
+#include "detray/coordinates/coordinates.hpp"
 #include "detray/definitions/indexing.hpp"
-#include "detray/masks/masks.hpp"
-#include "detray/surface_finders/grid/axis.hpp"
+#include "detray/surface_finders/grid/detail/axis.hpp"
+#include "detray/surface_finders/grid/detail/axis_binning.hpp"
+#include "detray/surface_finders/grid/detail/axis_bounds.hpp"
 #include "detray/test/types.hpp"
 
+// GTest include(s)
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <limits>
+
 using namespace detray;
-using namespace detray::n_axis;
+using namespace detray::axis;
 
 namespace {
 
@@ -56,9 +55,9 @@ GTEST_TEST(detray_grid, open_regular_axis) {
     single_axis<open<label::e_x>, regular<>> or_axis{edge_range, &bin_edges};
 
     // Test axis bounds
-    EXPECT_EQ(or_axis.label(), n_axis::label::e_x);
-    EXPECT_EQ(or_axis.bounds(), n_axis::bounds::e_open);
-    EXPECT_EQ(or_axis.binning(), n_axis::binning::e_regular);
+    EXPECT_EQ(or_axis.label(), axis::label::e_x);
+    EXPECT_EQ(or_axis.bounds(), axis::bounds::e_open);
+    EXPECT_EQ(or_axis.binning(), axis::binning::e_regular);
 
     // N bins
     EXPECT_EQ(or_axis.nbins(), 10u + 2u);
@@ -80,7 +79,7 @@ GTEST_TEST(detray_grid, open_regular_axis) {
     const darray<dindex, 2> nhood44i = {4u, 4u};
     const darray<dindex, 2> nhood55i = {5u, 5u};
 
-    n_axis::bin_range expected_range = {6u, 7u};
+    axis::bin_range expected_range = {6u, 7u};
     EXPECT_EQ(or_axis.range(2.5f, nhood00i), expected_range);
     expected_range = {6u, 8u};
     EXPECT_EQ(or_axis.range(2.5f, nhood01i), expected_range);
@@ -125,9 +124,9 @@ GTEST_TEST(detray_grid, closed_regular_axis) {
     single_axis<closed<label::e_r>, regular<>> cr_axis{edge_range, &bin_edges};
 
     // Test axis bounds
-    EXPECT_EQ(cr_axis.label(), n_axis::label::e_r);
-    EXPECT_EQ(cr_axis.bounds(), n_axis::bounds::e_closed);
-    EXPECT_EQ(cr_axis.binning(), n_axis::binning::e_regular);
+    EXPECT_EQ(cr_axis.label(), axis::label::e_r);
+    EXPECT_EQ(cr_axis.bounds(), axis::bounds::e_closed);
+    EXPECT_EQ(cr_axis.binning(), axis::binning::e_regular);
 
     // N bins
     EXPECT_EQ(cr_axis.nbins(), 10u);
@@ -149,7 +148,7 @@ GTEST_TEST(detray_grid, closed_regular_axis) {
     const darray<dindex, 2> nhood44i = {4u, 4u};
     const darray<dindex, 2> nhood55i = {5u, 5u};
 
-    n_axis::bin_range expected_range = {5u, 6u};
+    axis::bin_range expected_range = {5u, 6u};
     EXPECT_EQ(cr_axis.range(2.5f, nhood00i), expected_range);
     expected_range = {5u, 7u};
     EXPECT_EQ(cr_axis.range(2.5f, nhood01i), expected_range);
@@ -196,9 +195,9 @@ GTEST_TEST(detray_grid, circular_regular_axis) {
     single_axis<circular<>, regular<>> cr_axis(edge_range, &bin_edges);
 
     // Test axis bounds
-    EXPECT_EQ(cr_axis.label(), n_axis::label::e_phi);
-    EXPECT_EQ(cr_axis.bounds(), n_axis::bounds::e_circular);
-    EXPECT_EQ(cr_axis.binning(), n_axis::binning::e_regular);
+    EXPECT_EQ(cr_axis.label(), axis::label::e_phi);
+    EXPECT_EQ(cr_axis.bounds(), axis::bounds::e_circular);
+    EXPECT_EQ(cr_axis.binning(), axis::binning::e_regular);
 
     // N bins
     EXPECT_EQ(cr_axis.nbins(), 36u);
@@ -224,7 +223,7 @@ GTEST_TEST(detray_grid, circular_regular_axis) {
     const darray<dindex, 2> nhood11i = {1u, 1u};
     const darray<dindex, 2> nhood22i = {2u, 2u};
 
-    n_axis::bin_range expected_range = {0u, 1u};
+    axis::bin_range expected_range = {0u, 1u};
     EXPECT_EQ(circ_bounds.wrap(
                   cr_axis.range(constant<scalar>::pi + tol, nhood00i), 36u),
               expected_range);
@@ -274,9 +273,9 @@ GTEST_TEST(detray_grid, closed_irregular_axis) {
                                                           &bin_edges);
 
     // Test axis bounds
-    EXPECT_EQ(cir_axis.label(), n_axis::label::e_z);
-    EXPECT_EQ(cir_axis.bounds(), n_axis::bounds::e_closed);
-    EXPECT_EQ(cir_axis.binning(), n_axis::binning::e_irregular);
+    EXPECT_EQ(cir_axis.label(), axis::label::e_z);
+    EXPECT_EQ(cir_axis.bounds(), axis::bounds::e_closed);
+    EXPECT_EQ(cir_axis.binning(), axis::binning::e_irregular);
 
     // Axis bin access
     //
@@ -297,7 +296,7 @@ GTEST_TEST(detray_grid, closed_irregular_axis) {
     const darray<dindex, 2> nhood11i = {1u, 1u};
     const darray<dindex, 2> nhood22i = {2u, 2u};
 
-    n_axis::bin_range expected_range = {2u, 3u};
+    axis::bin_range expected_range = {2u, 3u};
     EXPECT_EQ(cir_axis.range(3.f, nhood00i), expected_range);
     expected_range = {1u, 4u};
     EXPECT_EQ(cir_axis.range(3.f, nhood11i), expected_range);
@@ -337,7 +336,7 @@ GTEST_TEST(detray_grid, multi_axis) {
     cartesian_3D<is_not_owning, host_container_types> axes(edge_ranges,
                                                            bin_edges);
 
-    EXPECT_EQ(axes.Dim, 3u);
+    EXPECT_EQ(axes.dim, 3u);
 
     // Get single axis objects
     auto x_axis = axes.get_axis<label::e_x>();
@@ -368,7 +367,7 @@ GTEST_TEST(detray_grid, multi_axis) {
     const darray<dindex, 2> nhood01i = {0u, 1u};
     const darray<dindex, 2> nhood22i = {2u, 2u};
 
-    n_axis::multi_bin_range<3> expected_ranges{};
+    axis::multi_bin_range<3> expected_ranges{};
     expected_ranges[0] = {11u, 12u};
     expected_ranges[1] = {21u, 22u};
     expected_ranges[2] = {5u, 6u};

--- a/tests/unit_tests/cpu/grid_grid_builder.cpp
+++ b/tests/unit_tests/cpu/grid_grid_builder.cpp
@@ -15,6 +15,7 @@
 #include "detray/tools/grid_builder.hpp"
 #include "detray/tools/surface_factory.hpp"
 #include "detray/tools/volume_builder.hpp"
+#include "detray/utils/type_list.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -26,7 +27,7 @@
 #include <limits>
 
 using namespace detray;
-using namespace detray::n_axis;
+using namespace detray::axis;
 
 namespace {
 
@@ -130,9 +131,9 @@ GTEST_TEST(detray_tools, grid_factory) {
 GTEST_TEST(detray_tools, grid_builder) {
 
     // cylinder grid type of the toy detector
-    using cyl_grid_t =
-        grid<coordinate_axes<cylinder2D<>::axes<>, false, host_container_types>,
-             bins::static_array<detector_t::surface_type, 1>>;
+    using cyl_grid_t = grid<axes<cylinder2D<>>,
+                            bins::static_array<detector_t::surface_type, 1>,
+                            simple_serializer, host_container_types, false>;
 
     auto gbuilder =
         grid_builder<detector_t, cyl_grid_t, detray::detail::bin_associator>{
@@ -166,9 +167,9 @@ GTEST_TEST(detray_tools, decorator_grid_builder) {
     using mask_id = typename detector_t::masks::id;
 
     // cylinder grid type of the toy detector
-    using cyl_grid_t =
-        grid<coordinate_axes<cylinder2D<>::axes<>, false, host_container_types>,
-             bins::static_array<detector_t::surface_type, 1>>;
+    using cyl_grid_t = grid<axes<cylinder2D<>>,
+                            bins::static_array<detector_t::surface_type, 1>,
+                            simple_serializer, host_container_types, false>;
 
     using pt_cylinder_t = cylinder2D<false, cylinder_portal_intersector>;
     using pt_cylinder_factory_t = surface_factory<detector_t, pt_cylinder_t>;

--- a/tests/unit_tests/cpu/grid_grid_collection.cpp
+++ b/tests/unit_tests/cpu/grid_grid_collection.cpp
@@ -8,7 +8,6 @@
 // Detray include(s)
 #include "detray/definitions/indexing.hpp"
 #include "detray/masks/cylinder3D.hpp"
-#include "detray/surface_finders/grid/axis.hpp"
 #include "detray/surface_finders/grid/grid.hpp"
 #include "detray/surface_finders/grid/grid_collection.hpp"
 #include "detray/surface_finders/grid/populators.hpp"
@@ -24,7 +23,7 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using namespace detray::n_axis;
+using namespace detray::axis;
 
 namespace {
 
@@ -52,11 +51,9 @@ struct bin_content_sequence {
 /// Unittest: Test the construction of a collection of grids
 GTEST_TEST(detray_grid, grid_collection) {
 
-    // grid type
-
     // Non-owning grid type with array<dindex, 3> as bin content
-    using cylindrical_3D = coordinate_axes<cylinder3D::axes<>, is_n_owning>;
-    using grid_t = grid<cylindrical_3D, bins::static_array<dindex, 3>>;
+    using grid_t = grid<axes<cylinder3D>, bins::static_array<dindex, 3>,
+                        simple_serializer, host_container_types, is_n_owning>;
 
     // Build test data
 
@@ -96,7 +93,7 @@ GTEST_TEST(detray_grid, grid_collection) {
     static_assert(std::is_same_v<decltype(single_grid), grid_t>,
                   "Grid from collection has wrong type");
 
-    EXPECT_EQ(single_grid.Dim, 3);
+    EXPECT_EQ(single_grid.dim, 3);
     EXPECT_EQ(single_grid.nbins(), 24u);
     auto r_axis = single_grid.get_axis<label::e_r>();
     EXPECT_EQ(r_axis.nbins(), 1u);

--- a/tests/unit_tests/cpu/grid_serializer.cpp
+++ b/tests/unit_tests/cpu/grid_serializer.cpp
@@ -5,16 +5,15 @@
  * Mozilla Public License Version 2.0
  */
 
-// detray test
-#include <vecmem/containers/vector.hpp>
-#include <vecmem/memory/host_memory_resource.hpp>
-
 // detray core
 #include "detray/definitions/indexing.hpp"
 #include "detray/masks/masks.hpp"
-#include "detray/surface_finders/grid/axis.hpp"
+#include "detray/surface_finders/grid/detail/axis.hpp"
 #include "detray/surface_finders/grid/serializers.hpp"
 #include "detray/test/types.hpp"
+
+// vecmem include(s)
+#include <vecmem/containers/vector.hpp>
 
 // GTest include(s)
 #include <gtest/gtest.h>
@@ -23,7 +22,7 @@
 #include <climits>
 
 using namespace detray;
-using namespace detray::n_axis;
+using namespace detray::axis;
 
 namespace {
 

--- a/tests/unit_tests/cpu/material_maps.cpp
+++ b/tests/unit_tests/cpu/material_maps.cpp
@@ -14,7 +14,7 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using namespace detray::n_axis;
+using namespace detray::axis;
 
 using material_t = typename material_map_factory<scalar>::bin_type::entry_type;
 
@@ -36,7 +36,7 @@ GTEST_TEST(detray_material, annulus_map) {
 
     auto annulus_map = mat_map_factory.new_grid(ann2, {10u, 20u});
 
-    EXPECT_EQ(annulus_map.Dim, 2u);
+    EXPECT_EQ(annulus_map.dim, 2u);
     EXPECT_EQ(annulus_map.nbins(), 200u);
 
     auto r_axis = annulus_map.get_axis<label::e_r>();
@@ -79,7 +79,7 @@ GTEST_TEST(detray_material, cylinder_map) {
 
     auto cylinder_map = mat_map_factory.new_grid(cyl, {10u, 20u});
 
-    EXPECT_EQ(cylinder_map.Dim, 2u);
+    EXPECT_EQ(cylinder_map.dim, 2u);
     EXPECT_EQ(cylinder_map.nbins(), 200u);
 
     auto rphi_axis = cylinder_map.get_axis<label::e_rphi>();
@@ -121,7 +121,7 @@ GTEST_TEST(detray_material, rectangle_map) {
 
     auto rectangle_map = mat_map_factory.new_grid(r2, {10u, 20u});
 
-    EXPECT_EQ(rectangle_map.Dim, 2u);
+    EXPECT_EQ(rectangle_map.dim, 2u);
     EXPECT_EQ(rectangle_map.nbins(), 200u);
 
     auto x_axis = rectangle_map.get_axis<label::e_x>();
@@ -163,7 +163,7 @@ GTEST_TEST(detray_material, disc_map) {
 
     auto disc_map = mat_map_factory.new_grid(r2, {10u, 20u});
 
-    EXPECT_EQ(disc_map.Dim, 2u);
+    EXPECT_EQ(disc_map.dim, 2u);
     EXPECT_EQ(disc_map.nbins(), 200u);
 
     auto r_axis = disc_map.get_axis<label::e_r>();
@@ -207,7 +207,7 @@ GTEST_TEST(detray_material, trapezoid_map) {
 
     auto trapezoid_map = mat_map_factory.new_grid(t2, {10u, 20u});
 
-    EXPECT_EQ(trapezoid_map.Dim, 2u);
+    EXPECT_EQ(trapezoid_map.dim, 2u);
     EXPECT_EQ(trapezoid_map.nbins(), 200u);
 
     auto x_axis = trapezoid_map.get_axis<label::e_x>();

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
@@ -26,8 +26,8 @@ TEST(grids_cuda, grid2_replace_populator) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // axis
-    axis::regular<> xaxis{4u, -1.f, 3.f, mng_mr};
-    axis::regular<> yaxis{6u, 0.f, 6.f, mng_mr};
+    axis2::regular<> xaxis{4u, -1.f, 3.f, mng_mr};
+    axis2::regular<> yaxis{6u, 0.f, 6.f, mng_mr};
 
     auto x_interval =
         (xaxis.max - xaxis.min) / static_cast<detray::scalar>(xaxis.n_bins);
@@ -74,8 +74,8 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // axis
-    axis::circular<> caxis{4u, -2.f, 2.f, mng_mr};
-    axis::irregular<> iaxis{{1.f, 3.f, 9.f, 27.f, 81.f}, mng_mr};
+    axis2::circular<> caxis{4u, -2.f, 2.f, mng_mr};
+    axis2::irregular<> iaxis{{1.f, 3.f, 9.f, 27.f, 81.f}, mng_mr};
 
     auto x_interval =
         (caxis.max - caxis.min) / static_cast<detray::scalar>(caxis.n_bins);
@@ -122,8 +122,8 @@ TEST(grids_cuda, grid2_complete_populator) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // axis
-    axis::regular<> xaxis{7u, -1.f, 6.f, mng_mr};
-    axis::regular<> yaxis{3u, 0.f, 3.f, mng_mr};
+    axis2::regular<> xaxis{7u, -1.f, 6.f, mng_mr};
+    axis2::regular<> yaxis{3u, 0.f, 3.f, mng_mr};
 
     // declare grid
     host_grid2_complete g2(std::move(xaxis), std::move(yaxis), mng_mr,
@@ -179,9 +179,9 @@ TEST(grids_cuda, grid2_attach_populator) {
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;
 
-    axis::circular<> xaxis{65u, -detray::constant<scalar>::pi,
-                           detray::constant<scalar>::pi, mng_mr};
-    axis::regular<> yaxis{2u, 0.f, 6.f, mng_mr};
+    axis2::circular<> xaxis{65u, -detray::constant<scalar>::pi,
+                            detray::constant<scalar>::pi, mng_mr};
+    axis2::regular<> yaxis{2u, 0.f, 6.f, mng_mr};
 
     auto x_interval =
         (xaxis.max - xaxis.min) / static_cast<detray::scalar>(xaxis.n_bins);
@@ -222,8 +222,8 @@ TEST(grids_cuda, grid2_buffer_attach_populator) {
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;
 
-    axis::circular<> xaxis{2u, -1.f, 3.f, mng_mr};
-    axis::regular<> yaxis{2u, 0.f, 6.f, mng_mr};
+    axis2::circular<> xaxis{2u, -1.f, 3.f, mng_mr};
+    axis2::regular<> yaxis{2u, 0.f, 6.f, mng_mr};
 
     grid2_buffer<host_grid2_attach> g2_buffer(
         xaxis, yaxis, {100, 200, 300, 400}, mng_mr, nullptr,
@@ -269,8 +269,8 @@ TEST(grids_cuda, grid2_buffer_attach_populator2) {
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;
 
-    axis::circular<> xaxis{2u, -1.f, 3.f, mng_mr};
-    axis::regular<> yaxis{2u, 0.f, 6.f, mng_mr};
+    axis2::circular<> xaxis{2u, -1.f, 3.f, mng_mr};
+    axis2::regular<> yaxis{2u, 0.f, 6.f, mng_mr};
 
     grid2_buffer<host_grid2_attach> g2_buffer(xaxis, yaxis, {1, 2, 3, 4},
                                               mng_mr);

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda_kernel.hpp
@@ -22,47 +22,47 @@ namespace detray {
 static constexpr int n_points = 3;
 
 using host_grid2_replace =
-    grid2<replace_populator, axis::regular, axis::regular, serializer2,
+    grid2<replace_populator, axis2::regular, axis2::regular, serializer2,
           vecmem::vector, vecmem::jagged_vector, darray, std::tuple,
           test::point3<detray::scalar> >;
 
 using device_grid2_replace =
-    grid2<replace_populator, axis::regular, axis::regular, serializer2,
+    grid2<replace_populator, axis2::regular, axis2::regular, serializer2,
           vecmem::device_vector, vecmem::jagged_device_vector, darray,
           std::tuple, test::point3<detray::scalar> >;
 
 using host_grid2_replace_ci =
-    grid2<replace_populator, axis::circular, axis::irregular, serializer2,
+    grid2<replace_populator, axis2::circular, axis2::irregular, serializer2,
           vecmem::vector, vecmem::jagged_vector, darray, std::tuple,
           test::point3<detray::scalar> >;
 
 using device_grid2_replace_ci =
-    grid2<replace_populator, axis::circular, axis::irregular, serializer2,
+    grid2<replace_populator, axis2::circular, axis2::irregular, serializer2,
           vecmem::device_vector, vecmem::jagged_device_vector, darray,
           std::tuple, test::point3<detray::scalar> >;
 
 using host_grid2_complete =
-    grid2<complete_populator, axis::regular, axis::regular, serializer2,
+    grid2<complete_populator, axis2::regular, axis2::regular, serializer2,
           vecmem::vector, vecmem::jagged_vector, darray, std::tuple,
           test::point3<detray::scalar>, false, n_points>;
 
 using device_grid2_complete =
-    grid2<complete_populator, axis::regular, axis::regular, serializer2,
+    grid2<complete_populator, axis2::regular, axis2::regular, serializer2,
           vecmem::device_vector, vecmem::jagged_device_vector, darray,
           std::tuple, test::point3<detray::scalar>, false, n_points>;
 
 using host_grid2_attach =
-    grid2<attach_populator, axis::circular, axis::regular, serializer2,
+    grid2<attach_populator, axis2::circular, axis2::regular, serializer2,
           vecmem::vector, vecmem::jagged_vector, darray, std::tuple,
           test::point3<detray::scalar>, false>;
 
 using device_grid2_attach =
-    grid2<attach_populator, axis::circular, axis::regular, serializer2,
+    grid2<attach_populator, axis2::circular, axis2::regular, serializer2,
           vecmem::device_vector, vecmem::jagged_device_vector, darray,
           std::tuple, test::point3<detray::scalar>, false>;
 
 using const_device_grid2_attach =
-    grid2<attach_populator, axis::circular, axis::regular, serializer2,
+    grid2<attach_populator, axis2::circular, axis2::regular, serializer2,
           vecmem::device_vector, vecmem::jagged_device_vector, darray,
           std::tuple, const test::point3<detray::scalar>, false>;
 

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
@@ -54,7 +54,7 @@ TEST(grids_cuda, grid3_replace_populator) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // Build multi-axis
-    using axes_t = cartesian_3D<host_container_types>;
+    using axes_t = host_grid3_single::axes_type;
     using bin_t = host_grid3_single::bin_type;
 
     typename axes_t::edge_offset_container_type axis_data(&mng_mr);
@@ -75,9 +75,9 @@ TEST(grids_cuda, grid3_replace_populator) {
 
     host_grid3_single g3(std::move(bin_data), std::move(axes));
 
-    const auto& axis_x = g3.template get_axis<n_axis::label::e_x>();
-    const auto& axis_y = g3.template get_axis<n_axis::label::e_y>();
-    const auto& axis_z = g3.template get_axis<n_axis::label::e_z>();
+    const auto& axis_x = g3.template get_axis<axis::label::e_x>();
+    const auto& axis_y = g3.template get_axis<axis::label::e_y>();
+    const auto& axis_z = g3.template get_axis<axis::label::e_z>();
 
     // pre-check
     for (unsigned int i_x = 0u; i_x < axis_x.nbins(); i_x++) {
@@ -120,7 +120,7 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // Build multi-axis
-    using axes_t = polar_ir<host_container_types>;
+    using axes_t = host_grid2_single_ci::axes_type;
     using bin_t = host_grid2_single_ci::bin_type;
 
     typename axes_t::edge_offset_container_type axis_data(&mng_mr);
@@ -140,8 +140,8 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
 
     host_grid2_single_ci g2(std::move(bin_data), std::move(axes));
 
-    const auto& axis_r = g2.template get_axis<n_axis::label::e_r>();
-    const auto& axis_phi = g2.template get_axis<n_axis::label::e_phi>();
+    const auto& axis_r = g2.template get_axis<axis::label::e_r>();
+    const auto& axis_phi = g2.template get_axis<axis::label::e_phi>();
 
     // pre-check
     for (unsigned int i_r = 0u; i_r < axis_r.nbins(); i_r++) {
@@ -181,7 +181,7 @@ TEST(grids_cuda, grid2_complete_populator) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // Build multi-axis
-    using axes_t = polar<host_container_types>;
+    using axes_t = host_grid2_array::axes_type;
     using bin_t = host_grid2_array::bin_type;
 
     typename axes_t::edge_offset_container_type axis_data(&mng_mr);
@@ -203,8 +203,8 @@ TEST(grids_cuda, grid2_complete_populator) {
 
     host_grid2_array g2(std::move(bin_data), std::move(axes));
 
-    const auto& axis_r = g2.template get_axis<n_axis::label::e_r>();
-    const auto& axis_phi = g2.template get_axis<n_axis::label::e_phi>();
+    const auto& axis_r = g2.template get_axis<axis::label::e_r>();
+    const auto& axis_phi = g2.template get_axis<axis::label::e_phi>();
 
     auto width_r = axis_r.bin_width();
     auto width_phi = axis_phi.bin_width();
@@ -257,7 +257,7 @@ TEST(grids_cuda, grid2_attach_populator) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // Build multi-axis
-    using axes_t = polar<host_container_types>;
+    using axes_t = host_grid2_array::axes_type;
     using bin_t = host_grid2_array::bin_type;
 
     typename axes_t::edge_offset_container_type axis_data(&mng_mr);
@@ -281,8 +281,8 @@ TEST(grids_cuda, grid2_attach_populator) {
 
     host_grid2_array g2(std::move(bin_data), std::move(axes));
 
-    const auto& axis_r = g2.template get_axis<n_axis::label::e_r>();
-    const auto& axis_phi = g2.template get_axis<n_axis::label::e_phi>();
+    const auto& axis_r = g2.template get_axis<axis::label::e_r>();
+    const auto& axis_phi = g2.template get_axis<axis::label::e_phi>();
 
     auto width_r = axis_r.bin_width();
     auto width_phi = axis_phi.bin_width();
@@ -335,7 +335,7 @@ TEST(grids_cuda, cylindrical3D_collection) {
     // Data-owning grid collection
     vecmem::cuda::managed_memory_resource mng_mr;
 
-    using grid_collection_t = grid_collection<n_own_host_grid2_array>;
+    using grid_collection_t = grid_collection<n_own_host_grid3_array>;
     using bin_t = grid_collection_t::value_type::bin_type;
 
     vecmem::vector<typename grid_collection_t::size_type> grid_offsets(&mng_mr);
@@ -364,6 +364,7 @@ TEST(grids_cuda, cylindrical3D_collection) {
     // Bin test entries
     bin_data.resize(197u, bin_t{});
 
+    // Read the number of bins and bin entries on device
     vecmem::vector<unsigned int> n_bins(9u, &mng_mr);
     vecmem::vector<std::array<dindex, 3>> result_bins(bin_data.size(), &mng_mr);
 
@@ -371,10 +372,9 @@ TEST(grids_cuda, cylindrical3D_collection) {
                                 std::move(edge_ranges), std::move(bin_edges));
 
     // Call test function
-    const auto& axis_r = grid_coll[2].template get_axis<n_axis::label::e_r>();
-    const auto& axis_phi =
-        grid_coll[2].template get_axis<n_axis::label::e_phi>();
-    const auto& axis_z = grid_coll[2].template get_axis<n_axis::label::e_z>();
+    const auto& axis_r = grid_coll[2].template get_axis<axis::label::e_r>();
+    const auto& axis_phi = grid_coll[2].template get_axis<axis::label::e_phi>();
+    const auto& axis_z = grid_coll[2].template get_axis<axis::label::e_z>();
 
     grid_collection_test(get_data(grid_coll), vecmem::get_data(n_bins),
                          vecmem::get_data(result_bins), grid_coll.size(),

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.cu
@@ -24,12 +24,12 @@ __global__ void grid_replace_test_kernel(
     device_grid3_single g3_device(grid_view);
 
     // Get axes on the device-side
-    const auto& axis_x = g3_device.template get_axis<n_axis::label::e_x>();
-    const auto& axis_y = g3_device.template get_axis<n_axis::label::e_y>();
-    const auto& axis_z = g3_device.template get_axis<n_axis::label::e_z>();
+    const auto& axis_x = g3_device.template get_axis<axis::label::e_x>();
+    const auto& axis_y = g3_device.template get_axis<axis::label::e_y>();
+    const auto& axis_z = g3_device.template get_axis<axis::label::e_z>();
 
     dindex gid = g3_device.serialize(
-        detray::n_axis::multi_bin<3>{threadIdx.x, threadIdx.y, threadIdx.z});
+        detray::axis::multi_bin<3>{threadIdx.x, threadIdx.y, threadIdx.z});
 
     point3 tp{axis_x.min() + gid * axis_x.bin_width(),
               axis_y.min() + gid * axis_y.bin_width(),
@@ -61,8 +61,8 @@ __global__ void grid_replace_ci_test_kernel(
     device_grid2_single_ci g2_device(grid_view);
 
     // Get axes on the device-side
-    const auto& axis_r = g2_device.template get_axis<n_axis::label::e_r>();
-    const auto& axis_phi = g2_device.template get_axis<n_axis::label::e_phi>();
+    const auto& axis_r = g2_device.template get_axis<axis::label::e_r>();
+    const auto& axis_phi = g2_device.template get_axis<axis::label::e_phi>();
 
     auto gid = threadIdx.x + threadIdx.y * blockDim.x;
 
@@ -98,8 +98,8 @@ __global__ void grid_complete_kernel(host_grid2_array::view_type grid_view) {
     device_grid2_array g2_device(grid_view);
 
     // Get axes on the device-side
-    const auto& axis_r = g2_device.template get_axis<n_axis::label::e_r>();
-    const auto& axis_phi = g2_device.template get_axis<n_axis::label::e_phi>();
+    const auto& axis_r = g2_device.template get_axis<axis::label::e_r>();
+    const auto& axis_phi = g2_device.template get_axis<axis::label::e_phi>();
 
     auto gid = threadIdx.x + threadIdx.y * blockDim.x;
     auto tp = point3{axis_r.min() + gid * axis_r.bin_width(),
@@ -134,8 +134,8 @@ __global__ void grid_attach_kernel(host_grid2_array::view_type grid_view) {
     device_grid2_array g2_device(grid_view);
 
     // Get axes on the device-side
-    const auto& axis_r = g2_device.template get_axis<n_axis::label::e_r>();
-    const auto& axis_phi = g2_device.template get_axis<n_axis::label::e_phi>();
+    const auto& axis_r = g2_device.template get_axis<axis::label::e_r>();
+    const auto& axis_phi = g2_device.template get_axis<axis::label::e_phi>();
 
     auto width_r = axis_r.m_binning.bin_width();
     auto width_phi = axis_phi.m_binning.bin_width();
@@ -172,8 +172,8 @@ __global__ void print_grid_kernel(view_t grid_view) {
     // Let's try building the grid object
     device_grid_t g2_device(grid_view);
 
-    n_axis::multi_bin<device_grid_t::Dim> mbin;
-    if constexpr (device_grid_t::Dim == 2) {
+    axis::multi_bin<device_grid_t::dim> mbin;
+    if constexpr (device_grid_t::dim == 2) {
         mbin = {threadIdx.x, threadIdx.y};
     } else {
         mbin = {threadIdx.x, threadIdx.y, threadIdx.z};
@@ -215,22 +215,23 @@ template void print_grid<device_grid2_array>(host_grid2_array::view_type,
 
 /// cuda kernel for grid_collection_test
 __global__ void grid_collection_test_kernel(
-    grid_collection<n_own_host_grid2_array>::view_type grid_coll_view,
+    grid_collection<n_own_host_grid3_array>::view_type grid_coll_view,
     vecmem::data::vector_view<dindex> n_bins_view,
     vecmem::data::vector_view<std::array<dindex, 3>> result_bins_view) {
+
     // Let's try building the grid object
-    grid_collection<n_own_device_grid2_array> device_coll(grid_coll_view);
+    grid_collection<n_own_device_grid3_array> device_coll(grid_coll_view);
     vecmem::device_vector<dindex> n_bins(n_bins_view);
     vecmem::device_vector<std::array<dindex, 3>> result_bins(result_bins_view);
 
     // test the grid axes of the second grid in the collection
     if (threadIdx.x == 0 and threadIdx.y == 0 and threadIdx.z == 0) {
         const auto& axis_r =
-            device_coll[blockIdx.x].template get_axis<n_axis::label::e_r>();
+            device_coll[blockIdx.x].template get_axis<axis::label::e_r>();
         const auto& axis_phi =
-            device_coll[blockIdx.x].template get_axis<n_axis::label::e_phi>();
+            device_coll[blockIdx.x].template get_axis<axis::label::e_phi>();
         const auto& axis_z =
-            device_coll[blockIdx.x].template get_axis<n_axis::label::e_z>();
+            device_coll[blockIdx.x].template get_axis<axis::label::e_z>();
 
         n_bins[0 + blockIdx.x * 3] = axis_r.nbins();
         n_bins[1 + blockIdx.x * 3] = axis_phi.nbins();
@@ -250,7 +251,7 @@ __global__ void grid_collection_test_kernel(
 
 /// grid_collection_test implementation
 void grid_collection_test(
-    grid_collection<n_own_host_grid2_array>::view_type grid_coll_view,
+    grid_collection<n_own_host_grid3_array>::view_type grid_coll_view,
     vecmem::data::vector_view<dindex> n_bins_view,
     vecmem::data::vector_view<std::array<dindex, 3>> result_bins_view,
     std::size_t n_grids, std::size_t dim_x, std::size_t dim_y,

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.hpp
@@ -10,7 +10,6 @@
 // detray core
 #include "detray/definitions/algebra.hpp"
 #include "detray/masks/masks.hpp"
-#include "detray/surface_finders/grid/axis.hpp"
 #include "detray/surface_finders/grid/grid.hpp"
 #include "detray/surface_finders/grid/grid_collection.hpp"
 #include "detray/surface_finders/grid/populators.hpp"
@@ -28,60 +27,43 @@ using point3 = __plugin::point3<detray::scalar>;
 
 namespace detray {
 
-using namespace n_axis;
+using namespace axis;
 
-static constexpr scalar tol{1e-7f};
-static constexpr std::size_t n_points{3u};
-static constexpr bool is_owning = true;
-
-// Coordinate system definitions (all data-owning)
-
-// 3D cartesian coordinate axes with closed bin boundaries and regular binning
-template <typename containers = host_container_types>
-using cartesian_3D = coordinate_axes<cuboid3D<>::axes<>, is_owning, containers>;
-
-// 2D polar coordinate axes with closed bin boundaries, irregular binning in r
-// and regular binning in phi
-template <typename containers = host_container_types>
-using polar_ir =
-    coordinate_axes<ring2D<>::axes<bounds::e_closed, irregular, regular>,
-                    is_owning, containers>;
-
-// 2D polar coordinate axes with closed bin boundaries and regular binning
-template <typename containers = host_container_types>
-using polar = coordinate_axes<ring2D<>::axes<>, is_owning, containers>;
-
-// 3D cylindrical coordinate axes with open bin boundaries and regular binning
-// non-owning
-template <typename containers = host_container_types>
-using cylindrical_3D = coordinate_axes<cylinder3D::axes<bounds::e_open>,
-                                       not is_owning, containers>;
+inline constexpr scalar tol{1e-7f};
+inline constexpr std::size_t n_points{3u};
+inline constexpr bool is_owning{true};
 
 // host and device grid definitions
 
 // replacer
-using host_grid3_single = grid<cartesian_3D<>, bins::single<point3>>;
+using host_grid3_single = grid<axes<cuboid3D<>>, bins::single<point3>>;
 
-using device_grid3_single =
-    grid<cartesian_3D<device_container_types>, bins::single<point3>>;
+using device_grid3_single = grid<axes<cuboid3D<>>, bins::single<point3>,
+                                 simple_serializer, device_container_types>;
 
-using host_grid2_single_ci = grid<polar_ir<>, bins::single<point3>>;
+using host_grid2_single_ci =
+    grid<axes<ring2D<>, bounds::e_closed, irregular>, bins::single<point3>>;
 
 using device_grid2_single_ci =
-    grid<polar_ir<device_container_types>, bins::single<point3>>;
+    grid<axes<ring2D<>, bounds::e_closed, irregular>, bins::single<point3>,
+         simple_serializer, device_container_types>;
 
 // completer/attacher
-using host_grid2_array = grid<polar<>, bins::static_array<point3, n_points>>;
+using host_grid2_array =
+    grid<axes<ring2D<>>, bins::static_array<point3, n_points>>;
 
 using device_grid2_array =
-    grid<polar<device_container_types>, bins::static_array<point3, n_points>>;
+    grid<axes<ring2D<>>, bins::static_array<point3, n_points>,
+         simple_serializer, device_container_types>;
 
 // grid collection
-using n_own_host_grid2_array =
-    grid<cylindrical_3D<>, bins::static_array<dindex, n_points>>;
+template <typename containers>
+using cylinder3D_grid =
+    grid<axes<cylinder3D, bounds::e_open>, bins::static_array<dindex, n_points>,
+         simple_serializer, containers, !is_owning>;
 
-using n_own_device_grid2_array = grid<cylindrical_3D<device_container_types>,
-                                      bins::static_array<dindex, n_points>>;
+using n_own_host_grid3_array = cylinder3D_grid<host_container_types>;
+using n_own_device_grid3_array = cylinder3D_grid<device_container_types>;
 
 /// test function for replace populator
 void grid_replace_test(host_grid3_single::view_type grid_view,
@@ -105,7 +87,7 @@ void print_grid(view_t grid_view, I... dims);
 
 // test function for a collection of grids
 void grid_collection_test(
-    grid_collection<n_own_host_grid2_array>::view_type grid_collection_view,
+    grid_collection<n_own_host_grid3_array>::view_type grid_collection_view,
     vecmem::data::vector_view<dindex> n_bins_view,
     vecmem::data::vector_view<std::array<dindex, 3>> result_bins_view,
     std::size_t n_grids, std::size_t dim_x, std::size_t dim_y,

--- a/tests/unit_tests/io/io_json_payload.cpp
+++ b/tests/unit_tests/io/io_json_payload.cpp
@@ -67,9 +67,9 @@ TEST(io, json_algebra_payload) {
 TEST(io, json_axis_payload) {
 
     detray::axis_payload ea;
-    ea.binning = detray::n_axis::binning::e_regular;
-    ea.bounds = detray::n_axis::bounds::e_circular;
-    ea.label = detray::n_axis::label::e_phi;
+    ea.binning = detray::axis::binning::e_regular;
+    ea.bounds = detray::axis::bounds::e_circular;
+    ea.label = detray::axis::label::e_phi;
     ea.edges = {-detray::constant<detray::real_io>::pi,
                 detray::constant<detray::real_io>::pi};
     ea.bins = 10UL;
@@ -86,9 +86,9 @@ TEST(io, json_axis_payload) {
     EXPECT_EQ(ea.bins, pea.bins);
 
     detray::axis_payload va;
-    va.binning = detray::n_axis::binning::e_irregular;
-    va.bounds = detray::n_axis::bounds::e_closed;
-    va.label = detray::n_axis::label::e_r;
+    va.binning = detray::axis::binning::e_irregular;
+    va.bounds = detray::axis::bounds::e_closed;
+    va.label = detray::axis::label::e_r;
     va.edges = {0.f, 1.f, 4.f, 5.f, 8.f, 10.f};
     va.bins = va.edges.size() - 1UL;
 
@@ -127,14 +127,14 @@ TEST(io, json_grid_payload) {
         {{0u, 1u}, {0u, 2u}}, {{1u, 1u}, {1u, 2u}}, {{2u, 1u}, {2u, 2u}}};
 
     detray::axis_payload a0{
-        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_circular,
-        detray::n_axis::label::e_phi, 3u,
+        detray::axis::binning::e_regular, detray::axis::bounds::e_circular,
+        detray::axis::label::e_phi, 3u,
         std::vector<detray::real_io>{-detray::constant<detray::real_io>::pi,
                                      detray::constant<detray::real_io>::pi}};
 
     detray::axis_payload a1{
-        detray::n_axis::binning::e_regular, detray::n_axis::bounds::e_closed,
-        detray::n_axis::label::e_r, 2u, std::vector<detray::real_io>{0.f, 2.f}};
+        detray::axis::binning::e_regular, detray::axis::bounds::e_closed,
+        detray::axis::label::e_r, 2u, std::vector<detray::real_io>{0.f, 2.f}};
 
     detray::grid_payload<> g;
     g.acc_link = {detray::grid_payload<>::grid_type::polar2_grid, 12u};

--- a/tutorials/include/detray/tutorial/detector_metadata.hpp
+++ b/tutorials/include/detray/tutorial/detector_metadata.hpp
@@ -147,11 +147,9 @@ struct my_metadata {
     /// given position. Here: Uniform grid with a 3D cylindrical shape
     template <typename container_t = host_container_types>
     using volume_finder =
-        grid<coordinate_axes<
-                 cylinder3D::axes<n_axis::bounds::e_open, n_axis::irregular,
-                                  n_axis::regular, n_axis::irregular>,
-                 true, container_t>,
-             bins::single<dindex>, simple_serializer>;
+        grid<axes<cylinder3D, axis::bounds::e_open, axis::irregular,
+                  axis::regular, axis::irregular>,
+             bins::single<dindex>, simple_serializer, container_t>;
 };
 
 }  // namespace tutorial

--- a/tutorials/include/detray/tutorial/my_square2D.hpp
+++ b/tutorials/include/detray/tutorial/my_square2D.hpp
@@ -52,33 +52,14 @@ class square2D {
 
     /// Local coordinate frame for boundary checks: cartesian
     template <typename algebra_t>
-    using local_frame_type = cartesian3<algebra_t>;
+    using local_frame_type = cartesian2<algebra_t>;
 
     /// Underlying surface geometry: planar
     template <typename intersection_t>
     using intersector_type = intersector_t<intersection_t>;
 
-    /// Behaviour of the two local axes (linear in x, linear in y)
-    /// Needed to map a grid onto the square (material maps)
-    template <
-        n_axis::bounds e_s = n_axis::bounds::e_closed,
-        template <typename, typename> class binning_loc0 = n_axis::regular,
-        template <typename, typename> class binning_loc1 = n_axis::regular>
-    struct axes {
-        static constexpr n_axis::label axis_loc0 = n_axis::label::e_x;
-        static constexpr n_axis::label axis_loc1 = n_axis::label::e_y;
-        static constexpr std::size_t dim{2u};
-
-        /// How to convert into the local axis system and back
-        template <typename algebra_t>
-        using coordinate_type = local_frame_type<algebra_t>;
-
-        using types = dtuple<n_axis::bounds_t<e_s, axis_loc0>,
-                             n_axis::bounds_t<e_s, axis_loc1>>;
-
-        template <typename C, typename S>
-        using binning = dtuple<binning_loc0<C, S>, binning_loc1<C, S>>;
-    };
+    /// Dimension of the local coordinate system
+    static constexpr std::size_t dim{2u};
 
     /// @brief Check boundary values for a local point.
     ///

--- a/utils/include/detray/detectors/create_toy_geometry.hpp
+++ b/utils/include/detray/detectors/create_toy_geometry.hpp
@@ -1229,13 +1229,10 @@ inline auto create_toy_geometry(vecmem::memory_resource &resource,
         std::vector<scalar>{-half_size_z, half_size_z}};
 
     grid_factory_type<typename detector_t::volume_finder> vgrid_factory{};
-    auto vgrid =
-        vgrid_factory.template new_grid<n_axis::open<n_axis::label::e_r>,
-                                        n_axis::circular<n_axis::label::e_phi>,
-                                        n_axis::open<n_axis::label::e_z>,
-                                        n_axis::irregular<>, n_axis::regular<>,
-                                        n_axis::irregular<>>(
-            vgrid_dims, n_vgrid_bins, bin_edges);
+    auto vgrid = vgrid_factory.template new_grid<
+        axis::open<axis::label::e_r>, axis::circular<axis::label::e_phi>,
+        axis::open<axis::label::e_z>, axis::irregular<>, axis::regular<>,
+        axis::irregular<>>(vgrid_dims, n_vgrid_bins, bin_edges);
     det.set_volume_finder(std::move(vgrid));
 
     return std::make_pair(std::move(det), std::move(name_map));

--- a/utils/include/detray/detectors/create_wire_chamber.hpp
+++ b/utils/include/detray/detectors/create_wire_chamber.hpp
@@ -318,11 +318,9 @@ inline auto create_wire_chamber(vecmem::memory_resource &resource,
 
         grid_factory_type<typename detector_t::volume_finder> vgrid_factory{};
         auto vgrid = vgrid_factory.template new_grid<
-            n_axis::open<n_axis::label::e_r>,
-            n_axis::circular<n_axis::label::e_phi>,
-            n_axis::open<n_axis::label::e_z>, n_axis::irregular<>,
-            n_axis::regular<>, n_axis::irregular<>>(vgrid_dims, n_vgrid_bins,
-                                                    bin_edges);
+            axis::open<axis::label::e_r>, axis::circular<axis::label::e_phi>,
+            axis::open<axis::label::e_z>, axis::irregular<>, axis::regular<>,
+            axis::irregular<>>(vgrid_dims, n_vgrid_bins, bin_edges);
         det.set_volume_finder(std::move(vgrid));
     }
 

--- a/utils/include/detray/detectors/detector_helper.hpp
+++ b/utils/include/detray/detectors/detector_helper.hpp
@@ -293,7 +293,7 @@ struct detector_helper {
             for (dindex bin0 = 0u; bin0 < n_bins_per_axis[0]; ++bin0) {
                 for (dindex bin1 = 0u; bin1 < n_bins_per_axis[1]; ++bin1) {
                     material_map.template populate<replace<>>(
-                        n_axis::multi_bin<2>{bin0, bin1},
+                        axis::multi_bin<2>{bin0, bin1},
                         mat[is_disc_map ? bin0 : bin1]);
                 }
             }

--- a/utils/include/detray/detectors/itk_metadata.hpp
+++ b/utils/include/detray/detectors/itk_metadata.hpp
@@ -62,17 +62,15 @@ struct itk_metadata {
 
     // Cylindrical material map
     template <typename container_t>
-    using cylinder_map_t =
-        material_map<cylinder2D<>::axes<>, scalar, container_t>;
+    using cylinder_map_t = material_map<cylinder2D<>, scalar, container_t>;
 
     // Disc material map
     template <typename container_t>
-    using disc_map_t = material_map<ring2D<>::axes<>, scalar, container_t>;
+    using disc_map_t = material_map<ring2D<>, scalar, container_t>;
 
     // Rectangular material map
     template <typename container_t>
-    using rectangular_map_t =
-        material_map<rectangle2D<>::axes<>, scalar, container_t>;
+    using rectangular_map_t = material_map<rectangle2D<>, scalar, container_t>;
 
     /// How to store and link transforms. The geometry context allows to resolve
     /// the conditions data for e.g. module alignment
@@ -167,11 +165,9 @@ struct itk_metadata {
     /// given position. Here: Uniform grid with a 3D cylindrical shape
     template <typename container_t = host_container_types>
     using volume_finder =
-        grid<coordinate_axes<
-                 cylinder3D::axes<n_axis::bounds::e_open, n_axis::irregular,
-                                  n_axis::regular, n_axis::irregular>,
-                 true, container_t>,
-             bins::single<dindex>, simple_serializer>;
+        grid<axes<cylinder3D, axis::bounds::e_open, axis::irregular,
+                  axis::regular, axis::irregular>,
+             bins::single<dindex>, simple_serializer, container_t>;
 };
 
 }  // namespace detray

--- a/utils/include/detray/detectors/toy_metadata.hpp
+++ b/utils/include/detray/detectors/toy_metadata.hpp
@@ -43,36 +43,33 @@ struct toy_metadata {
 
     // Cylindrical material grid
     template <typename container_t>
-    using cylinder_map_t =
-        material_map<cylinder2D<>::axes<>, scalar, container_t>;
+    using cylinder_map_t = material_map<cylinder2D<>, scalar, container_t>;
 
     // Disc material grid
     template <typename container_t>
-    using disc_map_t = material_map<ring2D<>::axes<>, scalar, container_t>;
+    using disc_map_t = material_map<ring2D<>, scalar, container_t>;
 
     // Rectangular material grid
     template <typename container_t>
-    using rectangular_map_t =
-        material_map<rectangle2D<>::axes<>, scalar, container_t>;
+    using rectangular_map_t = material_map<rectangle2D<>, scalar, container_t>;
 
     /// Surface grid types (regular, open binning)
     /// @{
 
     // Surface grid definition: bin-content: std::array<sf_descriptor, 1>
-    template <typename grid_shape_t, typename bin_entry_t, typename container_t>
-    using surface_grid_t =
-        grid<coordinate_axes<grid_shape_t, false, container_t>,
-             bins::static_array<bin_entry_t, 1>, simple_serializer>;
+    template <typename axes_t, typename bin_entry_t, typename container_t>
+    using surface_grid_t = grid<axes_t, bins::static_array<bin_entry_t, 1>,
+                                simple_serializer, container_t, false>;
 
     // cylindrical grid for the barrel layers
     template <typename bin_entry_t, typename container_t>
     using cylinder_sf_grid =
-        surface_grid_t<cylinder2D<>::axes<>, bin_entry_t, container_t>;
+        surface_grid_t<axes<cylinder2D<>>, bin_entry_t, container_t>;
 
     // disc grid for the endcap layers
     template <typename bin_entry_t, typename container_t>
     using disc_sf_grid =
-        surface_grid_t<ring2D<>::axes<>, bin_entry_t, container_t>;
+        surface_grid_t<axes<ring2D<>>, bin_entry_t, container_t>;
 
     /// @}
 
@@ -157,11 +154,9 @@ struct toy_metadata {
     /// Volume search grid
     template <typename container_t = host_container_types>
     using volume_finder =
-        grid<coordinate_axes<
-                 cylinder3D::axes<n_axis::bounds::e_open, n_axis::irregular,
-                                  n_axis::regular, n_axis::irregular>,
-                 true, container_t>,
-             bins::single<dindex>, simple_serializer>;
+        grid<axes<cylinder3D, axis::bounds::e_open, axis::irregular,
+                  axis::regular, axis::irregular>,
+             bins::single<dindex>, simple_serializer, container_t>;
 };
 
 }  // namespace detray


### PR DESCRIPTION
This moves the axes definitions out of the shapes, hence decoupling the grids from the geometry, and adds a few more helper traits that make grid type definitions a bit simpler.

Renames ```axis``` (the current axis namespace of ```grid2```) to ```axis2``` and ```n_axis``` to ```axis```. Harmonizes the capitalization of the ```dim``` parameter over the classes that define a local dimension.

Adds a few more convenience grid creation overloads to the grid factory, which are used in the grid builder.

Removes an unnecessary typedef on the ```scalar_t``` from the stepper.