### PR TITLE
fix: Remove transform from concentric cylinders and improved error reporting

### DIFF
--- a/core/include/detray/geometry/coordinates/concentric_cylindrical2D.hpp
+++ b/core/include/detray/geometry/coordinates/concentric_cylindrical2D.hpp
@@ -32,45 +32,38 @@ struct concentric_cylindrical2D {
     /// This method transforms a point from a global cartesian 3D frame to a
     /// local 2D cylindrical point
     DETRAY_HOST_DEVICE
-    static inline point3_type global_to_local_3D(const transform3_type &trf,
-                                                 const point3_type &p,
-                                                 const vector3_type & /*dir*/) {
-        const point3_type local3 = p - trf.translation();
-        const scalar_type r{getter::perp(local3)};
-
-        return {r * getter::phi(local3), local3[2], r};
+    static inline point3_type global_to_local_3D(
+        const transform3_type & /*trf*/, const point3_type &p,
+        const vector3_type & /*dir*/) {
+        return {getter::phi(p), p[2], getter::perp(p)};
     }
 
     /// This method transforms a point from a global cartesian 3D frame to a
     /// local 2D cylindrical point
     DETRAY_HOST_DEVICE
-    static inline loc_point global_to_local(const transform3_type &trf,
+    static inline loc_point global_to_local(const transform3_type & /*trf*/,
                                             const point3_type &p,
                                             const vector3_type & /*dir*/) {
-        const point3_type local3 = p - trf.translation();
-
-        return {getter::phi(local3), local3[2]};
+        return {getter::phi(p), p[2]};
     }
 
     /// This method transforms from a local 3D cylindrical point to a point in
     /// the global cartesian 3D frame
     DETRAY_HOST_DEVICE static inline point3_type local_to_global(
-        const transform3_type &trf, const point3_type &p) {
+        const transform3_type & /*trf*/, const point3_type &p) {
 
-        const scalar_type r{p[2]};
-        const scalar_type phi{p[0] / r};
-        const scalar_type x{r * math::cos(phi)};
-        const scalar_type y{r * math::sin(phi)};
+        const scalar_type x{p[2] * math::cos(p[0])};
+        const scalar_type y{p[2] * math::sin(p[0])};
         const scalar_type z{p[1]};
 
-        return point3_type{x, y, z} + trf.translation();
+        return point3_type{x, y, z};
     }
 
     /// This method transforms from a local 2D cylindrical point to a point in
     /// the global cartesian 3D frame
     template <typename mask_t>
     DETRAY_HOST_DEVICE static inline point3_type local_to_global(
-        const transform3_type &trf, const mask_t &mask, const loc_point &p,
+        const transform3_type & /*trf*/, const mask_t &mask, const loc_point &p,
         const vector3_type & /*dir*/) {
 
         const scalar_type r{mask[mask_t::shape::e_r]};
@@ -78,7 +71,7 @@ struct concentric_cylindrical2D {
         const scalar_type y{r * math::sin(p[0])};
         const scalar_type z{p[1]};
 
-        return point3_type{x, y, z} + trf.translation();
+        return point3_type{x, y, z};
     }
 
     /// @returns the normal vector in global coordinates
@@ -86,7 +79,6 @@ struct concentric_cylindrical2D {
     DETRAY_HOST_DEVICE static inline vector3_type normal(
         const transform3_type &, const point2_type &p,
         const mask_t & /*mask*/) {
-
         // normal vector in global coordinates (concentric cylinders have no
         // rotation)
         return {math::cos(p[0]), math::sin(p[0]), 0.f};
@@ -95,10 +87,9 @@ struct concentric_cylindrical2D {
     /// @returns the normal vector given a local position @param p
     DETRAY_HOST_DEVICE static inline vector3_type normal(
         const transform3_type &, const point3_type &p) {
-        const scalar_type phi{p[0] / p[2]};
         // normal vector in global coordinates (concentric cylinders have no
         // rotation)
-        return {math::cos(phi), math::sin(phi), 0.f};
+        return {math::cos(p[0]), math::sin(p[0]), 0.f};
     }
 
 };  // struct concentric_cylindrical2D

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -139,8 +139,9 @@ class surface {
     DETRAY_HOST_DEVICE
     constexpr auto has_material() const -> bool {
         return m_desc.material().id() !=
-               static_cast<typename descr_t::material_link::id_type>(
-                   detector_t::materials::id::e_none);
+                   static_cast<typename descr_t::material_link::id_type>(
+                       detector_t::materials::id::e_none) &&
+               !m_desc.material().is_invalid();
     }
 
     /// @returns the mask volume link
@@ -204,7 +205,7 @@ class surface {
                                                 const vector3_type &dir,
                                                 const point_t &p) const
         -> scalar_type {
-        return vector::dot(dir, normal(ctx, p));
+        return math::abs(vector::dot(dir, normal(ctx, p)));
     }
 
     /// @returns the material parameters at the local position @param loc_p

--- a/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
@@ -202,9 +202,8 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
                 is.volume_link = mask.volume_link();
 
                 // Get incidence angle
-                const scalar_type phi{is.local[0] / is.local[2]};
-                const vector3_type normal = {math::cos(phi), math::sin(phi),
-                                             0.f};
+                const vector3_type normal =
+                    mask.local_frame().normal(trf, is.local);
                 is.cos_incidence_angle = vector::dot(rd, normal);
             }
         } else {

--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -21,6 +21,17 @@
 
 namespace detray::detail {
 
+/// @returns a string that identifies the volume
+template <typename detector_t>
+std::string print_volume_name(const detector_volume<detector_t> &vol,
+                              const typename detector_t::name_map &names) {
+    if (names.empty()) {
+        return std::to_string(vol.index());
+    } else {
+        return vol.name(names);
+    }
+}
+
 /// Checks every collection in a multistore to be emtpy and prints a warning
 template <typename store_t, std::size_t... I>
 void report_empty(const store_t &store, const std::string &store_name,
@@ -41,10 +52,13 @@ struct surface_checker {
     template <typename detector_t>
     DETRAY_HOST_DEVICE void operator()(
         const typename detector_t::surface_type &sf_descr,
-        const detector_t &det, const dindex vol_idx) const {
+        const detector_t &det, const dindex vol_idx,
+        const typename detector_t::name_map &names) const {
 
         const auto sf = surface{det, sf_descr};
+        const auto vol = detector_volume{det, vol_idx};
         std::stringstream err_stream{};
+        err_stream << "VOLUME \"" << print_volume_name(vol, names) << "\":\n";
 
         if (not sf.self_check(err_stream)) {
             throw std::invalid_argument(err_stream.str());
@@ -63,6 +77,16 @@ struct surface_checker {
             err_stream << "ERROR: Incorrect volume link to non-existent volume "
                        << sf.volume_link();
             throw std::invalid_argument(err_stream.str());
+        }
+
+        // A passive surface should have material, if the detector was
+        // constructed with material
+        if (!det.material_store().all_empty() &&
+            (sf.is_passive() && !sf.has_material())) {
+            std::cout << err_stream.str()
+                      << "WARNING: Passive surface without material: "
+                      << sf_descr << "\n"
+                      << std::endl;
         }
 
         // Check that the same surface is registered in the detector surface
@@ -243,7 +267,7 @@ inline void check_empty(const detector_t &det, const bool verbose) {
 
     // Check the material description
     if (det.material_store().all_empty()) {
-        std::cout << "WARNING: No material in detector" << std::endl;
+        std::cout << "WARNING: No material in detector\n" << std::endl;
     } else if (verbose) {
         // Check for empty material collections
         detail::report_empty(
@@ -265,14 +289,14 @@ inline void check_empty(const detector_t &det, const bool verbose) {
 
     // Check volume search data structure
     if (not find_volumes(det.volume_search_grid())) {
-        std::cout << "WARNING: No entries in volume finder" << std::endl;
+        std::cout << "WARNING: No entries in volume finder\n" << std::endl;
     }
 }
 
 /// @brief Checks the internal consistency of a detector
 template <typename detector_t>
-inline bool check_consistency(const detector_t &det,
-                              const bool verbose = false) {
+inline bool check_consistency(const detector_t &det, const bool verbose = false,
+                              const typename detector_t::name_map &names = {}) {
     check_empty(det, verbose);
 
     std::stringstream err_stream{};
@@ -280,6 +304,7 @@ inline bool check_consistency(const detector_t &det,
     for (const auto &[idx, vol_desc] :
          detray::views::enumerate(det.volumes())) {
         const auto vol = detector_volume{det, vol_desc};
+        err_stream << "VOLUME \"" << print_volume_name(vol, names) << "\":\n";
 
         // Check that nothing is obviously broken
         if (not vol.self_check(err_stream)) {
@@ -294,7 +319,8 @@ inline bool check_consistency(const detector_t &det,
         }
 
         // Go through the acceleration data structures and check the surfaces
-        vol.template visit_surfaces<detail::surface_checker>(det, vol.index());
+        vol.template visit_surfaces<detail::surface_checker>(det, vol.index(),
+                                                             names);
 
         // Check the volume material, if present
         if (vol.has_material()) {
@@ -307,6 +333,8 @@ inline bool check_consistency(const detector_t &det,
     for (const auto &[idx, sf_desc] :
          detray::views::enumerate(det.surfaces())) {
         const auto sf = surface{det, sf_desc};
+        const auto vol = detector_volume{det, sf.volume()};
+        err_stream << "VOLUME \"" << print_volume_name(vol, names) << "\":\n";
 
         // Check that nothing is obviously broken
         if (not sf.self_check(err_stream)) {
@@ -324,7 +352,6 @@ inline bool check_consistency(const detector_t &det,
         // Check that the surface can be found in its volume's acceleration
         // data structures (if there are no grids, must at least be in the
         // brute force method)
-        const auto vol = detector_volume{det, sf.volume()};
         bool is_registered = false;
 
         vol.template visit_surfaces<detail::surface_checker>(

--- a/io/include/detray/io/frontend/detector_reader.hpp
+++ b/io/include/detray/io/frontend/detector_reader.hpp
@@ -70,7 +70,7 @@ auto read_detector(vecmem::memory_resource& resc,
 
     if (cfg.do_check()) {
         // This will throw an exception in case of inconsistencies
-        detray::detail::check_consistency(det, cfg.verbose_check());
+        detray::detail::check_consistency(det, cfg.verbose_check(), names);
         std::cout << "Detector check: OK" << std::endl;
     }
 

--- a/tests/include/detray/test/detector_consistency.hpp
+++ b/tests/include/detray/test/detector_consistency.hpp
@@ -65,7 +65,7 @@ class consistency_check : public detray::test::fixture_base<> {
         // Build the graph
         volume_graph graph(m_det);
 
-        ASSERT_TRUE(detail::check_consistency(m_det, true))
+        ASSERT_TRUE(detail::check_consistency(m_det, true, m_names))
             << graph.to_string();
 
         if (m_cfg.write_graph()) {

--- a/tests/include/detray/test/toy_detector_test.hpp
+++ b/tests/include/detray/test/toy_detector_test.hpp
@@ -118,7 +118,7 @@ inline bool toy_detector_test(
     EXPECT_EQ(names.at(0u), "toy_detector");
 
     // Test general consistency
-    detail::check_consistency(toy_det, true);
+    detail::check_consistency(toy_det, true, names);
 
     geo_context_t ctx{};
     auto& volumes = toy_det.volumes();

--- a/tests/tools/include/detray/validation/detector_material_scan.hpp
+++ b/tests/tools/include/detray/validation/detector_material_scan.hpp
@@ -74,6 +74,8 @@ class material_scan : public test::fixture_base<> {
     /// Run the ray scan
     void TestBody() override {
 
+        const typename detector_t::geometry_context gctx{};
+
         std::size_t n_tracks{0u};
         auto ray_generator = track_generator_t(m_cfg.track_generator());
 
@@ -123,8 +125,7 @@ class material_scan : public test::fixture_base<> {
                 const auto &p = record.intersection.local;
                 const auto [seg, t, mx0, ml0] =
                     sf.template visit_material<get_material_params>(
-                        point2_t{p[0], p[1]},
-                        record.intersection.cos_incidence_angle);
+                        point2_t{p[0], p[1]}, sf.cos_angle(gctx, ray.dir(), p));
 
                 if (mx0 > 0.f) {
                     mat_sX0 += seg / mx0;
@@ -170,6 +171,8 @@ class material_scan : public test::fixture_base<> {
 
             using material_t = typename mat_group_t::value_type;
 
+            constexpr auto inv{detail::invalid_value<scalar_t>()};
+
             // Access homogeneous surface material or material maps
             if constexpr ((detail::is_hom_material_v<material_t> &&
                            !std::is_same_v<material_t, material<scalar_t>>) ||
@@ -179,6 +182,13 @@ class material_scan : public test::fixture_base<> {
                 const auto mat =
                     detail::material_accessor::get(mat_group, index, loc);
 
+                // Empty material can occur in material maps, skip it
+                if (!mat) {
+                    // Set the pathlength and thickness to zero so that they
+                    // are not counted
+                    return std::tuple(scalar_t{0}, scalar_t{0}, inv, inv);
+                }
+
                 const scalar_t seg{mat.path_segment(cos_inc_angle, loc[0])};
                 const scalar_t t{mat.thickness()};
                 const scalar_t mat_X0{mat.get_material().X0()};
@@ -186,7 +196,6 @@ class material_scan : public test::fixture_base<> {
 
                 return std::tuple(seg, t, mat_X0, mat_L0);
             } else {
-                constexpr auto inv{detail::invalid_value<scalar_t>()};
                 return std::tuple(inv, inv, inv, inv);
             }
         }

--- a/tests/tools/src/material_validation.cpp
+++ b/tests/tools/src/material_validation.cpp
@@ -32,6 +32,9 @@ int main(int argc, char **argv) {
     using detector_t = detray::detector<>;
     using scalar_t = detector_t::scalar_type;
 
+    // Filter out the google test flags
+    ::testing::InitGoogleTest(&argc, argv);
+
     // Options parsing
     po::options_description desc("\ndetray material validation options");
 

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -119,7 +119,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     EXPECT_EQ(z_tel_names1.at(1u), "telescope_world_0");
 
     // Check general consistency of the detector
-    detail::check_consistency(z_tel_det1, verbose_check);
+    detail::check_consistency(z_tel_det1, verbose_check, z_tel_names1);
 
     // Build the same telescope detector with rectangular planes and given
     // length/number of surfaces
@@ -128,7 +128,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         build_telescope_detector(host_mr, tel_cfg);
 
     // Check general consistency of the detector
-    detail::check_consistency(z_tel_det2, verbose_check);
+    detail::check_consistency(z_tel_det2, verbose_check, z_tel_names2);
 
     // Compare
     for (std::size_t i{0u}; i < z_tel_det1.surfaces().size(); ++i) {
@@ -151,7 +151,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         build_telescope_detector(host_mr, tel_cfg.pilot_track(x_track));
 
     // Check general consistency of the detector
-    detail::check_consistency(x_tel_det, verbose_check);
+    detail::check_consistency(x_tel_det, verbose_check, x_tel_names);
 
     //
     // test propagation in all telescope detector instances
@@ -253,7 +253,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         build_telescope_detector(host_mr, htel_cfg);
 
     // Check general consistency of the detector
-    detail::check_consistency(tel_detector, verbose_check);
+    detail::check_consistency(tel_detector, verbose_check, tel_names);
 
     // make at least sure it is navigatable
     navigator<decltype(tel_detector), inspector_t> tel_navigator;

--- a/tests/unit_tests/cpu/detectors/wire_chamber.cpp
+++ b/tests/unit_tests/cpu/detectors/wire_chamber.cpp
@@ -25,5 +25,5 @@ GTEST_TEST(detray_detectors, wire_chamber) {
         create_wire_chamber(host_mr, wire_chamber_config{});
 
     // Check general consistency of the detector
-    detail::check_consistency(wire_det, true);
+    detail::check_consistency(wire_det, true, names);
 }

--- a/tests/unit_tests/cpu/geometry/coordinates/cylindrical2D.cpp
+++ b/tests/unit_tests/cpu/geometry/coordinates/cylindrical2D.cpp
@@ -9,6 +9,7 @@
 #include "detray/geometry/coordinates/cylindrical2D.hpp"
 
 #include "detray/definitions/units.hpp"
+#include "detray/geometry/coordinates/concentric_cylindrical2D.hpp"
 #include "detray/test/types.hpp"
 
 // GTest include(s).
@@ -20,6 +21,7 @@
 using namespace detray;
 
 using point3 = test::point3;
+using point2 = test::point2;
 using vector3 = test::vector3;
 using transform3 = test::transform3;
 
@@ -58,6 +60,42 @@ GTEST_TEST(detray_coordinates, cylindrical2D) {
 
     // Normal vector
     const vector3 n = c2.normal(trf, local);
+    ASSERT_NEAR(n[0], constant<scalar>::inv_sqrt2, isclose);
+    ASSERT_NEAR(n[1], constant<scalar>::inv_sqrt2, isclose);
+    ASSERT_NEAR(n[2], 0.f, isclose);
+}
+
+// This test concentric cylindrical2D coordinate
+GTEST_TEST(detray_coordinates, concentric_cylindrical2D) {
+
+    const transform3 trf{};
+    // Global position on surface
+    const point3 global1 = {constant<scalar>::sqrt2, constant<scalar>::sqrt2,
+                            9.f};
+    const scalar r{2.f};
+
+    const concentric_cylindrical2D<test::algebra> c2;
+
+    // Global to local transformation
+    const point3 local3 = c2.global_to_local_3D(trf, global1, {});
+    const point2 local2 = c2.global_to_local(trf, global1, {});
+
+    // Check if the local position is correct
+    ASSERT_NEAR(local3[0], constant<scalar>::pi_4, isclose);
+    ASSERT_NEAR(local3[1], 9.f, isclose);
+    ASSERT_NEAR(local3[2], r, isclose);
+    ASSERT_NEAR(local2[0], constant<scalar>::pi_4, isclose);
+    ASSERT_NEAR(local2[1], 9.f, isclose);
+
+    // Local to global transformation
+    const point3 global2 = c2.local_to_global(trf, local3);
+    // Check if the same global position is obtained
+    ASSERT_NEAR(global1[0], global2[0], isclose);
+    ASSERT_NEAR(global1[1], global2[1], isclose);
+    ASSERT_NEAR(global1[2], global2[2], isclose);
+
+    // Normal vector
+    const vector3 n = c2.normal(trf, local3);
     ASSERT_NEAR(n[0], constant<scalar>::inv_sqrt2, isclose);
     ASSERT_NEAR(n[1], constant<scalar>::inv_sqrt2, isclose);
     ASSERT_NEAR(n[2], 0.f, isclose);

--- a/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
@@ -95,9 +95,8 @@ GTEST_TEST(detray_intersection, intersection_kernel_ray) {
     transform_store.emplace_back(static_context, vector3{0.f, 0.f, 50.f},
                                  vector3{1.f, 0.f, 0.f},
                                  vector3{0.f, 0.f, -1.f});
-    transform_store.emplace_back(static_context, vector3{0.f, 0.f, 100.f},
-                                 vector3{1.f, 0.f, 0.f},
-                                 vector3{0.f, 0.f, -1.f});
+    // Identity transform for concentric cylinder
+    transform_store.emplace_back(static_context, vector3{0.f, 0.f, 0.f});
 
     // The masks & their store
     mask_container_t mask_store(host_mr);
@@ -106,7 +105,7 @@ GTEST_TEST(detray_intersection, intersection_kernel_ray) {
     const trapezoid_t trap{0u, 10.f, 20.f, 30.f};
     const annulus_t annl{0u, 15.f, 55.f, 0.75f, 1.95f, 0.f, 2.f, -2.f};
     const cylinder_t cyl{0u, 5.f, -10.f, 10.f};
-    const cylinder_portal_t cyl_portal{0u, 4.f, -10.f, 10.f};
+    const cylinder_portal_t cyl_portal{0u, 1.f, 0.f, 1000.f};
 
     mask_store.template push_back<e_rectangle2>(rect, empty_context{});
     mask_store.template push_back<e_trapezoid2>(trap, empty_context{});
@@ -140,7 +139,7 @@ GTEST_TEST(detray_intersection, intersection_kernel_ray) {
     const point3 expected_annulus{0.03f, 0.03f, 30.f};
     const point3 expected_cylinder1{0.045f, 0.045f, 45.0f};
     const point3 expected_cylinder2{0.055f, 0.055f, 55.0f};
-    const point3 expected_cylinder_pt{0.096001f, 0.096001f, 96.001f};
+    const point3 expected_cylinder_pt{0.7071068f, 0.7071068f, 707.1068f};
 
     const std::vector<point3> expected_points = {
         expected_rectangle, expected_trapezoid, expected_annulus,

--- a/utils/include/detray/detectors/build_telescope_detector.hpp
+++ b/utils/include/detray/detectors/build_telescope_detector.hpp
@@ -257,7 +257,8 @@ inline auto build_telescope_detector(
     auto det = det_builder.build(resource);
 
     if (cfg.do_check()) {
-        detray::detail::check_consistency(det);
+        const bool verbose_check{false};
+        detray::detail::check_consistency(det, verbose_check, name_map);
     }
 
     return std::make_pair(std::move(det), std::move(name_map));

--- a/utils/include/detray/detectors/build_toy_detector.hpp
+++ b/utils/include/detray/detectors/build_toy_detector.hpp
@@ -1085,7 +1085,8 @@ inline auto build_toy_detector(vecmem::memory_resource &resource,
     auto det = det_builder.build(resource);
 
     if (cfg.do_check()) {
-        detray::detail::check_consistency(det);
+        const bool verbose_check{false};
+        detray::detail::check_consistency(det, verbose_check, name_map);
     }
 
     return std::make_pair(std::move(det), std::move(name_map));


### PR DESCRIPTION
Remove usage of a transform from concentric cylinders and fix boundaries. This requires to use the normal for angle calculations, which will be done properly in #723. Plus some improved error printing and skipping empty material in the material scan.