### PR TITLE
fix: and test source link default search

### DIFF
--- a/core/include/detray/core/detail/surface_lookup.hpp
+++ b/core/include/detray/core/detail/surface_lookup.hpp
@@ -26,9 +26,8 @@ namespace detray {
 /// General case: Brute force search for the corresponding sf-descriptor
 struct default_searcher {
 
-    template <typename src_link_t,
-              template <typename...> class container_t = dvector>
-    auto operator()(const container_t<src_link_t> &sf_container) {
+    template <typename source_link_contianer_t>
+    auto operator()(const source_link_contianer_t &sf_container) {
         // Check that this searcher can be used on the passed surface container
         static_assert(
             std::is_same_v<decltype(sf_container[0].source), std::uint64_t>,
@@ -40,6 +39,8 @@ struct default_searcher {
                 return sf;
             }
         }
+
+        return typename source_link_contianer_t::value_type{};
     }
 
     /// The query source link

--- a/tests/common/include/tests/common/test_toy_detector.hpp
+++ b/tests/common/include/tests/common/test_toy_detector.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -165,6 +165,23 @@ inline bool test_toy_detector(
         EXPECT_EQ(materials.template size<material_ids::e_cylinder2_map>(),
                   51u);
         EXPECT_EQ(materials.template size<material_ids::e_disc2_map>(), 52u);
+    }
+
+    // Check the surface source links
+    for (dindex i = 0u; i < toy_det.surfaces().size(); ++i) {
+
+        // The source link was prepared during building as: sf index + 42
+        std::uint64_t source{i + 42u};
+        const auto& ref_sf = toy_det.surface(i);
+
+        // Only sensitive surfaces were given a source link in the toy detector
+        if (ref_sf.is_sensitive()) {
+            const auto& result_sf = toy_det.surface(default_searcher{source});
+
+            EXPECT_EQ(result_sf.index(), i) << result_sf;
+            EXPECT_EQ(ref_sf, result_sf)
+                << "expected: " << ref_sf << ", result: " << result_sf;
+        }
     }
 
     /// Test the surface ranges in the volume

--- a/utils/include/detray/detectors/create_toy_geometry.hpp
+++ b/utils/include/detray/detectors/create_toy_geometry.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -294,7 +294,7 @@ inline dindex_range add_cylinder_grid(
         sf_desc.set_index(sf_offset++);
 
         // Copy surface descriptor into global lookup
-        det.surfaces().insert(sf_desc);
+        det.surfaces().insert(sf_desc, sf_desc.index() + 42u);
     }
 
     // Add transforms, masks and material to detector
@@ -378,7 +378,7 @@ inline dindex_range add_disc_grid(
         sf_desc.set_index(sf_offset++);
 
         // Copy surface descriptor into global lookup
-        det.surfaces().insert(sf_desc);
+        det.surfaces().insert(sf_desc, sf_desc.index() + 42u);
     }
 
     // Add transforms, masks and material to detector


### PR DESCRIPTION
Equips the toy detector with some test source links on the sensitive surfaces to test the surface lookup