### PR TITLE
fix: Remove gcc 13 warnings

### DIFF
--- a/core/include/detray/builders/homogeneous_material_factory.hpp
+++ b/core/include/detray/builders/homogeneous_material_factory.hpp
@@ -154,6 +154,8 @@ class homogeneous_material_factory final
     public:
     using scalar_type = typename detector_t::scalar_type;
 
+    using base_factory::operator();
+
     /// Factory with surfaces potentially already filled or empty placeholder
     /// that will not be used.
     DETRAY_HOST

--- a/core/include/detray/builders/material_map_factory.hpp
+++ b/core/include/detray/builders/material_map_factory.hpp
@@ -47,6 +47,8 @@ class material_map_factory final : public factory_decorator<detector_t> {
     using scalar_type = typename detector_t::scalar_type;
     using data_type = material_data<scalar_type>;
 
+    using base_factory::operator();
+
     /// Factory with surfaces potentially already filled or empty placeholder
     /// that will not be used.
     DETRAY_HOST

--- a/tests/unit_tests/cpu/builders/grid_builder.cpp
+++ b/tests/unit_tests/cpu/builders/grid_builder.cpp
@@ -91,8 +91,8 @@ GTEST_TEST(detray_tools, grid_factory_static) {
     const std::vector<scalar> bin_edges_phi{};
 
     auto cyl_gr = gr_factory.template new_grid<cylinder2D>(
-        {0.f, 2.f * constant<scalar>::pi, bin_edges_z.front(),
-         bin_edges_z.back()},
+        std::vector<scalar>{0.f, 2.f * constant<scalar>::pi,
+                            bin_edges_z.front(), bin_edges_z.back()},
         {10u, bin_edges_z.size() - 1}, {}, {bin_edges_phi, bin_edges_z},
         types::list<circular<label::e_rphi>, closed<label::e_cyl_z>>{},
         types::list<regular<>, irregular<>>{});
@@ -229,8 +229,8 @@ GTEST_TEST(detray_tools, grid_factory_dynamic) {
     }
 
     auto cyl_gr = gr_factory.template new_grid<concentric_cylinder2D>(
-        {0.f, 2.f * constant<scalar>::pi, bin_edges_z.front(),
-         bin_edges_z.back()},
+        std::vector<scalar>{0.f, 2.f * constant<scalar>::pi,
+                            bin_edges_z.front(), bin_edges_z.back()},
         {10u, bin_edges_z.size() - 1}, capacities, {bin_edges_phi, bin_edges_z},
         types::list<circular<label::e_rphi>, closed<label::e_cyl_z>>{},
         types::list<regular<>, irregular<>>{});


### PR DESCRIPTION
Removes a few warnings that pop up with gcc 13, except for one that comes from the rms method in utils/statistics.hpp, which seems to go away, if the function is no longer inlined.