### PR TITLE
Rework RKN stepper

### DIFF
--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -78,13 +78,10 @@ class rk_stepper final
             vector3 b_first{0.f, 0.f, 0.f};
             vector3 b_middle{0.f, 0.f, 0.f};
             vector3 b_last{0.f, 0.f, 0.f};
-            vector3 k1{0.f, 0.f, 0.f};
-            vector3 k2{0.f, 0.f, 0.f};
-            vector3 k3{0.f, 0.f, 0.f};
-            vector3 k4{0.f, 0.f, 0.f};
-            // @NOTE: qop2 = qop3
-            scalar_type qop2{0.f};
-            scalar_type qop4{0.f};
+            std::array<vector3, 4u> t;
+            std::array<vector3, 4u> dtds;
+            std::array<scalar, 4u> qop;
+            std::array<scalar, 4u> dqopds;
         } _step_data;
 
         /// Magnetic field view
@@ -101,23 +98,25 @@ class rk_stepper final
         DETRAY_HOST_DEVICE
         inline void advance_jacobian(const stepping::config& cfg = {});
 
-        /// evaulate qop for a given step size and material
+        /// evaulate dqopds for a given step size and material
         DETRAY_HOST_DEVICE
-        inline scalar_type evaluate_qop(const scalar_type h,
-                                        const stepping::config& cfg = {}) const;
+        inline scalar_type evaluate_dqopds(
+            const std::size_t i, const typename transform3_t::scalar_type h,
+            const scalar dqopds_prev, const detray::stepping::config& cfg);
 
-        /// evaulate k_n for runge kutta stepping
+        /// evaulate dtds for runge kutta stepping
         DETRAY_HOST_DEVICE
-        inline vector3 evaluate_k(const vector3& b_field, const int i,
-                                  const scalar_type h, const vector3& k_prev,
-                                  const scalar_type qop);
+        inline vector3 evaluate_dtds(const vector3& b_field,
+                                     const std::size_t i, const scalar_type h,
+                                     const vector3& dtds_prev,
+                                     const scalar_type qop);
 
         DETRAY_HOST_DEVICE
         inline matrix_type<3, 3> evaluate_field_gradient(const vector3& pos);
 
         /// Evaluate dtds, where t is the unit tangential direction
         DETRAY_HOST_DEVICE
-        inline vector3 dtds() const { return this->_step_data.k4; }
+        inline vector3 dtds() const { return this->_step_data.dtds[3u]; }
 
         /// Evaulate d(qop)/ds
         DETRAY_HOST_DEVICE
@@ -125,6 +124,14 @@ class rk_stepper final
 
         DETRAY_HOST_DEVICE
         inline scalar_type dqopds(const scalar_type qop) const;
+
+        /// Evaulate dg/dqop where g = -stopping_power
+        DETRAY_HOST_DEVICE
+        inline scalar_type dgdqop(const scalar_type qop) const;
+
+        /// Evaulate d(d(qop)/ds)dqop
+        DETRAY_HOST_DEVICE
+        inline scalar_type d2qopdsdqop(const scalar_type qop) const;
 
         /// Call the stepping inspector
         template <typename... Args>

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -27,20 +27,22 @@ void detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
     auto dir = track.dir();
 
     // Update the track parameters according to the equations of motion
-    pos = pos + h * (dir + h_6 * (sd.k1 + sd.k2 + sd.k3));
+    // Reference: Eq (82) of https://doi.org/10.1016/0029-554X(81)90063-X
+    pos = pos + h * (sd.t[0u] + h_6 * (sd.dtds[0] + sd.dtds[1] + sd.dtds[2]));
     track.set_pos(pos);
 
