### PR TITLE
Restore the density effect data

### DIFF
--- a/core/include/detray/materials/detail/density_effect_data.hpp
+++ b/core/include/detray/materials/detail/density_effect_data.hpp
@@ -1,0 +1,85 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
+
+namespace detray::detail {
+
+/// @note Ported from Geant4 and simplified
+template <typename scalar_t>
+struct density_effect_data {
+
+    using scalar_type = scalar_t;
+
+    constexpr density_effect_data() = default;
+
+    DETRAY_HOST_DEVICE
+    constexpr density_effect_data(const scalar_type a, const scalar_type m,
+                                  const scalar_type X0, const scalar_type X1,
+                                  const scalar_type I, const scalar_type nC,
+                                  const scalar_type delta0)
+        : m_a(a),
+          m_m(m),
+          m_X0(X0),
+          m_X1(X1),
+          m_I(I * unit<scalar_type>::eV),
+          m_nC(nC),
+          m_delta0(delta0) {}
+
+    /// Equality operator
+    ///
+    /// @param rhs is the right hand side to be compared to
+    DETRAY_HOST_DEVICE constexpr bool operator==(
+        const density_effect_data &rhs) const {
+        return (m_a == rhs.get_A_density() && m_m == rhs.get_M_density() &&
+                m_X0 == rhs.get_X0_density() && m_X1 == rhs.get_X1_density() &&
+                m_I == rhs.get_mean_excitation_energy() &&
+                m_nC == rhs.get_C_density() &&
+                m_delta0 == rhs.get_delta0_density());
+    }
+
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type get_A_density() const { return m_a; }
+
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type get_M_density() const { return m_m; }
+
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type get_X0_density() const { return m_X0; }
+
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type get_X1_density() const { return m_X1; }
+
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type get_mean_excitation_energy() const { return m_I; }
+
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type get_C_density() const { return m_nC; }
+
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type get_delta0_density() const { return m_delta0; }
+
+    /// Fitting parameters of Eq. 33.7 of RPP 2018
+    /// @{
+    scalar_type m_a = 0.f;
+    scalar_type m_m = 0.f;
+    scalar_type m_X0 = 0.f;
+    scalar_type m_X1 = 0.f;
+    /// @}
+    /// Mean excitation energy in eV
+    scalar_type m_I = 0.f;
+    /// -C
+    scalar_type m_nC = 0.f;
+    /// Density-effect value delta(X_0)
+    scalar_type m_delta0 = 0.f;
+};
+
+}  // namespace detray::detail

--- a/core/include/detray/materials/material.hpp
+++ b/core/include/detray/materials/material.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/materials/detail/density_effect_data.hpp"
 #include "detray/utils/invalid_values.hpp"
 
 // System include(s)
@@ -55,6 +56,26 @@ struct material {
         m_molar_rho = mass_to_molar_density(ar, mass_rho);
     }
 
+    DETRAY_HOST_DEVICE
+    constexpr material(const scalar_type x0, const scalar_type l0,
+                       const scalar_type ar, const scalar_type z,
+                       const scalar_type mass_rho, const material_state state,
+                       const scalar_type d_a, const scalar_type d_m,
+                       const scalar_type d_X0, const scalar_type d_X1,
+                       const scalar_type d_I, const scalar_type d_nC,
+                       const scalar_type d_delta0)
+        : m_x0(x0),
+          m_l0(l0),
+          m_ar(ar),
+          m_z(z),
+          m_mass_rho(mass_rho),
+          m_state(state),
+          m_density(d_a, d_m, d_X0, d_X1, d_I, d_nC, d_delta0),
+          m_has_density_effect_data(true) {
+
+        m_molar_rho = mass_to_molar_density(ar, mass_rho);
+    }
+
     /// Equality operator
     ///
     /// @param rhs is the right hand side to be compared to
@@ -91,12 +112,23 @@ struct material {
         return m_z * m_molar_rho;
     }
 
+    /// @returns the density effect data
+    DETRAY_HOST_DEVICE
+    constexpr detail::density_effect_data<scalar_type> density_effect_data()
+        const {
+        return m_density;
+    }
+
     /// @returns the (Approximated) mean excitation energy
     DETRAY_HOST_DEVICE
     scalar_type mean_excitation_energy() const {
-        // use approximative computation as defined in ATL-SOFT-PUB-2008-003
-        return 16.f * unit<scalar_type>::eV *
-               math_ns::pow(m_z, static_cast<scalar_type>(0.9));
+        if (!m_has_density_effect_data) {
+            // use approximative computation as defined in ATL-SOFT-PUB-2008-003
+            return 16.f * unit<scalar_type>::eV *
+                   math_ns::pow(m_z, static_cast<scalar_type>(0.9));
+        } else {
+            return m_density.get_mean_excitation_energy();
+        }
     }
 
     DETRAY_HOST_DEVICE
@@ -150,6 +182,9 @@ struct material {
         return os;
     }
 
