### PR TITLE
First prototype of a context-aware store

### DIFF
--- a/core/include/detray/core/detail/context_aware_store.hpp
+++ b/core/include/detray/core/detail/context_aware_store.hpp
@@ -1,0 +1,360 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/core/detail/container_buffers.hpp"
+#include "detray/core/detail/container_views.hpp"
+#include "detray/core/detail/data_context.hpp"
+#include "detray/definitions/detail/indexing.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/memory_resource.hpp>
+
+// System include(s)
+#include <type_traits>
+
+namespace detray {
+
+/// @brief Wraps a jagged vector-like container and implements a data store
+/// around it.
+///
+/// @tparam T The type of the collection data, e.g. transforms
+/// @tparam container_t The type of container to use for the data collection.
+/// @tparam context_t the context with which to retrieve the correct data.
+template <typename T, template <typename...> class container_t,
+          typename context_t>
+class context_aware_store {
+    public:
+    using base_type = container_t<T>;
+    using vector_type = typename base_type::value_type;
+    using context_type = context_t;
+
+    // TODO: do we need this?
+    /*
+    /// How to find data in the store
+    /// @{
+    using link_type = dindex;
+    using single_link = dindex;
+    using range_link = dindex_range;
+    /// @}
+    */
+
+    /// Vecmem view types
+    using view_type = detail::get_view_t<container_t<T>>;
+    /*
+     TODO: uncommenting the next line results in compilation problems:
+     Originated from container_views.hpp
+     error: more than one partial specialization matches the template argument
+     list of class "detray::detail::has_view<.......>"
+     "detray::detail::has_view<const vecmem::vector<T>, void>"
+     "detray::detail::has_view<const vecmem::jagged_vector<T>, void>"
+    */
+    // using const_view_type = detail::get_view_t<const container_t<T>>;
+
+    /// Empty container
+    constexpr context_aware_store() = default;
+
+    // Delegate constructors to container, which handles the memory
+
+    /// Copy construct from element types
+    // TODO: do we need this?
+    /* constexpr explicit single_store(const T &arg) : m_container(arg) {} */
+
+    /// Construct with a specific memory resource @param resource
+    /// (host-side only)
+    template <typename allocator_t = vecmem::memory_resource,
+              std::enable_if_t<not detail::is_device_view_v<allocator_t>,
+                               bool> = true>
+    DETRAY_HOST explicit context_aware_store(allocator_t& resource)
+        : m_container(&resource) {}
+
+    /// Copy Construct with a specific memory resource @param resource
+    /// (host-side only)
+    // TODO: do we need this?
+    /*
+    template <typename allocator_t = vecmem::memory_resource,
+              typename C = container_t<T>,
+              std::enable_if_t<std::is_same_v<C, std::vector<T>>, bool> = true>
+    DETRAY_HOST explicit context_aware_store(allocator_t &resource, const T
+    &arg) : m_container(&resource, arg) {}
+    */
+
+    /// Construct from the container @param view . Mainly used device-side.
+    template <typename container_view_t,
+              std::enable_if_t<detail::is_device_view_v<container_view_t>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE context_aware_store(container_view_t& view)
+        : m_container(view) {}
+
+    /// @returns a pointer to the underlying container - const
+    DETRAY_HOST_DEVICE
+    constexpr auto data() const noexcept -> const base_type* {
+        return &m_container;
+    }
+
+    /// @returns a pointer to the underlying container - non-const
+    DETRAY_HOST_DEVICE
+    constexpr auto data() noexcept -> base_type* { return &m_container; }
+
+    /// @returns the size of the underlying container
+    DETRAY_HOST_DEVICE
+    constexpr auto size(const context_type& ctx) const noexcept -> dindex {
+        return static_cast<dindex>(m_container.at(ctx.get()).size());
+    }
+
+    /// @returns true if the underlying container is empty
+    DETRAY_HOST_DEVICE
+    constexpr auto empty(const context_type& ctx) const noexcept -> bool {
+        return m_container.at(ctx.get()).empty();
+    }
+
+    /// @returns the collections iterator at the start position.
+    DETRAY_HOST_DEVICE
+    constexpr auto begin(const context_type& ctx) {
+        return m_container.at(ctx.get()).begin();
+    }
+
+    /// @returns the collections iterator sentinel.
+    DETRAY_HOST_DEVICE
+    constexpr auto end(const context_type& ctx) {
+        return m_container.at(ctx.get()).end();
+    }
+
+    /// @returns access to the second-level vector in underlying container -
+    /// const
+    DETRAY_HOST_DEVICE
+    auto get(const context_type& ctx) const noexcept -> const vector_type& {
+        return m_container.at(ctx.get());
+    }
+
+    /// @returns access to the second-level vector in underlying container -
+    /// non-const
+    DETRAY_HOST_DEVICE
+    auto get(const context_type& ctx) noexcept -> vector_type& {
+        return m_container.at(ctx.get());
+    }
+
+    /// @returns access to the underlying container - const
+    DETRAY_HOST_DEVICE
+    auto get() const noexcept -> const base_type& { return m_container; }
+
+    /// @returns access to the underlying container - non-const
+    DETRAY_HOST_DEVICE
+    auto get() noexcept -> base_type& { return m_container; }
+
+    // TODO: does it make sense to introduce the operator[] for this store?
+    /// Elementwise access. Needs @c operator[] for storage type - non-const
+    /*
+    DETRAY_HOST_DEVICE
+    constexpr decltype(auto) operator[](const dindex i) {
+      return m_container[i];
+    }
+
+    /// Elementwise access. Needs @c operator[] for storage type - const
+    DETRAY_HOST_DEVICE
+    constexpr decltype(auto) operator[](const dindex i) const {
+      return m_container[i];
+    }
+    */
+
+    /// @returns context based access to an element (also range checked)
+    DETRAY_HOST_DEVICE
+    constexpr auto at(const dindex i, const context_type& ctx) const noexcept
+        -> const T& {
+        return m_container.at(ctx.get()).at(i);
+    }
+
+    /// @returns context based access to an element (also range checked)
+    DETRAY_HOST_DEVICE
+    constexpr auto at(const dindex i, const context_type& ctx) noexcept -> T& {
+        return m_container.at(ctx.get()).at(i);
+    }
+
+    /// Removes and destructs all elements in the container for a given context
+    DETRAY_HOST void clear(const context_type& ctx) {
+        m_container.at(ctx.get()).clear();
+    }
+
+    /// Reserve memory of size @param n for a given geometry context
+    DETRAY_HOST void reserve(std::size_t n, const context_type& ctx) {
+        if (ctx.get() <= m_container.size()) {
+            auto& vect =
+                ctx.get() == m_container.size()
+                    ? *(m_container.insert(m_container.end(), vector_type()))
+                    : m_container.at(ctx.get());
+            vect.reserve(n);
+        } else {
+            // TODO: how to react to these situations?
+        }
+    }
+
+    /// Resize the underlying container to @param n for a given geometry context
+    DETRAY_HOST void resize(std::size_t n, const context_type& ctx) {
+        if (ctx.get() <= m_container.size()) {
+            auto& vect =
+                ctx.get() == m_container.size()
+                    ? *(m_container.insert(m_container.end(), vector_type()))
+                    : m_container.at(ctx.get());
+            vect.resize(n);
+        } else {
+            // TODO: how to react to these situations?
+        }
+    }
+
+    /// Add a new element to the collection - copy
+    ///
+    /// @tparam U type that can be converted to T
+    ///
+    /// @param arg the constructor argument
+    ///
+    /// @note in general can throw an exception
+    template <typename U>
+    DETRAY_HOST constexpr auto push_back(
+        const U& arg, const context_type& ctx) noexcept(false) -> void {
+        if (ctx.get() <= m_container.size()) {
+            auto& vect =
+                ctx.get() == m_container.size()
+                    ? *(m_container.insert(m_container.end(), vector_type()))
+                    : m_container.at(ctx.get());
+            vect.push_back(arg);
+        } else {
+            // TODO: how to react to these situations?
+        }
+    }
+
+    /// Add a new element to the collection - move
+    ///
+    /// @tparam U type that can be converted to T
+    ///
+    /// @param arg the constructor argument
+    ///
+    /// @note in general can throw an exception
+    template <typename U>
+    DETRAY_HOST constexpr auto push_back(
+        U&& arg, const context_type& ctx) noexcept(false) -> void {
+        if (ctx.get() <= m_container.size()) {
+            auto& vect =
+                ctx.get() == m_container.size()
+                    ? *(m_container.insert(m_container.end(), vector_type()))
+                    : m_container.at(ctx.get());
+            vect.push_back(std::move(arg));
+        } else {
+            // TODO: how to react to these situations?
+        }
+    }
+
+    /// Add a new element to the collection in place
+    ///
+    /// @tparam Args are the types of the constructor arguments
+    ///
+    /// @param args is the list of constructor arguments
+    ///
+    /// @note in general can throw an exception
+    template <typename... Args>
+    DETRAY_HOST constexpr decltype(auto) emplace_back(
+        const context_type& ctx, Args&&... args) noexcept(false) {
+        if (ctx.get() <= m_container.size()) {
+            auto& vect =
+                ctx.get() == m_container.size()
+                    ? *(m_container.insert(m_container.end(), vector_type()))
+                    : m_container.at(ctx.get());
+            return vect.emplace_back(std::forward<Args>(args)...);
+        } else {
+            // TODO: how to react to these situations? For now throw an
+            // exception to avoid warnings
+            throw std::runtime_error{""};
+        }
+    }
+
+    /// Insert another collection - copy
+    ///
+    /// @tparam U type that represents second level vector in a jagged vector
+    ///
+    /// @param new_data is the new collection to be added for the given context
+    ///
+    /// @note in general can throw an exception
+    template <typename U>
+    DETRAY_HOST auto insert(U& new_data,
+                            const context_type& ctx) noexcept(false) -> void {
+        if (ctx.get() <= m_container.size()) {
+            auto& vect =
+                ctx.get() == m_container.size()
+                    ? *(m_container.insert(m_container.end(), vector_type()))
+                    : m_container.at(ctx.get());
+            vect.reserve(vect.size() + new_data.size());
+            vect.insert(vect.end(), new_data.begin(), new_data.end());
+        } else {
+            // TODO: how to react to these situations?
+        }
+    }
+
+    /// Insert another collection - move
+    ///
+    /// @tparam U type that represents second level vector in a jagged vector
+    ///
+    /// @param new_data is the new collection to be added for the given context
+    ///
+    /// @note in general can throw an exception
+    template <typename U>
+    DETRAY_HOST auto insert(U&& new_data,
+                            const context_type& ctx) noexcept(false) -> void {
+        if (ctx.get() <= m_container.size()) {
+            auto& vect =
+                ctx.get() == m_container.size()
+                    ? *(m_container.insert(m_container.end(), vector_type()))
+                    : m_container.at(ctx.get());
+            vect.reserve(vect.size() + new_data.size());
+            vect.insert(vect.end(), std::make_move_iterator(new_data.begin()),
+                        std::make_move_iterator(new_data.end()));
+        } else {
+            // TODO: how to react to these situations?
+        }
+    }
+
+    /// Append the content from another store to the current one for a given
+    /// context
+    ///
+    /// @param other The other container
+    ///
+    /// @note in general can throw an exception
+    DETRAY_HOST void append(context_aware_store& other,
+                            const context_type& ctx) noexcept(false) {
+        insert(other.m_container.at(ctx.get()), ctx);
+    }
+
+    /// Append the content from another store to the current one for a given
+    /// context - move
+    ///
+    /// @param other The other container
+    ///
+    /// @note in general can throw an exception
+    DETRAY_HOST void append(context_aware_store&& other,
+                            const context_type& ctx) noexcept(false) {
+        insert(std::move(other.m_container.at(ctx.get())), ctx);
+    }
+
+    /// @return the view on the underlying container - non-const
+    DETRAY_HOST auto get_data() -> view_type {
+        return detray::get_data(m_container);
+    }
+
+    // TODO: uncomment this after the issue with const_view_type gets sorted out
+    /*
+    /// @return the view on the underlying container - const
+    DETRAY_HOST auto get_data() const -> const_view_type {
+        return detray::get_data(m_container);
+    }
+    */
+
+    private:
+    base_type m_container;
+};
+
+}  // namespace detray

