### PR TITLE
feat: Add material map display to svgtools

### DIFF
--- a/extern/actsvg/CMakeLists.txt
+++ b/extern/actsvg/CMakeLists.txt
@@ -19,7 +19,7 @@ message( STATUS "Building actsvg as part of the Detray project" )
 # Declare where to get Actsvg from.
 set( DETRAY_ACTSVG_GIT_REPOSITORY "https://github.com/acts-project/actsvg.git"
    CACHE STRING "Git repository to take actsvg from" )
-set( DETRAY_ACTSVG_GIT_TAG "v0.4.40" CACHE STRING "Version of actsvg to build" )
+set( DETRAY_ACTSVG_GIT_TAG "v0.4.42" CACHE STRING "Version of actsvg to build" )
 mark_as_advanced( DETRAY_ACTSVG_GIT_REPOSITORY DETRAY_ACTSVG_GIT_TAG )
 FetchContent_Declare( actsvg
    GIT_REPOSITORY "${DETRAY_ACTSVG_GIT_REPOSITORY}"

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
@@ -95,6 +95,31 @@ inline auto grid_type_and_edges(const grid_t& grid, const view_t&) {
                       dvector<scalar_t>{});
 }
 
+/// @returns the actsvg grid type and edge values for a detray rectangular grid.
+template <
+    typename grid_t, typename view_t,
+    std::enable_if_t<
+        std::is_same_v<typename grid_t::local_frame_type,
+                       detray::cartesian2D<
+                           typename grid_t::local_frame_type::algebra_type>>,
+        bool> = true>
+inline auto grid_type_and_edges(const grid_t& grid, const view_t&) {
+
+    using scalar_t = typename grid_t::local_frame_type::scalar_type;
+    using axis_label = detray::axis::label;
+
+    auto edges_x = grid.template get_axis<axis_label::e_x>().bin_edges();
+    auto edges_y = grid.template get_axis<axis_label::e_y>().bin_edges();
+
+    if constexpr (std::is_same_v<view_t, typename actsvg::views::x_y>) {
+        return std::tuple(grid_type::e_endcap, actsvg::proto::grid::e_x_y,
+                          edges_x, edges_y);
+    }
+
+    return std::tuple(grid_type::e_endcap, actsvg::proto::grid::e_x_y, edges_y,
+                      dvector<scalar_t>{});
+}
+
 /// A functor to access the type and bin edges of a grid.
 template <typename scalar_t>
 struct type_and_edge_getter {
@@ -105,10 +130,13 @@ struct type_and_edge_getter {
         [[maybe_unused]] const index_t index,
         [[maybe_unused]] const view_t& view) const {
 
-        using accel_t = typename group_t::value_type;
+        using value_t = typename group_t::value_type;
 
-        if constexpr (detray::detail::is_grid_v<accel_t>) {
-            return grid_type_and_edges(group[index], view);
+        if constexpr (detray::detail::is_grid_v<value_t>) {
+            // Only two dimensional grids for actsvg
+            if constexpr (value_t::dim == 2) {
+                return grid_type_and_edges(group[index], view);
+            }
         }
 
         return std::tuple(grid_type::e_unknown, actsvg::proto::grid::e_x_y,
@@ -116,213 +144,75 @@ struct type_and_edge_getter {
     }
 };
 
-/// A functor to access the bins and get the associated surface indices
-struct bin_association_getter {
-
-    template <typename group_t, typename index_t, typename volume_t>
-    DETRAY_HOST_DEVICE std::vector<std::vector<std::size_t>> operator()(
-        [[maybe_unused]] const group_t& group,
-        [[maybe_unused]] const index_t index,
-        [[maybe_unused]] const volume_t& vol_desc,
-        [[maybe_unused]] const std::array<dindex, 2>& search_window) const {
-
-        using accel_t = typename group_t::value_type;
-
-        if constexpr (detray::detail::is_grid_v<accel_t>) {
-
-            using algebra_t = typename accel_t::local_frame_type::algebra_type;
-            using scalar_t = dscalar<algebra_t>;
-            using point2_t = dpoint2D<algebra_t>;
-
-            // The sheet display only works for 2-dimensional grids
-            if constexpr (accel_t::dim != 2u) {
-                std::cout
-                    << "WARNIGN: Only 2D grids can be displayed as actvg sheets"
-                    << std::endl;
-                return {};
-            }
-
-            const accel_t grid = group[index];
-            const std::size_t n_bins{grid.nbins()};
-
-            std::vector<std::vector<std::size_t>> bin_assoc;
-            bin_assoc.reserve(n_bins);
-
-            // Create the bin associations
-            auto edges0 = grid.template get_axis<0>().bin_edges();
-            auto edges1 = grid.template get_axis<1>().bin_edges();
-
-            // In the svg convention the phi axis has to be the second axis to
-            // loop over
-            constexpr bool is_cyl{
-                std::is_same_v<typename accel_t::local_frame_type,
-                               detray::cylindrical2D<algebra_t>>};
-            if constexpr (is_cyl) {
-                edges0.swap(edges1);
-            }
-
-            for (std::size_t i = 1u; i < edges0.size(); ++i) {
-                scalar_t p0 = 0.5f * (edges0[i] + edges0[i - 1]);
-
-                for (std::size_t j = 1u; j < edges1.size(); ++j) {
-                    scalar_t p1 = 0.5f * (edges1[j] + edges1[j - 1]);
-
-                    // Create the bin center position estimates
-                    point2_t bin_center{p0, p1};
-                    if constexpr (is_cyl) {
-                        bin_center = {p1, p0};
-                    }
-
-                    // Get all the bin entries and calculate the loc index
-                    std::vector<std::size_t> entries;
-
-                    for (const auto& sf_desc :
-                         grid.search(bin_center, search_window)) {
-                        // actsvg expects the sensitive surfaces to be numbered
-                        // starting from zero
-                        dindex offset{vol_desc.template sf_link<
-                            surface_id::e_sensitive>()[0]};
-                        entries.push_back(sf_desc.index() - offset);
-                    }
-
-                    // Remove duplicates
-                    std::sort(entries.begin(), entries.end());
-                    auto last = std::unique(entries.begin(), entries.end());
-                    entries.erase(last, entries.end());
-
-                    bin_assoc.push_back(std::move(entries));
-                }
-            }
-
-            return bin_assoc;
-        }
-
-        return {};
-    }
-};
-
 }  // namespace detail
 
 /// @brief Converts a detray grid to a actsvg proto grid.
 ///
-/// @param detector the detector
-/// @param index the index of the grid's volume
+/// @param store the data store that contains the grid
+/// @param link the type id and index of the grid to be converted
 /// @param view the view
+/// @param ref_radius radius of the grid (only needed for cylindrical grids)
 /// @param style the style settings
 ///
 /// @returns a proto grid
-template <typename detector_t, typename view_t>
-auto grid(const detector_t& detector, const dindex index, const view_t& view,
+template <typename store_t, typename link_t, typename view_t, typename scalar_t>
+auto grid(const store_t& store, const link_t& link, const view_t& view,
+          const scalar_t ref_radius,
           const styling::grid_style& style =
               styling::tableau_colorblind::grid_style) {
 
-    using scalar_t = typename detector_t::scalar_type;
-    using geo_object_ids = typename detector_t::geo_obj_ids;
+    if (link.is_invalid()) {
+        return std::tuple(std::optional<actsvg::proto::grid>{},
+                          detail::grid_type::e_unknown);
+    }
 
-    const auto vol_desc = detector.volume(index);
-    const auto link =
-        vol_desc.template accel_link<geo_object_ids::e_sensitive>();
+    auto [gr_type, view_type, edges0, edges1] =
+        store.template visit<detail::type_and_edge_getter<scalar_t>>(link,
+                                                                     view);
     actsvg::proto::grid p_grid;
+    p_grid._type = view_type;
 
-    if (not link.is_invalid()) {
-        auto [gr_type, view_type, edges0, edges1] =
-            detector.accelerator_store()
-                .template visit<detail::type_and_edge_getter<scalar_t>>(link,
-                                                                        view);
-        p_grid._type = view_type;
+    // Find the correct grid radius
+    if (gr_type == detail::grid_type::e_barrel) {
 
-        // Find the correct grid radius
+        p_grid._reference_r = static_cast<actsvg::scalar>(ref_radius);
+
+        // Add the cylinder radius to the axis binning
+        if constexpr (std::is_same_v<view_t, actsvg::views::x_y>) {
+            if (edges0.empty()) {
+                edges0 = {p_grid._reference_r, p_grid._reference_r};
+            }
+        }
+        if constexpr (std::is_same_v<view_t, actsvg::views::z_r>) {
+            if (edges1.empty()) {
+                edges1 = {p_grid._reference_r, p_grid._reference_r};
+            }
+        }
+
+    } else if (gr_type == detail::grid_type::e_endcap) {
+        // An axis is always sorted
+        p_grid._reference_r = static_cast<actsvg::scalar>(edges0.back());
+    }
+
+    // Transform cylinder grid to rphi edges, if rphi view is requested
+    if constexpr (std::is_same_v<view_t, typename actsvg::views::z_rphi>) {
         if (gr_type == detail::grid_type::e_barrel) {
-            // Get the the radii of the volume portal surfaces
-            std::vector<scalar_t> radii{};
-            const auto vol = detector_volume{detector, vol_desc};
-
-            // Passive surfaces could be in the brute force finder, but no
-            // sensitive surfaces, since the volume has a grid. Their radii are,
-            // however, always within the interval of the portal radii
-            for (const auto& pt_desc : vol.portals()) {
-                auto r = detector.mask_store()
-                             .template visit<
-                                 detray::svgtools::utils::outer_radius_getter>(
-                                 pt_desc.mask());
-                if (r.has_value()) {
-                    radii.push_back(*r);
-                }
-            }
-
-            scalar_t inner_r = *std::min_element(radii.begin(), radii.end());
-            scalar_t outer_r = *std::max_element(radii.begin(), radii.end());
-
-            p_grid._reference_r =
-                0.5f * static_cast<actsvg::scalar>(inner_r + outer_r);
-
-            // Add the cylinder radius to the axis binning
-            if constexpr (std::is_same_v<view_t, actsvg::views::x_y>) {
-                if (edges0.empty()) {
-                    edges0 = {p_grid._reference_r, p_grid._reference_r};
-                }
-            }
-            if constexpr (std::is_same_v<view_t, actsvg::views::z_r>) {
-                if (edges1.empty()) {
-                    edges1 = {p_grid._reference_r, p_grid._reference_r};
-                }
-            }
-
-        } else if (gr_type == detail::grid_type::e_endcap) {
-            // An axis is always sorted
-            p_grid._reference_r = static_cast<actsvg::scalar>(edges0.back());
-        }
-
-        // Transform cylinder grid to rphi edges, if rphi view is requested
-        if constexpr (std::is_same_v<view_t, typename actsvg::views::z_rphi>) {
-            if (gr_type == detail::grid_type::e_barrel) {
-                for (auto& e : edges1) {
-                    e *= p_grid._reference_r;
-                }
+            for (auto& e : edges1) {
+                e *= p_grid._reference_r;
             }
         }
-
-        std::transform(
-            edges0.cbegin(), edges0.cend(), std::back_inserter(p_grid._edges_0),
-            [](scalar_t v) { return static_cast<actsvg::scalar>(v); });
-        std::transform(
-            edges1.cbegin(), edges1.cend(), std::back_inserter(p_grid._edges_1),
-            [](scalar_t v) { return static_cast<actsvg::scalar>(v); });
-
-        svgtools::styling::apply_style(p_grid, style);
-
-        return std::tuple(std::optional<actsvg::proto::grid>{p_grid}, gr_type);
     }
 
-    return std::tuple(std::optional<actsvg::proto::grid>{},
-                      detail::grid_type::e_unknown);
-}
+    std::transform(edges0.cbegin(), edges0.cend(),
+                   std::back_inserter(p_grid._edges_0),
+                   [](scalar_t v) { return static_cast<actsvg::scalar>(v); });
+    std::transform(edges1.cbegin(), edges1.cend(),
+                   std::back_inserter(p_grid._edges_1),
+                   [](scalar_t v) { return static_cast<actsvg::scalar>(v); });
 
-/// @brief Get the surfaces indices that are registered in the bin neighborhoods
-///
-/// @param detector the detector
-/// @param vol the volume that holds the grid and surfaces
-/// @param offset transform a global surface index to a local one for the volume
-///
-/// @returns a vector of surface indices per neighborhood
-template <typename detector_t>
-std::vector<std::vector<std::size_t>> get_bin_association(
-    const detector_t& det, const detray::detector_volume<detector_t>& vol,
-    const std::array<dindex, 2>& search_window = {2u, 2u}) {
+    svgtools::styling::apply_style(p_grid, style);
 
-    using geo_object_ids = typename detector_t::geo_obj_ids;
-
-    const auto& vol_desc = det.volume(vol.index());
-    const auto& link =
-        vol_desc.template accel_link<geo_object_ids::e_sensitive>();
-
-    if (not link.is_invalid()) {
-        return det.accelerator_store()
-            .template visit<detail::bin_association_getter>(link, vol_desc,
-                                                            search_window);
-    }
-
-    return {};
+    return std::tuple(std::optional<actsvg::proto::grid>{p_grid}, gr_type);
 }
 
 }  // namespace detray::svgtools::conversion

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/portal.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/portal.hpp
@@ -21,27 +21,31 @@ namespace detray::svgtools::conversion {
 
 /// @returns An actsvg proto portal representing the portal.
 /// @note detray portal is_portal() should be true.
-template <typename detector_t>
+template <typename detector_t, typename view_t>
 auto portal(const typename detector_t::geometry_context& context,
             const detector_t& detector,
-            const detray::surface<detector_t>& d_portal,
+            const detray::surface<detector_t>& d_portal, const view_t& view,
             const styling::portal_style& style =
                 styling::tableau_colorblind::portal_style,
-            bool hide_links = false) {
+            bool hide_links = false, bool hide_material = false) {
 
     assert(d_portal.is_portal());
 
     using point3_container_t = std::vector<typename detector_t::point3_type>;
     using p_portal_t = actsvg::proto::portal<point3_container_t>;
+    using p_surface_t = actsvg::proto::surface<point3_container_t>;
 
     p_portal_t p_portal;
     p_portal._name = "portal_" + std::to_string(d_portal.index());
+    p_portal._surface._sf_type = p_surface_t::sf_type::e_portal;
+
     if (!hide_links && svgtools::utils::is_not_world_portal(d_portal)) {
         p_portal._volume_links = {
             svgtools::conversion::link(context, detector, d_portal)};
     }
 
-    p_portal._surface = svgtools::conversion::surface(context, d_portal);
+    p_portal._surface = svgtools::conversion::surface(
+        context, detector, d_portal, view, style._surface_style, hide_material);
 
     svgtools::styling::apply_style(p_portal, style);
 

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
@@ -1,0 +1,200 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/core/detector.hpp"
+#include "detray/definitions/grid_axis.hpp"
+#include "detray/definitions/units.hpp"
+#include "detray/plugins/svgtools/conversion/grid.hpp"
+#include "detray/plugins/svgtools/styling/styling.hpp"
+
+// Actsvg include(s)
+#include "actsvg/proto/grid.hpp"
+
+// System include(s)
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace detray::svgtools::conversion {
+
+namespace detail {
+
+/// A functor to access the bins and get the associated surface indices
+struct bin_association_getter {
+
+    template <typename group_t, typename index_t, typename volume_t>
+    DETRAY_HOST_DEVICE std::vector<std::vector<std::size_t>> operator()(
+        [[maybe_unused]] const group_t& group,
+        [[maybe_unused]] const index_t index,
+        [[maybe_unused]] const volume_t& vol_desc,
+        [[maybe_unused]] const std::array<dindex, 2>& search_window) const {
+
+        using accel_t = typename group_t::value_type;
+
+        if constexpr (detray::detail::is_grid_v<accel_t>) {
+
+            using transform3_t =
+                typename accel_t::local_frame_type::transform3_type;
+            using algebra_t = typename accel_t::local_frame_type::algebra_type;
+            using scalar_t = typename transform3_t::scalar_type;
+            using point2_t = typename transform3_t::point2;
+
+            // The sheet display only works for 2-dimensional grids
+            if constexpr (accel_t::dim != 2u) {
+                std::cout
+                    << "WARNIGN: Only 2D grids can be displayed as actvg sheets"
+                    << std::endl;
+                return {};
+            }
+
+            const accel_t grid = group[index];
+            const std::size_t n_bins{grid.nbins()};
+
+            std::vector<std::vector<std::size_t>> bin_assoc;
+            bin_assoc.reserve(n_bins);
+
+            // Create the bin associations
+            auto edges0 = grid.template get_axis<0>().bin_edges();
+            auto edges1 = grid.template get_axis<1>().bin_edges();
+
+            // In the svg convention the phi axis has to be the second axis to
+            // loop over
+            constexpr bool is_cyl{
+                std::is_same_v<typename accel_t::local_frame_type,
+                               detray::cylindrical2D<algebra_t>> ||
+                std::is_same_v<typename accel_t::local_frame_type,
+                               detray::concentric_cylindrical2D<algebra_t>>};
+            if constexpr (is_cyl) {
+                edges0.swap(edges1);
+            }
+
+            for (std::size_t i = 1u; i < edges0.size(); ++i) {
+                scalar_t p0 = 0.5f * (edges0[i] + edges0[i - 1]);
+
+                for (std::size_t j = 1u; j < edges1.size(); ++j) {
+                    scalar_t p1 = 0.5f * (edges1[j] + edges1[j - 1]);
+
+                    // Create the bin center position estimates
+                    point2_t bin_center{p0, p1};
+                    if constexpr (is_cyl) {
+                        bin_center = {p1, p0};
+                    }
+
+                    // Get all the bin entries and calculate the loc index
+                    std::vector<std::size_t> entries;
+
+                    for (const auto& sf_desc :
+                         grid.search(bin_center, search_window)) {
+                        // actsvg expects the sensitive surfaces to be numbered
+                        // starting from zero
+                        dindex offset{vol_desc.template sf_link<
+                            surface_id::e_sensitive>()[0]};
+                        entries.push_back(sf_desc.index() - offset);
+                    }
+
+                    // Remove duplicates
+                    std::sort(entries.begin(), entries.end());
+                    auto last = std::unique(entries.begin(), entries.end());
+                    entries.erase(last, entries.end());
+
+                    bin_assoc.push_back(std::move(entries));
+                }
+            }
+
+            return bin_assoc;
+        }
+
+        return {};
+    }
+};
+
+}  // namespace detail
+
+/// @brief Converts a the grid of a detray volume to a actsvg proto grid.
+///
+/// @param detector the detector
+/// @param index the index of the grid's volume
+/// @param view the view
+/// @param style the style settings
+///
+/// @returns a proto grid
+template <typename detector_t, typename view_t>
+auto surface_grid(const detector_t& detector, const dindex index,
+                  const view_t& view,
+                  const styling::grid_style& style =
+                      styling::tableau_colorblind::grid_style) {
+
+    using scalar_t = typename detector_t::scalar_type;
+    using geo_object_ids = typename detector_t::geo_obj_ids;
+
+    const auto vol_desc = detector.volume(index);
+    const auto link =
+        vol_desc.template accel_link<geo_object_ids::e_sensitive>();
+
+    // Proactively calculate the reference radius for a cylinder grid
+    // (will only be used if the volume actually holds a barrel grid)
+
+    // Get the the radii of the volume portal surfaces
+    std::vector<scalar_t> radii{};
+    const auto vol = detector_volume{detector, vol_desc};
+
+    // Passive surfaces could be in the brute force finder, but no
+    // sensitive surfaces, since the volume has a grid. Their radii are,
+    // however, always within the interval of the portal radii
+    for (const auto& pt_desc : vol.portals()) {
+        auto r =
+            detector.mask_store()
+                .template visit<detray::svgtools::utils::outer_radius_getter>(
+                    pt_desc.mask());
+        if (r.has_value()) {
+            radii.push_back(*r);
+        }
+    }
+
+    scalar_t inner_r = *std::min_element(radii.begin(), radii.end());
+    scalar_t outer_r = *std::max_element(radii.begin(), radii.end());
+
+    scalar_t cyl_ref_radius =
+        0.5f * static_cast<actsvg::scalar>(inner_r + outer_r);
+
+    return svgtools::conversion::grid(detector.accelerator_store(), link, view,
+                                      cyl_ref_radius, style);
+}
+
+/// @brief Get the surfaces indices that are registered in the bin neighborhoods
+///
+/// @param detector the detector
+/// @param vol the volume that holds the grid and surfaces
+/// @param offset transform a global surface index to a local one for the volume
+///
+/// @returns a vector of surface indices per neighborhood
+template <typename detector_t>
+std::vector<std::vector<std::size_t>> get_bin_association(
+    const detector_t& det, const detray::detector_volume<detector_t>& vol,
+    const std::array<dindex, 2>& search_window = {2u, 2u}) {
+
+    using geo_object_ids = typename detector_t::geo_obj_ids;
+
+    const auto& vol_desc = det.volume(vol.index());
+    const auto& link =
+        vol_desc.template accel_link<geo_object_ids::e_sensitive>();
+
+    if (not link.is_invalid()) {
+        return det.accelerator_store()
+            .template visit<detail::bin_association_getter>(link, vol_desc,
+                                                            search_window);
+    }
+
+    return {};
+}
+
+}  // namespace detray::svgtools::conversion

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
@@ -1,0 +1,167 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/geometry/surface.hpp"
+#include "detray/plugins/svgtools/conversion/grid.hpp"
+#include "detray/plugins/svgtools/styling/styling.hpp"
+
+// Actsvg include(s)
+#include "actsvg/proto/surface.hpp"
+
+// System include(s)
+#include <algorithm>
+#include <iterator>
+
+namespace detray::svgtools::conversion {
+
+/// @brief Converts a the material grid of a detray surface to an actsvg proto
+///        grid.
+///
+/// @param detector the detector
+/// @param index the index of the surface
+/// @param view the view
+/// @param style the style settings
+///
+/// @returns a proto grid
+template <typename detector_t, typename view_t>
+auto material_grid(const detector_t& detector, const dindex index,
+                   const view_t& view,
+                   const styling::grid_style& style =
+                       styling::tableau_colorblind::grid_style) {
+
+    using scalar_t = typename detector_t::scalar_type;
+
+    const auto& sf_desc = detector.surface(index);
+    const auto& link = sf_desc.material();
+
+    // Proactively calculate the reference radius for a cylinder grid
+    // (will only be used if the volume actually holds a barrel grid)
+    auto r = detector.mask_store()
+                 .template visit<detray::svgtools::utils::outer_radius_getter>(
+                     sf_desc.mask());
+
+    scalar_t cyl_ref_radius{0.f};
+    if (r.has_value()) {
+        cyl_ref_radius = *r;
+    }
+
+    return svgtools::conversion::grid(detector.material_store(), link, view,
+                                      cyl_ref_radius, style);
+}
+
+namespace {
+
+/// @brief A functor to fill the material proto grid with proto material slabs
+struct material_converter {
+
+    template <typename mat_coll_t, typename index_t, typename transform_t>
+    DETRAY_HOST inline auto operator()(const mat_coll_t& mat_coll,
+                                       const index_t& index,
+                                       const transform_t&) const {
+        using material_t = typename mat_coll_t::value_type;
+
+        std::vector<std::vector<actsvg::proto::material_slab>> m_matrix;
+
+        if constexpr (detray::detail::is_grid_v<material_t>) {
+
+            using loc_bin_idx_t = typename material_t::loc_bin_index;
+            using algebra_t =
+                typename material_t::local_frame_type::algebra_type;
+
+            const auto material_map = mat_coll[index];
+
+            // Create the bin associations
+            auto edges0 = material_map.template get_axis<0>().bin_edges();
+            auto edges1 = material_map.template get_axis<1>().bin_edges();
+
+            // In the svg convention the phi axis has to be the second axis to
+            // loop over
+            constexpr bool is_cyl{
+                std::is_same_v<typename material_t::local_frame_type,
+                               detray::cylindrical2D<algebra_t>> ||
+                std::is_same_v<typename material_t::local_frame_type,
+                               detray::concentric_cylindrical2D<algebra_t>>};
+            if constexpr (is_cyl) {
+                edges0.swap(edges1);
+            }
+
+            m_matrix.reserve(edges1.size());
+
+            // Material map is always 2-dimensional
+            for (dindex j = 0u; j < edges1.size(); ++j) {
+
+                std::vector<actsvg::proto::material_slab> m_matrix_row;
+                m_matrix_row.reserve(edges1.size());
+
+                for (dindex i = 0u; i < edges0.size(); ++i) {
+
+                    loc_bin_idx_t bin_idx{i, j};
+                    if constexpr (is_cyl) {
+                        bin_idx = {j, i};
+                    }
+
+                    const auto& mat_slab = *(material_map.bin(bin_idx));
+                    const auto& mat = mat_slab.get_material();
+
+                    actsvg::proto::material_slab p_mat_slab;
+                    p_mat_slab._properties = {
+                        mat.X0(), mat.L0(),           mat.Ar(),
+                        mat.Z(),  mat.mass_density(), mat_slab.thickness()};
+
+                    m_matrix_row.push_back(std::move(p_mat_slab));
+                }
+
+                m_matrix.push_back(std::move(m_matrix_row));
+            }
+        }
+
+        return m_matrix;
+    }
+};
+
+}  // namespace
+
+/// @brief Calculates the proto surface material of a surface.
+///
+/// @param d_surface The detray surface.
+/// @param context The geometry context.
+///
+/// @returns An actsvg proto surface material the material map.
+template <typename detector_t, typename view_t>
+auto surface_material(const detector_t& detector,
+                      const detray::surface<detector_t>& d_surface,
+                      const view_t& view,
+                      const styling::surface_material_style& style =
+                          styling::tableau_colorblind::material_style) {
+
+    // Convert grid, if present
+    auto [p_grid, grid_type] = svgtools::conversion::material_grid(
+        detector, d_surface.index(), view, style._grid_style);
+
+    actsvg::proto::surface_material p_material;
+
+    // Create the surface material
+    if (p_grid.has_value()) {
+
+        // Fill material data
+        auto m_matrix = d_surface.template visit_material<material_converter>(
+            d_surface.transform({}));
+
+        p_material = {m_matrix, *p_grid};
+        p_material._material_ranges =
+            actsvg::proto::material_ranges(p_material._material_matrix);
+
+        svgtools::styling::apply_style(p_material, style);
+    }
+
+    return p_material;
+}
+
+}  // namespace detray::svgtools::conversion

--- a/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,6 +15,7 @@
 #include "detray/plugins/svgtools/conversion/intersection.hpp"
 #include "detray/plugins/svgtools/conversion/landmark.hpp"
 #include "detray/plugins/svgtools/conversion/surface.hpp"
+#include "detray/plugins/svgtools/conversion/surface_material.hpp"
 #include "detray/plugins/svgtools/conversion/trajectory.hpp"
 #include "detray/plugins/svgtools/conversion/volume.hpp"
 #include "detray/plugins/svgtools/meta/display/geometry.hpp"
@@ -23,6 +24,7 @@
 #include "detray/plugins/svgtools/meta/proto/eta_lines.hpp"
 #include "detray/plugins/svgtools/styling/styling.hpp"
 #include "detray/plugins/svgtools/utils/groups.hpp"
+#include "detray/utils/ranges.hpp"
 
 // Actsvg include(s)
 #include "actsvg/meta.hpp"
@@ -30,6 +32,7 @@
 // System include(s)
 #include <array>
 #include <optional>
+#include <stdexcept>
 #include <vector>
 
 namespace detray::svgtools {
@@ -76,8 +79,10 @@ class illustrator {
     void show_info(bool toggle = true) { _show_info = toggle; }
     /// Toggle eta lines in detector rz-view
     void hide_eta_lines(bool toggle = true) { _hide_eta_lines = toggle; }
-    /// Toggle info boxes
+    /// Toggle surface grids
     void hide_grids(bool toggle = true) { _hide_grids = toggle; }
+    /// Toggle surface material
+    void hide_material(bool toggle = true) { _hide_material = toggle; }
     /// Toggle portal surfaces
     void hide_portals(bool toggle = true) { _hide_portals = toggle; }
     /// Toggle passive surfaces
@@ -101,23 +106,38 @@ class illustrator {
 
         const auto surface = detray::surface{_detector, index};
 
-        actsvg::svg::object ret;
+        actsvg::svg::object ret, material;
         const auto& style = _style._detector_style._volume_style;
 
         if (surface.is_portal()) {
             auto p_portal = svgtools::conversion::portal(
-                gctx, _detector, surface, style._portal_style, false);
+                gctx, _detector, surface, view, style._portal_style, false,
+                _hide_material);
 
             // Draw the portal directly
             std::string id = p_portal._name + "_" + svg_id(view);
             ret = actsvg::display::portal(std::move(id), p_portal, view);
+
+            if (!_hide_material) {
+                material = actsvg::display::surface_material(
+                    id + "_material_map", p_portal._surface._material);
+            }
         } else {
+            const auto& sf_style = surface.is_sensitive()
+                                       ? style._sensitive_surface_style
+                                       : style._passive_surface_style;
+
             auto p_surface = svgtools::conversion::surface(
-                gctx, surface, style._surface_style);
+                gctx, _detector, surface, view, sf_style, _hide_material);
 
             // Draw the surface directly
             std::string id = p_surface._name + "_" + svg_id(view);
             ret = actsvg::display::surface(std::move(id), p_surface, view);
+
+            if (!_hide_material) {
+                material = actsvg::display::surface_material(
+                    id + "_material_map", p_surface._material);
+            }
         }
         // Add an optional info box
         if (_show_info) {
@@ -130,7 +150,7 @@ class illustrator {
             ret.add_object(info_box);
         }
 
-        return ret;
+        return std::tuple{ret, material};
     }
 
     /// @brief Converts a multiple of detray surfaces of the detector to an svg.
@@ -149,8 +169,97 @@ class illustrator {
         auto ret = svgtools::utils::group(_name_map.at(0) + "_surfaces_" +
                                           svg_id(view));
 
-        for (const dindex index : indices) {
-            ret.add_object(draw_surface(index, view, gctx));
+        auto material = svgtools::utils::group(_name_map.at(0) + "_material_" +
+                                               svg_id(view));
+
+        for (const auto [i, index] : detray::views::enumerate(indices)) {
+            auto [sf_svg, mat_svg] = draw_surface(index, view, gctx);
+
+            ret.add_object(sf_svg);
+
+            // Only add one gradient box
+            if (i == 0) {
+                material.add_object(mat_svg);
+            } else {
+                material.add_object(mat_svg._sub_objects[0]);
+            }
+        }
+
+        return std::tuple{ret, material};
+    }
+
+    /// @brief Converts the material map of a single detray surface to an svg.
+    ///
+    /// @param index the index of the surface in the detector.
+    /// @param view the display view.
+    /// @param gctx the geometry context.
+    ///
+    /// @returns @c actsvg::svg::object of the surface's material map.
+    template <typename view_t>
+    inline auto draw_surface_material(const dindex index,
+                                      const view_t& view) const {
+
+        const auto surface = detray::surface{_detector, index};
+
+        if (_hide_material) {
+            return actsvg::svg::object{};
+        }
+
+        const styling::surface_material_style* mat_style{nullptr};
+        const auto& vol_style = _style._detector_style._volume_style;
+        switch (surface.id()) {
+            case surface_id::e_portal: {
+                mat_style =
+                    &vol_style._portal_style._surface_style._material_style;
+                break;
+            }
+            case surface_id::e_sensitive: {
+                mat_style = &vol_style._sensitive_surface_style._material_style;
+                break;
+            }
+            case surface_id::e_passive: {
+                mat_style = &vol_style._passive_surface_style._material_style;
+                break;
+            }
+            case surface_id::e_unknown: {
+                throw std::runtime_error(
+                    "Encountered surface of unknown type.");
+                break;
+            }
+        };
+
+        auto p_material = svgtools::conversion::surface_material(
+            _detector, surface, view, *mat_style);
+
+        std::string id = _name_map.at(0) + "_material_map_" +
+                         std::to_string(surface.index()) + svg_id(view);
+
+        return actsvg::display::surface_material(std::move(id), p_material);
+    }
+
+    /// @brief Converts the material of multiple detray surfaces to an svg.
+    ///
+    /// @param indices the collection of surface indices in the detector to
+    /// convert.
+    /// @param view the display view.
+    ///
+    /// @returns @c actsvg::svg::object of the surface's material maps.
+    template <typename range_t, typename view_t>
+    inline auto draw_surface_materials(const range_t& indices,
+                                       const view_t& view) const {
+
+        auto ret = svgtools::utils::group(_name_map.at(0) +
+                                          "_surface_materials_" + svg_id(view));
+
+        for (const auto [i, index] : detray::views::enumerate(indices)) {
+            auto mat_svg = draw_surface_material(index, view);
+
+            // Only add one gradient box
+            if (i == 0) {
+                ret.add_object(mat_svg);
+            } else {
+                ret.add_object(mat_svg._sub_objects[0]);
+            }
         }
 
         return ret;
@@ -173,7 +282,7 @@ class illustrator {
         auto [p_volume, gr_type] = svgtools::conversion::volume(
             gctx, _detector, d_volume, view,
             _style._detector_style._volume_style, _hide_portals, _hide_passives,
-            _hide_grids, _search_window);
+            _hide_grids, _hide_material, _search_window);
 
         // Draw the basic volume
         p_volume._name = d_volume.name(_name_map);
@@ -481,6 +590,7 @@ class illustrator {
     bool _show_info = true;
     bool _hide_eta_lines = false;
     bool _hide_grids = false;
+    bool _hide_material = true;
     bool _hide_portals = false;
     bool _hide_passives = false;
     std::array<dindex, 2> _search_window = {2u, 2u};

--- a/plugins/svgtools/include/detray/plugins/svgtools/styling/colors.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/styling/colors.hpp
@@ -12,6 +12,7 @@
 
 // System include(s)
 #include <array>
+#include <stdexcept>
 #include <vector>
 
 namespace detray::svgtools::styling::colors {
@@ -59,6 +60,113 @@ inline constexpr std::array aquamarine1{188, 255, 219};
 inline constexpr std::array aquamarine2{141, 255, 205};
 inline constexpr std::array emerald{104, 216, 155};
 inline constexpr std::array shamrock_green{79, 157, 105};
+
+// Yellow/orange tones
+inline constexpr std::array yellow{0, 255, 0};
+
+namespace gradient {
+
+inline std::vector<actsvg::style::color> rainbow_scale{
+    actsvg::style::color{{255, 0, 0}, 1.f},
+    actsvg::style::color{{255, 51, 0}, 1.f},
+    actsvg::style::color{{255, 102, 0}, 1.f},
+    actsvg::style::color{{255, 153, 0}, 1.f},
+    actsvg::style::color{{255, 204, 0}, 1.f},
+    actsvg::style::color{{255, 255, 0}, 1.f},
+    actsvg::style::color{{204, 255, 0}, 1.f},
+    actsvg::style::color{{153, 255, 0}, 1.f},
+    actsvg::style::color{{102, 255, 0}, 1.f},
+    actsvg::style::color{{51, 255, 0}, 1.f},
+    actsvg::style::color{{0, 255, 0}, 1.f},
+    actsvg::style::color{{0, 255, 51}, 1.f},
+    actsvg::style::color{{0, 255, 102}, 1.f},
+    actsvg::style::color{{0, 255, 153}, 1.f},
+    actsvg::style::color{{0, 255, 204}, 1.f},
+    actsvg::style::color{{0, 255, 255}, 1.f},
+    actsvg::style::color{{0, 204, 255}, 1.f},
+    actsvg::style::color{{0, 153, 255}, 1.f},
+    actsvg::style::color{{0, 102, 255}, 1.f},
+    actsvg::style::color{{0, 51, 255}, 1.f}};
+
+inline std::vector<actsvg::style::color> viridis_scale{
+    actsvg::style::color{{253, 231, 37}, 1.f},
+    actsvg::style::color{{221, 227, 24}, 1.f},
+    actsvg::style::color{{186, 222, 40}, 1.f},
+    actsvg::style::color{{149, 216, 64}, 1.f},
+    actsvg::style::color{{117, 208, 84}, 1.f},
+    actsvg::style::color{{86, 198, 103}, 1.f},
+    actsvg::style::color{{61, 188, 116}, 1.f},
+    actsvg::style::color{{41, 175, 127}, 1.f},
+    actsvg::style::color{{32, 163, 134}, 1.f},
+    actsvg::style::color{{31, 150, 139}, 1.f},
+    actsvg::style::color{{35, 138, 141}, 1.f},
+    actsvg::style::color{{40, 125, 142}, 1.f},
+    actsvg::style::color{{45, 113, 142}, 1.f},
+    actsvg::style::color{{51, 99, 141}, 1.f},
+    actsvg::style::color{{57, 85, 140}, 1.f},
+    actsvg::style::color{{64, 70, 136}, 1.f},
+    actsvg::style::color{{69, 55, 129}, 1.f},
+    actsvg::style::color{{72, 37, 118}, 1.f},
+    actsvg::style::color{{72, 20, 103}, 1.f},
+    actsvg::style::color{{68, 1, 84}, 1.f}};
+
+inline std::vector<actsvg::style::color> plasma_scale{
+    actsvg::style::color{{240, 249, 33}, 1.f},
+    actsvg::style::color{{247, 226, 37}, 1.f},
+    actsvg::style::color{{252, 205, 37}, 1.f},
+    actsvg::style::color{{254, 183, 45}, 1.f},
+    actsvg::style::color{{252, 163, 56}, 1.f},
+    actsvg::style::color{{247, 144, 68}, 1.f},
+    actsvg::style::color{{240, 127, 79}, 1.f},
+    actsvg::style::color{{231, 110, 91}, 1.f},
+    actsvg::style::color{{221, 94, 102}, 1.f},
+    actsvg::style::color{{209, 78, 114}, 1.f},
+    actsvg::style::color{{197, 64, 126}, 1.f},
+    actsvg::style::color{{182, 48, 139}, 1.f},
+    actsvg::style::color{{167, 33, 151}, 1.f},
+    actsvg::style::color{{149, 17, 161}, 1.f},
+    actsvg::style::color{{131, 5, 167}, 1.f},
+    actsvg::style::color{{110, 0, 168}, 1.f},
+    actsvg::style::color{{89, 1, 165}, 1.f},
+    actsvg::style::color{{67, 3, 158}, 1.f},
+    actsvg::style::color{{44, 5, 148}, 1.f},
+    actsvg::style::color{{13, 8, 135}, 1.f},
+};
+
+/// Generate stops for actsvg gradients
+inline std::vector<actsvg::style::gradient::stop> generate_stops(
+    const std::vector<actsvg::style::color> &scale, unsigned int n_stops) {
+
+    if (n_stops > scale.size()) {
+        throw std::invalid_argument(
+            "Too many gradient stops for given color scale! Color scale has "
+            "only " +
+            std::to_string(scale.size()) + " entries.");
+    }
+
+    std::vector<actsvg::style::gradient::stop> stops{};
+    stops.reserve(n_stops);
+
+    // Choose a color from the scale
+    std::size_t color_step{static_cast<std::size_t>(scale.size() / n_stops)};
+    std::size_t i_color{0u};
+
+    // Find the gradient percentage for the color
+    float grad_step{1.f / static_cast<float>(n_stops - 1u)};
+    float grad{0.f};
+
+    for (std::size_t i = 0u; i < n_stops; ++i) {
+
+        stops.push_back(actsvg::style::gradient::stop{grad, scale[i_color]});
+
+        i_color += color_step;
+        grad += grad_step;
+    }
+
+    return stops;
+}
+
+}  // namespace gradient
 
 inline std::vector<actsvg::style::color> black_theme(
     const actsvg::scalar opacity) {

--- a/tests/unit_tests/svgtools/CMakeLists.txt
+++ b/tests/unit_tests/svgtools/CMakeLists.txt
@@ -16,6 +16,7 @@ detray_add_unit_test( svgtools
    "intersections.cpp"
    "landmarks.cpp"
    "masks.cpp"
+   "material.cpp"
    "surfaces.cpp"
    "trajectories.cpp"
    "volumes.cpp"

--- a/tests/unit_tests/svgtools/grids.cpp
+++ b/tests/unit_tests/svgtools/grids.cpp
@@ -37,16 +37,16 @@ GTEST_TEST(svgtools, grids) {
 
     // In this example we want to draw the grids of the volumes with indices 0,
     // 1, ... in the detector.
-    std::vector<detray::dindex> indices = {0u,  1u,  2u,  3u,  4u,  5u,  6u,
-                                           7u,  8u,  9u,  10u, 11u, 12u, 13u,
-                                           14u, 15u, 16u, 17u, 18u, 19u};
+    std::vector<detray::dindex> indices = {3u, 5u, 7u, 9u};
 
     for (const detray::dindex i : indices) {
         // Draw volume i.
         il.hide_grids(false);
         const auto [volume_svg, sheet] = il.draw_volume(i, view);
+
         // Write volume i and its grid
-        detray::svgtools::write_svg(volume_svg._id, volume_svg);
-        detray::svgtools::write_svg(sheet._id, sheet);
+        detray::svgtools::write_svg("test_svgtools_volume_" + volume_svg._id,
+                                    volume_svg);
+        detray::svgtools::write_svg("test_svgtools_grid_" + sheet._id, sheet);
     }
 }

--- a/tests/unit_tests/svgtools/groups.cpp
+++ b/tests/unit_tests/svgtools/groups.cpp
@@ -46,12 +46,12 @@ GTEST_TEST(svgtools, groups) {
     // Visualisation of a group of surfaces.
     const std::array surface_group_indices{1u, 100u, 10u, 200u};
 
-    const auto svg_surface_group_xy =
+    const auto [svg_surface_group_xy, mat_group_xy] =
         il.draw_surfaces(surface_group_indices, xy);
     detray::svgtools::write_svg("test_svgtools_surface_group_xy",
                                 {axes, svg_surface_group_xy});
 
-    const auto svg_surface_group_zr =
+    const auto [svg_surface_group_zr, mat_group_zr] =
         il.draw_surfaces(surface_group_indices, zr);
     detray::svgtools::write_svg("test_svgtools_surface_group_zr.svg",
                                 {axes, svg_surface_group_zr});

--- a/tests/unit_tests/svgtools/material.cpp
+++ b/tests/unit_tests/svgtools/material.cpp
@@ -1,0 +1,83 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/core/detector.hpp"
+#include "detray/detectors/create_toy_geometry.hpp"
+#include "detray/plugins/svgtools/illustrator.hpp"
+#include "detray/plugins/svgtools/writer.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// Actsvg include(s)
+#include "actsvg/core.hpp"
+
+// GTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <array>
+#include <string>
+
+GTEST_TEST(svgtools, material) {
+
+    // This test creates the visualization using the illustrator class.
+
+    // Axes.
+    const auto axes = actsvg::draw::x_y_axes("axes", {-250, 250}, {-250, 250},
+                                             actsvg::style::stroke());
+
+    // Creating the views.
+    const actsvg::views::x_y xy;
+    const actsvg::views::z_r zr;
+    const actsvg::views::z_phi zphi;
+
+    // Creating the detector and geomentry context.
+    vecmem::host_memory_resource host_mr;
+    detray::toy_det_config toy_cfg{};
+    toy_cfg.use_material_maps(true).cyl_map_bins(20, 20).disc_map_bins(5, 20);
+    const auto [det, names] = detray::create_toy_geometry(host_mr, toy_cfg);
+
+    // Creating the svg generator for the detector.
+    detray::svgtools::illustrator il{det, names};
+    il.hide_material(false);
+
+    // Indexes of the surfaces in the detector to be visualized.
+    std::array indices{370u, 371u, 372u, 373u};
+
+    auto& portal_mat_style = il.style()
+                                 ._detector_style._volume_style._portal_style
+                                 ._surface_style._material_style;
+
+    portal_mat_style._gradient_color_scale =
+        detray::svgtools::styling::colors::gradient::viridis_scale;
+    for (detray::dindex i : indices) {
+        std::string name = "test_svgtools_material_" + std::to_string(i);
+        // Visualization of material map of portal i:
+        const auto svg_xy = il.draw_surface_material(i, xy);
+        detray::svgtools::write_svg(name + "_xy", {axes, svg_xy});
+        const auto svg_zr = il.draw_surface_material(i, zr);
+        detray::svgtools::write_svg(name + "_zr", {axes, svg_zr});
+        const auto svg_zphi = il.draw_surface_material(i, zphi);
+        detray::svgtools::write_svg(name + "_zphi", {axes, svg_zphi});
+    }
+
+    // Draw multiple material maps together
+    portal_mat_style._gradient_color_scale =
+        detray::svgtools::styling::colors::gradient::plasma_scale;
+
+    std::vector indices2{362u, 363u, 364u, 365u, 366u, 367u, 368u, 369u};
+    std::string name = "test_svgtools_disc_materials";
+
+    const auto svg_xy = il.draw_surface_materials(indices2, xy);
+    detray::svgtools::write_svg(name + "_xy", {axes, svg_xy});
+    const auto svg_zr = il.draw_surface_materials(indices2, zr);
+    detray::svgtools::write_svg(name + "_zr", {axes, svg_zr});
+    const auto svg_zphi = il.draw_surface_materials(indices2, zphi);
+    detray::svgtools::write_svg(name + "_zphi", {axes, svg_zphi});
+}

--- a/tests/unit_tests/svgtools/surfaces.cpp
+++ b/tests/unit_tests/svgtools/surfaces.cpp
@@ -53,9 +53,11 @@ GTEST_TEST(svgtools, surfaces) {
     for (detray::dindex i : indices) {
         std::string name = "test_svgtools_surface" + std::to_string(i);
         // Visualization of surface/portal i:
-        const auto svg_xy = il.draw_surface(i, xy);
+        const auto [svg_xy, mat_xy] = il.draw_surface(i, xy);
         detray::svgtools::write_svg(name + "_xy", {axes, svg_xy});
-        const auto svg_zr = il.draw_surface(i, zr);
+        detray::svgtools::write_svg(name + "mat_xy", {axes, mat_xy});
+        const auto [svg_zr, mat_zr] = il.draw_surface(i, zr);
         detray::svgtools::write_svg(name + "_zr", {axes, svg_zr});
+        detray::svgtools::write_svg(name + "mat_zr", {axes, mat_zr});
     }
 }


### PR DESCRIPTION
Adds material a maps display to detray svgtools. The material maps will be drawn with the detray_detector_display tool alongside their surfaces, if a material maps file was provided. Three different color maps are currently available, but need to be set in c++ for now.

Also, fixes the proto surface type, so that passive surfaces can be drawn in a different color than sensitive surfaces, e.g. the toy detector beampipe is now grey.