### PR TITLE
feat: Add missing masks to benchmark

### DIFF
--- a/core/include/detray/builders/material_map_builder.hpp
+++ b/core/include/detray/builders/material_map_builder.hpp
@@ -213,8 +213,8 @@ struct add_sf_material_map {
         using mask_shape_t = typename coll_t::value_type::shape;
 
         constexpr bool is_line{
-            std::is_same_v<mask_shape_t, detray::line<true>> ||
-            std::is_same_v<mask_shape_t, detray::line<false>>};
+            std::is_same_v<mask_shape_t, detray::wire_cell> ||
+            std::is_same_v<mask_shape_t, detray::straw_tube>};
 
         // No material maps for line surfaces
         if constexpr (!is_line && mask_shape_t::dim == DIM) {

--- a/core/include/detray/builders/telescope_generator.hpp
+++ b/core/include/detray/builders/telescope_generator.hpp
@@ -151,8 +151,8 @@ class telescope_generator final : public surface_factory_interface<detector_t> {
             // Local z axis is the global normal vector
             vector3_t m_local_z = algebra::vector::normalize(mod_placement.dir);
 
-            if constexpr (std::is_same_v<mask_shape_t, detray::line<true>> ||
-                          std::is_same_v<mask_shape_t, detray::line<false>>) {
+            if constexpr (std::is_same_v<mask_shape_t, detray::wire_cell> ||
+                          std::is_same_v<mask_shape_t, detray::straw_tube>) {
 
                 // For a telescope with wires, rotate z axis 90
                 // degree around vector on x-y plane

--- a/core/include/detray/core/detector_metadata.hpp
+++ b/core/include/detray/core/detector_metadata.hpp
@@ -39,8 +39,8 @@ struct default_metadata {
     using cylinder = mask<cylinder2D, nav_link>;
     using cylinder_portal = mask<concentric_cylinder2D, nav_link>;
     using disc = mask<ring2D, nav_link>;
-    using straw_wire = mask<line<false>, nav_link>;
-    using cell_wire = mask<line<true>, nav_link>;
+    using straw_wire = mask<straw_tube, nav_link>;
+    using cell_wire = mask<wire_cell, nav_link>;
     using single_1 = mask<single3D<1>, nav_link>;
     using single_2 = mask<single3D<2>, nav_link>;
     // TODO: Can single3 be used instead of cylinder portal type or remove it?
@@ -51,8 +51,8 @@ struct default_metadata {
     using unbounded_annulus = mask<unbounded<annulus2D>, nav_link>;
     using unbounded_cylinder = mask<unbounded<cylinder2D>, nav_link>;
     using unbounded_disc = mask<unbounded<ring2D>, nav_link>;
-    using unbounded_straw = mask<unbounded<line<false>>, nav_link>;
-    using unbounded_cell = mask<unbounded<line<true>>, nav_link>;
+    using unbounded_straw = mask<unbounded<straw_tube>, nav_link>;
+    using unbounded_cell = mask<unbounded<wire_cell>, nav_link>;
     using unmasked_plane = mask<unmasked, nav_link>;
 
     /// Material types

--- a/core/include/detray/geometry/shapes/line.hpp
+++ b/core/include/detray/geometry/shapes/line.hpp
@@ -178,4 +178,9 @@ class line {
     }
 };
 
+// Radial crossection, boundary check in polar coordiantes
+using straw_tube = line<false>;
+// Square crossection, boundary check in cartesian coordiantes
+using wire_cell = line<true>;
+
 }  // namespace detray

--- a/io/include/detray/io/common/detail/type_info.hpp
+++ b/io/include/detray/io/common/detail/type_info.hpp
@@ -34,7 +34,7 @@ constexpr io::shape_id get_id() {
     using shape_registry =
         type_registry<io::shape_id, annulus2D, cuboid3D, cylinder2D, cylinder3D,
                       concentric_cylinder2D, rectangle2D, ring2D, trapezoid2D,
-                      line<true>, line<false>, single3D<0>, single3D<1>,
+                      wire_cell, straw_tube, single3D<0>, single3D<1>,
                       single3D<2>>;
 
     // Find the correct shape IO id;
@@ -170,9 +170,9 @@ struct mask_info<
 template <typename detector_t>
 struct mask_info<io::shape_id::cell_wire, detector_t,
                  std::enable_if_t<detector_t::masks::template is_defined<
-                                      mask<line<true>, std::uint_least16_t>>(),
+                                      mask<wire_cell, std::uint_least16_t>>(),
                                   void>> {
-    using type = line<true>;
+    using type = wire_cell;
     static constexpr typename detector_t::masks::id value{
         detector_t::masks::id::e_cell_wire};
 };
@@ -181,9 +181,9 @@ struct mask_info<io::shape_id::cell_wire, detector_t,
 template <typename detector_t>
 struct mask_info<io::shape_id::straw_wire, detector_t,
                  std::enable_if_t<detector_t::masks::template is_defined<
-                                      mask<line<false>, std::uint_least16_t>>(),
+                                      mask<straw_tube, std::uint_least16_t>>(),
                                   void>> {
-    using type = line<false>;
+    using type = straw_tube;
     static constexpr typename detector_t::masks::id value{
         detector_t::masks::id::e_straw_wire};
 };

--- a/tests/integration_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/integration_tests/cpu/propagator/covariance_transport.cpp
@@ -37,8 +37,8 @@ using rectangle_type = detray::mask<detray::rectangle2D>;
 using trapezoid_type = detray::mask<detray::trapezoid2D>;
 using ring_type = detray::mask<detray::ring2D>;
 using cylinder_type = detray::mask<detray::cylinder2D>;
-using straw_wire_type = detray::mask<detray::line<false>>;
-using cell_wire_type = detray::mask<detray::line<true>>;
+using straw_wire_type = detray::mask<detray::straw_tube>;
+using cell_wire_type = detray::mask<detray::wire_cell>;
 
 // Test class for covariance transport
 template <typename T>

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -97,7 +97,7 @@ std::uniform_real_distribution<scalar> rand_shift(-shift, shift);
 
 // surface types
 using rect_type = rectangle2D;
-using wire_type = line<true>;
+using wire_type = wire_cell;
 
 }  // namespace
 

--- a/tests/unit_tests/cpu/geometry/masks/line.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/line.cpp
@@ -37,10 +37,10 @@ GTEST_TEST(detray_masks, line_radial_cross_sect) {
     const point_t ln_out1{1.2f, 0.f, 0.f};
     const point_t ln_out2{0.09f, -51.f, 0.f};
 
-    const mask<line<>> ln{0u, cell_size, hz};
+    const mask<straw_tube> ln{0u, cell_size, hz};
 
-    ASSERT_NEAR(ln[line<>::e_cross_section], 1.f * unit<scalar>::mm, tol);
-    ASSERT_NEAR(ln[line<>::e_half_z], 50.f * unit<scalar>::mm, tol);
+    ASSERT_NEAR(ln[straw_tube::e_cross_section], 1.f * unit<scalar>::mm, tol);
+    ASSERT_NEAR(ln[straw_tube::e_half_z], 50.f * unit<scalar>::mm, tol);
 
     ASSERT_TRUE(ln.is_inside(ln_in) == intersection::status::e_inside);
     ASSERT_TRUE(ln.is_inside(ln_edge) == intersection::status::e_inside);
@@ -73,10 +73,10 @@ GTEST_TEST(detray_masks, line_square_cross_sect) {
     const point_t ln_out2{0.09f, -51.f, 0.f};
 
     // 50 mm wire with 1 mm square cell sizes
-    const mask<line<true>> ln{0u, cell_size, hz};
+    const mask<wire_cell> ln{0u, cell_size, hz};
 
-    ASSERT_NEAR(ln[line<>::e_cross_section], 1.f * unit<scalar>::mm, tol);
-    ASSERT_NEAR(ln[line<>::e_half_z], 50.f * unit<scalar>::mm, tol);
+    ASSERT_NEAR(ln[straw_tube::e_cross_section], 1.f * unit<scalar>::mm, tol);
+    ASSERT_NEAR(ln[straw_tube::e_half_z], 50.f * unit<scalar>::mm, tol);
 
     ASSERT_TRUE(ln.is_inside(ln_in) == intersection::status::e_inside);
     ASSERT_TRUE(ln.is_inside(ln_edge, 1e-5f) == intersection::status::e_inside);

--- a/tests/unit_tests/cpu/material/materials.cpp
+++ b/tests/unit_tests/cpu/material/materials.cpp
@@ -180,10 +180,10 @@ GTEST_TEST(detray_material, material_rod) {
     const free_track_parameters<transform3> trk(pos, 0.f, dir, -1.f);
 
     // Infinite wire with 1 mm radial cell size
-    const mask<line<>> ln{0u, 1.f * unit<scalar>::mm,
-                          std::numeric_limits<scalar>::infinity()};
+    const mask<straw_tube> ln{0u, 1.f * unit<scalar>::mm,
+                              std::numeric_limits<scalar>::infinity()};
 
-    auto is = ray_intersector<line<>, transform3>{}(
+    auto is = ray_intersector<straw_tube, transform3>{}(
         detail::ray<transform3>(trk), surface_descriptor<>{}, ln, tf);
 
     const scalar cos_inc_ang{is.cos_incidence_angle};

--- a/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
@@ -263,7 +263,7 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector) {
 GTEST_TEST(detray_intersection, helix_line_intersector) {
 
     // Intersector object
-    const helix_intersector<line<>, transform3_t> hli;
+    const helix_intersector<straw_tube, transform3_t> hli;
 
     // Get radius of track
     const scalar R{hlx.radius()};
@@ -276,10 +276,10 @@ GTEST_TEST(detray_intersection, helix_line_intersector) {
     const scalar half_z = std::numeric_limits<scalar>::max();
 
     // Straw wire
-    const mask<line<false>> straw_wire{0u, scope, half_z};
+    const mask<straw_tube> straw_wire{0u, scope, half_z};
 
     // Cell wire
-    const mask<line<true>> cell_wire{0u, scope, half_z};
+    const mask<wire_cell> cell_wire{0u, scope, half_z};
 
     // Offset to shift the translation of transform matrix
     const scalar offset = 1.f * unit<scalar>::cm;

--- a/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
@@ -31,7 +31,7 @@ using vector3 = test::vector3;
 using point3 = test::point3;
 using point2 = test::point2;
 using intersection_t = intersection2D<surface_descriptor<>, transform3>;
-using line_intersector_type = ray_intersector<line<>, transform3>;
+using line_intersector_type = ray_intersector<straw_tube, transform3>;
 
 constexpr scalar tol{1e-5f};
 
@@ -50,7 +50,8 @@ GTEST_TEST(detray_intersection, line_intersector_case1) {
                       -1.f);
 
     // Infinite wire with 10 mm radial cell size
-    const mask<line<>> ln{0u, 10.f, std::numeric_limits<scalar>::infinity()};
+    const mask<straw_tube> ln{0u, 10.f,
+                              std::numeric_limits<scalar>::infinity()};
 
     // Test intersect
     std::vector<intersection_t> is(3u);
@@ -106,7 +107,8 @@ GTEST_TEST(detray_intersection, line_intersector_case2) {
 
     // Infinite wire with 10 mm
     // radial cell size
-    const mask<line<>> ln{0u, 10.f, std::numeric_limits<scalar>::infinity()};
+    const mask<straw_tube> ln{0u, 10.f,
+                              std::numeric_limits<scalar>::infinity()};
 
     // Test intersect
     const intersection_t is = line_intersector_type()(
@@ -158,7 +160,7 @@ GTEST_TEST(detray_intersection, line_intersector_square_scope) {
                       -1.f);
 
     // Infinite wire with 1 mm square cell size
-    mask<line<true>, std::uint_least16_t, transform3> ln{
+    mask<wire_cell, std::uint_least16_t, transform3> ln{
         0u, 1.f, std::numeric_limits<scalar>::infinity()};
 
     // Test intersect

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -44,8 +44,8 @@ using rectangle_type = detray::mask<detray::rectangle2D>;
 using trapezoid_type = detray::mask<detray::trapezoid2D>;
 using ring_type = detray::mask<detray::ring2D>;
 using cylinder_type = detray::mask<detray::cylinder2D>;
-using straw_wire_type = detray::mask<detray::line<false>>;
-using cell_wire_type = detray::mask<detray::line<true>>;
+using straw_wire_type = detray::mask<detray::straw_tube>;
+using cell_wire_type = detray::mask<detray::wire_cell>;
 
 constexpr scalar tol{1e-6f};
 

--- a/tests/unit_tests/cpu/utils/bounding_volume.cpp
+++ b/tests/unit_tests/cpu/utils/bounding_volume.cpp
@@ -172,8 +172,8 @@ GTEST_TEST(detray_tools, line2D_aabb) {
     constexpr scalar cell_size{1.f * unit<scalar>::mm};
     constexpr scalar hz{50.f * unit<scalar>::mm};
 
-    const mask<line<>> ln_r{0u, cell_size, hz};
-    const mask<line<true>> ln_sq{0u, cell_size, hz};
+    const mask<straw_tube> ln_r{0u, cell_size, hz};
+    const mask<wire_cell> ln_sq{0u, cell_size, hz};
 
     // Construct local aabb around mask
     axis_aligned_bounding_volume<cuboid3D> aabb_r{ln_r, 0u, envelope};

--- a/tests/unit_tests/svgtools/masks.cpp
+++ b/tests/unit_tests/svgtools/masks.cpp
@@ -86,7 +86,7 @@ GTEST_TEST(svgtools, masks) {
 
     // Visualize a line.
     // e_cross_section, e_half_z
-    detray::mask<detray::line<>> lin2D{0u, 10.f, 100.f};
+    detray::mask<detray::straw_tube> lin2D{0u, 10.f, 100.f};
     const auto lin2D_proto =
         detray::svgtools::conversion::surface(transform, lin2D);
     const auto lin2D_svg = actsvg::display::surface("", lin2D_proto, view);

--- a/utils/include/detray/detectors/create_telescope_detector.hpp
+++ b/utils/include/detray/detectors/create_telescope_detector.hpp
@@ -207,8 +207,8 @@ inline auto create_telescope_detector(
         material_data<scalar>{cfg.mat_thickness(), cfg.module_material()});
 
     using material_id = typename detector_t::materials::id;
-    constexpr bool is_line{std::is_same_v<mask_shape_t, detray::line<true>> ||
-                           std::is_same_v<mask_shape_t, detray::line<false>>};
+    constexpr bool is_line{std::is_same_v<mask_shape_t, detray::wire_cell> ||
+                           std::is_same_v<mask_shape_t, detray::straw_tube>};
     const auto mat_id = is_line ? material_id::e_rod : material_id::e_slab;
 
     auto tel_mat_generator =

--- a/utils/include/detray/detectors/telescope_metadata.hpp
+++ b/utils/include/detray/detectors/telescope_metadata.hpp
@@ -32,8 +32,8 @@ struct telescope_metadata {
     /// Mask types (these types are needed for the portals, which are always
     /// there, and to resolve the wire surface material, i.e. slab vs. rod)
     using rectangle = mask<rectangle2D, nav_link>;
-    using straw_wire = mask<line<false>, nav_link>;
-    using cell_wire = mask<line<true>, nav_link>;
+    using straw_wire = mask<straw_tube, nav_link>;
+    using cell_wire = mask<wire_cell, nav_link>;
 
     /// Material types
     using rod = material_rod<detray::scalar>;


### PR DESCRIPTION
Adds a typedef for the line shapes and add them with a few other missing masks to the benchmark