### PR TITLE
Mix the bisection method with helix intersection

### DIFF
--- a/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
+++ b/tests/common/include/tests/common/tools/intersectors/helix_plane_intersector.hpp
@@ -16,7 +16,6 @@
 
 // System include(s)
 #include <cmath>
-#include <limits>
 #include <type_traits>
 
 namespace detray {


### PR DESCRIPTION
I might need to fix the line and cylinder as well. 

Motivation: The derivative of f (`dfds`) is very small when the track is nearly parallel to the plane, leading to the large value of `f/dfds` and non-convergence in newton's method. This is a usual pitfall of Newton's method.

Following is the example value of f and dfds of a such track, which didn't converge even after `n_max_tries`
<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
s | f | dfds
-- | -- | --
-171.548146 | -0.384253 | -0.002026
-361.170481 | -0.45147 | 0.002735
-196.117594 | -0.342045 | -0.001409
-438.803827 | -0.73949 | 0.004685
-280.950921 | -0.312841 | 0.000721
152.998879 | -2.36453 | -0.010177
-79.340734 | -0.67786 | -0.004342
-235.457172 | -0.306031 | -0.000422
-961.493193 | -6.617737 | 0.017807
-589.852268 | -1.733538 | 0.008477
-385.359212 | -0.52498 | 0.003343
-228.306267 | -0.309687 | -0.000601
-743.521764 | -3.332666 | 0.012335
-473.347408 | -0.916296 | 0.005552
-308.309582 | -0.341963 | 0.001408
-65.425869 | -0.74071 | -0.004691
-223.310384 | -0.313003 | -0.000727
-654.1244 | -2.330246 | 0.010091
-423.19895 | -0.669443 | 0.004293
-267.255002 | -0.305323 | 0.000377
542.640042 | -8.23642 | -0.019963
130.055311 | -2.137642 | -0.009601
-92.596807 | -0.622508 | -0.004009
-247.870236 | -0.302733 | -0.00011
-3005.161551 | -95.380541 | 0.069032
-1623.473246 | -23.903858 | 0.034417
-928.929801 | -6.051195 | 0.016989
-572.756241 | -1.59228 | 0.008048
-374.908637 | -0.491418 | 0.00308
-215.3717 | -0.319562 | -0.000926
-560.510077 | -1.495606 | 0.007741
-367.292937 | -0.468688 | 0.002889
-205.063614 | -0.330441 | -0.001185
-483.974198 | -0.976714 | 0.005819
-316.121111 | -0.353727 | 0.001604
-95.604613 | -0.610563 | -0.003934
-250.823051 | -0.302518 | -0.000036
-8738.227381 | -899.807178 | 0.21103
-4474.352613 | -223.770898 | 0.10572
-2357.724916 | -55.932901 | 0.052822
-1298.840445 | -14.052881 | 0.026273
-763.956708 | -3.589978 | 0.012848
-484.542851 | -0.980027 | 0.005833
-316.532673 | -0.354389 | 0.001614
-97.017573 | -0.605031 | -0.003898
-252.229561 | -0.302493 | 0
-936031.3043 | -6654.768264 | -0.907166
-943367.0799 | -320.049259 | -0.81492
-943759.8169 | -1.12947 | -0.809155
-943761.2127 | -0.000014 | -0.809134
-943761.2127 | 0 | -0.809134
-943761.2127 | 0 | -0.809134




One way to achieve the convergence is mixing with [the bisection method](https://en.wikipedia.org/wiki/Bisection_method) that limits the change is solution `s` (I copy-pasted the example code from [Numerical Recipe 3rd edition])

Following is the same table with bisection + Newton's method.

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
s | f | dfds
-- | -- | --
-173.872206 | -0.379611 | -0.001968
-86.936103 | -0.645605 | -0.004151
-43.468051 | -0.849778 | -0.005243
-21.734026 | -0.969659 | -0.005789
-10.867013 | -1.034048 | -0.006062
-5.433506 | -1.067355 | -0.006198
-2.716753 | -1.084287 | -0.006266
-1.358377 | -1.092822 | -0.0063
-0.679188 | -1.097107 | -0.006317
-0.339594 | -1.099254 | -0.006326
-0.169797 | -1.100328 | -0.00633
-0.084899 | -1.100866 | -0.006332
-0.042449 | -1.101134 | -0.006333
-0.021225 | -1.101269 | -0.006334
-0.010612 | -1.101336 | -0.006334
-0.005306 | -1.10137 | -0.006334
-0.002653 | -1.101387 | -0.006334
-0.001327 | -1.101395 | -0.006335
-0.000663 | -1.101399 | -0.006335
-0.000332 | -1.101401 | -0.006335
-0.000166 | -1.101402 | -0.006335
-0.000083 | -1.101403 | -0.006335
-0.000041 | -1.101403 | -0.006335
-0.000021 | -1.101403 | -0.006335
-0.00001 | -1.101403 | -0.006335
-0.000005 | -1.101403 | -0.006335
-0.000003 | -1.101403 | -0.006335
-0.000001 | -1.101403 | -0.006335
-0.000001 | -1.101403 | -0.006335
0 | -1.101403 | -0.006335
0 | -1.101403 | -0.006335
0 | -1.101403 | -0.006335
0 | -1.101403 | -0.006335
0 | -1.101403 | -0.006335
0 | -1.101403 | -0.006335
0 | -1.101403 | -0.006335
0 | -1.101403 | -0.006335
0 | -1.101403 | -0.006335






