### PR TITLE
ref: Allow printing of propagation config and remove templates

### DIFF
--- a/core/include/detray/navigation/navigation_config.hpp
+++ b/core/include/detray/navigation/navigation_config.hpp
@@ -9,7 +9,11 @@
 
 // Project include(s)
 #include "detray/definitions/detail/indexing.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
+
+// System include(s)
+#include <ostream>
 
 namespace detray::navigation {
 
@@ -22,22 +26,39 @@ enum class trust_level {
 };
 
 /// Navigation configuration
-template <typename scalar_t>
 struct config {
-    /// Maximal absolute path distance for a track to be considered 'on surface'
-    scalar_t on_surface_tolerance{1.f * unit<scalar_t>::um};
     /// Tolerance on the mask 'is_inside' check:
     /// @{
     /// Minimal tolerance: ~ position uncertainty on surface
-    scalar_t min_mask_tolerance{1e-5f * unit<scalar_t>::mm};
+    float min_mask_tolerance{1e-5f * unit<float>::mm};
     /// Maximal tolerance: loose tolerance when still far away from surface
-    scalar_t max_mask_tolerance{1.f * unit<scalar_t>::mm};
+    float max_mask_tolerance{1.f * unit<float>::mm};
     ///@}
+    /// Maximal absolute path distance for a track to be considered 'on surface'
+    float path_tolerance{1.f * unit<float>::um};
     /// How far behind the track position to look for candidates
-    scalar_t overstep_tolerance{-100.f * unit<scalar_t>::um};
+    float overstep_tolerance{-100.f * unit<float>::um};
     /// Search window size for grid based acceleration structures
     /// (0, 0): only look at current bin
     std::array<dindex, 2> search_window = {0u, 0u};
 };
+
+/// Print the navigation configuration
+DETRAY_HOST
+inline std::ostream& operator<<(std::ostream& out,
+                                const detray::navigation::config& cfg) {
+    out << "  Minimal mask tolerance: "
+        << cfg.min_mask_tolerance / detray::unit<float>::mm << " [mm]\n"
+        << "  Maximal mask tolerance: "
+        << cfg.max_mask_tolerance / detray::unit<float>::mm << " [mm]\n"
+        << "  Path tolerance        : "
+        << cfg.path_tolerance / detray::unit<float>::um << " [um]\n"
+        << "  Overstep tolerance    : "
+        << cfg.overstep_tolerance / detray::unit<float>::um << " [um]\n"
+        << "  Search window         : " << cfg.search_window[0] << " x "
+        << cfg.search_window[1] << "\n";
+
+    return out;
+}
 
 }  // namespace detray::navigation

--- a/core/include/detray/navigation/navigation_config.hpp
+++ b/core/include/detray/navigation/navigation_config.hpp
@@ -47,9 +47,9 @@ struct config {
 DETRAY_HOST
 inline std::ostream& operator<<(std::ostream& out,
                                 const detray::navigation::config& cfg) {
-    out << "  Minimal mask tolerance: "
+    out << "  Min. mask tolerance   : "
         << cfg.min_mask_tolerance / detray::unit<float>::mm << " [mm]\n"
-        << "  Maximal mask tolerance: "
+        << "  Max. mask tolerance   : "
         << cfg.max_mask_tolerance / detray::unit<float>::mm << " [mm]\n"
         << "  Path tolerance        : "
         << cfg.path_tolerance / detray::unit<float>::um << " [um]\n"

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -128,15 +128,16 @@ class navigator {
             const typename detector_type::surface_type &sf_descr,
             const detector_type &det, const track_t &track,
             vector_type<intersection_type> &candidates,
-            const std::array<float, 2> mask_tol,
-            const float overstep_tol) const {
+            const std::array<scalar_type, 2> mask_tol,
+            const scalar_type overstep_tol) const {
 
             const auto sf = surface{det, sf_descr};
 
             sf.template visit_mask<intersection_initialize<ray_intersector>>(
                 candidates, detail::ray(track), sf_descr, det.transform_store(),
-                sf.is_portal() ? std::array<scalar_t, 2>{0.f, 0.f} : mask_tol,
-                static_cast<scalar_t>(overstep_tol));
+                sf.is_portal() ? std::array<scalar_type, 2>{0.f, 0.f}
+                               : mask_tol,
+                overstep_tol);
         }
     };
 