-    dir = dir + h_6 * (sd.k1 + 2.f * (sd.k2 + sd.k3) + sd.k4);
+    // Reference: Eq (82) of https://doi.org/10.1016/0029-554X(81)90063-X
+    dir =
+        dir + h_6 * (sd.dtds[0] + 2.f * (sd.dtds[1] + sd.dtds[2]) + sd.dtds[3]);
     dir = vector::normalize(dir);
     track.set_dir(dir);
 
     auto qop = track.qop();
     if (!(this->_mat == vacuum<scalar_t>())) {
-        const scalar_t dqopds1 = this->dqopds(qop);
-        const scalar_t dqopds2 = this->dqopds(sd.qop2);
-        const scalar_t dqopds3 = dqopds2;
-        const scalar_t dqopds4 = this->dqopds(sd.qop4);
-        qop = qop + h_6 * (dqopds1 + 2.f * (dqopds2 + dqopds3) + dqopds4);
+        // Reference: Eq (82) of https://doi.org/10.1016/0029-554X(81)90063-X
+        qop =
+            qop + h_6 * (sd.dqopds[0u] + 2.f * (sd.dqopds[1u] + sd.dqopds[2u]) +
+                         sd.dqopds[3u]);
     }
     track.set_qop(qop);
 
@@ -62,11 +64,11 @@ void detray::rk_stepper<
     /// different parts. The first one is given by the upper left 3x3 matrix
     /// that are calculated by the derivatives dF/dT (called dFdT) and dG/dT
     /// (calles dGdT). The second is given by the top 3 lines of the rightmost
-    /// column. This is calculated by dFdL and dGdL. The remaining non-zero term
-    /// is calculated directly. The naming of the variables is explained in eq.
-    /// 11 and are directly related to the initial problem in eq. 7.
-    /// The evaluation is based by propagating the parameters T and lambda as
-    /// given in eq. 16 and evaluating the derivations for matrix A.
+    /// column. This is calculated by dFdqop and dGdqop. The remaining non-zero
+    /// term is calculated directly. The naming of the variables is explained in
+    /// eq. 11 and are directly related to the initial problem in eq. 7. The
+    /// evaluation is based by propagating the parameters T and lambda as given
+    /// in eq. 16 and evaluating the derivations for matrix A.
     /// @note The translation for u_{n+1} in eq. 7 is in this case a
     /// 3-dimensional vector without a dependency of Lambda or lambda neither in
     /// u_n nor in u_n'. The second and fourth eq. in eq. 14 have the constant
@@ -82,34 +84,27 @@ void detray::rk_stepper<
     auto& track = this->_track;
 
     // Half step length
+    const scalar_t h2{h * h};
     const scalar_t half_h{h * 0.5f};
     const scalar_t h_6{h * static_cast<scalar>(1. / 6.)};
-
-    // Direction
-    const auto dir1 = track.dir();
-    const vector3 dir2 = dir1 + half_h * sd.k1;
-    const vector3 dir3 = dir1 + half_h * sd.k2;
-    const vector3 dir4 = dir1 + h * sd.k3;
-
-    // Q over P
-    const auto qop1 = track.qop();
-    const auto qop2 = sd.qop2;
-    const auto qop3 = qop2;
-    const auto qop4 = sd.qop4;
 
     /*---------------------------------------------------------------------------
      * k_{n} is always in the form of [ A(T) X B ] where A is a function of r'
      * and B is magnetic field and X symbol is for cross product. Hence dk{n}dT
      * can be represented as follows:
      *
-     *  dk{n}dT =  d/dT [ A(T) X B ] = dA(T)/dr (X) B
+     *  dk{n}dT =  d/dT [ A(T) X B ]  = dA(T)/dr (X) B
+     *
+     *  dk{n}dT = d/dT qop_n * ( T_n X B ) = qop_n ( d(T_n)/dT X B )
+     *
+     *  dk{n}dT = d/dT qop_n * ( T_n X B ) = qop_n ( d(T_n)/dT X B )
      *
      *  where,
      *  (X) symbol is column-wise cross product between matrix and vector,
      *  k1 = qop * T X B_first,
      *  k2 = qop * ( T + h / 2 * k1 ) X B_middle,
      *  k3 = qop * ( T + h / 2 * k2 ) X B_middle,
-     *  k4 = qop * ( T + h * k3 ) * B_last.
+     *  k4 = qop * ( T + h * k3 ) X B_last.
     ---------------------------------------------------------------------------*/
     auto dk1dT = matrix_operator().template identity<3, 3>();
     auto dk2dT = matrix_operator().template identity<3, 3>();
