### PR TITLE
ref: Move the propgation config into own header

### DIFF
--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,18 +13,12 @@
 #include "detray/geometry/surface.hpp"
 #include "detray/propagator/actors/parameter_resetter.hpp"
 #include "detray/propagator/constrained_step.hpp"
+#include "detray/propagator/stepping_config.hpp"
 #include "detray/tracks/tracks.hpp"
 
 namespace detray {
 
 namespace stepping {
-
-enum class id {
-    // False for non-charged tracks
-    e_linear = 0,
-    // True for charged tracks
-    e_rk = 1,
-};
 
 /// A void inpector that does nothing.
 ///
@@ -33,22 +27,6 @@ struct void_inspector {
     template <typename state_t>
     DETRAY_HOST_DEVICE constexpr void operator()(const state_t & /*ignored*/,
                                                  const char * /*ignored*/) {}
-};
-
-struct config {
-    /// Minimum step size
-    scalar min_stepsize{1e-4f};
-    /// Runge-Kutta numeric error tolerance
-    scalar rk_error_tol{1e-4f};
-    /// Maximum number of Runge-Kutta step trials
-    std::size_t max_rk_updates{10000u};
-    /// Use mean energy loss (Bethe)
-    /// if false, most probable energy loss (Landau) will be used
-    bool use_mean_loss{true};
-    /// Use eloss gradient in error propagation
-    bool use_eloss_gradient{false};
-    /// Use b field gradient in error propagation
-    bool use_field_gradient{false};
 };
 
 }  // namespace stepping
@@ -211,8 +189,9 @@ class base_stepper {
 
         /// Call the stepping inspector
         DETRAY_HOST_DEVICE
-        inline void run_inspector([[maybe_unused]] const stepping::config &cfg,
-                                  [[maybe_unused]] const char *message) {
+        inline void run_inspector(
+            [[maybe_unused]] const stepping::config<scalar_type> &cfg,
+            [[maybe_unused]] const char *message) {
             if constexpr (not std::is_same_v<inspector_t,
                                              stepping::void_inspector>) {
                 _inspector(*this, cfg, message);

--- a/core/include/detray/propagator/constrained_step.hpp
+++ b/core/include/detray/propagator/constrained_step.hpp
@@ -14,7 +14,7 @@
 #include "detray/definitions/qualifiers.hpp"
 
 // System include(s).
-#include <climits>
+#include <limits>
 #include <type_traits>
 
 namespace detray {

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -96,7 +96,7 @@ class line_stepper final
     /// @return returning the heartbeat, indicating if the stepping is alive
     template <typename propagation_state_t>
     DETRAY_HOST_DEVICE bool step(propagation_state_t& propagation,
-                                 const stepping::config& cfg = {}) {
+                                 const stepping::config<scalar>& cfg = {}) {
         // Get stepper and navigator states
         state& stepping = propagation._stepping;
         auto& navigation = propagation._navigation;

--- a/core/include/detray/propagator/navigation_config.hpp
+++ b/core/include/detray/propagator/navigation_config.hpp
@@ -1,0 +1,37 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/indexing.hpp"
+#include "detray/definitions/units.hpp"
+
+namespace detray::navigation {
+
+/// Navigation trust levels determine how the candidates chache is updated
+enum class trust_level {
+    e_no_trust = 0,  ///< re-initialize the volume (i.e. run local navigation)
+    e_fair = 1,      ///< update the distance & order of the candidates
+    e_high = 3,  ///< update the distance to the next candidate (current target)
+    e_full = 4   ///< don't update anything
+};
+
+/// Navigation configuration
+template <typename scalar_t>
+struct config {
+    /// Tolerance on the masks 'is_inside' check
+    scalar_t mask_tolerance{15.f * unit<scalar_t>::um};
+    /// Maximal absolute path distance for a track to be considered 'on surface'
+    scalar_t on_surface_tolerance{1.f * unit<scalar_t>::um};
+    /// How far behind the track position to look for candidates
+    scalar_t overstep_tolerance{-100.f * unit<scalar_t>::um};
+    /// Search window size for grid based acceleration structures
+    std::array<dindex, 2> search_window = {0u, 0u};
+};
+
+}  // namespace detray::navigation

--- a/core/include/detray/propagator/propagation_config.hpp
+++ b/core/include/detray/propagator/propagation_config.hpp
@@ -1,0 +1,21 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "detray/propagator/navigation_config.hpp"
+#include "detray/propagator/stepping_config.hpp"
+
+namespace detray::propagation {
+
+/// Configuration of the propagation
+template <typename scalar_t>
+struct config : public stepping::config<scalar_t>,
+                public navigation::config<scalar_t> {};
+
+}  // namespace detray::propagation

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -14,17 +14,13 @@
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/base_stepper.hpp"
 #include "detray/propagator/navigator.hpp"
+#include "detray/propagator/propagation_config.hpp"
 #include "detray/tracks/tracks.hpp"
 
 // System include(s).
 #include <iomanip>
 
 namespace detray {
-
-namespace propagation {
-/// Configuration of the propagation
-struct config : public stepping::config, public navigation::config {};
-}  // namespace propagation
 
 /// Templated propagator class, using a stepper and a navigator object in
 /// succession.
@@ -40,12 +36,13 @@ struct propagator {
     using detector_type = typename navigator_type::detector_type;
     using actor_chain_type = actor_chain_t;
     using transform3_type = typename stepper_t::transform3_type;
+    using scalar_type = typename transform3_type::scalar_type;
     using free_track_parameters_type =
         typename stepper_t::free_track_parameters_type;
     using bound_track_parameters_type =
         typename stepper_t::bound_track_parameters_type;
 
-    propagation::config m_cfg;
+    propagation::config<scalar_type> m_cfg;
 
     stepper_t m_stepper;
     navigator_t m_navigator;
@@ -58,7 +55,7 @@ struct propagator {
 
     /// Construct from a propagator configuration
     DETRAY_HOST_DEVICE
-    propagator(propagation::config cfg = {})
+    propagator(propagation::config<scalar_type> cfg = {})
         : m_cfg{cfg}, m_stepper{}, m_navigator{} {}
 
     /// Propagation that state aggregates a stepping and a navigation state. It

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -99,13 +99,15 @@ class rk_stepper final
 
         /// Update the jacobian transport from free propagation
         DETRAY_HOST_DEVICE
-        inline void advance_jacobian(const stepping::config& cfg = {});
+        inline void advance_jacobian(
+            const stepping::config<scalar_type>& cfg = {});
 
         /// evaulate dqopds for a given step size and material
         DETRAY_HOST_DEVICE
         inline scalar_type evaluate_dqopds(
             const std::size_t i, const typename transform3_t::scalar_type h,
-            const scalar dqopds_prev, const detray::stepping::config& cfg);
+            const scalar dqopds_prev,
+            const detray::stepping::config<scalar_type>& cfg);
 
         /// evaulate dtds for runge kutta stepping
         DETRAY_HOST_DEVICE
@@ -139,7 +141,7 @@ class rk_stepper final
         /// Call the stepping inspector
         template <typename... Args>
         DETRAY_HOST_DEVICE inline void run_inspector(
-            [[maybe_unused]] const stepping::config& cfg,
+            [[maybe_unused]] const stepping::config<scalar_type>& cfg,
             [[maybe_unused]] const char* message,
             [[maybe_unused]] Args&&... args) {
             if constexpr (not std::is_same_v<inspector_t,
@@ -155,7 +157,7 @@ class rk_stepper final
     /// @return returning the heartbeat, indicating if the stepping is alive
     template <typename propagation_state_t>
     DETRAY_HOST_DEVICE bool step(propagation_state_t& propagation,
-                                 const stepping::config& cfg = {});
+                                 const stepping::config<scalar_type>& cfg = {});
 };
 
 }  // namespace detray

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -53,9 +53,10 @@ detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
 template <typename magnetic_field_t, typename transform3_t,
           typename constraint_t, typename policy_t, typename inspector_t,
           template <typename, std::size_t> class array_t>
-DETRAY_HOST_DEVICE void detray::rk_stepper<
-    magnetic_field_t, transform3_t, constraint_t, policy_t, inspector_t,
-    array_t>::state::advance_jacobian(const detray::stepping::config& cfg) {
+DETRAY_HOST_DEVICE void
+detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
+                   inspector_t, array_t>::state::
+    advance_jacobian(const detray::stepping::config<scalar_type>& cfg) {
     /// The calculations are based on ATL-SOFT-PUB-2009-002. The update of the
     /// Jacobian matrix is requires only the calculation of eq. 17 and 18.
     /// Since the terms of eq. 18 are currently 0, this matrix is not needed
@@ -393,12 +394,13 @@ DETRAY_HOST_DEVICE void detray::rk_stepper<
 template <typename magnetic_field_t, typename transform3_t,
           typename constraint_t, typename policy_t, typename inspector_t,
           template <typename, std::size_t> class array_t>
-DETRAY_HOST_DEVICE auto detray::rk_stepper<
-    magnetic_field_t, transform3_t, constraint_t, policy_t, inspector_t,
-    array_t>::state::evaluate_dqopds(const std::size_t i,
-                                     const typename transform3_t::scalar_type h,
-                                     const scalar dqopds_prev,
-                                     const detray::stepping::config& cfg) ->
+DETRAY_HOST_DEVICE auto
+detray::rk_stepper<magnetic_field_t, transform3_t, constraint_t, policy_t,
+                   inspector_t, array_t>::state::
+    evaluate_dqopds(const std::size_t i,
+                    const typename transform3_t::scalar_type h,
+                    const scalar dqopds_prev,
+                    const detray::stepping::config<scalar_type>& cfg) ->
     typename transform3_t::scalar_type {
 
     const auto& track = this->_track;
@@ -610,7 +612,7 @@ template <typename propagation_state_t>
 DETRAY_HOST_DEVICE bool detray::rk_stepper<
     magnetic_field_t, transform3_t, constraint_t, policy_t, inspector_t,
     array_t>::step(propagation_state_t& propagation,
-                   const detray::stepping::config& cfg) {
+                   const detray::stepping::config<scalar_type>& cfg) {
 
     // Get stepper and navigator states
     state& stepping = propagation._stepping;

--- a/core/include/detray/propagator/stepping_config.hpp
+++ b/core/include/detray/propagator/stepping_config.hpp
@@ -1,0 +1,46 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "detray/definitions/units.hpp"
+
+// System include(s).
+#include <limits>
+
+namespace detray::stepping {
+
+enum class id {
+    // False for non-charged tracks
+    e_linear = 0,
+    // True for charged tracks
+    e_rk = 1,
+};
+
+template <typename scalar_t>
+struct config {
+    /// Minimum step size
+    scalar_t min_stepsize{1e-4f * unit<scalar_t>::mm};
+    /// Runge-Kutta numeric error tolerance
+    scalar_t rk_error_tol{1e-4f * unit<scalar_t>::mm};
+    /// Step size constraint
+    scalar_t step_constraint{std::numeric_limits<scalar_t>::max()};
+    /// Maximal path length of track
+    scalar_t path_limit{5.f * unit<scalar_t>::m};
+    /// Maximum number of Runge-Kutta step trials
+    std::size_t max_rk_updates{10000u};
+    /// Use mean energy loss (Bethe)
+    /// if false, most probable energy loss (Landau) will be used
+    bool use_mean_loss{true};
+    /// Use eloss gradient in error propagation
+    bool use_eloss_gradient{false};
+    /// Use b field gradient in error propagation
+    bool use_field_gradient{false};
+};
+
+}  // namespace detray::stepping

--- a/core/include/detray/utils/inspectors.hpp
+++ b/core/include/detray/utils/inspectors.hpp
@@ -32,8 +32,9 @@ struct aggregate_inspector {
     inspector_tuple_t _inspectors{};
 
     /// Inspector interface
-    template <unsigned int current_id = 0, typename state_type>
-    auto operator()(state_type &state, const navigation::config &cfg,
+    template <unsigned int current_id = 0, typename state_type,
+              typename scalar_t>
+    auto operator()(state_type &state, const navigation::config<scalar_t> &cfg,
                     const char *message) {
         // Call inspector
         std::get<current_id>(_inspectors)(state, cfg, message);
@@ -64,8 +65,8 @@ struct object_tracer {
     vector_t<candidate_t> object_trace = {};
 
     /// Inspector interface
-    template <typename state_type>
-    auto operator()(state_type &state, const navigation::config &,
+    template <typename state_type, typename scalar_t>
+    auto operator()(state_type &state, const navigation::config<scalar_t> &,
                     const char * /*message*/) {
 
         // Record the candidate of an encountered object
@@ -93,8 +94,9 @@ struct print_inspector {
     std::stringstream debug_stream{};
 
     /// Inspector interface. Gathers detailed information during navigation
-    template <typename state_type>
-    auto operator()(const state_type &state, const navigation::config &cfg,
+    template <typename state_type, typename scalar_t>
+    auto operator()(const state_type &state,
+                    const navigation::config<scalar_t> &cfg,
                     const char *message) {
         std::string msg(message);
         std::string tabs = "\t\t\t\t";
@@ -198,8 +200,8 @@ struct print_inspector {
     std::stringstream debug_stream{};
 
     /// Inspector interface. Gathers detailed information during stepping
-    template <typename state_type>
-    void operator()(const state_type &state, const stepping::config &,
+    template <typename state_type, typename scalar_t>
+    void operator()(const state_type &state, const stepping::config<scalar_t> &,
                     const char *message) {
         std::string msg(message);
         std::string tabs = "\t\t\t\t";
@@ -233,8 +235,8 @@ struct print_inspector {
     }
 
     /// Inspector interface. Gathers detailed information during stepping
-    template <typename state_type>
-    void operator()(const state_type &state, const stepping::config &,
+    template <typename state_type, typename scalar_t>
+    void operator()(const state_type &state, const stepping::config<scalar_t> &,
                     const char *message, const std::size_t n_trials,
                     const scalar step_scalor) {
         std::string msg(message);

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -51,7 +51,7 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
     auto bfield = bfield::create_const_field(B);
 
     // Create propagator
-    propagation::config cfg{};
+    propagation::config<scalar> cfg{};
     cfg.search_window = {3u, 3u};
     propagator_host_type p{cfg};
 

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
@@ -29,7 +29,7 @@ __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
     }
 
     // Create propagator
-    propagation::config cfg{};
+    propagation::config<scalar> cfg{};
     cfg.search_window = {3u, 3u};
     propagator_device_type p{cfg};
 

--- a/tests/common/include/tests/common/test_base/fixture_base.hpp
+++ b/tests/common/include/tests/common/test_base/fixture_base.hpp
@@ -49,9 +49,7 @@ class fixture_base : public scope {
 
         /// Propagation
         /// @{
-        propagation::config m_prop_cfg{};
-        scalar m_path_limit{5.f * unit<scalar>::cm};
-        scalar m_step_constraint{std::numeric_limits<scalar>::max()};
+        propagation::config<scalar> m_prop_cfg{};
         /// @}
 
         /// Setters
@@ -60,34 +58,26 @@ class fixture_base : public scope {
             m_tolerance = t;
             return *this;
         }
-        configuration& path_limit(scalar lim) {
-            assert(lim > 0.f);
-            m_path_limit = lim;
-            return *this;
-        }
-        configuration& step_constraint(scalar constr) {
-            assert(constr > 0.f);
-            m_step_constraint = constr;
-            return *this;
-        }
         /// @}
 
         /// Getters
         /// @{
         scalar tol() const { return m_tolerance; }
-        scalar path_limit() const { return m_path_limit; }
-        propagation::config& propagation() { return m_prop_cfg; }
-        const propagation::config& propagation() const { return m_prop_cfg; }
-        scalar step_constraint() const { return m_step_constraint; }
+        propagation::config<scalar>& propagation() { return m_prop_cfg; }
+        const propagation::config<scalar>& propagation() const {
+            return m_prop_cfg;
+        }
         /// @}
 
         /// Print configuration
         std::ostream& operator<<(std::ostream& os) {
             os << " -> test tolerance:  \t " << tol() << std::endl;
-            os << " -> trk path limit:  \t " << path_limit() << std::endl;
+            os << " -> trk path limit:  \t " << propagation().path_limit
+               << std::endl;
             os << " -> overstepping tol:\t " << propagation().overstep_tolerance
                << std::endl;
-            os << " -> step constraint:  \t " << step_constraint() << std::endl;
+            os << " -> step constraint:  \t " << propagation().step_constraint
+               << std::endl;
             os << std::endl;
 
             return os;
@@ -99,9 +89,9 @@ class fixture_base : public scope {
         : tolerance{cfg.tol()},
           inf{cfg.inf},
           epsilon{cfg.epsilon},
-          path_limit{cfg.path_limit()},
+          path_limit{cfg.propagation().path_limit},
           overstep_tolerance{cfg.propagation().overstep_tolerance},
-          step_constraint{cfg.step_constraint()} {}
+          step_constraint{cfg.propagation().step_constraint} {}
 
     /// @returns the benchmark name
     std::string name() const { return "detray_test"; };

--- a/tests/common/include/tests/common/test_base/propagator_test.hpp
+++ b/tests/common/include/tests/common/test_base/propagator_test.hpp
@@ -155,7 +155,7 @@ inline auto run_propagation_host(vecmem::memory_resource *mr,
 
     using propagator_host_t =
         propagator<decltype(stepr), decltype(nav), actor_chain_host_t>;
-    propagation::config cfg{};
+    propagation::config<scalar> cfg{};
     cfg.search_window = {3u, 3u};
     cfg.rk_error_tol = rk_tolerance;
     propagator_host_t p{cfg};

--- a/tests/unit_tests/cpu/tools_navigator.cpp
+++ b/tests/unit_tests/cpu/tools_navigator.cpp
@@ -133,7 +133,7 @@ GTEST_TEST(detray_navigator, toy_geometry) {
 
     stepper_t stepper;
     navigator_t nav;
-    navigation::config cfg{};
+    navigation::config<scalar> cfg{};
     cfg.on_surface_tolerance = 1.f * unit<scalar>::um;
     cfg.search_window = {3u, 3u};
 
@@ -296,7 +296,7 @@ GTEST_TEST(detray_navigator, wire_chamber) {
 
     stepper_t stepper;
     navigator_t nav;
-    navigation::config cfg{};
+    navigation::config<scalar> cfg{};
     cfg.on_surface_tolerance = 1.f * unit<scalar>::um;
     cfg.search_window = {3u, 3u};
 

--- a/tests/unit_tests/cpu/tools_propagator.cpp
+++ b/tests/unit_tests/cpu/tools_propagator.cpp
@@ -204,7 +204,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
     const bfield_t bfield = bfield::create_const_field(std::get<2>(GetParam()));
 
     // Propagator is built from the stepper and navigator
-    propagation::config cfg{};
+    propagation::config<scalar> cfg{};
     cfg.overstep_tolerance = overstep_tol;
     propagator_t p{cfg};
 
@@ -305,7 +305,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
     const bfield_t bfield = bfield::create_inhom_field();
 
     // Propagator is built from the stepper and navigator
-    propagation::config cfg{};
+    propagation::config<scalar> cfg{};
     cfg.overstep_tolerance = overstep_tol;
     propagator_t p{cfg};
 

--- a/tests/unit_tests/device/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda.cpp
@@ -31,7 +31,7 @@ TEST(navigator_cuda, navigator) {
 
     // Create navigator
     navigator_host_t nav;
-    navigation::config cfg{};
+    navigation::config<scalar> cfg{};
     cfg.search_window = {1u, 1u};
 
     // Create the vector of initial track parameters

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.cu
@@ -11,7 +11,8 @@
 namespace detray {
 
 __global__ void navigator_test_kernel(
-    typename detector_host_t::view_type det_data, navigation::config cfg,
+    typename detector_host_t::view_type det_data,
+    navigation::config<scalar> cfg,
     vecmem::data::vector_view<free_track_parameters<transform3>> tracks_data,
     vecmem::data::jagged_vector_view<intersection_t> candidates_data,
     vecmem::data::jagged_vector_view<dindex> volume_records_data,
@@ -63,7 +64,8 @@ __global__ void navigator_test_kernel(
 }
 
 void navigator_test(
-    typename detector_host_t::view_type det_data, navigation::config& cfg,
+    typename detector_host_t::view_type det_data,
+    navigation::config<scalar>& cfg,
     vecmem::data::vector_view<free_track_parameters<transform3>>& tracks_data,
     vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
@@ -52,7 +52,8 @@ namespace detray {
 
 /// test function for navigator with single state
 void navigator_test(
-    typename detector_host_t::view_type det_data, navigation::config& cfg,
+    typename detector_host_t::view_type det_data,
+    navigation::config<scalar>& cfg,
     vecmem::data::vector_view<free_track_parameters<transform3>>& tracks_data,
     vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,

--- a/tests/unit_tests/device/cuda/propagator_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/propagator_cuda_kernel.cu
@@ -49,7 +49,7 @@ __global__ void propagator_test_kernel(
     using propagator_device_t =
         propagator<decltype(stepr), decltype(nav), actor_chain_device_t>;
 
-    propagation::config cfg{};
+    propagation::config<scalar> cfg{};
     cfg.search_window = {3u, 3u};
     cfg.rk_error_tol = rk_tolerance;
     propagator_device_t p{cfg};

--- a/tests/unit_tests/device/sycl/propagator_kernel.sycl
+++ b/tests/unit_tests/device/sycl/propagator_kernel.sycl
@@ -70,7 +70,7 @@ void propagator_test(
                 using propagator_device_t =
                     propagator<decltype(stepr), decltype(nav),
                                actor_chain_device_t>;
-                propagation::config cfg{};
+                propagation::config<scalar> cfg{};
                 cfg.search_window = {3u, 3u};
                 cfg.rk_error_tol = rk_tolerance;
                 propagator_device_t p{cfg};

--- a/tests/validation/include/detray/validation/helix_navigation.hpp
+++ b/tests/validation/include/detray/validation/helix_navigation.hpp
@@ -155,8 +155,8 @@ class helix_navigation : public test::fixture_base<> {
                 m_det, helix, 15.f * unit<scalar_t>::um);
 
             // Build actor and propagator states
-            pathlimit_aborter::state pathlimit_aborter_state{5.f *
-                                                             unit<scalar_t>::m};
+            pathlimit_aborter::state pathlimit_aborter_state{
+                m_cfg.propagation().path_limit};
             auto actor_states = std::tie(pathlimit_aborter_state);
 
             typename propagator_t::state propagation(track, hom_bfield, m_det);

--- a/tests/validation/include/detray/validation/straight_line_navigation.hpp
+++ b/tests/validation/include/detray/validation/straight_line_navigation.hpp
@@ -147,8 +147,8 @@ class straight_line_navigation : public test::fixture_base<> {
             free_track_parameters_t track(ray.pos(), 0.f, ray.dir(), -1.f);
 
             // Build actor and propagator states
-            pathlimit_aborter::state pathlimit_aborter_state{5.f *
-                                                             unit<scalar_t>::m};
+            pathlimit_aborter::state pathlimit_aborter_state{
+                m_cfg.propagation().path_limit};
             auto actor_states = std::tie(pathlimit_aborter_state);
 
             typename propagator_t::state propagation(track, m_det);

--- a/tests/validation/src/jacobian_validation.cpp
+++ b/tests/validation/src/jacobian_validation.cpp
@@ -249,7 +249,7 @@ bound_getter<transform3_type>::state evaluate_bound_param(
     bool use_field_gradient) {
 
     // Propagator is built from the stepper and navigator
-    propagation::config cfg{};
+    propagation::config<scalar> cfg{};
     cfg.overstep_tolerance = overstep_tolerance;
     cfg.on_surface_tolerance = on_surface_tolerance;
     cfg.rk_error_tol = rk_tolerance;
@@ -286,7 +286,7 @@ get_displaced_bound_vector(
     const scalar rk_tolerance, const scalar constraint_step,
     const unsigned int target_index, const scalar displacement) {
 
-    propagation::config cfg{};
+    propagation::config<scalar> cfg{};
     cfg.overstep_tolerance = overstep_tolerance;
     cfg.on_surface_tolerance = on_surface_tolerance;
     cfg.rk_error_tol = rk_tolerance;

--- a/tutorials/src/device/cuda/propagation_kernel.cu
+++ b/tutorials/src/device/cuda/propagation_kernel.cu
@@ -42,7 +42,7 @@ __global__ void propagation_kernel(
         candidates_data);
 
     // Create propagator from a stepper and a navigator
-    propagation::config cfg{};
+    propagation::config<scalar> cfg{};
     cfg.search_window = {3u, 3u};
     detray::tutorial::propagator_t p{cfg};
 


### PR DESCRIPTION
Following the design of traccc, this splits the propagation config from the implementation and adds the step size contraints and path limit to the config