### PR TITLE
ref: Make verbosity of detector consistency checker configurable

### DIFF
--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -111,7 +111,7 @@ struct surface_checker {
 /// In case the default metadata is used, the unused containers are allowed to
 /// be empty.
 template <typename detector_t>
-inline void check_empty(const detector_t &det) {
+inline void check_empty(const detector_t &det, const bool verbose) {
 
     // Check if there is at least one portal in the detector
     auto find_portals = [&det]() -> bool {
@@ -158,15 +158,10 @@ inline void check_empty(const detector_t &det) {
 
     // Warnings
 
-    // Check for empty mask collections
-    detail::report_empty(
-        det.mask_store(), "mask store",
-        std::make_index_sequence<detector_t::masks::n_types>{});
-
     // Check the material description
     if (det.material_store().all_empty()) {
         std::cout << "WARNING: No material in detector" << std::endl;
-    } else {
+    } else if (verbose) {
         // Check for empty material collections
         detail::report_empty(
             det.material_store(), "material store",
@@ -174,9 +169,16 @@ inline void check_empty(const detector_t &det) {
     }
 
     // Check for empty acceleration data structure collections (e.g. grids)
-    detail::report_empty(
-        det.accelerator_store(), "acceleration data structures store",
-        std::make_index_sequence<detector_t::accel::n_types>{});
+    if (verbose) {
+        // Check for empty mask collections
+        detail::report_empty(
+            det.mask_store(), "mask store",
+            std::make_index_sequence<detector_t::masks::n_types>{});
+
+        detail::report_empty(
+            det.accelerator_store(), "acceleration data structures store",
+            std::make_index_sequence<detector_t::accel::n_types>{});
+    }
 
     // Check volume search data structure
     if (not find_volumes(det.volume_search_grid())) {
@@ -186,8 +188,9 @@ inline void check_empty(const detector_t &det) {
 
 /// @brief Checks the internal consistency of a detector
 template <typename detector_t>
-inline bool check_consistency(const detector_t &det) {
-    check_empty(det);
+inline bool check_consistency(const detector_t &det,
+                              const bool verbose = false) {
+    check_empty(det, verbose);
 
     std::stringstream err_stream{};
     // Check the volumes

--- a/io/include/detray/io/frontend/detector_reader.hpp
+++ b/io/include/detray/io/frontend/detector_reader.hpp
@@ -70,7 +70,7 @@ auto read_detector(vecmem::memory_resource& resc,
 
     if (cfg.do_check()) {
         // This will throw an exception in case of inconsistencies
-        detray::detail::check_consistency(det);
+        detray::detail::check_consistency(det, cfg.verbose_check());
         std::cout << "Detector check: OK" << std::endl;
     }
 

--- a/io/include/detray/io/frontend/detector_reader_config.hpp
+++ b/io/include/detray/io/frontend/detector_reader_config.hpp
@@ -20,11 +20,14 @@ struct detector_reader_config {
     std::vector<std::string> m_files;
     /// Run detector consistency check after reading
     bool m_do_check{true};
+    /// Verbosity of the detector consistency check
+    bool m_verbose{false};
 
     /// Getters
     /// @{
     const std::vector<std::string>& files() const { return m_files; }
     bool do_check() const { return m_do_check; }
+    bool verbose_check() const { return m_verbose; }
     /// @}
 
     /// Setters
@@ -35,6 +38,13 @@ struct detector_reader_config {
     }
     detector_reader_config& do_check(const bool check) {
         m_do_check = check;
+        return *this;
+    }
+    detector_reader_config& verbose_check(const bool verbose) {
+        if (verbose && !m_do_check) {
+            m_do_check = true;
+        }
+        m_verbose = verbose;
         return *this;
     }
     /// @}

--- a/tests/include/detray/test/detector_consistency.hpp
+++ b/tests/include/detray/test/detector_consistency.hpp
@@ -65,7 +65,8 @@ class consistency_check : public detray::test::fixture_base<> {
         // Build the graph
         volume_graph graph(m_det);
 
-        ASSERT_TRUE(detail::check_consistency(m_det)) << graph.to_string();
+        ASSERT_TRUE(detail::check_consistency(m_det, true))
+            << graph.to_string();
 
         if (m_cfg.write_graph()) {
             std::cout << graph.to_string() << std::endl;

--- a/tests/include/detray/test/toy_detector_test.hpp
+++ b/tests/include/detray/test/toy_detector_test.hpp
@@ -117,7 +117,7 @@ inline bool toy_detector_test(
     EXPECT_EQ(names.at(0u), "toy_detector");
 
     // Test general consistency
-    detail::check_consistency(toy_det);
+    detail::check_consistency(toy_det, true);
 
     geo_context_t ctx{};
     auto& volumes = toy_det.volumes();

--- a/tests/integration_tests/io/io_json_detector_roundtrip.cpp
+++ b/tests/integration_tests/io/io_json_detector_roundtrip.cpp
@@ -90,7 +90,7 @@ auto test_detector_json_io(const detector_t& det,
 
     // Read the detector back in
     io::detector_reader_config reader_cfg{};
-    reader_cfg.do_check(true);
+    reader_cfg.verbose_check(true);
     for (auto& [_, name] : file_names) {
         reader_cfg.add_file(name);
     }

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -55,6 +55,8 @@ struct prop_state {
     scalar mask_tolerance() const { return 15.f * unit<scalar>::um; }
 };
 
+static constexpr bool verbose_check = true;
+
 }  // anonymous namespace
 
 }  // namespace detray
@@ -117,7 +119,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     EXPECT_EQ(z_tel_names1.at(1u), "telescope_world_0");
 
     // Check general consistency of the detector
-    detail::check_consistency(z_tel_det1);
+    detail::check_consistency(z_tel_det1, verbose_check);
 
     // Build the same telescope detector with rectangular planes and given
     // length/number of surfaces
@@ -126,7 +128,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         create_telescope_detector(host_mr, tel_cfg);
 
     // Check general consistency of the detector
-    detail::check_consistency(z_tel_det2);
+    detail::check_consistency(z_tel_det2, verbose_check);
 
     // Compare
     for (std::size_t i{0u}; i < z_tel_det1.surfaces().size(); ++i) {
@@ -150,7 +152,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         create_telescope_detector(host_mr, tel_cfg.pilot_track(x_track));
 
     // Check general consistency of the detector
-    detail::check_consistency(x_tel_det);
+    detail::check_consistency(x_tel_det, verbose_check);
 
     //
     // test propagation in all telescope detector instances
@@ -252,7 +254,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         create_telescope_detector(host_mr, htel_cfg);
 
     // Check general consistency of the detector
-    detail::check_consistency(tel_detector);
+    detail::check_consistency(tel_detector, verbose_check);
 
     // make at least sure it is navigatable
     navigator<decltype(tel_detector), inspector_t> tel_navigator;

--- a/tests/unit_tests/cpu/detectors/wire_chamber.cpp
+++ b/tests/unit_tests/cpu/detectors/wire_chamber.cpp
@@ -25,5 +25,5 @@ GTEST_TEST(detray_detectors, wire_chamber) {
         create_wire_chamber(host_mr, wire_chamber_config{});
 
     // Check general consistency of the detector
-    detail::check_consistency(wire_det);
+    detail::check_consistency(wire_det, true);
 }


### PR DESCRIPTION
Make verbosity of detector consistency checker configurable. Default is "not verbose"