### PR TITLE
Update algebra-plugins and Vectorize the benchmark

### DIFF
--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@ message(STATUS "Building Algebra Plugins as part of the Detray project")
 
 # Declare where to get Algebra Plugins from.
 set( DETRAY_ALGEBRA_PLUGINS_SOURCE
-   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.22.0.tar.gz;URL_MD5;42bcaad8d19a2c773993a974816dfdf5"
+   "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.23.0.tar.gz;URL_MD5;29f4f2f812ed2623f1610872f4a1aa87"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced(DETRAY_ALGEBRA_PLUGINS_SOURCE)
 FetchContent_Declare(AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE})

--- a/tests/benchmarks/cuda/CMakeLists.txt
+++ b/tests/benchmarks/cuda/CMakeLists.txt
@@ -34,6 +34,9 @@ detray_add_executable( benchmark_cuda_${algebra}
    target_compile_definitions( detray_benchmark_cuda_${algebra}
       PRIVATE ${algebra}=${algebra} )
 
+   target_compile_options( detray_benchmark_cuda_${algebra} PRIVATE
+   "-march=native" "-ftree-vectorize")
+
 if( OpenMP_CXX_FOUND )
   target_link_libraries( detray_benchmark_cuda_${algebra} PRIVATE OpenMP::OpenMP_CXX )
 endif()


### PR DESCRIPTION
This PR allows the vectorization in the detray benchmark with the following tag` "-march=native" "-ftree-vectorize"`
It seems `-ftree-vectorize` is still required for `RelWithDebInfo` build type.

The detray benchmark test (`detray_benchmark_cuda_array`) was done in the LBL server which is less noisy.
Even though It is still subtle a bit, the CPU benchmark seems faster with the matrix multiplication optimization in acts-project/algebra-plugins#116. (All tests were done with `float` precision)

<details>
  <summary>Click for the previous benchmarks</summary>

<img src="https://github.com/acts-project/detray/assets/63090140/069dd376-057b-403c-99dc-32e4e369a24f" width="600"/>

As expected, there was not impact on GPU benchmark 

<img src="https://github.com/acts-project/detray/assets/63090140/59675072-8e8b-49b1-9ef1-4f4033bcb4b7" width="600"/>

### **Update**

The speedup with the double precision is more obvious:

<img src="https://github.com/acts-project/detray/assets/63090140/58b8fc7a-fc5a-48c6-9c6f-49fa4372221f" width="600"/>

</details>

### **Update**

The benchmark was done with better statistics (averged over 10 iterations)

<img src="https://github.com/acts-project/detray/assets/63090140/d9aeebb7-fd30-41f8-ad96-df7ce6a257ef" width="600"/>

The google sheets does not allow the fluctuation in the graph (...) so I just attached the benchmark logs here for the three cases:

### w/o vectorization (main)

```
CPU unsync propagation/8_mean           74161 ns        73571 ns           10 TracksPropagated=874.376k/s
CPU unsync propagation/8_median         70265 ns        70280 ns           10 TracksPropagated=910.65k/s
CPU unsync propagation/8_stddev          7085 ns         5726 ns           10 TracksPropagated=63.7653k/s
CPU unsync propagation/8_cv              9.55 %          7.78 %            10 TracksPropagated=7.29%
CPU unsync propagation/16_mean         261213 ns       260696 ns           10 TracksPropagated=985.358k/s
CPU unsync propagation/16_median       252603 ns       252576 ns           10 TracksPropagated=1013.56k/s
CPU unsync propagation/16_stddev        17384 ns        16550 ns           10 TracksPropagated=59.0269k/s
CPU unsync propagation/16_cv             6.66 %          6.35 %            10 TracksPropagated=5.99%
CPU unsync propagation/32_mean        1243851 ns      1237213 ns           10 TracksPropagated=830.545k/s
CPU unsync propagation/32_median      1186577 ns      1185797 ns           10 TracksPropagated=863.554k/s
CPU unsync propagation/32_stddev        88492 ns        78883 ns           10 TracksPropagated=50.1814k/s
CPU unsync propagation/32_cv             7.11 %          6.38 %            10 TracksPropagated=6.04%
CPU unsync propagation/64_mean        4824766 ns      4777637 ns           10 TracksPropagated=858.895k/s
CPU unsync propagation/64_median      4645167 ns      4644977 ns           10 TracksPropagated=881.813k/s
CPU unsync propagation/64_stddev       287267 ns       221264 ns           10 TracksPropagated=37.628k/s
CPU unsync propagation/64_cv             5.95 %          4.63 %            10 TracksPropagated=4.38%
CPU unsync propagation/128_mean      18211812 ns     18041077 ns           10 TracksPropagated=908.229k/s
CPU unsync propagation/128_median    17984800 ns     17956089 ns           10 TracksPropagated=912.448k/s
CPU unsync propagation/128_stddev      394820 ns       177626 ns           10 TracksPropagated=8.91166k/s
CPU unsync propagation/128_cv            2.17 %          0.98 %            10 TracksPropagated=0.98%
CPU unsync propagation/256_mean      69280975 ns     65501487 ns           10 TracksPropagated=1000.53k/s
CPU unsync propagation/256_median    68867357 ns     65531274 ns           10 TracksPropagated=1000.07k/s
CPU unsync propagation/256_stddev     1047027 ns       135675 ns           10 TracksPropagated=2.07339k/s
CPU unsync propagation/256_cv            1.51 %          0.21 %            10 TracksPropagated=0.21%
```

### w/ vectorization

```
CPU unsync propagation/8_mean           72510 ns        72246 ns           10 TracksPropagated=891.274k/s
CPU unsync propagation/8_median         69040 ns        69136 ns           10 TracksPropagated=925.714k/s
CPU unsync propagation/8_stddev          6333 ns         6246 ns           10 TracksPropagated=69.6818k/s
CPU unsync propagation/8_cv              8.73 %          8.65 %            10 TracksPropagated=7.82%
CPU unsync propagation/16_mean         264697 ns       262710 ns           10 TracksPropagated=982.432k/s
CPU unsync propagation/16_median       244345 ns       244027 ns           10 TracksPropagated=1049.07k/s
CPU unsync propagation/16_stddev        28613 ns        25551 ns           10 TracksPropagated=91.1367k/s
CPU unsync propagation/16_cv            10.81 %          9.73 %            10 TracksPropagated=9.28%
CPU unsync propagation/32_mean        1225226 ns      1195862 ns           10 TracksPropagated=858.307k/s
CPU unsync propagation/32_median      1162825 ns      1162109 ns           10 TracksPropagated=881.157k/s
CPU unsync propagation/32_stddev       113636 ns        62278 ns           10 TracksPropagated=43.1368k/s
CPU unsync propagation/32_cv             9.27 %          5.21 %            10 TracksPropagated=5.03%
CPU unsync propagation/64_mean        4697568 ns      4656133 ns           10 TracksPropagated=880.986k/s
CPU unsync propagation/64_median      4541518 ns      4541571 ns           10 TracksPropagated=901.891k/s
CPU unsync propagation/64_stddev       258437 ns       190917 ns           10 TracksPropagated=34.8629k/s
CPU unsync propagation/64_cv             5.50 %          4.10 %            10 TracksPropagated=3.96%
CPU unsync propagation/128_mean      17826772 ns     17641016 ns           10 TracksPropagated=928.825k/s
CPU unsync propagation/128_median    17633604 ns     17528039 ns           10 TracksPropagated=934.731k/s
CPU unsync propagation/128_stddev      360701 ns       173998 ns           10 TracksPropagated=9.09306k/s
CPU unsync propagation/128_cv            2.02 %          0.99 %            10 TracksPropagated=0.98%
CPU unsync propagation/256_mean      67879223 ns     63125037 ns           10 TracksPropagated=1038.23k/s
CPU unsync propagation/256_median    67488056 ns     63242679 ns           10 TracksPropagated=1036.26k/s
CPU unsync propagation/256_stddev      859107 ns       378437 ns           10 TracksPropagated=6.30441k/s
CPU unsync propagation/256_cv            1.27 %          0.60 %            10 TracksPropagated=0.61%
```

### w/ vectorization + algebra-plugins v0.23.0 (This PR)

```
CPU unsync propagation/8_mean           70458 ns        70546 ns           10 TracksPropagated=914.55k/s
CPU unsync propagation/8_median         66036 ns        66134 ns           10 TracksPropagated=967.737k/s
CPU unsync propagation/8_stddev          7003 ns         6962 ns           10 TracksPropagated=82.7296k/s
CPU unsync propagation/8_cv              9.94 %          9.87 %            10 TracksPropagated=9.05%
CPU unsync propagation/16_mean         245678 ns       242113 ns           10 TracksPropagated=1060.44k/s
CPU unsync propagation/16_median       233864 ns       233759 ns           10 TracksPropagated=1095.14k/s
CPU unsync propagation/16_stddev        20240 ns        14152 ns           10 TracksPropagated=58.7053k/s
CPU unsync propagation/16_cv             8.24 %          5.85 %            10 TracksPropagated=5.54%
CPU unsync propagation/32_mean        1174343 ns      1156186 ns           10 TracksPropagated=889.174k/s
CPU unsync propagation/32_median      1104003 ns      1104053 ns           10 TracksPropagated=927.492k/s
CPU unsync propagation/32_stddev        99986 ns        79321 ns           10 TracksPropagated=56.849k/s
CPU unsync propagation/32_cv             8.51 %          6.86 %            10 TracksPropagated=6.39%
CPU unsync propagation/64_mean        4492988 ns      4439544 ns           10 TracksPropagated=923.27k/s
CPU unsync propagation/64_median      4428305 ns      4380351 ns           10 TracksPropagated=935.085k/s
CPU unsync propagation/64_stddev       173877 ns       125758 ns           10 TracksPropagated=25.5952k/s
CPU unsync propagation/64_cv             3.87 %          2.83 %            10 TracksPropagated=2.77%
CPU unsync propagation/128_mean      17018470 ns     16870439 ns           10 TracksPropagated=971.39k/s
CPU unsync propagation/128_median    16744250 ns     16741787 ns           10 TracksPropagated=978.629k/s
CPU unsync propagation/128_stddev      495564 ns       271515 ns           10 TracksPropagated=15.4385k/s
CPU unsync propagation/128_cv            2.91 %          1.61 %            10 TracksPropagated=1.59%
CPU unsync propagation/256_mean      64701149 ns     60797787 ns           10 TracksPropagated=1077.96k/s
CPU unsync propagation/256_median    64673834 ns     60690979 ns           10 TracksPropagated=1079.83k/s
CPU unsync propagation/256_stddev      412200 ns       299458 ns           10 TracksPropagated=5.27396k/s
CPU unsync propagation/256_cv            0.64 %          0.49 %            10 TracksPropagated=0.49%
```