@@ -117,13 +112,13 @@ void detray::rk_stepper<
     auto dk4dT = matrix_operator().template identity<3, 3>();
 
     // Top-left 3x3 submatrix of Eq 3.12 of [JINST 4 P04016]
-    dk1dT = qop1 * mat_helper().column_wise_cross(dk1dT, sd.b_first);
+    dk1dT = sd.qop[0u] * mat_helper().column_wise_cross(dk1dT, sd.b_first);
     dk2dT = dk2dT + half_h * dk1dT;
-    dk2dT = qop2 * mat_helper().column_wise_cross(dk2dT, sd.b_middle);
+    dk2dT = sd.qop[1u] * mat_helper().column_wise_cross(dk2dT, sd.b_middle);
     dk3dT = dk3dT + half_h * dk2dT;
-    dk3dT = qop3 * mat_helper().column_wise_cross(dk3dT, sd.b_middle);
+    dk3dT = sd.qop[2u] * mat_helper().column_wise_cross(dk3dT, sd.b_middle);
     dk4dT = dk4dT + h * dk3dT;
-    dk4dT = qop4 * mat_helper().column_wise_cross(dk4dT, sd.b_last);
+    dk4dT = sd.qop[3u] * mat_helper().column_wise_cross(dk4dT, sd.b_last);
 
     auto dFdT = matrix_operator().template identity<3, 3>();
     auto dGdT = matrix_operator().template identity<3, 3>();
@@ -131,58 +126,45 @@ void detray::rk_stepper<
     dFdT = h * dFdT;
     dGdT = dGdT + h_6 * (dk1dT + 2.f * (dk2dT + dk3dT) + dk4dT);
 
-    // Calculate dk{n}dL where L is qop
-    vector3 dk1dL = vector::cross(dir1, sd.b_first);
-    vector3 dk2dL = vector::cross(dir2, sd.b_middle) +
-                    qop2 * half_h * vector::cross(dk1dL, sd.b_middle);
-    vector3 dk3dL = vector::cross(dir3, sd.b_middle) +
-                    qop3 * half_h * vector::cross(dk2dL, sd.b_middle);
-    vector3 dk4dL = vector::cross(dir4, sd.b_last) +
-                    qop4 * h * vector::cross(dk3dL, sd.b_last);
+    // Calculate dk{n}dqop where L is qop
+    // d(k_n)d(qop_1) = d(qop_n * t_n X B_n)/d(qop_1)
+    // = d(qop_n)/d(qop_1) * [ t_n (X) B_n ] + qop_n * [ d(t_n)/d(qop_1) X B_n ]
+    //
+    // Note that [ qop_n = qop_1 + h * d(qop_{n-1})/ds) ] as indicated by
+    // Eq (84) of https://doi.org/10.1016/0029-554X(81)90063-X
+    //
+    // d(qop_n)/d(qop_1) = 1 + h * d(d(qop_{n-1})/ds)/d(qop_1))
+    //
+    // Let us assume that
+    // d(d(qop_{n-1})/ds)/d(qop_1)) ~ d(d(qop_{n-1})/ds)/d(qop_{n-1}))
+    vector3 dk1dqop = vector::cross(sd.t[0u], sd.b_first);
+    vector3 dk2dqop = (1 + half_h * this->d2qopdsdqop(sd.qop[0u])) *
+                          vector::cross(sd.t[1u], sd.b_middle) +
+                      sd.qop[1u] * half_h * vector::cross(dk1dqop, sd.b_middle);
+    vector3 dk3dqop = (1 + half_h * this->d2qopdsdqop(sd.qop[1u])) *
+                          vector::cross(sd.t[2u], sd.b_middle) +
+                      sd.qop[2u] * half_h * vector::cross(dk2dqop, sd.b_middle);
+    vector3 dk4dqop = (1 + h * this->d2qopdsdqop(sd.qop[2u])) *
+                          vector::cross(sd.t[3u], sd.b_last) +
+                      sd.qop[3u] * h * vector::cross(dk3dqop, sd.b_last);
 
