### PR TITLE
feat: Add simd intersectors and benchmark them

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -69,6 +69,12 @@ if( DETRAY_VC_PLUGIN )
       INTERFACE detray::core detray::algebra_vc )
 endif()
 
+if( DETRAY_VC_SOA_PLUGIN )
+   detray_add_library( detray_core_vc_soa core_vc_soa )
+   target_link_libraries( detray_core_vc_soa
+      INTERFACE detray::core detray::algebra_vc_soa )
+endif()
+
 # Test the public headers of the detray core libraries.
 if( BUILD_TESTING AND DETRAY_BUILD_TESTING )
    string( REPLACE "include/" "" _detray_core_public_headers

--- a/core/include/detray/definitions/detail/algebra.hpp
+++ b/core/include/detray/definitions/detail/algebra.hpp
@@ -15,6 +15,8 @@
 #include "detray/plugins/algebra/smatrix_definitions.hpp"
 #elif DETRAY_ALGEBRA_VC
 #include "detray/plugins/algebra/vc_array_definitions.hpp"
+#elif DETRAY_ALGEBRA_VC_SOA
+#include "detray/plugins/algebra/vc_soa_definitions.hpp"
 #else
 #error "No algebra plugin selected! Please link to one of the algebra plugins."
 #endif
@@ -111,5 +113,22 @@ using dsize_type = typename detail::get_matrix<A>::size_type;
 
 template <typename A, std::size_t R, std::size_t C>
 using dmatrix = typename detail::get_matrix<A>::template matrix<R, C>;
+
+namespace detail {
+
+/// Check if an algebra has soa layout
+/// @{
+template <typename A, typename = void>
+struct is_soa : public std::false_type {};
+
+template <typename A>
+struct is_soa<A, std::enable_if_t<!std::is_arithmetic_v<dscalar<A>>, void>>
+    : public std::true_type {};
+
+template <typename A>
+inline constexpr bool is_soa_v = is_soa<A>::value;
+/// @}
+
+}  // namespace detail
 
 }  // namespace detray

