### PR TITLE
ref: Turn consistency checks off for detector construction

### DIFF
--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -253,7 +253,7 @@ inline void check_empty(const detector_t &det, const bool verbose) {
 
     // Check the material description
     if (det.material_store().all_empty()) {
-        std::cout << "WARNING: No material in detector" << std::endl;
+        std::cout << "INFO: No material in detector" << std::endl;
     } else if (verbose) {
         // Check for empty material collections
         detail::report_empty(

--- a/utils/include/detray/detectors/build_telescope_detector.hpp
+++ b/utils/include/detray/detectors/build_telescope_detector.hpp
@@ -80,7 +80,7 @@ struct tel_det_config {
     /// Safety envelope between the test surfaces and the portals
     scalar m_envelope{0.1f * unit<scalar>::mm};
     /// Run detector consistency check after reading
-    bool m_do_check{true};
+    bool m_do_check{false};
 
     /// Setters
     /// @{
@@ -204,7 +204,7 @@ inline auto build_telescope_detector(
             cfg.length(), cfg.n_surfaces(), cfg.module_mask().values(),
             cfg.pilot_track());
     } else {
-        // Put the modules in the requested poritions along pilot track
+        // Put the modules in the requested positions along pilot track
         tel_generator = std::make_unique<telescope_factory>(
             cfg.positions(), cfg.module_mask().values(), cfg.pilot_track());
     }

--- a/utils/include/detray/detectors/build_toy_detector.hpp
+++ b/utils/include/detray/detectors/build_toy_detector.hpp
@@ -133,7 +133,7 @@ struct toy_config {
     /// Config for the module generation (endcaps)
     endcap_generator_config<scalar_t> m_endcap_factory_cfg{};
     /// Run detector consistency check after reading
-    bool m_do_check{true};
+    bool m_do_check{false};
 
     /// Setters
     /// @{


### PR DESCRIPTION
Sets the default to check detector consistency to off for inbuilt detectors, but switch it on in the unittests, where there is no IO is used, to catch potential bug after changes to the telescope detector generation or builder infrastructure