### PR TITLE
ref: Remove the incidence angle from the intersection

### DIFF
--- a/core/include/detray/geometry/tracking_surface.hpp
+++ b/core/include/detray/geometry/tracking_surface.hpp
@@ -211,6 +211,7 @@ class tracking_surface {
 
     /// @returns the cosine of the incidence angle given a local/bound position
     /// @param p and a global direction @param dir
+    /// @note The direction has to be normalized
     template <typename point_t = point2_type,
               std::enable_if_t<std::is_same_v<point_t, point3_type> or
                                    std::is_same_v<point_t, point2_type>,

--- a/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
@@ -164,28 +164,22 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
                 sfi.path = s;
                 const auto p3 = h.pos(s);
                 sfi.local = mask.to_local_frame(trf, p3);
-                sfi.cos_incidence_angle = vector::dot(
+                const scalar_type cos_incidence_angle = vector::dot(
                     mask.local_frame().normal(trf, sfi.local), h.dir(s));
 
                 scalar_type tol{mask_tolerance[1]};
                 if (detail::is_invalid_value(tol)) {
                     // Due to floating point errors this can be negative if cos
                     // ~ 1
-                    const scalar_type sin_inc2{
-                        math::abs(1.f - sfi.cos_incidence_angle *
-                                            sfi.cos_incidence_angle)};
+                    const scalar_type sin_inc2{math::fabs(
+                        1.f - cos_incidence_angle * cos_incidence_angle)};
 
-                    tol = math::abs((s - s_prev) * math::sqrt(sin_inc2));
+                    tol = math::fabs((s - s_prev) * math::sqrt(sin_inc2));
                 }
                 sfi.status = mask.is_inside(sfi.local, tol);
-
-                // Compute some additional information if the intersection is
-                // valid
-                if (sfi.status) {
-                    sfi.sf_desc = sf_desc;
-                    sfi.direction = !math::signbit(s);
-                    sfi.volume_link = mask.volume_link();
-                }
+                sfi.sf_desc = sf_desc;
+                sfi.direction = !math::signbit(s);
+                sfi.volume_link = mask.volume_link();
             }
 
             return ret;

--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -153,24 +153,20 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
             // Build intersection struct from helix parameters
             sfi.path = s;
             sfi.local = mask.to_local_frame(trf, h.pos(s), h.dir(s));
-            sfi.cos_incidence_angle = vector::dot(
+            const scalar_type cos_incidence_angle = vector::dot(
                 mask.local_frame().normal(trf, sfi.local), h.dir(s));
             scalar_type tol{mask_tolerance[1]};
             if (detail::is_invalid_value(tol)) {
                 // Due to floating point errors this can be negative if cos ~ 1
-                const scalar_type sin_inc2{math::abs(
-                    1.f - sfi.cos_incidence_angle * sfi.cos_incidence_angle)};
+                const scalar_type sin_inc2{math::fabs(
+                    1.f - cos_incidence_angle * cos_incidence_angle)};
 
-                tol = math::abs((s - s_prev) * math::sqrt(sin_inc2));
+                tol = math::fabs((s - s_prev) * math::sqrt(sin_inc2));
             }
             sfi.status = mask.is_inside(sfi.local, tol);
-
-            // Compute some additional information if the intersection is valid
-            if (sfi.status) {
-                sfi.sf_desc = sf_desc;
-                sfi.direction = !math::signbit(s);
-                sfi.volume_link = mask.volume_link();
-            }
+            sfi.sf_desc = sf_desc;
+            sfi.direction = !math::signbit(s);
+            sfi.volume_link = mask.volume_link();
 
             return sfi;
         } else {

--- a/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
@@ -113,25 +113,21 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
             // Build intersection struct from helix parameters
             sfi.path = s;
             sfi.local = mask.to_local_frame(trf, h.pos(s), h.dir(s));
-            sfi.cos_incidence_angle = vector::dot(
+            const scalar_type cos_incidence_angle = vector::dot(
                 mask.local_frame().normal(trf, sfi.local), h.dir(s));
 
             scalar_type tol{mask_tolerance[1]};
             if (detail::is_invalid_value(tol)) {
                 // Due to floating point errors this can be negative if cos ~ 1
-                const scalar_type sin_inc2{math::abs(
-                    1.f - sfi.cos_incidence_angle * sfi.cos_incidence_angle)};
+                const scalar_type sin_inc2{math::fabs(
+                    1.f - cos_incidence_angle * cos_incidence_angle)};
 
-                tol = math::abs((s - s_prev) * math::sqrt(sin_inc2));
+                tol = math::fabs((s - s_prev) * math::sqrt(sin_inc2));
             }
             sfi.status = mask.is_inside(sfi.local, tol);
-
-            // Compute some additional information if the intersection is valid
-            if (sfi.status) {
-                sfi.sf_desc = sf_desc;
-                sfi.direction = !math::signbit(s);
-                sfi.volume_link = mask.volume_link();
-            }
+            sfi.sf_desc = sf_desc;
+            sfi.direction = !math::signbit(s);
+            sfi.volume_link = mask.volume_link();
 
             return sfi;
         } else {

--- a/core/include/detray/navigation/intersection/intersection.hpp
+++ b/core/include/detray/navigation/intersection/intersection.hpp
@@ -48,9 +48,6 @@ struct intersection2D {
     /// Distance between track and candidate
     scalar_type path = detail::invalid_value<T>();
 
-    /// Cosine of incidence angle
-    scalar_type cos_incidence_angle = detail::invalid_value<T>();
-
     /// Navigation information (next volume to go to)
     nav_link_t volume_link{detail::invalid_value<nav_link_t>()};
 

--- a/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
@@ -119,19 +119,9 @@ struct ray_concentric_cylinder_intersector {
                     math::max(mask_tolerance[0],
                               math::min(mask_tolerance[1],
                                         mask_tol_scalor * math::abs(is.path))));
-
-                // prepare some additional information in case the intersection
-                // is valid
-                if (is.status) {
-                    is.sf_desc = sf;
-                    is.direction = !detail::signbit(is.path);
-                    is.volume_link = mask.volume_link();
-
-                    // Get incidence angle
-                    const vector3_type normal = {math::cos(phi), math::sin(phi),
-                                                 0.f};
-                    is.cos_incidence_angle = vector::dot(rd, normal);
-                }
+                is.sf_desc = sf;
+                is.direction = !detail::signbit(is.path);
+                is.volume_link = mask.volume_link();
             }
         }
         return is;

--- a/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
@@ -195,18 +195,8 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, false> {
                 math::max(mask_tolerance[0],
                           math::min(mask_tolerance[1],
                                     mask_tol_scalor * math::fabs(is.path))));
-
-            // prepare some additional information in case the intersection
-            // is valid
-            if (is.status) {
-                is.direction = !detail::signbit(is.path);
-                is.volume_link = mask.volume_link();
-
-                // Get incidence angle
-                const vector3_type normal =
-                    mask.local_frame().normal(trf, is.local);
-                is.cos_incidence_angle = vector::dot(rd, normal);
-            }
+            is.direction = !detail::signbit(is.path);
+            is.volume_link = mask.volume_link();
         } else {
             is.status = false;
         }

--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -108,17 +108,9 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, false> {
                 math::max(mask_tolerance[0],
                           math::min(mask_tolerance[1],
                                     mask_tol_scalor * math::fabs(is.path))));
-
-            // prepare some additional information in case the intersection
-            // is valid
-            if (is.status) {
-                is.sf_desc = sf;
-                is.direction = !detail::signbit(is.path);
-                is.volume_link = mask.volume_link();
-
-                // Get incidence angle
-                is.cos_incidence_angle = math::fabs(zd);
-            }
+            is.sf_desc = sf;
+            is.direction = !detail::signbit(is.path);
+            is.volume_link = mask.volume_link();
         }
         return is;
     }