@@ -412,7 +413,7 @@ class navigator {
         DETRAY_HOST_DEVICE inline auto is_on_object(
             const intersection_type &candidate,
             const navigation::config &cfg) const -> bool {
-            return (math::fabs(candidate.path) < cfg.on_surface_tolerance);
+            return (math::fabs(candidate.path) < cfg.path_tolerance);
         }
 
         /// @returns next object that we want to reach (current target)
@@ -521,9 +522,9 @@ class navigator {
         // Search for neighboring surfaces and fill candidates into cache
         volume.template visit_neighborhood<candidate_search>(
             track, cfg, *det, track, navigation.candidates(),
-            std::array<scalar_t, 2u>{cfg.min_mask_tolerance,
-                                  cfg.max_mask_tolerance},
-            static_cast<scalar_t>(cfg.overstep_tolerance));
+            std::array<scalar_type, 2u>{cfg.min_mask_tolerance,
+                                        cfg.max_mask_tolerance},
+            static_cast<scalar_type>(cfg.overstep_tolerance));
 
         // Sort all candidates and pick the closest one
         detail::sequential_sort(navigation.candidates().begin(),
@@ -780,10 +781,10 @@ class navigator {
         // Check whether this candidate is reachable by the track
         return sf.template visit_mask<intersection_update<ray_intersector>>(
             detail::ray(track), candidate, det->transform_store(),
-            sf.is_portal() ? std::array<scalar_t, 2>{0.f, 0.f}
-                           : std::array<scalar_t, 2>{cfg.min_mask_tolerance,
-                                                  cfg.max_mask_tolerance},
-            static_cast<scalar_t>(cfg.overstep_tolerance));
+            sf.is_portal() ? std::array<scalar_type, 2>{0.f, 0.f}
+                           : std::array<scalar_type, 2>{cfg.min_mask_tolerance,
+                                                        cfg.max_mask_tolerance},
+            static_cast<scalar_type>(cfg.overstep_tolerance));
     }
 
     /// Helper to evict all unreachable/invalid candidates from the cache:

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -188,9 +188,8 @@ class base_stepper {
 
         /// Call the stepping inspector
         DETRAY_HOST_DEVICE
-        inline void run_inspector(
-            [[maybe_unused]] const stepping::config<scalar_type> &cfg,
-            [[maybe_unused]] const char *message) {
+        inline void run_inspector([[maybe_unused]] const stepping::config &cfg,
+                                  [[maybe_unused]] const char *message) {
             if constexpr (not std::is_same_v<inspector_t,
                                              stepping::void_inspector>) {
                 _inspector(*this, cfg, message);

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -95,7 +95,7 @@ class line_stepper final
     /// @return returning the heartbeat, indicating if the stepping is alive
     template <typename propagation_state_t>
     DETRAY_HOST_DEVICE bool step(propagation_state_t& propagation,
-                                 const stepping::config<scalar>& cfg = {}) {
+                                 const stepping::config& cfg = {}) {
         // Get stepper and navigator states
         state& stepping = propagation._stepping;
         auto& navigation = propagation._navigation;

--- a/core/include/detray/propagator/propagation_config.hpp
+++ b/core/include/detray/propagator/propagation_config.hpp
@@ -28,9 +28,9 @@ DETRAY_HOST
 inline std::ostream& operator<<(std::ostream& out,
                                 const detray::propagation::config& cfg) {
     out << "Navigation\n"
-        << " -------------------\n"
+        << "----------------------------\n"
         << cfg.navigation << "\nParameter Transport\n"
-        << " -------------------\n"
+        << "----------------------------\n"
         << cfg.stepping << "\n";
 
     return out;

--- a/core/include/detray/propagator/propagation_config.hpp
+++ b/core/include/detray/propagator/propagation_config.hpp
@@ -8,16 +8,32 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/navigation/navigation_config.hpp"
 #include "detray/propagator/stepping_config.hpp"
+
+// System inlcudes
+#include <ostream>
 
 namespace detray::propagation {
 
 /// Configuration of the propagation
-template <typename scalar_t>
 struct config {
-    navigation::config<scalar_t> navigation{};
-    stepping::config<scalar_t> stepping{};
+    navigation::config navigation{};
+    stepping::config stepping{};
 };
+
+/// Print the propagation configuration
+DETRAY_HOST
+inline std::ostream& operator<<(std::ostream& out,
+                                const detray::propagation::config& cfg) {
+    out << "Navigation\n"
+        << " -------------------\n"
+        << cfg.navigation << "\nParameter Transport\n"
+        << " -------------------\n"
+        << cfg.stepping << "\n";
+
+    return out;
+}
 
 }  // namespace detray::propagation

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -42,7 +42,7 @@ struct propagator {
     using bound_track_parameters_type =
         typename stepper_t::bound_track_parameters_type;
 
-    propagation::config<scalar_type> m_cfg;
+    propagation::config m_cfg;
 
     stepper_t m_stepper;
     navigator_t m_navigator;
@@ -55,7 +55,7 @@ struct propagator {
 
     /// Construct from a propagator configuration
     DETRAY_HOST_DEVICE
-    propagator(propagation::config<scalar_type> cfg = {})
+    propagator(propagation::config cfg = {})
         : m_cfg{cfg}, m_stepper{}, m_navigator{} {}
 
     /// Propagation that state aggregates a stepping and a navigation state. It

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -104,14 +104,14 @@ class rk_stepper final
 
         /// Update the jacobian transport from free propagation
         DETRAY_HOST_DEVICE
-        inline void advance_jacobian(
-            const stepping::config<scalar_type>& cfg = {});
+        inline void advance_jacobian(const stepping::config& cfg = {});
 
         /// evaulate dqopds for a given step size and material
         DETRAY_HOST_DEVICE
-        inline scalar_type evaluate_dqopds(
-            const std::size_t i, const scalar_type h, const scalar dqopds_prev,
-            const detray::stepping::config<scalar_type>& cfg);
+        inline scalar_type evaluate_dqopds(const std::size_t i,
+                                           const scalar_type h,
+                                           const scalar_type dqopds_prev,
+                                           const detray::stepping::config& cfg);
 
         /// evaulate dtds for runge kutta stepping
         DETRAY_HOST_DEVICE
@@ -143,7 +143,7 @@ class rk_stepper final
         /// Call the stepping inspector
         template <typename... Args>
         DETRAY_HOST_DEVICE inline void run_inspector(
-            [[maybe_unused]] const stepping::config<scalar_type>& cfg,
+            [[maybe_unused]] const stepping::config& cfg,
             [[maybe_unused]] const char* message,
             [[maybe_unused]] Args&&... args) {
             if constexpr (not std::is_same_v<inspector_t,
@@ -159,7 +159,7 @@ class rk_stepper final
     /// @return returning the heartbeat, indicating if the stepping is alive
     template <typename propagation_state_t>
     DETRAY_HOST_DEVICE bool step(propagation_state_t& propagation,
-                                 const stepping::config<scalar_type>& cfg = {});
+                                 const stepping::config& cfg = {});
 };
 
 }  // namespace detray

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -54,8 +54,8 @@ template <typename magnetic_field_t, typename algebra_t, typename constraint_t,
           typename policy_t, typename inspector_t,
           template <typename, std::size_t> class array_t>
 DETRAY_HOST_DEVICE void detray::rk_stepper<
-    magnetic_field_t, algebra_t, constraint_t, policy_t, inspector_t, array_t>::
-    state::advance_jacobian(const detray::stepping::config<scalar_type>& cfg) {
+    magnetic_field_t, algebra_t, constraint_t, policy_t, inspector_t,
+    array_t>::state::advance_jacobian(const detray::stepping::config& cfg) {
     /// The calculations are based on ATL-SOFT-PUB-2009-002. The update of the
     /// Jacobian matrix is requires only the calculation of eq. 17 and 18.
     /// Since the terms of eq. 18 are currently 0, this matrix is not needed
@@ -405,11 +405,11 @@ template <typename magnetic_field_t, typename algebra_t, typename constraint_t,
           typename policy_t, typename inspector_t,
           template <typename, std::size_t> class array_t>
 DETRAY_HOST_DEVICE auto detray::rk_stepper<
-    magnetic_field_t, algebra_t, constraint_t, policy_t, inspector_t, array_t>::
-    state::evaluate_dqopds(const std::size_t i, const scalar_type h,
-                           const scalar dqopds_prev,
-                           const detray::stepping::config<scalar_type>& cfg)
-        -> scalar_type {
+    magnetic_field_t, algebra_t, constraint_t, policy_t, inspector_t,
+    array_t>::state::evaluate_dqopds(const std::size_t i, const scalar_type h,
+                                     const scalar_type dqopds_prev,
+                                     const detray::stepping::config& cfg)
+    -> scalar_type {
 
     const auto& track = this->_track;
     const scalar_type qop = track.qop();
@@ -623,7 +623,7 @@ template <typename propagation_state_t>
 DETRAY_HOST_DEVICE bool detray::rk_stepper<
     magnetic_field_t, algebra_t, constraint_t, policy_t, inspector_t,
     array_t>::step(propagation_state_t& propagation,
-                   const detray::stepping::config<scalar_type>& cfg) {
+                   const detray::stepping::config& cfg) {
 
     // Get stepper and navigator states
     state& stepping = propagation._stepping;

--- a/core/include/detray/propagator/stepping_config.hpp
+++ b/core/include/detray/propagator/stepping_config.hpp
@@ -50,24 +50,26 @@ struct config {
 DETRAY_HOST
 inline std::ostream& operator<<(std::ostream& out,
                                 const detray::stepping::config& cfg) {
-    out << "  Minimum Stepsize     : "
+    out << "  Min. Stepsize         : "
         << cfg.min_stepsize / detray::unit<float>::mm << " [mm]\n"
-        << "  Runge-Kutta tolerance: "
+        << "  Runge-Kutta tolerance : "
         << cfg.rk_error_tol / detray::unit<float>::mm << " [mm]\n"
-        << "  Maximum #step updates: " << cfg.max_rk_updates << "\n"
-        << "  Stepsize  constraint : "
+        << "  Max. step updates     : " << cfg.max_rk_updates << "\n"
+        << "  Stepsize  constraint  : "
         << cfg.step_constraint / detray::unit<float>::mm << " [mm]\n"
-        << "  Path limit           : "
+        << "  Path limit            : "
         << cfg.path_limit / detray::unit<float>::m << " [m]\n"
-        << std::boolalpha << "  Use Bethe energy loss: " << cfg.use_mean_loss
+        << std::boolalpha << "  Use Bethe energy loss : " << cfg.use_mean_loss
         << "\n"
-        << "  Do cov. transport    : " << cfg.do_covariance_transport << "\n";
+        << "  Do cov. transport     : " << cfg.do_covariance_transport << "\n";
 
     if (cfg.do_covariance_transport) {
         out << std::boolalpha
-            << "  Use eloss gradient   : " << cfg.use_eloss_gradient << "\n"
-            << "  Use B-field gradient : " << cfg.use_field_gradient << "\n";
+            << "  Use eloss gradient    : " << cfg.use_eloss_gradient << "\n"
+            << "  Use B-field gradient  : " << cfg.use_field_gradient << "\n";
     }
+    // Reset state
+    out << std::noboolalpha;
 
     return out;
 }

--- a/core/include/detray/propagator/stepping_config.hpp
+++ b/core/include/detray/propagator/stepping_config.hpp
@@ -8,10 +8,12 @@
 #pragma once
 
 // Project include(s).
+#include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 
 // System include(s).
 #include <limits>
+#include <ostream>
 
 namespace detray::stepping {
 
@@ -22,16 +24,15 @@ enum class id {
     e_rk = 1,
 };
 
-template <typename scalar_t>
 struct config {
     /// Minimum step size
-    scalar_t min_stepsize{1e-4f * unit<scalar_t>::mm};
+    float min_stepsize{1e-4f * unit<float>::mm};
     /// Runge-Kutta numeric error tolerance
-    scalar_t rk_error_tol{1e-4f * unit<scalar_t>::mm};
+    float rk_error_tol{1e-4f * unit<float>::mm};
     /// Step size constraint
-    scalar_t step_constraint{std::numeric_limits<scalar_t>::max()};
+    float step_constraint{std::numeric_limits<float>::max()};
     /// Maximal path length of track
-    scalar_t path_limit{5.f * unit<scalar_t>::m};
+    float path_limit{5.f * unit<float>::m};
     /// Maximum number of Runge-Kutta step trials
     std::size_t max_rk_updates{10000u};
     /// Use mean energy loss (Bethe)
@@ -44,5 +45,31 @@ struct config {
     /// Do covariance transport
     bool do_covariance_transport{true};
 };
+
+/// Print the stepping configuration
+DETRAY_HOST
+inline std::ostream& operator<<(std::ostream& out,
+                                const detray::stepping::config& cfg) {
+    out << "  Minimum Stepsize     : "
+        << cfg.min_stepsize / detray::unit<float>::mm << " [mm]\n"
+        << "  Runge-Kutta tolerance: "
+        << cfg.rk_error_tol / detray::unit<float>::mm << " [mm]\n"
+        << "  Maximum #step updates: " << cfg.max_rk_updates << "\n"
+        << "  Stepsize  constraint : "
+        << cfg.step_constraint / detray::unit<float>::mm << " [mm]\n"
+        << "  Path limit           : "
+        << cfg.path_limit / detray::unit<float>::m << " [m]\n"
+        << std::boolalpha << "  Use Bethe energy loss: " << cfg.use_mean_loss
+        << "\n"
+        << "  Do cov. transport    : " << cfg.do_covariance_transport << "\n";
+
+    if (cfg.do_covariance_transport) {
+        out << std::boolalpha
+            << "  Use eloss gradient   : " << cfg.use_eloss_gradient << "\n"
+            << "  Use B-field gradient : " << cfg.use_field_gradient << "\n";
+    }
+
+    return out;
+}
 
 }  // namespace detray::stepping

--- a/core/include/detray/utils/inspectors.hpp
+++ b/core/include/detray/utils/inspectors.hpp
@@ -52,7 +52,7 @@ struct aggregate_inspector {
     template <unsigned int current_id = 0, typename state_type,
               typename scalar_t, typename point3_t, typename vector3_t>
     DETRAY_HOST_DEVICE auto operator()(state_type &state,
-                                       const navigation::config<scalar_t> &cfg,
+                                       const navigation::config &cfg,
                                        const point3_t &pos,
                                        const vector3_t &dir,
                                        const char *message) {
@@ -131,7 +131,7 @@ struct object_tracer {
     template <typename state_type, typename scalar_t, typename point3_t,
               typename vector3_t>
     DETRAY_HOST_DEVICE auto operator()(state_type &state,
-                                       const navigation::config<scalar_t> &,
+                                       const navigation::config &,
                                        const point3_t &pos,
                                        const vector3_t &dir,
                                        const char * /*message*/) {
@@ -166,7 +166,7 @@ struct print_inspector {
     template <typename state_type, typename scalar_t, typename point3_t,
               typename vector3_t>
     auto operator()(const state_type &state,
-                    const navigation::config<scalar_t> &cfg,
+                    const navigation::config &cfg,
                     const point3_t &track_pos, const vector3_t &track_dir,
                     const char *message) {
         std::string msg(message);
@@ -236,7 +236,7 @@ struct print_inspector {
         }
 
         debug_stream << "distance to next\t\t";
-        if (math::abs(state()) < cfg.on_surface_tolerance) {
+        if (math::abs(state()) < static_cast<scalar>(cfg.path_tolerance)) {
             debug_stream << "on obj (within tol)" << std::endl;
         } else {
             debug_stream << state() << std::endl;
@@ -275,8 +275,8 @@ struct print_inspector {
     std::stringstream debug_stream{};
 
     /// Inspector interface. Gathers detailed information during stepping
-    template <typename state_type, typename scalar_t>
-    void operator()(const state_type &state, const stepping::config<scalar_t> &,
+    template <typename state_type>
+    void operator()(const state_type &state, const stepping::config &,
                     const char *message) {
         std::string msg(message);
         std::string tabs = "\t\t\t\t";
@@ -310,8 +310,8 @@ struct print_inspector {
     }
 
     /// Inspector interface. Gathers detailed information during stepping
-    template <typename state_type, typename scalar_t>
-    void operator()(const state_type &state, const stepping::config<scalar_t> &,
+    template <typename state_type>
+    void operator()(const state_type &state, const stepping::config &,
                     const char *message, const std::size_t n_trials,
                     const scalar step_scalor) {
         std::string msg(message);

--- a/core/include/detray/utils/inspectors.hpp
+++ b/core/include/detray/utils/inspectors.hpp
@@ -50,7 +50,7 @@ struct aggregate_inspector {
 
     /// Inspector interface
     template <unsigned int current_id = 0, typename state_type,
-              typename scalar_t, typename point3_t, typename vector3_t>
+              typename point3_t, typename vector3_t>
     DETRAY_HOST_DEVICE auto operator()(state_type &state,
                                        const navigation::config &cfg,
                                        const point3_t &pos,
@@ -128,8 +128,7 @@ struct object_tracer {
     vector_t<candidate_record_t> object_trace;
 
     /// Inspector interface
-    template <typename state_type, typename scalar_t, typename point3_t,
-              typename vector3_t>
+    template <typename state_type, typename point3_t, typename vector3_t>
     DETRAY_HOST_DEVICE auto operator()(state_type &state,
                                        const navigation::config &,
                                        const point3_t &pos,
@@ -163,10 +162,8 @@ struct print_inspector {
     std::stringstream debug_stream{};
 
     /// Inspector interface. Gathers detailed information during navigation
-    template <typename state_type, typename scalar_t, typename point3_t,
-              typename vector3_t>
-    auto operator()(const state_type &state,
-                    const navigation::config &cfg,
+    template <typename state_type, typename point3_t, typename vector3_t>
+    auto operator()(const state_type &state, const navigation::config &cfg,
                     const point3_t &track_pos, const vector3_t &track_dir,
                     const char *message) {
         std::string msg(message);

--- a/io/include/detray/io/frontend/detector_reader_config.hpp
+++ b/io/include/detray/io/frontend/detector_reader_config.hpp
@@ -9,6 +9,7 @@
 
 // System include(s)
 #include <array>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -49,5 +50,19 @@ struct detector_reader_config {
     }
     /// @}
 };
+
+/// Print the detector reader configuration
+inline std::ostream& operator<<(std::ostream& out,
+                                const detector_reader_config& cfg) {
+
+    out << "\nDetector reader\n"
+        << "----------------------------\n"
+        << "  Detector files:       : \n";
+    for (const auto& file_name : cfg.files()) {
+        out << "    -> " << file_name << "\n";
+    }
+
+    return out;
+}
 
 }  // namespace detray::io

--- a/io/include/detray/io/frontend/detector_writer_config.hpp
+++ b/io/include/detray/io/frontend/detector_writer_config.hpp
@@ -11,6 +11,7 @@
 #include "detray/io/frontend/definitions.hpp"
 
 // System include(s)
+#include <ostream>
 #include <string>
 
 namespace detray::io {
@@ -26,9 +27,9 @@ struct detector_writer_config {
     /// Compactify json output, if not json format this flag does nothing
     bool m_compact_io = false;
     /// Whether to write the material to file
-    bool m_write_material = true;
+    bool m_write_material = false;
     /// Whether to write the accelerator grids to file
-    bool m_write_grids = true;
+    bool m_write_grids = false;
 
     /// Getters
     /// @{
@@ -68,5 +69,24 @@ struct detector_writer_config {
     }
     /// @}
 };
+
+/// Print the detector writer configuration
+inline std::ostream& operator<<(std::ostream& out,
+                                const detector_writer_config& cfg) {
+    out << "\nDetector writer\n"
+        << "----------------------------\n"
+        << "  Path                  : " << cfg.path() << "\n"
+        << "  Write grids           : " << std::boolalpha << cfg.write_grids()
+        << "\n"
+        << "  Write material        : " << cfg.write_material() << "\n";
+
+    if (cfg.format() == detray::io::format::json) {
+        out << "  Compactify json       : " << cfg.compactify_json() << "\n";
+    }
+    // Reset state
+    out << std::noboolalpha;
+
+    return out;
+}
 
 }  // namespace detray::io

--- a/io/include/detray/io/utils/create_path.hpp
+++ b/io/include/detray/io/utils/create_path.hpp
@@ -24,6 +24,7 @@ inline bool file_exists(const std::string& outdir) {
 /// @returns an alternative file name by counting up, if file exists
 inline std::string alt_file_name(const std::string& name) {
     auto path = std::filesystem::path(name);
+    auto parent_path = path.parent_path();
     std::string stem = path.stem();
     std::string extension = path.extension();
 
@@ -52,7 +53,7 @@ inline std::string alt_file_name(const std::string& name) {
     std::size_t n_trials{2u};
     while (std::filesystem::exists(path)) {
         stem = get_alternate_file_stem(stem, n_trials);
-        path = std::filesystem::path{stem + extension};
+        path = parent_path / std::filesystem::path{stem + extension};
         ++n_trials;
 
         // The maximum here is arbitrary
@@ -62,7 +63,8 @@ inline std::string alt_file_name(const std::string& name) {
         }
     }
 
-    return stem + extension;
+    path = parent_path / std::filesystem::path{stem + extension};
+    return path.string();
 }
 
 /// Check if a given file path exists and generate it if not
@@ -70,9 +72,9 @@ inline auto create_path(const std::string& outdir) {
 
     auto path = std::filesystem::path(outdir);
 
-    if (not std::filesystem::exists(path)) {
-        std::error_code err;
-        if (!std::filesystem::create_directories(path, err)) {
+    if (!std::filesystem::exists(path)) {
+        if (std::error_code err;
+            !std::filesystem::create_directories(path, err)) {
             throw std::runtime_error(err.message());
         }
     }

--- a/tests/benchmarks/cpu/find_volume.cpp
+++ b/tests/benchmarks/cpu/find_volume.cpp
@@ -30,7 +30,7 @@ void BM_FIND_VOLUMES(benchmark::State &state) {
 
     // Detector configuration
     vecmem::host_memory_resource host_mr;
-    toy_det_config<scalar> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.n_edc_layers(7u);
     auto [d, names] = build_toy_detector(host_mr, toy_cfg);
 

--- a/tests/benchmarks/cpu/intersect_all.cpp
+++ b/tests/benchmarks/cpu/intersect_all.cpp
@@ -43,7 +43,7 @@ void BM_INTERSECT_ALL(benchmark::State &state) {
 
     // Detector configuration
     vecmem::host_memory_resource host_mr;
-    toy_det_config<test::scalar> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.n_edc_layers(7u);
     auto [d, names] = build_toy_detector(host_mr, toy_cfg);
 

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -53,7 +53,7 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
     auto bfield = bfield::create_const_field(B);
 
     // Create propagator
-    propagation::config<scalar> cfg{};
+    propagation::config cfg{};
     cfg.navigation.search_window = {3u, 3u};
     propagator_host_type p{cfg};
 

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -30,7 +30,7 @@ vecmem::binary_page_memory_resource bp_mng_mr(mng_mr);
 
 // detector configuration
 auto toy_cfg =
-    toy_det_config<scalar>{}.n_brl_layers(4u).n_edc_layers(7u).do_check(false);
+    toy_det_config{}.n_brl_layers(4u).n_edc_layers(7u).do_check(false);
 
 void fill_tracks(vecmem::vector<free_track_parameters<algebra_t>> &tracks,
                  const std::size_t theta_steps, const std::size_t phi_steps) {

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
@@ -28,7 +28,7 @@ __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
     }
 
     // Create propagator
-    propagation::config<scalar> cfg{};
+    propagation::config cfg{};
     cfg.navigation.search_window = {3u, 3u};
     propagator_device_type p{cfg};
 

--- a/tests/include/detray/test/detector_scan_config.hpp
+++ b/tests/include/detray/test/detector_scan_config.hpp
@@ -37,8 +37,8 @@ struct detector_scan_config : public test::fixture_base<>::configuration {
     std::string m_track_param_file{""};
     /// Mask tolerance for the intersectors
     std::array<scalar_type, 2> m_mask_tol{
-        std::numeric_limits<scalar_type>::epsilon(),
-        std::numeric_limits<scalar_type>::epsilon()};
+        std::numeric_limits<float>::epsilon(),
+        std::numeric_limits<float>::epsilon()};
     /// B-field vector for helix
     vector3_type m_B{0.f * unit<scalar_type>::T, 0.f * unit<scalar_type>::T,
                      2.f * unit<scalar_type>::T};

--- a/tests/include/detray/test/fixture_base.hpp
+++ b/tests/include/detray/test/fixture_base.hpp
@@ -44,21 +44,21 @@ class fixture_base : public scope {
         /// General testing
         /// @{
         /// Tolerance to compare two floating point values
-        scalar m_tolerance{std::numeric_limits<scalar>::epsilon()};
+        float m_tolerance{std::numeric_limits<float>::epsilon()};
         /// Shorthand for infinity
-        scalar inf{std::numeric_limits<scalar>::infinity()};
+        float inf{std::numeric_limits<float>::infinity()};
         /// Shorthand for the floating point epsilon
-        scalar epsilon{std::numeric_limits<scalar>::epsilon()};
+        float epsilon{std::numeric_limits<float>::epsilon()};
         /// @}
 
         /// Propagation
         /// @{
-        propagation::config<scalar> m_prop_cfg{};
+        propagation::config m_prop_cfg{};
         /// @}
 
         /// Setters
         /// @{
-        configuration& tol(scalar t) {
+        configuration& tol(float t) {
             m_tolerance = t;
             return *this;
         }
@@ -66,11 +66,9 @@ class fixture_base : public scope {
 
         /// Getters
         /// @{
-        scalar tol() const { return m_tolerance; }
-        propagation::config<scalar>& propagation() { return m_prop_cfg; }
-        const propagation::config<scalar>& propagation() const {
-            return m_prop_cfg;
-        }
+        float tol() const { return m_tolerance; }
+        propagation::config& propagation() { return m_prop_cfg; }
+        const propagation::config& propagation() const { return m_prop_cfg; }
         /// @}
 
         /// Print configuration
@@ -101,7 +99,7 @@ class fixture_base : public scope {
     std::string name() const { return "detray_test"; };
 
     protected:
-    scalar tolerance{}, inf{}, epsilon{}, path_limit{}, overstep_tolerance{},
+    float tolerance{}, inf{}, epsilon{}, path_limit{}, overstep_tolerance{},
         step_constraint{};
 
     static void SetUpTestSuite() {}

--- a/tests/include/detray/test/propagator_test.hpp
+++ b/tests/include/detray/test/propagator_test.hpp
@@ -66,7 +66,7 @@ constexpr scalar_t is_close{1e-4f};
 /// Test configuration
 struct propagator_test_config {
     generator_t::configuration track_generator;
-    propagation::config<scalar_t> propagation;
+    propagation::config propagation;
 };
 
 template <template <typename...> class vector_t>
@@ -145,7 +145,7 @@ inline auto generate_tracks(
 template <typename bfield_bknd_t, typename host_detector_t>
 inline auto run_propagation_host(vecmem::memory_resource *mr,
                                  const host_detector_t &det,
-                                 const propagation::config<scalar_t> &cfg,
+                                 const propagation::config &cfg,
                                  covfie::field<bfield_bknd_t> &field,
                                  const vecmem::vector<track_t> &tracks)
     -> std::tuple<vecmem::jagged_vector<scalar_t>,

--- a/tests/include/detray/test/toy_detector_test.hpp
+++ b/tests/include/detray/test/toy_detector_test.hpp
@@ -75,7 +75,7 @@ inline void test_mat_map(const mat_map_t& mat_map, const bool is_cyl) {
 
         for (const auto& mat_slab : mat_map.all()) {
             EXPECT_TRUE(mat_slab.get_material() ==
-                            toy_det_config<scalar>{}.mapped_material() ||
+                            toy_det_config{}.mapped_material() ||
                         mat_slab.get_material() == beryllium_tml<scalar_t>{});
         }
     } else {
@@ -93,7 +93,7 @@ inline void test_mat_map(const mat_map_t& mat_map, const bool is_cyl) {
 
         for (const auto& mat_slab : mat_map.all()) {
             EXPECT_TRUE(mat_slab.get_material() ==
-                        toy_det_config<scalar>{}.mapped_material());
+                        toy_det_config{}.mapped_material());
         }
     }
 }
@@ -130,9 +130,8 @@ inline bool toy_detector_test(
     auto& materials = toy_det.material_store();
 
     // Materials
-    auto portal_mat =
-        material_slab<scalar_t>(toy_det_config<scalar_t>{}.mapped_material(),
-                                1.5f * unit<scalar_t>::mm);
+    auto portal_mat = material_slab<scalar_t>(
+        toy_det_config{}.mapped_material(), 1.5f * unit<scalar_t>::mm);
     auto beampipe_mat = material_slab<scalar_t>(beryllium_tml<scalar_t>(),
                                                 0.8f * unit<scalar_t>::mm);
     auto pixel_mat = material_slab<scalar_t>(silicon_tml<scalar_t>(),

--- a/tests/include/detray/test/utils/detector_scanner.hpp
+++ b/tests/include/detray/test/utils/detector_scanner.hpp
@@ -53,12 +53,11 @@ struct brute_force_scan {
 
     template <typename detector_t>
     inline auto operator()(const typename detector_t::geometry_context,
-                           const detector_t &detector, const trajectory_t &traj,
-                           const std::array<typename detector_t::scalar_type, 2>
-                               mask_tolerance = {0.f, 0.f},
-                           const typename detector_t::scalar_type p =
-                               1.f *
-                               unit<typename detector_t::scalar_type>::GeV) {
+        const detector_t &detector, const trajectory_t &traj,
+        const std::array<float, 2> mask_tolerance = {0.f,
+                                                     0.f * unit<float>::um},
+        const typename detector_t::scalar_type p =
+            1.f * unit<typename detector_t::scalar_type>::GeV) {
 
         using scalar_t = typename detector_t::scalar_type;
         using sf_desc_t = typename detector_t::surface_type;
@@ -82,8 +81,8 @@ struct brute_force_scan {
             const auto sf = surface{detector, sf_desc};
             sf.template visit_mask<intersection_kernel_t>(
                 intersections, traj, sf_desc, trf_store,
-                sf.is_portal() ? std::array<scalar_t, 2>{0.f, 0.f}
-                               : std::array<scalar_t, 2>{mask_tolerance[0],
+                sf.is_portal() ? std::array<float, 2>{0.f, 0.f}
+                               : std::array<float, 2>{mask_tolerance[0],
                                                          mask_tolerance[1]});
 
             // Candidate is invalid if it lies in the opposite direction
@@ -154,8 +153,8 @@ inline auto run(const typename detector_t::geometry_context gctx,
     // Make sure the intersection record terminates at world portals
     auto is_world_exit = [](const record_t &r) {
         return r.intersection.volume_link ==
-               detray::detail::invalid_value<decltype(
-                   r.intersection.volume_link)>();
+               detray::detail::invalid_value<
+                   decltype(r.intersection.volume_link)>();
     };
 
     if (auto it = std::find_if(intersection_record.begin(),

--- a/tests/include/detray/test/utils/detector_scanner.hpp
+++ b/tests/include/detray/test/utils/detector_scanner.hpp
@@ -53,11 +53,12 @@ struct brute_force_scan {
 
     template <typename detector_t>
     inline auto operator()(const typename detector_t::geometry_context,
-        const detector_t &detector, const trajectory_t &traj,
-        const std::array<float, 2> mask_tolerance = {0.f,
-                                                     0.f * unit<float>::um},
-        const typename detector_t::scalar_type p =
-            1.f * unit<typename detector_t::scalar_type>::GeV) {
+                           const detector_t &detector, const trajectory_t &traj,
+                           const std::array<typename detector_t::scalar_type, 2>
+                               mask_tolerance = {0.f, 0.f},
+                           const typename detector_t::scalar_type p =
+                               1.f *
+                               unit<typename detector_t::scalar_type>::GeV) {
 
         using scalar_t = typename detector_t::scalar_type;
         using sf_desc_t = typename detector_t::surface_type;
@@ -81,9 +82,8 @@ struct brute_force_scan {
             const auto sf = surface{detector, sf_desc};
             sf.template visit_mask<intersection_kernel_t>(
                 intersections, traj, sf_desc, trf_store,
-                sf.is_portal() ? std::array<float, 2>{0.f, 0.f}
-                               : std::array<float, 2>{mask_tolerance[0],
-                                                         mask_tolerance[1]});
+                sf.is_portal() ? std::array<scalar_t, 2>{0.f, 0.f}
+                               : mask_tolerance);
 
             // Candidate is invalid if it lies in the opposite direction
             for (auto &sfi : intersections) {
@@ -153,8 +153,8 @@ inline auto run(const typename detector_t::geometry_context gctx,
     // Make sure the intersection record terminates at world portals
     auto is_world_exit = [](const record_t &r) {
         return r.intersection.volume_link ==
-               detray::detail::invalid_value<
-                   decltype(r.intersection.volume_link)>();
+               detray::detail::invalid_value<decltype(
+                   r.intersection.volume_link)>();
     };
 
     if (auto it = std::find_if(intersection_record.begin(),

--- a/tests/include/detray/test/utils/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/utils/navigation_validation_utils.hpp
@@ -29,7 +29,7 @@ template <typename stepper_t, typename detector_t,
           typename bfield_t = empty_bfield>
 inline auto record_propagation(
     const typename detector_t::geometry_context, const detector_t &det,
-    const propagation::config<typename detector_t::scalar_type> &cfg,
+    const propagation::config &cfg,
     const free_track_parameters<typename detector_t::algebra_type> &track,
     const bfield_t &bfield = {}) {
 

--- a/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
@@ -55,12 +55,12 @@ int main(int argc, char **argv) {
     cfg_ray_scan.whiteboard(white_board);
     cfg_ray_scan.track_generator().n_tracks(10000u);
     cfg_ray_scan.track_generator().origin({0.f, 0.f, -0.05f});
-    cfg_ray_scan.track_generator().theta_range(constant<scalar_t>::pi_4,
-                                               constant<scalar_t>::pi_2);
+    cfg_ray_scan.track_generator().theta_range(constant<float>::pi_4,
+                                               constant<scafloatlar_t>::pi_2);
     // Better momentum range fails because of bug in the object tracer
     /*cfg_ray_scan.track_generator().theta_range(0.f,
                                                0.25f *
-       constant<scalar_t>::pi_4);*/
+       constant<float>::pi_4);*/
 
     detail::register_checks<test::ray_scan>(tel_det, tel_names, cfg_ray_scan);
 
@@ -72,12 +72,12 @@ int main(int argc, char **argv) {
     cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
                                  detray::detail::invalid_value<scalar_t>()});
     cfg_hel_scan.track_generator().n_tracks(10000u);
-    cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_tot(10.f * unit<float>::GeV);
     cfg_hel_scan.track_generator().origin({0.f, 0.f, -0.05f});
-    cfg_hel_scan.track_generator().theta_range(constant<scalar_t>::pi_4,
-                                               constant<scalar_t>::pi_2);
+    cfg_hel_scan.track_generator().theta_range(constant<float>::pi_4,
+                                               constant<float>::pi_2);
     /*cfg_hel_scan.track_generator().theta_range(0.f,
-                                               constant<scalar_t>::pi_4);*/
+                                               constant<float>::pi_4);*/
     detail::register_checks<test::helix_scan>(tel_det, tel_names, cfg_hel_scan);
 
     // Comparison of straight line navigation with ray scan

--- a/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
@@ -55,12 +55,12 @@ int main(int argc, char **argv) {
     cfg_ray_scan.whiteboard(white_board);
     cfg_ray_scan.track_generator().n_tracks(10000u);
     cfg_ray_scan.track_generator().origin({0.f, 0.f, -0.05f});
-    cfg_ray_scan.track_generator().theta_range(constant<float>::pi_4,
-                                               constant<scafloatlar_t>::pi_2);
+    cfg_ray_scan.track_generator().theta_range(constant<scalar_t>::pi_4,
+                                               constant<scalar_t>::pi_2);
     // Better momentum range fails because of bug in the object tracer
     /*cfg_ray_scan.track_generator().theta_range(0.f,
                                                0.25f *
-       constant<float>::pi_4);*/
+       constant<scalar_t>::pi_4);*/
 
     detail::register_checks<test::ray_scan>(tel_det, tel_names, cfg_ray_scan);
 
@@ -72,12 +72,12 @@ int main(int argc, char **argv) {
     cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
                                  detray::detail::invalid_value<scalar_t>()});
     cfg_hel_scan.track_generator().n_tracks(10000u);
-    cfg_hel_scan.track_generator().p_tot(10.f * unit<float>::GeV);
+    cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar_t>::GeV);
     cfg_hel_scan.track_generator().origin({0.f, 0.f, -0.05f});
-    cfg_hel_scan.track_generator().theta_range(constant<float>::pi_4,
-                                               constant<float>::pi_2);
+    cfg_hel_scan.track_generator().theta_range(constant<scalar_t>::pi_4,
+                                               constant<scalar_t>::pi_2);
     /*cfg_hel_scan.track_generator().theta_range(0.f,
-                                               constant<float>::pi_4);*/
+                                               constant<scalar_t>::pi_4);*/
     detail::register_checks<test::helix_scan>(tel_det, tel_names, cfg_hel_scan);
 
     // Comparison of straight line navigation with ray scan
@@ -85,8 +85,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.name("telescope_detector_straight_line_navigation");
     cfg_str_nav.whiteboard(white_board);
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance = mask_tolerance[0];
-    cfg_str_nav.propagation().navigation.max_mask_tolerance = mask_tolerance[1];
+    cfg_str_nav.propagation().navigation.min_mask_tolerance =
+        static_cast<float>(mask_tolerance[0]);
+    cfg_str_nav.propagation().navigation.max_mask_tolerance =
+        static_cast<float>(mask_tolerance[1]);
 
     detail::register_checks<test::straight_line_navigation>(tel_det, tel_names,
                                                             cfg_str_nav);

--- a/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
     //
     // Toy detector configuration
     //
-    toy_det_config<scalar_t> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.n_brl_layers(4u).n_edc_layers(7u);
 
     // Build the geometry
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
                                  detray::detail::invalid_value<scalar_t>()});
     cfg_hel_scan.track_generator().n_tracks(10000u);
     cfg_hel_scan.track_generator().eta_range(-4.f, 4.f);
-    cfg_hel_scan.track_generator().p_T(1.f * unit<float>::GeV);
+    cfg_hel_scan.track_generator().p_T(1.f * unit<scalar_t>::GeV);
 
     detail::register_checks<test::helix_scan>(toy_det, toy_names, cfg_hel_scan);
 
@@ -74,8 +74,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.whiteboard(white_board);
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance = mask_tolerance[0];
-    cfg_str_nav.propagation().navigation.max_mask_tolerance = mask_tolerance[1];
+    cfg_str_nav.propagation().navigation.min_mask_tolerance =
+        static_cast<float>(mask_tolerance[0]);
+    cfg_str_nav.propagation().navigation.max_mask_tolerance =
+        static_cast<float>(mask_tolerance[1]);
 
     detail::register_checks<test::straight_line_navigation>(toy_det, toy_names,
                                                             cfg_str_nav);

--- a/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
                                  detray::detail::invalid_value<scalar_t>()});
     cfg_hel_scan.track_generator().n_tracks(10000u);
     cfg_hel_scan.track_generator().eta_range(-4.f, 4.f);
-    cfg_hel_scan.track_generator().p_T(1.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_T(1.f * unit<float>::GeV);
 
     detail::register_checks<test::helix_scan>(toy_det, toy_names, cfg_hel_scan);
 

--- a/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
     cfg_hel_scan.track_generator().n_tracks(10000u);
     cfg_hel_scan.track_generator().eta_range(-1.f, 1.f);
     // TODO: Fails for smaller momenta
-    cfg_hel_scan.track_generator().p_T(5.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_T(5.f * unit<float>::GeV);
 
     detail::register_checks<test::helix_scan>(det, names, cfg_hel_scan);
 

--- a/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
@@ -51,6 +51,7 @@ int main(int argc, char **argv) {
     test::ray_scan<wire_chamber_t>::config cfg_ray_scan{};
     cfg_ray_scan.name("wire_chamber_ray_scan");
     cfg_ray_scan.whiteboard(white_board);
+    cfg_ray_scan.track_generator().seed(42u);
     cfg_ray_scan.track_generator().n_tracks(10000u);
 
     detail::register_checks<test::ray_scan>(det, names, cfg_ray_scan);
@@ -65,7 +66,7 @@ int main(int argc, char **argv) {
     cfg_hel_scan.track_generator().n_tracks(10000u);
     cfg_hel_scan.track_generator().eta_range(-1.f, 1.f);
     // TODO: Fails for smaller momenta
-    cfg_hel_scan.track_generator().p_T(5.f * unit<float>::GeV);
+    cfg_hel_scan.track_generator().p_T(5.f * unit<scalar_t>::GeV);
 
     detail::register_checks<test::helix_scan>(det, names, cfg_hel_scan);
 
@@ -75,8 +76,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.whiteboard(white_board);
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance = mask_tolerance[0];
-    cfg_str_nav.propagation().navigation.max_mask_tolerance = mask_tolerance[1];
+    cfg_str_nav.propagation().navigation.min_mask_tolerance =
+        static_cast<float>(mask_tolerance[0]);
+    cfg_str_nav.propagation().navigation.max_mask_tolerance =
+        static_cast<float>(mask_tolerance[1]);
 
     detail::register_checks<test::straight_line_navigation>(det, names,
                                                             cfg_str_nav);
@@ -85,6 +88,7 @@ int main(int argc, char **argv) {
     test::helix_navigation<wire_chamber_t>::config cfg_hel_nav{};
     cfg_hel_nav.name("wire_chamber_helix_navigation");
     cfg_hel_nav.whiteboard(white_board);
+    cfg_hel_nav.propagation().navigation.min_mask_tolerance *= 0.9f;
     cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
 
     detail::register_checks<test::helix_navigation>(det, names, cfg_hel_nav);

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -454,14 +454,14 @@ bound_getter<algebra_type>::state evaluate_bound_param(
     const std::size_t trk_count, const scalar detector_length,
     const bound_track_parameters<algebra_type>& initial_param,
     const typename propagator_t::detector_type& det, const field_t& field,
-    const scalar overstep_tolerance, const scalar on_surface_tolerance,
+    const scalar overstep_tolerance, const scalar path_tolerance,
     const scalar rk_tolerance, const scalar constraint_step,
     bool use_field_gradient, bool do_covariance_transport, bool do_inspect) {
 
     // Propagator is built from the stepper and navigator
-    propagation::config<scalar> cfg{};
+    propagation::config cfg{};
     cfg.navigation.overstep_tolerance = overstep_tolerance;
-    cfg.navigation.on_surface_tolerance = on_surface_tolerance;
+    cfg.navigation.path_tolerance = path_tolerance;
     cfg.stepping.rk_error_tol = rk_tolerance;
     cfg.stepping.use_eloss_gradient = true;
     cfg.stepping.use_field_gradient = use_field_gradient;
@@ -500,13 +500,13 @@ bound_vector_type get_displaced_bound_vector(
     const bound_track_parameters<algebra_type>& ref_param,
     const typename propagator_t::detector_type& det,
     const scalar detector_length, const field_t& field,
-    const scalar overstep_tolerance, const scalar on_surface_tolerance,
+    const scalar overstep_tolerance, const scalar path_tolerance,
     const scalar rk_tolerance, const scalar constraint_step,
     const unsigned int target_index, const scalar displacement) {
 
-    propagation::config<scalar> cfg{};
+    propagation::config cfg{};
     cfg.navigation.overstep_tolerance = overstep_tolerance;
-    cfg.navigation.on_surface_tolerance = on_surface_tolerance;
+    cfg.navigation.path_tolerance = path_tolerance;
     cfg.stepping.rk_error_tol = rk_tolerance;
     cfg.stepping.do_covariance_transport = false;
 
@@ -551,7 +551,7 @@ bound_track_parameters<algebra_type>::covariance_type directly_differentiate(
     const bound_track_parameters<algebra_type>& ref_param,
     const typename propagator_t::detector_type& det,
     const scalar detector_length, const field_t& field,
-    const scalar overstep_tolerance, const scalar on_surface_tolerance,
+    const scalar overstep_tolerance, const scalar path_tolerance,
     const scalar rk_tolerance, const scalar constraint_step,
     const std::array<scalar, 5u> hs,
     std::array<unsigned int, 5u>& num_iterations,
@@ -567,12 +567,12 @@ bound_track_parameters<algebra_type>::covariance_type directly_differentiate(
 
         const auto vec1 = get_displaced_bound_vector<propagator_t, field_t>(
             trk_count, ref_param, det, detector_length, field,
-            overstep_tolerance, on_surface_tolerance, rk_tolerance,
-            constraint_step, i, 1.f * delta);
+            overstep_tolerance, path_tolerance, rk_tolerance, constraint_step,
+            i, 1.f * delta);
         const auto vec2 = get_displaced_bound_vector<propagator_t, field_t>(
             trk_count, ref_param, det, detector_length, field,
-            overstep_tolerance, on_surface_tolerance, rk_tolerance,
-            constraint_step, i, -1.f * delta);
+            overstep_tolerance, path_tolerance, rk_tolerance, constraint_step,
+            i, -1.f * delta);
 
         ridders_derivative ridder;
         ridder.initialize(vec1, vec2, delta);
@@ -583,12 +583,12 @@ bound_track_parameters<algebra_type>::covariance_type directly_differentiate(
             const auto nvec1 =
                 get_displaced_bound_vector<propagator_t, field_t>(
                     trk_count, ref_param, det, detector_length, field,
-                    overstep_tolerance, on_surface_tolerance, rk_tolerance,
+                    overstep_tolerance, path_tolerance, rk_tolerance,
                     constraint_step, i, 1.f * delta);
             const auto nvec2 =
                 get_displaced_bound_vector<propagator_t, field_t>(
                     trk_count, ref_param, det, detector_length, field,
-                    overstep_tolerance, on_surface_tolerance, rk_tolerance,
+                    overstep_tolerance, path_tolerance, rk_tolerance,
                     constraint_step, i, -1.f * delta);
 
             ridder.run(nvec1, nvec2, delta, p, i, differentiated_jacobian);
@@ -663,7 +663,7 @@ void evaluate_jacobian_difference(
     const typename propagator_t::detector_type& det,
     const scalar detector_length,
     const bound_track_parameters<algebra_type>& track, const field_t& field,
-    const scalar overstep_tolerance, const scalar on_surface_tolerance,
+    const scalar overstep_tolerance, const scalar path_tolerance,
     const scalar rk_tolerance, const scalar rk_tolerance_dis,
     const scalar constraint_step, const std::array<scalar, 5u>& hs,
     std::ofstream& file, scalar& ref_rel_diff, bool use_field_gradient,
@@ -679,8 +679,8 @@ void evaluate_jacobian_difference(
 
     auto bound_getter = evaluate_bound_param<propagator_t, field_t>(
         trk_count, detector_length, track, det, field, overstep_tolerance,
-        on_surface_tolerance, rk_tolerance, constraint_step, use_field_gradient,
-        true, do_inspect);
+        path_tolerance, rk_tolerance, constraint_step, use_field_gradient, true,
+        do_inspect);
 
     const auto reference_param = bound_getter.m_param_departure;
     const auto final_param = bound_getter.m_param_destination;
@@ -737,7 +737,7 @@ void evaluate_jacobian_difference(
     } else {
         differentiated_jacobian = directly_differentiate<propagator_t, field_t>(
             trk_count, reference_param, det, detector_length, field,
-            overstep_tolerance, on_surface_tolerance, rk_tolerance_dis,
+            overstep_tolerance, path_tolerance, rk_tolerance_dis,
             constraint_step, hs, num_iterations, convergence);
     }
 
@@ -803,7 +803,7 @@ void evaluate_jacobian_difference(
     file << math::log10(rk_tolerance) << ",";
 
     // Log10(on surface tolerance)
-    file << math::log10(on_surface_tolerance) << ",";
+    file << math::log10(path_tolerance) << ",";
 
     // Overstep tolerance
     file << overstep_tolerance << ",";
@@ -821,7 +821,7 @@ void evaluate_covariance_transport(
     const typename propagator_t::detector_type& det,
     const scalar detector_length,
     const bound_track_parameters<algebra_type>& track, const field_t& field,
-    const scalar overstep_tolerance, const scalar on_surface_tolerance,
+    const scalar overstep_tolerance, const scalar path_tolerance,
     const scalar rk_tolerance, const scalar rk_tolerance_dis,
     const scalar constraint_step, std::ofstream& file,
     bool use_field_gradient) {
@@ -837,8 +837,8 @@ void evaluate_covariance_transport(
 
     auto bound_getter = evaluate_bound_param<propagator_t, field_t>(
         trk_count, detector_length, track_copy, det, field, overstep_tolerance,
-        on_surface_tolerance, rk_tolerance, constraint_step, use_field_gradient,
-        true, false);
+        path_tolerance, rk_tolerance, constraint_step, use_field_gradient, true,
+        false);
 
     const auto reference_param = bound_getter.m_param_departure;
     const auto ini_vec = reference_param.vector();
@@ -879,8 +879,8 @@ void evaluate_covariance_transport(
 
     auto smeared_bound_getter = evaluate_bound_param<propagator_t, field_t>(
         trk_count, detector_length, smeared_track, det, field,
-        overstep_tolerance, on_surface_tolerance, rk_tolerance_dis,
-        constraint_step, use_field_gradient, false, false);
+        overstep_tolerance, path_tolerance, rk_tolerance_dis, constraint_step,
+        use_field_gradient, false, false);
 
     // Get smeared final bound vector
     bound_vector_type smeared_fin_vec =
@@ -968,7 +968,7 @@ void evaluate_covariance_transport(
     file << math::log10(rk_tolerance) << ",";
 
     // Log10(on surface tolerance)
-    file << math::log10(on_surface_tolerance) << ",";
+    file << math::log10(path_tolerance) << ",";
 
     // Overstep tolerance
     file << overstep_tolerance << ",";
@@ -1412,7 +1412,7 @@ int main(int argc, char** argv) {
                        "Set the overstep tolerance in mm unit");
     desc.add_options()("log10-on-surface-tolerance-mm",
                        po::value<scalar>()->default_value(-3.f),
-                       "Set log10(on_surface_tolerance_in_mm)");
+                       "Set log10(path_tolerance_in_mm)");
     desc.add_options()("rk-tolerance-iterate-mode",
                        po::value<bool>()->default_value(true),
                        "Iterate over the rk tolerances");

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -460,9 +460,9 @@ bound_getter<algebra_type>::state evaluate_bound_param(
 
     // Propagator is built from the stepper and navigator
     propagation::config cfg{};
-    cfg.navigation.overstep_tolerance = overstep_tolerance;
-    cfg.navigation.path_tolerance = path_tolerance;
-    cfg.stepping.rk_error_tol = rk_tolerance;
+    cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tolerance);
+    cfg.navigation.path_tolerance = static_cast<float>(path_tolerance);
+    cfg.stepping.rk_error_tol = static_cast<float>(rk_tolerance);
     cfg.stepping.use_eloss_gradient = true;
     cfg.stepping.use_field_gradient = use_field_gradient;
     cfg.stepping.do_covariance_transport = do_covariance_transport;
@@ -484,7 +484,7 @@ bound_getter<algebra_type>::state evaluate_bound_param(
     state.do_debug = do_inspect;
     state._stepping
         .template set_constraint<detray::step::constraint::e_accuracy>(
-            constraint_step);
+            static_cast<float>(constraint_step));
 
     p.propagate(state, actor_states);
     if (do_inspect) {
@@ -505,9 +505,9 @@ bound_vector_type get_displaced_bound_vector(
     const unsigned int target_index, const scalar displacement) {
 
     propagation::config cfg{};
-    cfg.navigation.overstep_tolerance = overstep_tolerance;
-    cfg.navigation.path_tolerance = path_tolerance;
-    cfg.stepping.rk_error_tol = rk_tolerance;
+    cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tolerance);
+    cfg.navigation.path_tolerance = static_cast<float>(path_tolerance);
+    cfg.stepping.rk_error_tol = static_cast<float>(rk_tolerance);
     cfg.stepping.do_covariance_transport = false;
 
     // Propagator is built from the stepper and navigator

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -212,8 +212,8 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
     const bfield_t bfield = bfield::create_const_field(std::get<2>(GetParam()));
 
     // Propagator is built from the stepper and navigator
-    propagation::config<scalar_t> cfg{};
-    cfg.navigation.overstep_tolerance = overstep_tol;
+    propagation::config cfg{};
+    cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tol);
     propagator_t p{cfg};
 
     // Iterate through uniformly distributed momentum directions
@@ -312,8 +312,8 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
     const bfield_t bfield = bfield::create_inhom_field();
 
     // Propagator is built from the stepper and navigator
-    propagation::config<scalar_t> cfg{};
-    cfg.navigation.overstep_tolerance = overstep_tol;
+    propagation::config cfg{};
+    cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tol);
     propagator_t p{cfg};
 
     // Iterate through uniformly distributed momentum directions

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -124,7 +124,7 @@ struct helix_inspector : actor {
 GTEST_TEST(detray_propagator, propagator_line_stepper) {
 
     vecmem::host_memory_resource host_mr;
-    toy_det_config<scalar_t> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.use_material_maps(false);
     const auto [d, names] = build_toy_detector(host_mr, toy_cfg);
 
@@ -170,8 +170,7 @@ class PropagatorWithRkStepper
     vecmem::host_memory_resource host_mr;
 
     /// Toy detector configuration
-    toy_det_config<scalar_t> toy_cfg =
-        toy_det_config<scalar_t>{}.n_brl_layers(4u).n_edc_layers(7u);
+    toy_det_config toy_cfg = toy_det_config{}.n_brl_layers(4u).n_edc_layers(7u);
 
     /// Track generator configuration
     generator_t::configuration trk_gen_cfg{};

--- a/tests/integration_tests/device/cuda/navigation_validation.cu
+++ b/tests/integration_tests/device/cuda/navigation_validation.cu
@@ -15,8 +15,7 @@ namespace detray::cuda {
 template <typename bfield_t, typename detector_t,
           typename intersection_record_t>
 __global__ void navigation_validation_kernel(
-    typename detector_t::view_type det_data,
-    const propagation::config<typename detector_t::scalar_type> cfg,
+    typename detector_t::view_type det_data, const propagation::config cfg,
     bfield_t field_data,
     vecmem::data::jagged_vector_view<
         typename intersection_record_t::intersection_type>
@@ -117,8 +116,7 @@ __global__ void navigation_validation_kernel(
 template <typename bfield_t, typename detector_t,
           typename intersection_record_t>
 void navigation_validation_device(
-    typename detector_t::view_type det_view,
-    const propagation::config<typename detector_t::scalar_type> &cfg,
+    typename detector_t::view_type det_view, const propagation::config &cfg,
     bfield_t field_data,
     vecmem::data::jagged_vector_view<
         typename intersection_record_t::intersection_type>
@@ -149,8 +147,7 @@ void navigation_validation_device(
     template void navigation_validation_device<                                \
         covfie::field_view<bfield::const_bknd_t>, detector<METADATA>,          \
         detray::intersection_record<detector<METADATA>>>(                      \
-        typename detector<METADATA>::view_type,                                \
-        const propagation::config<typename detector<METADATA>::scalar_type> &, \
+        typename detector<METADATA>::view_type, const propagation::config &,   \
         covfie::field_view<bfield::const_bknd_t>,                              \
         vecmem::data::jagged_vector_view<typename detray::intersection_record< \
             detector<METADATA>>::intersection_type> &,                         \
@@ -163,8 +160,7 @@ void navigation_validation_device(
     template void navigation_validation_device<                                \
         detray::navigation_validator::empty_bfield, detector<METADATA>,        \
         detray::intersection_record<detector<METADATA>>>(                      \
-        typename detector<METADATA>::view_type,                                \
-        const propagation::config<typename detector<METADATA>::scalar_type> &, \
+        typename detector<METADATA>::view_type, const propagation::config &,   \
         detray::navigation_validator::empty_bfield,                            \
         vecmem::data::jagged_vector_view<typename detray::intersection_record< \
             detector<METADATA>>::intersection_type> &,                         \

--- a/tests/integration_tests/device/cuda/navigation_validation.hpp
+++ b/tests/integration_tests/device/cuda/navigation_validation.hpp
@@ -41,8 +41,7 @@ namespace detray::cuda {
 template <typename bfield_t, typename detector_t,
           typename intersection_record_t>
 void navigation_validation_device(
-    typename detector_t::view_type det_view,
-    const propagation::config<typename detector_t::scalar_type> &cfg,
+    typename detector_t::view_type det_view, const propagation::config &cfg,
     bfield_t field_data,
     vecmem::data::jagged_vector_view<
         typename intersection_record_t::intersection_type>
@@ -58,9 +57,7 @@ template <typename bfield_t, typename detector_t,
           typename intersection_record_t>
 inline auto run_navigation_validation(
     vecmem::memory_resource *host_mr, vecmem::memory_resource *dev_mr,
-    const detector_t &det,
-    const propagation::config<typename detector_t::scalar_type> &cfg,
-    bfield_t field_data,
+    const detector_t &det, const propagation::config &cfg, bfield_t field_data,
     const std::vector<std::vector<intersection_record_t>>
         &truth_intersection_traces)
     -> vecmem::jagged_vector<navigation::detail::candidate_record<

--- a/tests/integration_tests/device/cuda/propagator_cuda.cpp
+++ b/tests/integration_tests/device/cuda/propagator_cuda.cpp
@@ -21,9 +21,8 @@
 
 using namespace detray;
 
-class CudaPropConstBFieldMng : public ::testing::TestWithParam<
-                                   std::tuple<scalar_t, scalar_t, vector3_t>> {
-};
+class CudaPropConstBFieldMng
+    : public ::testing::TestWithParam<std::tuple<float, float, vector3_t>> {};
 
 /// Propagation test using unified memory
 TEST_P(CudaPropConstBFieldMng, propagator) {
@@ -52,9 +51,8 @@ TEST_P(CudaPropConstBFieldMng, propagator) {
         &mng_mr, det, cfg, detray::get_data(det), std::move(field));
 }
 
-class CudaPropConstBFieldCpy : public ::testing::TestWithParam<
-                                   std::tuple<scalar_t, scalar_t, vector3_t>> {
-};
+class CudaPropConstBFieldCpy
+    : public ::testing::TestWithParam<std::tuple<float, float, vector3_t>> {};
 
 /// Propagation test using vecmem copy
 TEST_P(CudaPropConstBFieldCpy, propagator) {
@@ -91,67 +89,61 @@ TEST_P(CudaPropConstBFieldCpy, propagator) {
 
 INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation1, CudaPropConstBFieldMng,
-    ::testing::Values(std::make_tuple(-100.f * unit<scalar_t>::um,
-                                      std::numeric_limits<scalar_t>::max(),
+    ::testing::Values(std::make_tuple(-100.f * unit<float>::um,
+                                      std::numeric_limits<float>::max(),
                                       vector3_t{0.f * unit<scalar_t>::T,
                                                 0.f * unit<scalar_t>::T,
                                                 2.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(
-    CudaPropagatorValidation2, CudaPropConstBFieldMng,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      5.f * unit<scalar_t>::mm,
-                                      vector3_t{0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation2, CudaPropConstBFieldMng,
+                         ::testing::Values(std::make_tuple(
+                             -800.f * unit<float>::um, 5.f * unit<float>::mm,
+                             vector3_t{0.f * unit<scalar_t>::T,
+                                       1.f * unit<scalar_t>::T,
+                                       1.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(
-    CudaPropagatorValidation3, CudaPropConstBFieldMng,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      5.f * unit<scalar_t>::mm,
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation3, CudaPropConstBFieldMng,
+                         ::testing::Values(std::make_tuple(
+                             -800.f * unit<float>::um, 5.f * unit<float>::mm,
+                             vector3_t{1.f * unit<scalar_t>::T,
+                                       0.f * unit<scalar_t>::T,
+                                       1.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(
-    CudaPropagatorValidation4, CudaPropConstBFieldMng,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      1.f * unit<scalar_t>::mm,
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation4, CudaPropConstBFieldMng,
+                         ::testing::Values(std::make_tuple(
+                             -800.f * unit<float>::um, 1.f * unit<float>::mm,
+                             vector3_t{1.f * unit<scalar_t>::T,
+                                       1.f * unit<scalar_t>::T,
+                                       1.f * unit<scalar_t>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation5, CudaPropConstBFieldCpy,
-    ::testing::Values(std::make_tuple(-100.f * unit<scalar_t>::um,
-                                      std::numeric_limits<scalar_t>::max(),
+    ::testing::Values(std::make_tuple(-100.f * unit<float>::um,
+                                      std::numeric_limits<float>::max(),
                                       vector3_t{0.f * unit<scalar_t>::T,
                                                 0.f * unit<scalar_t>::T,
                                                 2.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(
-    CudaPropagatorValidation6, CudaPropConstBFieldCpy,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      5.f * unit<scalar_t>::mm,
-                                      vector3_t{0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation6, CudaPropConstBFieldCpy,
+                         ::testing::Values(std::make_tuple(
+                             -800.f * unit<float>::um, 5.f * unit<float>::mm,
+                             vector3_t{0.f * unit<scalar_t>::T,
+                                       1.f * unit<scalar_t>::T,
+                                       1.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(
-    CudaPropagatorValidation7, CudaPropConstBFieldCpy,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      5.f * unit<scalar_t>::mm,
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation7, CudaPropConstBFieldCpy,
+                         ::testing::Values(std::make_tuple(
+                             -800.f * unit<float>::um, 5.f * unit<float>::mm,
+                             vector3_t{1.f * unit<scalar_t>::T,
+                                       0.f * unit<scalar_t>::T,
+                                       1.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(
-    CudaPropagatorValidation8, CudaPropConstBFieldCpy,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      1.f * unit<scalar_t>::mm,
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation8, CudaPropConstBFieldCpy,
+                         ::testing::Values(std::make_tuple(
+                             -800.f * unit<float>::um, 1.f * unit<float>::mm,
+                             vector3_t{1.f * unit<scalar_t>::T,
+                                       1.f * unit<scalar_t>::T,
+                                       1.f * unit<scalar_t>::T})));
 
 /// This tests the device propagation in an inhomogenepus magnetic field
 TEST(CudaPropagatorValidation9, inhomogeneous_bfield_cpy) {

--- a/tests/integration_tests/device/cuda/propagator_cuda_kernel.cu
+++ b/tests/integration_tests/device/cuda/propagator_cuda_kernel.cu
@@ -12,8 +12,7 @@ namespace detray {
 
 template <typename bfield_bknd_t, typename detector_t>
 __global__ void propagator_test_kernel(
-    typename detector_t::view_type det_data,
-    const propagation::config<scalar_t> cfg,
+    typename detector_t::view_type det_data, const propagation::config cfg,
     covfie::field_view<bfield_bknd_t> field_data,
     vecmem::data::vector_view<track_t> tracks_data,
     vecmem::data::jagged_vector_view<intersection_t<detector_t>>
@@ -78,8 +77,7 @@ __global__ void propagator_test_kernel(
 /// Launch the device kernel
 template <typename bfield_bknd_t, typename detector_t>
 void propagator_test(
-    typename detector_t::view_type det_view,
-    const propagation::config<scalar_t>& cfg,
+    typename detector_t::view_type det_view, const propagation::config& cfg,
     covfie::field_view<bfield_bknd_t> field_data,
     vecmem::data::vector_view<track_t>& tracks_data,
     vecmem::data::jagged_vector_view<intersection_t<detector_t>>&
@@ -106,8 +104,7 @@ void propagator_test(
 template void propagator_test<bfield::const_bknd_t,
                               detector<toy_metadata, host_container_types>>(
     detector<toy_metadata, host_container_types>::view_type,
-    const propagation::config<scalar_t>&,
-    covfie::field_view<bfield::const_bknd_t>,
+    const propagation::config&, covfie::field_view<bfield::const_bknd_t>,
     vecmem::data::vector_view<track_t>&,
     vecmem::data::jagged_vector_view<
         intersection_t<detector<toy_metadata, host_container_types>>>&,
@@ -119,8 +116,7 @@ template void propagator_test<bfield::const_bknd_t,
 template void propagator_test<bfield::cuda::inhom_bknd_t,
                               detector<toy_metadata, host_container_types>>(
     detector<toy_metadata, host_container_types>::view_type,
-    const propagation::config<scalar_t>&,
-    covfie::field_view<bfield::cuda::inhom_bknd_t>,
+    const propagation::config&, covfie::field_view<bfield::cuda::inhom_bknd_t>,
     vecmem::data::vector_view<track_t>&,
     vecmem::data::jagged_vector_view<
         intersection_t<detector<toy_metadata, host_container_types>>>&,

--- a/tests/integration_tests/device/cuda/propagator_cuda_kernel.hpp
+++ b/tests/integration_tests/device/cuda/propagator_cuda_kernel.hpp
@@ -34,7 +34,7 @@ using inhom_bknd_t = covfie::backend::affine<covfie::backend::linear<
 /// Launch the propagation test kernel
 template <typename bfield_bknd_t, typename detector_t>
 void propagator_test(
-    typename detector_t::view_type, const propagation::config<scalar_t> &,
+    typename detector_t::view_type, const propagation::config &,
     covfie::field_view<bfield_bknd_t>, vecmem::data::vector_view<track_t> &,
     vecmem::data::jagged_vector_view<intersection_t<detector_t>> &,
     vecmem::data::jagged_vector_view<scalar> &,
@@ -45,8 +45,7 @@ void propagator_test(
 template <typename bfield_bknd_t, typename detector_t>
 inline auto run_propagation_device(
     vecmem::memory_resource *mr, detector_t &det,
-    const propagation::config<scalar_t> &cfg,
-    typename detector_t::view_type det_view,
+    const propagation::config &cfg, typename detector_t::view_type det_view,
     covfie::field_view<bfield_bknd_t> field_data, dvector<track_t> &tracks,
     const vecmem::jagged_vector<point3_t> &host_positions)
     -> std::tuple<vecmem::jagged_vector<scalar>,

--- a/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
@@ -67,8 +67,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.name("telescope_detector_straight_line_navigation_cuda");
     cfg_str_nav.whiteboard(white_board);
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance = mask_tolerance[0];
-    cfg_str_nav.propagation().navigation.max_mask_tolerance = mask_tolerance[1];
+    cfg_str_nav.propagation().navigation.min_mask_tolerance =
+        static_cast<float>(mask_tolerance[0]);
+    cfg_str_nav.propagation().navigation.max_mask_tolerance =
+        static_cast<float>(mask_tolerance[1]);
 
     detail::register_checks<detray::cuda::straight_line_navigation>(
         tel_det, tel_names, cfg_str_nav);

--- a/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
     //
     // Toy detector configuration
     //
-    toy_det_config<scalar_t> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.n_brl_layers(4u).n_edc_layers(7u);
 
     // Build the geometry
@@ -67,8 +67,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.whiteboard(white_board);
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance = mask_tolerance[0];
-    cfg_str_nav.propagation().navigation.max_mask_tolerance = mask_tolerance[1];
+    cfg_str_nav.propagation().navigation.min_mask_tolerance =
+        static_cast<float>(mask_tolerance[0]);
+    cfg_str_nav.propagation().navigation.max_mask_tolerance =
+        static_cast<float>(mask_tolerance[1]);
 
     detail::register_checks<detray::cuda::straight_line_navigation>(
         toy_det, toy_names, cfg_str_nav);

--- a/tests/integration_tests/device/cuda/wire_chamber_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/wire_chamber_navigation_validation.cpp
@@ -52,6 +52,7 @@ int main(int argc, char **argv) {
     test::ray_scan<wire_chamber_t>::config cfg_ray_scan{};
     cfg_ray_scan.name("wire_chamber_ray_scan_for_cuda");
     cfg_ray_scan.whiteboard(white_board);
+    cfg_ray_scan.track_generator().seed(42u);
     cfg_ray_scan.track_generator().n_tracks(1000u);
 
     detail::register_checks<test::ray_scan>(det, names, cfg_ray_scan);
@@ -63,8 +64,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.whiteboard(white_board);
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance = mask_tolerance[0];
-    cfg_str_nav.propagation().navigation.max_mask_tolerance = mask_tolerance[1];
+    cfg_str_nav.propagation().navigation.min_mask_tolerance =
+        static_cast<float>(mask_tolerance[0]);
+    cfg_str_nav.propagation().navigation.max_mask_tolerance =
+        static_cast<float>(mask_tolerance[1]);
 
     detail::register_checks<detray::cuda::straight_line_navigation>(
         det, names, cfg_str_nav);
@@ -87,6 +90,7 @@ int main(int argc, char **argv) {
     detray::cuda::helix_navigation<wire_chamber_t>::config cfg_hel_nav{};
     cfg_hel_nav.name("wire_chamber_helix_navigation_cuda");
     cfg_hel_nav.whiteboard(white_board);
+    cfg_hel_nav.propagation().navigation.min_mask_tolerance *= 0.9f;
     cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
 
     detail::register_checks<detray::cuda::helix_navigation>(det, names,

--- a/tests/integration_tests/device/sycl/propagator_kernel.sycl
+++ b/tests/integration_tests/device/sycl/propagator_kernel.sycl
@@ -13,8 +13,7 @@ namespace detray {
 /// Test function for propagator
 template <typename bfield_bknd_t, typename detector_t>
 void propagator_test(
-    typename detector_t::view_type det_data,
-    const propagation::config<scalar_t>& cfg,
+    typename detector_t::view_type det_data, const propagation::config& cfg,
     covfie::field_view<bfield_bknd_t> field_data,
     vecmem::data::vector_view<track_t>& tracks_data,
     vecmem::data::jagged_vector_view<intersection_t<detector_t>>&
@@ -105,8 +104,7 @@ void propagator_test(
 template void propagator_test<bfield::const_bknd_t,
                               detector<toy_metadata, host_container_types>>(
     detector<toy_metadata, host_container_types>::view_type,
-    const propagation::config<scalar_t>&,
-    covfie::field_view<bfield::const_bknd_t>,
+    const propagation::config&, covfie::field_view<bfield::const_bknd_t>,
     vecmem::data::vector_view<track_t>&,
     vecmem::data::jagged_vector_view<
         intersection_t<detector<toy_metadata, host_container_types>>>&,
@@ -119,7 +117,7 @@ template void propagator_test<bfield::const_bknd_t,
 /*template void propagator_test<bfield::sycl::inhom_bknd_t,
    detector<toy_metadata, host_container_types>>( detector<toy_metadata,
    host_container_types>::view_type,
-    const propagation::config<scalar_t>&,
+    const propagation::config&,
     covfie::field_view<bfield::sycl::inhom_bknd_t>,
     vecmem::data::vector_view<track_t>&,
     vecmem::data::jagged_vector_view<intersection_t<detector<toy_metadata,

--- a/tests/integration_tests/device/sycl/propagator_sycl_kernel.hpp
+++ b/tests/integration_tests/device/sycl/propagator_sycl_kernel.hpp
@@ -21,7 +21,7 @@ namespace detray {
 /// Launch the propagation test kernel
 template <typename bfield_bknd_t, typename detector_t>
 void propagator_test(
-    typename detector_t::view_type, const propagation::config<scalar_t> &,
+    typename detector_t::view_type, const propagation::config &,
     covfie::field_view<bfield_bknd_t>, vecmem::data::vector_view<track_t> &,
     vecmem::data::jagged_vector_view<intersection_t<detector_t>> &,
     vecmem::data::jagged_vector_view<scalar_t> &,
@@ -32,8 +32,7 @@ void propagator_test(
 template <typename bfield_bknd_t, typename detector_t>
 inline auto run_propagation_device(
     vecmem::memory_resource *mr, detector_t &det,
-    const propagation::config<scalar_t> &cfg,
-    typename detector_t::view_type det_view,
+    const propagation::config &cfg, typename detector_t::view_type det_view,
     covfie::field_view<bfield_bknd_t> field_data, sycl::queue_wrapper queue,
     dvector<track_t> &tracks,
     const vecmem::jagged_vector<point3_t> &host_positions)

--- a/tests/integration_tests/io/io_json_detector_roundtrip.cpp
+++ b/tests/integration_tests/io/io_json_detector_roundtrip.cpp
@@ -85,7 +85,9 @@ auto test_detector_json_io(const detector_t& det,
 
     auto writer_cfg = io::detector_writer_config{}
                           .format(io::format::json)
-                          .replace_files(true);
+                          .replace_files(true)
+                          .write_grids(true)
+                          .write_material(true);
     io::write_detector(det, names, writer_cfg);
 
     // Read the detector back in
@@ -176,7 +178,7 @@ GTEST_TEST(io, json_toy_geometry) {
 
     // Toy detector
     vecmem::host_memory_resource host_mr;
-    toy_det_config<scalar> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.use_material_maps(false);
     auto [toy_det, names] = build_toy_detector(host_mr, toy_cfg);
 
@@ -228,7 +230,7 @@ GTEST_TEST(io, json_toy_detector_roundtrip_homogeneous_material) {
 
     // Toy detector
     vecmem::host_memory_resource host_mr;
-    toy_det_config<scalar> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.use_material_maps(false);
     const auto [toy_det, toy_names] = build_toy_detector(host_mr, toy_cfg);
 
@@ -254,7 +256,7 @@ GTEST_TEST(io, json_toy_detector_roundtrip_material_maps) {
 
     // Toy detector
     vecmem::host_memory_resource host_mr;
-    toy_det_config<scalar> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.use_material_maps(true);
     const auto [toy_det, toy_names] = build_toy_detector(host_mr, toy_cfg);
 

--- a/tests/tools/include/detray/options/detector_io_options.hpp
+++ b/tests/tools/include/detray/options/detector_io_options.hpp
@@ -1,0 +1,95 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/io/frontend/detector_reader_config.hpp"
+#include "detray/io/frontend/detector_writer_config.hpp"
+#include "detray/options/options_handling.hpp"
+
+// Boost
+#include <boost/program_options.hpp>
+
+// System include(s)
+#include <stdexcept>
+#include <string>
+
+namespace detray::options {
+
+/// Add options for the detray detector reader
+template <>
+void add_options<detray::io::detector_reader_config>(
+    boost::program_options::options_description &desc,
+    const detray::io::detector_reader_config &) {
+
+    desc.add_options()("geometry_file",
+                       boost::program_options::value<std::string>(),
+                       "Detector geometry input file")(
+        "grid_file", boost::program_options::value<std::string>(),
+        "Detector surface grid input file")(
+        "material_file", boost::program_options::value<std::string>(),
+        "Detector material input file");
+}
+
+/// Configure the detray detector reader
+template <>
+void configure_options<detray::io::detector_reader_config>(
+    boost::program_options::variables_map &vm,
+    detray::io::detector_reader_config &cfg) {
+
+    // Input files
+    if (vm.count("geometry_file")) {
+        cfg.add_file(vm["geometry_file"].as<std::string>());
+    } else {
+        throw std::invalid_argument(
+            "Please specify a geometry input file!\n\n");
+    }
+    if (vm.count("material_file")) {
+        cfg.add_file(vm["material_file"].as<std::string>());
+    }
+    if (vm.count("grid_file")) {
+        cfg.add_file(vm["grid_file"].as<std::string>());
+    }
+}
+
+/// Add options for the detray detector writer
+template <>
+void add_options<detray::io::detector_writer_config>(
+    boost::program_options::options_description &desc,
+    const detray::io::detector_writer_config &cfg) {
+
+    desc.add_options()(
+        "outdir",
+        boost::program_options::value<std::string>()->default_value(cfg.path()),
+        "Output directory for detector files")("compactify_json",
+                                               "not implemented")(
+        "write_material", "toggle material output")("write_grids",
+                                                    "toggle grid output");
+}
+
+/// Configure the detray detector writer
+template <>
+void configure_options<detray::io::detector_writer_config>(
+    boost::program_options::variables_map &vm,
+    detray::io::detector_writer_config &cfg) {
+
+    if (!vm["outdir"].defaulted()) {
+        cfg.path(vm["outdir"].as<std::string>());
+    }
+    if (vm.count("compactify_json")) {
+        cfg.compactify_json(true);
+    }
+    if (vm.count("write_material")) {
+        cfg.write_material(true);
+    }
+    if (vm.count("write_grids")) {
+        cfg.write_grids(true);
+    }
+}
+
+}  // namespace detray::options

--- a/tests/tools/include/detray/options/options_handling.hpp
+++ b/tests/tools/include/detray/options/options_handling.hpp
@@ -1,0 +1,36 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Boost
+#include <boost/program_options.hpp>
+
+// System include(s)
+#include <iostream>
+
+namespace detray::options {
+
+/// Add options to the boost options description according to the type T
+template <typename T>
+void add_options(boost::program_options::options_description &,
+                 const T &) { /* Do nothing */
+}
+
+/// Fill the configuration type T from the boost variable map
+template <typename T>
+void configure_options(boost::program_options::variables_map &,
+                       T &) { /* Do nothing */
+}
+
+/// Print the configuration
+template <typename T>
+void print_options(T &cfg) {
+    std::cout << cfg << std::endl;
+}
+
+}  // namespace detray::options

--- a/tests/tools/include/detray/options/parse_options.hpp
+++ b/tests/tools/include/detray/options/parse_options.hpp
@@ -1,0 +1,82 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Boost
+#include <boost/program_options.hpp>
+
+// System include(s).
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace detray::options {
+
+// Forward declare the options handling for different configuration types
+template <typename T>
+void add_options(boost::program_options::options_description&, const T&);
+
+template <typename T>
+void configure_options(boost::program_options::variables_map&, T&);
+
+/// Parse commandline options and add them to detray configuration types
+template <typename... CONFIGS>
+auto parse_options(boost::program_options::options_description& desc, int argc,
+                   char* argv[], CONFIGS&... cfgs) {
+
+    static_assert(sizeof...(CONFIGS) > 0, "No commandline options configured");
+
+    desc.add_options()("help", "Produce help message");
+
+    // Add options according to the configurations that were passed
+    (add_options(desc, cfgs), ...);
+
+    // Parse options
+    boost::program_options::variables_map vm;
+    try {
+        boost::program_options::store(
+            parse_command_line(
+                argc, argv, desc,
+                boost::program_options::command_line_style::unix_style ^
+                    boost::program_options::command_line_style::allow_short),
+            vm);
+
+        boost::program_options::notify(vm);
+    } catch (const std::exception& ex) {
+        // Print help message in case of error
+        std::cout << ex.what() << "\n" << desc << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+
+    // Print help message when requested
+    if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        std::exit(EXIT_SUCCESS);
+    }
+
+    // Add the options to the configurations
+    (configure_options(vm, cfgs), ...);
+    // Make sure everything is configured correctly
+    (print_options(cfgs), ...);
+
+    return vm;
+}
+
+/// Parse commandline options and add them to detray configuration types
+template <typename... CONFIGS>
+auto parse_options(const std::string& description, int argc, char* argv[],
+                   CONFIGS&... cfgs) {
+    // Options description
+    boost::program_options::options_description desc(description);
+
+    // Run options parsing
+    return parse_options(desc, argc, argv, cfgs...);
+}
+
+}  // namespace detray::options

--- a/tests/tools/include/detray/options/propagation_options.hpp
+++ b/tests/tools/include/detray/options/propagation_options.hpp
@@ -1,0 +1,185 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/options/options_handling.hpp"
+#include "detray/propagator/propagation_config.hpp"
+
+// Boost
+#include <boost/program_options.hpp>
+
+// System include(s)
+#include <stdexcept>
+#include <string>
+
+namespace detray::options {
+
+/// Add options for the navigation
+template <>
+void add_options<detray::navigation::config>(
+    boost::program_options::options_description &desc,
+    const detray::navigation::config &cfg) {
+
+    desc.add_options()(
+        "search_window",
+        boost::program_options::value<std::vector<dindex>>()->multitoken(),
+        "Search window size for the grid")(
+        "min_mask_tolerance",
+        boost::program_options::value<float>()->default_value(
+            cfg.min_mask_tolerance),
+        "Minimum mask tolerance [mm]")(
+        "max_mask_tolerance",
+        boost::program_options::value<float>()->default_value(
+            cfg.max_mask_tolerance),
+        "Maximum mask tolerance [mm]")(
+        "overstep_tolerance",
+        boost::program_options::value<float>()->default_value(
+            cfg.overstep_tolerance),
+        "Overstepping tolerance [um] NOTE: Must be negative!")(
+        "path_tolerance",
+        boost::program_options::value<float>()->default_value(
+            cfg.path_tolerance),
+        "Tol. to decide when a track is on surface [um]");
+}
+
+/// Add options for the track parameter transport
+template <>
+void add_options<detray::stepping::config>(
+    boost::program_options::options_description &desc,
+    const detray::stepping::config &cfg) {
+
+    desc.add_options()(
+        "minimum_stepsize",
+        boost::program_options::value<float>()->default_value(cfg.min_stepsize),
+        "Minimum step size [mm]")(
+        "step_contraint",
+        boost::program_options::value<float>()->default_value(
+            cfg.step_constraint),
+        "Maximum step size [mm]")(
+        "rk-tolerance",
+        boost::program_options::value<float>()->default_value(cfg.rk_error_tol),
+        "The Runge-Kutta intergration error tolerance [mm]")(
+        "path_limit",
+        boost::program_options::value<float>()->default_value(cfg.path_limit),
+        "Maximum path length for a track [m]")("mean_energy_loss",
+                                               "Use Bethe energy loss")(
+        "covariance_transport", "Run the covariance transport")(
+        "eloss_gradient", "Use energy loss gradient in Jacobian transport")(
+        "bfield_gradient", "Use B-field gradient in Jacobian transport");
+}
+
+/// Add options for the detray propagation
+template <>
+void add_options<detray::propagation::config>(
+    boost::program_options::options_description &desc,
+    const detray::propagation::config &cfg) {
+
+    add_options(desc, cfg.navigation);
+    add_options(desc, cfg.stepping);
+}
+
+/// Configure the navigator
+template <>
+void configure_options<detray::navigation::config>(
+    boost::program_options::variables_map &vm,
+    detray::navigation::config &cfg) {
+
+    // Local navigation search window
+    if (vm.count("search_window")) {
+        const auto window = vm["search_window"].as<std::vector<dindex>>();
+        if (window.size() == 2u) {
+            cfg.search_window = {window[0], window[1]};
+        } else {
+            throw std::invalid_argument(
+                "Incorrect surface grid search window. Please provide two "
+                "integer distances.");
+        }
+    }
+    // Overstepping tolerance
+    if (!vm["min_mask_tolerance"].defaulted()) {
+        const float mask_tol{vm["min_mask_tolerance"].as<float>()};
+        assert(mask_tol >= 0.f);
+
+        cfg.min_mask_tolerance = mask_tol * unit<float>::mm;
+    }
+    if (!vm["max_mask_tolerance"].defaulted()) {
+        const float mask_tol{vm["max_mask_tolerance"].as<float>()};
+        assert(mask_tol >= 0.f);
+
+        cfg.max_mask_tolerance = mask_tol * unit<float>::mm;
+    }
+    if (!vm["overstep_tolerance"].defaulted()) {
+        const float overstep_tol{vm["overstep_tolerance"].as<float>()};
+        assert(overstep_tol <= 0.f);
+
+        cfg.overstep_tolerance = overstep_tol * unit<float>::um;
+    }
+    if (!vm["path_tolerance"].defaulted()) {
+        const float path_tol{vm["path_tolerance"].as<float>()};
+        assert(path_tol >= 0.f);
+
+        cfg.path_tolerance = path_tol * unit<float>::um;
+    }
+}
+
+/// Configure the stepper
+template <>
+void configure_options<detray::stepping::config>(
+    boost::program_options::variables_map &vm, detray::stepping::config &cfg) {
+
+    // Overstepping tolerance
+    if (!vm["minimum_stepsize"].defaulted()) {
+        const float min_step{vm["minimum_stepsize"].as<float>()};
+        assert(min_step >= 0.f);
+
+        cfg.min_stepsize = min_step * unit<float>::mm;
+    }
+    if (!vm["step_contraint"].defaulted()) {
+        const float constraint{vm["step_contraint"].as<float>()};
+        assert(constraint >= 0.f);
+
+        cfg.step_constraint = constraint * unit<float>::mm;
+    }
+    if (!vm["rk-tolerance"].defaulted()) {
+        const float err_tol{vm["rk-tolerance"].as<float>()};
+        assert(err_tol >= 0.f);
+
+        cfg.rk_error_tol = err_tol * unit<float>::mm;
+    }
+    if (!vm["path_limit"].defaulted()) {
+        const float path_limit{vm["path_limit"].as<float>()};
+        assert(path_limit <= 0.f);
+
+        cfg.path_limit = path_limit * unit<float>::m;
+    }
+    if (vm.count("covariance_transport")) {
+        cfg.do_covariance_transport = true;
+    }
+    if (vm.count("mean_eloss")) {
+        cfg.use_mean_loss = true;
+    }
+    if (vm.count("eloss_gradient")) {
+        cfg.use_eloss_gradient = true;
+    }
+    if (vm.count("bfield_gradient")) {
+        cfg.use_field_gradient = true;
+    }
+}
+
+/// Configure the propagation
+template <>
+void configure_options<detray::propagation::config>(
+    boost::program_options::variables_map &vm,
+    detray::propagation::config &cfg) {
+
+    configure_options(vm, cfg.navigation);
+    configure_options(vm, cfg.stepping);
+}
+
+}  // namespace detray::options

--- a/tests/tools/include/detray/options/toy_detector_options.hpp
+++ b/tests/tools/include/detray/options/toy_detector_options.hpp
@@ -1,0 +1,63 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/detectors/build_toy_detector.hpp"
+#include "detray/options/options_handling.hpp"
+
+// Boost
+#include <boost/program_options.hpp>
+
+// System include(s)
+#include <stdexcept>
+#include <string>
+
+namespace detray::options {
+
+/// Add options for the detray toy detector
+template <>
+void add_options<toy_det_config>(
+    boost::program_options::options_description &desc,
+    const toy_det_config &cfg) {
+
+    desc.add_options()(
+        "barrel_layers",
+        boost::program_options::value<unsigned int>()->default_value(
+            cfg.n_brl_layers()),
+        "number of barrel layers [0-4]")(
+        "endcap_layers",
+        boost::program_options::value<unsigned int>()->default_value(
+            cfg.n_edc_layers()),
+        "number of endcap layers on either side [0-7]")(
+        "homogeneous_material",
+        "Generate homogeneous material description (default)")(
+        "material_maps", "Generate material maps");
+}
+
+/// Configure the detray toy detector
+template <>
+void configure_options<toy_det_config>(
+    boost::program_options::variables_map &vm, toy_det_config &cfg) {
+
+    cfg.n_brl_layers(vm["barrel_layers"].as<unsigned int>());
+    cfg.n_edc_layers(vm["endcap_layers"].as<unsigned int>());
+
+    if (vm.count("homogeneous_material") && vm.count("material_maps")) {
+        throw std::invalid_argument(
+            "Please specify only one material description");
+    }
+    if (vm.count("homogeneous_material")) {
+        cfg.use_material_maps(false);
+    }
+    if (vm.count("material_maps")) {
+        cfg.use_material_maps(true);
+    }
+}
+
+}  // namespace detray::options

--- a/tests/tools/include/detray/options/track_generator_options.hpp
+++ b/tests/tools/include/detray/options/track_generator_options.hpp
@@ -1,0 +1,181 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/options/options_handling.hpp"
+#include "detray/simulation/event_generator/random_track_generator_config.hpp"
+#include "detray/simulation/event_generator/uniform_track_generator_config.hpp"
+
+// Boost
+#include <boost/program_options.hpp>
+
+// System include(s)
+#include <stdexcept>
+#include <vector>
+
+namespace detray::options {
+
+/// Add options for detray event generation
+template <>
+void add_options<uniform_track_generator_config>(
+    boost::program_options::options_description &desc,
+    const uniform_track_generator_config &cfg) {
+
+    desc.add_options()(
+        "phi_steps",
+        boost::program_options::value<std::size_t>()->default_value(
+            cfg.phi_steps()),
+        "No. phi steps for particle gun")(
+        "eta_steps",
+        boost::program_options::value<std::size_t>()->default_value(
+            cfg.eta_steps()),
+        "No. eta steps for particle gun")(
+        "eta_range",
+        boost::program_options::value<std::vector<float>>()->multitoken(),
+        "Min, Max range of eta values for particle gun")(
+        "origin",
+        boost::program_options::value<std::vector<float>>()->multitoken(),
+        "Coordintates for particle gun origin position [mm]")(
+        "p_tot",
+        boost::program_options::value<float>()->default_value(
+            static_cast<float>(cfg.m_p_mag)),
+        "Total momentum of the test particle [GeV]")(
+        "p_T",
+        boost::program_options::value<float>()->default_value(
+            static_cast<float>(cfg.m_p_mag)),
+        "Transverse momentum of the test particle [GeV]");
+}
+
+/// Add options for detray event generation
+template <>
+void configure_options<uniform_track_generator_config>(
+    boost::program_options::variables_map &vm,
+    uniform_track_generator_config &cfg) {
+
+    cfg.phi_steps(vm["phi_steps"].as<std::size_t>());
+    cfg.eta_steps(vm["eta_steps"].as<std::size_t>());
+
+    if (vm.count("eta_range")) {
+        const auto eta_range = vm["eta_range"].as<std::vector<float>>();
+        if (eta_range.size() == 2u) {
+            cfg.eta_range(eta_range[0], eta_range[1]);
+        } else {
+            throw std::invalid_argument("Eta range needs two arguments");
+        }
+    }
+    if (vm.count("origin")) {
+        const auto origin = vm["origin"].as<std::vector<float>>();
+        if (origin.size() == 3u) {
+            cfg.origin({origin[0] * unit<float>::mm,
+                        origin[1] * unit<float>::mm,
+                        origin[2] * unit<float>::mm});
+        } else {
+            throw std::invalid_argument(
+                "Particle gun origin needs three arguments");
+        }
+    }
+    if (!vm["p_T"].defaulted() && !vm["p_tot"].defaulted()) {
+        throw std::invalid_argument(
+            "Transverse and total momentum cannot be specified at the same "
+            "time");
+    }
+    if (!vm["p_T"].defaulted()) {
+        cfg.p_T(vm["p_T"].as<float>() * unit<float>::GeV);
+    } else {
+        cfg.p_tot(vm["p_tot"].as<float>() * unit<float>::GeV);
+    }
+}
+
+/// Add options for detray event generation
+template <>
+void add_options<random_track_generator_config>(
+    boost::program_options::options_description &desc,
+    const random_track_generator_config &cfg) {
+
+    desc.add_options()(
+        "n_tracks",
+        boost::program_options::value<std::size_t>()->default_value(
+            cfg.n_tracks()),
+        "No. of tracks for particle gun")(
+        "theta_range",
+        boost::program_options::value<std::vector<float>>()->multitoken(),
+        "Min, Max range of theta values for particle gun")(
+        "eta_range",
+        boost::program_options::value<std::vector<float>>()->multitoken(),
+        "Min, Max range of eta values for particle gun")(
+        "origin",
+        boost::program_options::value<std::vector<float>>()->multitoken(),
+        "Coordintates for particle gun origin position")(
+        "p_tot",
+        boost::program_options::value<float>()->default_value(
+            static_cast<float>(cfg.mom_range()[0])),
+        "Total momentum of the test particle [GeV]")(
+        "p_T",
+        boost::program_options::value<float>()->default_value(
+            static_cast<float>(cfg.mom_range()[0])),
+        "Transverse momentum of the test particle [GeV]");
+}
+
+/// Add options for detray event generation
+template <>
+void configure_options<random_track_generator_config>(
+    boost::program_options::variables_map &vm,
+    random_track_generator_config &cfg) {
+
+    cfg.n_tracks(vm["n_tracks"].as<std::size_t>());
+    if (vm.count("eta_range") && vm.count("theta_range")) {
+        throw std::invalid_argument(
+            "Eta range and theta range cannot be specified at the same time");
+    } else if (vm.count("eta_range")) {
+        const auto eta_range = vm["eta_range"].as<std::vector<float>>();
+        if (eta_range.size() == 2u) {
+            float min_theta{2.f * std::atan(std::exp(-eta_range[0]))};
+            float max_theta{2.f * std::atan(std::exp(-eta_range[1]))};
+
+            // Wrap around
+            if (min_theta > max_theta) {
+                float tmp{min_theta};
+                min_theta = max_theta;
+                max_theta = tmp;
+            }
+
+            cfg.theta_range(min_theta, max_theta);
+        } else {
+            throw std::invalid_argument("Eta range needs two arguments");
+        }
+    } else if (vm.count("theta_range")) {
+        const auto theta_range = vm["theta_range"].as<std::vector<float>>();
+        if (theta_range.size() == 2u) {
+            cfg.theta_range(theta_range[0], theta_range[1]);
+        } else {
+            throw std::invalid_argument("Theta range needs two arguments");
+        }
+    }
+    if (vm.count("origin")) {
+        const auto origin = vm["origin"].as<std::vector<float>>();
+        if (origin.size() == 3u) {
+            cfg.origin({origin[0], origin[1], origin[2]});
+        } else {
+            throw std::invalid_argument(
+                "Particle gun origin needs three arguments");
+        }
+    }
+    if (!vm["p_T"].defaulted() && !vm["p_tot"].defaulted()) {
+        throw std::invalid_argument(
+            "Transverse and total momentum cannot be specified at the same "
+            "time");
+    }
+    if (!vm["p_T"].defaulted()) {
+        cfg.p_T(vm["p_T"].as<float>() * unit<float>::GeV);
+    } else {
+        cfg.p_tot(vm["p_tot"].as<float>() * unit<float>::GeV);
+    }
+}
+
+}  // namespace detray::options

--- a/tests/tools/include/detray/options/wire_chamber_options.hpp
+++ b/tests/tools/include/detray/options/wire_chamber_options.hpp
@@ -1,0 +1,48 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/detectors/create_wire_chamber.hpp"
+#include "detray/options/options_handling.hpp"
+
+// Boost
+#include <boost/program_options.hpp>
+
+// System include(s)
+#include <string>
+
+namespace detray::options {
+
+/// Add options for the detray toy detector
+template <>
+void add_options<wire_chamber_config>(
+    boost::program_options::options_description &desc,
+    const wire_chamber_config &cfg) {
+
+    desc.add_options()(
+        "layers",
+        boost::program_options::value<unsigned int>()->default_value(
+            cfg.n_layers()),
+        "number of layers")(
+        "half_z",
+        boost::program_options::value<float>()->default_value(
+            static_cast<float>(cfg.half_z())),
+        "half length z of the chamber [mm]");
+}
+
+/// Configure the detray toy detector
+template <>
+void configure_options<wire_chamber_config>(
+    boost::program_options::variables_map &vm, wire_chamber_config &cfg) {
+
+    cfg.n_layers(vm["layers"].as<unsigned int>());
+    cfg.half_z(vm["half_z"].as<float>());
+}
+
+}  // namespace detray::options

--- a/tests/tools/src/CMakeLists.txt
+++ b/tests/tools/src/CMakeLists.txt
@@ -15,17 +15,17 @@ include_directories( SYSTEM $<TARGET_PROPERTY:actsvg::core,INTERFACE_INCLUDE_DIR
 # Generate test detectors
 detray_add_executable(generate_toy_detector
                       "generate_toy_detector.cpp"
-                      LINK_LIBRARIES Boost::program_options
+                      LINK_LIBRARIES Boost::program_options detray::tools
                       detray::io detray::utils detray::core_array)
 
 detray_add_executable(generate_wire_chamber
                       "generate_wire_chamber.cpp"
-                      LINK_LIBRARIES Boost::program_options
+                      LINK_LIBRARIES Boost::program_options detray::tools
                       detray::io detray::utils detray::core_array)
 
 detray_add_executable(generate_telescope_detector
                       "generate_telescope_detector.cpp"
-                      LINK_LIBRARIES Boost::program_options
+                      LINK_LIBRARIES Boost::program_options detray::tools
                       detray::io detray::utils detray::core_array)
 
 # Build the visualization executable.

--- a/tests/tools/src/detector_validation.cpp
+++ b/tests/tools/src/detector_validation.cpp
@@ -36,7 +36,6 @@ int main(int argc, char** argv) {
 
     // Use the most general type to be able to read in all detector files
     using detector_t = detray::detector<>;
-    using scalar_t = detector_t::scalar_type;
 
     // Filter out the google test flags
     ::testing::InitGoogleTest(&argc, argv);
@@ -53,19 +52,19 @@ int main(int argc, char** argv) {
         "material_file", po::value<std::string>(), "material input file")(
         "n_tracks", po::value<std::size_t>()->default_value(50u),
         "# of tracks for particle gun")(
-        "theta_range", po::value<std::vector<scalar_t>>()->multitoken(),
+        "theta_range", po::value<std::vector<float>>()->multitoken(),
         "min, max range of theta values for particle gun")(
-        "eta_range", po::value<std::vector<scalar_t>>()->multitoken(),
+        "eta_range", po::value<std::vector<float>>()->multitoken(),
         "min, max range of eta values for particle gun")(
-        "origin", po::value<std::vector<scalar_t>>()->multitoken(),
+        "origin", po::value<std::vector<float>>()->multitoken(),
         "coordintates for particle gun origin position")(
-        "p_tot", po::value<scalar_t>()->default_value(10.f),
+        "p_tot", po::value<float>()->default_value(10.f),
         "total momentum of the test particle [GeV]")(
-        "p_T", po::value<scalar_t>()->default_value(10.f),
+        "p_T", po::value<float>()->default_value(10.f),
         "transverse momentum of the test particle [GeV]")(
         "search_window", po::value<std::vector<dindex>>(&window)->multitoken(),
         "search window size for the grid")(
-        "overstep_tol", po::value<scalar_t>()->default_value(-100.f),
+        "overstep_tol", po::value<float>()->default_value(-100.f),
         "overstepping tolerance [um] NOTE: Must be negative!");
 
     po::variables_map vm;
@@ -130,14 +129,14 @@ int main(int argc, char** argv) {
         }
     }
     if (vm.count("eta_range")) {
-        const auto eta_range = vm["eta_range"].as<std::vector<scalar_t>>();
+        const auto eta_range = vm["eta_range"].as<std::vector<float>>();
         if (eta_range.size() == 2u) {
-            scalar_t min_theta{2.f * std::atan(std::exp(-eta_range[0]))};
-            scalar_t max_theta{2.f * std::atan(std::exp(-eta_range[1]))};
+            float min_theta{2.f * std::atan(std::exp(-eta_range[0]))};
+            float max_theta{2.f * std::atan(std::exp(-eta_range[1]))};
 
             // Wrap around
             if (min_theta > max_theta) {
-                scalar_t tmp{min_theta};
+                float tmp{min_theta};
                 min_theta = max_theta;
                 max_theta = tmp;
             }
@@ -153,7 +152,7 @@ int main(int argc, char** argv) {
                 "time");
         }
     } else if (vm.count("theta_range")) {
-        const auto theta_range = vm["theta_range"].as<std::vector<scalar_t>>();
+        const auto theta_range = vm["theta_range"].as<std::vector<float>>();
         if (theta_range.size() == 2u) {
             ray_scan_cfg.track_generator().theta_range(theta_range[0],
                                                        theta_range[1]);
@@ -164,7 +163,7 @@ int main(int argc, char** argv) {
         }
     }
     if (vm.count("origin")) {
-        const auto origin = vm["origin"].as<std::vector<scalar_t>>();
+        const auto origin = vm["origin"].as<std::vector<float>>();
         if (origin.size() == 3u) {
             ray_scan_cfg.track_generator().origin(
                 {origin[0], origin[1], origin[2]});
@@ -176,14 +175,14 @@ int main(int argc, char** argv) {
         }
     }
     if (vm.count("p_T")) {
-        const scalar_t p_T{vm["p_T"].as<scalar_t>()};
+        const float p_T{vm["p_T"].as<float>()};
 
-        hel_scan_cfg.track_generator().p_T(p_T * unit<scalar_t>::GeV);
+        hel_scan_cfg.track_generator().p_T(p_T * unit<float>::GeV);
     }
     if (!vm["p_tot"].defaulted()) {
-        const scalar_t p_mag{vm["p_tot"].as<scalar_t>()};
+        const float p_mag{vm["p_tot"].as<float>()};
 
-        hel_scan_cfg.track_generator().p_tot(p_mag * unit<scalar_t>::GeV);
+        hel_scan_cfg.track_generator().p_tot(p_mag * unit<float>::GeV);
     }
 
     // Navigation
@@ -201,10 +200,10 @@ int main(int argc, char** argv) {
     }
 
     if (vm.count("overstep_tol")) {
-        const scalar_t overstep_tol{vm["overstep_tol"].as<scalar_t>()};
+        const float overstep_tol{vm["overstep_tol"].as<float>()};
 
         hel_nav_cfg.propagation().navigation.overstep_tolerance =
-            overstep_tol * unit<scalar_t>::um;
+            overstep_tol * unit<float>::um;
     }
 
     vecmem::host_memory_resource host_mr;

--- a/tests/tools/src/generate_toy_detector.cpp
+++ b/tests/tools/src/generate_toy_detector.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,6 +9,9 @@
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/build_toy_detector.hpp"
 #include "detray/io/frontend/detector_writer.hpp"
+#include "detray/options/detector_io_options.hpp"
+#include "detray/options/parse_options.hpp"
+#include "detray/options/toy_detector_options.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -16,57 +19,26 @@
 // Boost
 #include <boost/program_options.hpp>
 
+namespace po = boost::program_options;
+
 int main(int argc, char **argv) {
 
-    namespace po = boost::program_options;
     using namespace detray;
 
-    // Options parsing
+    // Configuration
+    detray::toy_det_config toy_cfg{};
+    detray::io::detector_writer_config writer_cfg{};
+    writer_cfg.format(detray::io::format::json).replace_files(false);
+    // Default output path
+    writer_cfg.path("./toy_detector/");
+
+    // Specific options for this test
     po::options_description desc("\nToy detector generation options");
 
-    desc.add_options()("help", "produce help message")(
-        "outdir", po::value<std::string>(), "Output directory for files")(
-        "write_volume_graph", "Writes the volume graph to file")(
-        "compactify_json", "not implemented")(
-        "write_material", "Toggle material output")("write_grids",
-                                                    "Toggle grid output")(
-        "barrel_layers", po::value<unsigned int>()->default_value(4u),
-        "Number of barrel layers [0-4]")(
-        "endcap_layers", po::value<unsigned int>()->default_value(3u),
-        "Number of endcap layers on either side [0-7]")(
-        "homogeneous_material",
-        "Generate homogeneous material description (default)")(
-        "material_maps", "Generate material maps");
+    desc.add_options()("write_volume_graph", "Write the volume graph to file");
 
-    po::variables_map vm;
-    po::store(parse_command_line(argc, argv, desc,
-                                 po::command_line_style::unix_style ^
-                                     po::command_line_style::allow_short),
-              vm);
-    po::notify(vm);
-
-    // Help message
-    if (vm.count("help")) {
-        std::cout << desc << std::endl;
-        return EXIT_FAILURE;
-    }
-
-    // Configuration
-    detray::toy_det_config<detray::scalar> toy_cfg{};
-    detray::io::detector_writer_config writer_cfg{};
-    writer_cfg.format(detray::io::format::json).replace_files(true);
-
-    // General options
-    std::string outdir{vm.count("outdir") ? vm["outdir"].as<std::string>()
-                                          : "./toy_detector/"};
-    writer_cfg.path(std::move(outdir));
-    writer_cfg.compactify_json(vm.count("compactify_json"));
-    writer_cfg.write_material(vm.count("write_material"));
-    writer_cfg.write_grids(vm.count("write_grids"));
-
-    // Toy detector options
-    toy_cfg.n_brl_layers(vm["barrel_layers"].as<unsigned int>());
-    toy_cfg.n_edc_layers(vm["endcap_layers"].as<unsigned int>());
+    po::variables_map vm =
+        detray::options::parse_options(desc, argc, argv, toy_cfg, writer_cfg);
 
     if (vm.count("homogeneous_material") && vm.count("material_maps")) {
         std::cout << "Please specify only one material description"
@@ -88,4 +60,9 @@ int main(int argc, char **argv) {
 
     // Write to file
     detray::io::write_detector(toy_det, toy_names, writer_cfg);
+
+    // General options
+    if (vm.count("write_volume_graph")) {
+        throw std::invalid_argument("Writing of volume graph not implemented");
+    }
 }

--- a/tests/tools/src/generate_wire_chamber.cpp
+++ b/tests/tools/src/generate_wire_chamber.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,6 +9,9 @@
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/io/frontend/detector_writer.hpp"
+#include "detray/options/detector_io_options.hpp"
+#include "detray/options/parse_options.hpp"
+#include "detray/options/wire_chamber_options.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -21,53 +24,20 @@ int main(int argc, char **argv) {
     namespace po = boost::program_options;
     using namespace detray;
 
-    using detector_t = detector<>;
-    using scalar_t = typename detector_t::scalar_type;
-
     // Options parsing
     po::options_description desc("\nWire chamber generation options");
 
-    desc.add_options()("help", "produce help message")(
-        "outdir", po::value<std::string>(), "Output directory for files")(
-        "write_volume_graph", "writes the volume graph to file")(
-        "compactify_json", "not implemented")(
-        "write_material", "toggle material output")("write_grids",
-                                                    "toggle grid output")(
-        "layers", po::value<unsigned int>()->default_value(10u),
-        "number of layers")(
-        "half_z",
-        po::value<scalar_t>()->default_value(1000.f * unit<scalar_t>::mm),
-        "half length z of the chamber [mm]");
-
-    po::variables_map vm;
-    po::store(parse_command_line(argc, argv, desc,
-                                 po::command_line_style::unix_style ^
-                                     po::command_line_style::allow_short),
-              vm);
-    po::notify(vm);
-
-    // Help message
-    if (vm.count("help")) {
-        std::cout << desc << std::endl;
-        return EXIT_FAILURE;
-    }
+    desc.add_options()("write_volume_graph", "writes the volume graph to file");
 
     // Configuration
     detray::wire_chamber_config wire_cfg{};
     detray::io::detector_writer_config writer_cfg{};
     writer_cfg.format(detray::io::format::json).replace_files(false);
+    // Default output path
+    writer_cfg.path("./wire_chamber/");
 
-    // General options
-    std::string outdir{vm.count("outdir") ? vm["outdir"].as<std::string>()
-                                          : "./wire_chamber/"};
-    writer_cfg.path(std::move(outdir));
-    writer_cfg.compactify_json(vm.count("compactify_json"));
-    writer_cfg.write_material(vm.count("write_material"));
-    writer_cfg.write_grids(vm.count("write_grids"));
-
-    // Wire chamber options
-    wire_cfg.n_layers(vm["layers"].as<unsigned int>());
-    wire_cfg.half_z(vm["half_z"].as<scalar_t>());
+    po::variables_map vm =
+        detray::options::parse_options(desc, argc, argv, wire_cfg, writer_cfg);
 
     // Build the geometry
     vecmem::host_memory_resource host_mr;
@@ -75,4 +45,9 @@ int main(int argc, char **argv) {
 
     // Write to file
     detray::io::write_detector(wire_chamber, names, writer_cfg);
+
+    // General options
+    if (vm.count("write_volume_graph")) {
+        throw std::invalid_argument("Writing of volume graph not implemented");
+    }
 }

--- a/tests/tools/src/material_validation.cpp
+++ b/tests/tools/src/material_validation.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,14 +9,14 @@
 #include "detray/core/detector.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
+#include "detray/options/detector_io_options.hpp"
+#include "detray/options/parse_options.hpp"
+#include "detray/options/track_generator_options.hpp"
 #include "detray/test/detail/register_checks.hpp"
 #include "detray/validation/detector_material_scan.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
-
-// Boost
-#include <boost/program_options.hpp>
 
 // System include(s)
 #include <sstream>
@@ -30,93 +30,18 @@ int main(int argc, char **argv) {
 
     // Use the most general type to be able to read in all detector files
     using detector_t = detray::detector<>;
-    using scalar_t = detector_t::scalar_type;
 
     // Filter out the google test flags
     ::testing::InitGoogleTest(&argc, argv);
-
-    // Options parsing
-    po::options_description desc("\ndetray material validation options");
-
-    desc.add_options()("help", "produce help message")(
-        "geometry_file", po::value<std::string>(), "geometry input file")(
-        "material_file", po::value<std::string>(), "material input file")(
-        "phi_steps", po::value<std::size_t>()->default_value(50u),
-        "# phi steps for particle gun")(
-        "eta_steps", po::value<std::size_t>()->default_value(50u),
-        "# eta steps for particle gun")(
-        "eta_range", po::value<std::vector<scalar_t>>()->multitoken(),
-        "min, max range of eta values for particle gun")(
-        "origin", po::value<std::vector<scalar_t>>()->multitoken(),
-        "coordintates for particle gun origin position");
-
-    po::variables_map vm;
-    po::store(parse_command_line(argc, argv, desc,
-                                 po::command_line_style::unix_style ^
-                                     po::command_line_style::allow_short),
-              vm);
-    po::notify(vm);
-
-    // Help message
-    if (vm.count("help")) {
-        std::cout << desc << std::endl;
-        return EXIT_FAILURE;
-    }
 
     // Configs to be filled
     detray::io::detector_reader_config reader_cfg{};
     detray::material_scan<detector_t>::config mat_scan_cfg{};
     mat_scan_cfg.track_generator().uniform_eta(true);
 
-    // Input files
-    if (vm.count("geometry_file")) {
-        reader_cfg.add_file(vm["geometry_file"].as<std::string>());
-    } else {
-        std::stringstream err_stream{};
-        err_stream << "Please specify a geometry input file!\n\n" << desc;
-
-        throw std::invalid_argument(err_stream.str());
-    }
-    if (vm.count("material_file")) {
-        reader_cfg.add_file(vm["material_file"].as<std::string>());
-    } else {
-        std::stringstream err_stream{};
-        err_stream << "Please specify a material input file!\n\n" << desc;
-
-        throw std::invalid_argument(err_stream.str());
-    }
-
-    // Particle gun
-    if (vm.count("phi_steps")) {
-        const std::size_t phi_steps{vm["phi_steps"].as<std::size_t>()};
-
-        mat_scan_cfg.track_generator().phi_steps(phi_steps);
-    }
-    if (vm.count("eta_steps")) {
-        const std::size_t eta_steps{vm["eta_steps"].as<std::size_t>()};
-
-        mat_scan_cfg.track_generator().eta_steps(eta_steps);
-        mat_scan_cfg.track_generator().eta_range(-4.f, 4.f);
-    }
-    if (vm.count("eta_range")) {
-        const auto eta_range = vm["eta_range"].as<std::vector<scalar_t>>();
-        if (eta_range.size() == 2u) {
-            mat_scan_cfg.track_generator().eta_range(eta_range[0],
-                                                     eta_range[1]);
-        } else {
-            throw std::invalid_argument("Eta range needs two arguments");
-        }
-    }
-    if (vm.count("origin")) {
-        const auto origin = vm["origin"].as<std::vector<scalar_t>>();
-        if (origin.size() == 3u) {
-            mat_scan_cfg.track_generator().origin(
-                {origin[0], origin[1], -origin[2]});
-        } else {
-            throw std::invalid_argument(
-                "Particle gun origin needs three arguments");
-        }
-    }
+    std::string description{"\ndetray material validation options"};
+    detray::options::parse_options(description, argc, argv, reader_cfg,
+                                   mat_scan_cfg.track_generator());
 
     vecmem::host_memory_resource host_mr;
 

--- a/tests/unit_tests/cpu/detectors/toy_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/toy_detector.cpp
@@ -23,7 +23,7 @@ GTEST_TEST(detray_detectors, toy_detector) {
 
     vecmem::host_memory_resource host_mr;
 
-    toy_det_config<scalar> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.use_material_maps(false).do_check(true);
     const auto [toy_det, names] = build_toy_detector(host_mr, toy_cfg);
 

--- a/tests/unit_tests/cpu/navigation/navigator.cpp
+++ b/tests/unit_tests/cpu/navigation/navigator.cpp
@@ -140,8 +140,8 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
 
     stepper_t stepper;
     navigator_t nav;
-    navigation::config<scalar> cfg{};
-    cfg.on_surface_tolerance = 1.f * unit<scalar>::um;
+    navigation::config cfg{};
+    cfg.path_tolerance = 1.f * unit<scalar>::um;
     cfg.search_window = {3u, 3u};
 
     prop_state<stepper_t::state, navigator_t::state> propagation{
@@ -314,8 +314,8 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
 
     stepper_t stepper;
     navigator_t nav;
-    navigation::config<scalar> cfg{};
-    cfg.on_surface_tolerance = 1.f * unit<scalar>::um;
+    navigation::config cfg{};
+    cfg.path_tolerance = 1.f * unit<scalar>::um;
     cfg.search_window = {3u, 3u};
 
     prop_state<stepper_t::state, navigator_t::state> propagation{

--- a/tests/unit_tests/cpu/navigation/navigator.cpp
+++ b/tests/unit_tests/cpu/navigation/navigator.cpp
@@ -141,7 +141,7 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
     stepper_t stepper;
     navigator_t nav;
     navigation::config cfg{};
-    cfg.path_tolerance = 1.f * unit<scalar>::um;
+    cfg.path_tolerance = 1.f * unit<float>::um;
     cfg.search_window = {3u, 3u};
 
     prop_state<stepper_t::state, navigator_t::state> propagation{
@@ -315,7 +315,7 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
     stepper_t stepper;
     navigator_t nav;
     navigation::config cfg{};
-    cfg.path_tolerance = 1.f * unit<scalar>::um;
+    cfg.path_tolerance = 1.f * unit<float>::um;
     cfg.search_window = {3u, 3u};
 
     prop_state<stepper_t::state, navigator_t::state> propagation{

--- a/tests/unit_tests/cpu/navigation/volume_graph.cpp
+++ b/tests/unit_tests/cpu/navigation/volume_graph.cpp
@@ -27,7 +27,7 @@ GTEST_TEST(detray_navigation, volume_graph) {
 
     vecmem::host_memory_resource host_mr;
 
-    toy_det_config<scalar> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.n_edc_layers(1u);
 
     auto [det, names] = build_toy_detector(host_mr, toy_cfg);

--- a/tests/unit_tests/device/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda.cpp
@@ -31,7 +31,7 @@ TEST(navigator_cuda, navigator) {
 
     // Create navigator
     navigator_host_t nav;
-    navigation::config<scalar_t> cfg{};
+    navigation::config cfg{};
     cfg.search_window = {1u, 1u};
 
     // Create the vector of initial track parameters

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.cu
@@ -11,8 +11,7 @@
 namespace detray {
 
 __global__ void navigator_test_kernel(
-    typename detector_host_t::view_type det_data,
-    navigation::config<scalar_t> cfg,
+    typename detector_host_t::view_type det_data, navigation::config cfg,
     vecmem::data::vector_view<free_track_parameters<algebra_t>> tracks_data,
     vecmem::data::jagged_vector_view<intersection_t> candidates_data,
     vecmem::data::jagged_vector_view<dindex> volume_records_data,
@@ -63,8 +62,7 @@ __global__ void navigator_test_kernel(
 }
 
 void navigator_test(
-    typename detector_host_t::view_type det_data,
-    navigation::config<scalar_t>& cfg,
+    typename detector_host_t::view_type det_data, navigation::config& cfg,
     vecmem::data::vector_view<free_track_parameters<algebra_t>>& tracks_data,
     vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
@@ -53,8 +53,7 @@ namespace detray {
 
 /// test function for navigator with single state
 void navigator_test(
-    typename detector_host_t::view_type det_data,
-    navigation::config<scalar_t>& cfg,
+    typename detector_host_t::view_type det_data, navigation::config& cfg,
     vecmem::data::vector_view<free_track_parameters<algebra_t>>& tracks_data,
     vecmem::data::jagged_vector_view<intersection_t>& candidates_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,

--- a/tests/unit_tests/io/io_json_detector_writer.cpp
+++ b/tests/unit_tests/io/io_json_detector_writer.cpp
@@ -86,7 +86,7 @@ GTEST_TEST(io, json_toy_material_maps_writer) {
 
     // Toy detector
     vecmem::host_memory_resource host_mr;
-    toy_det_config<scalar> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.use_material_maps(true);
     auto [det, names] = build_toy_detector(host_mr, toy_cfg);
 
@@ -114,7 +114,7 @@ GTEST_TEST(io, json_toy_detector_writer) {
 
     // Toy detector
     vecmem::host_memory_resource host_mr;
-    toy_det_config<scalar> toy_cfg{};
+    toy_det_config toy_cfg{};
     toy_cfg.use_material_maps(true);
     const auto [det, names] = build_toy_detector(host_mr, toy_cfg);
 

--- a/tests/unit_tests/svgtools/material.cpp
+++ b/tests/unit_tests/svgtools/material.cpp
@@ -39,7 +39,7 @@ GTEST_TEST(svgtools, material) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    detray::toy_det_config<detray::scalar> toy_cfg{};
+    detray::toy_det_config toy_cfg{};
     toy_cfg.use_material_maps(true).cyl_map_bins(20, 20).disc_map_bins(5, 20);
     const auto [det, names] = detray::build_toy_detector(host_mr, toy_cfg);
 

--- a/tutorials/src/cpu/detector/build_predefined_detectors.cpp
+++ b/tutorials/src/cpu/detector/build_predefined_detectors.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
     //
     // Toy detector
     //
-    detray::toy_det_config<detray::scalar> toy_cfg{};
+    detray::toy_det_config toy_cfg{};
     // Number of barrel layers (0 - 4)
     toy_cfg.n_brl_layers(4u);
     // Number of endcap layers on either side (0 - 7)

--- a/tutorials/src/device/cuda/propagation_kernel.cu
+++ b/tutorials/src/device/cuda/propagation_kernel.cu
@@ -42,7 +42,7 @@ __global__ void propagation_kernel(
         candidates_data);
 
     // Create propagator from a stepper and a navigator
-    propagation::config<scalar> cfg{};
+    propagation::config cfg{};
     cfg.navigation.search_window = {3u, 3u};
     detray::tutorial::propagator_t p{cfg};
 

--- a/utils/include/detray/detectors/build_toy_detector.hpp
+++ b/utils/include/detray/detectors/build_toy_detector.hpp
@@ -43,70 +43,65 @@
 namespace detray {
 
 /// Configure the toy detector
-template <typename scalar_t>
 struct toy_det_config {
 
     /// Default toy detector configuration
     toy_det_config() {
         // Barrel module creator
-        m_barrel_factory_cfg.half_length(500.f * unit<scalar_t>::mm)
-            .module_bounds(
-                {8.4f * unit<scalar_t>::mm, 36.f * unit<scalar_t>::mm})
+        m_barrel_factory_cfg.half_length(500.f * unit<scalar>::mm)
+            .module_bounds({8.4f * unit<scalar>::mm, 36.f * unit<scalar>::mm})
             .tilt_phi(0.14f /*0.145*/)
-            .radial_stagger(0.5f * unit<scalar_t>::mm /*2.f*/)
-            .z_overlap(2.f * unit<scalar_t>::mm /*5.f*/);
+            .radial_stagger(0.5f * unit<scalar>::mm /*2.f*/)
+            .z_overlap(2.f * unit<scalar>::mm /*5.f*/);
 
         // Endcap module creator
         m_endcap_factory_cfg.inner_radius(m_beampipe_volume_radius)
             .outer_radius(m_outer_radius)
-            .module_bounds(
-                {{3.f * unit<scalar_t>::mm, 9.5f * unit<scalar_t>::mm,
-                  39.f * unit<scalar_t>::mm},
-                 {6.f * unit<scalar_t>::mm, 10.f * unit<scalar_t>::mm,
-                  39.f * unit<scalar_t>::mm}})
-            .ring_stagger(2.f * unit<scalar_t>::mm)
-            .phi_stagger({4.f * unit<scalar_t>::mm, 4.f * unit<scalar_t>::mm})
-            .phi_sub_stagger(
-                {0.5f * unit<scalar_t>::mm, 0.5f * unit<scalar_t>::mm})
+            .module_bounds({{3.f * unit<scalar>::mm, 9.5f * unit<scalar>::mm,
+                             39.f * unit<scalar>::mm},
+                            {6.f * unit<scalar>::mm, 10.f * unit<scalar>::mm,
+                             39.f * unit<scalar>::mm}})
+            .ring_stagger(2.f * unit<scalar>::mm)
+            .phi_stagger({4.f * unit<scalar>::mm, 4.f * unit<scalar>::mm})
+            .phi_sub_stagger({0.5f * unit<scalar>::mm, 0.5f * unit<scalar>::mm})
             .module_tilt({0.f, 0.f})
             .binning({40u, 68u});
 
         // Configure the material generation
-        m_material_config.sensitive_material(silicon_tml<scalar_t>())
-            .passive_material(beryllium_tml<scalar_t>())  // < beampipe
-            .portal_material(vacuum<scalar_t>())
-            .thickness(1.5f * unit<scalar_t>::mm);
+        m_material_config.sensitive_material(silicon_tml<scalar>())
+            .passive_material(beryllium_tml<scalar>())  // < beampipe
+            .portal_material(vacuum<scalar>())
+            .thickness(1.5f * unit<scalar>::mm);
 
         // Configure the material map generation
         m_beampipe_map_cfg.n_bins = {20u, 20u};
         m_beampipe_map_cfg.axis_index = 1u;
-        m_beampipe_map_cfg.mapped_material = beryllium_tml<scalar_t>();
-        // m_beampipe_map_cfg.thickness = 0.08f * unit<scalar_t>::um;
-        m_beampipe_map_cfg.thickness = 0.f * unit<scalar_t>::um;
+        m_beampipe_map_cfg.mapped_material = beryllium_tml<scalar>();
+        // m_beampipe_map_cfg.thickness = 0.08f * unit<scalar>::um;
+        m_beampipe_map_cfg.thickness = 0.f * unit<scalar>::um;
         // Don't scale the generation of the material thickness
         m_beampipe_map_cfg.scalor = 0.f;
         m_beampipe_map_cfg.mat_generator =
-            detray::detail::generate_cyl_mat<scalar_t>;
+            detray::detail::generate_cyl_mat<scalar>;
 
         m_disc_map_cfg.n_bins = {3u, 20u};
         m_disc_map_cfg.axis_index = 0u;
         m_disc_map_cfg.mapped_material =
-            mixture<scalar_t, silicon_tml<scalar_t, std::ratio<9, 10>>,
-                    aluminium<scalar_t, std::ratio<1, 10>>>{};
-        m_disc_map_cfg.thickness = 1.5f * unit<scalar_t>::mm;
+            mixture<scalar, silicon_tml<scalar, std::ratio<9, 10>>,
+                    aluminium<scalar, std::ratio<1, 10>>>{};
+        m_disc_map_cfg.thickness = 1.5f * unit<scalar>::mm;
         m_disc_map_cfg.scalor = 0.0001f;
         m_disc_map_cfg.mat_generator =
-            detray::detail::generate_disc_mat<scalar_t>;
+            detray::detail::generate_disc_mat<scalar>;
 
         m_cyl_map_cfg.n_bins = {20u, 20u};
         m_cyl_map_cfg.axis_index = 1u;
         m_cyl_map_cfg.mapped_material =
-            mixture<scalar_t, silicon_tml<scalar_t, std::ratio<9, 10>>,
-                    aluminium<scalar_t, std::ratio<1, 10>>>{};
-        m_cyl_map_cfg.thickness = 5.f * unit<scalar_t>::mm;
+            mixture<scalar, silicon_tml<scalar, std::ratio<9, 10>>,
+                    aluminium<scalar, std::ratio<1, 10>>>{};
+        m_cyl_map_cfg.thickness = 5.f * unit<scalar>::mm;
         m_cyl_map_cfg.scalor = 0.000001f;
-        m_cyl_map_cfg.mat_generator =
-            detray::detail::generate_cyl_mat<scalar_t>;
+        m_cyl_map_cfg.mat_generator = detray::detail::generate_cyl_mat<scalar>;
     }
 
     /// No. of barrel layers the detector should be built with
@@ -114,43 +109,43 @@ struct toy_det_config {
     /// No. of endcap layers (on either side) the detector should be built with
     unsigned int m_n_edc_layers{3u};
     /// Total outer radius of the pixel subdetector
-    scalar_t m_outer_radius{180.f * unit<scalar_t>::mm};
+    scalar m_outer_radius{180.f * unit<scalar>::mm};
     // Radius of the innermost volume that contains the beampipe
-    scalar_t m_beampipe_volume_radius{25.f * unit<scalar_t>::mm};
+    scalar m_beampipe_volume_radius{25.f * unit<scalar>::mm};
     // Envelope around the modules used by the cylinder portal generator
-    scalar_t m_portal_envelope{0.1f * unit<scalar_t>::mm};
+    scalar m_portal_envelope{0.1f * unit<scalar>::mm};
     /// Configuration for the homogeneous material generator
-    hom_material_config<scalar_t> m_material_config{};
+    hom_material_config<scalar> m_material_config{};
     /// Put material maps on portals or use homogenous material on modules
     bool m_use_material_maps{false};
     /// Configuration for the material map generator (beampipe)
-    typename material_map_config<scalar_t>::map_config m_beampipe_map_cfg{};
+    typename material_map_config<scalar>::map_config m_beampipe_map_cfg{};
     /// Configuration for the material map generator (disc)
-    typename material_map_config<scalar_t>::map_config m_disc_map_cfg{};
+    typename material_map_config<scalar>::map_config m_disc_map_cfg{};
     /// Configuration for the material map generator (cylinder)
-    typename material_map_config<scalar_t>::map_config m_cyl_map_cfg{};
+    typename material_map_config<scalar>::map_config m_cyl_map_cfg{};
     /// Thickness of the beampipe material
-    scalar_t m_beampipe_mat_thickness{0.8f * unit<scalar_t>::mm};
+    scalar m_beampipe_mat_thickness{0.8f * unit<scalar>::mm};
     /// Thickness of the material slabs in the homogeneous material description
-    scalar_t m_module_mat_thickness{1.5f * unit<scalar_t>::mm};
+    scalar m_module_mat_thickness{1.5f * unit<scalar>::mm};
     /// Radii at which to place the barrel module layers (including beampipe)
-    std::vector<scalar_t> m_barrel_layer_radii = {
-        19.f * unit<scalar_t>::mm, 32.f * unit<scalar_t>::mm,
-        72.f * unit<scalar_t>::mm, 116.f * unit<scalar_t>::mm,
-        172.f * unit<scalar_t>::mm};
+    std::vector<scalar> m_barrel_layer_radii = {
+        19.f * unit<scalar>::mm, 32.f * unit<scalar>::mm,
+        72.f * unit<scalar>::mm, 116.f * unit<scalar>::mm,
+        172.f * unit<scalar>::mm};
     /// Number of modules in phi and z for the barrel
     std::vector<std::pair<unsigned int, unsigned int>> m_barrel_binning = {
         {0u, 0u}, {16u, 14u}, {32u, 14u}, {52u, 14u}, {78u, 14u}};
     /// Positions at which to place the endcap module layers on either side
-    std::vector<scalar_t> m_endcap_layer_positions = {
-        600.f * unit<scalar_t>::mm,  700.f * unit<scalar_t>::mm,
-        820.f * unit<scalar_t>::mm,  960.f * unit<scalar_t>::mm,
-        1100.f * unit<scalar_t>::mm, 1300.f * unit<scalar_t>::mm,
-        1500.f * unit<scalar_t>::mm};
+    std::vector<scalar> m_endcap_layer_positions = {
+        600.f * unit<scalar>::mm,  700.f * unit<scalar>::mm,
+        820.f * unit<scalar>::mm,  960.f * unit<scalar>::mm,
+        1100.f * unit<scalar>::mm, 1300.f * unit<scalar>::mm,
+        1500.f * unit<scalar>::mm};
     /// Config for the module generation (barrel)
-    barrel_generator_config<scalar_t> m_barrel_factory_cfg{};
+    barrel_generator_config<scalar> m_barrel_factory_cfg{};
     /// Config for the module generation (endcaps)
-    endcap_generator_config<scalar_t> m_endcap_factory_cfg{};
+    endcap_generator_config<scalar> m_endcap_factory_cfg{};
     /// Run detector consistency check after reading
     bool m_do_check{true};
 
@@ -164,7 +159,7 @@ struct toy_det_config {
         m_n_edc_layers = n;
         return *this;
     }
-    constexpr toy_det_config &envelope(const scalar_t env) {
+    constexpr toy_det_config &envelope(const scalar env) {
         m_portal_envelope = env;
         return *this;
     }
@@ -182,23 +177,23 @@ struct toy_det_config {
         m_disc_map_cfg.n_bins = {n_r, n_phi};
         return *this;
     }
-    constexpr toy_det_config &material_map_min_thickness(const scalar_t t) {
+    constexpr toy_det_config &material_map_min_thickness(const scalar t) {
         assert(t > 0.f);
         m_cyl_map_cfg.thickness = t;
         m_disc_map_cfg.thickness = t;
         return *this;
     }
-    constexpr toy_det_config &beampipe_mat_thickness(const scalar_t t) {
+    constexpr toy_det_config &beampipe_mat_thickness(const scalar t) {
         assert(t > 0.f);
         m_beampipe_mat_thickness = t;
         return *this;
     }
-    constexpr toy_det_config &module_mat_thickness(const scalar_t t) {
+    constexpr toy_det_config &module_mat_thickness(const scalar t) {
         assert(t > 0.f);
         m_module_mat_thickness = t;
         return *this;
     }
-    constexpr toy_det_config &mapped_material(const material<scalar_t> &mat) {
+    constexpr toy_det_config &mapped_material(const material<scalar> &mat) {
         m_cyl_map_cfg.mapped_material = mat;
         m_disc_map_cfg.mapped_material = mat;
         return *this;
@@ -214,8 +209,8 @@ struct toy_det_config {
     constexpr unsigned int n_brl_layers() const { return m_n_brl_layers; }
     constexpr unsigned int n_edc_layers() const { return m_n_edc_layers; }
     constexpr const auto &outer_radius() const { return m_outer_radius; }
-    constexpr scalar_t envelope() const { return m_portal_envelope; }
-    constexpr scalar_t beampipe_vol_radius() const {
+    constexpr scalar envelope() const { return m_portal_envelope; }
+    constexpr scalar beampipe_vol_radius() const {
         return m_beampipe_volume_radius;
     }
     constexpr auto &material_config() { return m_material_config; }
@@ -235,19 +230,19 @@ struct toy_det_config {
     constexpr const std::array<std::size_t, 2> &disc_map_bins() const {
         return m_disc_map_cfg.n_bins;
     }
-    constexpr scalar_t material_map_min_thickness() const {
+    constexpr scalar material_map_min_thickness() const {
         assert(m_cyl_map_cfg.thickness == m_disc_map_cfg.thickness);
         return m_cyl_map_cfg.thickness;
     }
-    constexpr scalar_t beampipe_mat_thickness() const {
+    constexpr scalar beampipe_mat_thickness() const {
         return m_beampipe_mat_thickness;
     }
-    constexpr scalar_t module_mat_thickness() const {
+    constexpr scalar module_mat_thickness() const {
         return m_module_mat_thickness;
     }
     auto barrel_mat_generator() const { return m_cyl_map_cfg.mat_generator; }
     auto edc_mat_generator() const { return m_disc_map_cfg.mat_generator; }
-    constexpr material<scalar_t> mapped_material() const {
+    constexpr material<scalar> mapped_material() const {
         assert(m_cyl_map_cfg.mapped_material == m_disc_map_cfg.mapped_material);
         return m_cyl_map_cfg.mapped_material;
     }
@@ -260,15 +255,49 @@ struct toy_det_config {
     constexpr const auto &barrel_layer_binning() const {
         return m_barrel_binning;
     }
-    constexpr barrel_generator_config<scalar_t> &barrel_config() {
+    constexpr barrel_generator_config<scalar> &barrel_config() {
         return m_barrel_factory_cfg;
     }
-    constexpr endcap_generator_config<scalar_t> &endcap_config() {
+    constexpr endcap_generator_config<scalar> &endcap_config() {
         return m_endcap_factory_cfg;
     }
     constexpr bool do_check() const { return m_do_check; }
     /// @}
 };
+
+/// Print the toy detector configuration
+inline std::ostream &operator<<(std::ostream &out, const toy_det_config &cfg) {
+    out << "\nToy Detector\n"
+        << "----------------------------\n"
+        << "  No. barrel layers     : " << cfg.n_brl_layers() << "\n"
+        << "  No. endcap layers     : " << cfg.n_edc_layers() << "\n"
+        << "  Portal envelope       : " << cfg.envelope() << " [mm]\n";
+
+    if (cfg.use_material_maps()) {
+        const auto &cyl_map_bins = cfg.cyl_map_bins();
+        const auto &disc_map_bins = cfg.disc_map_bins();
+
+        out << "  Material maps \n"
+            << "    -> cyl. map bins    : (phi: " << cyl_map_bins[0]
+            << ", z: " << cyl_map_bins[1] << ")\n"
+            << "    -> disc map bins    : (r: " << disc_map_bins[0]
+            << ", phi: " << disc_map_bins[1] << ")\n"
+            << "    -> cyl. min. thickness: "
+            << cfg.cyl_material_map().thickness / detray::unit<float>::mm
+            << " [mm]\n"
+            << "    -> disc min. thickness: "
+            << cfg.disc_material_map().thickness / detray::unit<float>::mm
+            << " [mm]\n"
+            << "    -> Material         : " << cfg.mapped_material() << "\n";
+    } else {
+        out << "  Homogeneous material \n"
+            << "    -> Thickness        : "
+            << cfg.module_mat_thickness() / detray::unit<float>::mm << " [mm]\n"
+            << "    -> Material         : " << silicon_tml<scalar>() << "\n";
+    }
+
+    return out;
+}
 
 namespace detail {
 
@@ -324,7 +353,7 @@ volume_builder_interface<detector_t> *decorate_material(
 /// @returns the decorated volume builder and surface factory
 template <typename detector_t>
 std::shared_ptr<surface_factory_interface<detector_t>> decorate_material(
-    toy_det_config<typename detector_t::scalar_type> &cfg,
+    toy_det_config &cfg,
     std::unique_ptr<surface_factory_interface<detector_t>> sf_factory,
     bool is_module_factory = false) {
 
@@ -450,11 +479,8 @@ void add_cylinder_portals(volume_builder_interface<detector_t> *v_builder,
 /// @param cfg config for the toy detector
 /// @param vol_index index of the volume to which the grid should be added
 template <typename detector_builder_t>
-inline void add_cylinder_grid(
-    detector_builder_t &det_builder,
-    toy_det_config<typename detector_builder_t::detector_type::scalar_type>
-        &cfg,
-    const dindex vol_index) {
+inline void add_cylinder_grid(detector_builder_t &det_builder,
+                              toy_det_config &cfg, const dindex vol_index) {
 
     using detector_t = typename detector_builder_t::detector_type;
     using scalar_t = typename detector_t::scalar_type;
@@ -484,11 +510,8 @@ inline void add_cylinder_grid(
 /// @param cfg config for the toy detector
 /// @param vol_index index of the volume to which the grid should be added
 template <typename detector_builder_t>
-inline void add_disc_grid(
-    detector_builder_t &det_builder,
-    toy_det_config<typename detector_builder_t::detector_type::scalar_type>
-        &cfg,
-    const dindex vol_index) {
+inline void add_disc_grid(detector_builder_t &det_builder, toy_det_config &cfg,
+                          const dindex vol_index) {
 
     using detector_t = typename detector_builder_t::detector_type;
     using scalar_t = typename detector_t::scalar_type;
@@ -521,7 +544,7 @@ inline void add_disc_grid(
 /// @param[out] vol_bounds boundary struct
 template <typename detector_t>
 inline void get_volume_extent(
-    toy_det_config<typename detector_t::scalar_type> &cfg,
+    toy_det_config &cfg,
     std::shared_ptr<surface_factory_interface<detector_t>> sf_factory,
     typename cylinder_portal_generator<detector_t>::boundaries &vol_bounds) {
 
@@ -562,8 +585,7 @@ template <typename detector_builder_t>
 inline auto add_barrel_detector(
     detector_builder_t &det_builder,
     typename detector_builder_t::detector_type::geometry_context &gctx,
-    toy_det_config<typename detector_builder_t::detector_type::scalar_type>
-        &cfg,
+    toy_det_config &cfg,
     typename detector_builder_t::detector_type::name_map &names,
     dindex beampipe_idx) {
 
@@ -718,8 +740,7 @@ template <typename detector_builder_t>
 inline auto add_endcap_detector(
     detector_builder_t &det_builder,
     typename detector_builder_t::detector_type::geometry_context &gctx,
-    toy_det_config<typename detector_builder_t::detector_type::scalar_type>
-        &cfg,
+    toy_det_config &cfg,
     typename detector_builder_t::detector_type::name_map &names,
     dindex beampipe_idx) {
 
@@ -900,12 +921,11 @@ inline auto add_endcap_detector(
 /// @param neg_edc_lay_sizes indices and z-extent of the endcap volumes of one
 ///                          detector side (positive or negative)
 template <typename detector_builder_t, typename vol_extent_data_t>
-inline void add_connector_portals(
-    detector_builder_t &det_builder,
-    toy_det_config<typename detector_builder_t::detector_type::scalar_type>
-        &cfg,
-    const dindex beampipe_idx, const vol_extent_data_t edc_vol_extents,
-    const vol_extent_data_t &brl_vol_extents) {
+inline void add_connector_portals(detector_builder_t &det_builder,
+                                  toy_det_config &cfg,
+                                  const dindex beampipe_idx,
+                                  const vol_extent_data_t edc_vol_extents,
+                                  const vol_extent_data_t &brl_vol_extents) {
 
     using detector_t = typename detector_builder_t::detector_type;
     using transform3_t = typename detector_t::transform3_type;
@@ -990,7 +1010,7 @@ inline void add_connector_portals(
 template <typename detector_t>
 inline void add_beampipe_portals(
     volume_builder_interface<detector_t> *beampipe_builder,
-    toy_det_config<typename detector_t::scalar_type> &cfg) {
+    toy_det_config &cfg) {
 
     using scalar_t = typename detector_t::scalar_type;
     using transform3_t = typename detector_t::transform3_type;
@@ -1048,11 +1068,12 @@ inline void add_beampipe_portals(
 /// @param cfg config for the toy detector
 /// @param neg_edc_lay_sizes indices and z-extent of the endcap volumes of one
 ///                          detector side (positive or negative)
-template <typename detector_t, typename scalar_t, typename layer_size_cont_t>
+template <typename detector_t, typename layer_size_cont_t>
 inline void add_beampipe_portals(
-    volume_builder_interface<detector_t> *beampipe_builder,
-    toy_det_config<scalar_t> &cfg, const layer_size_cont_t &edc_lay_sizes) {
+    volume_builder_interface<detector_t> *beampipe_builder, toy_det_config &cfg,
+    const layer_size_cont_t &edc_lay_sizes) {
 
+    using scalar_t = typename detector_t::scalar_type;
     using transform3_t = typename detector_t::transform3_type;
     using point3_t = typename detector_t::point3_type;
     using nav_link_t = typename detector_t::surface_type::navigation_link;
@@ -1113,7 +1134,7 @@ inline void add_beampipe_portals(
 /// @returns a complete detector object
 template <typename scalar_t = detray::scalar>
 inline auto build_toy_detector(vecmem::memory_resource &resource,
-                               toy_det_config<scalar_t> cfg = {}) {
+                               toy_det_config cfg = {}) {
 
     using builder_t = detector_builder<toy_metadata, volume_builder>;
     using detector_t = typename builder_t::detector_type;

--- a/utils/include/detray/detectors/create_wire_chamber.hpp
+++ b/utils/include/detray/detectors/create_wire_chamber.hpp
@@ -243,6 +243,17 @@ void create_cyl_volume(const config_t & /*cfg*/, detector_t &det,
 
 }  // namespace detail
 
+/// Print the wire chamber configuration
+inline std::ostream &operator<<(std::ostream &out,
+                                const wire_chamber_config &cfg) {
+    out << "\nWire Chamber\n"
+        << "----------------------------\n"
+        << "  No. layers            : " << cfg.n_layers() << "\n"
+        << "  Half length z         : " << cfg.half_z() << " [mm]\n";
+
+    return out;
+}
+
 inline auto create_wire_chamber(vecmem::memory_resource &resource,
                                 const wire_chamber_config &cfg) {
 

--- a/utils/include/detray/simulation/event_generator/random_track_generator.hpp
+++ b/utils/include/detray/simulation/event_generator/random_track_generator.hpp
@@ -12,6 +12,7 @@
 #include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/simulation/event_generator/random_track_generator_config.hpp"
 #include "detray/utils/ranges/ranges.hpp"
 
 // System include(s)
@@ -21,69 +22,6 @@
 #include <random>
 
 namespace detray {
-
-/// Wrapper for CPU random number generatrion for the @c random_track_generator
-template <typename scalar_t = scalar,
-          typename distribution_t = std::uniform_real_distribution<scalar_t>,
-          typename engine_t = std::mt19937_64>
-struct random_numbers {
-
-    using distribution_type = distribution_t;
-    using engine_type = engine_t;
-    using seed_type = typename engine_t::result_type;
-
-    std::seed_seq m_seeds;
-    engine_t m_engine;
-
-    /// Default seed
-    DETRAY_HOST
-    random_numbers()
-        : m_seeds{random_numbers::default_seed()}, m_engine{m_seeds} {}
-
-    /// Different seed @param s for every instance
-    DETRAY_HOST
-    random_numbers(seed_type s) : m_seeds{s}, m_engine{m_seeds} {}
-
-    /// More entropy in seeds from collection @param s
-    DETRAY_HOST
-    random_numbers(const std::vector<seed_type>& s)
-        : m_seeds{s.begin(), s.end()}, m_engine{m_seeds} {}
-
-    /// Copy constructor
-    DETRAY_HOST
-    random_numbers(random_numbers&& other)
-        : m_engine(std::move(other.m_engine)) {}
-
-    /// Generate random numbers in a given range
-    DETRAY_HOST auto operator()(const std::array<scalar_t, 2> range = {
-                                    -std::numeric_limits<scalar_t>::max(),
-                                    std::numeric_limits<scalar_t>::max()}) {
-        const scalar_t min{range[0]}, max{range[1]};
-        assert(min <= max);
-
-        // Uniform
-        if constexpr (std::is_same_v<
-                          distribution_t,
-                          std::uniform_real_distribution<scalar_t>>) {
-            return distribution_t(min, max)(m_engine);
-
-            // Normal
-        } else if constexpr (std::is_same_v<
-                                 distribution_t,
-                                 std::normal_distribution<scalar_t>>) {
-            scalar_t mu{min + 0.5f * (max - min)};
-            return distribution_t(mu, 0.5f / 3.0f * (max - min))(m_engine);
-        }
-    }
-
-    /// Explicit normal distribution around a @param mean and @param stddev
-    DETRAY_HOST auto normal(const scalar_t mean, const scalar_t stddev) {
-        return std::normal_distribution<scalar_t>(mean, stddev)(m_engine);
-    }
-
-    /// Get the default seed of the engine
-    static constexpr seed_type default_seed() { return engine_t::default_seed; }
-};
 
 /// @brief Generates track states with random momentum directions.
 ///
@@ -110,186 +48,7 @@ class random_track_generator
     using track_type = track_t;
 
     /// Configure how tracks are generated
-    struct configuration {
-
-        using seed_t = typename generator_t::seed_type;
-
-        /// Gaussian vertex smearing
-        bool m_do_vtx_smearing = true;
-
-        /// Monte-Carlo seed
-        seed_t m_seed{generator_t::default_seed()};
-
-        /// How many tracks will be generated
-        std::size_t m_n_tracks{10u};
-
-        /// Range for phi [-pi, pi) and theta [0, pi)
-        std::array<scalar, 2> m_phi_range{-constant<scalar>::pi,
-                                          constant<scalar>::pi};
-        std::array<scalar, 2> m_theta_range{0.f, constant<scalar>::pi};
-
-        /// Momentum range
-        std::array<scalar, 2> m_mom_range{1.f * unit<scalar>::GeV,
-                                          1.f * unit<scalar>::GeV};
-        /// Whether to interpret the momentum @c m_mom_range as p_T
-        bool m_is_pT{false};
-
-        /// Track origin
-        point3 m_origin{0.f, 0.f, 0.f}, m_origin_stddev{0.f, 0.f, 0.f};
-
-        /// Time parameter and charge of the track
-        scalar m_time{0.f * unit<scalar>::us}, m_charge{-1.f * unit<scalar>::e};
-
-        /// Setters
-        /// @{
-        DETRAY_HOST_DEVICE configuration& seed(const seed_t s) {
-            m_seed = s;
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& do_vertex_smearing(bool b) {
-            m_do_vtx_smearing = b;
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& n_tracks(std::size_t n) {
-            assert(n > 0);
-            m_n_tracks = n;
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& phi_range(const scalar low,
-                                                    const scalar high) {
-            auto min_phi{
-                std::clamp(low, -constant<scalar>::pi, constant<scalar>::pi)};
-            auto max_phi{
-                std::clamp(high, -constant<scalar>::pi, constant<scalar>::pi)};
-
-            assert(min_phi <= max_phi);
-
-            m_phi_range = {min_phi, max_phi};
-            return *this;
-        }
-        template <typename scalar_t>
-        DETRAY_HOST_DEVICE configuration& phi_range(std::array<scalar_t, 2> r) {
-            phi_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& theta_range(scalar low, scalar high) {
-            auto min_theta{std::clamp(low, scalar{0.f}, constant<scalar>::pi)};
-            auto max_theta{std::clamp(high, scalar{0.f}, constant<scalar>::pi)};
-
-            assert(min_theta <= max_theta);
-
-            m_theta_range = {min_theta, max_theta};
-            return *this;
-        }
-        template <typename scalar_t>
-        DETRAY_HOST_DEVICE configuration& theta_range(
-            std::array<scalar_t, 2> r) {
-            theta_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& eta_range(scalar low, scalar high) {
-            // This value is more or less random
-            constexpr auto num_max{0.001f * std::numeric_limits<scalar>::max()};
-            auto min_eta{low > -num_max ? low : -num_max};
-            auto max_eta{high < num_max ? high : num_max};
-
-            assert(min_eta <= max_eta);
-
-            auto get_theta = [](const scalar eta) {
-                return 2.f * math::atan(math::exp(-eta));
-            };
-
-            theta_range(get_theta(max_eta), get_theta(min_eta));
-            return *this;
-        }
-        template <typename scalar_t>
-        DETRAY_HOST_DEVICE configuration& eta_range(std::array<scalar_t, 2> r) {
-            eta_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& mom_range(scalar low, scalar high) {
-            m_is_pT = false;
-            assert(low >= 0.f);
-            assert(low <= high);
-            m_mom_range = {low, high};
-            return *this;
-        }
-        template <typename scalar_t>
-        DETRAY_HOST_DEVICE configuration& mom_range(std::array<scalar_t, 2> r) {
-            mom_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& pT_range(scalar low, scalar high) {
-            m_is_pT = true;
-            assert(low >= 0.f);
-            assert(low <= high);
-            m_mom_range = {low, high};
-            return *this;
-        }
-        template <typename scalar_t>
-        DETRAY_HOST_DEVICE configuration& pT_range(std::array<scalar_t, 2> r) {
-            pT_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& p_tot(scalar p) {
-            mom_range(p, p);
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& p_T(scalar p) {
-            pT_range(p, p);
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& origin(point3 ori) {
-            m_origin = ori;
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& origin_stddev(point3 stddev) {
-            m_origin_stddev = stddev;
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& time(scalar t) {
-            assert(t >= 0.f);
-            m_time = t;
-            return *this;
-        }
-        DETRAY_HOST_DEVICE configuration& charge(scalar q) {
-            m_charge = q;
-            return *this;
-        }
-        /// @}
-
-        /// Getters
-        /// @{
-        DETRAY_HOST_DEVICE constexpr seed_t seed() const { return m_seed; }
-        DETRAY_HOST_DEVICE constexpr bool do_vertex_smearing() const {
-            return m_do_vtx_smearing;
-        }
-        DETRAY_HOST_DEVICE constexpr std::size_t n_tracks() const {
-            return m_n_tracks;
-        }
-        DETRAY_HOST_DEVICE constexpr const std::array<scalar, 2>& phi_range()
-            const {
-            return m_phi_range;
-        }
-        DETRAY_HOST_DEVICE constexpr const std::array<scalar, 2>& theta_range()
-            const {
-            return m_theta_range;
-        }
-        DETRAY_HOST_DEVICE constexpr const std::array<scalar, 2>& mom_range()
-            const {
-            return m_mom_range;
-        }
-        DETRAY_HOST_DEVICE constexpr const point3& origin() const {
-            return m_origin;
-        }
-        DETRAY_HOST_DEVICE constexpr const point3& origin_stddev() const {
-            return m_origin_stddev;
-        }
-        DETRAY_HOST_DEVICE constexpr bool is_pT() const { return m_is_pT; }
-        DETRAY_HOST_DEVICE constexpr scalar time() const { return m_time; }
-        DETRAY_HOST_DEVICE constexpr scalar charge() const { return m_charge; }
-        /// @}
-    };
+    using configuration = random_track_generator_config;
 
     private:
     /// @brief Nested iterator type that generates track states.
@@ -330,15 +89,15 @@ class random_track_generator
         DETRAY_HOST_DEVICE
         track_t operator*() const {
 
+            const auto& ori = m_cfg.origin();
+            const auto& ori_stddev = m_cfg.origin_stddev();
+
             const point3 vtx =
                 m_cfg.do_vertex_smearing()
-                    ? point3{m_rnd_numbers.normal(m_cfg.origin()[0],
-                                                  m_cfg.origin_stddev()[0]),
-                             m_rnd_numbers.normal(m_cfg.origin()[1],
-                                                  m_cfg.origin_stddev()[1]),
-                             m_rnd_numbers.normal(m_cfg.origin()[2],
-                                                  m_cfg.origin_stddev()[2])}
-                    : m_cfg.origin();
+                    ? point3{m_rnd_numbers.normal(ori[0], ori_stddev[0]),
+                             m_rnd_numbers.normal(ori[1], ori_stddev[1]),
+                             m_rnd_numbers.normal(ori[2], ori_stddev[2])}
+                    : point3{ori[0], ori[1], ori[2]};
 
             scalar p_mag{m_rnd_numbers(m_cfg.mom_range())};
             scalar phi{m_rnd_numbers(m_cfg.phi_range())};

--- a/utils/include/detray/simulation/event_generator/random_track_generator_config.hpp
+++ b/utils/include/detray/simulation/event_generator/random_track_generator_config.hpp
@@ -1,0 +1,330 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/algebra.hpp"
+#include "detray/definitions/detail/math.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
+
+// System include(s)
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <ostream>
+#include <random>
+
+namespace detray {
+
+/// Wrapper for CPU random number generatrion for the @c random_track_generator
+template <typename scalar_t = scalar,
+          typename distribution_t = std::uniform_real_distribution<scalar_t>,
+          typename engine_t = std::mt19937_64>
+struct random_numbers {
+
+    using distribution_type = distribution_t;
+    using engine_type = engine_t;
+    using seed_type = typename engine_t::result_type;
+
+    std::seed_seq m_seeds;
+    engine_t m_engine;
+
+    /// Default seed
+    DETRAY_HOST
+    random_numbers()
+        : m_seeds{random_numbers::default_seed()}, m_engine{m_seeds} {}
+
+    /// Different seed @param s for every instance
+    DETRAY_HOST
+    random_numbers(seed_type s) : m_seeds{s}, m_engine{m_seeds} {}
+
+    /// More entropy in seeds from collection @param s
+    DETRAY_HOST
+    random_numbers(const std::vector<seed_type>& s)
+        : m_seeds{s.begin(), s.end()}, m_engine{m_seeds} {}
+
+    /// Copy constructor
+    DETRAY_HOST
+    random_numbers(random_numbers&& other)
+        : m_engine(std::move(other.m_engine)) {}
+
+    /// Generate random numbers in a given range
+    DETRAY_HOST auto operator()(const std::array<scalar_t, 2> range = {
+                                    -std::numeric_limits<scalar_t>::max(),
+                                    std::numeric_limits<scalar_t>::max()}) {
+        const scalar_t min{range[0]}, max{range[1]};
+        assert(min <= max);
+
+        // Uniform
+        if constexpr (std::is_same_v<
+                          distribution_t,
+                          std::uniform_real_distribution<scalar_t>>) {
+            return distribution_t(min, max)(m_engine);
+
+            // Normal
+        } else if constexpr (std::is_same_v<
+                                 distribution_t,
+                                 std::normal_distribution<scalar_t>>) {
+            scalar_t mu{min + 0.5f * (max - min)};
+            return distribution_t(mu, 0.5f / 3.0f * (max - min))(m_engine);
+        }
+    }
+
+    /// Explicit normal distribution around a @param mean and @param stddev
+    DETRAY_HOST auto normal(const scalar_t mean, const scalar_t stddev) {
+        return std::normal_distribution<scalar_t>(mean, stddev)(m_engine);
+    }
+
+    /// Get the default seed of the engine
+    static constexpr seed_type default_seed() { return engine_t::default_seed; }
+};
+
+/// Configuration for the random track generator
+struct random_track_generator_config {
+
+    using seed_t = std::uint64_t;
+
+    /// Gaussian vertex smearing
+    bool m_do_vtx_smearing = false;
+
+    /// Monte-Carlo seed
+    seed_t m_seed{random_numbers<>::default_seed()};
+
+    /// How many tracks will be generated
+    std::size_t m_n_tracks{10u};
+
+    /// Range for phi [-pi, pi) and theta [0, pi)
+    std::array<scalar, 2> m_phi_range{-constant<scalar>::pi,
+                                      constant<scalar>::pi};
+    std::array<scalar, 2> m_theta_range{0.f, constant<scalar>::pi};
+
+    /// Momentum range
+    std::array<scalar, 2> m_mom_range{1.f * unit<scalar>::GeV,
+                                      1.f * unit<scalar>::GeV};
+    /// Whether to interpret the momentum @c m_mom_range as p_T
+    bool m_is_pT{false};
+
+    /// Track origin
+    std::array<scalar, 3> m_origin{0.f, 0.f, 0.f},
+        m_origin_stddev{0.f, 0.f, 0.f};
+
+    /// Time parameter and charge of the track
+    scalar m_time{0.f * unit<scalar>::us}, m_charge{-1.f * unit<scalar>::e};
+
+    /// Setters
+    /// @{
+    DETRAY_HOST_DEVICE random_track_generator_config& seed(const seed_t s) {
+        m_seed = s;
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& do_vertex_smearing(
+        bool b) {
+        m_do_vtx_smearing = b;
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& n_tracks(std::size_t n) {
+        assert(n > 0);
+        m_n_tracks = n;
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& phi_range(
+        const scalar low, const scalar high) {
+        auto min_phi{
+            std::clamp(low, -constant<scalar>::pi, constant<scalar>::pi)};
+        auto max_phi{
+            std::clamp(high, -constant<scalar>::pi, constant<scalar>::pi)};
+
+        assert(min_phi <= max_phi);
+
+        m_phi_range = {min_phi, max_phi};
+        return *this;
+    }
+    template <typename scalar_t>
+    DETRAY_HOST_DEVICE random_track_generator_config& phi_range(
+        std::array<scalar_t, 2> r) {
+        phi_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& theta_range(scalar low,
+                                                                  scalar high) {
+        auto min_theta{std::clamp(low, scalar{0.f}, constant<scalar>::pi)};
+        auto max_theta{std::clamp(high, scalar{0.f}, constant<scalar>::pi)};
+
+        assert(min_theta <= max_theta);
+
+        m_theta_range = {min_theta, max_theta};
+        return *this;
+    }
+    template <typename scalar_t>
+    DETRAY_HOST_DEVICE random_track_generator_config& theta_range(
+        std::array<scalar_t, 2> r) {
+        theta_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& eta_range(scalar low,
+                                                                scalar high) {
+        // This value is more or less random
+        constexpr auto num_max{0.001f * std::numeric_limits<scalar>::max()};
+        auto min_eta{low > -num_max ? low : -num_max};
+        auto max_eta{high < num_max ? high : num_max};
+
+        assert(min_eta <= max_eta);
+
+        auto get_theta = [](const scalar eta) {
+            return 2.f * math::atan(math::exp(-eta));
+        };
+
+        theta_range(get_theta(max_eta), get_theta(min_eta));
+        return *this;
+    }
+    template <typename scalar_t>
+    DETRAY_HOST_DEVICE random_track_generator_config& eta_range(
+        std::array<scalar_t, 2> r) {
+        eta_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& mom_range(scalar low,
+                                                                scalar high) {
+        m_is_pT = false;
+        assert(low >= 0.f);
+        assert(low <= high);
+        m_mom_range = {low, high};
+        return *this;
+    }
+    template <typename scalar_t>
+    DETRAY_HOST_DEVICE random_track_generator_config& mom_range(
+        std::array<scalar_t, 2> r) {
+        mom_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& pT_range(scalar low,
+                                                               scalar high) {
+        m_is_pT = true;
+        assert(low >= 0.f);
+        assert(low <= high);
+        m_mom_range = {low, high};
+        return *this;
+    }
+    template <typename scalar_t>
+    DETRAY_HOST_DEVICE random_track_generator_config& pT_range(
+        std::array<scalar_t, 2> r) {
+        pT_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& p_tot(scalar p) {
+        mom_range(p, p);
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& p_T(scalar p) {
+        pT_range(p, p);
+        return *this;
+    }
+    template <typename point3_t = std::array<scalar, 3>>
+    DETRAY_HOST_DEVICE random_track_generator_config& origin(point3_t ori) {
+        m_origin = {ori[0], ori[1], ori[2]};
+        return *this;
+    }
+    template <typename point3_t = std::array<scalar, 3>>
+    DETRAY_HOST_DEVICE random_track_generator_config& origin_stddev(
+        point3_t stddev) {
+        m_do_vtx_smearing = true;
+        m_origin_stddev = {stddev[0], stddev[1], stddev[2]};
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& time(scalar t) {
+        assert(t >= 0.f);
+        m_time = t;
+        return *this;
+    }
+    DETRAY_HOST_DEVICE random_track_generator_config& charge(scalar q) {
+        m_charge = q;
+        return *this;
+    }
+    /// @}
+
+    /// Getters
+    /// @{
+    DETRAY_HOST_DEVICE constexpr seed_t seed() const { return m_seed; }
+    DETRAY_HOST_DEVICE constexpr bool do_vertex_smearing() const {
+        return m_do_vtx_smearing;
+    }
+    DETRAY_HOST_DEVICE constexpr std::size_t n_tracks() const {
+        return m_n_tracks;
+    }
+    DETRAY_HOST_DEVICE constexpr const std::array<scalar, 2>& phi_range()
+        const {
+        return m_phi_range;
+    }
+    DETRAY_HOST_DEVICE constexpr const std::array<scalar, 2>& theta_range()
+        const {
+        return m_theta_range;
+    }
+    DETRAY_HOST_DEVICE constexpr const std::array<scalar, 2>& mom_range()
+        const {
+        return m_mom_range;
+    }
+    DETRAY_HOST_DEVICE constexpr const auto& origin() const { return m_origin; }
+    DETRAY_HOST_DEVICE constexpr const auto& origin_stddev() const {
+        return m_origin_stddev;
+    }
+    DETRAY_HOST_DEVICE constexpr bool is_pT() const { return m_is_pT; }
+    DETRAY_HOST_DEVICE constexpr scalar time() const { return m_time; }
+    DETRAY_HOST_DEVICE constexpr scalar charge() const { return m_charge; }
+    /// @}
+};
+
+/// Print the random track generator configuration
+DETRAY_HOST
+inline std::ostream& operator<<(std::ostream& out,
+                                const random_track_generator_config& cfg) {
+    const auto& ori = cfg.origin();
+    const auto& mom_range = cfg.mom_range();
+    const auto& phi_range = cfg.phi_range();
+    const auto& theta_range = cfg.theta_range();
+
+    // General
+    out << "\nRandom track generator\n"
+        << "----------------------------\n"
+        << "  No. tracks            : " << cfg.n_tracks() << "\n"
+        << "  Charge                : "
+        << cfg.charge() / detray::unit<scalar>::e << " [e]\n";
+
+    // Momentum and direction
+    if (cfg.is_pT()) {
+        out << "  Transverse mom.       : [";
+    } else {
+        out << "  Momentum              : [";
+    }
+    out << mom_range[0] / detray::unit<scalar>::GeV << ", "
+        << mom_range[1] / detray::unit<scalar>::GeV << ") [GeV]\n"
+        << "  Phi range             : ["
+        << phi_range[0] / detray::unit<scalar>::rad << ", "
+        << phi_range[1] / detray::unit<scalar>::rad << ") [rad]\n"
+        << "  Theta range           : ["
+        << theta_range[0] / detray::unit<scalar>::rad << ", "
+        << theta_range[1] / detray::unit<scalar>::rad << ") [rad]\n"
+        << "  Origin                : [" << ori[0] / detray::unit<scalar>::mm
+        << ", " << ori[1] / detray::unit<scalar>::mm << ", "
+        << ori[2] / detray::unit<scalar>::mm << "] [mm]\n"
+        << "  Do vertex smearing    : " << std::boolalpha
+        << cfg.do_vertex_smearing() << "\n"
+        << std::noboolalpha;
+
+    if (cfg.do_vertex_smearing()) {
+        const auto& ori_stddev = cfg.origin_stddev();
+        out << "  Origin stddev         : ["
+            << ori_stddev[0] / detray::unit<scalar>::mm << ", "
+            << ori_stddev[1] / detray::unit<scalar>::mm << ", "
+            << ori_stddev[2] / detray::unit<scalar>::mm << "] [mm]\n";
+    }
+
+    return out;
+}
+
+}  // namespace detray

--- a/utils/include/detray/simulation/event_generator/uniform_track_generator_config.hpp
+++ b/utils/include/detray/simulation/event_generator/uniform_track_generator_config.hpp
@@ -1,0 +1,239 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/algebra.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
+
+// System include(s)
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <ostream>
+
+namespace detray {
+
+/// Configuration for the uniform track generator
+struct uniform_track_generator_config {
+    /// Ensure same angle space as random track generator
+    static constexpr scalar k_max_pi{constant<scalar>::pi -
+                                     std::numeric_limits<scalar>::epsilon()};
+
+    /// Range for phi [-pi, pi) and theta [0, pi)
+    std::array<scalar, 2> m_phi_range{-constant<scalar>::pi, k_max_pi};
+    std::array<scalar, 2> m_theta_range{0.f, k_max_pi};
+    std::array<scalar, 2> m_eta_range{-5.f, 5.f};
+
+    /// Angular step size
+    std::size_t m_phi_steps{50u};
+    std::size_t m_theta_steps{50u};
+
+    /// Do uniform eta steps instead of uniform theta steps
+    /// (use same number of steps and range)
+    bool m_uniform_eta{false};
+
+    /// Track origin
+    std::array<scalar, 3> m_origin{0.f, 0.f, 0.f};
+
+    /// Magnitude of momentum: Default is one to keep directions normalized
+    /// if no momentum information is needed (e.g. for a ray)
+    scalar m_p_mag{1.f * unit<scalar>::GeV};
+    /// Whether to interpret the momentum @c m_p_mag as p_T
+    bool m_is_pT{false};
+
+    /// Time parameter and charge of the track
+    scalar m_time{0.f * unit<scalar>::us};
+    scalar m_charge{-1.f * unit<scalar>::e};
+
+    /// Setters
+    /// @{
+    DETRAY_HOST_DEVICE uniform_track_generator_config& phi_range(scalar low,
+                                                                 scalar high) {
+        auto min_phi{std::clamp(low, -constant<scalar>::pi, k_max_pi)};
+        auto max_phi{std::clamp(high, -constant<scalar>::pi, k_max_pi)};
+
+        assert(min_phi <= max_phi);
+
+        m_phi_range = {min_phi, max_phi};
+        return *this;
+    }
+    template <typename scalar_t>
+    DETRAY_HOST_DEVICE uniform_track_generator_config& phi_range(
+        std::array<scalar_t, 2> r) {
+        phi_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        return *this;
+    }
+    DETRAY_HOST_DEVICE uniform_track_generator_config& theta_range(
+        scalar low, scalar high) {
+        auto min_theta{std::clamp(low, scalar{0.f}, k_max_pi)};
+        auto max_theta{std::clamp(high, scalar{0.f}, k_max_pi)};
+
+        assert(min_theta <= max_theta);
+
+        m_theta_range = {min_theta, max_theta};
+        m_uniform_eta = false;
+        return *this;
+    }
+    template <typename scalar_t>
+    DETRAY_HOST_DEVICE uniform_track_generator_config& theta_range(
+        std::array<scalar_t, 2> r) {
+        theta_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        return *this;
+    }
+    DETRAY_HOST_DEVICE uniform_track_generator_config& eta_range(scalar low,
+                                                                 scalar high) {
+        // This value is more or less random
+        constexpr auto num_max{0.001f * std::numeric_limits<scalar>::max()};
+        auto min_eta{low > -num_max ? low : -num_max};
+        auto max_eta{high < num_max ? high : num_max};
+
+        assert(min_eta <= max_eta);
+
+        m_eta_range = {min_eta, max_eta};
+        m_uniform_eta = true;
+        return *this;
+    }
+    template <typename scalar_t>
+    DETRAY_HOST_DEVICE uniform_track_generator_config& eta_range(
+        std::array<scalar_t, 2> r) {
+        eta_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        return *this;
+    }
+    DETRAY_HOST_DEVICE uniform_track_generator_config& phi_steps(
+        std::size_t n) {
+        assert(n > 0);
+        m_phi_steps = n;
+        return *this;
+    }
+    DETRAY_HOST_DEVICE uniform_track_generator_config& theta_steps(
+        std::size_t n) {
+        assert(n > 0);
+        m_theta_steps = n;
+        m_uniform_eta = false;
+        return *this;
+    }
+    DETRAY_HOST_DEVICE uniform_track_generator_config& eta_steps(
+        std::size_t n) {
+        assert(n > 0);
+        m_theta_steps = n;
+        m_uniform_eta = true;
+        return *this;
+    }
+    DETRAY_HOST_DEVICE uniform_track_generator_config& uniform_eta(bool b) {
+        m_uniform_eta = b;
+        return *this;
+    }
+    template <typename point3_t = std::array<scalar, 3>>
+    DETRAY_HOST_DEVICE uniform_track_generator_config& origin(point3_t ori) {
+        m_origin = {ori[0], ori[1], ori[2]};
+        return *this;
+    }
+    DETRAY_HOST_DEVICE uniform_track_generator_config& p_tot(scalar p) {
+        assert(p > 0.f);
+        m_is_pT = false;
+        m_p_mag = p;
+        return *this;
+    }
+    DETRAY_HOST_DEVICE uniform_track_generator_config& p_T(scalar p) {
+        assert(p > 0.f);
+        m_is_pT = true;
+        m_p_mag = p;
+        return *this;
+    }
+    DETRAY_HOST_DEVICE uniform_track_generator_config& time(scalar t) {
+        m_time = t;
+        return *this;
+    }
+    DETRAY_HOST_DEVICE uniform_track_generator_config& charge(scalar q) {
+        m_charge = q;
+        return *this;
+    }
+    /// @}
+
+    /// Getters
+    /// @{
+    DETRAY_HOST_DEVICE constexpr std::array<scalar, 2> phi_range() const {
+        return m_phi_range;
+    }
+    DETRAY_HOST_DEVICE constexpr std::array<scalar, 2> theta_range() const {
+        return m_theta_range;
+    }
+    DETRAY_HOST_DEVICE constexpr std::array<scalar, 2> eta_range() const {
+        return m_eta_range;
+    }
+    DETRAY_HOST_DEVICE constexpr std::size_t phi_steps() const {
+        return m_phi_steps;
+    }
+    DETRAY_HOST_DEVICE constexpr std::size_t theta_steps() const {
+        return m_theta_steps;
+    }
+    DETRAY_HOST_DEVICE constexpr std::size_t eta_steps() const {
+        return m_theta_steps;
+    }
+    DETRAY_HOST_DEVICE constexpr bool uniform_eta() const {
+        return m_uniform_eta;
+    }
+    DETRAY_HOST_DEVICE constexpr const auto& origin() const { return m_origin; }
+    DETRAY_HOST_DEVICE constexpr bool is_pT() const { return m_is_pT; }
+    DETRAY_HOST_DEVICE constexpr scalar time() const { return m_time; }
+    DETRAY_HOST_DEVICE constexpr scalar charge() const { return m_charge; }
+    /// @}
+};
+
+/// Print the unifrom track generator configuration
+DETRAY_HOST
+inline std::ostream& operator<<(std::ostream& out,
+                                const uniform_track_generator_config& cfg) {
+    const auto& ori = cfg.origin();
+    const auto& phi_range = cfg.phi_range();
+    const std::size_t n_tracks{cfg.phi_steps() * cfg.theta_steps()};
+
+    // General
+    out << "\nUnform track generator\n"
+        << "----------------------------\n"
+        << "  No. tracks            : " << n_tracks << "\n"
+        << "    -> phi steps        : " << cfg.phi_steps() << "\n"
+        << "    -> theta/eta steps  : " << cfg.theta_steps() << "\n"
+        << "  Charge                : "
+        << cfg.charge() / detray::unit<scalar>::e << " [e]\n";
+
+    // Momentum
+    if (cfg.is_pT()) {
+        out << "  Transverse mom.       : "
+            << cfg.m_p_mag / detray::unit<scalar>::GeV << " [GeV]\n";
+    } else {
+        out << "  Momentum              : "
+            << cfg.m_p_mag / detray::unit<scalar>::GeV << " [GeV]\n";
+    }
+
+    // Direction
+    out << "  Phi range             : ["
+        << phi_range[0] / detray::unit<scalar>::rad << ", "
+        << phi_range[1] / detray::unit<scalar>::rad << ") [rad]\n";
+    if (cfg.uniform_eta()) {
+        const auto& eta_range = cfg.eta_range();
+        out << "  Eta range             : [" << eta_range[0] << ", "
+            << eta_range[1] << "] [rad]\n";
+    } else {
+        const auto& theta_range = cfg.theta_range();
+        out << "  Theta range           : ["
+            << theta_range[0] / detray::unit<scalar>::rad << ", "
+            << theta_range[1] / detray::unit<scalar>::rad << ") [rad]\n";
+    }
+
+    // Origin
+    out << "  Origin                : [" << ori[0] / detray::unit<scalar>::mm
+        << ", " << ori[1] / detray::unit<scalar>::mm << ", "
+        << ori[2] / detray::unit<scalar>::mm << "] [mm]\n";
+
+    return out;
+}
+
+}  // namespace detray


### PR DESCRIPTION
Remove the templating on the configuration structures and set the scalar types to ```float```. Also provides printouts for the configuration. Adds a centralized options parsing to the detray tools, so that the boost options code does not need to be repeated in new executables. For this, the track generator configs had to be moved out of their parent classes to avoid templating them. The options parsing is calling ```add_options``` (adds the options to boost description), ```configure_options``` (checks the options and puts them in the configs) and ```print_options``` for every configuration that is given to it. All of these functions exist as template specializations, so that they can be forward declared.

Also fixes a bug in the file handle, where it would not respect the parent path when writing files without replacing them.

The changed floating point precision in the propagation config seem to have made the wire chamber test fail in one track each, so I tweaked the parameters a little