### PR TITLE
External Updates, main branch (2024.03.14.)

### DIFF
--- a/extern/thrust/CMakeLists.txt
+++ b/extern/thrust/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,7 +18,7 @@ message( STATUS "Building Thrust as part of the Detray project" )
 
 # Declare where to get Thrust from.
 set( DETRAY_THRUST_SOURCE
-   "GIT_REPOSITORY;https://github.com/NVIDIA/thrust.git;GIT_TAG;1.15.0"
+   "GIT_REPOSITORY;https://github.com/NVIDIA/thrust.git;GIT_TAG;2.1.0"
    CACHE STRING "Source for Thrust, when built as part of this project" )
 mark_as_advanced( DETRAY_THRUST_SOURCE )
 FetchContent_Declare( Thrust ${DETRAY_THRUST_SOURCE} )

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message( STATUS "Building VecMem as part of the Detray project" )
 
 # Declare where to get VecMem from.
 set( DETRAY_VECMEM_SOURCE
-   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.3.0.tar.gz;URL_MD5;0ba29e2c5db4aaab02aeb93fc0900e3b"
+   "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.4.0.tar.gz;URL_MD5;af5434e34ca9c084678c2c043441f174"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( DETRAY_VECMEM_SOURCE )
 FetchContent_Declare( VecMem ${DETRAY_VECMEM_SOURCE} )


### PR DESCRIPTION
Updated the project to [Thrust 2.1.0](https://github.com/NVIDIA/thrust/releases/tag/2.1.0) and [VecMem 1.4.0](https://github.com/acts-project/vecmem/releases/tag/v1.4.0). Mainly to be able to build the project without errors and warnings coming from those projects, with:
  - oneAPI 2024.0.1 +
  - CUDA 12.4 +
  - ROCm 6.0.2.

(Actually, the code currently crashes Intel's `icpx` compiler. But that is something that I'll sort out with them...)