### PR TITLE
feat: Add homogeneous volume material builder

### DIFF
--- a/core/include/detray/builders/detector_builder.hpp
+++ b/core/include/detray/builders/detector_builder.hpp
@@ -63,13 +63,22 @@ class detector_builder {
     /// Decorate a volume builder at position @param volume_idx with more
     /// functionality
     template <class builder_t>
-    DETRAY_HOST auto decorate(dindex volume_idx)
-        -> volume_builder_interface<detector_type>* {
+    DETRAY_HOST auto decorate(dindex volume_idx) -> builder_t* {
 
         m_volumes[volume_idx] =
             std::make_unique<builder_t>(std::move(m_volumes[volume_idx]));
 
-        return m_volumes[volume_idx].get();
+        // Always works, we set it as this type in the line above
+        return dynamic_cast<builder_t*>(m_volumes[volume_idx].get());
+    }
+
+    /// Decorate a volume builder @param v_builder with more functionality
+    template <class builder_t>
+    DETRAY_HOST auto decorate(
+        const volume_builder_interface<detector_type>* v_builder)
+        -> builder_t* {
+
+        return decorate<builder_t>(v_builder->vol_index());
     }
 
     /// Access a particular volume builder by volume index @param volume_idx

--- a/core/include/detray/builders/homogeneous_volume_material_builder.hpp
+++ b/core/include/detray/builders/homogeneous_volume_material_builder.hpp
@@ -1,0 +1,82 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "detray/builders/volume_builder.hpp"
+#include "detray/builders/volume_builder_interface.hpp"
+#include "detray/materials/material.hpp"
+#include "detray/materials/predefined_materials.hpp"
+
+// System include(s)
+#include <iostream>
+#include <map>
+#include <memory>
+
+namespace detray {
+
+/// @brief Build a volume with homogeneous volume material.
+///
+/// Decorator class to a volume builder that adds the material data to the
+/// volume while building the volume.
+template <typename detector_t>
+class homogeneous_volume_material_builder final
+    : public volume_decorator<detector_t> {
+
+    public:
+    using scalar_type = typename detector_t::scalar_type;
+
+    /// @param vol_builder volume builder that should be decorated with volume
+    /// material
+    DETRAY_HOST
+    homogeneous_volume_material_builder(
+        std::unique_ptr<volume_builder_interface<detector_t>> vol_builder)
+        : volume_decorator<detector_t>(std::move(vol_builder)) {}
+
+    /// Add all necessary compontents for the volume material
+    ///
+    /// @param mat the material parameters
+    DETRAY_HOST
+    void set_material(material<scalar_type> mat) { m_volume_material = mat; }
+
+    /// Add the volume and the material to the detector @param det
+    DETRAY_HOST
+    auto build(detector_t &det, typename detector_t::geometry_context ctx = {})
+        -> typename detector_t::volume_type * override {
+
+        // Call the underlying volume builder(s)
+        typename detector_t::volume_type *vol =
+            volume_decorator<detector_t>::build(det, ctx);
+
+        // Nothing left to do
+        if (m_volume_material == detray::vacuum<scalar_type>{}) {
+            std::cout << "WARNING: Volume " << this->vol_index()
+                      << " has vacuum material";
+
+            return vol;
+        }
+
+        constexpr auto material_id{detector_t::materials::id::e_raw_material};
+
+        // Update the volume material link
+        dindex coll_size{det.material_store().template size<material_id>()};
+        vol->set_material(material_id, coll_size);
+
+        // Append the material
+        det.material_store().template push_back<material_id>(m_volume_material);
+
+        // Give the volume to the next decorator
+        return vol;
+    }
+
+    protected:
+    // Material for this volume
+    material<scalar_type> m_volume_material{};
+};
+
+}  // namespace detray

--- a/core/include/detray/builders/volume_builder.hpp
+++ b/core/include/detray/builders/volume_builder.hpp
@@ -62,7 +62,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
 
     /// @returns the volume index in the detector volume container
     DETRAY_HOST
-    auto vol_index() -> dindex override { return m_volume.index(); }
+    auto vol_index() const -> dindex override { return m_volume.index(); }
 
     /// Toggles whether sensitive surfaces are added to the brute force method
     DETRAY_HOST

--- a/core/include/detray/builders/volume_builder_interface.hpp
+++ b/core/include/detray/builders/volume_builder_interface.hpp
@@ -38,7 +38,7 @@ class volume_builder_interface {
     /// @returns the global index for the volume
     /// @note the correct index is only available after calling @c init_vol
     DETRAY_HOST
-    virtual auto vol_index() -> dindex = 0;
+    virtual auto vol_index() const -> dindex = 0;
 
     /// Toggles whether sensitive surfaces are added to the brute force method
     DETRAY_HOST
@@ -125,7 +125,7 @@ class volume_decorator : public volume_builder_interface<detector_t> {
     }
 
     DETRAY_HOST
-    auto vol_index() -> dindex override { return m_builder->vol_index(); }
+    auto vol_index() const -> dindex override { return m_builder->vol_index(); }
 
     DETRAY_HOST
     void has_accel(bool toggle) override { m_builder->has_accel(toggle); };

--- a/core/include/detray/materials/material.hpp
+++ b/core/include/detray/materials/material.hpp
@@ -79,6 +79,14 @@ struct material {
                 m_z == rhs.Z());
     }
 
+    /// Equality operator
+    ///
+    /// @param rhs is the right hand side to be compared to
+    DETRAY_HOST_DEVICE
+    constexpr bool operator!=(const material<scalar_t> &rhs) const {
+        return !(*this == rhs);
+    }
+
     /// @returns the radition length. Infinity in case of vacuum.
     DETRAY_HOST_DEVICE
     constexpr scalar_type X0() const { return m_x0; }
@@ -143,10 +151,10 @@ struct material {
     DETRAY_HOST
     std::string to_string() const {
         std::stringstream strm;
-        /*if (0.f < m_ar) {
+        if (m_ar <= 0.f) {
             strm << "vacuum";
             return strm.str();
-        }*/
+        }
         strm << "material: ";
         strm << " X0: " << m_x0;
         strm << " | L0: " << m_l0;

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -93,6 +93,13 @@ class rk_stepper final
         /// Material that track is passing through. Usually a volume material
         const detray::material<scalar_type>* _mat{nullptr};
 
+        /// Access the current volume material
+        DETRAY_HOST_DEVICE
+        const auto& volume_material() const {
+            assert(_mat != nullptr);
+            return *_mat;
+        }
+
         /// Update the track state by Runge-Kutta-Nystrom integration.
         DETRAY_HOST_DEVICE
         inline void advance_track();

--- a/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
@@ -7,7 +7,7 @@
 
 // Project include(s)
 #include "detray/definitions/units.hpp"
-#include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/test/detail/register_checks.hpp"
 #include "detray/test/detector_consistency.hpp"
 #include "detray/test/detector_helix_scan.hpp"
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
     vecmem::host_memory_resource host_mr;
 
     const auto [tel_det, tel_names] =
-        create_telescope_detector(host_mr, tel_cfg);
+        build_telescope_detector(host_mr, tel_cfg);
 
     // General data consistency of the detector
     consistency_check<tel_detector_t>::config cfg_cons{};

--- a/tests/integration_tests/cpu/material/material_interaction.cpp
+++ b/tests/integration_tests/cpu/material/material_interaction.cpp
@@ -9,7 +9,7 @@
 #include "detray/definitions/pdg_particle.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes/unbounded.hpp"
 #include "detray/materials/interaction.hpp"
@@ -61,7 +61,7 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
         .module_material(mat)
         .mat_thickness(thickness);
 
-    const auto [det, names] = create_telescope_detector(host_mr, tel_cfg);
+    const auto [det, names] = build_telescope_detector(host_mr, tel_cfg);
 
     using navigator_t = navigator<decltype(det)>;
     using stepper_t = line_stepper<transform3>;
@@ -240,7 +240,7 @@ GTEST_TEST(detray_material, telescope_geometry_scattering_angle) {
         .module_material(mat)
         .mat_thickness(thickness);
 
-    const auto [det, names] = create_telescope_detector(host_mr, tel_cfg);
+    const auto [det, names] = build_telescope_detector(host_mr, tel_cfg);
 
     using navigator_t = navigator<decltype(det)>;
     using stepper_t = line_stepper<transform3>;
@@ -379,7 +379,7 @@ GTEST_TEST(detray_material, telescope_geometry_volume_material) {
 
     for (const auto& mat : vol_mats) {
         tel_cfg.volume_material(mat);
-        const auto [det, names] = create_telescope_detector(host_mr, tel_cfg);
+        const auto [det, names] = build_telescope_detector(host_mr, tel_cfg);
 
         using navigator_t = navigator<decltype(det)>;
         using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;

--- a/tests/integration_tests/cpu/propagator/guided_navigator.cpp
+++ b/tests/integration_tests/cpu/propagator/guided_navigator.cpp
@@ -7,7 +7,7 @@
 
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes/unbounded.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -46,7 +46,7 @@ GTEST_TEST(detray_navigation, guided_navigator) {
     tel_cfg.positions(positions).envelope(0.2f * unit<scalar>::mm);
 
     const auto [telescope_det, names] =
-        create_telescope_detector(host_mr, tel_cfg);
+        build_telescope_detector(host_mr, tel_cfg);
 
     // Inspectors are optional, of course
     using detector_t = decltype(telescope_det);

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -8,7 +8,7 @@
 // Project include(s)
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/navigation/intersection/helix_intersector.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/actors/parameter_resetter.hpp"
@@ -1657,8 +1657,9 @@ int main(int argc, char** argv) {
         }
         auto gammaF = rand_gamma(mt1);
 
+        // Without volume material
         auto [rect_det, rect_names] =
-            create_telescope_detector(host_mr, rectangle_cfg);
+            build_telescope_detector(host_mr, rectangle_cfg);
         const auto [euler_rect_initial, shift_rect_initial] =
             tilt_surface<decltype(rect_det),
                          decltype(rect_det)::masks::id::e_rectangle2>(
@@ -1672,7 +1673,7 @@ int main(int argc, char** argv) {
         // With volume material
         rectangle_cfg.volume_material(volume_mat);
         auto [rect_det_w_mat, rect_names2] =
-            create_telescope_detector(host_mr, rectangle_cfg);
+            build_telescope_detector(host_mr, rectangle_cfg);
         [[maybe_unused]] const auto [euler_rect_initial2, shift_rect_initial2] =
             tilt_surface<decltype(rect_det_w_mat),
                          decltype(rect_det_w_mat)::masks::id::e_rectangle2>(
@@ -1693,7 +1694,7 @@ int main(int argc, char** argv) {
 
         // Without volume material
         auto [wire_det, wire_names] =
-            create_telescope_detector(host_mr, wire_cfg);
+            build_telescope_detector(host_mr, wire_cfg);
         const auto [euler_wire_initial, shift_wire_initial] =
             tilt_surface<decltype(wire_det),
                          decltype(wire_det)::masks::id::e_drift_cell>(
@@ -1707,7 +1708,7 @@ int main(int argc, char** argv) {
         // With volume material
         wire_cfg.volume_material(volume_mat);
         auto [wire_det_w_mat, wire_names2] =
-            create_telescope_detector(host_mr, wire_cfg);
+            build_telescope_detector(host_mr, wire_cfg);
         [[maybe_unused]] const auto [euler_wire_initial2, shift_wire_initial2] =
             tilt_surface<decltype(wire_det_w_mat),
                          decltype(wire_det_w_mat)::masks::id::e_drift_cell>(

--- a/tests/integration_tests/io/io_json_detector_roundtrip.cpp
+++ b/tests/integration_tests/io/io_json_detector_roundtrip.cpp
@@ -7,7 +7,7 @@
 
 // Project include(s)
 #include "detray/definitions/detail/algebra.hpp"
-#include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
 #include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/io/common/geometry_reader.hpp"
@@ -151,7 +151,7 @@ GTEST_TEST(io, json_telescope_detector_reader) {
 
     // Telescope detector
     vecmem::host_memory_resource host_mr;
-    auto [tel_det, tel_names] = create_telescope_detector(host_mr, tel_cfg);
+    auto [tel_det, tel_names] = build_telescope_detector(host_mr, tel_cfg);
 
     std::map<std::string, std::string> file_names;
     file_names["geometry"] = "telescope_detector_geometry.json";

--- a/tests/tools/src/generate_telescope_detector.cpp
+++ b/tests/tools/src/generate_telescope_detector.cpp
@@ -7,7 +7,7 @@
 
 // Project include(s)
 #include "detray/definitions/units.hpp"
-#include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes.hpp"
 #include "detray/io/frontend/detector_writer.hpp"
@@ -53,7 +53,7 @@ void write_telecope(const po::variables_map &vm,
 
     // Build the detector
     vecmem::host_memory_resource host_mr;
-    auto [tel_det, tel_names] = create_telescope_detector(host_mr, tel_cfg);
+    auto [tel_det, tel_names] = build_telescope_detector(host_mr, tel_cfg);
 
     // Write to file
     detray::io::write_detector(tel_det, tel_names, writer_cfg);

--- a/tests/unit_tests/cpu/CMakeLists.txt
+++ b/tests/unit_tests/cpu/CMakeLists.txt
@@ -31,6 +31,7 @@ macro( detray_add_cpu_test algebra )
       "coordinates/polar2.cpp"
       "builders/detector_builder.cpp"
       "builders/grid_builder.cpp"
+      "builders/homogeneous_volume_material_builder.cpp"
       "builders/homogeneous_material_builder.cpp"
       "builders/material_map_builder.cpp"
       "builders/volume_builder.cpp"

--- a/tests/unit_tests/cpu/builders/homogeneous_material_builder.cpp
+++ b/tests/unit_tests/cpu/builders/homogeneous_material_builder.cpp
@@ -9,7 +9,6 @@
 #include "detray/builders/homogeneous_material_builder.hpp"
 
 #include "detray/builders/cuboid_portal_generator.hpp"
-#include "detray/builders/detector_builder.hpp"
 #include "detray/builders/homogeneous_material_factory.hpp"
 #include "detray/builders/surface_factory.hpp"
 #include "detray/builders/volume_builder.hpp"

--- a/tests/unit_tests/cpu/builders/homogeneous_volume_material_builder.cpp
+++ b/tests/unit_tests/cpu/builders/homogeneous_volume_material_builder.cpp
@@ -1,0 +1,59 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Detray include(s)
+#include "detray/builders/homogeneous_volume_material_builder.hpp"
+
+#include "detray/core/detector.hpp"
+#include "detray/definitions/detail/indexing.hpp"
+#include "detray/materials/predefined_materials.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// GTest include(s)
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <limits>
+#include <memory>
+#include <vector>
+
+using namespace detray;
+
+/// Unittest: Test the construction of a collection of materials
+TEST(detray_tools, homogeneous_volume_material_builder) {
+
+    using detector_t = detector<>;
+
+    constexpr auto material_id{detector_t::materials::id::e_raw_material};
+
+    vecmem::host_memory_resource host_mr;
+    detector_t d(host_mr);
+
+    EXPECT_TRUE(d.material_store().template empty<material_id>());
+
+    // Add material to a new volume
+    auto vbuilder =
+        std::make_unique<volume_builder<detector_t>>(volume_id::e_cylinder);
+    auto mat_builder =
+        homogeneous_volume_material_builder<detector_t>{std::move(vbuilder)};
+
+    mat_builder.set_material(argon_liquid<scalar>{});
+
+    // Add the volume to the detector
+    mat_builder.build(d);
+
+    // Test the material data
+    EXPECT_EQ(d.volumes().size(), 1u);
+    const auto &vol_desc = d.volumes().at(0);
+    EXPECT_EQ(vol_desc.material().id(), material_id);
+    EXPECT_EQ(vol_desc.material().index(), 0u);
+    EXPECT_EQ(d.material_store().template size<material_id>(), 1u);
+    EXPECT_EQ(d.material_store().template get<material_id>()[0],
+              argon_liquid<scalar>{});
+}

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -8,7 +8,7 @@
 // Project include(s)
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
-#include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes/unbounded.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -105,7 +105,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
                                      300.f, 350.f, 400.f, 450.f, 500.f};
     // Build telescope detector with unbounded planes
     const auto [z_tel_det1, z_tel_names1] =
-        create_telescope_detector(host_mr, tel_cfg.positions(positions));
+        build_telescope_detector(host_mr, tel_cfg.positions(positions));
 
     // Some general checks
     const auto vol0 = detector_volume{z_tel_det1, 0u};
@@ -125,7 +125,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     // length/number of surfaces
     tel_cfg.positions({}).n_surfaces(11u).length(500.f * unit<scalar>::mm);
     const auto [z_tel_det2, z_tel_names2] =
-        create_telescope_detector(host_mr, tel_cfg);
+        build_telescope_detector(host_mr, tel_cfg);
 
     // Check general consistency of the detector
     detail::check_consistency(z_tel_det2, verbose_check);
@@ -149,7 +149,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
                                     -1.f);
 
     const auto [x_tel_det, x_tel_names] =
-        create_telescope_detector(host_mr, tel_cfg.pilot_track(x_track));
+        build_telescope_detector(host_mr, tel_cfg.pilot_track(x_track));
 
     // Check general consistency of the detector
     detail::check_consistency(x_tel_det, verbose_check);
@@ -251,7 +251,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     tel_det_config htel_cfg{rectangle, helix_bz};
     htel_cfg.n_surfaces(11u).length(500.f * unit<scalar>::mm);
     const auto [tel_detector, tel_names] =
-        create_telescope_detector(host_mr, htel_cfg);
+        build_telescope_detector(host_mr, htel_cfg);
 
     // Check general consistency of the detector
     detail::check_consistency(tel_detector, verbose_check);

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -7,7 +7,7 @@
 
 // Project include(s).
 #include "detray/definitions/units.hpp"
-#include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/geometry/detail/surface_descriptor.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes.hpp"
@@ -62,7 +62,7 @@ GTEST_TEST(detray_propagator, covariance_transport) {
     tel_cfg.positions(positions).pilot_track(traj);
 
     // Build telescope detector with unbounded planes
-    const auto [det, names] = create_telescope_detector(host_mr, tel_cfg);
+    const auto [det, names] = build_telescope_detector(host_mr, tel_cfg);
 
     using navigator_t = navigator<decltype(det)>;
     using cline_stepper_t = line_stepper<transform3>;

--- a/tests/unit_tests/io/io_json_detector_writer.cpp
+++ b/tests/unit_tests/io/io_json_detector_writer.cpp
@@ -8,8 +8,8 @@
 // Project include(s)
 #include "detray/definitions/detail/algebra.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/detectors/build_toy_detector.hpp"
-#include "detray/detectors/create_telescope_detector.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
 #include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/geometry/mask.hpp"
@@ -59,7 +59,7 @@ GTEST_TEST(io, json_telescope_geometry_writer) {
     // Telescope detector
     vecmem::host_memory_resource host_mr;
     auto [det, names] =
-        create_telescope_detector(host_mr, tel_cfg.positions(positions));
+        build_telescope_detector(host_mr, tel_cfg.positions(positions));
 
     io::json_writer<detector_t, io::geometry_writer> geo_writer;
     geo_writer.write(det, names);
@@ -74,7 +74,7 @@ GTEST_TEST(io, json_telescope_material_writer) {
     vecmem::host_memory_resource host_mr;
 
     auto [det, names] =
-        create_telescope_detector(host_mr, tel_cfg.positions(positions));
+        build_telescope_detector(host_mr, tel_cfg.positions(positions));
 
     io::json_writer<detector_t, io::homogeneous_material_writer> mat_writer;
     mat_writer.write(det, names);

--- a/tutorials/src/cpu/detector/build_predefined_detectors.cpp
+++ b/tutorials/src/cpu/detector/build_predefined_detectors.cpp
@@ -7,7 +7,7 @@
 
 // Project include(s)
 #include "detray/definitions/units.hpp"
-#include "detray/detectors/create_telescope_detector.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
 #include "detray/detectors/create_toy_geometry.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/materials/predefined_materials.hpp"
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
     //         10 rectangle surfaces, 500mm in length, modules evenly spaced,
     //         silicon material (80mm)
     const auto [tel_det1, tel_names1] =
-        detray::create_telescope_detector<detray::rectangle2D>(host_mr);
+        detray::build_telescope_detector<detray::rectangle2D>(host_mr);
 
     std::cout << "\nTelescope detector - case 1:\n"
               << "----------------------------\n"
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
     trp_cfg.n_surfaces(15).length(2000.f * detray::unit<detray::scalar>::mm);
 
     const auto [tel_det2, tel_names2] =
-        detray::create_telescope_detector(host_mr, trp_cfg);
+        detray::build_telescope_detector(host_mr, trp_cfg);
 
     std::cout << "\nTelescope detector - case 2:\n"
               << "----------------------------\n"
@@ -139,7 +139,7 @@ int main(int argc, char** argv) {
     rct_cfg.positions(positions).pilot_track(x_track);
 
     const auto [tel_det3, tel_names3] =
-        create_telescope_detector(host_mr, rct_cfg);
+        build_telescope_detector(host_mr, rct_cfg);
 
     std::cout << "\nTelescope detector - case 3:\n"
               << "----------------------------\n"
@@ -164,7 +164,7 @@ int main(int argc, char** argv) {
     htrp_cfg.positions(positions);
 
     const auto [tel_det4, tel_names4] =
-        detray::create_telescope_detector(host_mr, htrp_cfg);
+        detray::build_telescope_detector(host_mr, htrp_cfg);
 
     std::cout << "\nTelescope detector - case 4:\n"
               << "----------------------------\n"


### PR DESCRIPTION
Adds a volume builder for homogeneous volume material and a corresponding unittest. Also renaming to ```build_telescope_detector```, since it is already switched to the builder infrastructure