+    DETRAY_HOST_DEVICE
+    bool has_density_effect_data() const { return m_has_density_effect_data; }
+
     protected:
     DETRAY_HOST_DEVICE
     constexpr scalar_type mass_to_molar_density(double ar, double mass_rho) {
@@ -171,9 +206,11 @@ struct material {
     scalar_type m_mass_rho = 0.f;
     scalar_type m_molar_rho = 0.f;
     material_state m_state = material_state::e_unknown;
+    detail::density_effect_data<scalar_type> m_density = {};
+    bool m_has_density_effect_data = false;
 };
 
-// Macro for declaring the predefined materials (with Density effect data)
+// Macro for declaring the predefined materials (w/o Density effect data)
 #define DETRAY_DECLARE_MATERIAL(MATERIAL_NAME, X0, L0, Ar, Z, Rho, State)   \
     template <typename scalar_t, typename R = std::ratio<1, 1>>             \
     struct MATERIAL_NAME final : public material<scalar_t, R> {             \
@@ -181,6 +218,21 @@ struct material {
         using base_type::base_type;                                         \
         DETRAY_HOST_DEVICE                                                  \
         constexpr MATERIAL_NAME() : base_type(X0, L0, Ar, Z, Rho, State) {} \
+    }
+
+// !EXPERIMENTAL!
+// Macro for declaring the predefined materials (with Density effect data)
+#define DETRAY_DECLARE_MATERIAL_WITH_DED(                                    \
+    MATERIAL_NAME, X0, L0, Ar, Z, Rho, State, Density0, Density1, Density2,  \
+    Density3, Density4, Density5, Density6)                                  \
+    template <typename scalar_t, typename R = std::ratio<1, 1>>              \
+    struct MATERIAL_NAME final : public material<scalar_t, R> {              \
+        using base_type = material<scalar_t, R>;                             \
+        using base_type::base_type;                                          \
+        DETRAY_HOST_DEVICE                                                   \
+        constexpr MATERIAL_NAME()                                            \
+            : base_type(X0, L0, Ar, Z, Rho, State, Density0, Density1,       \
+                        Density2, Density3, Density4, Density5, Density6) {} \
     }
 
 }  // namespace detray

--- a/core/include/detray/materials/predefined_materials.hpp
+++ b/core/include/detray/materials/predefined_materials.hpp
@@ -101,6 +101,14 @@ DETRAY_DECLARE_MATERIAL(silicon, 93.7f * unit<scalar>::mm,
                                             unit<double>::cm3),
                         material_state::e_solid);
 
+// Si (14) with density effect data
+DETRAY_DECLARE_MATERIAL_WITH_DED(silicon_with_ded, 93.7f * unit<scalar>::mm,
+                                 465.2f * unit<scalar>::mm, 28.0855f, 14.f,
+                                 static_cast<scalar>(2.329 * unit<double>::g /
+                                                     unit<double>::cm3),
+                                 material_state::e_solid, 0.1492f, 3.2546f,
+                                 0.2015f, 2.8716f, 173.0f, 4.4355f, 0.14f);
+
 // Ar (18): Argon gas
 DETRAY_DECLARE_MATERIAL(argon_gas, 1.176E+02f * unit<scalar>::m,
                         7.204E+02f * unit<scalar>::m, 39.948f, 18.f,
@@ -191,5 +199,13 @@ DETRAY_DECLARE_MATERIAL(cesium_iodide, 1.86f * unit<scalar>::cm,
                         static_cast<scalar>(4.510f * unit<double>::g /
                                             unit<double>::cm3),
                         material_state::e_solid);
+
+DETRAY_DECLARE_MATERIAL_WITH_DED(cesium_iodide_with_ded,
+                                 1.86f * unit<scalar>::cm,
+                                 38.04f * unit<scalar>::cm, 259.81f, 108.f,
+                                 static_cast<scalar>(4.510f * unit<double>::g /
+                                                     unit<double>::cm3),
+                                 material_state::e_solid, 0.25381, 2.6657,
+                                 0.0395, 3.3353, 553.1, 6.2807, 0.00);
 
 }  // namespace detray