-    // dFdL and dGdL are top-right 3x1 submatrix of equation (17)
-    vector3 dFdL = h * h_6 * (dk1dL + dk2dL + dk3dL);
-    vector3 dGdL = h_6 * (dk1dL + 2.f * (dk2dL + dk3dL) + dk4dL);
+    // dFdqop and dGdqop are top-right 3x1 submatrix of equation (17)
+    vector3 dFdqop = h * h_6 * (dk1dqop + dk2dqop + dk3dqop);
+    vector3 dGdqop = h_6 * (dk1dqop + 2.f * (dk2dqop + dk3dqop) + dk4dqop);
 
     // Set transport matrix (D) and update Jacobian transport
     //( JacTransport = D * JacTransport )
     auto D = matrix_operator().template identity<e_free_size, e_free_size>();
     matrix_operator().set_block(D, dFdT, 0u, 4u);
-    matrix_operator().set_block(D, dFdL, 0u, 7u);
+    matrix_operator().set_block(D, dFdqop, 0u, 7u);
     matrix_operator().set_block(D, dGdT, 4u, 4u);
-    matrix_operator().set_block(D, dGdL, 4u, 7u);
+    matrix_operator().set_block(D, dGdqop, 4u, 7u);
 
     /// (4,4) element (right-bottom) of Eq. 3.12 [JINST 4 P04016]
     if (cfg.use_eloss_gradient) {
         if (this->_mat == vacuum<scalar_t>()) {
             getter::element(D, e_free_qoverp, e_free_qoverp) = 1.f;
         } else {
-            const scalar_t q = track.charge();
-            const scalar_t p = q / qop1;
-            const auto& mass = this->_mass;
-            const scalar_t p2 = p * p;
-            const scalar_t E2 = p2 + mass * mass;
-            const scalar_t E = math::sqrt(E2);
-
-            // Interaction object
-            interaction<scalar> I;
-
-            // g: dE/ds = -1 * stopping power
-            const scalar_t g =
-                -1.f *
-                I.compute_stopping_power(this->_mat, this->_pdg, mass, qop1, q);
-            // dg/d(qop) = -1 * derivation of stopping power
-            const scalar_t dg_dQop =
-                -1.f *
-                I.derive_stopping_power(this->_mat, this->_pdg, mass, qop1, q);
-
-            // d(Qop)/ds = - qop^3 * E * g / q^2
-            const scalar_t dQop_ds =
-                (-1.f * qop1 * qop1 * qop1 * E * g) / (q * q);
-
-            const scalar_t gradient =
-                dQop_ds * (1.f / qop1 * (3.f - p2 / E2) + 1.f / g * dg_dQop);
-
             // As the reference of [JINST 4 P04016] said that "The energy loss
             // and its gradient varies little within each recursion step, hence
             // the values calculated in the first stage are recycled by the
@@ -191,7 +173,7 @@ void detray::rk_stepper<
             //
             // But it would be better to be more precise in the future.
             getter::element(D, e_free_qoverp, e_free_qoverp) =
-                1.f + gradient * h;
+                1.f + d2qopdsdqop(sd.qop[0u]) * h;
         }
     }
 
@@ -201,28 +183,35 @@ void detray::rk_stepper<
         auto dGdR = matrix_operator().template identity<3, 3>();
 
         const vector3 pos1 = track.pos();
-        const vector3 pos2 = pos1 + half_h * dir1;
-        const vector3 pos3 = pos1 + half_h * dir2;
-        const vector3 pos4 = pos1 + h * dir3;
+        const vector3 pos2 =
+            pos1 + half_h * sd.t[0u] + h2 * 0.125f * sd.dtds[0u];
+        const vector3 pos4 = pos1 + h * sd.t[0u] + h2 * 0.5f * sd.dtds[2u];
 
         const matrix_type<3, 3> field_gradient1 = evaluate_field_gradient(pos1);
         const matrix_type<3, 3> field_gradient2 = evaluate_field_gradient(pos2);
