### PR TITLE
Multiply 1/6 to the local error estimate of RK stepper

### DIFF
--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -678,8 +678,11 @@ bool detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
 
         // Compute and check the local integration error estimate
         // @Todo
+        constexpr const scalar_type one_sixth{
+            static_cast<scalar_type>(1. / 6.)};
         const vector3 err_vec =
-            h2 * (sd.dtds[0u] - sd.dtds[1u] - sd.dtds[2u] + sd.dtds[3u]);
+            one_sixth * h2 *
+            (sd.dtds[0u] - sd.dtds[1u] - sd.dtds[2u] + sd.dtds[3u]);
         error_estimate =
             math::max(getter::norm(err_vec), static_cast<scalar_type>(1e-20));
 


### PR DESCRIPTION
The PR multiplies 1/6 to the local error estimate of RK stepper to follow the original form of local error estimate.
Reference: https://iopscience.iop.org/article/10.1088/1748-0221/4/04/P04001
![image](https://github.com/acts-project/detray/assets/63090140/000fe792-30ea-4bcb-aa0a-2e873175597c)

1/6 has been taken out on purpose because it is not an important factor in determining the next step size. But I prefer to have it in the full expression.