--- a/tests/unit_tests/cpu/energy_loss.cpp
+++ b/tests/unit_tests/cpu/energy_loss.cpp
@@ -152,6 +152,26 @@ INSTANTIATE_TEST_SUITE_P(
                                       100.1f * unit<scalar>::GeV, 2.451f)));
 
 INSTANTIATE_TEST_SUITE_P(
+    Bethe_0p1GeV_Si_with_DED, EnergyLossBetheValidation,
+    ::testing::Values(std::make_tuple(silicon_with_ded<scalar>(),
+                                      0.1003f * unit<scalar>::GeV, 2.608f)));
+
+INSTANTIATE_TEST_SUITE_P(
+    Bethe_1GeV_Si_with_DED, EnergyLossBetheValidation,
+    ::testing::Values(std::make_tuple(silicon_with_ded<scalar>(),
+                                      1.101f * unit<scalar>::GeV, 1.803f)));
+
+INSTANTIATE_TEST_SUITE_P(
+    Bethe_10GeV_Si_with_DED, EnergyLossBetheValidation,
+    ::testing::Values(std::make_tuple(silicon_with_ded<scalar>(),
+                                      10.11f * unit<scalar>::GeV, 2.177f)));
+
+INSTANTIATE_TEST_SUITE_P(
+    Bethe_100GeV_Si_with_DED, EnergyLossBetheValidation,
+    ::testing::Values(std::make_tuple(silicon_with_ded<scalar>(),
+                                      100.1f * unit<scalar>::GeV, 2.451f)));
+
+INSTANTIATE_TEST_SUITE_P(
     Bethe_0p1GeV_Fe, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(iron<scalar>(),
                                       0.1003f * unit<scalar>::GeV, 2.274f)));
@@ -198,6 +218,26 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     Bethe_100GeV_CsI, EnergyLossBetheValidation,
     ::testing::Values(std::make_tuple(cesium_iodide<scalar>(),
+                                      100.1f * unit<scalar>::GeV, 2.012f)));
+
+INSTANTIATE_TEST_SUITE_P(
+    Bethe_0p1GeV_CsI_with_DED, EnergyLossBetheValidation,
+    ::testing::Values(std::make_tuple(cesium_iodide_with_ded<scalar>(),
+                                      0.1003f * unit<scalar>::GeV, 1.869f)));
+
+INSTANTIATE_TEST_SUITE_P(
+    Bethe_1GeV_CsI_with_DED, EnergyLossBetheValidation,
+    ::testing::Values(std::make_tuple(cesium_iodide_with_ded<scalar>(),
+                                      1.101f * unit<scalar>::GeV, 1.391f)));
+
+INSTANTIATE_TEST_SUITE_P(
+    Bethe_10GeV_CsI_with_DED, EnergyLossBetheValidation,
+    ::testing::Values(std::make_tuple(cesium_iodide_with_ded<scalar>(),
+                                      10.11f * unit<scalar>::GeV, 1.755f)));
+
+INSTANTIATE_TEST_SUITE_P(
+    Bethe_100GeV_CsI_with_DED, EnergyLossBetheValidation,
+    ::testing::Values(std::make_tuple(cesium_iodide_with_ded<scalar>(),
                                       100.1f * unit<scalar>::GeV, 2.012f)));
 
 // Test class for MUON energy loss with Landau function

--- a/tests/unit_tests/cpu/stopping_power_derivative.cpp
+++ b/tests/unit_tests/cpu/stopping_power_derivative.cpp
@@ -88,4 +88,6 @@ INSTANTIATE_TEST_SUITE_P(
     StoppingPowerDerivative, DerivativeOfStoppingPowerValidation,
     ::testing::Values(hydrogen_gas<scalar>(), helium_gas<scalar>(),
                       isobutane<scalar>(), aluminium<scalar>(),
-                      silicon<scalar>(), tungsten<scalar>(), gold<scalar>()));
+                      silicon<scalar>(), tungsten<scalar>(), gold<scalar>(),
+                      cesium_iodide<scalar>(), silicon_with_ded<scalar>(),
+                      cesium_iodide_with_ded<scalar>()));


### PR DESCRIPTION
I am experiencing a weird step structure in the graph of jacobian elements (#610) due to the following code in `compute_delta_half` function `relativistic_quantities.hpp`:

```
           // Causing step structure
           if (m_betaGamma < 10.f) {
                return 0.f;
            }
            // Equation 34.6 of PDG2022
            // @NOTE A factor of 1000 is required to convert the unit of density
            // (mm^-3 to cm^-3)
            const scalar_type plasmaEnergy{
                PlasmaEnergyScale *
                std::sqrt(1000.f * mat.molar_electron_density())};
            return math_ns::log(m_betaGamma * plasmaEnergy /
                                mat.mean_excitation_energy()) -
                   0.5f;
```
 
So the step structure is caused when betagamma ~ 10, which correponds 1 GeV for muon.

Removing the branch is only possible by introducing the density effect data so I had to restore what I deleted in #450.
Hopefully, it won't touch the main code at all as `material` will have two constructors (w/ and w/o density effect data)

Following figures are showing the relative difference of d(qop_f)/d(qop_i) between semi-analytical (`parameter_transporter`) and numerical differentiation vs. momentum [GeV].

**w/o Density effect data**

There are definitely weird points around ~1 GeV (betagamma ~ 10).

<img src="https://github.com/acts-project/detray/assets/63090140/b3a9e47c-830e-4b63-b749-1dfa0a5fa587"  width="300" height="200" />

**w/ Density effect data**

And they are goind with density effect data calculation

<img src="https://github.com/acts-project/detray/assets/63090140/3bdfc6e4-4a74-47b7-8946-d1e839189ba7"  width="300" height="200" />