-        const matrix_type<3, 3> field_gradient3 = evaluate_field_gradient(pos3);
+        const matrix_type<3, 3> field_gradient3 = field_gradient2;
         const matrix_type<3, 3> field_gradient4 = evaluate_field_gradient(pos4);
 
         // dk{n}dR = d(qop_n * t_n X B_n)/dR
         //         = qop_n * [ d(t_n)/dR (X) B_n - d(B_n)/dR (X) t_n ]
+        //
+        // t_n = t_1 + h * dtds_{n-1}
+        // ===> d(t_n)/dR = h * dk{n-1}dR  ( Note that k == dtds )
         matrix_type<3, 3> dk1dR =
-            -1.f * qop1 * mat_helper().column_wise_cross(field_gradient1, dir1);
-        matrix_type<3, 3> dk2dR = qop2 * half_h * dk1dR;
+            -1.f * sd.qop[0u] *
+            mat_helper().column_wise_cross(field_gradient1, sd.t[0u]);
+        matrix_type<3, 3> dk2dR = sd.qop[1u] * half_h * dk1dR;
         dk2dR = mat_helper().column_wise_cross(dk2dR, sd.b_middle) -
-                qop2 * mat_helper().column_wise_cross(field_gradient2, dir2);
-        matrix_type<3, 3> dk3dR = qop3 * half_h * dk2dR;
+                sd.qop[1u] *
+                    mat_helper().column_wise_cross(field_gradient2, sd.t[1u]);
+        matrix_type<3, 3> dk3dR = sd.qop[2u] * half_h * dk2dR;
         dk3dR = mat_helper().column_wise_cross(dk3dR, sd.b_middle) -
-                qop3 * mat_helper().column_wise_cross(field_gradient3, dir3);
-        matrix_type<3, 3> dk4dR = qop4 * h * dk3dR;
+                sd.qop[2u] *
+                    mat_helper().column_wise_cross(field_gradient3, sd.t[2u]);
+        matrix_type<3, 3> dk4dR = sd.qop[3u] * h * dk3dR;
         dk4dR = mat_helper().column_wise_cross(dk4dR, sd.b_last) -
-                qop4 * mat_helper().column_wise_cross(field_gradient4, dir4);
+                sd.qop[3u] *
+                    mat_helper().column_wise_cross(field_gradient4, sd.t[3u]);
 
         dFdR = dFdR + h * h_6 * (dk1dR + dk2dR + dk3dR);
         dGdR = h_6 * (dk1dR + 2.f * (dk2dR + dk3dR) + dk4dR);
@@ -230,12 +219,6 @@ void detray::rk_stepper<
         matrix_operator().set_block(D, dFdR, 0u, 0u);
         matrix_operator().set_block(D, dGdR, 4u, 0u);
     }
-
-    /// Calculate (4,4) element of equation (17)
-    /// NOTE: Let's skip this element for the moment
-    /// const auto p = getter::norm(track.mom());
-    /// matrix_operator().element(D, 3, 7) =
-    /// h * mass * mass * qop * getter::perp(vector2{1, mass / p});
 
     this->_jac_transport = D * this->_jac_transport;
 }
@@ -245,46 +228,39 @@ template <typename magnetic_field_t, typename transform3_t,
           template <typename, std::size_t> class array_t>
 auto detray::rk_stepper<
     magnetic_field_t, transform3_t, constraint_t, policy_t, inspector_t,
