### PR TITLE
ref: remove radius from 2D cylinder grid

### DIFF
--- a/core/include/detray/coordinates/cylindrical2.hpp
+++ b/core/include/detray/coordinates/cylindrical2.hpp
@@ -72,14 +72,14 @@ struct cylindrical2 : public coordinate_base<cylindrical2, transform3_t> {
                 getter::perp(local3)};
     }
 
-    /** This method transforms a point from a global cartesian 3D frame to a
-     * bound 2D cylindrical point */
+    /// @returns the projection of a global position onto the grid axis
+    /// @note Does not scale with r, due to projection effects in the navigation
     DETRAY_HOST_DEVICE
     inline loc_point project_to_axes(const transform3_t &trf, const point3 &p,
                                      const vector3 & /*d*/) const {
         const auto local3 = trf.point_to_local(p);
 
-        return {getter::perp(local3) * getter::phi(local3), local3[2]};
+        return {getter::phi(local3), local3[2]};
     }
 
     /** This method transform from a local 2D cylindrical point to a point

--- a/core/include/detray/tools/grid_factory.hpp
+++ b/core/include/detray/tools/grid_factory.hpp
@@ -173,8 +173,7 @@ class grid_factory {
         auto b_values = grid_bounds.values();
 
         return new_grid<local_frame>(
-            {-constant<scalar_type>::pi * b_values[boundary::e_r],
-             constant<scalar_type>::pi * b_values[boundary::e_r],
+            {-constant<scalar_type>::pi, constant<scalar_type>::pi,
              b_values[boundary::e_n_half_z], b_values[boundary::e_p_half_z]},
             {n_bins[e_rphi_axis], n_bins[e_z_axis]},
             {bin_edges[e_rphi_axis], bin_edges[e_z_axis]},
@@ -214,8 +213,7 @@ class grid_factory {
         auto b_values = grid_bounds.values();
 
         return new_grid<local_frame>(
-            {-constant<scalar_type>::pi * b_values[boundary::e_r],
-             constant<scalar_type>::pi * b_values[boundary::e_r],
+            {-constant<scalar_type>::pi, constant<scalar_type>::pi,
              b_values[boundary::e_n_half_z], b_values[boundary::e_p_half_z]},
             {n_bins[e_rphi_axis], n_bins[e_z_axis]},
             {bin_edges[e_rphi_axis], bin_edges[e_z_axis]},

--- a/tests/unit_tests/cpu/material_maps.cpp
+++ b/tests/unit_tests/cpu/material_maps.cpp
@@ -84,8 +84,8 @@ GTEST_TEST(detray_material, cylinder_map) {
 
     auto rphi_axis = cylinder_map.get_axis<label::e_rphi>();
     EXPECT_EQ(rphi_axis.nbins(), 10u);
-    EXPECT_EQ(rphi_axis.min(), -constant<scalar>::pi * r);
-    EXPECT_EQ(rphi_axis.max(), constant<scalar>::pi * r);
+    EXPECT_EQ(rphi_axis.min(), -constant<scalar>::pi);
+    EXPECT_EQ(rphi_axis.max(), constant<scalar>::pi);
 
     auto z_axis = cylinder_map.get_axis<label::e_cyl_z>();
     EXPECT_EQ(z_axis.nbins(), 20u);


### PR DESCRIPTION
Remove r-dependency from 2D cylinder grids, since it might lead to projection effects in the local navigation