### PR TITLE
feat: dynamic capacity grid building

### DIFF
--- a/core/include/detray/core/detector_metadata.hpp
+++ b/core/include/detray/core/detector_metadata.hpp
@@ -97,7 +97,7 @@ struct default_metadata {
 
     // surface grid definition: bin-content: std::array<surface_type, 9>
     template <typename axes_t, typename bin_entry_t, typename container_t>
-    using surface_grid_t = grid<axes_t, bins::static_array<bin_entry_t, 50>,
+    using surface_grid_t = grid<axes_t, bins::dynamic_array<bin_entry_t>,
                                 simple_serializer, container_t, false>;
 
     // 2D cylindrical grid for the barrel layers

--- a/core/include/detray/surface_finders/grid/detail/axis.hpp
+++ b/core/include/detray/surface_finders/grid/detail/axis.hpp
@@ -31,7 +31,9 @@ namespace detray::axis {
 
 /// @brief Multi-bin: contains bin indices from multiple axes
 template <std::size_t DIM, typename index_t = dindex>
-struct multi_bin : public dmulti_index<index_t, DIM> {};
+struct multi_bin : public dmulti_index<index_t, DIM> {
+    constexpr multi_bin() = default;
+};
 
 /// @brief Helper to tie two bin indices to a range.
 /// @note Cannot use dindex_range for signed integer bin indices.

--- a/core/include/detray/surface_finders/grid/detail/bin_storage.hpp
+++ b/core/include/detray/surface_finders/grid/detail/bin_storage.hpp
@@ -244,6 +244,10 @@ class bin_storage<is_owning, detray::bins::dynamic_array<entry_t>, containers>
             return *this;
         }
         DETRAY_HOST_DEVICE
+        difference_type operator-(const iterator_adapter& other) {
+            return m_itr - other.m_itr;
+        }
+        DETRAY_HOST_DEVICE
         iterator_adapter operator-(difference_type i) {
             return {m_itr - i, m_entry_data};
         }
@@ -327,6 +331,9 @@ class bin_storage<is_owning, detray::bins::dynamic_array<entry_t>, containers>
     DETRAY_HOST_DEVICE bin_storage(const view_t& view)
         : m_bin_data(detray::detail::get<0>(view.m_view)),
           m_entry_data(detray::detail::get<1>(view.m_view)) {}
+
+    const bin_range_t& bin_data() const { return m_bin_data; }
+    const entry_range_t& entry_data() const { return m_entry_data; }
 
     /// begin and end of the bin range
     /// @{

--- a/core/include/detray/surface_finders/grid/detail/bin_storage.hpp
+++ b/core/include/detray/surface_finders/grid/detail/bin_storage.hpp
@@ -133,8 +133,8 @@ struct dynamic_bin_container {
 
     constexpr dynamic_bin_container() = default;
     DETRAY_HOST
-    dynamic_bin_container(vecmem::memory_resource& resource)
-        : bins{&resource}, entries{&resource} {}
+    dynamic_bin_container(vecmem::memory_resource* resource)
+        : bins{resource}, entries{resource} {}
     dynamic_bin_container(const dynamic_bin_container& other) = default;
     dynamic_bin_container(dynamic_bin_container&& other) = default;
 
@@ -150,10 +150,19 @@ struct dynamic_bin_container {
     template <typename grid_bin_range_t>
     DETRAY_HOST void append(const grid_bin_range_t& grid_bins) {
 
-        const auto& g_bins = grid_bins.bins;
-        const auto& g_entries = grid_bins.entries;
+        const auto& g_bins = grid_bins.bin_data();
+        const auto& g_entries = grid_bins.entry_data();
 
         bins.insert(bins.end(), g_bins.begin(), g_bins.end());
+
+        // Update the bin offsets
+        dindex_range new_bins{
+            static_cast<dindex>(bins.size() - grid_bins.size()),
+            static_cast<dindex>(bins.size())};
+        for (auto& bin : detray::ranges::subrange{bins, new_bins}) {
+            bin.update_offset(entries.size());
+        }
+
         entries.insert(entries.end(), g_entries.begin(), g_entries.end());
     }
 

--- a/core/include/detray/surface_finders/grid/detail/grid_bins.hpp
+++ b/core/include/detray/surface_finders/grid/detail/grid_bins.hpp
@@ -229,6 +229,10 @@ class dynamic_array
     /// @note This does not check the state of the containter it points to!!!
     template <typename E = entry_type>
     DETRAY_HOST_DEVICE constexpr void push_back(E&& entry) {
+        assert(m_capacity > 0);
+        assert(m_data->size < m_capacity);
+        assert(m_global_storage);
+
         if (m_data->size < m_capacity) {
             *(const_cast<entry_type*>(m_global_storage) + m_data->size) =
                 std::forward<E>(entry);

--- a/core/include/detray/surface_finders/grid/detail/grid_bins.hpp
+++ b/core/include/detray/surface_finders/grid/detail/grid_bins.hpp
@@ -181,6 +181,11 @@ class dynamic_array
     public:
     struct data {
         dindex offset{0u}, size{0u}, capacity{0u};
+
+        DETRAY_HOST_DEVICE
+        constexpr void update_offset(std::size_t shift) {
+            offset += static_cast<dindex>(shift);
+        }
     };
 
     using entry_type = entry_t;
@@ -210,10 +215,16 @@ class dynamic_array
 
     /// @returns view iterator over bin content in start or end position
     /// @{
-    DETRAY_HOST_DEVICE auto begin() { return detray::ranges::begin(view()); }
+    DETRAY_HOST_DEVICE auto begin() {
+        bin_view_t bv{view()};
+        return detray::ranges::begin(bv);
+    }
+    DETRAY_HOST_DEVICE auto end() {
+        bin_view_t bv{view()};
+        return detray::ranges::end(bv);
+    }
     DETRAY_HOST_DEVICE
     auto begin() const { return detray::ranges::cbegin(view()); }
-    DETRAY_HOST_DEVICE auto end() { return detray::ranges::end(view()); }
     DETRAY_HOST_DEVICE auto end() const { return detray::ranges::cend(view()); }
     /// @}
 

--- a/core/include/detray/tools/detector_builder.hpp
+++ b/core/include/detray/tools/detector_builder.hpp
@@ -119,7 +119,7 @@ class detector_builder {
                 axis::circular<axis::label::e_phi>,
                 axis::open<axis::label::e_z>, axis::irregular<>,
                 axis::regular<>, axis::irregular<>>(vgrid_dims, n_vgrid_bins,
-                                                    bin_edges);
+                                                    {}, bin_edges);
         } else {
             m_vol_finder = vol_finder_t{args...};
         }

--- a/core/include/detray/tools/grid_builder.hpp
+++ b/core/include/detray/tools/grid_builder.hpp
@@ -63,6 +63,8 @@ class grid_builder final : public volume_decorator<detector_t> {
     DETRAY_HOST void init_grid(
         const mask<grid_shape_t> &m,
         const std::array<std::size_t, grid_t::dim> &n_bins,
+        const std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
+            &bin_capacities = {},
         const std::array<std::vector<scalar_type>, grid_t::dim> &ax_bin_edges =
             {{}}) {
 
@@ -72,17 +74,20 @@ class grid_builder final : public volume_decorator<detector_t> {
                            typename grid_t::local_frame_type>,
             "Mask has incorrect shape");
 
-        m_grid = m_factory.template new_grid<grid_t>(m, n_bins, ax_bin_edges);
+        m_grid = m_factory.template new_grid<grid_t>(m, n_bins, bin_capacities,
+                                                     ax_bin_edges);
     }
 
     /// Build the empty grid from axis parameters
     DETRAY_HOST void init_grid(
         const std::vector<scalar_type> &spans,
         const std::vector<std::size_t> &n_bins,
+        const std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
+            &bin_capacities = {},
         const std::vector<std::vector<scalar_type>> &ax_bin_edges = {{}}) {
 
-        m_grid =
-            m_factory.template new_grid<grid_t>(spans, n_bins, ax_bin_edges);
+        m_grid = m_factory.template new_grid<grid_t>(
+            spans, n_bins, bin_capacities, ax_bin_edges);
     }
 
     /// Fill grid from existing volume using a bin filling strategy

--- a/core/include/detray/tools/grid_builder.hpp
+++ b/core/include/detray/tools/grid_builder.hpp
@@ -150,25 +150,15 @@ class grid_builder final : public volume_decorator<detector_t> {
             // correct surface indices per bin (e.g. from file IO).
             // Now add the rest of the linking information, which is only
             // available after the volume builder ran
-            for (auto &sf_desc : vol.surfaces()) {
+            for (surface_desc_t &sf_desc : m_grid.all()) {
 
-                if (sf_desc.is_sensitive() or
-                    (m_add_passives and sf_desc.is_passive())) {
-                    // The current volume is already built, so the surface
-                    // interface is safe to use
-                    const auto sf = surface{det, sf_desc};
-                    const auto &sf_trf = sf.transform(ctx);
-                    const auto t = sf_trf.point_to_global(sf.centroid());
-                    const auto loc_pos = m_grid.project(vol.transform(), t, t);
-                    auto &bin_content = m_grid.search(loc_pos);
+                const auto &new_sf_desc = det.surface(sf_desc.index());
 
-                    for (surface_desc_t &sf_in_grid : bin_content) {
-                        // Find the correct surface and update all links
-                        if (sf_in_grid.index() == sf.index()) {
-                            sf_in_grid = sf_desc;
-                        }
-                    }
-                }
+                assert(!detail::is_invalid_value(sf_desc.index()));
+                assert(!new_sf_desc.barcode().is_invalid());
+                assert(new_sf_desc.index() == sf_desc.index());
+
+                sf_desc = new_sf_desc;
             }
         }
 

--- a/core/include/detray/tools/grid_factory.hpp
+++ b/core/include/detray/tools/grid_factory.hpp
@@ -46,7 +46,9 @@ class grid_factory {
 
     using bin_type = bin_t;
     template <typename grid_shape_t>
-    using grid_type = grid<grid_shape_t, bin_type, serializer_t>;
+    using grid_type = grid<axes<grid_shape_t>, bin_type, serializer_t>;
+    template <typename grid_shape_t>
+    using loc_bin_index = typename grid_type<grid_shape_t>::loc_bin_index;
 
     using scalar_type = typename algebra_t::scalar_type;
     template <typename T>
@@ -74,10 +76,13 @@ class grid_factory {
         typename phi_binning = axis::regular<host_container_types, scalar_type>,
         std::enable_if_t<std::is_enum_v<decltype(r_bounds::label)>, bool> =
             true>
-    auto new_grid(const mask<annulus2D<>> &grid_bounds,
-                  const std::array<std::size_t, 2UL> n_bins,
-                  const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
-                      {}}) const {
+    auto new_grid(
+        const mask<annulus2D<>> &grid_bounds,
+        const std::array<std::size_t, 2UL> n_bins,
+        const std::vector<std::pair<loc_bin_index<annulus2D<>>, dindex>>
+            &bin_capacities = {},
+        const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
+            {}}) const {
 
         static_assert(
             std::is_same_v<phi_bounds, axis::circular<>>,
@@ -99,7 +104,7 @@ class grid_factory {
                  b_values[boundary::e_min_phi_rel],
              b_values[boundary::e_average_phi] +
                  b_values[boundary::e_max_phi_rel]},
-            {n_bins[e_r_axis], n_bins[e_phi_axis]},
+            {n_bins[e_r_axis], n_bins[e_phi_axis]}, bin_capacities,
             {bin_edges[e_r_axis], bin_edges[e_phi_axis]},
             types::list<r_bounds, phi_bounds>{},
             types::list<r_binning, phi_binning>{});
@@ -117,10 +122,13 @@ class grid_factory {
         typename z_binning = axis::regular<host_container_types, scalar_type>,
         std::enable_if_t<std::is_enum_v<decltype(x_bounds::label)>, bool> =
             true>
-    auto new_grid(const mask<cuboid3D<>> &grid_bounds,
-                  const std::array<std::size_t, 3UL> n_bins,
-                  const std::array<std::vector<scalar_type>, 3UL> &bin_edges = {
-                      {}}) const {
+    auto new_grid(
+        const mask<cuboid3D<>> &grid_bounds,
+        const std::array<std::size_t, 3UL> n_bins,
+        const std::vector<std::pair<loc_bin_index<cuboid3D<>>, dindex>>
+            &bin_capacities = {},
+        const std::array<std::vector<scalar_type>, 3UL> &bin_edges = {
+            {}}) const {
         // Axes boundaries and local indices
         using boundary = cuboid3D<>::boundaries;
         using axes_t = axes<cuboid3D<>>::template type<algebra_t>;
@@ -137,6 +145,7 @@ class grid_factory {
              b_values[boundary::e_min_y], b_values[boundary::e_max_y],
              b_values[boundary::e_min_z], b_values[boundary::e_max_z]},
             {n_bins[e_x_axis], n_bins[e_y_axis], n_bins[e_z_axis]},
+            bin_capacities,
             {bin_edges[e_x_axis], bin_edges[e_y_axis], bin_edges[e_z_axis]},
             types::list<x_bounds, y_bounds, z_bounds>{},
             types::list<x_binning, y_binning, z_binning>{});
@@ -153,10 +162,13 @@ class grid_factory {
         typename z_binning = axis::regular<host_container_types, scalar_type>,
         std::enable_if_t<std::is_enum_v<decltype(rphi_bounds::label)>, bool> =
             true>
-    auto new_grid(const mask<cylinder2D<>> &grid_bounds,
-                  const std::array<std::size_t, 2UL> n_bins,
-                  const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
-                      {}}) const {
+    auto new_grid(
+        const mask<cylinder2D<>> &grid_bounds,
+        const std::array<std::size_t, 2UL> n_bins,
+        const std::vector<std::pair<loc_bin_index<cylinder2D<>>, dindex>>
+            &bin_capacities = {},
+        const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
+            {}}) const {
 
         static_assert(
             std::is_same_v<rphi_bounds, axis::circular<axis::label::e_rphi>>,
@@ -175,7 +187,7 @@ class grid_factory {
         return new_grid<local_frame>(
             {-constant<scalar_type>::pi, constant<scalar_type>::pi,
              b_values[boundary::e_n_half_z], b_values[boundary::e_p_half_z]},
-            {n_bins[e_rphi_axis], n_bins[e_z_axis]},
+            {n_bins[e_rphi_axis], n_bins[e_z_axis]}, bin_capacities,
             {bin_edges[e_rphi_axis], bin_edges[e_z_axis]},
             types::list<rphi_bounds, z_bounds>{},
             types::list<rphi_binning, z_binning>{});
@@ -195,6 +207,9 @@ class grid_factory {
     auto new_grid(
         const mask<cylinder2D<false, cylinder_portal_intersector>> &grid_bounds,
         const std::array<std::size_t, 2UL> n_bins,
+        const std::vector<std::pair<
+            loc_bin_index<cylinder2D<false, cylinder_portal_intersector>>,
+            dindex>> &bin_capacities = {},
         const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
             {}}) const {
 
@@ -215,7 +230,7 @@ class grid_factory {
         return new_grid<local_frame>(
             {-constant<scalar_type>::pi, constant<scalar_type>::pi,
              b_values[boundary::e_n_half_z], b_values[boundary::e_p_half_z]},
-            {n_bins[e_rphi_axis], n_bins[e_z_axis]},
+            {n_bins[e_rphi_axis], n_bins[e_z_axis]}, bin_capacities,
             {bin_edges[e_rphi_axis], bin_edges[e_z_axis]},
             types::list<rphi_bounds, z_bounds>{},
             types::list<rphi_binning, z_binning>{});
@@ -233,10 +248,13 @@ class grid_factory {
         typename z_binning = axis::regular<host_container_types, scalar_type>,
         std::enable_if_t<std::is_enum_v<decltype(r_bounds::label)>, bool> =
             true>
-    auto new_grid(const mask<cylinder3D> &grid_bounds,
-                  const std::array<std::size_t, 3UL> n_bins,
-                  const std::array<std::vector<scalar_type>, 3UL> &bin_edges = {
-                      {}}) const {
+    auto new_grid(
+        const mask<cylinder3D> &grid_bounds,
+        const std::array<std::size_t, 3UL> n_bins,
+        const std::vector<std::pair<loc_bin_index<cylinder3D>, dindex>>
+            &bin_capacities = {},
+        const std::array<std::vector<scalar_type>, 3UL> &bin_edges = {
+            {}}) const {
 
         static_assert(
             std::is_same_v<phi_bounds, axis::circular<>>,
@@ -258,6 +276,7 @@ class grid_factory {
              b_values[boundary::e_min_phi], b_values[boundary::e_max_phi],
              -b_values[boundary::e_min_z], b_values[boundary::e_max_z]},
             {n_bins[e_r_axis], n_bins[e_phi_axis], n_bins[e_z_axis]},
+            bin_capacities,
             {bin_edges[e_r_axis], bin_edges[e_phi_axis], bin_edges[e_z_axis]},
             types::list<r_bounds, phi_bounds, z_bounds>{},
             types::list<r_binning, phi_binning, z_binning>{});
@@ -275,6 +294,8 @@ class grid_factory {
             true>
     auto new_grid(const mask<ring2D<>> &grid_bounds,
                   const std::array<std::size_t, 2UL> n_bins,
+                  const std::vector<std::pair<loc_bin_index<ring2D<>>, dindex>>
+                      &bin_capacities = {},
                   const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
                       {}}) const {
 
@@ -294,7 +315,7 @@ class grid_factory {
         return new_grid<local_frame>(
             {b_values[boundary::e_inner_r], b_values[boundary::e_outer_r],
              -constant<scalar_type>::pi, constant<scalar_type>::pi},
-            {n_bins[e_r_axis], n_bins[e_phi_axis]},
+            {n_bins[e_r_axis], n_bins[e_phi_axis]}, bin_capacities,
             {bin_edges[e_r_axis], bin_edges[e_phi_axis]},
             types::list<r_bounds, phi_bounds>{},
             types::list<r_binning, phi_binning>{});
@@ -310,10 +331,13 @@ class grid_factory {
         typename y_binning = axis::regular<host_container_types, scalar_type>,
         std::enable_if_t<std::is_enum_v<decltype(x_bounds::label)>, bool> =
             true>
-    auto new_grid(const mask<rectangle2D<>> &grid_bounds,
-                  const std::array<std::size_t, 2UL> n_bins,
-                  const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
-                      {}}) const {
+    auto new_grid(
+        const mask<rectangle2D<>> &grid_bounds,
+        const std::array<std::size_t, 2UL> n_bins,
+        const std::vector<std::pair<loc_bin_index<rectangle2D<>>, dindex>>
+            &bin_capacities = {},
+        const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
+            {}}) const {
         // Axes boundaries and local indices
         using boundary = rectangle2D<>::boundaries;
         using axes_t = axes<rectangle2D<>>::template type<algebra_t>;
@@ -327,7 +351,7 @@ class grid_factory {
         return new_grid<local_frame>(
             {-b_values[boundary::e_half_x], b_values[boundary::e_half_x],
              -b_values[boundary::e_half_y], b_values[boundary::e_half_y]},
-            {n_bins[e_x_axis], n_bins[e_y_axis]},
+            {n_bins[e_x_axis], n_bins[e_y_axis]}, bin_capacities,
             {bin_edges[e_x_axis], bin_edges[e_y_axis]},
             types::list<x_bounds, y_bounds>{},
             types::list<x_binning, y_binning>{});
@@ -343,10 +367,13 @@ class grid_factory {
         typename y_binning = axis::regular<host_container_types, scalar_type>,
         std::enable_if_t<std::is_enum_v<decltype(x_bounds::label)>, bool> =
             true>
-    auto new_grid(const mask<trapezoid2D<>> &grid_bounds,
-                  const std::array<std::size_t, 2UL> n_bins,
-                  const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
-                      {}}) const {
+    auto new_grid(
+        const mask<trapezoid2D<>> &grid_bounds,
+        const std::array<std::size_t, 2UL> n_bins,
+        const std::vector<std::pair<loc_bin_index<trapezoid2D<>>, dindex>>
+            &bin_capacities = {},
+        const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {
+            {}}) const {
         // Axes boundaries and local indices
         using boundary = trapezoid2D<>::boundaries;
         using axes_t = axes<trapezoid2D<>>::template type<algebra_t>;
@@ -362,6 +389,7 @@ class grid_factory {
                                       -b_values[boundary::e_half_length_2],
                                       b_values[boundary::e_half_length_2]},
                                      {n_bins[e_x_axis], n_bins[e_y_axis]},
+                                     bin_capacities,
                                      {bin_edges[e_x_axis], bin_edges[e_y_axis]},
                                      types::list<x_bounds, y_bounds>{},
                                      types::list<x_binning, y_binning>{});
@@ -387,11 +415,14 @@ class grid_factory {
         std::enable_if_t<
             std::is_object_v<typename grid_frame_t::rotation_matrix>, bool> =
             true>
-    auto new_grid(const std::vector<scalar_type> spans,
-                  const std::vector<std::size_t> n_bins,
-                  const std::vector<std::vector<scalar_type>> &ax_bin_edges,
-                  const types::list<bound_ts...> & = {},
-                  const types::list<binning_ts...> & = {}) const {
+    auto new_grid(
+        const std::vector<scalar_type> spans,
+        const std::vector<std::size_t> n_bins,
+        const std::vector<std::pair<axis::multi_bin<sizeof...(bound_ts)>,
+                                    dindex>> &bin_capacities = {},
+        const std::vector<std::vector<scalar_type>> &ax_bin_edges = {},
+        const types::list<bound_ts...> & = {},
+        const types::list<binning_ts...> & = {}) const {
 
         static_assert(sizeof...(bound_ts) == sizeof...(binning_ts),
                       "number of axis bounds and binning types has to match");
@@ -402,7 +433,7 @@ class grid_factory {
                              axis::single_axis<bound_ts, binning_ts>...>;
         using grid_t = grid<axes_t, bin_t, serializer_t>;
 
-        return new_grid<grid_t>(spans, n_bins, ax_bin_edges);
+        return new_grid<grid_t>(spans, n_bins, bin_capacities, ax_bin_edges);
     }
 
     /// Helper to build grid from shape plus binning and bounds types
@@ -410,27 +441,33 @@ class grid_factory {
         typename grid_shape_t, typename... bound_ts, typename... binning_ts,
         std::enable_if_t<std::is_enum_v<typename grid_shape_t::boundaries>,
                          bool> = true>
-    auto new_grid(const std::vector<scalar_type> spans,
-                  const std::vector<std::size_t> n_bins,
-                  const std::vector<std::vector<scalar_type>> &ax_bin_edges,
-                  const types::list<bound_ts...> &bounds,
-                  const types::list<binning_ts...> &binnings) const {
+    auto new_grid(
+        const std::vector<scalar_type> spans,
+        const std::vector<std::size_t> n_bins,
+        const std::vector<std::pair<axis::multi_bin<sizeof...(bound_ts)>,
+                                    dindex>> &bin_capacities = {},
+        const std::vector<std::vector<scalar_type>> &ax_bin_edges = {},
+        const types::list<bound_ts...> &bounds = {},
+        const types::list<binning_ts...> &binnings = {}) const {
 
         return new_grid<
             typename grid_shape_t::template local_frame_type<algebra_t>>(
-            spans, n_bins, ax_bin_edges, bounds, binnings);
+            spans, n_bins, bin_capacities, ax_bin_edges, bounds, binnings);
     }
 
     /// Helper overload for grid builder: Build from mask and resolve bounds
     /// and binnings from concrete grid type
     template <typename grid_t, typename grid_shape_t,
               std::enable_if_t<detail::is_grid_v<grid_t>, bool> = true>
-    auto new_grid(const mask<grid_shape_t> &spans,
-                  const std::array<std::size_t, grid_t::dim> &n_bins,
-                  const std::array<std::vector<scalar_type>, grid_t::dim>
-                      &ax_bin_edges) const {
+    auto new_grid(
+        const mask<grid_shape_t> &spans,
+        const std::array<std::size_t, grid_t::dim> &n_bins,
+        const std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
+            &bin_capacities = {},
+        const std::array<std::vector<scalar_type>, grid_t::dim> &ax_bin_edges =
+            {}) const {
 
-        return new_grid(spans, n_bins, ax_bin_edges,
+        return new_grid(spans, n_bins, bin_capacities, ax_bin_edges,
                         typename grid_t::axes_type::bounds{},
                         typename grid_t::axes_type::binnings{});
     }
@@ -443,13 +480,16 @@ class grid_factory {
                          bool> = true>
     auto new_grid(const mask<grid_shape_t> &spans,
                   const std::array<std::size_t, grid_shape_t::dim> &n_bins,
+                  const std::vector<
+                      std::pair<axis::multi_bin<sizeof...(bound_ts)>, dindex>>
+                      &bin_capacities = {},
                   const std::array<std::vector<scalar_type>, grid_shape_t::dim>
-                      &ax_bin_edges,
-                  const types::list<bound_ts...> &,
-                  const types::list<binning_ts...> &) const {
+                      &ax_bin_edges = {},
+                  const types::list<bound_ts...> & = {},
+                  const types::list<binning_ts...> & = {}) const {
 
-        return new_grid<bound_ts..., binning_ts...>(spans, n_bins,
-                                                    ax_bin_edges);
+        return new_grid<bound_ts..., binning_ts...>(
+            spans, n_bins, bin_capacities, ax_bin_edges);
     }
 
     /// @brief Create and empty grid with fully initialized axes.
@@ -467,7 +507,10 @@ class grid_factory {
     auto new_grid(
         const std::vector<scalar_type> spans,
         const std::vector<std::size_t> n_bins,
-        const std::vector<std::vector<scalar_type>> &ax_bin_edges) const {
+        [[maybe_unused]] const std::vector<
+            std::pair<typename grid_t::loc_bin_index, dindex>> &bin_capacities =
+            {},
+        const std::vector<std::vector<scalar_type>> &ax_bin_edges = {}) const {
 
         using owning_grid_t = typename grid_t::template type<true>;
         using axes_t = typename owning_grid_t::axes_type;
@@ -484,9 +527,39 @@ class grid_factory {
         // Assemble the grid and return it
         axes_t axes(std::move(axes_data), std::move(bin_edges));
 
-        vector_type<bin_type> bin_data{};
-        bin_data.resize(axes.nbins_per_axis()[0] * axes.nbins_per_axis()[1],
-                        bin_type{});
+        typename owning_grid_t::bin_container_type bin_data{};
+
+        // Bins with dynamic capacity and "index grids" need different treatment
+        if constexpr (std::is_same_v<bin_t, bins::dynamic_array<
+                                                typename grid_t::value_type>>) {
+            // Bin and bin entries vector are separate containers
+            bin_data.bins.resize(axes.nbins());
+            // Set correct bin capacities, if they were provided
+            if (!bin_capacities.empty()) {
+                // Set memory offsets correctly
+                typename grid_t::template serializer_type<grid_t::dim>
+                    serializer{};
+                dindex total_cap{0u};
+                for (const auto &capacity : bin_capacities) {
+                    // Get the empty bin by its global index
+                    auto &data =
+                        bin_data.bins[serializer(axes, capacity.first)];
+
+                    data.offset = total_cap;
+                    data.capacity = capacity.second;
+                    data.size = 0u;
+
+                    total_cap += data.capacity;
+                }
+                assert(total_cap > 0);
+                bin_data.entries.resize(
+                    total_cap,
+                    detail::invalid_value<typename grid_t::value_type>());
+            }
+        } else {
+            // Bin entries are contained in the bins directly
+            bin_data.resize(axes.nbins(), bin_type{});
+        }
 
         return owning_grid_t(std::move(bin_data), std::move(axes));
     }

--- a/core/include/detray/tools/telescope_generator.hpp
+++ b/core/include/detray/tools/telescope_generator.hpp
@@ -150,10 +150,6 @@ class telescope_generator final : public surface_factory_interface<detector_t> {
             // Local z axis is the global normal vector
             vector3_t m_local_z = algebra::vector::normalize(mod_placement.dir);
 
-            // Local x axis is the curvilinear vector with respect to local_z
-            auto m_local_x =
-                unit_vectors<vector3_t>().make_curvilinear_unit_u(m_local_z);
-
             if constexpr (std::is_same_v<mask_shape_t, detray::line<true>> ||
                           std::is_same_v<mask_shape_t, detray::line<false>>) {
 
@@ -165,9 +161,11 @@ class telescope_generator final : public surface_factory_interface<detector_t> {
                 axis_rotation<transform3_t> axis_rot(
                     curvi_u, constant<scalar>::pi / 2.f);
                 m_local_z = axis_rot(m_local_z);
-                m_local_x = unit_vectors<vector3_t>().make_curvilinear_unit_u(
-                    m_local_z);
             }
+
+            // Local x axis is the curvilinear vector with respect to local_z
+            auto m_local_x =
+                unit_vectors<vector3_t>().make_curvilinear_unit_u(m_local_z);
 
             // Create the global-to-local transform of the module
             transforms.emplace_back(ctx, mod_placement.pos, m_local_z,

--- a/io/include/detray/io/common/detector_reader.hpp
+++ b/io/include/detray/io/common/detector_reader.hpp
@@ -137,7 +137,7 @@ namespace io {
 /// @param cfg the detector reader configuration
 ///
 /// @returns a complete detector object + a map that contains the volume names
-template <class detector_t, std::size_t CAP = 50u, std::size_t DIM = 2u,
+template <class detector_t, std::size_t CAP = 0u, std::size_t DIM = 2u,
           template <typename> class volume_builder_t = volume_builder>
 auto read_detector(vecmem::memory_resource& resc,
                    const detector_reader_config& cfg) noexcept(false) {

--- a/io/include/detray/io/common/grid_reader.hpp
+++ b/io/include/detray/io/common/grid_reader.hpp
@@ -325,7 +325,7 @@ class grid_reader : public reader_interface<detector_t> {
                 spans.push_back(static_cast<scalar_t>(axis_data.edges.back()));
             }
 
-            vgr_builder->init_grid(spans, n_bins_per_axis, ax_bin_edges);
+            vgr_builder->init_grid(spans, n_bins_per_axis, {}, ax_bin_edges);
             auto &grid = vgr_builder->get();
             const std::size_t n_bins{grid.nbins()};
 

--- a/io/include/detray/io/common/grid_reader.hpp
+++ b/io/include/detray/io/common/grid_reader.hpp
@@ -30,7 +30,7 @@ namespace detray {
 /// @brief Abstract base class for surface grid readers
 template <class detector_t,
           typename value_t = typename detector_t::surface_type,
-          typename CAP = std::integral_constant<std::size_t, 9>,
+          typename CAP = std::integral_constant<std::size_t, 0>,
           typename DIM = std::integral_constant<std::size_t, 2>>
 class grid_reader : public reader_interface<detector_t> {
 
@@ -287,8 +287,10 @@ class grid_reader : public reader_interface<detector_t> {
             axis::multi_axis<false, local_frame_t,
                              axis::single_axis<bounds_ts, binning_ts>...>;
         // Ok for now: Only have this serializer
-        using grid_t = grid<axes_t, bins::static_array<value_t, bin_capacity>,
-                            simple_serializer>;
+        using bin_t =
+            std::conditional_t<bin_capacity == 0, bins::dynamic_array<value_t>,
+                               bins::static_array<value_t, bin_capacity>>;
+        using grid_t = grid<axes_t, bin_t, simple_serializer>;
 
         static_assert(grid_t::dim == dim,
                       "Grid dimension does not meet dimension of grid reader");
@@ -325,17 +327,35 @@ class grid_reader : public reader_interface<detector_t> {
                 spans.push_back(static_cast<scalar_t>(axis_data.edges.back()));
             }
 
-            vgr_builder->init_grid(spans, n_bins_per_axis, {}, ax_bin_edges);
+            std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
+                capacities{};
+
+            // If the grid has dynamic bin capacities, find them
+            if constexpr (std::is_same_v<typename grid_t::bin_type,
+                                         bins::dynamic_array<value_t>>) {
+                axis::multi_bin<dim> mbin;
+                for (const auto &bin_data : grid_data.bins) {
+                    assert(dim == bin_data.loc_index.size() &&
+                           "Numer of local bin indices in input file does not "
+                           "match grid dimension");
+
+                    // The local bin indices for the bin to be filled
+                    for (const auto &[i, bin_idx] :
+                         detray::views::enumerate(bin_data.loc_index)) {
+                        mbin[i] = bin_idx;
+                    }
+                    capacities.emplace_back(mbin, bin_data.content.size());
+                }
+            }
+
+            vgr_builder->init_grid(spans, n_bins_per_axis, capacities,
+                                   ax_bin_edges);
             auto &grid = vgr_builder->get();
             const std::size_t n_bins{grid.nbins()};
 
             value_t empty_sf{};
             axis::multi_bin<dim> mbin;
             for (const auto &bin_data : grid_data.bins) {
-
-                assert(dim == bin_data.loc_index.size() &&
-                       "Numer of local bin indices in input file does not "
-                       "match grid dimension");
 
                 // The local bin indices for the bin to be filled
                 for (const auto &[i, bin_idx] :
@@ -351,6 +371,12 @@ class grid_reader : public reader_interface<detector_t> {
 
                 // For now assume surfaces ids as the only grid input
                 for (const auto c : bin_data.content) {
+                    if (detail::is_invalid_value(static_cast<dindex>(c))) {
+                        std::cout << "WARNING: Encountered invalid surface "
+                                  << "index in grid (" << err_stream.str()
+                                  << ")" << std::endl;
+                        continue;
+                    }
                     empty_sf.set_volume(volume_idx);
                     empty_sf.set_index(static_cast<dindex>(c));
                     vgr_builder->get().template populate<attach<>>(mbin,

--- a/io/include/detray/io/json/json_reader.hpp
+++ b/io/include/detray/io/json/json_reader.hpp
@@ -98,7 +98,7 @@ using json_homogeneous_material_reader =
 /// Reads a homogeneous material descritption from file in json format
 template <typename detector_t,
           typename value_t = typename detector_t::surface_type,
-          typename CAP = std::integral_constant<std::size_t, 2>,
+          typename CAP = std::integral_constant<std::size_t, 0>,
           typename DIM = std::integral_constant<std::size_t, 2>>
 using json_grid_reader =
     json_reader<detector_t, grid_reader, value_t, CAP, DIM>;

--- a/tests/benchmarks/cpu/grid.cpp
+++ b/tests/benchmarks/cpu/grid.cpp
@@ -64,7 +64,7 @@ auto make_regular_grid(vecmem::memory_resource &mr) {
 
     // Rectangular grid with closed bin bounds and regular binning on all axes
     return gr_factory.template new_grid<rectangle2D<>>(
-        spans, nbins, {},
+        spans, nbins, {}, {},
         types::list<axis::closed<axis::label::e_x>,
                     axis::closed<axis::label::e_y>>{},
         types::list<axis::regular<>, axis::regular<>>{});
@@ -90,7 +90,7 @@ auto make_irregular_grid(vecmem::memory_resource &mr) {
 
     // Rectangular grid with closed bin bounds and irregular binning on all axes
     return gr_factory.template new_grid<rectangle2D<>>(
-        {}, {}, boundaries,
+        {}, {}, {}, boundaries,
         types::list<axis::closed<axis::label::e_x>,
                     axis::closed<axis::label::e_y>>{},
         types::list<axis::irregular<>, axis::irregular<>>{});

--- a/tests/unit_tests/cpu/grid_grid_builder.cpp
+++ b/tests/unit_tests/cpu/grid_grid_builder.cpp
@@ -41,7 +41,7 @@ using detector_t = detector<toy_metadata>;
 }  // anonymous namespace
 
 /// Unittest: Test the construction of a collection of grids
-GTEST_TEST(detray_tools, grid_factory) {
+GTEST_TEST(detray_tools, grid_factory_static) {
 
     // Data-owning grid collection
     vecmem::host_memory_resource host_mr;
@@ -90,13 +90,23 @@ GTEST_TEST(detray_tools, grid_factory) {
     const std::vector<scalar> bin_edges_phi{};
 
     auto cyl_gr = gr_factory.template new_grid<cylinder2D<>>(
-        {bin_edges_z.front(), bin_edges_z.back(), 0.f,
-         2.f * constant<scalar>::pi},
-        {bin_edges_z.size() - 1, 10u}, {bin_edges_phi, bin_edges_z},
+        {0.f, 2.f * constant<scalar>::pi, bin_edges_z.front(),
+         bin_edges_z.back()},
+        {10u, bin_edges_z.size() - 1}, {}, {bin_edges_phi, bin_edges_z},
         types::list<circular<label::e_rphi>, closed<label::e_cyl_z>>{},
         types::list<regular<>, irregular<>>{});
 
     // Test axis
+    const auto& cyl_axis_rphi = cyl_gr.template get_axis<label::e_rphi>();
+    EXPECT_EQ(cyl_axis_rphi.label(), label::e_rphi);
+    EXPECT_EQ(cyl_axis_rphi.bounds(), bounds::e_circular);
+    EXPECT_EQ(cyl_axis_rphi.binning(), binning::e_regular);
+    EXPECT_EQ(cyl_axis_rphi.nbins(), 10u);
+    EXPECT_NEAR(cyl_axis_rphi.span()[0], 0.f,
+                std::numeric_limits<scalar>::epsilon());
+    EXPECT_NEAR(cyl_axis_rphi.span()[1], 2.f * constant<scalar>::pi,
+                std::numeric_limits<scalar>::epsilon());
+
     const auto& cyl_axis_z = cyl_gr.template get_axis<label::e_cyl_z>();
     EXPECT_EQ(cyl_axis_z.label(), label::e_cyl_z);
     EXPECT_EQ(cyl_axis_z.bounds(), bounds::e_closed);
@@ -124,7 +134,171 @@ GTEST_TEST(detray_tools, grid_factory) {
     auto cyl_gr2 = gr_factory.template new_grid<circular<label::e_rphi>,
                                                 closed<label::e_cyl_z>,
                                                 regular<>, irregular<>>(
-        cyl2, {bin_edges_z.size() - 1, 10u}, {bin_edges_phi, bin_edges_z});
+        cyl2, {bin_edges_z.size() - 1, 10u}, {}, {bin_edges_phi, bin_edges_z});
+}
+
+/// Unittest: Test the construction of a collection of grids
+GTEST_TEST(detray_tools, grid_factory_dynamic) {
+
+    // Data-owning grid collection
+    vecmem::host_memory_resource host_mr;
+    auto gr_factory =
+        grid_factory<bins::dynamic_array<dindex>, simple_serializer>{host_mr};
+
+    // Build from existing mask of a surface
+    const scalar minR{0.f};
+    const scalar maxR{10.f};
+    const scalar minPhi{0.f};
+    const scalar maxPhi{constant<scalar>::pi};
+    mask<annulus2D<>> ann2{0u, minR, maxR, minPhi, maxPhi, 0.f, 0.f, 0.f};
+
+    // Grid with correctly initialized axes and bins, but empty bin content
+    using ann_grid_t =
+        typename decltype(gr_factory)::template grid_type<annulus2D<>>;
+    std::vector<std::pair<typename ann_grid_t::loc_bin_index, dindex>>
+        capacities;
+
+    auto bin_indexer2D = detray::views::cartesian_product{
+        detray::views::iota{0u, 2u}, detray::views::iota{0u, 3u}};
+    dindex capacity{0u};
+    for (const auto& bin_idx : bin_indexer2D) {
+        typename ann_grid_t::loc_bin_index mbin{std::get<0>(bin_idx),
+                                                std::get<1>(bin_idx)};
+        capacities.emplace_back(mbin, ++capacity);
+    }
+
+    ann_grid_t ann_gr = gr_factory.new_grid(ann2, {2, 3}, capacities);
+
+    // Test axis
+    const auto& ann_axis_r = ann_gr.template get_axis<label::e_r>();
+    EXPECT_EQ(ann_axis_r.label(), label::e_r);
+    EXPECT_EQ(ann_axis_r.bounds(), bounds::e_closed);
+    EXPECT_EQ(ann_axis_r.binning(), binning::e_regular);
+    EXPECT_EQ(ann_axis_r.nbins(), 2u);
+    EXPECT_NEAR(ann_axis_r.span()[0], 0.f,
+                std::numeric_limits<scalar>::epsilon());
+    EXPECT_NEAR(ann_axis_r.span()[1], 10.f,
+                std::numeric_limits<scalar>::epsilon());
+
+    // Test bin storage
+    EXPECT_EQ(ann_gr.bins().size(), 6u);
+    for (const auto& bin : ann_gr.bins()) {
+        EXPECT_EQ(bin.size(), 0u);
+        EXPECT_TRUE(bin.capacity() >= 1u);
+    }
+    EXPECT_EQ(ann_gr.size(), 0u);
+
+    EXPECT_EQ(ann_gr.bins().entry_data().size(), 21u);
+    EXPECT_EQ(ann_gr.bins().entry_data().capacity(), 21u);
+
+    // Test fill a bin to see, if bin content was correctly initialized
+    point3 p = {0.5f, 2.f, 0.f};
+    vector3 d{};
+    auto loc_p = ann_gr.project(Identity, p, d);
+    auto bin2 = ann_gr.search(loc_p);
+    EXPECT_TRUE(bin2.capacity() == 2u);
+    EXPECT_TRUE(bin2.empty());
+    EXPECT_TRUE(bin2.size() == 0u);
+    ann_gr.template populate<attach<>>(loc_p, 3u);
+    ann_gr.template populate<attach<>>(loc_p, 5u);
+
+    EXPECT_TRUE(bin2.capacity() == 2u);
+    EXPECT_TRUE(bin2.size() == 2u);
+    EXPECT_FALSE(bin2.empty());
+    EXPECT_EQ(bin2[0], 3u);
+    EXPECT_EQ(bin2[1], 5u);
+
+    EXPECT_EQ(ann_gr.size(), 2u);
+
+    // gr_builder.to_string(ann_gr);
+
+    // Build from parameters
+    const std::vector<scalar> bin_edges_z{-10.f, -8.f, -6.5f, -1.f,
+                                          4.f,   5.f,  6.f,   9.f};
+    const std::vector<scalar> bin_edges_phi{};
+
+    bin_indexer2D = detray::views::cartesian_product{
+        detray::views::iota{0u, 10u}, detray::views::iota{0u, 7u}};
+    capacity = 0u;
+    capacities.clear();
+    for (const auto& bin_idx : bin_indexer2D) {
+        typename ann_grid_t::loc_bin_index mbin{std::get<0>(bin_idx),
+                                                std::get<1>(bin_idx)};
+        capacities.emplace_back(mbin, ++capacity);
+    }
+
+    auto cyl_gr = gr_factory.template new_grid<cylinder2D<>>(
+        {0.f, 2.f * constant<scalar>::pi, bin_edges_z.front(),
+         bin_edges_z.back()},
+        {10u, bin_edges_z.size() - 1}, capacities, {bin_edges_phi, bin_edges_z},
+        types::list<circular<label::e_rphi>, closed<label::e_cyl_z>>{},
+        types::list<regular<>, irregular<>>{});
+
+    // Test axis
+    const auto& cyl_axis_rphi = cyl_gr.template get_axis<label::e_rphi>();
+    EXPECT_EQ(cyl_axis_rphi.label(), label::e_rphi);
+    EXPECT_EQ(cyl_axis_rphi.bounds(), bounds::e_circular);
+    EXPECT_EQ(cyl_axis_rphi.binning(), binning::e_regular);
+    EXPECT_EQ(cyl_axis_rphi.nbins(), 10u);
+    EXPECT_NEAR(cyl_axis_rphi.span()[0], 0.f,
+                std::numeric_limits<scalar>::epsilon());
+    EXPECT_NEAR(cyl_axis_rphi.span()[1], 2.f * constant<scalar>::pi,
+                std::numeric_limits<scalar>::epsilon());
+
+    const auto& cyl_axis_z = cyl_gr.template get_axis<label::e_cyl_z>();
+    EXPECT_EQ(cyl_axis_z.label(), label::e_cyl_z);
+    EXPECT_EQ(cyl_axis_z.bounds(), bounds::e_closed);
+    EXPECT_EQ(cyl_axis_z.binning(), binning::e_irregular);
+    EXPECT_EQ(cyl_axis_z.nbins(), 7u);
+    EXPECT_NEAR(cyl_axis_z.span()[0], -10.f,
+                std::numeric_limits<scalar>::epsilon());
+    EXPECT_NEAR(cyl_axis_z.span()[1], 9.f,
+                std::numeric_limits<scalar>::epsilon());
+
+    // Test bin storage
+    EXPECT_EQ(cyl_gr.bins().size(), 70u);
+    for (const auto& bin : cyl_gr.bins()) {
+        EXPECT_EQ(bin.size(), 0u);
+        EXPECT_TRUE(bin.capacity() >= 1u);
+    }
+    EXPECT_EQ(cyl_gr.size(), 0u);
+
+    EXPECT_EQ(cyl_gr.bins().entry_data().size(), 2485u);
+    EXPECT_EQ(cyl_gr.bins().entry_data().capacity(), 2485u);
+
+    // Test fill a bin to see, if bin content was correctly initialized
+    loc_p = cyl_gr.project(Identity, p, d);
+    auto bin3 = cyl_gr.search(loc_p);
+
+    EXPECT_TRUE(bin3.capacity() == 18u);
+    EXPECT_TRUE(bin3.empty());
+    EXPECT_TRUE(bin3.size() == 0u);
+
+    cyl_gr.template populate<attach<>>(loc_p, 33u);
+    cyl_gr.template populate<attach<>>(loc_p, 55u);
+    cyl_gr.template populate<attach<>>(loc_p, 77u);
+
+    EXPECT_TRUE(bin3.capacity() == 18u);
+    EXPECT_FALSE(bin3.empty());
+    EXPECT_TRUE(bin3.size() == 3u);
+    EXPECT_EQ(bin3[0], 33u);
+    EXPECT_EQ(bin3[1], 55u);
+    EXPECT_EQ(bin3[2], 77u);
+
+    EXPECT_EQ(cyl_gr.size(), 3u);
+
+    // Build the same cylinder grid from a mask
+    const scalar r{5.f};
+    const scalar n_half_z{-10.f};
+    const scalar p_half_z{9.f};
+    mask<cylinder2D<>> cyl2{0u, r, n_half_z, p_half_z};
+
+    auto cyl_gr2 =
+        gr_factory
+            .template new_grid<circular<label::e_rphi>, closed<label::e_cyl_z>,
+                               regular<>, irregular<>>(
+                cyl2, {10u, bin_edges_z.size() - 1}, capacities,
+                {bin_edges_phi, bin_edges_z});
 }
 
 /// Unittest: Test the grid builder

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
@@ -356,7 +356,7 @@ TEST(grids_cuda, grid2_dynamic_attach_populator) {
     const point3 first_tp{3.f, 3.f, 3.f};
     const point3 invalid_tp{0.f, 0.f, 0.f};
 
-    host_grid2_dynamic_array::bin_container_type bin_data{mng_mr};
+    host_grid2_dynamic_array::bin_container_type bin_data{&mng_mr};
     vecmem::vector<bin_t::entry_type> entries{&mng_mr};
     bin_data.bins.resize(2 * 65);
     bin_data.entries.resize(4 * bin_data.bins.size());

--- a/utils/include/detray/detectors/create_toy_geometry.hpp
+++ b/utils/include/detray/detectors/create_toy_geometry.hpp
@@ -1232,7 +1232,7 @@ inline auto create_toy_geometry(vecmem::memory_resource &resource,
     auto vgrid = vgrid_factory.template new_grid<
         axis::open<axis::label::e_r>, axis::circular<axis::label::e_phi>,
         axis::open<axis::label::e_z>, axis::irregular<>, axis::regular<>,
-        axis::irregular<>>(vgrid_dims, n_vgrid_bins, bin_edges);
+        axis::irregular<>>(vgrid_dims, n_vgrid_bins, {}, bin_edges);
     det.set_volume_finder(std::move(vgrid));
 
     return std::make_pair(std::move(det), std::move(name_map));

--- a/utils/include/detray/detectors/create_wire_chamber.hpp
+++ b/utils/include/detray/detectors/create_wire_chamber.hpp
@@ -288,8 +288,19 @@ inline auto create_wire_chamber(vecmem::memory_resource &resource,
                     outer_cyl_mask.values()[cylinder2D<>::e_r]);
         const cyl_mask_t cyl_mask{mask_values, 0u};
 
+        std::vector<std::pair<typename cyl_grid_t::loc_bin_index, dindex>>
+            capacities{};
+        auto bin_indexer2D = detray::views::cartesian_product{
+            detray::views::iota{0u, 100u}, detray::views::iota{0u, 1u}};
+        for (const auto &bin_idx : bin_indexer2D) {
+            typename cyl_grid_t::loc_bin_index mbin{std::get<0>(bin_idx),
+                                                    std::get<1>(bin_idx)};
+            // @Todo: fine-tune capacity
+            capacities.emplace_back(mbin, 3u);
+        }
+
         // Add new grid to the detector
-        gbuilder.init_grid(cyl_mask, {100u, 1u});
+        gbuilder.init_grid(cyl_mask, {100u, 1u}, capacities);
         gbuilder.fill_grid(vol, det.surfaces(), det.transform_store(),
                            det.mask_store(), ctx0);
 

--- a/utils/include/detray/detectors/create_wire_chamber.hpp
+++ b/utils/include/detray/detectors/create_wire_chamber.hpp
@@ -320,7 +320,7 @@ inline auto create_wire_chamber(vecmem::memory_resource &resource,
         auto vgrid = vgrid_factory.template new_grid<
             axis::open<axis::label::e_r>, axis::circular<axis::label::e_phi>,
             axis::open<axis::label::e_z>, axis::irregular<>, axis::regular<>,
-            axis::irregular<>>(vgrid_dims, n_vgrid_bins, bin_edges);
+            axis::irregular<>>(vgrid_dims, n_vgrid_bins, {}, bin_edges);
         det.set_volume_finder(std::move(vgrid));
     }
 


### PR DESCRIPTION
Add the respective options to the grid builder and grid factory to build grids with dynamic bin capacities. Also switches the default metadata to grids with dynamic bin capacity. If a compile-time capacity is given to the detector reader, it will try to build a grid with ```static_array``` bins, otherwise it will build ``` dynamic_array``` bins. 

Does not yet provide an interface to explicitly set the bin offsets, which will be needed in the future for the indexed material grids.