### PR TITLE
fix: navigation and stepper config as members

### DIFF
--- a/core/include/detray/propagator/propagation_config.hpp
+++ b/core/include/detray/propagator/propagation_config.hpp
@@ -15,7 +15,9 @@ namespace detray::propagation {
 
 /// Configuration of the propagation
 template <typename scalar_t>
-struct config : public stepping::config<scalar_t>,
-                public navigation::config<scalar_t> {};
+struct config {
+    navigation::config<scalar_t> navigation{};
+    stepping::config<scalar_t> stepping{};
+};
 
 }  // namespace detray::propagation

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -140,28 +140,33 @@ struct propagator {
                                       actor_states_t &&actor_states = {}) {
 
         // Initialize the navigation
-        propagation._heartbeat = m_navigator.init(propagation, m_cfg);
+        propagation._heartbeat =
+            m_navigator.init(propagation, m_cfg.navigation);
 
         // Run all registered actors/aborters after init
         run_actors(actor_states, propagation);
 
         // Find next candidate
-        propagation._heartbeat &= m_navigator.update(propagation, m_cfg);
+        propagation._heartbeat &=
+            m_navigator.update(propagation, m_cfg.navigation);
 
         // Run while there is a heartbeat
         while (propagation._heartbeat) {
 
             // Take the step
-            propagation._heartbeat &= m_stepper.step(propagation, m_cfg);
+            propagation._heartbeat &=
+                m_stepper.step(propagation, m_cfg.stepping);
 
             // Find next candidate
-            propagation._heartbeat &= m_navigator.update(propagation, m_cfg);
+            propagation._heartbeat &=
+                m_navigator.update(propagation, m_cfg.navigation);
 
             // Run all registered actors/aborters after update
             run_actors(actor_states, propagation);
 
             // And check the status
-            propagation._heartbeat &= m_navigator.update(propagation, m_cfg);
+            propagation._heartbeat &=
+                m_navigator.update(propagation, m_cfg.navigation);
 
 #if defined(__NO_DEVICE__)
             if (propagation.do_debug) {
@@ -191,24 +196,27 @@ struct propagator {
                                            actor_states_t &&actor_states = {}) {
 
         // Initialize the navigation
-        propagation._heartbeat = m_navigator.init(propagation, m_cfg);
+        propagation._heartbeat =
+            m_navigator.init(propagation, m_cfg.navigation);
 
         // Run all registered actors/aborters after init
         run_actors(actor_states, propagation);
 
         // Find next candidate
-        propagation._heartbeat &= m_navigator.update(propagation, m_cfg);
+        propagation._heartbeat &=
+            m_navigator.update(propagation, m_cfg.navigation);
 
         while (propagation._heartbeat) {
 
             while (propagation._heartbeat) {
 
                 // Take the step
-                propagation._heartbeat &= m_stepper.step(propagation, m_cfg);
+                propagation._heartbeat &=
+                    m_stepper.step(propagation, m_cfg.stepping);
 
                 // Find next candidate
                 propagation._heartbeat &=
-                    m_navigator.update(propagation, m_cfg);
+                    m_navigator.update(propagation, m_cfg.navigation);
 
                 // If the track is on a sensitive surface, break the loop to
                 // synchornize the threads
@@ -219,7 +227,7 @@ struct propagator {
 
                     // And check the status
                     propagation._heartbeat &=
-                        m_navigator.update(propagation, m_cfg);
+                        m_navigator.update(propagation, m_cfg.navigation);
                 }
             }
 
@@ -229,7 +237,7 @@ struct propagator {
 
                 // And check the status
                 propagation._heartbeat &=
-                    m_navigator.update(propagation, m_cfg);
+                    m_navigator.update(propagation, m_cfg.navigation);
 
 #if defined(__NO_DEVICE__)
                 if (propagation.do_debug) {

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -52,7 +52,7 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
 
     // Create propagator
     propagation::config<scalar> cfg{};
-    cfg.search_window = {3u, 3u};
+    cfg.navigation.search_window = {3u, 3u};
     propagator_host_type p{cfg};
 
     std::size_t total_tracks = 0;

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
@@ -30,7 +30,7 @@ __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
 
     // Create propagator
     propagation::config<scalar> cfg{};
-    cfg.search_window = {3u, 3u};
+    cfg.navigation.search_window = {3u, 3u};
     propagator_device_type p{cfg};
 
     parameter_transporter<transform3>::state transporter_state{};

--- a/tests/common/include/tests/common/test_base/fixture_base.hpp
+++ b/tests/common/include/tests/common/test_base/fixture_base.hpp
@@ -72,12 +72,12 @@ class fixture_base : public scope {
         /// Print configuration
         std::ostream& operator<<(std::ostream& os) {
             os << " -> test tolerance:  \t " << tol() << std::endl;
-            os << " -> trk path limit:  \t " << propagation().path_limit
-               << std::endl;
-            os << " -> overstepping tol:\t " << propagation().overstep_tolerance
-               << std::endl;
-            os << " -> step constraint:  \t " << propagation().step_constraint
-               << std::endl;
+            os << " -> trk path limit:  \t "
+               << propagation().stepping.path_limit << std::endl;
+            os << " -> overstepping tol:\t "
+               << propagation().navigation.overstep_tolerance << std::endl;
+            os << " -> step constraint:  \t "
+               << propagation().stepping.step_constraint << std::endl;
             os << std::endl;
 
             return os;
@@ -89,9 +89,9 @@ class fixture_base : public scope {
         : tolerance{cfg.tol()},
           inf{cfg.inf},
           epsilon{cfg.epsilon},
-          path_limit{cfg.propagation().path_limit},
-          overstep_tolerance{cfg.propagation().overstep_tolerance},
-          step_constraint{cfg.propagation().step_constraint} {}
+          path_limit{cfg.propagation().stepping.path_limit},
+          overstep_tolerance{cfg.propagation().navigation.overstep_tolerance},
+          step_constraint{cfg.propagation().stepping.step_constraint} {}
 
     /// @returns the benchmark name
     std::string name() const { return "detray_test"; };

--- a/tests/common/include/tests/common/test_base/propagator_test.hpp
+++ b/tests/common/include/tests/common/test_base/propagator_test.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -156,8 +156,8 @@ inline auto run_propagation_host(vecmem::memory_resource *mr,
     using propagator_host_t =
         propagator<decltype(stepr), decltype(nav), actor_chain_host_t>;
     propagation::config<scalar> cfg{};
-    cfg.search_window = {3u, 3u};
-    cfg.rk_error_tol = rk_tolerance;
+    cfg.navigation.search_window = {3u, 3u};
+    cfg.stepping.rk_error_tol = rk_tolerance;
     propagator_host_t p{cfg};
 
     // Create vector for track recording

--- a/tests/unit_tests/cpu/tools_propagator.cpp
+++ b/tests/unit_tests/cpu/tools_propagator.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -205,7 +205,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
 
     // Propagator is built from the stepper and navigator
     propagation::config<scalar> cfg{};
-    cfg.overstep_tolerance = overstep_tol;
+    cfg.navigation.overstep_tolerance = overstep_tol;
     propagator_t p{cfg};
 
     // Iterate through uniformly distributed momentum directions
@@ -306,7 +306,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
 
     // Propagator is built from the stepper and navigator
     propagation::config<scalar> cfg{};
-    cfg.overstep_tolerance = overstep_tol;
+    cfg.navigation.overstep_tolerance = overstep_tol;
     propagator_t p{cfg};
 
     // Iterate through uniformly distributed momentum directions

--- a/tests/unit_tests/device/cuda/propagator_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/propagator_cuda_kernel.cu
@@ -50,8 +50,8 @@ __global__ void propagator_test_kernel(
         propagator<decltype(stepr), decltype(nav), actor_chain_device_t>;
 
     propagation::config<scalar> cfg{};
-    cfg.search_window = {3u, 3u};
-    cfg.rk_error_tol = rk_tolerance;
+    cfg.navigation.search_window = {3u, 3u};
+    cfg.stepping.rk_error_tol = rk_tolerance;
     propagator_device_t p{cfg};
 
     // Create actor states

--- a/tests/unit_tests/device/sycl/propagator_kernel.sycl
+++ b/tests/unit_tests/device/sycl/propagator_kernel.sycl
@@ -71,8 +71,8 @@ void propagator_test(
                     propagator<decltype(stepr), decltype(nav),
                                actor_chain_device_t>;
                 propagation::config<scalar> cfg{};
-                cfg.search_window = {3u, 3u};
-                cfg.rk_error_tol = rk_tolerance;
+                cfg.navigation.search_window = {3u, 3u};
+                cfg.stepping.rk_error_tol = rk_tolerance;
                 propagator_device_t p{cfg};
 
                 // Create actor states

--- a/tests/validation/include/detray/validation/helix_navigation.hpp
+++ b/tests/validation/include/detray/validation/helix_navigation.hpp
@@ -156,7 +156,7 @@ class helix_navigation : public test::fixture_base<> {
 
             // Build actor and propagator states
             pathlimit_aborter::state pathlimit_aborter_state{
-                m_cfg.propagation().path_limit};
+                m_cfg.propagation().stepping.path_limit};
             auto actor_states = std::tie(pathlimit_aborter_state);
 
             typename propagator_t::state propagation(track, hom_bfield, m_det);

--- a/tests/validation/include/detray/validation/straight_line_navigation.hpp
+++ b/tests/validation/include/detray/validation/straight_line_navigation.hpp
@@ -148,7 +148,7 @@ class straight_line_navigation : public test::fixture_base<> {
 
             // Build actor and propagator states
             pathlimit_aborter::state pathlimit_aborter_state{
-                m_cfg.propagation().path_limit};
+                m_cfg.propagation().stepping.path_limit};
             auto actor_states = std::tie(pathlimit_aborter_state);
 
             typename propagator_t::state propagation(track, m_det);

--- a/tests/validation/src/detector_validation.cpp
+++ b/tests/validation/src/detector_validation.cpp
@@ -171,14 +171,16 @@ int main(int argc, char **argv) {
                 "Incorrect surface grid search window. Please provide two "
                 "integer distances.");
         }
-        str_nav_cfg.propagation().search_window = {window[0], window[1]};
-        hel_nav_cfg.propagation().search_window = {window[0], window[1]};
+        str_nav_cfg.propagation().navigation.search_window = {window[0],
+                                                              window[1]};
+        hel_nav_cfg.propagation().navigation.search_window = {window[0],
+                                                              window[1]};
     }
 
     if (vm.count("overstep_tol")) {
         const scalar_t overstep_tol{vm["overstep_tol"].as<scalar_t>()};
 
-        hel_nav_cfg.propagation().overstep_tolerance =
+        hel_nav_cfg.propagation().navigation.overstep_tolerance =
             overstep_tol * unit<scalar_t>::um;
     }
 

--- a/tests/validation/src/jacobian_validation.cpp
+++ b/tests/validation/src/jacobian_validation.cpp
@@ -250,11 +250,11 @@ bound_getter<transform3_type>::state evaluate_bound_param(
 
     // Propagator is built from the stepper and navigator
     propagation::config<scalar> cfg{};
-    cfg.overstep_tolerance = overstep_tolerance;
-    cfg.on_surface_tolerance = on_surface_tolerance;
-    cfg.rk_error_tol = rk_tolerance;
-    cfg.use_eloss_gradient = true;
-    cfg.use_field_gradient = use_field_gradient;
+    cfg.navigation.overstep_tolerance = overstep_tolerance;
+    cfg.navigation.on_surface_tolerance = on_surface_tolerance;
+    cfg.stepping.rk_error_tol = rk_tolerance;
+    cfg.stepping.use_eloss_gradient = true;
+    cfg.stepping.use_field_gradient = use_field_gradient;
     propagator_t p(cfg);
 
     // Actor states
@@ -287,9 +287,9 @@ get_displaced_bound_vector(
     const unsigned int target_index, const scalar displacement) {
 
     propagation::config<scalar> cfg{};
-    cfg.overstep_tolerance = overstep_tolerance;
-    cfg.on_surface_tolerance = on_surface_tolerance;
-    cfg.rk_error_tol = rk_tolerance;
+    cfg.navigation.overstep_tolerance = overstep_tolerance;
+    cfg.navigation.on_surface_tolerance = on_surface_tolerance;
+    cfg.stepping.rk_error_tol = rk_tolerance;
 
     // Propagator is built from the stepper and navigator
     propagator_t p(cfg);

--- a/tests/validation/src/toy_detector_validation.cpp
+++ b/tests/validation/src/toy_detector_validation.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
     // Comparision of straight line navigation with ray scan
     straight_line_navigation<toy_detector_t>::config cfg_str_nav{};
     cfg_str_nav.name("toy_detector_straight_line_navigation");
-    cfg_str_nav.propagation().search_window = {3u, 3u};
+    cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
     cfg_str_nav.track_generator().theta_steps(100u).phi_steps(100u);
 
     detail::register_checks<straight_line_navigation>(toy_det, toy_names,
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
     // Comparision of navigation in a constant B-field with helix
     helix_navigation<toy_detector_t>::config cfg_hel_nav{};
     cfg_hel_nav.name("toy_detector_helix_navigation");
-    cfg_hel_nav.propagation().search_window = {3u, 3u};
+    cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
     cfg_hel_nav.track_generator() = cfg_hel_scan.track_generator();
     // TODO: Fails due to mask tolerances for more helices, regardless of edc
     // configuration/precision

--- a/tests/validation/src/wire_chamber_validation.cpp
+++ b/tests/validation/src/wire_chamber_validation.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
     // Comparision of straight line navigation with ray scan
     straight_line_navigation<wire_chamber_t>::config cfg_str_nav{};
     cfg_str_nav.name("wire_chamber_straight_line_navigation");
-    cfg_str_nav.propagation().search_window = {2u, 2u};
+    cfg_str_nav.propagation().navigation.search_window = {2u, 2u};
     cfg_str_nav.track_generator().theta_steps(100u).phi_steps(100u);
 
     detail::register_checks<straight_line_navigation>(det, names, cfg_str_nav);
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
     // Comparision of navigation in a constant B-field with helix
     helix_navigation<wire_chamber_t>::config cfg_hel_nav{};
     cfg_hel_nav.name("wire_chamber_helix_navigation");
-    cfg_hel_nav.propagation().search_window = {3u, 3u};
+    cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
     cfg_hel_nav.track_generator() = cfg_hel_scan.track_generator();
     // TODO: Fails for more helices
     // cfg_hel_nav.track_generator().theta_steps(100u).phi_steps(100u);

--- a/tutorials/src/device/cuda/propagation_kernel.cu
+++ b/tutorials/src/device/cuda/propagation_kernel.cu
@@ -43,7 +43,7 @@ __global__ void propagation_kernel(
 
     // Create propagator from a stepper and a navigator
     propagation::config<scalar> cfg{};
-    cfg.search_window = {3u, 3u};
+    cfg.navigation.search_window = {3u, 3u};
     detray::tutorial::propagator_t p{cfg};
 
     // Create actor states


### PR DESCRIPTION
Make the navigation and stepper configs members instead of inheriting. It seems CUDA does not handle object slicing correctly.