--- a/core/include/detray/definitions/detail/boolean.hpp
+++ b/core/include/detray/definitions/detail/boolean.hpp
@@ -1,0 +1,79 @@
+
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/algebra.hpp"
+
+// System include(s)
+#include <type_traits>
+
+namespace detray {
+
+namespace detail {
+/// The detray boolean (mask) types (can be SIMD)
+/// @{
+template <typename A, typename = void>
+struct get_bool {};
+
+template <typename A>
+struct get_bool<A, std::enable_if_t<!detray::detail::is_soa_v<A>, void>> {
+    using boolean = bool;
+};
+
+template <typename A>
+struct get_bool<A, std::enable_if_t<detray::detail::is_soa_v<A>, void>> {
+    using boolean = typename A::boolean;
+};
+/// @}
+
+}  // namespace detail
+
+template <typename A>
+using dbool = typename detail::get_bool<A>::boolean;
+
+// TODO: Move to algebra plugins
+namespace detail {
+
+/// boolean utilities
+/// @{
+constexpr bool any_of(bool b) {
+    return b;
+}
+constexpr bool all_of(bool b) {
+    return b;
+}
+constexpr bool none_of(bool b) {
+    return !b;
+}
+
+#if (IS_SOA)
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_mask<T>::value, bool> = true>
+inline bool any_of(T &&mask) {
+    return Vc::any_of(std::forward<T>(mask));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_mask<T>::value, bool> = true>
+inline bool all_of(T &&mask) {
+    return Vc::all_of(std::forward<T>(mask));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_mask<T>::value, bool> = true>
+inline bool none_of(T &&mask) {
+    return Vc::none_of(std::forward<T>(mask));
+}
+#endif
+/// @}
+
+}  // namespace detail
+
+}  // namespace detray

--- a/core/include/detray/definitions/detail/math.hpp
+++ b/core/include/detray/definitions/detail/math.hpp
@@ -20,6 +20,111 @@ namespace detray {
 /// Namespace to pick up math functions from
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
 namespace math = cl::sycl;
+#elif IS_SOA
+
+namespace math {
+
+using std::abs;
+using std::asin;
+using std::atan;
+using std::copysign;
+using std::cos;
+using std::exp;
+using std::fabs;
+using std::fma;
+using std::log;
+using std::max;
+using std::min;
+using std::pow;
+using std::signbit;
+using std::sin;
+using std::sqrt;
+using std::tan;
+
+/// Vc overloads of common math functions
+/// @{
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) abs(T &&vec) {
+    return Vc::abs(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) fabs(T &&vec) {
+    return Vc::abs(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) sqrt(T &&vec) {
+    return Vc::sqrt(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) exp(T &&vec) {
+    return Vc::exp(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) log(T &&vec) {
+    return Vc::log(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) sin(T &&vec) {
+    return Vc::sin(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) asin(T &&vec) {
+    return Vc::asin(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) cos(T &&vec) {
+    return Vc::cos(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) tan(T &&vec) {
+    // It seems there is no dedicated @c Vc::tan function ?
+    return Vc::sin(std::forward<T>(vec)) / Vc::cos(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) atan(T &&vec) {
+    return Vc::atan(std::forward<T>(vec));
+}
+
+template <typename T, typename S,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true,
+          std::enable_if_t<Vc::Traits::is_simd_vector<S>::value, bool> = true>
+inline decltype(auto) copysign(T &&mag, S &&sgn) {
+    return Vc::copysign(std::forward<T>(mag), std::forward<S>(sgn));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) signbit(T &&vec) {
+    return Vc::isnegative(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) fma(T &&x, T &&y, T &&z) {
+    return Vc::fma(std::forward<T>(x), std::forward<T>(y), std::forward<T>(z));
+}
+/// @}
+
+}  // namespace math
 #else
 namespace math = std;
 #endif  // SYCL

--- a/core/include/detray/geometry/mask.hpp
+++ b/core/include/detray/geometry/mask.hpp
@@ -153,12 +153,10 @@ class mask {
     DETRAY_HOST_DEVICE
     inline auto is_inside(
         const point3_type& loc_p,
-        const scalar_type t = std::numeric_limits<scalar_type>::epsilon()) const
-        -> intersection::status {
+        const scalar_type t =
+            std::numeric_limits<scalar_type>::epsilon()) const {
 
-        return _shape.check_boundaries(_values, loc_p, t)
-                   ? intersection::status::e_inside
-                   : intersection::status::e_outside;
+        return _shape.check_boundaries(_values, loc_p, t);
     }
 
     /// @returns return local frame object (used in geometrical checks)

--- a/core/include/detray/geometry/shapes/annulus2D.hpp
+++ b/core/include/detray/geometry/shapes/annulus2D.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/detail/boolean.hpp"
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/math.hpp"
@@ -89,40 +90,39 @@ class annulus2D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
         // The two quantities to check: r^2 in beam system, phi in focal system:
 
         // Rotate by avr phi in the focal system (this is usually zero)
-        const scalar_t phi_strp{loc_p[1] - bounds[e_average_phi]};
+        const scalar_t phi_strp = loc_p[1] - bounds[e_average_phi];
 
         // Check phi boundaries, which are well def. in focal frame
-        if ((phi_strp < bounds[e_min_phi_rel] - tol) or
-            (phi_strp > bounds[e_max_phi_rel] + tol)) {
-            return false;
-        }
+        const auto phi_check = !((phi_strp < (bounds[e_min_phi_rel] - tol)) or
+                                 (phi_strp > (bounds[e_max_phi_rel] + tol)));
 
         // Now go to beam frame to check r boundaries. Use the origin
         // shift in polar coordinates for that
         // TODO: Put shift in r-phi into the bounds?
         const point_t shift_xy = {-bounds[e_shift_x], -bounds[e_shift_y], 0.f};
-        const scalar_t shift_r{getter::perp(shift_xy)};
-        const scalar_t shift_phi{getter::phi(shift_xy)};
+        const scalar_t shift_r = getter::perp(shift_xy);
+        const scalar_t shift_phi = getter::phi(shift_xy);
 
-        const scalar_t r_mod2{shift_r * shift_r + loc_p[0] * loc_p[0] +
-                              2.f * shift_r * loc_p[0] *
-                                  math::cos(phi_strp - shift_phi)};
+        const scalar_t r_mod2 =
+            shift_r * shift_r + loc_p[0] * loc_p[0] +
+            2.f * shift_r * loc_p[0] * math::cos(phi_strp - shift_phi);
 
         // Apply tolerances as squares: 0 <= a, 0 <= b: a^2 <= b^2 <=> a <= b
-        const scalar_t minR_tol{bounds[e_min_r] - tol};
-        const scalar_t maxR_tol{bounds[e_max_r] + tol};
+        const scalar_t minR_tol = bounds[e_min_r] - tol;
+        const scalar_t maxR_tol = bounds[e_max_r] + tol;
 
-        assert(minR_tol >= 0.f);
+        assert(!detail::any_of(minR_tol >= scalar_t(0.f)));
 
-        return ((r_mod2 >= minR_tol * minR_tol) and
-                (r_mod2 <= maxR_tol * maxR_tol));
+        return ((r_mod2 >= (minR_tol * minR_tol)) &&
+                (r_mod2 <= (maxR_tol * maxR_tol))) &&
+               phi_check;
     }
 
     /// @brief Measure of the shape: Area

--- a/core/include/detray/geometry/shapes/concentric_cylinder2D.hpp
+++ b/core/include/detray/geometry/shapes/concentric_cylinder2D.hpp
@@ -62,7 +62,7 @@ class concentric_cylinder2D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 

--- a/core/include/detray/geometry/shapes/cuboid3D.hpp
+++ b/core/include/detray/geometry/shapes/cuboid3D.hpp
@@ -62,15 +62,15 @@ class cuboid3D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
-        return (bounds[e_min_x] - tol <= loc_p[0] and
-                bounds[e_min_y] - tol <= loc_p[1] and
-                bounds[e_min_x] - tol <= loc_p[2] and
-                loc_p[0] <= bounds[e_max_x] + tol and
-                loc_p[1] <= bounds[e_max_y] + tol and
-                loc_p[2] <= bounds[e_max_z] + tol);
+        return ((bounds[e_min_x] - tol) <= loc_p[0] &&
+                (bounds[e_min_y] - tol) <= loc_p[1] &&
+                (bounds[e_min_x] - tol) <= loc_p[2] &&
+                loc_p[0] <= (bounds[e_max_x] + tol) &&
+                loc_p[1] <= (bounds[e_max_y] + tol) &&
+                loc_p[2] <= (bounds[e_max_z] + tol));
     }
 
     /// @brief Measure of the shape: Volume

--- a/core/include/detray/geometry/shapes/cylinder2D.hpp
+++ b/core/include/detray/geometry/shapes/cylinder2D.hpp
@@ -62,12 +62,12 @@ class cylinder2D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
-        return (bounds[e_n_half_z] - tol <= loc_p[1] and
-                loc_p[1] <= bounds[e_p_half_z] + tol);
+        return ((bounds[e_n_half_z] - tol) <= loc_p[1] &&
+                loc_p[1] <= (bounds[e_p_half_z] + tol));
     }
 
     /// @brief Measure of the shape: Area

--- a/core/include/detray/geometry/shapes/cylinder3D.hpp
+++ b/core/include/detray/geometry/shapes/cylinder3D.hpp
@@ -62,15 +62,15 @@ class cylinder3D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
-        return (bounds[e_min_r] - tol <= loc_p[0] and
-                bounds[e_min_phi] - tol <= loc_p[1] and
-                bounds[e_min_z] - tol <= loc_p[2] and
-                loc_p[0] <= bounds[e_max_r] + tol and
-                loc_p[1] <= bounds[e_max_phi] + tol and
-                loc_p[2] <= bounds[e_max_z] + tol);
+        return ((bounds[e_min_r] - tol) <= loc_p[0] &&
+                (bounds[e_min_phi] - tol) <= loc_p[1] &&
+                (bounds[e_min_z] - tol) <= loc_p[2] &&
+                loc_p[0] <= (bounds[e_max_r] + tol) &&
+                loc_p[1] <= (bounds[e_max_phi] + tol) &&
+                loc_p[2] <= (bounds[e_max_z] + tol));
     }
 
     /// @brief Measure of the shape: Volume

--- a/core/include/detray/geometry/shapes/line.hpp
+++ b/core/include/detray/geometry/shapes/line.hpp
@@ -72,7 +72,7 @@ class line {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == 2u, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
@@ -82,9 +82,9 @@ class line {
         // line from the line center is less than the half line length
         if constexpr (square_cross_sect) {
             return (math::fabs(loc_p[0] * math::cos(loc_p[2])) <=
-                        bounds[e_cross_section] + tol &&
+                        (bounds[e_cross_section] + tol) &&
                     math::fabs(loc_p[0] * math::sin(loc_p[2])) <=
-                        bounds[e_cross_section] + tol &&
+                        (bounds[e_cross_section] + tol) &&
                     math::fabs(loc_p[1]) <= bounds[e_half_z] + tol);
 
         }
@@ -93,8 +93,8 @@ class line {
         // of closest approach on the line from the line center is less than the
         // line half length
         else {
-            return (math::fabs(loc_p[0]) <= bounds[e_cross_section] + tol &&
-                    math::fabs(loc_p[1]) <= bounds[e_half_z] + tol);
+            return (math::fabs(loc_p[0]) <= (bounds[e_cross_section] + tol) &&
+                    math::fabs(loc_p[1]) <= (bounds[e_half_z] + tol));
         }
     }
 

--- a/core/include/detray/geometry/shapes/rectangle2D.hpp
+++ b/core/include/detray/geometry/shapes/rectangle2D.hpp
@@ -55,11 +55,11 @@ class rectangle2D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
-        return (math::fabs(loc_p[0]) <= bounds[e_half_x] + tol and
-                math::fabs(loc_p[1]) <= bounds[e_half_y] + tol);
+        return (math::fabs(loc_p[0]) <= (bounds[e_half_x] + tol) &&
+                math::fabs(loc_p[1]) <= (bounds[e_half_y] + tol));
     }
 
     /// @brief Measure of the shape: Area

--- a/core/include/detray/geometry/shapes/ring2D.hpp
+++ b/core/include/detray/geometry/shapes/ring2D.hpp
@@ -58,12 +58,12 @@ class ring2D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
-        return (loc_p[0] + tol >= bounds[e_inner_r] and
-                loc_p[0] <= bounds[e_outer_r] + tol);
+        return ((loc_p[0] + tol) >= bounds[e_inner_r] &&
+                loc_p[0] <= (bounds[e_outer_r] + tol));
     }
 
     /// @brief Measure of the shape: Area

--- a/core/include/detray/geometry/shapes/single3D.hpp
+++ b/core/include/detray/geometry/shapes/single3D.hpp
@@ -58,7 +58,7 @@ class single3D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         return (bounds[e_lower] - tol <= loc_p[kCheckIndex] and

--- a/core/include/detray/geometry/shapes/trapezoid2D.hpp
+++ b/core/include/detray/geometry/shapes/trapezoid2D.hpp
@@ -61,16 +61,16 @@ class trapezoid2D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
-        const scalar_t rel_y{(bounds[e_half_length_2] + loc_p[1]) *
-                             bounds[e_divisor]};
-        return (math::fabs(loc_p[0]) <= bounds[e_half_length_0] +
-                                            rel_y * (bounds[e_half_length_1] -
-                                                     bounds[e_half_length_0]) +
-                                            tol and
-                math::fabs(loc_p[1]) <= bounds[e_half_length_2] + tol);
+        const scalar_t rel_y =
+            (bounds[e_half_length_2] + loc_p[1]) * bounds[e_divisor];
+        return (math::fabs(loc_p[0]) <= (bounds[e_half_length_0] +
+                                         rel_y * (bounds[e_half_length_1] -
+                                                  bounds[e_half_length_0]) +
+                                         tol) &&
+                math::fabs(loc_p[1]) <= (bounds[e_half_length_2] + tol));
     }
 
     /// @brief Measure of the shape: Area

--- a/core/include/detray/geometry/shapes/unbounded.hpp
+++ b/core/include/detray/geometry/shapes/unbounded.hpp
@@ -46,7 +46,7 @@ class unbounded {
     ///
     /// @return always true
     template <typename bounds_t, typename point_t, typename scalar_t>
-    DETRAY_HOST_DEVICE inline constexpr bool check_boundaries(
+    DETRAY_HOST_DEVICE inline constexpr auto check_boundaries(
         const bounds_t& /*bounds*/, const point_t& /*loc_p*/,
         const scalar_t /*tol*/) const {
         return true;

--- a/core/include/detray/geometry/shapes/unmasked.hpp
+++ b/core/include/detray/geometry/shapes/unmasked.hpp
@@ -44,7 +44,7 @@ class unmasked {
     ///
     /// @return always true
     template <typename bounds_t, typename point_t, typename scalar_t>
-    DETRAY_HOST_DEVICE inline constexpr bool check_boundaries(
+    DETRAY_HOST_DEVICE inline constexpr auto check_boundaries(
         const bounds_t& /*bounds*/, const point_t& /*loc_p*/,
         const scalar_t /*tol*/) const {
         return true;

--- a/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
@@ -35,7 +35,7 @@ struct helix_intersector_impl;
 /// @note Don't use for low p_t tracks!
 template <typename algebra_t>
 struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
-    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
+    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, false> {
 
     using scalar_type = dscalar<algebra_t>;
     using point3_type = dpoint3D<algebra_t>;
@@ -179,11 +179,9 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
             sfi.status = mask.is_inside(sfi.local, tol);
 
             // Compute some additional information if the intersection is valid
-            if (sfi.status == intersection::status::e_inside) {
+            if (sfi.status) {
                 sfi.sf_desc = sf_desc;
-                sfi.direction = math::signbit(s)
-                                    ? intersection::direction::e_opposite
-                                    : intersection::direction::e_along;
+                sfi.direction = !math::signbit(s);
                 sfi.volume_link = mask.volume_link();
             }
         }

--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -89,7 +89,7 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
         // @NOTE We might not have to call this which is meant to be for ray
         // intersection...
         if (denom < 1e-5f) {
-            sfi.status = intersection::status::e_missed;
+            sfi.status = false;
             return sfi;
         }
 
@@ -166,11 +166,9 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
         sfi.status = mask.is_inside(sfi.local, tol);
 
         // Compute some additional information if the intersection is valid
-        if (sfi.status == intersection::status::e_inside) {
+        if (sfi.status) {
             sfi.sf_desc = sf_desc;
-            sfi.direction = math::signbit(s)
-                                ? intersection::direction::e_opposite
-                                : intersection::direction::e_along;
+            sfi.direction = !math::signbit(s);
             sfi.volume_link = mask.volume_link();
         }
 

--- a/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
@@ -120,11 +120,9 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
         sfi.status = mask.is_inside(sfi.local, tol);
 
         // Compute some additional information if the intersection is valid
-        if (sfi.status == intersection::status::e_inside) {
+        if (sfi.status) {
             sfi.sf_desc = sf_desc;
-            sfi.direction = math::signbit(s)
-                                ? intersection::direction::e_opposite
-                                : intersection::direction::e_along;
+            sfi.direction = !math::signbit(s);
             sfi.volume_link = mask.volume_link();
         }
 

--- a/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
@@ -120,11 +120,9 @@ struct ray_concentric_cylinder_intersector {
 
                 // prepare some additional information in case the intersection
                 // is valid
-                if (is.status == intersection::status::e_inside) {
+                if (is.status) {
                     is.sf_desc = sf;
-                    is.direction = detail::signbit(is.path)
-                                       ? intersection::direction::e_opposite
-                                       : intersection::direction::e_along;
+                    is.direction = !detail::signbit(is.path);
                     is.volume_link = mask.volume_link();
 
                     // Get incidence angle

--- a/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
@@ -21,14 +21,14 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t>
+template <typename frame_t, typename algebra_t, bool is_soa>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between a ray and a 2D cylinder mask
 template <typename algebra_t>
-struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
+struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, false> {
 
-    /// linear algebra types
+    /// Linear algebra types
     /// @{
     using scalar_type = dscalar<algebra_t>;
     using point3_type = dpoint3D<algebra_t>;
@@ -80,8 +80,8 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
                 ret[0].sf_desc = sf;
                 break;
             case 0:
-                ret[0].status = intersection::status::e_missed;
-                ret[1].status = intersection::status::e_missed;
+                ret[0].status = false;
+                ret[1].status = false;
         };
 
         // Even if there are two geometrically valid solutions, the smaller one
@@ -128,7 +128,7 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
                     ray, mask, trf, qe.smaller(), mask_tolerance, overstep_tol);
                 break;
             case 0:
-                sfi.status = intersection::status::e_missed;
+                sfi.status = false;
         };
     }
 
@@ -195,10 +195,8 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
 
             // prepare some additional information in case the intersection
             // is valid
-            if (is.status == intersection::status::e_inside) {
-                is.direction = detail::signbit(is.path)
-                                   ? intersection::direction::e_opposite
-                                   : intersection::direction::e_along;
+            if (is.status) {
+                is.direction = !detail::signbit(is.path);
                 is.volume_link = mask.volume_link();
 
                 // Get incidence angle
@@ -207,7 +205,7 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
                 is.cos_incidence_angle = vector::dot(rd, normal);
             }
         } else {
-            is.status = intersection::status::e_missed;
+            is.status = false;
         }
 
         return is;

--- a/core/include/detray/navigation/intersection/ray_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_intersector.hpp
@@ -12,6 +12,10 @@
 #include "detray/navigation/intersection/ray_cylinder_portal_intersector.hpp"
 #include "detray/navigation/intersection/ray_line_intersector.hpp"
 #include "detray/navigation/intersection/ray_plane_intersector.hpp"
+#include "detray/navigation/intersection/soa/ray_cylinder_intersector.hpp"
+#include "detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp"
+#include "detray/navigation/intersection/soa/ray_line_intersector.hpp"
+#include "detray/navigation/intersection/soa/ray_plane_intersector.hpp"
 
 namespace detray {
 
@@ -20,12 +24,12 @@ namespace detray {
 ///
 /// @note specialized into the concrete intersectors for the different local
 /// geometries in the respective header files
-template <typename frame_t, typename algebra_t>
+template <typename frame_t, typename algebra_t, bool is_soa = false>
 struct ray_intersector_impl {};
 
 template <typename shape_t, typename algebra_t>
 using ray_intersector =
     ray_intersector_impl<typename shape_t::template local_frame_type<algebra_t>,
-                         algebra_t>;
+                         algebra_t, detail::is_soa_v<algebra_t>>;
 
 }  // namespace detray

--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -19,12 +19,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t>
+template <typename frame_t, typename algebra_t, bool is_soa>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between trajectory and line mask
 template <typename algebra_t>
-struct ray_intersector_impl<line2D<algebra_t>, algebra_t> {
+struct ray_intersector_impl<line2D<algebra_t>, algebra_t, false> {
 
     using scalar_type = dscalar<algebra_t>;
     using point3_type = dpoint3D<algebra_t>;
@@ -81,7 +81,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t> {
 
         // Case for wire is parallel to track
         if (denom < 1e-5f) {
-            is.status = intersection::status::e_missed;
+            is.status = false;
             return is;
         }
 
@@ -113,12 +113,9 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t> {
 
             // prepare some additional information in case the intersection
             // is valid
-            if (is.status == intersection::status::e_inside) {
+            if (is.status) {
                 is.sf_desc = sf;
-
-                is.direction = detail::signbit(is.path)
-                                   ? intersection::direction::e_opposite
-                                   : intersection::direction::e_along;
+                is.direction = !detail::signbit(is.path);
                 is.volume_link = mask.volume_link();
 
                 // Get incidence angle

--- a/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
@@ -20,12 +20,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t>
+template <typename frame_t, typename algebra_t, bool is_soa>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between straight line and planar surface
 template <typename algebra_t>
-struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
+struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {
 
     /// linear algebra types
     /// @{
@@ -93,12 +93,9 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
 
                 // prepare some additional information in case the intersection
                 // is valid
-                if (is.status == intersection::status::e_inside) {
+                if (is.status) {
                     is.sf_desc = sf;
-
-                    is.direction = detail::signbit(is.path)
-                                       ? intersection::direction::e_opposite
-                                       : intersection::direction::e_along;
+                    is.direction = !detail::signbit(is.path);
                     is.volume_link = mask.volume_link();
 
                     // Get incidene angle
@@ -106,7 +103,7 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
                 }
             }
         } else {
-            is.status = intersection::status::e_missed;
+            is.status = false;
         }
 
         return is;
@@ -146,7 +143,7 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
 };
 
 template <typename algebra_t>
-struct ray_intersector_impl<polar2D<algebra_t>, algebra_t>
-    : public ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {};
+struct ray_intersector_impl<polar2D<algebra_t>, algebra_t, false>
+    : public ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {};
 
 }  // namespace detray

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_intersector.hpp
@@ -1,0 +1,184 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/boolean.hpp"
+#include "detray/definitions/detail/math.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/geometry/coordinates/cylindrical2D.hpp"
+#include "detray/navigation/detail/ray.hpp"
+#include "detray/navigation/intersection/intersection.hpp"
+#include "detray/utils/quadratic_equation.hpp"
+
+// System include(s)
+#include <type_traits>
+
+namespace detray {
+
+template <typename frame_t, typename algebra_t, bool is_soa>
+struct ray_intersector_impl;
+
+/// A functor to find intersections between straight line and planar surface
+template <typename algebra_t>
+struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, true> {
+
+    /// Linear algebra types
+    /// @{
+    using scalar_type = dscalar<algebra_t>;
+    using point3_type = dpoint3D<algebra_t>;
+    using vector3_type = dvector3D<algebra_t>;
+    using transform3_type = dtransform3D<algebra_t>;
+    /// @}
+
+    template <typename surface_descr_t>
+    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+
+    /// Operator function to find intersections between a ray and a 2D cylinder
+    ///
+    /// @tparam mask_t is the input mask type
+    /// @tparam surface_t is the type of surface handle
+    ///
+    /// @param ray is the input ray trajectory
+    /// @param sf the surface handle the mask is associated with
+    /// @param mask is the input mask that defines the surface extent
+    /// @param trf is the surface placement transform
+    /// @param mask_tolerance is the tolerance for mask edges
+    ///
+    /// @return the intersections.
+    template <typename surface_descr_t, typename mask_t,
+              typename other_algebra_t>
+    DETRAY_HOST_DEVICE inline std::array<intersection_type<surface_descr_t>, 2>
+    operator()(const detail::ray<other_algebra_t> &ray,
+               const surface_descr_t &sf, const mask_t &mask,
+               const transform3_type &trf,
+               const scalar_type mask_tolerance = 0.f,
+               const scalar_type overstep_tol = 0.f) const {
+
+        // One or both of these solutions might be invalid
+        const auto qe = solve_intersection(ray, mask, trf);
+
+        std::array<intersection_type<surface_descr_t>, 2> ret;
+        ret[1] = build_candidate<surface_descr_t>(ray, mask, trf, qe.larger(),
+                                                  mask_tolerance, overstep_tol);
+        ret[1].sf_desc = sf;
+
+        ret[0] = build_candidate<surface_descr_t>(ray, mask, trf, qe.smaller(),
+                                                  mask_tolerance, overstep_tol);
+        ret[0].sf_desc = sf;
+
+        // Even if there are two geometrically valid solutions, the smaller one
+        // might not be passed on if it is below the overstepping tolerance:
+        // see 'build_candidate'
+        return ret;
+    }
+
+    /// Operator function to find intersections between a ray and a 2D cylinder
+    ///
+    /// @tparam mask_t is the input mask type
+    ///
+    /// @param ray is the input ray trajectory
+    /// @param sfi the intersection to be updated
+    /// @param mask is the input mask that defines the surface extent
+    /// @param trf is the surface placement transform
+    /// @param mask_tolerance is the tolerance for mask edges
+    template <typename mask_t, typename surface_descr_t,
+              typename other_algebra_t>
+    DETRAY_HOST_DEVICE inline void update(
+        const detail::ray<other_algebra_t> &ray,
+        intersection_type<surface_descr_t> &sfi, const mask_t &mask,
+        const transform3_type &trf, const scalar_type mask_tolerance = 0.f,
+        const scalar_type overstep_tol = 0.f) const {
+
+        // One or both of these solutions might be invalid
+        const auto qe = solve_intersection(ray, mask, trf);
+
+        // Construct the candidate only when needed
+        sfi.status = (qe.solutions() > 0.f);
+
+        if (detray::detail::none_of(sfi.status)) {
+            return;
+        }
+
+        sfi = build_candidate<surface_descr_t>(ray, mask, trf, qe.smaller(),
+                                               mask_tolerance, overstep_tol);
+    }
+
+    protected:
+    /// Calculates the distance to the (two) intersection points on the
+    /// cylinder in global coordinates.
+    ///
+    /// @returns a quadratic equation object that contains the solution(s).
+    template <typename mask_t, typename other_algebra_t>
+    DETRAY_HOST_DEVICE inline auto solve_intersection(
+        const detail::ray<other_algebra_t> &ray, const mask_t &mask,
+        const transform3_type &trf) const {
+        const auto &m = trf.matrix();
+        const vector3_type sz = getter::vector<3>(m, 0u, 2u);
+        const vector3_type sc = getter::vector<3>(m, 0u, 3u);
+
+        const scalar_type r = mask[mask_t::shape::e_r];
+
+        const auto &pos = ray.pos();
+        const auto &dir = ray.dir();
+        const point3_type ro{pos[0], pos[1], pos[2]};
+        const vector3_type rd{dir[0], dir[1], dir[2]};
+
+        const vector3_type tmp = ro - sc;
+        const auto pc_cross_sz = vector::cross(tmp, sz);
+        const auto rd_cross_sz = vector::cross(rd, sz);
+        const scalar_type a = vector::dot(rd_cross_sz, rd_cross_sz);
+        const scalar_type b = 2.f * vector::dot(rd_cross_sz, pc_cross_sz);
+        const scalar_type c = vector::dot(pc_cross_sz, pc_cross_sz) - (r * r);
+
+        return detail::quadratic_equation<scalar_type>{a, b, c};
+    }
+
+    /// From the intersection path, construct an intersection candidate and
+    /// check it against the surface boundaries (mask).
+    ///
+    /// @returns the intersection candidate. Might be (partially) uninitialized
+    /// if the overstepping tolerance is not met or the intersection lies
+    /// outside of the mask.
+    template <typename surface_descr_t, typename mask_t,
+              typename other_algebra_t>
+    DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t>
+    build_candidate(const detail::ray<other_algebra_t> &ray, const mask_t &mask,
+                    const transform3_type &trf, const scalar_type path,
+                    const scalar_type mask_tolerance = 0.f,
+                    const scalar_type overstep_tol = 0.f) const {
+
+        intersection_type<surface_descr_t> is;
+
+        const auto &pos = ray.pos();
+        const auto &dir = ray.dir();
+        const point3_type ro{pos[0], pos[1], pos[2]};
+        const vector3_type rd{dir[0], dir[1], dir[2]};
+
+        is.path = path;
+        const point3_type p3 = ro + is.path * rd;
+
+        is.local = mask.to_local_frame(trf, p3);
+        is.status = mask.is_inside(is.local, mask_tolerance);
+
+        is.direction = !math::signbit(is.path);
+        is.volume_link = mask.volume_link();
+
+        // Get incidence angle
+        const scalar_type phi{is.local[0] / is.local[2]};
+        const vector3_type normal = {math::cos(phi), math::sin(phi), 0.f};
+        is.cos_incidence_angle = vector::dot(rd, normal);
+
+        // Mask the values where the overstepping tolerance was not met
+        is.status &= (is.path >= overstep_tol);
+
+        return is;
+    }
+};
+
+}  // namespace detray

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,22 +8,18 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/detail/boolean.hpp"
 #include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/geometry/coordinates/concentric_cylindrical2D.hpp"
-#include "detray/geometry/coordinates/cylindrical2D.hpp"
 #include "detray/navigation/detail/ray.hpp"
 #include "detray/navigation/intersection/intersection.hpp"
-#include "detray/navigation/intersection/ray_cylinder_intersector.hpp"
-#include "detray/utils/quadratic_equation.hpp"
+#include "detray/navigation/intersection/soa/ray_cylinder_intersector.hpp"
 
 // System include(s)
 #include <type_traits>
 
 namespace detray {
-
-template <typename frame_t, typename algebra_t, bool is_soa>
-struct ray_intersector_impl;
 
 /// @brief A functor to find intersections between a straight line and a
 /// cylindrical portal surface.
@@ -32,10 +28,10 @@ struct ray_intersector_impl;
 /// intersection points is needed in the case of a cylinderical portal surface.
 template <typename algebra_t>
 struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
-                            false>
-    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, false> {
+                            true>
+    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, true> {
 
-    /// linear algebra types
+    /// Linear algebra types
     /// @{
     using scalar_type = dscalar<algebra_t>;
     using point3_type = dpoint3D<algebra_t>;
@@ -45,27 +41,25 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
 
     template <typename surface_descr_t>
     using intersection_type = intersection2D<surface_descr_t, algebra_t>;
-    using ray_type = detail::ray<algebra_t>;
 
     /// Operator function to find intersections between ray and cylinder mask
     ///
     /// @tparam mask_t is the input mask type
-    /// @tparam surface_descr_t is the type of surface handle
+    /// @tparam surface_t is the type of surface handle
     ///
     /// @param ray is the input ray trajectory
     /// @param sf the surface handle the mask is associated with
     /// @param mask is the input mask that defines the surface extent
     /// @param trf is the surface placement transform
     /// @param mask_tolerance is the tolerance for mask edges
-    /// @param overstep_tol negative cutoff for the path
     ///
     /// @return the closest intersection
-    template <typename surface_descr_t, typename mask_t>
+    template <typename surface_descr_t, typename mask_t,
+              typename other_algebra_t>
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
-        const ray_type &ray, const surface_descr_t &sf, const mask_t &mask,
-        const transform3_type &trf,
-        const std::array<scalar_type, 2u> mask_tolerance =
-            {0.f, 1.f * unit<scalar_type>::mm},
+        const detail::ray<other_algebra_t> &ray, const surface_descr_t &sf,
+        const mask_t &mask, const transform3_type &trf,
+        const scalar_type mask_tolerance = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
         intersection_type<surface_descr_t> is;
@@ -74,30 +68,25 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
         // along the direction of the track and one behind it
         const auto qe = this->solve_intersection(ray, mask, trf);
 
-        // Find the closest valid intersection
-        if (qe.solutions() > 0 and qe.larger() > overstep_tol) {
-            // Only the closest intersection that is outside the overstepping
-            // tolerance is needed
-            const scalar_type t{(qe.smaller() > overstep_tol) ? qe.smaller()
-                                                              : qe.larger()};
-            is = this->template build_candidate<surface_descr_t>(
-                ray, mask, trf, t, mask_tolerance, overstep_tol);
-            is.sf_desc = sf;
-        } else {
-            is.status = false;
+        // None of the cylinders has a valid intersection
+        if (detray::detail::all_of(qe.solutions() <= 0) or
+            detray::detail::all_of(qe.larger() <= overstep_tol)) {
+            is.status = decltype(is.status)(false);
+            return is;
         }
 
-        return is;
-    }
+        // Only the closest intersection that is outside the overstepping
+        // tolerance is needed
+        const auto valid_smaller = (qe.smaller() > overstep_tol);
+        scalar_type t = 0.f;
+        t(valid_smaller) = qe.smaller();
+        t(!valid_smaller) = qe.larger();
 
-    /// Interface to use fixed mask tolerance
-    template <typename surface_descr_t, typename mask_t>
-    DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
-        const ray_type &ray, const surface_descr_t &sf, const mask_t &mask,
-        const transform3_type &trf, const scalar_type mask_tolerance,
-        const scalar_type overstep_tol = 0.f) const {
-        return this->operator()(ray, sf, mask, trf, {mask_tolerance, 0.f},
-                                overstep_tol);
+        is = this->template build_candidate<surface_descr_t>(
+            ray, mask, trf, t, mask_tolerance, overstep_tol);
+        is.sf_desc = sf;
+
+        return is;
     }
 
     /// Operator function to find intersections between a ray and a 2D cylinder
@@ -109,13 +98,12 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
     /// @param mask is the input mask that defines the surface extent
     /// @param trf is the surface placement transform
     /// @param mask_tolerance is the tolerance for mask edges
-    /// @param overstep_tol negative cutoff for the path
-    template <typename surface_descr_t, typename mask_t>
+    template <typename surface_descr_t, typename mask_t,
+              typename other_algebra_t>
     DETRAY_HOST_DEVICE inline void update(
-        const ray_type &ray, intersection_type<surface_descr_t> &sfi,
-        const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance =
-            {0.f, 1.f * unit<scalar_type>::mm},
+        const detail::ray<other_algebra_t> &ray,
+        intersection_type<surface_descr_t> &sfi, const mask_t &mask,
+        const transform3_type &trf, const scalar_type mask_tolerance = 0.f,
         const scalar_type overstep_tol = 0.f) const {
         sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,
                                overstep_tol);

--- a/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
@@ -1,0 +1,143 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/boolean.hpp"
+#include "detray/definitions/detail/math.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/geometry/coordinates/line2D.hpp"
+#include "detray/navigation/detail/ray.hpp"
+#include "detray/navigation/intersection/intersection.hpp"
+
+// System include(s)
+#include <type_traits>
+
+namespace detray {
+
+template <typename frame_t, typename algebra_t, bool is_soa>
+struct ray_intersector_impl;
+
+/// A functor to find intersections between straight line and planar surface
+template <typename algebra_t>
+struct ray_intersector_impl<line2D<algebra_t>, algebra_t, true> {
+
+    /// Linear algebra types
+    /// @{
+    using scalar_type = dscalar<algebra_t>;
+    using point3_type = dpoint3D<algebra_t>;
+    using vector3_type = dvector3D<algebra_t>;
+    using transform3_type = dtransform3D<algebra_t>;
+    /// @}
+
+    template <typename surface_descr_t>
+    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+
+    /// Operator function to find intersections between ray and line mask
+    ///
+    /// @tparam mask_t is the input mask type
+    /// @tparam surface_t is the type of surface handle
+    ///
+    /// @param ray is the input ray trajectory
+    /// @param sf the surface handle the mask is associated with
+    /// @param mask is the input mask that defines the surface extent
+    /// @param trf is the surface placement transform
+    /// @param mask_tolerance is the tolerance for mask edges
+    //
+    /// @return the intersection
+    template <typename surface_descr_t, typename mask_t,
+              typename other_algebra_t>
+    DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
+        const detail::ray<other_algebra_t> &ray, const surface_descr_t &sf,
+        const mask_t &mask, const transform3_type &trf,
+        const scalar_type mask_tolerance = 0.f,
+        const scalar_type overstep_tol = 0.f) const {
+
+        intersection_type<surface_descr_t> is;
+
+        // line direction
+        const vector3_type sz = getter::vector<3>(trf.matrix(), 0u, 2u);
+
+        // line center
+        const point3_type st = trf.translation();
+
+        // Broadcast ray data
+        const auto &pos = ray.pos();
+        const auto &dir = ray.dir();
+        const vector3_type ro{pos[0], pos[1], pos[2]};
+        const vector3_type rd{dir[0], dir[1], dir[2]};
+
+        // Projection of line to track direction
+        const scalar_type zd = vector::dot(sz, rd);
+
+        const scalar_type denom = 1.f - (zd * zd);
+
+        // Case for wire is parallel to track
+        if (detray::detail::all_of(denom < 1e-5f)) {
+            is.status = decltype(is.status)(false);
+            return is;
+        }
+
+        // vector from track position to line center
+        const vector3_type t2l = st - ro;
+
+        // t2l projection on line direction
+        const scalar_type t2l_on_line = vector::dot(t2l, sz);
+
+        // t2l projection on track direction
+        const scalar_type t2l_on_track = vector::dot(t2l, rd);
+
+        // path length to the point of closest approach on the track
+        is.path = (t2l_on_track - t2l_on_line * zd) / denom;
+
+        // point of closest approach on the track
+        const point3_type m = ro + rd * is.path;
+        is.local = mask.to_local_frame(trf, m, rd);
+        is.status = mask.is_inside(is.local, mask_tolerance);
+
+        // Early return, in case all intersections are invalid
+        if (detray::detail::none_of(is.status)) {
+            return is;
+        }
+
+        is.sf_desc = sf;
+
+        is.direction = math::signbit(is.path);
+        is.volume_link = mask.volume_link();
+
+        // Get incidence angle
+        is.cos_incidence_angle = math::abs(zd);
+
+        // Mask the values where the overstepping tolerance was not met
+        is.status &= (is.path >= overstep_tol);
+
+        return is;
+    }
+
+    /// Operator function to find intersections between a ray and a line.
+    ///
+    /// @tparam mask_t is the input mask type
+    ///
+    /// @param ray is the input ray trajectory
+    /// @param sfi the intersection to be updated
+    /// @param mask is the input mask that defines the surface extent
+    /// @param trf is the surface placement transform
+    /// @param mask_tolerance is the tolerance for mask edges
+    template <typename surface_descr_t, typename mask_t,
+              typename other_algebra_t>
+    DETRAY_HOST_DEVICE inline void update(
+        const detail::ray<other_algebra_t> &ray,
+        intersection_type<surface_descr_t> &sfi, const mask_t &mask,
+        const transform3_type &trf, const scalar_type mask_tolerance = 0.f,
+        const scalar_type overstep_tol = 0.f) const {
+        sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,
+                               overstep_tol);
+    }
+};
+
+}  // namespace detray

--- a/core/include/detray/navigation/intersection/soa/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_plane_intersector.hpp
@@ -1,0 +1,135 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/boolean.hpp"
+#include "detray/definitions/detail/math.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/geometry/coordinates/cartesian2D.hpp"
+#include "detray/geometry/coordinates/polar2D.hpp"
+#include "detray/navigation/detail/ray.hpp"
+#include "detray/navigation/intersection/intersection.hpp"
+
+// System include(s)
+#include <type_traits>
+
+namespace detray {
+
+template <typename frame_t, typename algebra_t, bool is_soa>
+struct ray_intersector_impl;
+
+/// A functor to find intersections between straight line and planar surface
+template <typename algebra_t>
+struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, true> {
+
+    /// Linear algebra types
+    /// @{
+    using scalar_type = dscalar<algebra_t>;
+    using point3_type = dpoint3D<algebra_t>;
+    using vector3_type = dvector3D<algebra_t>;
+    using transform3_type = dtransform3D<algebra_t>;
+    /// @}
+
+    template <typename surface_descr_t>
+    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+
+    /// Operator function to find intersections between ray and planar mask
+    ///
+    /// @tparam mask_t is the input mask type
+    /// @tparam surface_t is the type of surface handle
+    ///
+    /// @param ray is the input ray trajectory
+    /// @param sf the surface handle the mask is associated with
+    /// @param mask is the input mask that defines the surface extent
+    /// @param trf is the surface placement transform
+    /// @param mask_tolerance is the tolerance for mask edges
+    ///
+    /// @return the intersection
+    template <typename surface_descr_t, typename mask_t,
+              typename other_algebra_t>
+    DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
+        const detail::ray<other_algebra_t> &ray, const surface_descr_t &sf,
+        const mask_t &mask, const transform3_type &trf,
+        const scalar_type mask_tolerance = 0.f,
+        const scalar_type overstep_tol = 0.f) const {
+
+        intersection_type<surface_descr_t> is;
+
+        // Retrieve the surface normal & translation (context resolved)
+        const auto &sm = trf.matrix();
+        // const vector3 sn = getter::vector<3>(sm, 0u, 2u);
+        const vector3_type sn = sm.z;
+        const vector3_type st = trf.translation();
+
+        // Broadcast ray data
+        const auto &pos = ray.pos();
+        const auto &dir = ray.dir();
+        const vector3_type ro{pos[0], pos[1], pos[2]};
+        const vector3_type rd{dir[0], dir[1], dir[2]};
+
+        const scalar_type denom = vector::dot(rd, sn);
+        const vector3_type diff = st - ro;
+        is.path = vector::dot(sn, diff) / denom;
+
+        // Check if we divided by zero
+        const auto check_sum = is.path.sum();
+        if (!std::isnan(check_sum) and !std::isinf(check_sum)) {
+
+            const point3_type p3 = ro + is.path * rd;
+            is.local = mask.to_local_frame(trf, p3, rd);
+            is.status = mask.is_inside(is.local, mask_tolerance);
+
+            // Early return, if no intersection was found
+            if (detray::detail::none_of(is.status)) {
+                return is;
+            }
+
+            is.sf_desc = sf;
+            is.direction = !math::signbit(is.path);
+            is.volume_link = mask.volume_link();
+
+            // Get incidene angle
+            is.cos_incidence_angle = math::abs(denom);
+
+            // Mask the values where the overstepping tolerance was not met
+            is.status &= (is.path >= overstep_tol);
+        } else {
+            is.status = decltype(is.status)(false);
+        }
+
+        return is;
+    }
+
+    /// Operator function to updtae an intersections between a ray and a planar
+    /// surface.
+    ///
+    /// @tparam mask_t is the input mask type
+    ///
+    /// @param ray is the input ray trajectory
+    /// @param sfi the intersection to be updated
+    /// @param mask is the input mask that defines the surface extent
+    /// @param trf is the surface placement transform
+    /// @param mask_tolerance is the tolerance for mask edges
+    template <typename surface_descr_t, typename mask_t,
+              typename other_algebra_t>
+    DETRAY_HOST_DEVICE inline void update(
+        const detail::ray<other_algebra_t> &ray,
+        intersection_type<surface_descr_t> &sfi, const mask_t &mask,
+        const transform3_type &trf, const scalar_type mask_tolerance = 0.f,
+        const scalar_type overstep_tol = 0.f) const {
+        sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,
+                               overstep_tol);
+    }
+};
+
+template <typename algebra_t>
+struct ray_intersector_impl<polar2D<algebra_t>, algebra_t, true>
+    : public ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, true> {};
+
+}  // namespace detray

--- a/core/include/detray/navigation/intersection_kernel.hpp
+++ b/core/include/detray/navigation/intersection_kernel.hpp
@@ -70,15 +70,15 @@ struct intersection_initialize {
     private:
     template <typename is_container_t>
     DETRAY_HOST_DEVICE bool place_in_collection(
-        typename is_container_t::value_type &&sfi,
+        const typename is_container_t::value_type &sfi,
         is_container_t &intersections) const {
-        bool is_inside = (sfi.status == intersection::status::e_inside);
-        if (is_inside) {
+
+        if (sfi.status) {
             assert(intersections.size() < intersections.capacity() &&
                    "Navigation cache size too small");
             intersections.push_back(sfi);
         }
-        return is_inside;
+        return sfi.status;
     }
 
     template <typename is_container_t>
@@ -87,13 +87,12 @@ struct intersection_initialize {
         is_container_t &intersections) const {
         bool is_valid = false;
         for (auto &sfi : solutions) {
-            bool is_inside = (sfi.status == intersection::status::e_inside);
-            if (is_inside) {
+            if (sfi.status) {
                 assert(intersections.size() < intersections.capacity() &&
                        "Navigation cache size too small");
                 intersections.push_back(sfi);
             }
-            is_valid |= is_inside;
+            is_valid |= sfi.status;
         }
         return is_valid;
     }
@@ -145,7 +144,7 @@ struct intersection_update {
             intersector_t<typename mask_t::shape, algebra_t>{}.update(
                 traj, sfi, mask, ctf, mask_tolerance, overstep_tol);
 
-            if (sfi.status == intersection::status::e_inside) {
+            if (sfi.status) {
                 return true;
             }
         }

--- a/core/include/detray/utils/bounding_volume.hpp
+++ b/core/include/detray/utils/bounding_volume.hpp
@@ -296,10 +296,9 @@ class axis_aligned_bounding_volume {
     /// in the coordinate frame that is spanned by the box axes.
     DETRAY_HOST_DEVICE
     template <typename point_t>
-    constexpr auto is_inside(
+    constexpr bool is_inside(
         const point_t& loc_p,
-        const scalar_t t = std::numeric_limits<scalar_t>::epsilon()) const
-        -> intersection::status {
+        const scalar_t t = std::numeric_limits<scalar_t>::epsilon()) const {
         return m_mask.is_inside(loc_p, t);
     }
 
@@ -317,20 +316,18 @@ class axis_aligned_bounding_volume {
     /// @TODO: Overlapping aabbs
     /*DETRAY_HOST_DEVICE
     template<typename algebra_t>
-    constexpr auto intersect(
+    constexpr bool intersect(
         const axis_aligned_bounding_volume &aabb,
-        const scalar_t t = std::numeric_limits<scalar_t>::epsilon()) const
-        -> intersection::status {
+        const scalar_t t = std::numeric_limits<scalar_t>::epsilon()) const {
         return m_mask.is_overlap(aabb.bounds());
     }*/
 
     /// @TODO: Frustum intersection
     /*DETRAY_HOST_DEVICE
     template<typename algebra_t>
-    constexpr auto intersect(
+    constexpr bool intersect(
         const detail::frustum<algebra_t> frustum,
-        const scalar_t t = std::numeric_limits<scalar_t>::epsilon()) const
-        -> intersection::status {
+        const scalar_t t = std::numeric_limits<scalar_t>::epsilon()) const {
         ....
     }*/
 

--- a/core/include/detray/utils/quadratic_equation.hpp
+++ b/core/include/detray/utils/quadratic_equation.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/detail/algebra.hpp"
+#include "detray/definitions/detail/boolean.hpp"
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
@@ -18,13 +20,17 @@
 
 namespace detray::detail {
 
+template <typename scalar_t, typename = void>
+class quadratic_equation {};
+
 /// Class to solve a quadratic equation of type a * x^2 + b * x + c = 0
 ///
 /// @note If there are no real solutions, the result is undefined
 /// @note The solutions are sorted by default. If there is only one solution,
 /// the larger value is undefined.
 template <typename scalar_t>
-class quadratic_equation {
+class quadratic_equation<
+    scalar_t, std::enable_if_t<std::is_arithmetic_v<scalar_t>, void>> {
     public:
     quadratic_equation() = delete;
 
@@ -83,5 +89,95 @@ class quadratic_equation {
     std::array<scalar_t, 2> m_values{detail::invalid_value<scalar_t>(),
                                      detail::invalid_value<scalar_t>()};
 };
+
+/// Class to solve a quadratic equation of type a * x^2 + b * x + c = 0
+///
+/// @note If there are no real solutions, the result is undefined
+/// @note The solutions are sorted by default. If there is only one
+/// solution, the larger value is undefined.
+template <typename scalar_t>
+class quadratic_equation<
+    scalar_t, std::enable_if_t<!std::is_arithmetic_v<scalar_t>, void>> {
+    public:
+    quadratic_equation() = delete;
+
+    DETRAY_HOST_DEVICE
+    constexpr quadratic_equation(const scalar_t &a, const scalar_t &b,
+                                 const scalar_t &c,
+                                 const scalar_t &tolerance = 1e-6f) {
+        // Linear case
+        auto one_sol = (math::abs(a) <= tolerance);
+        m_solutions(one_sol) = 1.f;
+        m_values[0] = -c / b;
+
+        // Early exit
+        if (detray::detail::all_of(one_sol)) {
+            return;
+        }
+
+        const scalar_t discriminant = b * b - (4.f * a) * c;
+
+        const auto two_sol = (discriminant > tolerance);
+        one_sol = !two_sol && (discriminant >= 0.f);
+
+        // If there is more than one solution, then a != 0 and q != 0
+        if (detray::detail::any_of(two_sol)) {
+            m_solutions = 2.f;
+            m_solutions.setZeroInverted(two_sol);
+
+            const scalar_t q =
+                -0.5f * (b + math::copysign(math::sqrt(discriminant), b));
+
+            scalar_t first = q / a;
+            scalar_t second = c / q;
+            first.setZeroInverted(two_sol);
+            second.setZeroInverted(two_sol);
+
+            // Sort the solutions
+            const auto do_swap = (second < first);
+            if (detray::detail::all_of(do_swap)) {
+                m_values = {second, first};
+            } else if (detray::detail::none_of(do_swap)) {
+                m_values = {first, second};
+            } else {
+                const auto tmp = second;
+                second(do_swap) = first;
+                first(do_swap) = tmp;
+                m_values = {first, second};
+            }
+        }
+
+        // Only one solution and a != 0
+        if (detray::detail::any_of(one_sol)) {
+            scalar_t sol = 1.f;
+            scalar_t result = -0.5f * b / a;
+            sol.setZeroInverted(one_sol);
+            result.setZeroInverted(one_sol);
+
+            m_solutions += sol;
+            m_values[0] += result;
+        }
+        // discriminant < 0 is not allowed, since all solutions should
+        // be real
+    }
+
+    /// Getters for the solution(s)
+    /// @{
+    constexpr const auto &solutions() const { return m_solutions; }
+    constexpr const scalar_t &smaller() const { return m_values[0]; }
+    constexpr const scalar_t &larger() const { return m_values[1]; }
+    /// @}
+
+    private:
+    /// Number of solutions of the equation (needs to be floating point to
+    /// apply the masks correctly)
+    scalar_t m_solutions = 0.f;
+    /// The solutions
+    darray<scalar_t, 2> m_values{scalar_t(0.f), scalar_t(0.f)};
+};
+
+template <typename S>
+quadratic_equation(const S a, const S &b, const S &c, const S &tolerance)
+    -> quadratic_equation<S>;
 
 }  // namespace detray::detail

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@ message(STATUS "Building Algebra Plugins as part of the Detray project")
 
 # Declare where to get Algebra Plugins from.
 set( DETRAY_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.23.0.tar.gz;URL_MD5;29f4f2f812ed2623f1610872f4a1aa87"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.24.0.tar.gz;URL_MD5;e9b4c531c61d9988aae6cab95f257948"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced(DETRAY_ALGEBRA_PLUGINS_SOURCE)
 FetchContent_Declare(AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE})

--- a/io/include/detray/io/csv/intersection2D.hpp
+++ b/io/include/detray/io/csv/intersection2D.hpp
@@ -91,9 +91,8 @@ inline auto read_intersection2D(const std::string &file_name) {
         inters.cos_incidence_angle =
             static_cast<scalar_t>(inters_data.cos_theta);
         inters.volume_link = static_cast<nav_link_t>(inters_data.volume_link);
-        inters.direction =
-            static_cast<intersection::direction>(inters_data.direction);
-        inters.status = static_cast<intersection::status>(inters_data.status);
+        inters.direction = static_cast<bool>(inters_data.direction);
+        inters.status = static_cast<bool>(inters_data.status);
 
         // Add to collection
         intersections_per_track[trk_index].push_back(inters);

--- a/plugins/algebra/CMakeLists.txt
+++ b/plugins/algebra/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,4 +18,7 @@ if( DETRAY_SMATRIX_PLUGIN )
 endif()
 if( DETRAY_VC_PLUGIN )
    add_subdirectory( vc )
+endif()
+if( DETRAY_VC_SOA_PLUGIN )
+   add_subdirectory( vc_soa )
 endif()

--- a/plugins/algebra/vc_soa/CMakeLists.txt
+++ b/plugins/algebra/vc_soa/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# A sanity check.
+if( NOT ALGEBRA_PLUGINS_INCLUDE_VC )
+   message( WARNING "Vc not available from Algebra Plugins. "
+      "The configuration will likely fail." )
+endif()
+
+include( detray-compiler-options-cpp )
+
+# Use the preferred compiler flags from Vc for the entire project.
+vc_set_preferred_compiler_flags()
+
+# Set up the SoA library.
+detray_add_library( detray_algebra_vc_soa algebra_vc_soa
+   "include/detray/plugins/algebra/vc_soa_definitions.hpp" )
+target_link_libraries( detray_algebra_vc_soa
+   INTERFACE algebra::vc_soa algebra::vc_soa_storage vecmem::core )
+target_compile_definitions( detray_algebra_vc_soa
+   INTERFACE DETRAY_CUSTOM_SCALARTYPE=${DETRAY_CUSTOM_SCALARTYPE}
+             DETRAY_ALGEBRA_VC_SOA ${Vc_DEFINITIONS} )
+target_compile_options(detray_algebra_vc_soa
+   INTERFACE ${Vc_COMPILE_FLAGS} ${Vc_ARCHITECTURE_FLAGS} )
+
+# Set up tests for the public header(s) of detray::algebra_vc_soa.
+detray_test_public_headers( detray_algebra_vc_soa
+   "detray/plugins/algebra/vc_soa_definitions.hpp" )

--- a/plugins/algebra/vc_soa/include/detray/plugins/algebra/vc_soa_definitions.hpp
+++ b/plugins/algebra/vc_soa/include/detray/plugins/algebra/vc_soa_definitions.hpp
@@ -1,0 +1,113 @@
+
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Algebra-Plugins include
+#include "algebra/math/vc_soa.hpp"
+#include "algebra/storage/vc_soa.hpp"
+
+#define IS_SOA 1
+
+namespace detray {
+
+using algebra::storage::operator*;
+using algebra::storage::operator/;
+using algebra::storage::operator-;
+using algebra::storage::operator+;
+
+using scalar = DETRAY_CUSTOM_SCALARTYPE;
+
+/// Define affine transformation types
+/// @{
+template <typename V = DETRAY_CUSTOM_SCALARTYPE>
+struct vc_soa {
+    /// Define scalar precision
+    using value_type = V;
+
+    template <typename T>
+    using simd = Vc::Vector<T>;
+
+    using boolean = Vc::Mask<V>;
+
+    /// Linear Algebra type definitions
+    /// @{
+    using scalar = simd<value_type>;
+    using transform3D = algebra::vc_soa::math::transform3<value_type>;
+    using point2D = algebra::vc_soa::point2<value_type>;
+    using point3D = algebra::vc_soa::point3<value_type>;
+    using vector3D = algebra::vc_soa::vector3<value_type>;
+    /// @}
+};
+/// @}
+
+namespace vector {
+
+using algebra::vc_soa::math::cross;
+using algebra::vc_soa::math::dot;
+using algebra::vc_soa::math::normalize;
+
+}  // namespace vector
+
+namespace getter {
+
+using algebra::vc_soa::math::eta;
+using algebra::vc_soa::math::norm;
+using algebra::vc_soa::math::perp;
+using algebra::vc_soa::math::phi;
+using algebra::vc_soa::math::theta;
+
+/// Function extracting a slice from the matrix used by
+/// @c algebra::vc::transform3<float>
+template <std::size_t SIZE, std::enable_if_t<SIZE <= 4, bool> = true>
+ALGEBRA_HOST_DEVICE inline auto vector(
+    const algebra::vc_soa::math::transform3<float>::matrix44& m,
+    [[maybe_unused]] std::size_t row, std::size_t col) {
+
+    assert(row == 0);
+    assert(col < 4);
+    switch (col) {
+        case 0:
+            return m.x;
+        case 1:
+            return m.y;
+        case 2:
+            return m.z;
+        case 3:
+            return m.t;
+        default:
+            return m.x;
+    }
+}
+
+/// Function extracting a slice from the matrix used by
+/// @c algebra::vc::transform3<double>
+template <std::size_t SIZE, std::enable_if_t<SIZE <= 4, bool> = true>
+ALGEBRA_HOST_DEVICE inline auto vector(
+    const algebra::vc_soa::math::transform3<double>::matrix44& m,
+    [[maybe_unused]] std::size_t row, std::size_t col) {
+
+    assert(row == 0);
+    assert(col < 4);
+    switch (col) {
+        case 0:
+            return m.x;
+        case 1:
+            return m.y;
+        case 2:
+            return m.z;
+        case 3:
+            return m.t;
+        default:
+            return m.x;
+    }
+}
+
+}  // namespace getter
+
+}  // namespace detray

--- a/tests/benchmarks/cpu/CMakeLists.txt
+++ b/tests/benchmarks/cpu/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2023 CERN for the benefit of the ACTS project
+# (c) 2023-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -51,4 +51,28 @@ endif()
 # Build the Vc benchmark executable.
 if( DETRAY_VC_PLUGIN )
    detray_add_cpu_benchmark( vc )
+endif()
+
+if( DETRAY_VC_SOA_PLUGIN )
+
+   macro( detray_add_soa_benchmark algebra )
+      # Build the benchmark executable.
+      detray_add_executable( benchmark_soa_${algebra}
+         "intersectors.cpp"
+         LINK_LIBRARIES benchmark::benchmark benchmark::benchmark_main vecmem::core detray::core_vc_soa detray::core_${algebra} detray::test 
+         detray::utils_${algebra} )
+
+      # Set the benchmark specific compilation options.
+      if( DETRAY_BENCHMARKS_MULTITHREAD )
+         target_compile_definitions( detray_benchmark_soa_${algebra} PRIVATE
+            DETRAY_BENCHMARKS_MULTITHREAD )
+      endif()
+      if( DETRAY_BENCHMARK_PRINTOUTS )
+         target_compile_definitions( detray_benchmark_soa_${algebra} PRIVATE
+            DETRAY_BENCHMARK_PRINTOUTS )
+      endif()
+
+   endmacro()
+
+   detray_add_soa_benchmark( array )
 endif()

--- a/tests/benchmarks/cpu/intersect_surfaces.cpp
+++ b/tests/benchmarks/cpu/intersect_surfaces.cpp
@@ -62,7 +62,7 @@ void BM_INTERSECT_PLANES(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(sfhit);
                 benchmark::DoNotOptimize(sfmiss);
-                if (is.status == intersection::status::e_inside) {
+                if (is.status) {
                     ++sfhit;
                 } else {
                     ++sfmiss;
@@ -136,7 +136,7 @@ void BM_INTERSECT_CYLINDERS(benchmark::State &state) {
                 benchmark::DoNotOptimize(sfhit);
                 benchmark::DoNotOptimize(sfmiss);
                 for (const auto &sfi : inters) {
-                    if (sfi.status == intersection::status::e_inside) {
+                    if (sfi.status) {
                         ++sfhit;
                     } else {
                         ++sfmiss;
@@ -191,7 +191,7 @@ void BM_INTERSECT_PORTAL_CYLINDERS(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(sfhit);
                 benchmark::DoNotOptimize(sfmiss);
-                if (is.status == intersection::status::e_inside) {
+                if (is.status) {
                     ++sfhit;
                 } else {
                     ++sfmiss;
@@ -240,7 +240,7 @@ void BM_INTERSECT_CONCETRIC_CYLINDERS(benchmark::State &state) {
 
                 benchmark::DoNotOptimize(sfhit);
                 benchmark::DoNotOptimize(sfmiss);
-                if (is.status == intersection::status::e_inside) {
+                if (is.status) {
                     ++sfhit;
                 } else {
                     ++sfmiss;

--- a/tests/benchmarks/cpu/intersectors.cpp
+++ b/tests/benchmarks/cpu/intersectors.cpp
@@ -1,0 +1,471 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Algebra include(s).
+#include "detray/plugins/algebra/vc_soa_definitions.hpp"
+
+// Detray core include(s).
+#include "detray/definitions/detail/containers.hpp"
+#include "detray/definitions/detail/indexing.hpp"
+#include "detray/geometry/detail/surface_descriptor.hpp"
+#include "detray/geometry/mask.hpp"
+#include "detray/geometry/shapes.hpp"
+#include "detray/navigation/detail/ray.hpp"
+#include "detray/navigation/intersection/ray_intersector.hpp"
+#include "detray/simulation/event_generator/track_generators.hpp"
+
+// Detray test include(s).
+#include "detray/test/types.hpp"
+#include "detray/test/utils/planes_along_direction.hpp"
+
+// Google Benchmark include(s)
+#include <benchmark/benchmark.h>
+
+using namespace detray;
+
+static constexpr unsigned int theta_steps{2000u};
+static constexpr unsigned int phi_steps{2000u};
+static constexpr unsigned int n_surfaces{16u};
+
+/// Linear algebra implementation using SoA memory layout
+using algebra_v = detray::vc_soa<test::scalar>;
+
+/// Linear algebra implementation using AoS memory layout
+using algebra_s = detray::cmath<test::scalar>;
+
+// Size of an SOA batch
+constexpr std::size_t simd_size{dscalar<algebra_v>::size()};
+
+namespace {
+
+enum mask_ids : unsigned int {
+    e_rectangle2 = 0,
+    e_cylinder2 = 1,
+    e_conc_cylinder3 = 2,
+};
+
+enum material_ids : unsigned int {
+    e_slab = 0,
+};
+
+// Helper type definitions.
+using mask_link_t = dtyped_index<mask_ids, dindex>;
+using material_link_t = dtyped_index<material_ids, dindex>;
+
+template <typename transform3_t>
+using surface_desc_t =
+    surface_descriptor<mask_link_t, material_link_t, transform3_t>;
+
+/// Generate a number of test rays
+std::vector<detail::ray<algebra_s>> generate_rays() {
+
+    using ray_generator_t = uniform_track_generator<detail::ray<algebra_s>>;
+
+    // Iterate through uniformly distributed momentum directions
+    auto ray_generator = ray_generator_t{};
+    ray_generator.config().theta_steps(theta_steps).phi_steps(phi_steps);
+
+    std::vector<detail::ray<algebra_s>> rays;
+    std::copy(ray_generator.begin(), ray_generator.end(),
+              std::back_inserter(rays));
+
+    return rays;
+}
+
+/// Generate the translation distances to place the surfaces
+template <typename algebra_t>
+dvector<dscalar<algebra_t>> get_dists(std::size_t n) {
+
+    using scalar_t = dscalar<algebra_t>;
+
+    dvector<test::scalar> dists;
+
+    for (std::size_t i = 1u; i <= n; ++i) {
+        dists.push_back(static_cast<scalar_t>(i));
+    }
+
+    return dists;
+}
+
+/// Specialization for hthe SOA memory layout (need n/simd_size samples)
+template <>
+dvector<dscalar<algebra_v>> get_dists<algebra_v>(std::size_t n) {
+
+    using scalar_t = dscalar<algebra_v>;
+    using value_t = typename algebra_v::value_type;
+
+    dvector<scalar_t> dists;
+    dists.resize(static_cast<std::size_t>(std::ceil(n / simd_size)));
+    for (std::size_t i = 0u; i < dists.size(); ++i) {
+        dists[i] = scalar_t::IndexesFromZero() +
+                   scalar_t(static_cast<value_t>(i)) * simd_size +
+                   scalar_t(1.f);
+    }
+
+    return dists;
+}
+
+}  // namespace
+
+/// This benchmark runs intersection with the planar intersector
+void BM_INTERSECT_PLANES_AOS(benchmark::State& state) {
+
+    using mask_t = mask<rectangle2D, std::uint_least16_t, algebra_s>;
+
+    auto dists = get_dists<algebra_s>(n_surfaces);
+    auto planes = test::planes_along_direction<algebra_s>(
+        dists, test::vector3{1.f, 1.f, 1.f});
+
+    constexpr mask_t rect{0u, 100.f, 200.f};
+    std::vector<mask_t> masks(dists.size(), rect);
+
+    const auto rays = generate_rays();
+    const auto pi = ray_intersector<rectangle2D, algebra_s>{};
+
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::size_t hit{0u};
+    std::size_t miss{0u};
+#endif
+
+    for (auto _ : state) {
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+        hit = 0u;
+        miss = 0u;
+#endif
+
+        // Iterate through uniformly distributed momentum directions
+        for (const auto& ray : rays) {
+
+            for (std::size_t i = 0u; i < planes.size(); ++i) {
+                const auto& plane = planes[i];
+                auto is = pi(ray, plane, masks[i], plane.transform());
+
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+                if (is.status) {
+                    ++hit;
+                } else {
+                    ++miss;
+                }
+#endif
+
+                benchmark::DoNotOptimize(is);
+            }
+        }
+    }
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::cout << mask_t::shape::name << " AoS: hit/miss ... " << hit << " / "
+              << miss << " (total: " << rays.size() * masks.size() << ")"
+              << std::endl;
+#endif  // DETRAY_BENCHMARK_PRINTOUTS
+}
+
+BENCHMARK(BM_INTERSECT_PLANES_AOS)
+#ifdef DETRAY_BENCHMARK_MULTITHREAD
+    ->ThreadRange(1, benchmark::CPUInfo::Get().num_cpus)
+#endif
+    ->Unit(benchmark::kMillisecond);
+
+/// This benchmark runs intersection with the planar intersector
+void BM_INTERSECT_PLANES_SOA(benchmark::State& state) {
+
+    using mask_t = mask<rectangle2D, std::uint_least16_t, algebra_v>;
+    using vector3_t = dvector3D<algebra_v>;
+
+    auto dists = get_dists<algebra_v>(n_surfaces);
+    auto planes = test::planes_along_direction<algebra_v>(
+        dists, vector3_t{1.f, 1.f, 1.f});
+
+    std::vector<mask_t> masks{};
+    for (std::size_t i = 0u; i < dists.size(); ++i) {
+        masks.emplace_back(0u, 100.f, 200.f);
+    }
+
+    const auto rays = generate_rays();
+    const auto pi = ray_intersector<rectangle2D, algebra_v>{};
+
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::size_t hit{0u};
+    std::size_t miss{0u};
+#endif
+
+    for (auto _ : state) {
+
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+        hit = 0u;
+        miss = 0u;
+#endif
+
+        // Iterate through uniformly distributed momentum directions
+        for (const auto& ray : rays) {
+
+            for (std::size_t i = 0u; i < planes.size(); ++i) {
+                const auto& plane = planes[i];
+                auto is = pi(ray, plane, masks[i], plane.transform());
+
+                benchmark::DoNotOptimize(is);
+
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+                hit += is.status.count();
+                miss += simd_size - is.status.count();
+#endif
+            }
+        }
+    }
+
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::cout << mask_t::shape::name << " SoA: hit/miss ... " << hit << " / "
+              << miss << " (total: " << rays.size() * masks.size() * simd_size
+              << ")" << std::endl;
+#endif  // DETRAY_BENCHMARK_PRINTOUTS
+}
+
+BENCHMARK(BM_INTERSECT_PLANES_SOA)
+#ifdef DETRAY_BENCHMARK_MULTITHREAD
+    ->ThreadRange(1, benchmark::CPUInfo::Get().num_cpus)
+#endif
+    ->Unit(benchmark::kMillisecond);
+
+/// This benchmark runs intersection with the cylinder intersector
+void BM_INTERSECT_CYLINDERS_AOS(benchmark::State& state) {
+
+    using transform3_t = dtransform3D<algebra_s>;
+    using scalar_t = dscalar<algebra_s>;
+
+    using mask_t = mask<cylinder2D, std::uint_least16_t, algebra_s>;
+
+    std::vector<mask_t> masks;
+    for (const scalar_t r : get_dists<algebra_s>(n_surfaces)) {
+        masks.emplace_back(0u, r, -100.f, 100.f);
+    }
+
+    mask_link_t mask_link{mask_ids::e_conc_cylinder3, 0u};
+    material_link_t material_link{material_ids::e_slab, 0u};
+    surface_desc_t<transform3_t> cyl_desc(
+        transform3_t{}, mask_link, material_link, 0u, surface_id::e_sensitive);
+
+    // Iterate through uniformly distributed momentum directions
+    const auto rays = generate_rays();
+    const auto cci = ray_intersector<cylinder2D, algebra_s>{};
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::size_t hit{0u};
+    std::size_t miss{0u};
+#endif
+    for (auto _ : state) {
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+        hit = 0u;
+        miss = 0u;
+#endif
+
+        // Iterate through uniformly distributed momentum directions
+        for (const auto& ray : rays) {
+
+            for (const auto& cylinder : masks) {
+                auto is = cci(ray, cyl_desc, cylinder, cyl_desc.transform());
+
+                static_assert(is.size() == 2u, "Wrong number of solutions");
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+                for (const auto& i : is) {
+                    if (i.status) {
+                        ++hit;
+                    } else {
+                        ++miss;
+                    }
+                }
+#endif
+                benchmark::DoNotOptimize(is);
+            }
+        }
+    }
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::cout << mask_t::shape::name << " AoS: hit/miss ... " << hit << " / "
+              << miss << " (total: " << rays.size() * masks.size() << ")"
+              << std::endl;
+#endif  // DETRAY_BENCHMARK_PRINTOUTS
+}
+
+BENCHMARK(BM_INTERSECT_CYLINDERS_AOS)
+#ifdef DETRAY_BENCHMARK_MULTITHREAD
+    ->ThreadRange(1, benchmark::CPUInfo::Get().num_cpus)
+#endif
+    ->Unit(benchmark::kMillisecond);
+
+/// This benchmark runs intersection with the cylinder intersector
+void BM_INTERSECT_CYLINDERS_SOA(benchmark::State& state) {
+
+    using transform3_t = dtransform3D<algebra_v>;
+    using scalar_t = dscalar<algebra_v>;
+
+    using mask_t = mask<cylinder2D, std::uint_least16_t, algebra_v>;
+
+    std::vector<mask_t> masks;
+    for (const scalar_t r : get_dists<algebra_v>(n_surfaces)) {
+        masks.emplace_back(0u, r, -100.f, 100.f);
+    }
+
+    mask_link_t mask_link{mask_ids::e_conc_cylinder3, 0u};
+    material_link_t material_link{material_ids::e_slab, 0u};
+    surface_desc_t<transform3_t> cyl_desc(
+        transform3_t{}, mask_link, material_link, 0u, surface_id::e_sensitive);
+
+    // Iterate through uniformly distributed momentum directions
+    const auto rays = generate_rays();
+    const auto cci = ray_intersector<cylinder2D, algebra_v>{};
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::size_t hit{0u};
+    std::size_t miss{0u};
+#endif
+    for (auto _ : state) {
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+        hit = 0u;
+        miss = 0u;
+#endif
+
+        // Iterate through uniformly distributed momentum directions
+        for (const auto& ray : rays) {
+
+            for (const auto& cylinder : masks) {
+                auto is = cci(ray, cyl_desc, cylinder, cyl_desc.transform());
+
+                static_assert(is.size() == 2u, "Wrong number of solutions");
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+                for (const auto& i : is) {
+                    hit += i.status.count();
+                    miss += simd_size - i.status.count();
+                }
+#endif
+                benchmark::DoNotOptimize(is);
+            }
+        }
+    }
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::cout << mask_t::shape::name << " SoA: hit/miss ... " << hit << " / "
+              << miss << " (total: " << rays.size() * masks.size() * simd_size
+              << ")" << std::endl;
+#endif  // DETRAY_BENCHMARK_PRINTOUTS
+}
+
+BENCHMARK(BM_INTERSECT_CYLINDERS_SOA)
+#ifdef DETRAY_BENCHMARK_MULTITHREAD
+    ->ThreadRange(1, benchmark::CPUInfo::Get().num_cpus)
+#endif
+    ->Unit(benchmark::kMillisecond);
+
+/// This benchmark runs intersection with the concentric cylinder intersector
+void BM_INTERSECT_CONCETRIC_CYLINDERS_AOS(benchmark::State& state) {
+
+    using transform3_t = dtransform3D<algebra_s>;
+    using scalar_t = dscalar<algebra_s>;
+
+    using mask_t = mask<concentric_cylinder2D, std::uint_least16_t, algebra_s>;
+
+    std::vector<mask_t> masks;
+    for (const scalar_t r : get_dists<algebra_s>(n_surfaces)) {
+        masks.emplace_back(0u, r, -100.f, 100.f);
+    }
+
+    mask_link_t mask_link{mask_ids::e_conc_cylinder3, 0u};
+    material_link_t material_link{material_ids::e_slab, 0u};
+    surface_desc_t<transform3_t> cyl_desc(
+        transform3_t{}, mask_link, material_link, 0u, surface_id::e_sensitive);
+
+    // Iterate through uniformly distributed momentum directions
+    const auto rays = generate_rays();
+    const auto cci = ray_intersector<concentric_cylinder2D, algebra_s>{};
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::size_t hit{0u};
+    std::size_t miss{0u};
+#endif
+
+    for (auto _ : state) {
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+        hit = 0u;
+        miss = 0u;
+#endif
+        // Iterate through uniformly distributed momentum directions
+        for (const auto& ray : rays) {
+
+            for (const auto& cylinder : masks) {
+                auto is = cci(ray, cyl_desc, cylinder, cyl_desc.transform());
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+                if (is.status) {
+                    ++hit;
+                } else {
+                    ++miss;
+                }
+#endif
+                benchmark::DoNotOptimize(is);
+            }
+        }
+    }
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::cout << mask_t::shape::name << " AoS: hit/miss ... " << hit << " / "
+              << miss << " (total: " << rays.size() * masks.size() << ")"
+              << std::endl;
+#endif  // DETRAY_BENCHMARK_PRINTOUTS
+}
+
+BENCHMARK(BM_INTERSECT_CONCETRIC_CYLINDERS_AOS)
+#ifdef DETRAY_BENCHMARK_MULTITHREAD
+    ->ThreadRange(1, benchmark::CPUInfo::Get().num_cpus)
+#endif
+    ->Unit(benchmark::kMillisecond);
+
+/// This benchmark runs intersection with the concentric cylinder intersector
+void BM_INTERSECT_CONCETRIC_CYLINDERS_SOA(benchmark::State& state) {
+
+    using transform3_t = dtransform3D<algebra_v>;
+    using scalar_t = dscalar<algebra_v>;
+
+    using mask_t = mask<concentric_cylinder2D, std::uint_least16_t, algebra_v>;
+
+    std::vector<mask_t> masks;
+    for (const scalar_t r : get_dists<algebra_v>(n_surfaces)) {
+        masks.emplace_back(0u, r, -100.f, 100.f);
+    }
+
+    mask_link_t mask_link{mask_ids::e_conc_cylinder3, 0u};
+    material_link_t material_link{material_ids::e_slab, 0u};
+    surface_desc_t<transform3_t> cyl_desc(
+        transform3_t{}, mask_link, material_link, 0u, surface_id::e_sensitive);
+
+    // Iterate through uniformly distributed momentum directions
+    const auto rays = generate_rays();
+    const auto cci = ray_intersector<concentric_cylinder2D, algebra_v>{};
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::size_t hit{0u};
+    std::size_t miss{0u};
+#endif
+    for (auto _ : state) {
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+        hit = 0u;
+        miss = 0u;
+#endif
+        // Iterate through uniformly distributed momentum directions
+        for (const auto& ray : rays) {
+
+            for (const auto& cylinder : masks) {
+                auto is = cci(ray, cyl_desc, cylinder, cyl_desc.transform());
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+                hit += is.status.count();
+                miss += simd_size - is.status.count();
+#endif
+                benchmark::DoNotOptimize(is);
+            }
+        }
+    }
+#ifdef DETRAY_BENCHMARK_PRINTOUTS
+    std::cout << mask_t::shape::name << " SoA: hit/miss ... " << hit << " / "
+              << miss << " (total: " << rays.size() * masks.size() * simd_size
+              << ")" << std::endl;
+#endif
+}
+
+BENCHMARK(BM_INTERSECT_CONCETRIC_CYLINDERS_SOA)
+#ifdef DETRAY_BENCHMARK_MULTITHREAD
+    ->ThreadRange(1, benchmark::CPUInfo::Get().num_cpus)
+#endif
+    ->Unit(benchmark::kMillisecond);

--- a/tests/benchmarks/cpu/masks.cpp
+++ b/tests/benchmarks/cpu/masks.cpp
@@ -59,8 +59,7 @@ void BM_MASK_CUBOID_3D(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{cb.to_local_frame(trf, {x, y, z})};
-                    if (cb.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (cb.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;
@@ -112,8 +111,7 @@ void BM_MASK_RECTANGLE_2D(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{r.to_local_frame(trf, {x, y, z})};
-                    if (r.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (r.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;
@@ -165,8 +163,7 @@ void BM_MASK_TRAPEZOID_2D(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{t.to_local_frame(trf, {x, y, z})};
-                    if (t.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (t.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;
@@ -218,8 +215,7 @@ void BM_MASK_DISC_2D(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{r.to_local_frame(trf, {x, y, z})};
-                    if (r.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (r.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;
@@ -271,8 +267,7 @@ void BM_MASK_RING_2D(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{r.to_local_frame(trf, {x, y, z})};
-                    if (r.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (r.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;
@@ -325,8 +320,7 @@ void BM_MASK_CYLINDER_3D(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{c.to_local_frame(trf, {x, y, z})};
-                    if (c.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (c.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;
@@ -379,8 +373,7 @@ void BM_MASK_CYLINDER_2D(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{c.to_local_frame(trf, {x, y, z})};
-                    if (c.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (c.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;
@@ -430,8 +423,7 @@ void BM_MASK_CONCENTRIC_CYLINDER_2D(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{c.to_local_frame(trf, {x, y, z})};
-                    if (c.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (c.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;
@@ -481,8 +473,7 @@ void BM_MASK_ANNULUS_2D(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{ann.to_local_frame(trf, {x, y, z})};
-                    if (ann.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (ann.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;
@@ -532,8 +523,7 @@ void BM_MASK_LINE_CIRCULAR(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{st.to_local_frame(trf, {x, y, z})};
-                    if (st.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (st.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;
@@ -585,8 +575,7 @@ void BM_MASK_LINE_SQUARE(benchmark::State &state) {
                     benchmark::DoNotOptimize(inside);
                     benchmark::DoNotOptimize(outside);
                     const point3 loc_p{dcl.to_local_frame(trf, {x, y, z})};
-                    if (dcl.is_inside(loc_p, tol) ==
-                        intersection::status::e_inside) {
+                    if (dcl.is_inside(loc_p, tol)) {
                         ++inside;
                     } else {
                         ++outside;

--- a/tests/include/detray/test/utils/detector_scanner.hpp
+++ b/tests/include/detray/test/utils/detector_scanner.hpp
@@ -88,7 +88,7 @@ struct brute_force_scan {
 
             // Candidate is invalid if it lies in the opposite direction
             for (auto &sfi : intersections) {
-                if (sfi.direction == intersection::direction::e_along) {
+                if (sfi.direction) {
                     sfi.sf_desc = sf_desc;
                     // Record the intersection
                     intersection_trace.push_back(

--- a/tests/include/detray/test/utils/planes_along_direction.hpp
+++ b/tests/include/detray/test/utils/planes_along_direction.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,22 +31,28 @@ using plane_mask_link_t = dtyped_index<plane_mask_ids, dindex>;
 using plane_material_link_t = dtyped_index<plane_material_ids, dindex>;
 
 /// This method creates a number (distances.size()) planes along a direction
+template <typename algebra_t = test::algebra>
 dvector<surface_descriptor<plane_mask_link_t, plane_material_link_t,
-                           test::transform3>>
-planes_along_direction(const dvector<test::scalar> &distances,
-                       test::vector3 direction) {
+                           dtransform3D<algebra_t>>>
+planes_along_direction(const dvector<dscalar<algebra_t>> &distances,
+                       const dvector3D<algebra_t> &direction) {
 
-    // Rotation matrix
-    test::vector3 z = direction;
-    test::vector3 x = vector::normalize(test::vector3{0.f, -z[2], z[1]});
+    using vector3_t = dvector3D<algebra_t>;
+    using transform3_t = dtransform3D<algebra_t>;
+
+    // New z- and x-axes
+    vector3_t z{vector::normalize(direction)};
+    vector3_t x = vector::normalize(vector3_t{0.f, -z[2], z[1]});
 
     dvector<surface_descriptor<plane_mask_link_t, plane_material_link_t,
-                               test::transform3>>
+                               transform3_t>>
         surfaces;
     surfaces.reserve(distances.size());
     for (const auto [idx, d] : detray::views::enumerate(distances)) {
-        test::vector3 t = d * direction;
-        test::transform3 trf(t, z, x);
+
+        vector3_t t = d * direction;
+        transform3_t trf(t, z, x);
+
         plane_mask_link_t mask_link{plane_mask_ids::e_plane_rectangle2, idx};
         plane_material_link_t material_link{plane_material_ids::e_plane_slab,
                                             0u};
@@ -55,6 +61,7 @@ planes_along_direction(const dvector<test::scalar> &distances,
                               surface_id::e_sensitive);
         surfaces.back().set_index(idx);
     }
+
     return surfaces;
 }
 

--- a/tests/integration_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/integration_tests/cpu/propagator/covariance_transport.cpp
@@ -352,8 +352,8 @@ TYPED_TEST(detray_propagation_HelixCovarianceTransportValidation,
 
     ASSERT_EQ(sfis.size(), n_planes);
     for (std::size_t i = 0u; i < n_planes; i++) {
-        EXPECT_TRUE(sfis[i].status == intersection::status::e_inside);
-        EXPECT_TRUE(sfis[i].direction == intersection::direction::e_along);
+        EXPECT_TRUE(sfis[i].status);
+        EXPECT_TRUE(sfis[i].direction);
     }
 
     // Check if the same vector is obtained after one loop

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -628,7 +628,7 @@ bound_track_parameters<algebra_type> get_initial_parameter(
     helix_intersector<typename mask_t::shape, algebra_type> hlx_is{};
     hlx_is.convergence_tolerance = helix_tolerance;
     auto sfi = hlx_is(hlx, departure_sf, departure_mask, departure_trf, 0.f);
-    EXPECT_EQ(sfi.status, intersection::status::e_inside)
+    EXPECT_TRUE(sfi.status)
         << " Initial surface not found" << std::endl
         << " log10(Helix tolerance): " << math::log10(helix_tolerance)
         << " Phi: " << getter::phi(vertex.dir())
@@ -1062,7 +1062,7 @@ void evaluate_jacobian_difference_helix(
     auto sfi =
         hlx_is(hlx, destination_sf, destination_mask, destination_trf, 0.f);
 
-    EXPECT_EQ(sfi.status, intersection::status::e_inside)
+    EXPECT_TRUE(sfi.status)
         << " Final surface not found" << std::endl
         << " log10(Helix tolerance): " << math::log10(helix_tolerance)
         << " Phi: " << track.phi() << " Theta: " << track.theta()

--- a/tests/unit_tests/cpu/geometry/masks/annulus2D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/annulus2D.cpp
@@ -56,21 +56,14 @@ GTEST_TEST(detray_masks, annulus2D) {
     ASSERT_NEAR(ann2[annulus2D::e_shift_y], 2.0f, tol);
     ASSERT_NEAR(ann2[annulus2D::e_average_phi], 0.f, tol);
 
-    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_in)) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out1)) ==
-                intersection::status::e_outside);
-    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out2)) ==
-                intersection::status::e_outside);
-    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out3)) ==
-                intersection::status::e_outside);
-    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out4)) ==
-                intersection::status::e_outside);
+    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_in)));
+    ASSERT_FALSE(ann2.is_inside(toStripFrame(p2_out1)));
+    ASSERT_FALSE(ann2.is_inside(toStripFrame(p2_out2)));
+    ASSERT_FALSE(ann2.is_inside(toStripFrame(p2_out3)));
+    ASSERT_FALSE(ann2.is_inside(toStripFrame(p2_out4)));
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out1), 1.3f) ==
-                intersection::status::e_inside);
-    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out4), 0.07f) ==
-                intersection::status::e_inside);
+    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out1), 1.3f));
+    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out4), 0.07f));
 
     // Check area: @TODO not implemented, yet
     scalar a = ann2.area();
@@ -124,7 +117,7 @@ GTEST_TEST(detray_masks, annulus2D_ratio_test) {
                         const test::transform3 &trf, const scalar t) {
 
             const test::point3 loc_p{ann.to_local_frame(trf, p)};
-            return ann.is_inside(loc_p, t) == intersection::status::e_inside;
+            return ann.is_inside(loc_p, t);
         }
     };
 

--- a/tests/unit_tests/cpu/geometry/masks/cylinder.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/cylinder.cpp
@@ -38,11 +38,11 @@ GTEST_TEST(detray_masks, cylinder2D) {
     ASSERT_NEAR(c[cylinder2D::e_n_half_z], -hz, tol);
     ASSERT_NEAR(c[cylinder2D::e_p_half_z], hz, tol);
 
-    ASSERT_TRUE(c.is_inside(p2_in) == intersection::status::e_inside);
-    ASSERT_TRUE(c.is_inside(p2_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(c.is_inside(p2_out) == intersection::status::e_outside);
+    ASSERT_TRUE(c.is_inside(p2_in));
+    ASSERT_TRUE(c.is_inside(p2_edge));
+    ASSERT_FALSE(c.is_inside(p2_out));
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(c.is_inside(p2_out, 0.6f) == intersection::status::e_inside);
+    ASSERT_TRUE(c.is_inside(p2_out, 0.6f));
 
     // Check area
     const scalar a{c.area()};
@@ -73,7 +73,7 @@ GTEST_TEST(detray_masks, cylinder2D_ratio_test) {
                         const test::transform3 &trf, const scalar t) {
 
             const test::point3 loc_p{cyl.to_local_frame(trf, p)};
-            return cyl.is_inside(loc_p, t) == intersection::status::e_inside;
+            return cyl.is_inside(loc_p, t);
         }
     };
 
@@ -118,12 +118,12 @@ GTEST_TEST(detray_masks, cylinder3D) {
     ASSERT_NEAR(c[cylinder3D::e_min_z], -hz, tol);
     ASSERT_NEAR(c[cylinder3D::e_max_z], hz, tol);
 
-    ASSERT_TRUE(c.is_inside(p3_in) == intersection::status::e_inside);
-    ASSERT_TRUE(c.is_inside(p3_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(c.is_inside(p3_out) == intersection::status::e_outside);
-    ASSERT_TRUE(c.is_inside(p3_off) == intersection::status::e_outside);
+    ASSERT_TRUE(c.is_inside(p3_in));
+    ASSERT_TRUE(c.is_inside(p3_edge));
+    ASSERT_FALSE(c.is_inside(p3_out));
+    ASSERT_FALSE(c.is_inside(p3_off));
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(c.is_inside(p3_out, 0.6f) == intersection::status::e_inside);
+    ASSERT_TRUE(c.is_inside(p3_out, 0.6f));
 
     // Check volume
     const scalar v{c.volume()};
@@ -154,7 +154,7 @@ GTEST_TEST(detray_masks, cylinder3D_ratio_test) {
                         const test::transform3 &trf, const scalar t) {
 
             const test::point3 loc_p{cyl.to_local_frame(trf, p)};
-            return cyl.is_inside(loc_p, t) == intersection::status::e_inside;
+            return cyl.is_inside(loc_p, t);
         }
     };
 

--- a/tests/unit_tests/cpu/geometry/masks/line.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/line.cpp
@@ -44,10 +44,10 @@ GTEST_TEST(detray_masks, line_circular) {
                 tol);
     ASSERT_NEAR(ln[line_circular::e_half_z], 50.f * unit<scalar>::mm, tol);
 
-    ASSERT_TRUE(ln.is_inside(ln_in) == intersection::status::e_inside);
-    ASSERT_TRUE(ln.is_inside(ln_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(ln.is_inside(ln_out1) == intersection::status::e_outside);
-    ASSERT_TRUE(ln.is_inside(ln_out2) == intersection::status::e_outside);
+    ASSERT_TRUE(ln.is_inside(ln_in));
+    ASSERT_TRUE(ln.is_inside(ln_edge));
+    ASSERT_FALSE(ln.is_inside(ln_out1));
+    ASSERT_FALSE(ln.is_inside(ln_out2));
 
     // Check area and measure
     EXPECT_NEAR(ln.area(), 628.318531f * unit<scalar>::mm2, tol);
@@ -78,7 +78,7 @@ GTEST_TEST(detray_masks, line_circular_ratio_test) {
                         const scalar t) {
 
             const test::point3 loc_p{st.to_local_frame(trf, p, dir)};
-            return st.is_inside(loc_p, t) == intersection::status::e_inside;
+            return st.is_inside(loc_p, t);
         }
     };
 
@@ -119,12 +119,11 @@ GTEST_TEST(detray_masks, line_square) {
                 tol);
     ASSERT_NEAR(ln[line_circular::e_half_z], 50.f * unit<scalar>::mm, tol);
 
-    ASSERT_TRUE(ln.is_inside(ln_in) == intersection::status::e_inside);
-    ASSERT_TRUE(ln.is_inside(ln_edge, 1e-5f) == intersection::status::e_inside);
-    ASSERT_TRUE(ln.is_inside(ln_edge, -1e-5f) ==
-                intersection::status::e_outside);
-    ASSERT_TRUE(ln.is_inside(ln_out1) == intersection::status::e_outside);
-    ASSERT_TRUE(ln.is_inside(ln_out2) == intersection::status::e_outside);
+    ASSERT_TRUE(ln.is_inside(ln_in));
+    ASSERT_TRUE(ln.is_inside(ln_edge, 1e-5f));
+    ASSERT_FALSE(ln.is_inside(ln_edge, -1e-5f));
+    ASSERT_FALSE(ln.is_inside(ln_out1));
+    ASSERT_FALSE(ln.is_inside(ln_out2));
 
     // Check area and measure
     EXPECT_NEAR(ln.area(), 800.f * unit<scalar>::mm2, tol);
@@ -155,7 +154,7 @@ GTEST_TEST(detray_masks, line_square_ratio_test) {
                         const scalar t) {
 
             const test::point3 loc_p{dcl.to_local_frame(trf, p, dir)};
-            return dcl.is_inside(loc_p, t) == intersection::status::e_inside;
+            return dcl.is_inside(loc_p, t);
         }
     };
 

--- a/tests/unit_tests/cpu/geometry/masks/rectangle2D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/rectangle2D.cpp
@@ -38,11 +38,11 @@ GTEST_TEST(detray_masks, rectangle2D) {
     ASSERT_NEAR(r2[rectangle2D::e_half_x], hx, tol);
     ASSERT_NEAR(r2[rectangle2D::e_half_y], hy, tol);
 
-    ASSERT_TRUE(r2.is_inside(p2_in) == intersection::status::e_inside);
-    ASSERT_TRUE(r2.is_inside(p2_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(r2.is_inside(p2_out) == intersection::status::e_outside);
+    ASSERT_TRUE(r2.is_inside(p2_in));
+    ASSERT_TRUE(r2.is_inside(p2_edge));
+    ASSERT_FALSE(r2.is_inside(p2_out));
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(r2.is_inside(p2_out, 1.f) == intersection::status::e_inside);
+    ASSERT_TRUE(r2.is_inside(p2_out, 1.f));
 
     // Check area
     const scalar a{r2.area()};
@@ -73,7 +73,7 @@ GTEST_TEST(detray_masks, rectangle2D_ratio_test) {
                         const test::transform3 &trf, const scalar t) {
 
             const test::point3 loc_p{r.to_local_frame(trf, p)};
-            return r.is_inside(loc_p, t) == intersection::status::e_inside;
+            return r.is_inside(loc_p, t);
         }
     };
 
@@ -113,11 +113,11 @@ GTEST_TEST(detray_masks, cuboid3D) {
     ASSERT_NEAR(c3[cuboid3D::e_max_y], hy, tol);
     ASSERT_NEAR(c3[cuboid3D::e_max_z], hz, tol);
 
-    ASSERT_TRUE(c3.is_inside(p2_in) == intersection::status::e_inside);
-    ASSERT_TRUE(c3.is_inside(p2_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(c3.is_inside(p2_out) == intersection::status::e_outside);
+    ASSERT_TRUE(c3.is_inside(p2_in));
+    ASSERT_TRUE(c3.is_inside(p2_edge));
+    ASSERT_FALSE(c3.is_inside(p2_out));
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(c3.is_inside(p2_out, 1.f) == intersection::status::e_inside);
+    ASSERT_TRUE(c3.is_inside(p2_out, 1.f));
 
     // Check volume
     const scalar v{c3.volume()};
@@ -143,7 +143,7 @@ GTEST_TEST(detray_masks, cuboid3D_ratio_test) {
                         const test::transform3 &trf, const scalar t) {
 
             const test::point3 loc_p{cb.to_local_frame(trf, p)};
-            return cb.is_inside(loc_p, t) == intersection::status::e_inside;
+            return cb.is_inside(loc_p, t);
         }
     };
 

--- a/tests/unit_tests/cpu/geometry/masks/ring2D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/ring2D.cpp
@@ -37,12 +37,11 @@ GTEST_TEST(detray_masks, ring2D) {
     ASSERT_NEAR(r2[ring2D::e_inner_r], 0.f, tol);
     ASSERT_NEAR(r2[ring2D::e_outer_r], 3.5f, tol);
 
-    ASSERT_TRUE(r2.is_inside(p2_pl_in) == intersection::status::e_inside);
-    ASSERT_TRUE(r2.is_inside(p2_pl_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(r2.is_inside(p2_pl_out) == intersection::status::e_outside);
+    ASSERT_TRUE(r2.is_inside(p2_pl_in));
+    ASSERT_TRUE(r2.is_inside(p2_pl_edge));
+    ASSERT_FALSE(r2.is_inside(p2_pl_out));
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(r2.is_inside(p2_pl_out, 1.2f) ==
-                intersection::status::e_inside);
+    ASSERT_TRUE(r2.is_inside(p2_pl_out, 1.2f));
 
     // Check area
     const scalar a{r2.area()};
@@ -73,7 +72,7 @@ GTEST_TEST(detray_masks, ring2D_ratio_test) {
                         const test::transform3 &trf, const scalar t) {
 
             const test::point3 loc_p{r.to_local_frame(trf, p)};
-            return r.is_inside(loc_p, t) == intersection::status::e_inside;
+            return r.is_inside(loc_p, t);
         }
     };
 

--- a/tests/unit_tests/cpu/geometry/masks/single3D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/single3D.cpp
@@ -34,11 +34,11 @@ GTEST_TEST(detray_masks, single3_0) {
     ASSERT_NEAR(m1_0[single3D<>::e_lower], -h0, tol);
     ASSERT_NEAR(m1_0[single3D<>::e_upper], h0, tol);
 
-    ASSERT_TRUE(m1_0.is_inside(p3_in) == intersection::status::e_inside);
-    ASSERT_TRUE(m1_0.is_inside(p3_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(m1_0.is_inside(p3_out) == intersection::status::e_outside);
+    ASSERT_TRUE(m1_0.is_inside(p3_in));
+    ASSERT_TRUE(m1_0.is_inside(p3_edge));
+    ASSERT_FALSE(m1_0.is_inside(p3_out));
     // Move outside point inside using a tolerance - take t0 not t1
-    ASSERT_TRUE(m1_0.is_inside(p3_out, 0.6f) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_0.is_inside(p3_out, 0.6f));
 
     // Check the measure
     EXPECT_NEAR(m1_0.measure(), 2.f * unit<scalar>::mm2, tol);
@@ -73,11 +73,11 @@ GTEST_TEST(detray_masks, single3_1) {
     ASSERT_NEAR(m1_1[single3D<>::e_lower], -h1, tol);
     ASSERT_NEAR(m1_1[single3D<>::e_upper], h1, tol);
 
-    ASSERT_TRUE(m1_1.is_inside(p3_in) == intersection::status::e_inside);
-    ASSERT_TRUE(m1_1.is_inside(p3_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(m1_1.is_inside(p3_out) == intersection::status::e_outside);
+    ASSERT_TRUE(m1_1.is_inside(p3_in));
+    ASSERT_TRUE(m1_1.is_inside(p3_edge));
+    ASSERT_FALSE(m1_1.is_inside(p3_out));
     // Move outside point inside using a tolerance - take t1 not t1
-    ASSERT_TRUE(m1_1.is_inside(p3_out, 0.6f) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_1.is_inside(p3_out, 0.6f));
 
     // Check the measure
     EXPECT_NEAR(m1_1.measure(), 18.6f * unit<scalar>::mm2, tol);
@@ -112,11 +112,11 @@ GTEST_TEST(detray_masks, single3_2) {
     ASSERT_NEAR(m1_2[single3D<>::e_lower], -h2, tol);
     ASSERT_NEAR(m1_2[single3D<>::e_upper], h2, tol);
 
-    ASSERT_TRUE(m1_2.is_inside(p3_in) == intersection::status::e_inside);
-    ASSERT_TRUE(m1_2.is_inside(p3_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(m1_2.is_inside(p3_out) == intersection::status::e_outside);
+    ASSERT_TRUE(m1_2.is_inside(p3_in));
+    ASSERT_TRUE(m1_2.is_inside(p3_edge));
+    ASSERT_FALSE(m1_2.is_inside(p3_out));
     // Move outside point inside using a tolerance - take t1 not t1
-    ASSERT_TRUE(m1_2.is_inside(p3_out, 6.1f) == intersection::status::e_inside);
+    ASSERT_TRUE(m1_2.is_inside(p3_out, 6.1f));
 
     // Check the measure
     EXPECT_NEAR(m1_2.measure(), 4.f * unit<scalar>::mm2, tol);

--- a/tests/unit_tests/cpu/geometry/masks/trapezoid2D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/trapezoid2D.cpp
@@ -41,9 +41,9 @@ GTEST_TEST(detray_masks, trapezoid2D) {
     ASSERT_NEAR(t2[trapezoid2D::e_half_length_2], hy, tol);
     ASSERT_NEAR(t2[trapezoid2D::e_divisor], divisor, tol);
 
-    ASSERT_TRUE(t2.is_inside(p2_in) == intersection::status::e_inside);
-    ASSERT_TRUE(t2.is_inside(p2_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(t2.is_inside(p2_out) == intersection::status::e_outside);
+    ASSERT_TRUE(t2.is_inside(p2_in));
+    ASSERT_TRUE(t2.is_inside(p2_edge));
+    ASSERT_FALSE(t2.is_inside(p2_out));
     // Move outside point inside using a tolerance
 
     // Check area
@@ -75,7 +75,7 @@ GTEST_TEST(detray_masks, trapezoid2D_ratio_test) {
                         const test::transform3 &trf, const scalar t) {
 
             const test::point3 loc_p{tp.to_local_frame(trf, p)};
-            return tp.is_inside(loc_p, t) == intersection::status::e_inside;
+            return tp.is_inside(loc_p, t);
         }
     };
 

--- a/tests/unit_tests/cpu/geometry/masks/unbounded.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/unbounded.cpp
@@ -51,7 +51,7 @@ GTEST_TEST(detray_masks, unbounded) {
 
     // Test boundary check
     typename mask<unbounded_t>::point3_type p2 = {0.5f, -9.f, 0.f};
-    ASSERT_TRUE(u.is_inside(p2, 0.f) == intersection::status::e_inside);
+    ASSERT_TRUE(u.is_inside(p2, 0.f));
 
     // Check bounding box
     constexpr scalar envelope{0.01f};

--- a/tests/unit_tests/cpu/geometry/masks/unmasked.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/unmasked.cpp
@@ -25,7 +25,7 @@ GTEST_TEST(detray_masks, unmasked) {
 
     mask<unmasked<>> u{};
 
-    ASSERT_TRUE(u.is_inside(p2, 0.f) == intersection::status::e_inside);
+    ASSERT_TRUE(u.is_inside(p2, 0.f));
 
     // Check bounding box
     constexpr scalar envelope{0.01f};

--- a/tests/unit_tests/cpu/navigation/intersection/cylinder_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/cylinder_intersector.cpp
@@ -58,8 +58,8 @@ GTEST_TEST(detray_intersection, translated_cylinder) {
         ci(ray, surface_descriptor<>{}, cylinder, shifted, tol, -not_defined);
 
     // first intersection lies behind the track
-    EXPECT_TRUE(hits_bound[0].status == intersection::status::e_inside);
-    EXPECT_TRUE(hits_bound[0].direction == intersection::direction::e_opposite);
+    EXPECT_TRUE(hits_bound[0].status);
+    ASSERT_FALSE(hits_bound[0].direction);
 
     const auto global0 = cylinder.to_global_frame(shifted, hits_bound[0].local);
     EXPECT_NEAR(global0[0], -1.f, tol);
@@ -74,8 +74,8 @@ GTEST_TEST(detray_intersection, translated_cylinder) {
     EXPECT_NEAR(hits_bound[0].cos_incidence_angle, -1.f, tol);
 
     // second intersection lies in front of the track
-    EXPECT_TRUE(hits_bound[1].status == intersection::status::e_inside);
-    EXPECT_TRUE(hits_bound[1].direction == intersection::direction::e_along);
+    EXPECT_TRUE(hits_bound[1].status);
+    EXPECT_TRUE(hits_bound[1].direction);
 
     const auto global1 = cylinder.to_global_frame(shifted, hits_bound[1].local);
     EXPECT_NEAR(global1[0], 7.f, tol);
@@ -130,12 +130,10 @@ GTEST_TEST(detray_intersection, cylinder_portal) {
     const auto hit_cocylindrical =
         cpi(ray, surface_descriptor<>{}, cylinder, identity, tol);
 
-    ASSERT_TRUE(hits_cylinrical[1].status == intersection::status::e_inside);
-    ASSERT_TRUE(hit_cocylindrical.status == intersection::status::e_inside);
-    ASSERT_TRUE(hits_cylinrical[1].direction ==
-                intersection::direction::e_along);
-    ASSERT_TRUE(hit_cocylindrical.direction ==
-                intersection::direction::e_along);
+    ASSERT_TRUE(hits_cylinrical[1].status);
+    ASSERT_TRUE(hit_cocylindrical.status);
+    ASSERT_TRUE(hits_cylinrical[1].direction);
+    ASSERT_TRUE(hit_cocylindrical.direction);
 
     const auto global0 =
         cylinder.to_global_frame(identity, hits_cylinrical[1].local);
@@ -176,12 +174,10 @@ GTEST_TEST(detray_intersection, concentric_cylinders) {
     const auto hit_cocylindrical =
         cci(ray, surface_descriptor<>{}, cylinder, identity, tol);
 
-    ASSERT_TRUE(hits_cylinrical[1].status == intersection::status::e_inside);
-    ASSERT_TRUE(hit_cocylindrical.status == intersection::status::e_inside);
-    ASSERT_TRUE(hits_cylinrical[1].direction ==
-                intersection::direction::e_along);
-    ASSERT_TRUE(hit_cocylindrical.direction ==
-                intersection::direction::e_along);
+    ASSERT_TRUE(hits_cylinrical[1].status);
+    ASSERT_TRUE(hit_cocylindrical.status);
+    ASSERT_TRUE(hits_cylinrical[1].direction);
+    ASSERT_TRUE(hit_cocylindrical.direction);
 
     const auto global0 =
         cylinder.to_global_frame(identity, hits_cylinrical[1].local);

--- a/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
@@ -83,7 +83,7 @@ GTEST_TEST(detray_intersection, helix_plane_intersector_no_bfield) {
     const auto hit_bound =
         pi(h, surface_descriptor<>{}, unmasked_bound, shifted, tol);
 
-    ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
+    ASSERT_TRUE(hit_bound.status);
     // Global intersection information - unchanged
     const auto global0 =
         unmasked_bound.to_global_frame(shifted, hit_bound.local);
@@ -100,7 +100,7 @@ GTEST_TEST(detray_intersection, helix_plane_intersector_no_bfield) {
     mask<rectangle2D> rect_for_inside{0u, 3.f, 3.f};
     const auto hit_bound_inside =
         pi(h, surface_descriptor<>{}, rect_for_inside, shifted, tol);
-    ASSERT_TRUE(hit_bound_inside.status == intersection::status::e_inside);
+    ASSERT_TRUE(hit_bound_inside.status);
     // Global intersection information - unchanged
     const auto global1 =
         rect_for_inside.to_global_frame(shifted, hit_bound_inside.local);
@@ -115,7 +115,7 @@ GTEST_TEST(detray_intersection, helix_plane_intersector_no_bfield) {
     mask<rectangle2D> rect_for_outside{0u, 0.5f, 3.5f};
     const auto hit_bound_outside =
         pi(h, surface_descriptor<>{}, rect_for_outside, shifted, tol);
-    ASSERT_TRUE(hit_bound_outside.status == intersection::status::e_outside);
+    ASSERT_FALSE(hit_bound_outside.status);
     const auto global2 =
         rect_for_outside.to_global_frame(shifted, hit_bound_outside.local);
     // Global intersection information - unchanged
@@ -146,7 +146,7 @@ GTEST_TEST(detray_intersection, helix_plane_intersector) {
     const auto is = hpi(hlx, surface_descriptor<>{}, rectangle, trf, tol);
 
     // Check the values
-    EXPECT_TRUE(is.status == intersection::status::e_inside);
+    EXPECT_TRUE(is.status);
     EXPECT_NEAR(is.path, path, tol);
     EXPECT_NEAR(is.local[0], 0.f, tol);
     EXPECT_NEAR(is.local[1], 0.f, tol);
@@ -182,8 +182,8 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector_no_bfield) {
     // No magnetic field, so the solutions must be the same as for a ray
 
     // second intersection lies in front of the track
-    EXPECT_TRUE(hits_bound[0].status == intersection::status::e_inside);
-    EXPECT_TRUE(hits_bound[0].direction == intersection::direction::e_opposite);
+    EXPECT_TRUE(hits_bound[0].status);
+    EXPECT_FALSE(hits_bound[0].direction);
 
     const auto global0 = cylinder.to_global_frame(shifted, hits_bound[0].local);
 
@@ -199,8 +199,8 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector_no_bfield) {
 
     // first intersection lies behind the track
     const auto global1 = cylinder.to_global_frame(shifted, hits_bound[1].local);
-    EXPECT_TRUE(hits_bound[1].status == intersection::status::e_inside);
-    EXPECT_TRUE(hits_bound[1].direction == intersection::direction::e_along);
+    EXPECT_TRUE(hits_bound[1].status);
+    EXPECT_TRUE(hits_bound[1].direction);
     EXPECT_NEAR(global1[0], 7.f, tol);
     EXPECT_NEAR(global1[1], 2.f, tol);
     EXPECT_NEAR(global1[2], 5.f, tol);
@@ -233,7 +233,7 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector) {
     const scalar phi_near = std::acos(
         vector::dot(w, loc_near) / (getter::norm(w) * getter::norm(loc_near)));
 
-    EXPECT_TRUE(is[0].status == intersection::status::e_inside);
+    EXPECT_TRUE(is[0].status);
     // Not precise due to helix curvature
     EXPECT_NEAR(is[0].path, path - r, 5000.f * tol);
     EXPECT_NEAR(is[0].local[0], r * phi_near, tol);
@@ -250,7 +250,7 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector) {
     const scalar phi_far = std::acos(vector::dot(w, loc_far) /
                                      (getter::norm(w) * getter::norm(loc_far)));
 
-    EXPECT_TRUE(is[1].status == intersection::status::e_inside);
+    EXPECT_TRUE(is[1].status);
     // Not precise due to helix curvature
     EXPECT_NEAR(is[1].path, path + r, 5000.f * tol);
     EXPECT_NEAR(is[1].local[0], r * phi_far, tol);
@@ -288,8 +288,8 @@ GTEST_TEST(detray_intersection,
     // No magnetic field, so the solutions must be the same as for a ray
 
     // second intersection lies in front of the track
-    EXPECT_TRUE(hits_bound[0].status == intersection::status::e_inside);
-    EXPECT_TRUE(hits_bound[0].direction == intersection::direction::e_opposite);
+    EXPECT_TRUE(hits_bound[0].status);
+    EXPECT_FALSE(hits_bound[0].direction);
 
     const auto global0 =
         cylinder.to_global_frame(identity, hits_bound[0].local);
@@ -306,8 +306,8 @@ GTEST_TEST(detray_intersection,
     // first intersection lies behind the track
     const auto global1 =
         cylinder.to_global_frame(identity, hits_bound[1].local);
-    EXPECT_TRUE(hits_bound[1].status == intersection::status::e_inside);
-    EXPECT_TRUE(hits_bound[1].direction == intersection::direction::e_along);
+    EXPECT_TRUE(hits_bound[1].status);
+    EXPECT_TRUE(hits_bound[1].direction);
     EXPECT_NEAR(global1[0], 4.f, tol);
     EXPECT_NEAR(global1[1], 0.f, tol);
     EXPECT_NEAR(global1[2], -5.f, tol);
@@ -362,8 +362,8 @@ GTEST_TEST(detray_intersection, helix_line_intersector) {
     // track (helix) is at the left side w.r.t wire
     EXPECT_NEAR(is.local[0], offset, tol);
     EXPECT_NEAR(is.local[1], 0.f, tol);
-    EXPECT_EQ(is.status, intersection::status::e_inside);
-    EXPECT_EQ(is.direction, intersection::direction::e_along);
+    EXPECT_TRUE(is.status);
+    EXPECT_TRUE(is.direction);
     EXPECT_NEAR(is.cos_incidence_angle, 0.f, tol);
 
     // Get the intersection on the next surface
@@ -373,8 +373,8 @@ GTEST_TEST(detray_intersection, helix_line_intersector) {
     // track (helix) is at the left side w.r.t wire
     EXPECT_NEAR(is.local[0], offset, tol);
     EXPECT_NEAR(is.local[1], 0.f, tol);
-    EXPECT_EQ(is.status, intersection::status::e_inside);
-    EXPECT_EQ(is.direction, intersection::direction::e_along);
+    EXPECT_TRUE(is.status);
+    EXPECT_TRUE(is.direction);
     EXPECT_NEAR(is.cos_incidence_angle, 0.f, tol);
 
     //---------------------
@@ -397,8 +397,8 @@ GTEST_TEST(detray_intersection, helix_line_intersector) {
     // track (helix) is at the right side w.r.t wire
     EXPECT_NEAR(is.local[0], -offset, tol);
     EXPECT_NEAR(is.local[1], 0.f, tol);
-    EXPECT_EQ(is.status, intersection::status::e_inside);
-    EXPECT_EQ(is.direction, intersection::direction::e_opposite);
+    EXPECT_TRUE(is.status);
+    EXPECT_FALSE(is.direction);
     EXPECT_NEAR(is.cos_incidence_angle, 0.f, tol);
 
     // Get the intersection on the next surface
@@ -408,7 +408,7 @@ GTEST_TEST(detray_intersection, helix_line_intersector) {
     // track (helix) is at the right side w.r.t wire
     EXPECT_NEAR(is.local[0], -offset, tol);
     EXPECT_NEAR(is.local[1], 0.f, tol);
-    EXPECT_EQ(is.status, intersection::status::e_inside);
-    EXPECT_EQ(is.direction, intersection::direction::e_opposite);
+    EXPECT_TRUE(is.status);
+    EXPECT_FALSE(is.direction);
     EXPECT_NEAR(is.cos_incidence_angle, 0.f, tol);
 }

--- a/tests/unit_tests/cpu/navigation/intersection/intersection2D.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection2D.cpp
@@ -50,26 +50,15 @@ GTEST_TEST(detray_intersection, intersection2D) {
 
     using intersection_t = intersection2D<surface_t, algebra_t>;
 
-    intersection_t i0 = {surface_t{},
-                         point3{0.2f, 0.4f, 0.f},
-                         2.f,
-                         1.f,
-                         1u,
-                         intersection::status::e_outside,
-                         intersection::direction::e_along};
+    intersection_t i0 = {
+        surface_t{}, point3{0.2f, 0.4f, 0.f}, 2.f, 1.f, 1u, false, true};
 
     intersection_t i1 = {
-        surface_t{},
-        point3{0.2f, 0.4f, 0.f},
-        1.7f,
-        -1.f,
-        0u,
-        intersection::status::e_inside,
-        intersection::direction::e_opposite,
+        surface_t{}, point3{0.2f, 0.4f, 0.f}, 1.7f, -1.f, 0u, true, false,
     };
 
-    intersection_t invalid;
-    ASSERT_TRUE(invalid.status == intersection::status::e_undefined);
+    intersection_t invalid{};
+    ASSERT_FALSE(invalid.status);
 
     dvector<intersection_t> intersections = {invalid, i0, i1};
     std::sort(intersections.begin(), intersections.end());

--- a/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
@@ -157,7 +157,7 @@ GTEST_TEST(detray_intersection, intersection_kernel_ray) {
     // Also check intersections
     for (std::size_t i = 0u; i < expected_points.size(); ++i) {
 
-        EXPECT_EQ(sfi_init[i].direction, intersection::direction::e_along);
+        EXPECT_TRUE(sfi_init[i].direction);
         EXPECT_EQ(sfi_init[i].volume_link, 0u);
 
         vector3 global;
@@ -199,9 +199,9 @@ GTEST_TEST(detray_intersection, intersection_kernel_ray) {
             surface.mask(), detail::ray(track), sfi_update[idx],
             transform_store);
 
-        if(sfi_update[idx].status != intersection::status::e_inside) {
-    continue; } ASSERT_EQ(sfi_update[idx].direction,
-    intersection::direction::e_along) << " at surface " << sfi_update[idx]
+        if(!sfi_update[idx].status) {
+    continue; } ASSERT_TRUE(sfi_update[idx].direction) << " at surface " <<
+    sfi_update[idx]
     << ", " << sfi_init[idx]; ASSERT_EQ(sfi_update[idx].volume_link, 0u);
         ASSERT_NEAR(sfi_update[idx].p3[0], expected_points[idx][0],
     is_close)

--- a/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
@@ -63,7 +63,7 @@ GTEST_TEST(detray_intersection, line_intersector_case1) {
     is[2] = line_intersector_type()(detail::ray(trks[2]),
                                     surface_descriptor<>{}, ln, tf, tol);
 
-    EXPECT_EQ(is[0].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[0].status);
     EXPECT_EQ(is[0].path, 1.f);
 
     const auto global0 = ln.to_global_frame(tf, is[0].local);
@@ -72,7 +72,7 @@ GTEST_TEST(detray_intersection, line_intersector_case1) {
     EXPECT_EQ(is[0].local[1], 0.f);
     EXPECT_NEAR(is[0].cos_incidence_angle, 0.f, tol);
 
-    EXPECT_EQ(is[1].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[1].status);
     EXPECT_EQ(is[1].path, 1.f);
     const auto global1 = ln.to_global_frame(tf, is[1].local);
     EXPECT_NEAR(global1[0], -1.f, tol);
@@ -82,7 +82,7 @@ GTEST_TEST(detray_intersection, line_intersector_case1) {
     EXPECT_EQ(is[1].local[1], 0.f);
     EXPECT_NEAR(is[1].cos_incidence_angle, 0.f, tol);
 
-    EXPECT_EQ(is[2].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[2].status);
     EXPECT_NEAR(is[2].path, constant<scalar>::sqrt2, tol);
     const auto global2 = ln.to_global_frame(tf, is[2].local);
     EXPECT_NEAR(global2[0], 1.f, tol);
@@ -115,7 +115,7 @@ GTEST_TEST(detray_intersection, line_intersector_case2) {
     const intersection_t is = line_intersector_type()(
         detail::ray<algebra_t>(trk), surface_descriptor<>{}, ln, tf, tol);
 
-    EXPECT_EQ(is.status, intersection::status::e_inside);
+    EXPECT_TRUE(is.status);
     EXPECT_NEAR(is.path, 2.f, tol);
     const auto global = ln.to_global_frame(tf, is.local);
     EXPECT_NEAR(global[0], 1.f, tol);
@@ -171,7 +171,7 @@ GTEST_TEST(detray_intersection, line_intersector_square_scope) {
             detail::ray<algebra_t>(trk), surface_descriptor<>{}, ln, tf, tol));
     }
 
-    EXPECT_EQ(is[0].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[0].status);
     EXPECT_NEAR(is[0].path, constant<scalar>::sqrt2, tol);
     const auto local0 = ln.to_local_frame(
         tf,
@@ -184,29 +184,29 @@ GTEST_TEST(detray_intersection, line_intersector_square_scope) {
     EXPECT_NEAR(is[0].local[0], -constant<scalar>::sqrt2, tol);
     EXPECT_NEAR(is[0].local[1], 0.f, tol);
 
-    EXPECT_EQ(is[1].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[1].status);
     EXPECT_TRUE(std::signbit(is[1].local[0]));
-    EXPECT_EQ(is[2].status, intersection::status::e_outside);
+    EXPECT_FALSE(is[2].status);
     EXPECT_TRUE(std::signbit(is[2].local[0]));
 
-    EXPECT_EQ(is[3].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[3].status);
     EXPECT_FALSE(std::signbit(is[3].local[0]));
-    EXPECT_EQ(is[4].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[4].status);
     EXPECT_FALSE(std::signbit(is[4].local[0]));
-    EXPECT_EQ(is[5].status, intersection::status::e_outside);
+    EXPECT_FALSE(is[5].status);
     EXPECT_FALSE(std::signbit(is[5].local[0]));
 
-    EXPECT_EQ(is[6].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[6].status);
     EXPECT_FALSE(std::signbit(is[6].local[0]));
-    EXPECT_EQ(is[7].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[7].status);
     EXPECT_FALSE(std::signbit(is[7].local[0]));
-    EXPECT_EQ(is[8].status, intersection::status::e_outside);
+    EXPECT_FALSE(is[8].status);
     EXPECT_FALSE(std::signbit(is[8].local[0]));
 
-    EXPECT_EQ(is[9].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[9].status);
     EXPECT_TRUE(std::signbit(is[9].local[0]));
-    EXPECT_EQ(is[10].status, intersection::status::e_inside);
+    EXPECT_TRUE(is[10].status);
     EXPECT_TRUE(std::signbit(is[10].local[0]));
-    EXPECT_EQ(is[11].status, intersection::status::e_outside);
+    EXPECT_FALSE(is[11].status);
     EXPECT_TRUE(std::signbit(is[11].local[0]));
 }

--- a/tests/unit_tests/cpu/navigation/intersection/plane_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/plane_intersector.cpp
@@ -47,7 +47,7 @@ GTEST_TEST(detray_intersection, translated_plane_ray) {
     const auto hit_bound =
         pi(r, surface_descriptor<>{}, unmasked_bound, shifted);
 
-    ASSERT_TRUE(hit_bound.status == intersection::status::e_inside);
+    ASSERT_TRUE(hit_bound.status);
     // Global intersection information - unchanged
     const auto global0 =
         unmasked_bound.to_global_frame(shifted, hit_bound.local);
@@ -64,7 +64,7 @@ GTEST_TEST(detray_intersection, translated_plane_ray) {
     mask<rectangle2D> rect_for_inside{0u, 3.f, 3.f};
     const auto hit_bound_inside =
         pi(r, surface_descriptor<>{}, rect_for_inside, shifted, tol);
-    ASSERT_TRUE(hit_bound_inside.status == intersection::status::e_inside);
+    ASSERT_TRUE(hit_bound_inside.status);
     // Global intersection information - unchanged
     const auto global1 =
         rect_for_inside.to_global_frame(shifted, hit_bound_inside.local);
@@ -79,7 +79,7 @@ GTEST_TEST(detray_intersection, translated_plane_ray) {
     mask<rectangle2D> rect_for_outside{0u, 0.5f, 3.5f};
     const auto hit_bound_outside =
         pi(r, surface_descriptor<>{}, rect_for_outside, shifted, tol);
-    ASSERT_TRUE(hit_bound_outside.status == intersection::status::e_outside);
+    ASSERT_FALSE(hit_bound_outside.status);
     // Global intersection information - not written out anymore
     const auto global2 =
         rect_for_outside.to_global_frame(shifted, hit_bound_outside.local);

--- a/tests/unit_tests/cpu/utils/bounding_volume.cpp
+++ b/tests/unit_tests/cpu/utils/bounding_volume.cpp
@@ -57,11 +57,11 @@ GTEST_TEST(detray_tools, bounding_cuboid3D) {
     ASSERT_NEAR(bounds[cuboid3D::e_max_y], hy + envelope, tol);
     ASSERT_NEAR(bounds[cuboid3D::e_max_z], hz + envelope, tol);
 
-    ASSERT_TRUE(aabb.is_inside(p2_in) == intersection::status::e_inside);
-    ASSERT_TRUE(aabb.is_inside(p2_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(aabb.is_inside(p2_out) == intersection::status::e_outside);
+    ASSERT_TRUE(aabb.is_inside(p2_in));
+    ASSERT_TRUE(aabb.is_inside(p2_edge));
+    ASSERT_FALSE(aabb.is_inside(p2_out));
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(aabb.is_inside(p2_out, 1.) == intersection::status::e_inside);
+    ASSERT_TRUE(aabb.is_inside(p2_out, 1.));
 }
 
 /// This tests the basic functionality cylindrical axis aligned bounding box
@@ -92,12 +92,12 @@ GTEST_TEST(detray_tools, bounding_cylinder3D) {
     ASSERT_NEAR(bounds[cylinder3D::e_min_z], -hz, tol);
     ASSERT_NEAR(bounds[cylinder3D::e_max_z], hz, tol);
 
-    ASSERT_TRUE(aabc.is_inside(p3_in) == intersection::status::e_inside);
-    ASSERT_TRUE(aabc.is_inside(p3_edge) == intersection::status::e_inside);
-    ASSERT_TRUE(aabc.is_inside(p3_out) == intersection::status::e_outside);
-    ASSERT_TRUE(aabc.is_inside(p3_off) == intersection::status::e_outside);
+    ASSERT_TRUE(aabc.is_inside(p3_in));
+    ASSERT_TRUE(aabc.is_inside(p3_edge));
+    ASSERT_FALSE(aabc.is_inside(p3_out));
+    ASSERT_FALSE(aabc.is_inside(p3_off));
     // Move outside point inside using a tolerance
-    ASSERT_TRUE(aabc.is_inside(p3_out, 0.6f) == intersection::status::e_inside);
+    ASSERT_TRUE(aabc.is_inside(p3_out, 0.6f));
 }
 
 /// This tests the basic functionality of an aabb around a stereo annulus

--- a/tests/unit_tests/device/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda.cpp
@@ -55,7 +55,7 @@ TEST(mask_store_cuda, mask_store) {
     }
 
     /** host output for intersection status **/
-    vecmem::jagged_vector<intersection::status> output_host(5, &mng_mr);
+    vecmem::jagged_vector<int> output_host(5, &mng_mr);
 
     /** get mask objects **/
     const auto& rectangle_mask = store.get<e_rectangle2>()[0];
@@ -77,7 +77,7 @@ TEST(mask_store_cuda, mask_store) {
     vecmem::cuda::copy copy;
 
     /** device output for intersection status **/
-    vecmem::data::jagged_vector_buffer<intersection::status> output_buffer(
+    vecmem::data::jagged_vector_buffer<int> output_buffer(
         {n_points, n_points, n_points, n_points, n_points}, mng_mr, nullptr,
         vecmem::data::buffer_type::resizable);
 
@@ -90,7 +90,7 @@ TEST(mask_store_cuda, mask_store) {
     /** run the kernel **/
     mask_test(store_data, input_point3_data, output_buffer);
 
-    vecmem::jagged_vector<intersection::status> output_device(&mng_mr);
+    vecmem::jagged_vector<int> output_device(&mng_mr);
     copy(output_buffer, output_device);
 
     /** Compare the values **/

--- a/tests/unit_tests/device/cuda/mask_store_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/mask_store_cuda_kernel.cu
@@ -15,15 +15,14 @@ namespace detray {
 __global__ void mask_test_kernel(
     typename host_store_type::view_type store_data,
     vecmem::data::vector_view<point3> input_point3_data,
-    vecmem::data::jagged_vector_view<intersection::status> output_data) {
+    vecmem::data::jagged_vector_view<int> output_data) {
 
     /** get mask store **/
     device_store_type store(store_data);
 
     /** get mask objects **/
     vecmem::device_vector<point3> input_point3(input_point3_data);
-    vecmem::jagged_device_vector<intersection::status> output_device(
-        output_data);
+    vecmem::jagged_device_vector<int> output_device(output_data);
 
     const auto& rectangle_mask = store.get<e_rectangle2>()[0];
     const auto& trapezoid_mask = store.get<e_trapezoid2>()[0];
@@ -41,10 +40,9 @@ __global__ void mask_test_kernel(
     }
 }
 
-void mask_test(
-    typename host_store_type::view_type store_data,
-    vecmem::data::vector_view<point3> input_point3_data,
-    vecmem::data::jagged_vector_view<intersection::status> output_data) {
+void mask_test(typename host_store_type::view_type store_data,
+               vecmem::data::vector_view<point3> input_point3_data,
+               vecmem::data::jagged_vector_view<int> output_data) {
 
     int block_dim = 1;
     int thread_dim = 1;

--- a/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
@@ -56,9 +56,8 @@ using device_store_type =
                         rectangle, trapezoid, ring, cylinder, single, annulus>;
 
 /// test function for mask store
-void mask_test(
-    typename host_store_type::view_type store_data,
-    vecmem::data::vector_view<point3> input_point3_data,
-    vecmem::data::jagged_vector_view<intersection::status> output_data);
+void mask_test(typename host_store_type::view_type store_data,
+               vecmem::data::vector_view<point3> input_point3_data,
+               vecmem::data::jagged_vector_view<int> output_data);
 
 }  // namespace detray

--- a/tutorials/include/detray/tutorial/my_square2D.hpp
+++ b/tutorials/include/detray/tutorial/my_square2D.hpp
@@ -52,7 +52,7 @@ class square2D {
     template <template <typename, std::size_t> class bounds_t,
               typename scalar_t, std::size_t kDIM, typename point_t,
               typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline bool check_boundaries(
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         return (math::abs(loc_p[0]) <= bounds[e_half_length] + tol and


### PR DESCRIPTION
This adds SOA intersectors that are explicitly vectorized in order to find out what the interfaces towards ```algebra_plugins``` need to be to later also include simd for GPU. It is based on the algebra-plugins abstraction layer introduced in #711 , so that it becomes easier to differentiate between scalar types that are fundamental types and simd types. For the same reason, this also introduces a separate boolean handling, since these are boolean masks in SOA memory layouts. A lot of the glue code that is still needed in this PR should eventually become part of algebra-plugins.

This adds the SOA implementations of the ray-surfaces intersectors, which at this point can completely reuse the coordinates, shapes, mask and intersection types in detray, but need special handling for the intersectors themselves. This is mainly due to the way the control flow is handled at surface inside/outside checks. The goal remains to find a unified implementation at some point.

Benchmarks have been added, that can compare the SOA/Vc implementation to any other AOS  algebra-plugin