### PR TITLE
CMake Updates, main branch (2024.04.12.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -37,10 +37,9 @@ jobs:
     - uses: actions/checkout@v2
     # Run the CMake configuration.
     - name: Configure
-      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }}
-                 -DDETRAY_EIGEN_PLUGIN=ON
-                 -DDETRAY_VC_PLUGIN=ON
-                 -DDETRAY_BUILD_CUDA=FALSE 
+      run: cmake --preset default-fp64
+                 -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }}
+                 -DDETRAY_FAIL_ON_WARNINGS=ON
                  -S ${{ github.workspace }} -B build
                  -G "${{ matrix.PLATFORM.GENERATOR }}"
     # Perform the build.
@@ -86,7 +85,7 @@ jobs:
     - name: Configure
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DDETRAY_CUSTOM_SCALARTYPE=${{ matrix.SCALAR_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -S ${GITHUB_WORKSPACE} -B build
+        cmake -DDETRAY_FAIL_ON_WARNINGS=ON -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DDETRAY_CUSTOM_SCALARTYPE=${{ matrix.SCALAR_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -S ${GITHUB_WORKSPACE} -B build
     # Perform the build.
     - name: Build
       run: |
@@ -139,7 +138,7 @@ jobs:
     - name: Configure
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DDETRAY_CUSTOM_SCALARTYPE=${{ matrix.SCALAR_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -S ${GITHUB_WORKSPACE} -B build
+        cmake -DDETRAY_FAIL_ON_WARNINGS=ON -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DDETRAY_CUSTOM_SCALARTYPE=${{ matrix.SCALAR_TYPE }} ${{ matrix.PLATFORM.OPTIONS }} -S ${GITHUB_WORKSPACE} -B build
     # Perform the build.
     - name: Build
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /bin
 /build
 /run
+/out
 
 # python files
 **/__pycache__

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,9 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2021-2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
 stages:
   - build
   - test
@@ -14,15 +20,11 @@ build_cuda:
       - git clone $CLONE_URL src
       - git -C src checkout $HEAD_SHA
       - >
-        cmake -S src -B build 
+        cmake --preset cuda -S src -B build
         -DCMAKE_BUILD_TYPE=Release
-        -DDETRAY_CUSTOM_SCALARTYPE=float
         -DBUILD_TESTING=ON
         -DDETRAY_BUILD_TESTING=ON
-        -DDETRAY_BUILD_CUDA=ON
-        -DDETRAY_VC_PLUGIN=OFF
-        -DDETRAY_SMATRIX_PLUGIN=OFF
-        -DDETRAY_EIGEN_PLUGIN=ON
+        -DDETRAY_FAIL_ON_WARNINGS=ON
       - cmake --build build
 
 
@@ -57,16 +59,11 @@ build_sycl:
       - git -C src checkout $HEAD_SHA
       - source src/.github/ci_setup.sh SYCL
       - >
-        cmake -S src -B build 
+        cmake --preset sycl -S src -B build
         -DCMAKE_BUILD_TYPE=Release
-        -DDETRAY_CUSTOM_SCALARTYPE=float
-        -DDETRAY_BUILD_CUDA=OFF
-        -DDETRAY_BUILD_SYCL=ON
-        -DBUILD_TESTING=ON 
+        -DBUILD_TESTING=ON
         -DDETRAY_BUILD_TESTING=ON
-        -DDETRAY_VC_PLUGIN=OFF
-        -DDETRAY_SMATRIX_PLUGIN=OFF
-        -DDETRAY_EIGEN_PLUGIN=ON
+        -DDETRAY_FAIL_ON_WARNINGS=ON
       - cmake --build build
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -62,6 +62,8 @@ cmake_dependent_option( DETRAY_BENCHMARKS "Enable benchmark tests" TRUE
    "DETRAY_BUILD_TESTING" OFF )
 option( DETRAY_BUILD_TUTORIALS "Build the tutorial executables of Detray"
    ON )
+option( DETRAY_FAIL_ON_WARNINGS
+   "Make the build fail on compiler/linker warnings" FALSE )
 
 # Clean up.
 unset( DETRAY_BUILD_CUDA_DEFAULT )

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,59 @@
+{
+   "version" : 3,
+   "configurePresets": [
+      {
+         "name" : "base",
+         "displayName" : "Base Developer Configuration",
+         "warnings": {
+            "deprecated": true
+         },
+         "cacheVariables": {
+            "CMAKE_BUILD_TYPE" : "RelWithDebInfo"
+         }
+      },
+      {
+         "name" : "default-fp64",
+         "displayName" : "FP64 Developer Configuration",
+         "inherits" : [ "base" ],
+         "cacheVariables" : {
+            "DETRAY_CUSTOM_SCALARTYPE" : "double"
+         }
+      },
+      {
+         "name" : "default-fp32",
+         "displayName" : "FP32 Developer Configuration",
+         "inherits" : [ "base" ],
+         "cacheVariables" : {
+            "DETRAY_CUSTOM_SCALARTYPE" : "float"
+         }
+      },
+      {
+         "name" : "cuda",
+         "displayName" : "CUDA Developer Configuration",
+         "inherits" : [ "default-fp32" ],
+         "cacheVariables" : {
+            "DETRAY_BUILD_CUDA"     : "TRUE",
+            "DETRAY_VC_PLUGIN"      : "FALSE",
+            "DETRAY_SMATRIX_PLUGIN" : "FALSE"
+         }
+      },
+      {
+         "name" : "sycl",
+         "displayName" : "SYCL Developer Configuration",
+         "inherits" : [ "default-fp32" ],
+         "cacheVariables" : {
+            "DETRAY_BUILD_SYCL"     : "TRUE",
+            "DETRAY_VC_PLUGIN"      : "FALSE",
+            "DETRAY_SMATRIX_PLUGIN" : "FALSE"
+         }
+      },
+      {
+         "name" : "smatrix",
+         "displayName" : "SMatrix Developer Configuration",
+         "inherits" : [ "default-fp64" ],
+         "cacheVariables" : {
+            "DETRAY_SMATRIX_PLUGIN" : "TRUE"
+         }
+      }
+   ]
+}

--- a/cmake/detray-compiler-options-cpp.cmake
+++ b/cmake/detray-compiler-options-cpp.cmake
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -30,12 +30,14 @@ if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR
    detray_add_flag(CMAKE_CXX_FLAGS "-Wextra")
    detray_add_flag(CMAKE_CXX_FLAGS "-Wshadow")
    detray_add_flag(CMAKE_CXX_FLAGS "-Wunused-local-typedefs")
-
-   # More rigorous tests for the Debug builds.
-   detray_add_flag(CMAKE_CXX_FLAGS_DEBUG "-Werror")
-   detray_add_flag(CMAKE_CXX_FLAGS_DEBUG "-pedantic")
+   detray_add_flag(CMAKE_CXX_FLAGS "-pedantic")
    # No implicit single to double conversions from floating point literals
-   detray_add_flag(CMAKE_CXX_FLAGS_DEBUG "-Wconversion")
+   detray_add_flag(CMAKE_CXX_FLAGS "-Wconversion")
+
+   # Fail on warnings, if asked for that behaviour.
+   if(DETRAY_FAIL_ON_WARNINGS)
+      detray_add_flag(CMAKE_CXX_FLAGS "-Werror")
+   endif()
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
    # Basic flags for all build modes.
@@ -43,6 +45,8 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
       "${CMAKE_CXX_FLAGS}")
    detray_add_flag(CMAKE_CXX_FLAGS "/W4")
 
-   # More rigorous tests for the Debug builds.
-   detray_add_flag(CMAKE_CXX_FLAGS_DEBUG "/WX")
+   # Fail on warnings, if asked for that behaviour.
+   if(DETRAY_FAIL_ON_WARNINGS)
+      detray_add_flag(CMAKE_CXX_FLAGS "/WX")
+   endif()
 endif()

--- a/cmake/detray-compiler-options-cuda.cmake
+++ b/cmake/detray-compiler-options-cuda.cmake
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -35,7 +35,12 @@ endif()
 # build.
 detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G" )
 
-# More rigorous tests for the Debug builds.
-if( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2" )
-   detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-Werror all-warnings" )
+# Fail on warnings, if asked for that behaviour.
+if( DETRAY_FAIL_ON_WARNINGS )
+   if( ( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2" ) AND
+       ( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA" ) )
+      detray_add_flag( CMAKE_CUDA_FLAGS "-Werror all-warnings" )
+   elseif( "${CMAKE_CUDA_COMPILER_ID}" MATCHES "Clang" )
+      detray_add_flag( CMAKE_CUDA_FLAGS "-Werror" )
+   endif()
 endif()

--- a/cmake/detray-compiler-options-sycl.cmake
+++ b/cmake/detray-compiler-options-sycl.cmake
@@ -1,6 +1,6 @@
 # TRACCC library, part of the ACTS project (R&D line)
 #
-# (c) 2023 CERN for the benefit of the ACTS project
+# (c) 2023-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -8,24 +8,22 @@
 include( detray-functions )
 
 # Basic flags for all build modes.
-foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
-   detray_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wall" )
-   detray_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wextra" )
-   detray_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wno-unknown-cuda-version" )
-   detray_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wshadow" )
-   detray_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wunused-local-typedefs" )
-endforeach()
-
-# More rigorous tests for the Debug builds.
-detray_add_flag( CMAKE_SYCL_FLAGS_DEBUG "-Werror" )
+detray_add_flag( CMAKE_SYCL_FLAGS "-Wall" )
+detray_add_flag( CMAKE_SYCL_FLAGS "-Wextra" )
+detray_add_flag( CMAKE_SYCL_FLAGS "-Wno-unknown-cuda-version" )
+detray_add_flag( CMAKE_SYCL_FLAGS "-Wshadow" )
+detray_add_flag( CMAKE_SYCL_FLAGS "-Wunused-local-typedefs" )
 if( NOT WIN32 )
-   detray_add_flag( CMAKE_SYCL_FLAGS_DEBUG "-pedantic" )
+   detray_add_flag( CMAKE_SYCL_FLAGS "-pedantic" )
 endif()
 
 # Avoid issues coming from MSVC<->DPC++ argument differences.
 if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
-   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
-      detray_add_flag( CMAKE_SYCL_FLAGS_${mode}
-         "-Wno-unused-command-line-argument" )
-   endforeach()
+   detray_add_flag( CMAKE_SYCL_FLAGS
+      "-Wno-unused-command-line-argument" )
+endif()
+
+# Fail on warnings, if asked for that behaviour.
+if( DETRAY_FAIL_ON_WARNINGS )
+   detray_add_flag( CMAKE_SYCL_FLAGS "-Werror" )
 endif()


### PR DESCRIPTION
In order to make fixes similar to https://github.com/acts-project/algebra-plugins/pull/115 for [oneAPI 2024.1.0](https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpc-c-compiler-release-notes.html), I wanted to make it more convenient (for me personally...) to build Detray with [VSCode](https://code.visualstudio.com/). And hence this PR...
  - I switched the project to handle `-Werror` options in the same way as [vecmem](https://github.com/acts-project/vecmem) and [traccc](https://github.com/acts-project/traccc) do since a while. I.e. not to activate errors for warnings just in Debug builds, but to activate them using a dedicated CMake cache variable (`DETRAY_FAIL_ON_WARNINGS`).
  - Introduced some (not entirely exhaustive) set of CMake presets, to make it a bit more convenient to do SYCL builds from VSCode. (With proper warning and error highlighting in the code. :stuck_out_tongue:)

Unfortunately this just unleashed a wealth of warnings with oneAPI 2024.1.0. :frowning:

```
[build] In file included from /home/krasznaa/ATLAS/projects/detray/detray/tests/unit_tests/cpu/utils/bounding_volume.cpp:9:
[build] In file included from /home/krasznaa/ATLAS/projects/detray/detray/core/include/detray/utils/bounding_volume.hpp:13:
[build] In file included from /home/krasznaa/ATLAS/projects/detray/detray/core/include/detray/geometry/mask.hpp:13:
[build] In file included from /home/krasznaa/ATLAS/projects/detray/detray/core/include/detray/geometry/shapes/cuboid3D.hpp:14:
[build] In file included from /home/krasznaa/ATLAS/projects/detray/detray/core/include/detray/geometry/coordinates/cartesian3D.hpp:11:
[build] In file included from /home/krasznaa/ATLAS/projects/detray/detray/core/include/detray/definitions/detail/algebra.hpp:17:
[build] In file included from /home/krasznaa/ATLAS/projects/detray/detray/plugins/algebra/vc/include/detray/plugins/algebra/vc_array_definitions.hpp:11:
[build] In file included from /home/krasznaa/ATLAS/projects/detray/detray/out/build/default-fp32/_deps/algebraplugins-src/frontend/vc_cmath/include/algebra/vc_cmath.hpp:11:
[build] In file included from /home/krasznaa/ATLAS/projects/detray/detray/out/build/default-fp32/_deps/algebraplugins-src/math/cmath/include/algebra/math/cmath.hpp:14:
[build] /home/krasznaa/ATLAS/projects/detray/detray/out/build/default-fp32/_deps/algebraplugins-src/math/cmath/include/algebra/math/impl/cmath_transform3.hpp:83:43: warning: implicit conversion between floating point types of different sizes [-Wimplicit-float-size-conversion]
[build]    83 |     matrix_actor().element(_data, 3, 0) = 0.;
[build]       |                                         ~ ^~
```

```
[build] /home/krasznaa/ATLAS/projects/detray/detray/tests/unit_tests/cpu/utils/grids/grid_collection.cpp:73:75: warning: implicit conversion between floating point types of different sizes [-Wimplicit-float-size-conversion]
[build]    72 |     dvector<scalar> bin_edges = {-10, 10., -20., 20., 0.,  120., -5., 5., -15.,
[build]       |                                 ~
[build]    73 |                                  15., 0.,  50.,  -15, 15., -35., 35., 0., 550.};
[build]       |                                                                           ^~~~
```

etc,

Because of this, I didn't activate the new `DETRAY_FAIL_ON_WARNINGS` flag in the presets just yet... :thinking: