### PR TITLE
ref: Reactivate volume material types and add material consistency checks

### DIFF
--- a/core/include/detray/builders/volume_builder.hpp
+++ b/core/include/detray/builders/volume_builder.hpp
@@ -45,6 +45,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
         : m_has_accel{false}, m_volume{id} {
 
         m_volume.set_index(idx);
+        m_volume.set_material(volume_type::material_id::e_none, 0u);
 
         // The first acceleration data structure in every volume is a brute
         // force method that will at least contain the portals

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -110,7 +110,8 @@ class detector {
 
     /// Volume type
     using geo_obj_ids = typename metadata::geo_objects;
-    using volume_type = volume_descriptor<geo_obj_ids, scalar_type, accel_link>;
+    using volume_type =
+        volume_descriptor<geo_obj_ids, scalar_type, accel_link, material_link>;
     using volume_container = vector_type<volume_type>;
 
     /// Volume finder definition: Make volume index available from track

--- a/core/include/detray/core/detector_metadata.hpp
+++ b/core/include/detray/core/detector_metadata.hpp
@@ -196,27 +196,29 @@ unbounded_cell, unmasked_plane*/>;
         e_cell_wire_map = 5u,
         e_straw_wire_map = 5u,
         // Volume material
-        // e_cuboid3_map = 6u,
-        // e_cylinder3_map = 7u,
+        e_cuboid3_map = 7,
+        e_cylinder3_map = 8u,
         // Homogeneous mapetrial
         e_slab = 4u,
         e_rod = 5u,
-        e_none = 5u,
+        e_raw_material = 6u,
+        e_none = 9u,
     };
 
     /// How to store materials
     template <template <typename...> class tuple_t = dtuple,
               typename container_t = host_container_types>
-    using material_store =
-        multi_store<material_ids, empty_context, tuple_t,
-                    grid_collection<disc_map_t<container_t>>,
-                    grid_collection<concentric_cylinder2_map_t<container_t>>,
-                    grid_collection<cylinder2_map_t<container_t>>,
-                    grid_collection<rectangular_map_t<container_t>>,
-                    /*grid_collection<cuboid_map_t<container_t>>,
-                    grid_collection<cylinder3_map_t<container_t>>,*/
-                    typename container_t::template vector_type<slab>,
-                    typename container_t::template vector_type<rod>>;
+    using material_store = multi_store<
+        material_ids, empty_context, tuple_t,
+        grid_collection<disc_map_t<container_t>>,
+        grid_collection<concentric_cylinder2_map_t<container_t>>,
+        grid_collection<cylinder2_map_t<container_t>>,
+        grid_collection<rectangular_map_t<container_t>>,
+        typename container_t::template vector_type<slab>,
+        typename container_t::template vector_type<rod>,
+        typename container_t::template vector_type<material<detray::scalar>>,
+        grid_collection<cuboid_map_t<container_t>>,
+        grid_collection<cylinder3_map_t<container_t>>>;
 
     /// How to link to the entries in the data stores
     using transform_link = typename transform_store<>::link_type;

--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/materials/detail/material_accessor.hpp"
 #include "detray/tracks/tracks.hpp"
 
 // System include(s)
@@ -37,16 +38,6 @@ struct surface_kernels {
         typename matrix_operator::template matrix_type<ROWS, COLS>;
     using free_matrix = matrix_type<e_free_size, e_free_size>;
 
-    /// A functor to retrieve the masks volume link
-    struct get_volume_link {
-        template <typename mask_group_t, typename index_t>
-        DETRAY_HOST_DEVICE inline auto operator()(
-            const mask_group_t& mask_group, const index_t& index) const {
-
-            return mask_group[index].volume_link();
-        }
-    };
-
     /// A functor to retrieve the masks shape name
     struct get_shape_name {
         template <typename mask_group_t, typename index_t>
@@ -65,6 +56,28 @@ struct surface_kernels {
             std::ostream& os) const {
 
             return mask_group.at(index).self_check(os);
+        }
+    };
+
+    /// A functor to retrieve the masks volume link
+    struct get_volume_link {
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline auto operator()(
+            const mask_group_t& mask_group, const index_t& index) const {
+
+            return mask_group[index].volume_link();
+        }
+    };
+
+    /// A functor to retrieve the material parameters
+    struct get_material_params {
+        template <typename mat_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline auto operator()(const mat_group_t& mat_group,
+                                                  const index_t& idx,
+                                                  const point2& loc_p) const {
+
+            return detail::material_accessor::get(mat_group, idx, loc_p)
+                .get_maerial();
         }
     };
 

--- a/core/include/detray/materials/detail/material_accessor.hpp
+++ b/core/include/detray/materials/detail/material_accessor.hpp
@@ -1,0 +1,50 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/utils/type_traits.hpp"
+
+namespace detray::detail {
+
+/// @brief Access a single unit of material in different types of material
+/// description
+namespace material_accessor {
+
+/// Access to material slabs or rods in a homogeneous material
+/// description and to raw material in a homogeneous volume material
+/// description
+template <class material_coll_t, typename point_t = void,
+          std::enable_if_t<
+              detail::is_hom_material_v<typename material_coll_t::value_type>,
+              bool> = true>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    const material_coll_t &material_coll, const dindex idx,
+    const point_t &) noexcept {
+
+    return material_coll[idx];
+}
+
+/// Access to material slabs in a material map or volume material
+template <
+    class material_coll_t,
+    std::enable_if_t<detail::is_grid_v<typename material_coll_t::value_type>,
+                     bool> = true>
+DETRAY_HOST_DEVICE inline constexpr decltype(auto) get(
+    const material_coll_t &material_coll, const dindex idx,
+    const typename material_coll_t::value_type::point_type
+        &loc_point) noexcept {
+
+    // Find the material slab (only one entry per bin)
+    return *(material_coll[idx].search(loc_point));
+}
+
+}  // namespace material_accessor
+
+}  // namespace detray::detail

--- a/core/include/detray/materials/material.hpp
+++ b/core/include/detray/materials/material.hpp
@@ -13,19 +13,13 @@
 #include "detray/definitions/units.hpp"
 #include "detray/materials/detail/density_effect_data.hpp"
 #include "detray/utils/invalid_values.hpp"
+#include "detray/utils/type_traits.hpp"
 
 // System include(s)
 #include <ratio>
 #include <sstream>
 
 namespace detray {
-
-namespace detail {
-
-/// Tag a class as 'homogeneous material', i.e. a material slab or rod.
-struct homogeneous_material_tag {};
-
-}  // namespace detail
 
 /// Material State
 enum class material_state {
@@ -149,6 +143,10 @@ struct material {
     DETRAY_HOST
     std::string to_string() const {
         std::stringstream strm;
+        /*if (0.f < m_ar) {
+            strm << "vacuum";
+            return strm.str();
+        }*/
         strm << "material: ";
         strm << " X0: " << m_x0;
         strm << " | L0: " << m_l0;
@@ -211,6 +209,14 @@ struct material {
     detail::density_effect_data<scalar_type> m_density = {};
     bool m_has_density_effect_data = false;
 };
+
+namespace detail {
+
+// Pick the raw material type up for homogeneous volume material
+template <typename scalar_t>
+struct is_hom_material<material<scalar_t>, void> : public std::true_type {};
+
+}  // namespace detail
 
 // Macro for declaring the predefined materials (w/o Density effect data)
 #define DETRAY_DECLARE_MATERIAL(MATERIAL_NAME, X0, L0, Ar, Z, Rho, State)   \

--- a/core/include/detray/materials/material_map.hpp
+++ b/core/include/detray/materials/material_map.hpp
@@ -16,6 +16,9 @@
 #include "detray/utils/grid/grid.hpp"
 #include "detray/utils/grid/serializers.hpp"
 
+// System include(s)
+#include <type_traits>
+
 namespace detray {
 
 /// Definition of binned material
@@ -29,5 +32,33 @@ using material_map = grid<axes<shape>, bins::single<material_slab<scalar_t>>,
 template <typename scalar_t = detray::scalar>
 using material_grid_factory =
     grid_factory<bins::single<material_slab<scalar_t>>, simple_serializer>;
+
+namespace detail {
+
+// TODO: Define concepts
+
+template <class material_t>
+struct is_material_map<
+    material_t,
+    std::enable_if_t<
+        is_grid_v<material_t> &&
+            std::is_same_v<
+                typename material_t::value_type,
+                material_slab<typename material_t::value_type::scalar_type>> &&
+            (material_t::dim == 2),
+        void>> : public std::true_type {};
+
+template <class material_t>
+struct is_volume_material<
+    material_t,
+    std::enable_if_t<
+        is_grid_v<material_t> &&
+            std::is_same_v<
+                typename material_t::value_type,
+                material_slab<typename material_t::value_type::scalar_type>> &&
+            (material_t::dim == 3),
+        void>> : public std::true_type {};
+
+}  // namespace detail
 
 }  // namespace detray

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -21,7 +21,7 @@ namespace detray {
 
 // Rod structure to be mapped on the line mask
 template <typename scalar_t>
-struct material_rod : public detail::homogeneous_material_tag {
+struct material_rod {
     using scalar_type = scalar_t;
     using material_type = material<scalar_t>;
 
@@ -115,5 +115,13 @@ struct material_rod : public detail::homogeneous_material_tag {
     scalar_type m_radius_in_X0 = std::numeric_limits<scalar>::epsilon();
     scalar_type m_radius_in_L0 = std::numeric_limits<scalar>::epsilon();
 };
+
+namespace detail {
+
+// Used directly for homogeneous line-surface material
+template <typename scalar_t>
+struct is_hom_material<material_rod<scalar_t>, void> : public std::true_type {};
+
+}  // namespace detail
 
 }  // namespace detray

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -20,7 +20,7 @@ namespace detray {
 
 // Slab structure to be mapped on the mask (plane, cylinder)
 template <typename scalar_t>
-struct material_slab : public detail::homogeneous_material_tag {
+struct material_slab {
     using scalar_type = scalar_t;
     using material_type = material<scalar_t>;
 
@@ -49,8 +49,10 @@ struct material_slab : public detail::homogeneous_material_tag {
     DETRAY_HOST_DEVICE
     constexpr explicit operator bool() const {
         if (m_thickness <= std::numeric_limits<scalar_type>::epsilon() ||
-            m_material == vacuum<scalar_type>() || m_material.Z() == 0.f ||
-            m_material.mass_density() == 0.f) {
+            m_thickness == std::numeric_limits<scalar_type>::max() ||
+            m_material == vacuum<scalar_type>() ||
+            m_material.mass_density() == 0.f ||
+            m_material.molar_density() == 0.f) {
             return false;
         }
         return true;
@@ -110,5 +112,14 @@ struct material_slab : public detail::homogeneous_material_tag {
     scalar_type m_thickness_in_X0 = std::numeric_limits<scalar>::epsilon();
     scalar_type m_thickness_in_L0 = std::numeric_limits<scalar>::epsilon();
 };
+
+namespace detail {
+
+// Used directly for homogeneous surface material
+template <class scalar_t>
+struct is_hom_material<material_slab<scalar_t>, void> : public std::true_type {
+};
+
+}  // namespace detail
 
 }  // namespace detray

--- a/core/include/detray/materials/predefined_materials.hpp
+++ b/core/include/detray/materials/predefined_materials.hpp
@@ -29,7 +29,7 @@ namespace detray {
 // Vacuum
 DETRAY_DECLARE_MATERIAL(vacuum, std::numeric_limits<scalar>::max(),
                         std::numeric_limits<scalar>::max(), 0.f, 0.f, 0.f,
-                        material_state::e_gas);
+                        material_state::e_unknown);
 
 // H₂ (1): Hydrogen Gas
 DETRAY_DECLARE_MATERIAL(hydrogen_gas, 7.526E3f * unit<scalar>::m,

--- a/core/include/detray/navigation/accelerators/surface_grid.hpp
+++ b/core/include/detray/navigation/accelerators/surface_grid.hpp
@@ -8,8 +8,29 @@
 #pragma once
 
 // Project include(s)
+#include "detray/geometry/detail/surface_descriptor.hpp"
 #include "detray/utils/grid/detail/axis_helpers.hpp"
 #include "detray/utils/grid/detail/grid_bins.hpp"
 #include "detray/utils/grid/grid.hpp"
 #include "detray/utils/grid/grid_collection.hpp"
 #include "detray/utils/type_traits.hpp"
+
+namespace detray::detail {
+
+// TODO: Define concepts
+
+template <class accelerator_t>
+struct is_surface_grid<
+    accelerator_t,
+    std::enable_if_t<
+        is_grid_v<accelerator_t> &&
+            std::is_same_v<
+                typename accelerator_t::value_type,
+                surface_descriptor<
+                    typename accelerator_t::value_type::mask_link,
+                    typename accelerator_t::value_type::material_link,
+                    typename accelerator_t::value_type::transform_link,
+                    typename accelerator_t::value_type::navigation_link>>,
+        void>> : public std::true_type {};
+
+}  // namespace detray::detail

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -328,8 +328,8 @@ class navigator {
 
         /// Helper method to check the track has encountered material
         DETRAY_HOST_DEVICE
-        inline auto encountered_material() const -> bool {
-            return (is_on_module() or is_on_portal()) and
+        inline auto encountered_sf_material() const -> bool {
+            return (is_on_module() || is_on_portal()) &&
                    (current()->sf_desc.material().id() !=
                     detector_t::materials::id::e_none);
         }

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -143,6 +143,7 @@ class base_stepper {
 
         /// The particle mass
         scalar_type _mass{105.7f * unit<scalar_type>::MeV};
+
         /// The particle pdg
         int _pdg = 13;  // default muon
 

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -91,7 +91,7 @@ class rk_stepper final
         const magnetic_field_t _magnetic_field;
 
         /// Material that track is passing through. Usually a volume material
-        detray::material<scalar_type> _mat = detray::vacuum<scalar_type>();
+        const detray::material<scalar_type>* _mat{nullptr};
 
         /// Update the track state by Runge-Kutta-Nystrom integration.
         DETRAY_HOST_DEVICE
@@ -117,7 +117,7 @@ class rk_stepper final
                                      const scalar_type qop);
 
         DETRAY_HOST_DEVICE
-        inline matrix_type<3, 3> evaluate_field_gradient(const vector3& pos);
+        inline matrix_type<3, 3> evaluate_field_gradient(const point3& pos);
 
         /// Evaluate dtds, where t is the unit tangential direction
         DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/type_traits.hpp
+++ b/core/include/detray/utils/type_traits.hpp
@@ -136,4 +136,28 @@ struct is_grid : public std::false_type {};
 template <typename T>
 inline constexpr bool is_grid_v = is_grid<T>::value;
 
+template <class accelerator_t, typename = void>
+struct is_surface_grid : public std::false_type {};
+
+template <typename T>
+inline constexpr bool is_surface_grid_v = is_surface_grid<T>::value;
+
+template <class material_t, typename = void>
+struct is_hom_material : public std::false_type {};
+
+template <typename T>
+inline constexpr bool is_hom_material_v = is_hom_material<T>::value;
+
+template <class material_t, typename = void>
+struct is_material_map : public std::false_type {};
+
+template <typename T>
+inline constexpr bool is_material_map_v = is_material_map<T>::value;
+
+template <class material_t, typename = void>
+struct is_volume_material : public std::false_type {};
+
+template <typename T>
+inline constexpr bool is_volume_material_v = is_volume_material<T>::value;
+
 }  // namespace detray::detail

--- a/io/include/detray/io/frontend/definitions.hpp
+++ b/io/include/detray/io/frontend/definitions.hpp
@@ -49,7 +49,8 @@ enum class material_id : unsigned int {
     // Homogeneous materials
     slab = 6u,
     rod = 7u,
-    n_mats = 8u,
+    raw_material = 8u,
+    n_mats = 9u,
     unknown = n_mats
 };
 

--- a/tests/integration_tests/io/io_json_detector_roundtrip.cpp
+++ b/tests/integration_tests/io/io_json_detector_roundtrip.cpp
@@ -166,7 +166,7 @@ GTEST_TEST(io, json_telescope_detector_reader) {
         mat_store.get<decltype(tel_det)::materials::id::e_slab>();
 
     EXPECT_EQ(det_io.volumes().size(), 1u);
-    EXPECT_EQ(slabs.size(), positions.size() + 6u);
+    EXPECT_EQ(slabs.size(), positions.size());
 }
 
 /// Test the reading and writing of a toy detector geometry

--- a/utils/include/detray/detectors/create_toy_geometry.hpp
+++ b/utils/include/detray/detectors/create_toy_geometry.hpp
@@ -612,6 +612,7 @@ inline void add_beampipe(
     typename detector_t::transform_container transforms(resource);
 
     auto &beampipe = det.new_volume(volume_id::e_cylinder);
+    beampipe.set_material(detector_t::volume_type::material_id::e_none, 0u);
     const auto beampipe_idx = beampipe.index();
     names[beampipe_idx + 1u] = "beampipe_" + std::to_string(beampipe_idx);
     beampipe.set_transform(det.transform_store().size());
@@ -752,6 +753,8 @@ inline void add_endcap_barrel_connection(
     auto &connector_gap = det.new_volume(
         volume_id::e_cylinder,
         {detector_t::accel::id::e_default, detail::invalid_value<dindex>()});
+    connector_gap.set_material(detector_t::volume_type::material_id::e_none,
+                               0u);
     dindex connector_gap_idx{det.volumes().back().index()};
     names[connector_gap_idx + 1u] =
         "connector_gap_" + std::to_string(connector_gap_idx);

--- a/utils/include/detray/detectors/detector_helper.hpp
+++ b/utils/include/detray/detectors/detector_helper.hpp
@@ -206,6 +206,8 @@ struct detector_helper {
 
         auto &cyl_volume = det.new_volume(
             volume_id::e_cylinder, {detector_t::accel::id::e_default, 0u});
+        cyl_volume.set_material(detector_t::volume_type::material_id::e_none,
+                                0u);
 
         // volume placement
         cyl_volume.set_transform(det.transform_store().size());
@@ -307,12 +309,15 @@ struct detector_helper {
             sf.material() = material_link_type{
                 map_id, materials.template size<map_id>() - 1u};
         } else {
-            materials.template emplace_back<material_id::e_slab>(
-                {}, cfg.mapped_material(), cfg.thickness());
+            const auto &mat = cfg.mapped_material();
+            if (!(mat == vacuum<scalar>())) {
+                materials.template emplace_back<material_id::e_slab>(
+                    {}, mat, cfg.thickness());
 
-            sf.material() = material_link_type{
-                material_id::e_slab,
-                materials.template size<material_id::e_slab>() - 1u};
+                sf.material() = material_link_type{
+                    material_id::e_slab,
+                    materials.template size<material_id::e_slab>() - 1u};
+            }
         }
     }
 };

--- a/utils/include/detray/detectors/telescope_metadata.hpp
+++ b/utils/include/detray/detectors/telescope_metadata.hpp
@@ -80,9 +80,10 @@ struct telescope_metadata {
 
     /// Material type ids
     enum class material_ids : std::uint8_t {
-        e_slab = 0,
-        e_rod = 1,
-        e_none = 2,
+        e_slab = 0u,
+        e_raw_material = 1u,  //< used for homogeneous volume material
+        e_rod = 2u,
+        e_none = 3u,
     };
 
     /// How to store materials
@@ -92,9 +93,11 @@ struct telescope_metadata {
         std::is_same_v<mask<mask_shape_t, nav_link>, cell_wire> |
             std::is_same_v<mask<mask_shape_t, nav_link>, straw_wire>,
         regular_multi_store<material_ids, empty_context, tuple_t,
-                            container_t::template vector_type, slab, rod>,
+                            container_t::template vector_type, slab,
+                            material<detray::scalar>, rod>,
         regular_multi_store<material_ids, empty_context, tuple_t,
-                            container_t::template vector_type, slab>>;
+                            container_t::template vector_type, slab,
+                            material<detray::scalar>>>;
 
     /// How to link to the entries in the data stores
     using transform_link = typename transform_store<>::link_type;


### PR DESCRIPTION
In order to finalize the material file format, reactivate the volume material. All volume material is now properly put into the material store and referenced through the volume descriptor. In order to access the different types of materials, a ```material_accessor``` was added. Also adds full material consistency checks in the detector IO.