### PR TITLE
Make __host__ and __device__ function checks work with HIP

### DIFF
--- a/core/include/detray/definitions/qualifiers.hpp
+++ b/core/include/detray/definitions/qualifiers.hpp
@@ -8,25 +8,25 @@
 
 #pragma once
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIP__)
 #define DETRAY_DEVICE __device__
 #else
 #define DETRAY_DEVICE
 #endif
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIP__)
 #define DETRAY_HOST __host__
 #else
 #define DETRAY_HOST
 #endif
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIP__)
 #define DETRAY_HOST_DEVICE __host__ __device__
 #else
 #define DETRAY_HOST_DEVICE
 #endif
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIP__)
 #define DETRAY_ALIGN(x) __align__(x)
 #else
 #define DETRAY_ALIGN(x) alignas(x)


### PR DESCRIPTION
As proposed by @krasznaa in https://github.com/acts-project/vecmem/pull/261, extend the __host__ and __device__ macros for HIP.