--- a/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
@@ -87,17 +87,9 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {
                                         math::min(mask_tolerance[1],
                                                   mask_tol_scalor *
                                                       math::fabs(is.path))));
-
-                // prepare some additional information in case the intersection
-                // is valid
-                if (is.status) {
-                    is.sf_desc = sf;
-                    is.direction = !detail::signbit(is.path);
-                    is.volume_link = mask.volume_link();
-
-                    // Get incidene angle
-                    is.cos_incidence_angle = math::fabs(denom);
-                }
+                is.sf_desc = sf;
+                is.direction = !detail::signbit(is.path);
+                is.volume_link = mask.volume_link();
             }
         } else {
             is.status = false;

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_intersector.hpp
@@ -181,11 +181,6 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, true> {
         is.direction = !math::signbit(is.path);
         is.volume_link = mask.volume_link();
 
-        // Get incidence angle
-        const scalar_type phi{is.local[0] / is.local[2]};
-        const vector3_type normal = {math::cos(phi), math::sin(phi), 0.f};
-        is.cos_incidence_angle = vector::dot(rd, normal);
-
         // Mask the values where the overstepping tolerance was not met
         is.status &= (is.path >= overstep_tol);
 

--- a/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
@@ -111,12 +111,8 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, true> {
         }
 
         is.sf_desc = sf;
-
         is.direction = math::signbit(is.path);
         is.volume_link = mask.volume_link();
-
-        // Get incidence angle
-        is.cos_incidence_angle = math::abs(zd);
 
         // Mask the values where the overstepping tolerance was not met
         is.status &= (is.path >= overstep_tol);

--- a/core/include/detray/navigation/intersection/soa/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_plane_intersector.hpp
@@ -99,9 +99,6 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, true> {
             is.direction = !math::signbit(is.path);
             is.volume_link = mask.volume_link();
 
-            // Get incidene angle
-            is.cos_incidence_angle = math::abs(denom);
-
             // Mask the values where the overstepping tolerance was not met
             is.status &= (is.path >= overstep_tol);
         } else {

--- a/core/include/detray/utils/root_finding.hpp
+++ b/core/include/detray/utils/root_finding.hpp
@@ -275,25 +275,21 @@ DETRAY_HOST_DEVICE inline void build_intersection(
     if (!detail::is_invalid_value(s)) {
         sfi.path = s;
         sfi.local = mask.to_local_frame(trf, traj.pos(s), traj.dir(s));
-        sfi.cos_incidence_angle =
+        const scalar_t cos_incidence_angle =
             vector::dot(mask.local_frame().normal(trf, sfi.local), traj.dir(s));
 
         scalar_t tol{mask_tolerance[1]};
         if (detail::is_invalid_value(tol)) {
             // Due to floating point errors this can be negative if cos ~ 1
-            const scalar_t sin_inc2{math::fabs(
-                1.f - sfi.cos_incidence_angle * sfi.cos_incidence_angle)};
+            const scalar_t sin_inc2{
+                math::fabs(1.f - cos_incidence_angle * cos_incidence_angle)};
 
             tol = math::fabs(ds * math::sqrt(sin_inc2));
         }
         sfi.status = mask.is_inside(sfi.local, tol);
-
-        // Compute some additional information if the intersection is valid
-        if (sfi.status) {
-            sfi.sf_desc = sf_desc;
-            sfi.direction = !math::signbit(s);
-            sfi.volume_link = mask.volume_link();
-        }
+        sfi.sf_desc = sf_desc;
+        sfi.direction = !math::signbit(s);
+        sfi.volume_link = mask.volume_link();
     } else {
         // Not a valid intersection
         sfi.status = false;

--- a/io/include/detray/io/csv/intersection2D.hpp
+++ b/io/include/detray/io/csv/intersection2D.hpp
@@ -36,14 +36,13 @@ struct intersection2D {
     double l0 = 0.;
     double l1 = 0.;
     double path = 0.;
-    double cos_theta = 0.;
     unsigned int volume_link = 0u;
     int direction = 0;
     int status = 0;
 
     DFE_NAMEDTUPLE(intersection2D, track_id, identifier, type, transform_index,
                    mask_id, mask_index, material_id, material_index, l0, l1,
-                   path, cos_theta, volume_link, direction, status);
+                   path, volume_link, direction, status);
 };
 
 /// Read intersections from csv file
@@ -90,8 +89,6 @@ inline auto read_intersection2D(const std::string &file_name) {
         inters.local = {static_cast<scalar_t>(inters_data.l0),
                         static_cast<scalar_t>(inters_data.l1), 0.f};
         inters.path = static_cast<scalar_t>(inters_data.path);
-        inters.cos_incidence_angle =
-            static_cast<scalar_t>(inters_data.cos_theta);
         inters.volume_link = static_cast<nav_link_t>(inters_data.volume_link);
         inters.direction = static_cast<bool>(inters_data.direction);
         inters.status = static_cast<bool>(inters_data.status);
@@ -153,7 +150,6 @@ inline void write_intersection2D(
             inters_data.l0 = inters.local[0];
             inters_data.l1 = inters.local[1];
             inters_data.path = inters.path;
-            inters_data.cos_theta = inters.cos_incidence_angle;
             inters_data.volume_link = inters.volume_link;
             inters_data.direction = static_cast<int>(inters.direction);
             inters_data.status = static_cast<int>(inters.status);

--- a/tests/unit_tests/cpu/geometry/tracking_surface.cpp
+++ b/tests/unit_tests/cpu/geometry/tracking_surface.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/detectors/build_toy_detector.hpp"
+#include "detray/detectors/create_wire_chamber.hpp"
 #include "detray/test/common/types.hpp"
 
 // Vecmem include(s)
@@ -79,13 +80,15 @@ GTEST_TEST(detray_geometry, surface_descriptor) {
     ASSERT_EQ(desc.material().index(), 7u);
 }
 
-/// This tests the functionality of a surface interface
-GTEST_TEST(detray_geometry, surface) {
+/// This tests the functionality of a tracking surface interface for the toy
+/// detector
+GTEST_TEST(detray_geometry, surface_toy_detector) {
 
     using namespace detray;
 
     using detector_t = detector<toy_metadata>;
 
+    using scalar_t = tracking_surface<detector_t>::scalar_type;
     using point2_t = tracking_surface<detector_t>::point2_type;
     using point3_t = tracking_surface<detector_t>::point3_type;
     using vector3_t = tracking_surface<detector_t>::vector3_type;
@@ -97,6 +100,9 @@ GTEST_TEST(detray_geometry, surface) {
 
     auto ctx = typename detector_t::geometry_context{};
 
+    //
+    // Disc
+    //
     const auto disc_descr = toy_det.surfaces()[1u];
     const auto disc = tracking_surface{toy_det, disc_descr};
 
@@ -116,7 +122,7 @@ GTEST_TEST(detray_geometry, surface) {
     ASSERT_NEAR(disc_translation[0], 0.f, tol);
     ASSERT_NEAR(disc_translation[1], 0.f, tol);
     ASSERT_NEAR(disc_translation[2], -823.7f, tol);
-    const auto center = disc.center(ctx);
+    auto center = disc.center(ctx);
     ASSERT_NEAR(center[0], 0.f, tol);
     ASSERT_NEAR(center[1], 0.f, tol);
     ASSERT_NEAR(center[2], -823.7f, tol);
@@ -127,15 +133,30 @@ GTEST_TEST(detray_geometry, surface) {
     ASSERT_EQ(disc.normal(ctx, point3_t{0.f, 0.f, 0.f}), z_axis);
     ASSERT_EQ(disc.normal(ctx, point2_t{0.f, 0.f}), z_axis);
 
-    // Incidence angle
-    const auto dir = vector3_t{1.f, 1.f, 1.f};
-    ASSERT_NEAR(disc.cos_angle(ctx, dir, point3_t{0.f, 0.f, 0.f}), 1.f, tol);
-    ASSERT_NEAR(disc.cos_angle(ctx, dir, point2_t{0.f, 0.f}), 1.f, tol);
+    // Cos incidence angle
+    auto dir = vector::normalize(vector3_t{1.f, 0.f, 1.f});
+    ASSERT_NEAR(disc.cos_angle(ctx, dir, point3_t{0.f, 0.f, 0.f}),
+                constant<scalar_t>::inv_sqrt2, tol);
+    ASSERT_NEAR(disc.cos_angle(ctx, dir, point2_t{0.f, 0.f}),
+                constant<scalar_t>::inv_sqrt2, tol);
+
+    dir = vector::normalize(vector3_t{1.f, 1.f, 0.f});
+    ASSERT_NEAR(disc.cos_angle(ctx, dir, point3_t{1.f, 0.5f, 0.f}), 0.f, tol);
+    ASSERT_NEAR(disc.cos_angle(ctx, dir, point2_t{1.f, 0.5f}), 0.f, tol);
+
+    dir = vector::normalize(vector3_t{1.f, 0.f, constant<scalar_t>::pi});
+    scalar_t cos_inc_angle{
+        constant<scalar_t>::pi /
+        std::sqrt(1.f + std::pow(constant<scalar_t>::pi, 2.f))};
+    ASSERT_NEAR(disc.cos_angle(ctx, dir, point3_t{2.f, 1.f, 0.f}),
+                cos_inc_angle, tol);
+    ASSERT_NEAR(disc.cos_angle(ctx, dir, point2_t{2.f, 1.f}), cos_inc_angle,
+                tol);
 
     // Coordinate transformations
-    const point3_t glob_pos = {4.f, 7.f, 4.f};
-    const point3_t local = disc.global_to_local(ctx, glob_pos, {});
-    const point2_t bound = disc.global_to_bound(ctx, glob_pos, {});
+    point3_t glob_pos = {4.f, 7.f, 4.f};
+    point3_t local = disc.global_to_local(ctx, glob_pos, {});
+    point2_t bound = disc.global_to_bound(ctx, glob_pos, {});
 
     ASSERT_NEAR(local[0], std::sqrt(65.f), tol);
     ASSERT_NEAR(local[1], std::atan2(7.f, 4.f), tol);
@@ -143,8 +164,8 @@ GTEST_TEST(detray_geometry, surface) {
     ASSERT_NEAR(bound[1], local[1], tol);
 
     // Roundtrip
-    const point3_t global = disc.local_to_global(ctx, local, {});
-    const point3_t global2 = disc.bound_to_global(ctx, bound, {});
+    point3_t global = disc.local_to_global(ctx, local, {});
+    point3_t global2 = disc.bound_to_global(ctx, bound, {});
 
     ASSERT_NEAR(glob_pos[0], global[0], tol);
     ASSERT_NEAR(glob_pos[1], global[1], tol);
@@ -160,4 +181,290 @@ GTEST_TEST(detray_geometry, surface) {
     const auto* mat_param = disc.material_parameters({0.f, 0.f});
     ASSERT_TRUE(mat_param);
     ASSERT_EQ(*mat_param, toy_cfg.mapped_material());
+
+    //
+    // Rectangle
+    //
+    const auto rec_descr = toy_det.surfaces()[604u];
+    const auto rec = tracking_surface{toy_det, rec_descr};
+
+    // IDs
+    ASSERT_EQ(rec.barcode(), rec_descr.barcode());
+    ASSERT_EQ(rec.volume(), 9u);
+    ASSERT_EQ(rec.index(), 604u);
+    ASSERT_EQ(rec.id(), surface_id::e_sensitive);
+    ASSERT_EQ(rec.shape_id(), detector_t::masks::id::e_rectangle2);
+    ASSERT_TRUE(rec.is_sensitive());
+    ASSERT_FALSE(rec.is_passive());
+    ASSERT_FALSE(rec.is_portal());
+
+    // Transformation matrix
+    const auto& rec_translation = rec.transform(ctx).translation();
+    ASSERT_NEAR(rec_translation[0], -71.902099f, tol);
+    ASSERT_NEAR(rec_translation[1], -7.081735f, tol);
+    ASSERT_NEAR(rec_translation[2], -455.f, tol);
+    center = rec.center(ctx);
+    ASSERT_NEAR(center[0], -71.902099f, tol);
+    ASSERT_NEAR(center[1], -7.081735f, tol);
+    ASSERT_NEAR(center[2], -455.f, tol);
+
+    // Surface normal
+    // trigger all code paths
+    global = rec.transform(ctx).vector_to_global(z_axis);
+    ASSERT_EQ(rec.normal(ctx, point3_t{0.f, 0.f, 0.f}), global);
+    ASSERT_EQ(rec.normal(ctx, point2_t{0.f, 0.f}), global);
+
+    // Incidence angle
+    dir = vector::normalize(global);
+    ASSERT_NEAR(rec.cos_angle(ctx, dir, point3_t{0.f, 0.f, 0.f}), 1.f, tol);
+    ASSERT_NEAR(rec.cos_angle(ctx, dir, point2_t{0.f, 0.f}), 1.f, tol);
+
+    dir = vector::normalize(vector3_t{0.f, -global[2], global[1]});
+    ASSERT_NEAR(rec.cos_angle(ctx, dir, point3_t{1.f, 0.5f, 0.f}), 0.f, tol);
+    ASSERT_NEAR(rec.cos_angle(ctx, dir, point2_t{1.f, 0.5f}), 0.f, tol);
+
+    dir = vector::normalize(vector3_t{1.f, 0.f, constant<scalar_t>::pi});
+    cos_inc_angle = std::fabs(vector::dot(dir, global));
+    ASSERT_NEAR(rec.cos_angle(ctx, dir, point3_t{2.f, 1.f, 0.f}), cos_inc_angle,
+                tol);
+    ASSERT_NEAR(rec.cos_angle(ctx, dir, point2_t{2.f, 1.f}), cos_inc_angle,
+                tol);
+
+    // Coordinate transformation roundtrip
+    glob_pos = {4.f, 7.f, 4.f};
+
+    local = rec.global_to_local(ctx, glob_pos, {});
+    global = rec.local_to_global(ctx, local, {});
+    ASSERT_NEAR(glob_pos[0], global[0], tol);
+    ASSERT_NEAR(glob_pos[1], global[1], tol);
+    ASSERT_NEAR(glob_pos[2], global[2], tol);
+
+    glob_pos = {-71.902099f, -7.081735f, -460.f};
+
+    local = rec.global_to_local(ctx, glob_pos, {});
+    global = rec.local_to_global(ctx, local, {});
+    ASSERT_NEAR(glob_pos[0], global[0], tol);
+    ASSERT_NEAR(glob_pos[1], global[1], tol);
+    ASSERT_NEAR(glob_pos[2], global[2], tol);
+
+    bound = rec.global_to_bound(ctx, glob_pos, {});
+    global = rec.bound_to_global(ctx, bound, {});
+    ASSERT_NEAR(global[0], glob_pos[0], tol);
+    ASSERT_NEAR(global[1], glob_pos[1], tol);
+    ASSERT_NEAR(global[2], glob_pos[2], tol);
+
+    // Test the material (no material on sensitive surfaces)
+    ASSERT_FALSE(rec.has_material());
+    mat_param = rec.material_parameters({0.f, 0.f});
+    ASSERT_FALSE(mat_param);
+
+    //
+    // Concentric Cylinder
+    //
+    const auto cyl_descr = toy_det.surfaces()[8u];
+    const auto cyl = tracking_surface{toy_det, cyl_descr};
+
+    // IDs
+    ASSERT_EQ(cyl.barcode(), cyl_descr.barcode());
+    ASSERT_EQ(cyl.volume(), 0u);
+    ASSERT_EQ(cyl.index(), 8u);
+    ASSERT_EQ(cyl.id(), surface_id::e_portal);
+    ASSERT_EQ(cyl.shape_id(), detector_t::masks::id::e_portal_cylinder2);
+    ASSERT_FALSE(cyl.is_sensitive());
+    ASSERT_FALSE(cyl.is_passive());
+    ASSERT_TRUE(cyl.is_portal());
+
+    // Transformation matrix
+    const auto& cyl_translation = cyl.transform(ctx).translation();
+    ASSERT_NEAR(cyl_translation[0], 0.f, tol);
+    ASSERT_NEAR(cyl_translation[1], 0.f, tol);
+    ASSERT_NEAR(cyl_translation[2], 0.f, tol);
+    center = cyl.center(ctx);
+    ASSERT_NEAR(center[0], 0.f, tol);
+    ASSERT_NEAR(center[1], 0.f, tol);
+    ASSERT_NEAR(center[2], 0.f, tol);
+
+    // Surface normal
+    // trigger all code paths
+    constexpr scalar_t r{25.f * unit<scalar_t>::mm};
+    const vector3_t x_axis{1.f, 0.f, 0.f};
+    ASSERT_NEAR(getter::norm(cyl.normal(ctx, point3_t{0.f, 0.f, r}) - x_axis),
+                0.f, tol);
+    ASSERT_NEAR(getter::norm(cyl.normal(ctx, point2_t{0.f, 0.f}) - x_axis), 0.f,
+                tol);
+    ASSERT_NEAR(
+        getter::norm(
+            cyl.normal(ctx, point3_t{r * constant<scalar_t>::pi, 0.f, r}) +
+            x_axis),
+        0.f, tol);
+    ASSERT_NEAR(getter::norm(
+                    cyl.normal(ctx, point2_t{r * constant<scalar_t>::pi, 0.f}) +
+                    x_axis),
+                0.f, tol);
+
+    const vector3_t y_axis{0.f, 1.f, 0.f};
+    ASSERT_NEAR(
+        getter::norm(
+            cyl.normal(ctx, point3_t{r * constant<scalar_t>::pi_2, 0.f, r}) -
+            y_axis),
+        0.f, tol);
+    ASSERT_NEAR(
+        getter::norm(
+            cyl.normal(ctx, point2_t{r * constant<scalar_t>::pi_2, 0.f}) -
+            y_axis),
+        0.f, tol);
+
+    // Incidence angle
+    ASSERT_NEAR(cyl.cos_angle(ctx, x_axis,
+                              point3_t{r * constant<scalar_t>::pi, 0.f, r}),
+                1.f, tol);
+    ASSERT_NEAR(
+        cyl.cos_angle(ctx, x_axis, point2_t{r * constant<scalar_t>::pi, 0.f}),
+        1.f, tol);
+
+    ASSERT_NEAR(cyl.cos_angle(ctx, z_axis,
+                              point3_t{r * constant<scalar_t>::pi_2, 0.f, r}),
+                0.f, tol);
+    ASSERT_NEAR(
+        cyl.cos_angle(ctx, z_axis, point2_t{r * constant<scalar_t>::pi_2, 0.f}),
+        0.f, tol);
+
+    dir = vector::normalize(vector3_t{1.f, 1.f, 0.f});
+    ASSERT_NEAR(cyl.cos_angle(ctx, dir, point3_t{0.f, 1.f, r}),
+                constant<scalar_t>::inv_sqrt2, tol);
+    ASSERT_NEAR(cyl.cos_angle(ctx, dir, point2_t{0.f, 1.f}),
+                constant<scalar_t>::inv_sqrt2, tol);
+
+    // Coordinate transformation roundtrip
+    glob_pos = {4.f, 7.f, 4.f};
+
+    local = cyl.global_to_local(ctx, glob_pos, {});
+    global = cyl.local_to_global(ctx, local, {});
+    ASSERT_NEAR(glob_pos[0], global[0], tol);
+    ASSERT_NEAR(glob_pos[1], global[1], tol);
+    ASSERT_NEAR(glob_pos[2], global[2], tol);
+
+    glob_pos = {constant<scalar_t>::inv_sqrt2 * r,
+                constant<scalar_t>::inv_sqrt2 * r, 2.f};
+
+    local = cyl.global_to_local(ctx, glob_pos, {});
+    global = cyl.local_to_global(ctx, local, {});
+    ASSERT_NEAR(glob_pos[0], global[0], tol);
+    ASSERT_NEAR(glob_pos[1], global[1], tol);
+    ASSERT_NEAR(glob_pos[2], global[2], tol);
+
+    bound = cyl.global_to_bound(ctx, glob_pos, {});
+    global = cyl.bound_to_global(ctx, bound, {});
+    ASSERT_NEAR(global[0], glob_pos[0], tol);
+    ASSERT_NEAR(global[1], glob_pos[1], tol);
+    ASSERT_NEAR(global[2], glob_pos[2], tol);
+
+    // Test the material
+    ASSERT_TRUE(cyl.has_material());
+    mat_param = cyl.material_parameters({0.f, 0.f});
+    ASSERT_TRUE(mat_param);
+    ASSERT_EQ(*mat_param, toy_cfg.mapped_material());
+}
+
+/// This tests the functionality of a tracking surface interface for a wire
+/// chamber detector
+GTEST_TEST(detray_geometry, surface_wire_chamber) {
+
+    using namespace detray;
+
+    using detector_t = detector<default_metadata>;
+
+    using scalar_t = tracking_surface<detector_t>::scalar_type;
+    using point2_t = tracking_surface<detector_t>::point2_type;
+    using point3_t = tracking_surface<detector_t>::point3_type;
+    using vector3_t = tracking_surface<detector_t>::vector3_type;
+
+    vecmem::host_memory_resource host_mr;
+    const auto [wire_chmbr, names] =
+        create_wire_chamber(host_mr, wire_chamber_config{});
+
+    auto ctx = typename detector_t::geometry_context{};
+
+    //
+    // Line
+    //
+    const auto line_descr = wire_chmbr.surfaces()[23u];
+    const auto line = tracking_surface{wire_chmbr, line_descr};
+
+    // IDs
+    ASSERT_EQ(line.barcode(), line_descr.barcode());
+    ASSERT_EQ(line.volume(), 1u);
+    ASSERT_EQ(line.index(), 23u);
+    ASSERT_EQ(line.id(), surface_id::e_sensitive);
+    ASSERT_EQ(line.shape_id(), detector_t::masks::id::e_drift_cell);
+    ASSERT_TRUE(line.is_sensitive());
+    ASSERT_FALSE(line.is_passive());
+    ASSERT_FALSE(line.is_portal());
+
+    // Transformation matrix
+    const auto line_translation = line.transform(ctx).translation();
+    ASSERT_NEAR(line_translation[0], 412.858582f, tol);
+    ASSERT_NEAR(line_translation[1], 299.412414f, tol);
+    ASSERT_NEAR(line_translation[2], 0.f, tol);
+    auto center = line.center(ctx);
+    ASSERT_NEAR(center[0], 412.858582f, tol);
+    ASSERT_NEAR(center[1], 299.412414f, tol);
+    ASSERT_NEAR(center[2], 0.f, tol);
+
+    // Surface normal
+    const auto z_axis = vector3_t{0.f, 0.f, 1.f};
+    point3_t global = line.transform(ctx).vector_to_global(z_axis);
+    // trigger all code paths
+    ASSERT_EQ(line.normal(ctx, point3_t{1.f, 0.f, 0.f}), global);
+    ASSERT_EQ(line.normal(ctx, point2_t{1.f, 0.f}), global);
+    ASSERT_EQ(line.normal(ctx, point3_t{-1.f, 0.f, 0.f}), global);
+    ASSERT_EQ(line.normal(ctx, point2_t{-1.f, 0.f}), global);
+
+    // Cos incidence angle
+    auto dir = vector::normalize(global);
+    ASSERT_NEAR(line.cos_angle(ctx, dir, point3_t{1.f, 0.f, 0.f}), 1.f, tol);
+    ASSERT_NEAR(line.cos_angle(ctx, dir, point2_t{1.f, 0.f}), 1.f, tol);
+
+    dir = vector::normalize(vector3_t{0.f, -global[2], global[1]});
+    ASSERT_NEAR(line.cos_angle(ctx, dir, point3_t{1.f, 100.f, 0.f}), 0.f, tol);
+    ASSERT_NEAR(line.cos_angle(ctx, dir, point2_t{1.f, 100.f}), 0.f, tol);
+
+    dir = vector3_t{-0.685475f, -0.0404595f, 0.726971f};
+    ASSERT_NEAR(line.cos_angle(ctx, dir, point3_t{2.f, 1.f, 0.f}),
+                constant<scalar_t>::inv_sqrt2, 0.0005);
+    ASSERT_NEAR(line.cos_angle(ctx, dir, point2_t{2.f, 1.f}),
+                constant<scalar_t>::inv_sqrt2, 0.0005);
+
+    // Coordinate transformation roundtrip
+    point3_t glob_pos = {4.f, 7.f, 4.f};
+
+    point3_t local = line.global_to_local(ctx, glob_pos, dir);
+    global = line.local_to_global(ctx, local, dir);
+
+    // @TODO: Needs a reduced tolerance, why?
+    scalar_t red_tol{0.00015f};
+    ASSERT_NEAR(glob_pos[0], global[0], red_tol);
+    ASSERT_NEAR(glob_pos[1], global[1], red_tol);
+    ASSERT_NEAR(glob_pos[2], global[2], red_tol);
+
+    glob_pos = center;
+
+    local = line.global_to_local(ctx, glob_pos, dir);
+    global = line.local_to_global(ctx, local, dir);
+    red_tol = 7.f * 1e-5f;
+    ASSERT_NEAR(glob_pos[0], global[0], red_tol);
+    ASSERT_NEAR(glob_pos[1], global[1], red_tol);
+    ASSERT_NEAR(glob_pos[2], global[2], red_tol);
+
+    point2_t bound = line.global_to_bound(ctx, glob_pos, dir);
+    global = line.bound_to_global(ctx, bound, dir);
+    ASSERT_NEAR(global[0], glob_pos[0], red_tol);
+    ASSERT_NEAR(global[1], glob_pos[1], red_tol);
+    ASSERT_NEAR(global[2], glob_pos[2], red_tol);
+
+    // Test the material
+    ASSERT_TRUE(line.has_material());
+    const auto* mat_param = line.material_parameters({0.f, 0.f});
+    ASSERT_TRUE(mat_param);
+    ASSERT_EQ(*mat_param, tungsten<scalar_t>());
 }

--- a/tests/unit_tests/cpu/material/materials.cpp
+++ b/tests/unit_tests/cpu/material/materials.cpp
@@ -188,7 +188,8 @@ GTEST_TEST(detray_material, material_rod) {
     auto is = ray_intersector<line_circular, algebra_t>{}(
         detail::ray<algebra_t>(trk), surface_descriptor<>{}, ln, tf);
 
-    const scalar_t cos_inc_ang{is.cos_incidence_angle};
+    const scalar_t cos_inc_ang{std::abs(vector::dot(
+        line2D<algebra_t>::normal(tf, is.local), vector::normalize(dir)))};
     const scalar_t approach{is.local[0]};
 
     EXPECT_NEAR(rod.path_segment(cos_inc_ang, approach),

--- a/tests/unit_tests/cpu/navigation/intersection/cylinder_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/cylinder_intersector.cpp
@@ -71,7 +71,6 @@ GTEST_TEST(detray_intersection, translated_cylinder) {
     // p2[0] = r * phi : 180deg in the opposite direction with r = 4
     EXPECT_NEAR(hits_bound[0].local[0], 4.f * constant<scalar>::pi, tol);
     EXPECT_NEAR(hits_bound[0].local[1], -5., tol);
-    EXPECT_NEAR(hits_bound[0].cos_incidence_angle, -1.f, tol);
 
     // second intersection lies in front of the track
     EXPECT_TRUE(hits_bound[1].status);
@@ -86,27 +85,6 @@ GTEST_TEST(detray_intersection, translated_cylinder) {
                 hits_bound[1].local[1] != not_defined);
     EXPECT_NEAR(hits_bound[1].local[0], 0.f, tol);
     EXPECT_NEAR(hits_bound[1].local[1], -5.f, tol);
-    EXPECT_NEAR(hits_bound[1].cos_incidence_angle, 1.f, tol);
-}
-
-// This checks the inclindence angle calculation for a ray-cylinder intersection
-GTEST_TEST(detray_intersection, cylinder_incidence_angle) {
-    const transform3_t identity{};
-    ray_intersector<cylinder2D, algebra_t> ci;
-
-    // Test ray
-    const point3 ori = {0.f, 1.f, 0.f};
-    const point3 dir = {1.f, 0.f, 0.f};
-    ray_t ray(ori, 0.f, dir, 0.f);
-
-    // Intersect: Set an infinite overstep tolerance, so that no solution is
-    // optimized away
-    mask<cylinder2D, std::uint_least16_t, algebra_t> cylinder{0u, r, -hz, hz};
-    const auto hits_bound =
-        ci(ray, surface_descriptor<>{}, cylinder, identity, tol, -not_defined);
-
-    ASSERT_NEAR(hits_bound[0].cos_incidence_angle, -std::sqrt(15.f) / 4.f, tol);
-    ASSERT_NEAR(hits_bound[1].cos_incidence_angle, std::sqrt(15.f) / 4.f, tol);
 }
 
 // This checks the solution of a ray-cylinder portal intersection against

--- a/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
@@ -93,8 +93,6 @@ GTEST_TEST(detray_intersection, helix_plane_intersector_no_bfield) {
     // Local intersection information
     ASSERT_NEAR(hit_bound.local[0], -1.f, tol);
     ASSERT_NEAR(hit_bound.local[1], -1.f, tol);
-    // Incidence angle
-    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1.f, tol);
 
     // The same test but bound to local frame & masked - inside
     mask<rectangle2D> rect_for_inside{0u, 3.f, 3.f};
@@ -150,7 +148,6 @@ GTEST_TEST(detray_intersection, helix_plane_intersector) {
     EXPECT_NEAR(is.path, path, tol);
     EXPECT_NEAR(is.local[0], 0.f, tol);
     EXPECT_NEAR(is.local[1], 0.f, tol);
-    EXPECT_NEAR(is.cos_incidence_angle, 1.f, tol);
 
     const auto global = rectangle.to_global_frame(trf, is.local);
     EXPECT_NEAR(global[0], trl[0], tol);
@@ -195,7 +192,6 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector_no_bfield) {
     // p2[0] = r * phi : 180deg in the opposite direction with r = 4
     EXPECT_NEAR(hits_bound[0].local[0], 4.f * M_PI, tol);
     EXPECT_NEAR(hits_bound[0].local[1], -5.f, tol);
-    EXPECT_NEAR(hits_bound[0].cos_incidence_angle, -1.f, tol);
 
     // first intersection lies behind the track
     const auto global1 = cylinder.to_global_frame(shifted, hits_bound[1].local);
@@ -208,7 +204,6 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector_no_bfield) {
                 hits_bound[1].local[1] != not_defined);
     EXPECT_NEAR(hits_bound[1].local[0], 0.f, tol);
     EXPECT_NEAR(hits_bound[1].local[1], -5., tol);
-    EXPECT_NEAR(hits_bound[1].cos_incidence_angle, 1.f, tol);
 }
 
 /// Test the intersection between a helical trajectory and a cylinder
@@ -242,7 +237,6 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector) {
     EXPECT_NEAR(global0[0], pos_near[0], tol);
     EXPECT_NEAR(global0[1], pos_near[1], tol);
     EXPECT_NEAR(global0[2], pos_near[2], tol);
-    EXPECT_NEAR(is[0].cos_incidence_angle, -1.f, 50.f * tol);
 
     // Second solution
     const vector3 pos_far = hlx.pos(is[1].path);
@@ -259,7 +253,6 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector) {
     EXPECT_NEAR(global1[0], pos_far[0], tol);
     EXPECT_NEAR(global1[1], pos_far[1], tol);
     EXPECT_NEAR(global1[2], pos_far[2], tol);
-    EXPECT_NEAR(is[1].cos_incidence_angle, 1.f, 50.f * tol);
 }
 
 /// This checks the closest solution of a helix-concentric cylinder intersection
@@ -364,7 +357,6 @@ GTEST_TEST(detray_intersection, helix_line_intersector) {
     EXPECT_NEAR(is.local[1], 0.f, tol);
     EXPECT_TRUE(is.status);
     EXPECT_TRUE(is.direction);
-    EXPECT_NEAR(is.cos_incidence_angle, 0.f, tol);
 
     // Get the intersection on the next surface
     is = hli(hlx, surface_descriptor<>{}, drift_cell, trf_fw, tol);
@@ -375,7 +367,6 @@ GTEST_TEST(detray_intersection, helix_line_intersector) {
     EXPECT_NEAR(is.local[1], 0.f, tol);
     EXPECT_TRUE(is.status);
     EXPECT_TRUE(is.direction);
-    EXPECT_NEAR(is.cos_incidence_angle, 0.f, tol);
 
     //---------------------
     // Backward direction
@@ -399,7 +390,6 @@ GTEST_TEST(detray_intersection, helix_line_intersector) {
     EXPECT_NEAR(is.local[1], 0.f, tol);
     EXPECT_TRUE(is.status);
     EXPECT_FALSE(is.direction);
-    EXPECT_NEAR(is.cos_incidence_angle, 0.f, tol);
 
     // Get the intersection on the next surface
     is = hli(hlx, surface_descriptor<>{}, drift_cell, trf_bw, tol);
@@ -410,5 +400,4 @@ GTEST_TEST(detray_intersection, helix_line_intersector) {
     EXPECT_NEAR(is.local[1], 0.f, tol);
     EXPECT_TRUE(is.status);
     EXPECT_FALSE(is.direction);
-    EXPECT_NEAR(is.cos_incidence_angle, 0.f, tol);
 }

--- a/tests/unit_tests/cpu/navigation/intersection/intersection2D.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection2D.cpp
@@ -50,11 +50,11 @@ GTEST_TEST(detray_intersection, intersection2D) {
 
     using intersection_t = intersection2D<surface_t, algebra_t>;
 
-    intersection_t i0 = {
-        surface_t{}, point3{0.2f, 0.4f, 0.f}, 2.f, 1.f, 1u, false, true};
+    intersection_t i0 = {surface_t{}, point3{0.2f, 0.4f, 0.f}, 2.f, 1u, false,
+                         true};
 
     intersection_t i1 = {
-        surface_t{}, point3{0.2f, 0.4f, 0.f}, 1.7f, -1.f, 0u, true, false,
+        surface_t{}, point3{0.2f, 0.4f, 0.f}, 1.7f, 0u, true, false,
     };
 
     intersection_t invalid{};

--- a/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
@@ -70,7 +70,6 @@ GTEST_TEST(detray_intersection, line_intersector_case1) {
     EXPECT_EQ(global0, point3({1.f, 0.f, 0.f}));
     EXPECT_EQ(is[0].local[0], -1.f);  // right
     EXPECT_EQ(is[0].local[1], 0.f);
-    EXPECT_NEAR(is[0].cos_incidence_angle, 0.f, tol);
 
     EXPECT_TRUE(is[1].status);
     EXPECT_EQ(is[1].path, 1.f);
@@ -80,7 +79,6 @@ GTEST_TEST(detray_intersection, line_intersector_case1) {
     EXPECT_NEAR(global1[2], 0.f, tol);
     EXPECT_EQ(is[1].local[0], 1.f);  // left
     EXPECT_EQ(is[1].local[1], 0.f);
-    EXPECT_NEAR(is[1].cos_incidence_angle, 0.f, tol);
 
     EXPECT_TRUE(is[2].status);
     EXPECT_NEAR(is[2].path, constant<scalar>::sqrt2, tol);
@@ -90,7 +88,6 @@ GTEST_TEST(detray_intersection, line_intersector_case1) {
     EXPECT_NEAR(global2[2], 1.f, tol);
     EXPECT_NEAR(is[2].local[0], -1.f, tol);  // right
     EXPECT_NEAR(is[2].local[1], 1.f, tol);
-    EXPECT_NEAR(is[2].cos_incidence_angle, constant<scalar>::inv_sqrt2, tol);
 }
 
 // Test inclined wire

--- a/tests/unit_tests/cpu/navigation/intersection/plane_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/plane_intersector.cpp
@@ -57,8 +57,6 @@ GTEST_TEST(detray_intersection, translated_plane_ray) {
     // Local intersection information
     ASSERT_NEAR(hit_bound.local[0], -1.f, tol);
     ASSERT_NEAR(hit_bound.local[1], -1.f, tol);
-    // Incidence angle
-    ASSERT_NEAR(hit_bound.cos_incidence_angle, 1.f, tol);
 
     // The same test but bound to local frame & masked - inside
     mask<rectangle2D> rect_for_inside{0u, 3.f, 3.f};
@@ -89,28 +87,4 @@ GTEST_TEST(detray_intersection, translated_plane_ray) {
     // Local intersection infoimation - unchanged
     ASSERT_NEAR(hit_bound_outside.local[0], -1.f, tol);
     ASSERT_NEAR(hit_bound_outside.local[1], -1.f, tol);
-}
-
-// This defines the local frame test suite
-GTEST_TEST(detray_intersection, plane_incidence_angle) {
-    // tf3 with rotated axis
-    const vector3 x{1.f, 0.f, -1.f};
-    const vector3 z{1.f, 0.f, 1.f};
-    const vector3 t{0.f, 0.f, 0.f};
-
-    const transform3 rotated{t, vector::normalize(z), vector::normalize(x)};
-
-    ray_intersector<rectangle2D, algebra_t> pi;
-
-    // Test ray
-    const point3 pos{-1.f, 0.f, 0.f};
-    const vector3 mom{1.f, 0.f, 0.f};
-    const detail::ray<algebra_t> r(pos, 0.f, mom, 0.f);
-
-    // The same test but bound to local frame & masked - inside
-    mask<rectangle2D> rect{0u, 3.f, 3.f};
-
-    const auto is = pi(r, surface_descriptor<>{}, rect, rotated, tol);
-
-    ASSERT_NEAR(is.cos_incidence_angle, std::cos(constant<scalar>::pi_4), tol);
 }

--- a/utils/include/detray/simulation/random_scatterer.hpp
+++ b/utils/include/detray/simulation/random_scatterer.hpp
@@ -138,6 +138,10 @@ struct random_scatterer : actor {
     DETRAY_HOST inline void operator()(state& simulator_state,
                                        propagator_state_t& prop_state) const {
 
+        // @Todo: Make context part of propagation state
+        using detector_type = typename propagator_state_t::detector_type;
+        using geo_context_type = typename detector_type::geometry_context;
+
         auto& navigation = prop_state._navigation;
 
         if (not navigation.is_on_module()) {
@@ -148,9 +152,12 @@ struct random_scatterer : actor {
         auto& bound_params = stepping._bound_params;
         const auto& is = *navigation.current();
         const auto sf = navigation.get_surface();
+        const scalar_type cos_inc_angle{
+            sf.cos_angle(geo_context_type{}, bound_params.dir(),
+                         bound_params.bound_local())};
 
         sf.template visit_material<kernel>(simulator_state, bound_params,
-                                           is.cos_incidence_angle, is.local[0]);
+                                           cos_inc_angle, is.local[0]);
 
         // Get the new momentum
         const auto new_mom = attenuate(


### PR DESCRIPTION
Removes the incidence angle from the intersection, since it is only needed when the track is actually on surface and the surface has material. Instead, it is now calculated using the tracking surface interface directly in the material interactor. Seems to bring *very* slight speedup