--- a/tests/unit_tests/device/cuda/CMakeLists.txt
+++ b/tests/unit_tests/device/cuda/CMakeLists.txt
@@ -57,6 +57,9 @@ foreach(algebra ${algebras})
       "transform_store_cuda_kernel.hpp"
       "transform_store_cuda.cpp"
       "transform_store_cuda_kernel.cu"
+      "ca_transform_store_cuda_kernel.hpp"
+      "ca_transform_store_cuda.cpp"
+      "ca_transform_store_cuda_kernel.cu"
       LINK_LIBRARIES GTest::gtest_main vecmem::cuda detray::test covfie::cuda
                      detray::core detray::algebra_${algebra} detray::utils )
    target_compile_definitions(detray_unit_test_cuda_${algebra}

--- a/tests/unit_tests/device/cuda/ca_transform_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/ca_transform_store_cuda.cpp
@@ -1,0 +1,126 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+// Project include(s)
+#include "ca_transform_store_cuda_kernel.hpp"
+#include "detray/definitions/detail/algebra.hpp"
+#include "detray/utils/ranges.hpp"
+
+// System include(s)
+#include <climits>
+#include <vecmem/memory/cuda/managed_memory_resource.hpp>
+
+using namespace detray;
+
+TEST(ca_transform_store_cuda, ca_transform_store) {
+
+    // memory resource
+    vecmem::cuda::managed_memory_resource mng_mr;
+
+    host_ca_transform_store_t static_ca_store(mng_mr);
+    typename host_ca_transform_store_t::context_type ctx_0{0};
+    typename host_ca_transform_store_t::context_type ctx_1{1};
+
+    // Construct several transforms
+    point3 t0{1.f, 2.f, 3.f};
+    point3 z0{4.f, 2.f, 3.f};
+    point3 x0{1.f, 0.f, 3.f};
+    transform3 tf0{t0, z0, x0};
+
+    point3 t1{1.f, 1.f, 2.f};
+    point3 z1{1.f, 0.f, 0.f};
+    point3 x1{0.f, 0.f, 2.f};
+    transform3 tf1{t1, z1, x1};
+
+    point3 t2{2.f, 2.f, 5.f};
+    point3 z2{0.f, 0.f, 0.f};
+    point3 x2{1.f, 2.f, 3.f};
+    transform3 tf2{t2, z2, x2};
+
+    point3 t3{2.f, 0.f, 5.f};
+    point3 z3{1.f, 2.f, 3.f};
+    point3 x3{0.f, 0.f, 0.f};
+    transform3 tf3{t3, z3, x3};
+
+    point3 t4{2.f, 0.f, 5.f};
+    point3 z4{5.f, 3.f, 2.f};
+    point3 x4{0.f, 1.f, 1.f};
+
+    // Record the transforms into the store under two contexts
+    // Testing push_back() and emplace_back()
+    static_ca_store.reserve(3, ctx_0);
+    static_ca_store.reserve(2, ctx_1);
+
+    static_ca_store.push_back(tf0, ctx_0);
+    static_ca_store.push_back(tf1, ctx_1);
+    static_ca_store.push_back(tf2, ctx_0);
+    static_ca_store.push_back(tf3, ctx_1);
+    static_ca_store.emplace_back(ctx_0, t4, z4, x4);
+
+    ASSERT_EQ(static_ca_store.size(ctx_0), 3u);
+    ASSERT_EQ(static_ca_store.size(ctx_1), 2u);
+
+    // Compare the transform operation results
+    dindex n_transforms_ca0 = static_ca_store.size(ctx_0);
+    dindex n_transforms_ca1 = static_ca_store.size(ctx_1);
+    dindex n_transforms_total = n_transforms_ca0 + n_transforms_ca1;
+
+    // Fill input vector
+    vecmem::vector<point3> input(&mng_mr);
+    for (unsigned int i = 0u; i < n_transforms_total; ++i) {
+        input.push_back({static_cast<scalar>(i), static_cast<scalar>(i + 1u),
+                         static_cast<scalar>(i + 2u)});
+    }
+
+    // Get transformed vectors from the host side
+    std::vector<point3> output_host_ca0, output_host_ca1;
+    auto range_ca0 = ranges::subrange(static_ca_store.get(ctx_0),
+                                      dindex_range{0u, n_transforms_ca0});
+    auto range_ca1 = ranges::subrange(static_ca_store.get(ctx_1),
+                                      dindex_range{0u, n_transforms_ca1});
+
+    std::size_t count{0u};
+    for (const auto& tf : range_ca0) {
+        auto output = tf.point_to_global(input[2 * count]);
+        output_host_ca0.push_back(output);
+        count++;
+    }
+
+    count = 0u;
+    for (const auto& tf : range_ca1) {
+        auto output = tf.point_to_global(input[1 + 2 * count]);
+        output_host_ca1.push_back(output);
+        count++;
+    }
+
+    // Get transformed vectors from the device side
+    vecmem::vector<point3> output_device_ca0(n_transforms_ca0, &mng_mr);
+    vecmem::vector<point3> output_device_ca1(n_transforms_ca1, &mng_mr);
+
+    auto input_data = vecmem::get_data(input);
+    auto static_ca_store_data = vecmem::get_data(*(static_ca_store.data()));
+
+    // Context: 0
+    auto output_data_ca0 = vecmem::get_data(output_device_ca0);
+    ca_transform_test(input_data, static_ca_store_data, output_data_ca0,
+                      static_ca_store.size(ctx_0), ctx_0);
+
+    // Context: 1
+    auto output_data_ca1 = vecmem::get_data(output_device_ca1);
+    ca_transform_test(input_data, static_ca_store_data, output_data_ca1,
+                      static_ca_store.size(ctx_1), ctx_1);
+
+    // Compare the results of the transformations on host and device
+    for (unsigned int i = 0u; i < n_transforms_ca0; ++i) {
+        ASSERT_EQ(output_host_ca0[i], output_device_ca0[i]);
+    }
+    for (unsigned int i = 0u; i < n_transforms_ca1; ++i) {
+        ASSERT_EQ(output_host_ca1[i], output_device_ca1[i]);
+    }
+}

--- a/tests/unit_tests/device/cuda/ca_transform_store_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/ca_transform_store_cuda_kernel.cu
@@ -1,0 +1,47 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "ca_transform_store_cuda_kernel.hpp"
+#include "detray/definitions/detail/cuda_definitions.hpp"
+#include "detray/utils/ranges.hpp"
+
+namespace detray {
+
+__global__ void ca_transform_test_kernel(
+    vecmem::data::vector_view<detray::point3> input_data,
+    typename host_ca_transform_store_t::view_type store_data,
+    vecmem::data::vector_view<detray::point3> output_data,
+    detray::detail::data_context context) {
+
+    device_ca_transform_store_t store(store_data);
+
+    vecmem::device_vector<detray::point3> input(input_data);
+    vecmem::device_vector<detray::point3> output(output_data);
+
+    auto range = detray::ranges::subrange(
+        store.get().at(context.get()), dindex_range{0u, store.size(context)});
+    output[threadIdx.x] = range[threadIdx.x].point_to_global(
+        input[context.get() + 2 * threadIdx.x]);
+}
+
+void ca_transform_test(
+    vecmem::data::vector_view<detray::point3> input_data,
+    typename host_ca_transform_store_t::view_type ca_store_data,
+    vecmem::data::vector_view<detray::point3> output_data,
+    std::size_t n_transforms, detray::detail::data_context context) {
+    int block_dim = 1;
+    int thread_dim(n_transforms);
+
+    // run the kernel
+    ca_transform_test_kernel<<<block_dim, thread_dim>>>(
+        input_data, ca_store_data, output_data, context);
+
+    // cuda error check
+    DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());
+    DETRAY_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+}
+}  // namespace detray

