### PR TITLE
ref: simplify random track generator

### DIFF
--- a/tests/unit_tests/cpu/tools_track_generators.cpp
+++ b/tests/unit_tests/cpu/tools_track_generators.cpp
@@ -214,8 +214,7 @@ GTEST_TEST(detray_simulation, random_track_generator_uniform) {
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =
-        random_numbers<scalar, std::uniform_real_distribution<scalar>,
-                       std::seed_seq>;
+        random_numbers<scalar, std::uniform_real_distribution<scalar>>;
     using trk_generator_t =
         random_track_generator<free_track_parameters<transform3>,
                                uniform_gen_t>;
@@ -229,6 +228,7 @@ GTEST_TEST(detray_simulation, random_track_generator_uniform) {
 
     // Other params
     trk_generator_t::configuration trk_gen_cfg{};
+    trk_gen_cfg.seed(42u);
     trk_gen_cfg.n_tracks(n_gen_tracks);
     trk_gen_cfg.phi_range(-0.9f * constant<scalar>::pi,
                           0.8f * constant<scalar>::pi);
@@ -294,7 +294,7 @@ GTEST_TEST(detray_simulation, random_track_generator_normal) {
 
     // Use deterministic random number generator for testing
     using normal_gen_t =
-        random_numbers<scalar, std::normal_distribution<scalar>, std::seed_seq>;
+        random_numbers<scalar, std::normal_distribution<scalar>>;
     using trk_generator_t =
         random_track_generator<free_track_parameters<transform3>, normal_gen_t>;
 
@@ -307,6 +307,7 @@ GTEST_TEST(detray_simulation, random_track_generator_normal) {
 
     // Other params
     trk_generator_t::configuration trk_gen_cfg{};
+    trk_gen_cfg.seed(42u);
     trk_gen_cfg.n_tracks(n_gen_tracks);
     trk_gen_cfg.phi_range(-0.9f * constant<scalar>::pi,
                           0.8f * constant<scalar>::pi);

--- a/tests/validation/src/jacobian_validation.cpp
+++ b/tests/validation/src/jacobian_validation.cpp
@@ -1186,8 +1186,7 @@ int main(int argc, char** argv) {
     // Iterate over reference (pilot) tracks for a rectangular telescope
     // geometry and Jacobian calculation
     using uniform_gen_t =
-        random_numbers<scalar, std::uniform_real_distribution<scalar>,
-                       std::seed_seq>;
+        random_numbers<scalar, std::uniform_real_distribution<scalar>>;
     using trk_generator_t = random_track_generator<track_type, uniform_gen_t>;
     trk_generator_t::configuration trk_gen_cfg{};
     trk_gen_cfg.n_tracks(n_tracks + n_skips);

--- a/utils/include/detray/simulation/event_generator/random_track_generator.hpp
+++ b/utils/include/detray/simulation/event_generator/random_track_generator.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,47 +16,77 @@
 
 // System include(s)
 #include <algorithm>
-#include <cmath>
+#include <array>
 #include <random>
 
 namespace detray {
 
-/// Wrapper for random number generatrion for the @c random_track_generator
+/// Wrapper for CPU random number generatrion for the @c random_track_generator
 template <typename scalar_t = scalar,
           typename distribution_t = std::uniform_real_distribution<scalar_t>,
-          typename generator_t = std::random_device,
           typename engine_t = std::mt19937_64>
 struct random_numbers {
 
-    random_numbers(random_numbers&& other) : engine(std::move(other.engine)) {}
+    std::seed_seq m_seeds;
+    engine_t m_engine;
 
-    generator_t gen;
-    engine_t engine;
+    /// Random seed for increased entropy. Different random numbers each time
+    DETRAY_HOST
+    random_numbers() : m_seeds{get_random_seeds()}, m_engine{m_seeds} {}
 
-    template <
-        typename T = generator_t,
-        std::enable_if_t<std::is_same_v<T, std::random_device>, bool> = true>
-    random_numbers() : gen{}, engine{gen()} {}
+    /// Deterministic @param seed for reproducible results
+    DETRAY_HOST
+    random_numbers(std::size_t seed) : m_seeds{seed}, m_engine{m_seeds} {}
 
-    template <typename T = generator_t,
-              std::enable_if_t<std::is_same_v<T, std::seed_seq>, bool> = true>
-    random_numbers() : gen{42u}, engine{gen} {}
+    /// Copy constructor
+    DETRAY_HOST
+    random_numbers(random_numbers&& other)
+        : m_engine(std::move(other.m_engine)) {}
 
-    template <typename T = distribution_t,
-              std::enable_if_t<
-                  std::is_same_v<T, std::uniform_real_distribution<scalar_t>>,
-                  bool> = true>
-    DETRAY_HOST auto operator()(const scalar_t min, const scalar_t max) {
-        return distribution_t(min, max)(engine);
+    /// Generate random numbers in a given range
+    DETRAY_HOST auto operator()(const std::array<scalar_t, 2> range = {
+                                    -std::numeric_limits<scalar_t>::max(),
+                                    std::numeric_limits<scalar_t>::max()}) {
+        const scalar_t min{range[0]}, max{range[1]};
+        assert(min <= max);
+
+        // Uniform
+        if constexpr (std::is_same_v<
+                          distribution_t,
+                          std::uniform_real_distribution<scalar_t>>) {
+
+            return distribution_t(min, max)(m_engine);
+
+            // Normal
+        } else if constexpr (std::is_same_v<
+                                 distribution_t,
+                                 std::normal_distribution<scalar_t>>) {
+
+            scalar_t mu{min + 0.5f * (max - min)};
+            return distribution_t(mu, 0.5f / 3.0f * (max - min))(m_engine);
+        }
     }
 
-    template <
-        typename T = distribution_t,
-        std::enable_if_t<std::is_same_v<T, std::normal_distribution<scalar_t>>,
-                         bool> = true>
-    DETRAY_HOST auto operator()(const scalar_t min, const scalar_t max) {
-        scalar_t mu{min + 0.5f * (max - min)};
-        return distribution_t(mu, 0.5f / 3.0f * (max - min))(engine);
+    /// Explicit normal distribution around a @param mean and @param stddev
+    DETRAY_HOST auto normal(const scalar_t mean, const scalar_t stddev) {
+        return std::normal_distribution<scalar_t>(mean, stddev)(m_engine);
+    }
+
+    /// Get proper random seeds for RNG
+    DETRAY_HOST
+    auto get_random_seeds() {
+        std::random_device rd{};
+        if constexpr (std::is_same_v<engine_t, std::mt19937> ||
+                      std::is_same_v<engine_t, std::mt19937_64>) {
+            // Mersenne Twister 19937 needs 624(312) 32(64)-bit seeds to fully
+            // initialize its state
+            std::array<typename engine_t::result_type, engine_t::state_size>
+                seeds;
+            std::generate_n(seeds.begin(), seeds.size(), std::ref(rd));
+            return std::seed_seq{seeds.begin(), seeds.end()};
+        } else {
+            return std::seed_seq{rd()};
+        }
     }
 };
 
@@ -90,7 +120,7 @@ class random_track_generator
         bool m_do_vtx_smearing = true;
 
         /// Monte-Carlo seed
-        std::size_t m_seed;
+        std::size_t m_seed{0u};
 
         /// How many tracks will be generated
         std::size_t m_n_tracks{10u};
@@ -249,25 +279,22 @@ class random_track_generator
 
             const point3 vtx =
                 m_cfg.do_vertex_smearing()
-                    ? point3{std::normal_distribution<scalar>(
-                                 m_cfg.origin()[0], m_cfg.origin_stddev()[0])(
-                                 m_rnd_numbers.engine),
-                             std::normal_distribution<scalar>(
-                                 m_cfg.origin()[1], m_cfg.origin_stddev()[1])(
-                                 m_rnd_numbers.engine),
-                             std::normal_distribution<scalar>(
-                                 m_cfg.origin()[2], m_cfg.origin_stddev()[2])(
-                                 m_rnd_numbers.engine)}
+                    ? point3{m_rnd_numbers.normal(m_cfg.origin()[0],
+                                                  m_cfg.origin_stddev()[0]),
+                             m_rnd_numbers.normal(m_cfg.origin()[1],
+                                                  m_cfg.origin_stddev()[1]),
+                             m_rnd_numbers.normal(m_cfg.origin()[2],
+                                                  m_cfg.origin_stddev()[2])}
                     : m_cfg.origin();
 
             const std::array<scalar, 2>& phi_rng = m_cfg.phi_range();
             const std::array<scalar, 2>& theta_rng = m_cfg.theta_range();
             const std::array<scalar, 2>& mom_rng = m_cfg.mom_range();
-            scalar p_mag{
-                math::max(m_rnd_numbers(mom_rng[0], mom_rng[1]), scalar{0.f})};
-            scalar phi{std::clamp(m_rnd_numbers(phi_rng[0], phi_rng[1]),
+            scalar p_mag{math::max(m_rnd_numbers({mom_rng[0], mom_rng[1]}),
+                                   scalar{0.f})};
+            scalar phi{std::clamp(m_rnd_numbers({phi_rng[0], phi_rng[1]}),
                                   phi_rng[0], phi_rng[1])};
-            scalar theta{std::clamp(m_rnd_numbers(theta_rng[0], theta_rng[1]),
+            scalar theta{std::clamp(m_rnd_numbers({theta_rng[0], theta_rng[1]}),
                                     theta_rng[0], theta_rng[1])};
             const scalar sin_theta{math::sin(theta)};
 
@@ -302,10 +329,11 @@ class random_track_generator
     constexpr random_track_generator() = default;
 
     /// Construct from external configuration
+    /// If a concrete seed was given, use it otherwise prefer random seeds
     DETRAY_HOST_DEVICE
-    constexpr random_track_generator(configuration cfg) : m_gen{}, m_cfg(cfg) {
-        m_gen.engine.seed(m_cfg.seed());
-    }
+    constexpr random_track_generator(configuration cfg)
+        : m_gen{(cfg.seed() != 0u) ? generator_t{cfg.seed()} : generator_t{}},
+          m_cfg(cfg) {}
 
     /// Paramtetrized constructor for quick construction of simple tasks
     ///


### PR DESCRIPTION
Remove templating on std::seed_seq and add a more proper random seed sequence if no explicit seed is provided.