### PR TITLE
ref: Allow parameter transport to any surface with material

### DIFF
--- a/core/include/detray/propagator/actors/parameter_resetter.hpp
+++ b/core/include/detray/propagator/actors/parameter_resetter.hpp
@@ -66,7 +66,8 @@ struct parameter_resetter : actor {
         auto& stepping = propagation._stepping;
 
         // Do covariance transport when the track is on surface
-        if (not navigation.is_on_module()) {
+        if (!(navigation.is_on_sensitive() ||
+              navigation.encountered_sf_material())) {
             return;
         }
 

--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -124,7 +124,8 @@ struct parameter_transporter : actor {
         const auto& navigation = propagation._navigation;
 
         // Do covariance transport when the track is on surface
-        if (not navigation.is_on_module()) {
+        if (!(navigation.is_on_sensitive() ||
+              navigation.encountered_sf_material())) {
             return;
         }
 

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
@@ -156,7 +156,9 @@ struct bin_association_getter {
             // loop over
             constexpr bool is_cyl{
                 std::is_same_v<typename accel_t::local_frame_type,
-                               detray::cylindrical2D<algebra_t>>};
+                               detray::cylindrical2D<algebra_t>> ||
+                std::is_same_v<typename accel_t::local_frame_type,
+                               detray::concentric_cylindrical2D<algebra_t>>};
             if constexpr (is_cyl) {
                 edges0.swap(edges1);
             }


### PR DESCRIPTION
Trigger parameter transport to sensitive surfaces and any other surface that carries material. Also fixes a bug in the svg grid display that came up