-    array_t>::state::evaluate_qop(const typename transform3_t::scalar_type h,
-                                  const detray::stepping::config& cfg) const ->
+    array_t>::state::evaluate_dqopds(const std::size_t i,
+                                     const typename transform3_t::scalar_type h,
+                                     const scalar dqopds_prev,
+                                     const detray::stepping::config& cfg) ->
     typename transform3_t::scalar_type {
 
     using scalar_t = typename transform3_t::scalar_type;
 
     const auto& track = this->_track;
     const scalar_t qop = track.qop();
+    auto& sd = this->_step_data;
 
-    if (cfg.use_mean_loss) {
+    if (this->_mat == detray::vacuum<scalar_t>()) {
+        sd.qop[i] = qop;
+        return 0.f;
+    } else {
 
-        const auto& mat = this->_mat;
-        if (mat == detray::vacuum<scalar_t>()) {
-            return qop;
+        if (cfg.use_mean_loss) {
+            if (i == 0u) {
+                sd.qop[i] = qop;
+            } else {
+
+                // qop_n is calculated recursively like the direction of
+                // evaluate_dtds.
+                //
+                // https://doi.org/10.1016/0029-554X(81)90063-X says:
+                // "For y  we  have  similar  formulae  as  for x, for y' and
+                // \lambda similar  formulae as for  x'"
+                sd.qop[i] = qop + h * dqopds_prev;
+            }
         }
-
-        const scalar_t mass = this->_mass;
-        const auto pdg = this->_pdg;
-        const scalar_t p = track.p();
-        const scalar_t q = track.charge();
-        const auto direction = this->_direction;
-
-        const scalar_t eloss =
-            interaction<scalar_t>().compute_energy_loss_bethe(h, mat, pdg, mass,
-                                                              qop, q);
-
-        // @TODO: Recycle the codes in pointwise_material_interactor.hpp
-        // Get new Energy
-        const scalar_t nextE{
-            math::sqrt(mass * mass + p * p) -
-            math::copysign(eloss, static_cast<scalar_t>(direction))};
-
-        // Put particle at rest if energy loss is too large
-        const scalar_t nextP{
-            (mass < nextE) ? math::sqrt(nextE * nextE - mass * mass) : 0.f};
-
-        constexpr scalar_t inv{detail::invalid_value<scalar_t>()};
-        return (nextP == 0.f) ? inv : (q != 0.f) ? q / nextP : 1.f / nextP;
+        return this->dqopds(sd.qop[i]);
     }
-    return qop;
 }
 
 template <typename magnetic_field_t, typename transform3_t,
@@ -292,23 +268,24 @@ template <typename magnetic_field_t, typename transform3_t,
           template <typename, std::size_t> class array_t>
 auto detray::rk_stepper<
     magnetic_field_t, transform3_t, constraint_t, policy_t, inspector_t,
-    array_t>::state::evaluate_k(const vector3& b_field, const int i,
-                                const typename transform3_t::scalar_type h,
-                                const vector3& k_prev,
-                                const typename transform3_t::scalar_type qop)
+    array_t>::state::evaluate_dtds(const vector3& b_field, const std::size_t i,
+                                   const typename transform3_t::scalar_type h,
+                                   const vector3& dtds_prev,
+                                   const typename transform3_t::scalar_type qop)
     -> vector3 {
     auto& track = this->_track;
     const auto dir = track.dir();
+    auto& sd = this->_step_data;
 
-    vector3 k_new;
-
-    if (i == 0) {
-        k_new = qop * vector::cross(dir, b_field);
+    if (i == 0u) {
+        sd.t[i] = dir;
     } else {
-        k_new = qop * vector::cross(dir + h * k_prev, b_field);
+        // Eq (84) of https://doi.org/10.1016/0029-554X(81)90063-X
+        sd.t[i] = dir + h * dtds_prev;
     }
 
-    return k_new;
+    // dtds = qop * (t X B) from Lorentz force
+    return qop * vector::cross(sd.t[i], b_field);
 }
 
 template <typename magnetic_field_t, typename transform3_t,
@@ -360,7 +337,7 @@ template <typename magnetic_field_t, typename transform3_t,
 auto detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
                         inspector_t, array_t>::state::dqopds() const ->
     typename transform3_t::scalar_type {
-    return this->dqopds(this->_step_data.qop4);
+    return this->_step_data.dqopds[3u];
 }
 
 template <typename magnetic_field_t, typename transform3_t,
@@ -374,13 +351,13 @@ auto detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
     using scalar_t = typename transform3_t::scalar_type;
 
     const auto& mat = this->_mat;
-    const auto pdg = this->_pdg;
 
     // d(qop)ds is zero for empty space
     if (mat == detray::vacuum<scalar_t>()) {
         return 0.f;
     }
 
+    const auto pdg = this->_pdg;
     const scalar_t q = this->_track.charge();
     const scalar_t p = q / qop;
     const scalar_t mass = this->_mass;
@@ -395,6 +372,70 @@ auto detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
 
     // d(qop)ds, which is equal to (qop) * E * (-dE/ds) / p^2
     return qop * E * stopping_power / (p * p);
+}
+
+template <typename magnetic_field_t, typename transform3_t,
+          typename constraint_t, typename policy_t, typename inspector_t,
+          template <typename, std::size_t> class array_t>
+auto detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
+                        inspector_t, array_t>::state::dgdqop(const scalar_type
+                                                                 qop) const ->
+    typename transform3_t::scalar_type {
+
+    using scalar_t = typename transform3_t::scalar_type;
+
+    if (this->_mat == vacuum<scalar_t>()) {
+        return 0.f;
+    }
+
+    auto& track = this->_track;
+    const scalar_t q = track.charge();
+
+    // dg/d(qop) = -1 * derivation of stopping power
+    const scalar_t dgdqop =
+        -1.f * interaction<scalar_t>().derive_stopping_power(
+                   this->_mat, this->_pdg, this->_mass, qop, q);
+
+    return dgdqop;
+}
+
+template <typename magnetic_field_t, typename transform3_t,
+          typename constraint_t, typename policy_t, typename inspector_t,
+          template <typename, std::size_t> class array_t>
+auto detray::rk_stepper<
+    magnetic_field_t, transform3_t, constraint_t, policy_t, inspector_t,
+    array_t>::state::d2qopdsdqop(const scalar_type qop) const ->
+    typename transform3_t::scalar_type {
+
+    using scalar_t = typename transform3_t::scalar_type;
+
+    if (this->_mat == vacuum<scalar_t>()) {
+        return 0.f;
+    }
+
+    auto& track = this->_track;
+    const scalar_t q = track.charge();
+    const scalar_t p = q / qop;
+    const scalar_t p2 = p * p;
+
+    const auto& mass = this->_mass;
+    const scalar_t E2 = p2 + mass * mass;
+
+    // Interaction object
+    interaction<scalar_t> I;
+
+    // g = dE/ds = -1 * (-dE/ds) = -1 * stopping power
+    const scalar_type g =
+        -1.f * I.compute_stopping_power(this->_mat, this->_pdg, mass, qop, q);
+    // dg/d(qop) = -1 * derivation of stopping power
+    const scalar_t dgdqop = this->dgdqop(qop);
+
+    // d(qop)/ds = - qop^3 * E * g / q^2
+    const scalar_t dqopds = this->dqopds(qop);
+
+    // Check Eq 3.12 of
+    // (https://iopscience.iop.org/article/10.1088/1748-0221/4/04/P04016/meta)
+    return dqopds * (1.f / qop * (3.f - p2 / E2) + 1.f / g * dgdqop);
 }
 
 template <typename magnetic_field_t, typename transform3_t,
@@ -422,14 +463,16 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
 
     // First Runge-Kutta point
     const vector3 pos = stepping().pos();
-    const vector3 dir = stepping().dir();
     const auto bvec = magnetic_field.at(pos[0], pos[1], pos[2]);
     sd.b_first[0] = bvec[0];
     sd.b_first[1] = bvec[1];
     sd.b_first[2] = bvec[2];
 
-    sd.k1 = stepping.evaluate_k(sd.b_first, 0, 0.f, vector3{0.f, 0.f, 0.f},
-                                stepping().qop());
+    // qop should be recalcuated at every point
+    // Reference: Eq (84) of https://doi.org/10.1016/0029-554X(81)90063-X
+    sd.dqopds[0u] = stepping.evaluate_dqopds(0u, 0.f, 0.f, cfg);
+    sd.dtds[0u] = stepping.evaluate_dtds(sd.b_first, 0u, 0.f,
+                                         vector3{0.f, 0.f, 0.f}, sd.qop[0u]);
 
     const auto try_rk4 = [&](const scalar& h) -> bool {
         // State the square and half of the step size
@@ -437,30 +480,45 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
         const scalar_t half_h{h * 0.5f};
 
         // Second Runge-Kutta point
-        const vector3 pos1 = pos + half_h * dir + h2 * 0.125f * sd.k1;
+        // qop should be recalcuated at every point
+        // Eq (84) of https://doi.org/10.1016/0029-554X(81)90063-X
+        const vector3 pos1 =
+            pos + half_h * sd.t[0u] + h2 * 0.125f * sd.dtds[0u];
         const auto bvec1 = magnetic_field.at(pos1[0], pos1[1], pos1[2]);
         sd.b_middle[0] = bvec1[0];
         sd.b_middle[1] = bvec1[1];
         sd.b_middle[2] = bvec1[2];
 
-        sd.qop2 = stepping.evaluate_qop(half_h, cfg);
-        sd.k2 = stepping.evaluate_k(sd.b_middle, 1, half_h, sd.k1, sd.qop2);
+        sd.dqopds[1u] =
+            stepping.evaluate_dqopds(1u, half_h, sd.dqopds[0u], cfg);
+        sd.dtds[1u] = stepping.evaluate_dtds(sd.b_middle, 1u, half_h,
+                                             sd.dtds[0u], sd.qop[1u]);
 
         // Third Runge-Kutta point
-        sd.k3 = stepping.evaluate_k(sd.b_middle, 2, half_h, sd.k2, sd.qop2);
+        // qop should be recalcuated at every point
+        // Reference: Eq (84) of https://doi.org/10.1016/0029-554X(81)90063-X
+        sd.dqopds[2u] =
+            stepping.evaluate_dqopds(2u, half_h, sd.dqopds[1u], cfg);
+        sd.dtds[2u] = stepping.evaluate_dtds(sd.b_middle, 2u, half_h,
+                                             sd.dtds[1u], sd.qop[2u]);
 
         // Last Runge-Kutta point
-        const vector3 pos2 = pos + h * dir + h2 * 0.5f * sd.k3;
+        // qop should be recalcuated at every point
+        // Eq (84) of https://doi.org/10.1016/0029-554X(81)90063-X
+        const vector3 pos2 = pos + h * sd.t[0u] + h2 * 0.5f * sd.dtds[2u];
         const auto bvec2 = magnetic_field.at(pos2[0], pos2[1], pos2[2]);
         sd.b_last[0] = bvec2[0];
         sd.b_last[1] = bvec2[1];
         sd.b_last[2] = bvec2[2];
-        sd.qop4 = stepping.evaluate_qop(h, cfg);
-        sd.k4 = stepping.evaluate_k(sd.b_last, 3, h, sd.k3, sd.qop4);
+
+        sd.dqopds[3u] = stepping.evaluate_dqopds(3u, h, sd.dqopds[2u], cfg);
+        sd.dtds[3u] =
+            stepping.evaluate_dtds(sd.b_last, 3u, h, sd.dtds[2u], sd.qop[3u]);
 
         // Compute and check the local integration error estimate
         // @Todo
-        const vector3 err_vec = h2 * (sd.k1 - sd.k2 - sd.k3 + sd.k4);
+        const vector3 err_vec =
+            h2 * (sd.dtds[0u] - sd.dtds[1u] - sd.dtds[2u] + sd.dtds[3u]);
         error_estimate =
             math::max(getter::norm(err_vec), static_cast<scalar_t>(1e-20));
 


### PR DESCRIPTION
Changes

0. Obtain `qop` recursively as well as `k` (`dtds`)

1. ~~Normalize the direction of all four stages of RKN step~~ It seems the normalization actually doesn't help at all

2. Calculate d(qop_n)/d(qop_1) (n=1,2,3,4) correctly in the calculation of d(k_n)/d(qop_1), where k_n = qop_n ( t_n X B(r_n))

3. Change dL -> dqop for better readibility

4. The sign of `step_direction` in the calculation of `nextE` is removed which seems to be unnecessary. `eloss` already includes the sign from the step size of `h`
 
5. Rename a couple of functions to match its purpose.

6. Comment as much as possible with a reference 

The first two changes boost the precision of `d(theta)/d(qop)` of jacobian a couple of orders