--- a/tests/unit_tests/device/cuda/ca_transform_store_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/ca_transform_store_cuda_kernel.hpp
@@ -1,0 +1,37 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project includes(s)
+#include "detray/core/detail/context_aware_store.hpp"
+#include "detray/definitions/detail/algebra.hpp"
+
+// Vecmem include(s)
+#include <vecmem/containers/jagged_device_vector.hpp>
+
+namespace detray {
+
+using algebra_t = ALGEBRA_PLUGIN<scalar>;
+using point3 = dpoint3D<algebra_t>;
+using transform3 = dtransform3D<algebra_t>;
+
+using host_ca_transform_store_t =
+    context_aware_store<transform3, vecmem::jagged_vector,
+                        detail::data_context>;
+
+using device_ca_transform_store_t =
+    context_aware_store<transform3, vecmem::jagged_device_vector,
+                        detail::data_context>;
+
+void ca_transform_test(
+    vecmem::data::vector_view<point3> input_data,
+    typename host_ca_transform_store_t::view_type ca_store_data,
+    vecmem::data::vector_view<point3> output_data, std::size_t n_transforms,
+    detail::data_context context);
+
+}  // namespace detray

--- a/tests/unit_tests/device/cuda/transform_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/transform_store_cuda.cpp
@@ -58,7 +58,7 @@ TEST(transform_store_cuda, transform_store) {
     point3 z3{1.f, 2.f, 3.f};
     point3 x3{0.f, 0.f, 0.f};
     transform3 tf3{t3, z3, x3};
-    static_store.emplace_back(ctx0, std::move(t3));
+    static_store.emplace_back(ctx0, std::move(tf3));
     ASSERT_EQ(static_store.size(ctx0), 4u);
 
     static_store.emplace_back(ctx0);


### PR DESCRIPTION
The new class has been modeled after the `single_store`. Introduced in a new header file: `core/include/detray/core/detail/context_aware_store.hpp`. Also added a new unit test `ca_transform_store_cuda` modeled after the `transform_store_cuda`.