### PR TITLE
feat: cuda navigation validation

### DIFF
--- a/core/include/detray/core/detail/container_views.hpp
+++ b/core/include/detray/core/detail/container_views.hpp
@@ -56,9 +56,13 @@ struct dmulti_view_helper<true, view_ts...> : public dbase_view {
     dmulti_view_helper() = default;
 
     /// Tie multiple views together
-    DETRAY_HOST
+    DETRAY_HOST_DEVICE
     explicit dmulti_view_helper(view_ts&&... views)
-        : m_view(std::forward<view_ts>(views)...) {}
+        : m_view(std::move(views)...) {}
+
+    /// Tie multiple views together
+    DETRAY_HOST_DEVICE
+    explicit dmulti_view_helper(view_ts&... views) : m_view(views...) {}
 };
 
 /// Helper trait to determine if a type can be interpreted as a (composite)
@@ -153,6 +157,10 @@ template <typename T, typename A>
 dvector_view<const T> get_data(const std::vector<T, A>& vec) {
     return vecmem::get_data(vec);
 }
+
+/// Specialized view for @c vecmem::jagged_vector containers
+template <typename T>
+using djagged_vector_view = vecmem::data::jagged_vector_view<T>;
 
 /// Specialization of 'is view' for @c vecmem::data::vector_view containers
 template <typename T>

--- a/core/include/detray/core/detail/single_store.hpp
+++ b/core/include/detray/core/detail/single_store.hpp
@@ -198,7 +198,7 @@ class single_store {
     template <typename U>
     DETRAY_HOST constexpr auto push_back(
         U &&arg, const context_type & /*ctx*/ = {}) noexcept(false) -> void {
-        m_container.push_back(std::move(arg));
+        m_container.push_back(std::forward<U>(arg));
     }
 
     /// Add a new element to the collection in place

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -198,6 +198,9 @@ class detector {
           _volume_finder(detray::detail::get<6>(det_data.m_view)) {}
     /// @}
 
+    /// @returns a string that contains the detector name
+    const std::string &name(const name_map &names) const { return names.at(0); }
+
     /// @return the sub-volumes of the detector - const access
     DETRAY_HOST_DEVICE
     inline auto volumes() const -> const vector_type<volume_type> & {

--- a/core/include/detray/geometry/detail/volume_kernels.hpp
+++ b/core/include/detray/geometry/detail/volume_kernels.hpp
@@ -79,4 +79,13 @@ struct neighborhood_getter {
     }
 };
 
+/// Query the maximal number of candidates from the acceleration
+struct n_candidates_getter {
+    template <typename accel_group_t, typename accel_index_t>
+    DETRAY_HOST_DEVICE inline auto operator()(const accel_group_t &group,
+                                              const accel_index_t index) const {
+        return group[index].n_max_candidates();
+    }
+};
+
 }  // namespace detray::detail

--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -173,7 +173,7 @@ class detector_volume {
     /// @returns the maximum number of surface candidates during a neighborhood
     /// lookup
     // TODO: Remove
-    template <int I = static_cast<int>(descr_t::object_id::e_size) - 1>
+    template <int I = static_cast<int>(detector_t::accel::n_types) - 1>
     DETRAY_HOST_DEVICE constexpr auto n_max_candidates(
         unsigned int n = 0u) const -> unsigned int {
         // Get the index of the surface collection with type index 'I'

--- a/core/include/detray/geometry/detector_volume.hpp
+++ b/core/include/detray/geometry/detector_volume.hpp
@@ -173,12 +173,11 @@ class detector_volume {
     /// @returns the maximum number of surface candidates during a neighborhood
     /// lookup
     // TODO: Remove
-    template <int I = static_cast<int>(detector_t::accel::n_types) - 1>
+    template <int I = static_cast<int>(descr_t::object_id::e_size) - 1>
     DETRAY_HOST_DEVICE constexpr auto n_max_candidates(
         unsigned int n = 0u) const -> unsigned int {
+
         // Get the index of the surface collection with type index 'I'
-        constexpr auto sf_col_id{
-            static_cast<typename detector_t::accel::id>(I)};
         const auto &link{m_desc.template accel_link<
             static_cast<typename descr_t::object_id>(I)>()};
 
@@ -187,8 +186,7 @@ class detector_volume {
         if (not link.is_invalid()) {
             const unsigned int n_max{
                 m_detector.accelerator_store()
-                    .template get<sf_col_id>()[detail::get<1>(link)]
-                    .n_max_candidates()};
+                    .template visit<detail::n_candidates_getter>(link)};
             // @todo: Remove when local navigation becomes available !!!!
             n += n_max > 20u ? 20u : n_max;
         }

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -105,6 +105,26 @@ struct propagator {
               _stepping(param, magnetic_field, det),
               _navigation(det, std::move(candidates)) {}
 
+        /// Construct the propagation state from the navigator state view
+        DETRAY_HOST_DEVICE state(
+            const free_track_parameters_type &param, const detector_type &det,
+            std::size_t track_index,
+            typename navigator_type::state::view_type nav_view)
+            : m_param_type(parameter_type::e_bound),
+              _stepping(param),
+              _navigation(det, track_index, nav_view) {}
+
+        /// Construct the propagation state from the navigator state view
+        template <typename field_t>
+        DETRAY_HOST_DEVICE state(
+            const free_track_parameters_type &param,
+            const field_t &magnetic_field, const detector_type &det,
+            std::size_t track_index,
+            typename navigator_type::state::view_type nav_view)
+            : m_param_type(parameter_type::e_bound),
+              _stepping(param, magnetic_field),
+              _navigation(det, track_index, nav_view) {}
+
         DETRAY_HOST_DEVICE
         parameter_type param_type() const { return m_param_type; }
 
@@ -136,7 +156,7 @@ struct propagator {
     ///
     /// @return propagation success.
     template <typename state_t, typename actor_states_t = actor_chain<>::state>
-    DETRAY_HOST_DEVICE bool propagate(state_t &propagation,
+    DETRAY_HOST_DEVICE bool propagate(state_t &&propagation,
                                       actor_states_t &&actor_states = {}) {
 
         // Initialize the navigation

--- a/core/include/detray/utils/inspectors.hpp
+++ b/core/include/detray/utils/inspectors.hpp
@@ -175,9 +175,9 @@ struct print_inspector {
         debug_stream << msg << std::endl;
 
         debug_stream << "Volume" << tabs << state.volume() << std::endl;
-        debug_stream << "Track pos: " << track_pos[0] << ", " << track_pos[1]
-                     << ", " << track_pos[2] << ", dir: " << track_dir[0]
-                     << ", " << track_dir[1] << ", " << track_dir[2]
+        debug_stream << "Track pos: [r:" << getter::perp(track_pos)
+                     << ", z:" << track_pos[2] << "], dir: [" << track_dir[0]
+                     << ", " << track_dir[1] << ", " << track_dir[2] << "]"
                      << std::endl;
         debug_stream << "No. reachable\t\t\t" << state.n_candidates()
                      << std::endl;

--- a/io/include/detray/io/csv/intersection2D.hpp
+++ b/io/include/detray/io/csv/intersection2D.hpp
@@ -40,9 +40,8 @@ struct intersection2D {
     int status = 0;
 
     DFE_NAMEDTUPLE(intersection2D, track_id, identifier, transform_index,
-                   mask_id, mask_index, material_id, material_id,
-                   material_index, l0, l1, path, cos_theta, volume_link,
-                   direction, status);
+                   mask_id, mask_index, material_id, material_index, l0, l1,
+                   path, cos_theta, volume_link, direction, status);
 };
 
 /// Read intersections from csv file

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/intersection.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/intersection.hpp
@@ -30,9 +30,15 @@ inline auto intersection(const detector_t& detector,
     p_intersection_t p_ir;
 
     for (const auto& intr : intersections) {
+
         const detray::surface<detector_t> sf{detector, intr.sf_desc};
+        if (sf.barcode().is_invalid()) {
+            continue;
+        }
+
         const auto position = sf.local_to_global(gctx, intr.local, dir);
         const auto p_lm = svgtools::conversion::landmark(position, style);
+
         p_ir._landmarks.push_back(p_lm);
     }
 

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/intersection.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/intersection.hpp
@@ -19,7 +19,7 @@ namespace detray::svgtools::conversion {
 /// @returns The proto intersection of a detray intersection.
 template <typename detector_t, typename intersection_t>
 inline auto intersection(const detector_t& detector,
-                         const dvector<intersection_t>& intersections,
+                         const std::vector<intersection_t>& intersections,
                          const typename detector_t::vector3_type& dir = {},
                          const typename detector_t::geometry_context& gctx = {},
                          const styling::landmark_style& style =
@@ -30,8 +30,8 @@ inline auto intersection(const detector_t& detector,
     p_intersection_t p_ir;
 
     for (const auto& intr : intersections) {
-        const detray::surface surface{detector, intr.sf_desc};
-        const auto position = surface.local_to_global(gctx, intr.local, dir);
+        const detray::surface<detector_t> sf{detector, intr.sf_desc};
+        const auto position = sf.local_to_global(gctx, intr.local, dir);
         const auto p_lm = svgtools::conversion::landmark(position, style);
         p_ir._landmarks.push_back(p_lm);
     }

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/volume.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/volume.hpp
@@ -65,7 +65,7 @@ auto volume(const typename detector_t::geometry_context& context,
 
     for (const auto& desc : d_volume.surfaces()) {
 
-        const auto sf = detray::surface{detector, desc};
+        const auto sf = detray::surface<detector_t>{detector, desc};
 
         if (sf.is_portal()) {
             if (!hide_portals) {

--- a/plugins/svgtools/include/detray/plugins/svgtools/meta/display/geometry.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/meta/display/geometry.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,7 +14,6 @@
 #include "actsvg/display/geometry.hpp"
 
 // System include(s)
-#include <string>
 #include <tuple>
 
 namespace detray::svgtools::meta::display {
@@ -25,9 +24,10 @@ inline auto eta_lines(const std::string& id,
 
     return actsvg::display::eta_lines(
         id, el._z, el._r,
-        {std::tuple(el._values_main, el._stroke_main, el._show_label,
-                    el._label_font),
-         std::tuple(el._values_half, el._stroke_half, false, el._label_font)});
+        {std::make_tuple(el._values_main, el._stroke_main, el._show_label,
+                         el._label_font),
+         std::make_tuple(el._values_half, el._stroke_half, false,
+                         el._label_font)});
 }
 
 }  // namespace detray::svgtools::meta::display

--- a/tests/include/detray/test/detail/whiteboard.hpp
+++ b/tests/include/detray/test/detail/whiteboard.hpp
@@ -55,6 +55,10 @@ class whiteboard {
     template <typename T>
     const T& get(const std::string& name) const;
 
+    /// Get access to a stored object - non-const
+    template <typename T>
+    T& get(const std::string& name);
+
     private:
     /// Backend storage
     std::unordered_map<std::string, std::any> m_store;
@@ -80,6 +84,17 @@ inline const T& detray::test::whiteboard::get(const std::string& name) const
     }
     // Try to retrieve the value as the requested type
     return std::any_cast<const T&>(it->second);
+}
+
+template <typename T>
+inline T& detray::test::whiteboard::get(const std::string& name) noexcept(
+    false) {
+    auto it = m_store.find(name);
+    if (it == m_store.end()) {
+        throw std::out_of_range("Object '" + name + "' does not exists");
+    }
+    // Try to retrieve the value as the requested type
+    return std::any_cast<T&>(it->second);
 }
 
 inline bool detray::test::whiteboard::exists(const std::string& name) const {

--- a/tests/include/detray/test/detector_consistency.hpp
+++ b/tests/include/detray/test/detector_consistency.hpp
@@ -61,8 +61,8 @@ class consistency_check : public detray::test::fixture_base<> {
 
     /// Run the consistency check
     void TestBody() override {
-        std::cout << "INFO: Running consistency check on: " << m_names.at(0)
-                  << std::endl
+        std::cout << "INFO: Running consistency check on: "
+                  << m_det.name(m_names) << std::endl
                   << std::endl;
 
         // Build the graph

--- a/tests/include/detray/test/detector_scan.hpp
+++ b/tests/include/detray/test/detector_scan.hpp
@@ -11,6 +11,7 @@
 #include "detray/geometry/surface.hpp"
 #include "detray/io/utils/create_path.hpp"
 #include "detray/navigation/detail/ray.hpp"
+#include "detray/navigation/volume_graph.hpp"
 #include "detray/simulation/event_generator/track_generators.hpp"
 #include "detray/test/detail/whiteboard.hpp"
 #include "detray/test/detector_scan_config.hpp"
@@ -72,7 +73,7 @@ class detector_scan : public test::fixture_base<> {
         // Index of the volume that the test trajectory origin lies in
         dindex start_index{0u};
 
-        std::cout << "\nINFO: Running scan on: " << m_names.at(0) << "\n"
+        std::cout << "\nINFO: Running scan on: " << m_det.name(m_names) << "\n"
                   << std::endl;
 
         // Fill detector scan data to white board
@@ -92,8 +93,8 @@ class detector_scan : public test::fixture_base<> {
                    "Invalid intersection trace");
 
             // Retrieve the test trajectory
-            const auto &track = intersection_trace.front().track_param;
-            trajectory_type test_traj = get_parametrized_trajectory(track);
+            const auto &trck_param = intersection_trace.front().track_param;
+            trajectory_type test_traj = get_parametrized_trajectory(trck_param);
 
             // Run consistency checks on the trace
             bool success = detector_scanner::check_trace<detector_t>(
@@ -103,7 +104,8 @@ class detector_scan : public test::fixture_base<> {
             if (not success) {
                 detector_scanner::display_error(
                     m_gctx, m_det, m_names, m_cfg.name(), test_traj,
-                    intersection_trace, m_cfg.svg_style(), n_tracks, n_helices);
+                    intersection_trace, m_cfg.svg_style(), n_tracks, n_helices,
+                    intersection_trace_t{});
             }
 
             ASSERT_TRUE(success);

--- a/tests/include/detray/test/navigation_validation_config.hpp
+++ b/tests/include/detray/test/navigation_validation_config.hpp
@@ -31,6 +31,9 @@ struct navigation_validation_config
     std::string m_name{"navigation_validation"};
     /// Access to truth data
     std::shared_ptr<test::whiteboard> m_white_board;
+    /// Name of the input file, containing the complete ray scan traces
+    std::string m_intersection_file{""};
+    std::string m_track_param_file{""};
     /// The maximal number of test tracks to run
     std::size_t m_n_tracks{detray::detail::invalid_value<std::size_t>()};
     /// B-field vector for helix
@@ -47,6 +50,8 @@ struct navigation_validation_config
     std::shared_ptr<test::whiteboard> whiteboard() const {
         return m_white_board;
     }
+    const std::string &intersection_file() const { return m_intersection_file; }
+    const std::string &track_param_file() const { return m_track_param_file; }
     std::size_t n_tracks() const { return m_n_tracks; }
     const vector3_type &B_vector() { return m_B; }
     const auto &svg_style() const { return m_style; }
@@ -65,6 +70,14 @@ struct navigation_validation_config
                 "Helix navigation: No valid whiteboard instance");
         }
         m_white_board = std::move(w_board);
+        return *this;
+    }
+    navigation_validation_config &intersection_file(const std::string f) {
+        m_intersection_file = std::move(f);
+        return *this;
+    }
+    navigation_validation_config &track_param_file(const std::string f) {
+        m_track_param_file = std::move(f);
         return *this;
     }
     navigation_validation_config &n_tracks(std::size_t n) {

--- a/tests/include/detray/test/utils/detector_scan_utils.hpp
+++ b/tests/include/detray/test/utils/detector_scan_utils.hpp
@@ -583,19 +583,21 @@ inline bool check_trace(const std::vector<record_t> &intersection_trace,
 /// @param vol_names the volume name map of the detector
 /// @param test_name the name of the test for which to print the error
 /// @param test_track trajectory that was used for the scan (ray or helix)
-/// @param intersection_trace the intersection records along the test track
+/// @param truth_trace the intersection records along the test track
 /// @param svg_style svgtools style for the detector display
 /// @param i_track index of the test track
 /// @param n_track total number of test tracks
-template <typename detector_t, typename trajectory_t, typename record_t>
-inline void display_error(
-    const typename detector_t::geometry_context gctx, const detector_t &det,
-    const typename detector_t::name_map vol_names, const std::string &test_name,
-    const trajectory_t &test_track,
-    const std::vector<record_t> &intersection_trace,
-    const detray::svgtools::styling::style &svg_style,
-    const std::size_t i_track, const std::size_t n_tracks,
-    const dvector<typename record_t::intersection_type> &intersections = {}) {
+template <typename detector_t, typename trajectory_t, typename truth_trace_t,
+          typename recorded_trace_t>
+inline void display_error(const typename detector_t::geometry_context gctx,
+                          const detector_t &det,
+                          const typename detector_t::name_map vol_names,
+                          const std::string &test_name,
+                          const trajectory_t &test_track,
+                          const truth_trace_t &truth_trace,
+                          const detray::svgtools::styling::style &svg_style,
+                          const std::size_t i_track, const std::size_t n_tracks,
+                          const recorded_trace_t &recorded_trace = {}) {
 
     // Creating the svg generator for the detector.
     detray::svgtools::illustrator il{det, vol_names, svg_style};
@@ -614,8 +616,9 @@ inline void display_error(
         track_type = "helix";
     }
 
-    detail::svg_display(gctx, il, intersection_trace, test_track, track_type,
-                        test_name, intersections);
+    detail::svg_display(gctx, il, truth_trace, test_track,
+                        track_type + "_" + std::to_string(i_track), test_name,
+                        recorded_trace);
 
     std::cout << "\nFailed on " << track_type << ": " << i_track << "/"
               << n_tracks << "\n"

--- a/tests/include/detray/test/utils/detector_scan_utils.hpp
+++ b/tests/include/detray/test/utils/detector_scan_utils.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/plugins/svgtools/illustrator.hpp"
 #include "detray/test/utils/svg_display.hpp"
+#include "detray/utils/ranges.hpp"
 
 // System include(s)
 #include <algorithm>
@@ -157,6 +158,16 @@ inline bool check_connectivity(
             << "Didn't leave world or unconnected elements left in trace:"
             << "\n\nValid connections that were found:" << std::endl;
         err_stream << record_stream.str();
+
+        err_stream << "\nPairs left to match:" << std::endl;
+        for (std::size_t j = static_cast<std::size_t>(i); j < trace.size();
+             ++j) {
+            auto first_vol = std::get<1>(trace[j].first);
+            auto second_vol = std::get<1>(trace[j].second);
+
+            err_stream << "(" << first_vol << ", " << second_vol << ")"
+                       << std::endl;
+        }
 
         print_err(err_stream);
 
@@ -625,7 +636,33 @@ inline void display_error(const typename detector_t::geometry_context gctx,
               << test_track;
 }
 
-/// Print and adjacency list
+/// Print an intersection trace
+template <typename truth_trace_t>
+inline std::string print_trace(const truth_trace_t &truth_trace,
+                               std::size_t n) {
+
+    std::stringstream out_stream{};
+    out_stream << "TRACE NO. " << n << std::endl;
+
+    for (const auto &[idx, record] : detray::views::enumerate(truth_trace)) {
+        out_stream << "\nRecord " << idx << std::endl;
+
+        out_stream << " -> volume " << record.vol_idx << std::endl;
+
+        const auto pos = record.track_param.pos();
+        const auto dir = record.track_param.dir();
+        out_stream << " -> track pos: [" << pos[0] << ", " << pos[1] << ", "
+                   << pos[2] << std::endl;
+        out_stream << " -> track dir: [" << dir[0] << ", " << dir[1] << ", "
+                   << dir[2] << std::endl;
+
+        out_stream << " -> intersection " << record.intersection << std::endl;
+    }
+
+    return out_stream.str();
+}
+
+/// Print an adjacency list
 inline std::string print_adj(const dvector<dindex> &adjacency_matrix) {
 
     std::size_t dim = static_cast<dindex>(math::sqrt(adjacency_matrix.size()));

--- a/tests/include/detray/test/utils/detector_scanner.hpp
+++ b/tests/include/detray/test/utils/detector_scanner.hpp
@@ -192,9 +192,6 @@ inline auto write(
         track_params.back().reserve(trace.size());
 
         for (const auto &record : trace) {
-            // Ray/Helix scan should have been finished successfully
-            assert(record.intersection.volume_link == record.vol_idx);
-
             intersections.back().push_back(record.intersection);
             track_params.back().push_back(record.track_param);
         }

--- a/tests/include/detray/test/utils/detector_scanner.hpp
+++ b/tests/include/detray/test/utils/detector_scanner.hpp
@@ -106,6 +106,7 @@ struct brute_force_scan {
         intersection_t start_intersection{};
         start_intersection.sf_desc = first_record.intersection.sf_desc;
         start_intersection.sf_desc.set_id(surface_id::e_passive);
+        start_intersection.sf_desc.set_index(dindex_invalid);
         start_intersection.path = 0.f;
         start_intersection.local = {0.f, 0.f, 0.f};
         start_intersection.volume_link =

--- a/tests/include/detray/test/utils/svg_display.hpp
+++ b/tests/include/detray/test/utils/svg_display.hpp
@@ -53,47 +53,73 @@ std::unordered_set<dindex> get_volume_indices(
     return volumes;
 }
 
+/// Transcribe the intersections from an intersection trace into a standalone
+/// vector.
+///
+/// @param intersection_trace the input intersection trace
+///
+/// @returns a vector of intersections in the same order as the input trace.
+template <typename record_t, typename ALLOC>
+auto transcribe_intersections(
+    const std::vector<record_t, ALLOC> &intersection_trace) {
+
+    using intersection_t = typename record_t::intersection_type;
+
+    std::vector<intersection_t> intersections{};
+    intersections.reserve(intersection_trace.size());
+    for (auto &ir : intersection_trace) {
+        intersections.push_back(ir.intersection);
+    }
+
+    return intersections;
+}
+
 /// @returns the svg of the intersections (truth and track) and the trajectory
-template <typename detector_t, typename record_t, class traj_t, typename view_t>
+template <typename detector_t, typename truth_trace_t, class traj_t,
+          typename recorded_trace_t, typename view_t>
 auto draw_intersection_and_traj_svg(
     const typename detector_t::geometry_context gctx,
     detray::svgtools::illustrator<detector_t> &il,
-    const std::vector<record_t> &intersections_truth, const traj_t &traj,
-    const std::string &traj_name,
-    const dvector<typename record_t::intersection_type> &intersections,
+    const truth_trace_t &truth_trace, const traj_t &traj,
+    const std::string &traj_name, const recorded_trace_t &recorded_trace,
     const view_t &view) {
 
-    auto svg_traj = il.draw_intersections(
-        "truth_intersections", intersections_truth, traj.dir(), view, gctx);
+    // Get only the intersections from the traces
+    auto truth_intersections = transcribe_intersections(truth_trace);
+    auto recorded_intersections = transcribe_intersections(recorded_trace);
 
-    if (not intersections.empty()) {
+    // Draw the truth intersections
+    auto svg_traj = il.draw_intersections("truth_trace", truth_intersections,
+                                          traj.dir(), view, gctx);
+
+    // Draw an approximation of the trajectory with the recorded intersections
+    if (not recorded_intersections.empty()) {
         svg_traj.add_object(il.draw_intersections_and_trajectory(
-            traj_name, intersections, traj, view,
-            intersections_truth.back().intersection.path, gctx));
+            traj_name, recorded_intersections, traj, view,
+            truth_intersections.back().path, gctx));
     } else {
         svg_traj.add_object(il.draw_trajectory(
-            traj_name, traj, intersections_truth.back().intersection.path,
-            view));
+            traj_name, traj, truth_intersections.back().path, view));
     }
 
     return svg_traj;
 }
 
 /// Display the geometry, intersection and track data via @c svgtools
-template <typename detector_t, typename record_t, class traj_t>
-inline void svg_display(
-    const typename detector_t::geometry_context gctx,
-    detray::svgtools::illustrator<detector_t> &il,
-    const std::vector<record_t> &intersections_truth, const traj_t &traj,
-    const std::string &traj_name,
-    const std::string &outfile = "detector_display",
-    const dvector<typename record_t::intersection_type> &intersections = {},
-    const std::string &outdir = "./plots/") {
+template <typename detector_t, typename truth_trace_t, class traj_t,
+          typename recorded_trace_t>
+inline void svg_display(const typename detector_t::geometry_context gctx,
+                        detray::svgtools::illustrator<detector_t> &il,
+                        const truth_trace_t &truth_trace, const traj_t &traj,
+                        const std::string &traj_name,
+                        const std::string &outfile = "detector_display",
+                        const recorded_trace_t &recorded_trace = {},
+                        const std::string &outdir = "./plots/") {
 
     // Gather all volumes that need to be displayed
-    auto volumes = get_volume_indices(intersections_truth);
-    if (not intersections.empty()) {
-        const auto more_volumes = get_volume_indices(intersections_truth);
+    auto volumes = get_volume_indices(truth_trace);
+    if (not recorded_trace.empty()) {
+        const auto more_volumes = get_volume_indices(truth_trace);
         volumes.insert(more_volumes.begin(), more_volumes.end());
     }
 
@@ -109,12 +135,12 @@ inline void svg_display(
     auto zr_axis = actsvg::draw::x_y_axes("axes", {-3100, 3100}, {-5, 1100},
                                           stroke_black, "z", "r");
     // Creating the views.
-    const actsvg::views::x_y xy;
-    const actsvg::views::z_r zr;
+    const actsvg::views::x_y xy{};
+    const actsvg::views::z_r zr{};
 
     // xy - view
     auto svg_traj = draw_intersection_and_traj_svg(
-        gctx, il, intersections_truth, traj, traj_name, intersections, xy);
+        gctx, il, truth_trace, traj, traj_name, recorded_trace, xy);
 
     const auto [vol_xy_svg, _] = il.draw_volumes(volumes, xy, gctx);
     detray::svgtools::write_svg(
@@ -122,8 +148,8 @@ inline void svg_display(
         {xy_axis, vol_xy_svg, svg_traj});
 
     // zr - view
-    svg_traj = draw_intersection_and_traj_svg(
-        gctx, il, intersections_truth, traj, traj_name, intersections, zr);
+    svg_traj = draw_intersection_and_traj_svg(gctx, il, truth_trace, traj,
+                                              traj_name, recorded_trace, zr);
 
     const auto vol_zr_svg = il.draw_detector(zr, gctx);
     detray::svgtools::write_svg(

--- a/tests/include/detray/test/utils/svg_display.hpp
+++ b/tests/include/detray/test/utils/svg_display.hpp
@@ -90,7 +90,7 @@ auto draw_intersection_and_traj_svg(
 
     // Draw the truth intersections
     auto svg_traj = il.draw_intersections("truth_trace", truth_intersections,
-                                          traj.dir(), view, gctx);
+                                          traj.dir(0.f), view, gctx);
 
     // Draw an approximation of the trajectory with the recorded intersections
     if (not recorded_intersections.empty()) {

--- a/tests/integration_tests/cpu/propagator/guided_navigator.cpp
+++ b/tests/integration_tests/cpu/propagator/guided_navigator.cpp
@@ -98,7 +98,7 @@ GTEST_TEST(detray_navigation, guided_navigator) {
     EXPECT_EQ(obj_tracer.object_trace.size(), sf_sequence.size())
         << debug_printer.to_string();
     for (std::size_t i = 0u; i < sf_sequence.size(); ++i) {
-        const auto &candidate = obj_tracer.object_trace[i];
+        const auto &candidate = obj_tracer[i].intersection;
         auto bcd = geometry::barcode{};
         bcd.set_volume(0u).set_index(sf_sequence[i]);
         bcd.set_id((i == 11u) ? surface_id::e_portal : surface_id::e_sensitive);

--- a/tests/integration_tests/device/cuda/CMakeLists.txt
+++ b/tests/integration_tests/device/cuda/CMakeLists.txt
@@ -13,6 +13,10 @@ enable_language(CUDA)
 # Set the CUDA build flags.
 include(detray-compiler-options-cuda)
 
+# Silence actsvg internal warnings
+include_directories( SYSTEM $<TARGET_PROPERTY:actsvg::meta,INTERFACE_INCLUDE_DIRECTORIES> )
+include_directories( SYSTEM $<TARGET_PROPERTY:actsvg::core,INTERFACE_INCLUDE_DIRECTORIES> )
+
 # make unit tests for multiple algebras
 # Currently vc and smatrix is not supported
 set(algebras "array")
@@ -37,3 +41,36 @@ foreach(algebra ${algebras})
                         PROPERTIES DEPENDS
                      "detray_unit_test_cuda;detray_unit_test_cuda_${algebra}")
 endforeach()
+
+# CUDA navigation validation for the telescope detector
+detray_add_integration_test(telescope_detector_cuda
+                           "navigation_validation.hpp"
+                           "navigation_validation.cu"
+                           "telescope_navigation_validation.cpp"
+                            LINK_LIBRARIES GTest::gtest GTest::gtest_main
+                            vecmem::cuda detray::core_array
+                            detray::test detray::utils )
+
+set_tests_properties(detray_integration_test_telescope_detector_cuda PROPERTIES DEPENDS "detray_integration_test_cuda_array,detray_integration_test_telescope_detector")
+
+# CUDA navigation validation for the toy detector
+detray_add_integration_test(toy_detector_cuda
+                           "navigation_validation.hpp"
+                           "navigation_validation.cu"
+                           "toy_detector_navigation_validation.cpp"
+                            LINK_LIBRARIES GTest::gtest GTest::gtest_main
+                            vecmem::cuda covfie::cuda detray::core_array
+                            detray::test detray::utils )
+
+set_tests_properties(detray_integration_test_toy_detector_cuda PROPERTIES DEPENDS "detray_integration_test_cuda_array,detray_integration_test_toy_detector")
+
+# CUDA navigation validation for the wire chamber
+detray_add_integration_test(wire_chamber_cuda
+                           "navigation_validation.hpp"
+                           "navigation_validation.cu"
+                           "wire_chamber_navigation_validation.cpp"
+                            LINK_LIBRARIES GTest::gtest GTest::gtest_main
+                            vecmem::cuda detray::core_array
+                            detray::test detray::utils )
+
+set_tests_properties(detray_integration_test_wire_chamber_cuda PROPERTIES DEPENDS "detray_integration_test_cuda_array,detray_integration_test_wire_chamber")

--- a/tests/integration_tests/device/cuda/navigation_validation.cu
+++ b/tests/integration_tests/device/cuda/navigation_validation.cu
@@ -1,0 +1,181 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "detray/definitions/detail/cuda_definitions.hpp"
+#include "detray/detectors/telescope_metadata.hpp"
+#include "detray/detectors/toy_metadata.hpp"
+#include "navigation_validation.hpp"
+
+namespace detray::cuda {
+
+template <typename bfield_t, typename detector_t,
+          typename intersection_record_t>
+__global__ void navigation_validation_kernel(
+    typename detector_t::view_type det_data,
+    const propagation::config<typename detector_t::scalar_type> cfg,
+    bfield_t field_data,
+    vecmem::data::jagged_vector_view<
+        typename intersection_record_t::intersection_type>
+        navigation_cache_view,
+    vecmem::data::jagged_vector_view<const intersection_record_t>
+        truth_intersection_traces_view,
+    vecmem::data::jagged_vector_view<navigation::detail::candidate_record<
+        typename intersection_record_t::intersection_type>>
+        recorded_intersections_view) {
+
+    using detector_device_t =
+        detector<typename detector_t::metadata, device_container_types>;
+    using algebra_t = typename detector_device_t::algebra_type;
+
+    static_assert(std::is_same_v<typename detector_t::view_type,
+                                 typename detector_device_t::view_type>,
+                  "Host and device detector views do not match");
+
+    using hom_bfield_view_t = bfield::const_field_t::view_t;
+    using rk_stepper_t = rk_stepper<hom_bfield_view_t, algebra_t>;
+    using line_stepper_t = line_stepper<algebra_t>;
+    // Use RK-stepper when a non-empty b-field was passed
+    static constexpr auto is_no_bfield{
+        std::is_same_v<bfield_t, navigation_validator::empty_bfield>};
+    using stepper_t =
+        std::conditional_t<is_no_bfield, line_stepper_t, rk_stepper_t>;
+
+    // Inspector that records all encountered surfaces
+    using intersection_t = typename intersection_record_t::intersection_type;
+    using object_tracer_t =
+        navigation::object_tracer<intersection_t, vecmem::device_vector,
+                                  navigation::status::e_on_module,
+                                  navigation::status::e_on_portal>;
+    // Navigation with inspection
+    using navigator_t = navigator<detector_device_t, object_tracer_t>;
+
+    // Propagator with pathlimit aborter
+    using actor_chain_t = actor_chain<tuple, pathlimit_aborter>;
+    using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
+
+    detector_device_t det(det_data);
+
+    vecmem::jagged_device_vector<intersection_t> navigation_cache(
+        navigation_cache_view);
+    vecmem::jagged_device_vector<const intersection_record_t>
+        truth_intersection_traces(truth_intersection_traces_view);
+    vecmem::jagged_device_vector<
+        navigation::detail::candidate_record<intersection_t>>
+        recorded_intersections(recorded_intersections_view);
+
+    // Check the memory setup
+    assert(truth_intersection_traces.size() ==
+           recorded_intersections_view.size());
+    assert(truth_intersection_traces.size() == navigation_cache.size());
+    for (unsigned int i = 0u; i < navigation_cache.size(); ++i) {
+        assert(navigation_cache.at(i).capacity() > 0);
+    }
+
+    int trk_id = threadIdx.x + blockIdx.x * blockDim.x;
+    if (trk_id >= truth_intersection_traces.size()) {
+        return;
+    }
+
+    propagator_t p{cfg};
+
+    // Create the actor states
+    pathlimit_aborter::state aborter_state{cfg.stepping.path_limit};
+    auto actor_states = ::detray::tie(aborter_state);
+
+    // Get the initial track parameters
+    const auto &track = truth_intersection_traces[trk_id].front().track_param;
+
+    // Save the initial intersection, since it is not recorded by the
+    // object tracer
+    recorded_intersections.at(trk_id).push_back(
+        {track.pos(), track.dir(),
+         truth_intersection_traces[trk_id].front().intersection});
+
+    // Run propagation
+    if constexpr (is_no_bfield) {
+        p.propagate(typename propagator_t::state(
+                        track, det, trk_id,
+                        typename navigator_t::state::view_type{
+                            navigation_cache_view,
+                            recorded_intersections_view.ptr()[trk_id]}),
+                    actor_states);
+    } else {
+        p.propagate(typename propagator_t::state(
+                        track, field_data, det, trk_id,
+                        typename navigator_t::state::view_type{
+                            navigation_cache_view,
+                            recorded_intersections_view.ptr()[trk_id]}),
+                    actor_states);
+    }
+}
+
+/// Launch the device kernel
+template <typename bfield_t, typename detector_t,
+          typename intersection_record_t>
+void navigation_validation_device(
+    typename detector_t::view_type det_view,
+    const propagation::config<typename detector_t::scalar_type> &cfg,
+    bfield_t field_data,
+    vecmem::data::jagged_vector_view<
+        typename intersection_record_t::intersection_type>
+        &navigation_cache_view,
+    vecmem::data::jagged_vector_view<const intersection_record_t>
+        &truth_intersection_traces_view,
+    vecmem::data::jagged_vector_view<navigation::detail::candidate_record<
+        typename intersection_record_t::intersection_type>>
+        &recorded_intersections_view) {
+
+    constexpr int thread_dim = 2 * WARP_SIZE;
+    int block_dim = truth_intersection_traces_view.size() / thread_dim + 1;
+
+    // run the test kernel
+    navigation_validation_kernel<bfield_t, detector_t, intersection_record_t>
+        <<<block_dim, thread_dim>>>(
+            det_view, cfg, field_data, navigation_cache_view,
+            truth_intersection_traces_view, recorded_intersections_view);
+
+    // cuda error check
+    DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());
+    DETRAY_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+}
+
+/// Macro declaring the template instantiations for the different detector types
+#define DECLARE_NAVIGATION_VALIDATION(METADATA)                                \
+                                                                               \
+    template void navigation_validation_device<                                \
+        covfie::field_view<bfield::const_bknd_t>, detector<METADATA>,          \
+        detray::intersection_record<detector<METADATA>>>(                      \
+        typename detector<METADATA>::view_type,                                \
+        const propagation::config<typename detector<METADATA>::scalar_type> &, \
+        covfie::field_view<bfield::const_bknd_t>,                              \
+        vecmem::data::jagged_vector_view<typename detray::intersection_record< \
+            detector<METADATA>>::intersection_type> &,                         \
+        vecmem::data::jagged_vector_view<                                      \
+            const detray::intersection_record<detector<METADATA>>> &,          \
+        vecmem::data::jagged_vector_view<navigation::detail::candidate_record< \
+            typename detray::intersection_record<                              \
+                detector<METADATA>>::intersection_type>> &);                   \
+                                                                               \
+    template void navigation_validation_device<                                \
+        detray::navigation_validator::empty_bfield, detector<METADATA>,        \
+        detray::intersection_record<detector<METADATA>>>(                      \
+        typename detector<METADATA>::view_type,                                \
+        const propagation::config<typename detector<METADATA>::scalar_type> &, \
+        detray::navigation_validator::empty_bfield,                            \
+        vecmem::data::jagged_vector_view<typename detray::intersection_record< \
+            detector<METADATA>>::intersection_type> &,                         \
+        vecmem::data::jagged_vector_view<                                      \
+            const detray::intersection_record<detector<METADATA>>> &,          \
+        vecmem::data::jagged_vector_view<navigation::detail::candidate_record< \
+            typename detray::intersection_record<                              \
+                detector<METADATA>>::intersection_type>> &);
+
+DECLARE_NAVIGATION_VALIDATION(default_metadata)
+DECLARE_NAVIGATION_VALIDATION(toy_metadata)
+DECLARE_NAVIGATION_VALIDATION(telescope_metadata<rectangle2D>)
+
+}  // namespace detray::cuda

--- a/tests/integration_tests/device/cuda/navigation_validation.hpp
+++ b/tests/integration_tests/device/cuda/navigation_validation.hpp
@@ -1,0 +1,319 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/core/detector.hpp"
+#include "detray/detectors/bfield.hpp"
+#include "detray/navigation/detail/ray.hpp"
+#include "detray/propagator/line_stepper.hpp"
+#include "detray/propagator/rk_stepper.hpp"
+#include "detray/test/fixture_base.hpp"
+#include "detray/test/navigation_validation_config.hpp"
+#include "detray/test/utils/detector_scan_utils.hpp"
+#include "detray/test/utils/detector_scanner.hpp"
+#include "detray/test/utils/navigation_validation_utils.hpp"
+#include "detray/tracks/tracks.hpp"
+#include "detray/utils/inspectors.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+
+namespace detray::cuda {
+
+/// Launch the navigation validation kernel
+///
+/// @param[in] det_view the detector vecmem view
+/// @param[in] cfg the propagation configuration
+/// @param[in] field_data the magentic field view (maybe an empty field)
+/// @param[in] navigation_cache_view the navigation cache vecemem view
+/// @param[in] truth_intersection_traces_view vecemem view of the truth data
+/// @param[out] recorded_intersections_view vecemem view of the intersections
+///                                         recorded by the navigator
+template <typename bfield_t, typename detector_t,
+          typename intersection_record_t>
+void navigation_validation_device(
+    typename detector_t::view_type det_view,
+    const propagation::config<typename detector_t::scalar_type> &cfg,
+    bfield_t field_data,
+    vecmem::data::jagged_vector_view<
+        typename intersection_record_t::intersection_type>
+        &navigation_cache_view,
+    vecmem::data::jagged_vector_view<const intersection_record_t>
+        &truth_intersection_traces_view,
+    vecmem::data::jagged_vector_view<navigation::detail::candidate_record<
+        typename intersection_record_t::intersection_type>>
+        &recorded_intersections_view);
+
+/// Prepare data for device navigation run
+template <typename bfield_t, typename detector_t,
+          typename intersection_record_t>
+inline auto run_navigation_validation(
+    vecmem::memory_resource *host_mr, vecmem::memory_resource *dev_mr,
+    const detector_t &det,
+    const propagation::config<typename detector_t::scalar_type> &cfg,
+    bfield_t field_data,
+    const std::vector<std::vector<intersection_record_t>>
+        &truth_intersection_traces)
+    -> vecmem::jagged_vector<navigation::detail::candidate_record<
+        typename intersection_record_t::intersection_type>> {
+
+    using intersection_t = typename intersection_record_t::intersection_type;
+
+    // Helper object for performing memory copies (to CUDA devices)
+    vecmem::cuda::copy cuda_cpy;
+
+    // Copy the detector to device and get its view
+    auto det_buffer = detray::get_buffer(det, *dev_mr, cuda_cpy);
+    auto det_view = detray::get_data(det_buffer);
+
+    // Allocate memory for the navigation cache on the device
+    const std::size_t n_tracks{truth_intersection_traces.size()};
+    auto navigation_cache_buffer =
+        detray::create_candidates_buffer(det, n_tracks, *dev_mr, host_mr);
+    cuda_cpy.setup(navigation_cache_buffer);
+
+    // Move truth intersection traces data to device
+    auto truth_intersection_traces_data =
+        vecmem::get_data(truth_intersection_traces, host_mr);
+    auto truth_intersection_traces_buffer =
+        cuda_cpy.to(truth_intersection_traces_data, *dev_mr, host_mr,
+                    vecmem::copy::type::host_to_device);
+    vecmem::data::jagged_vector_view<const intersection_record_t>
+        truth_intersection_traces_view =
+            vecmem::get_data(truth_intersection_traces_buffer);
+
+    // Buffer for the intersections recorded by the navigator
+    std::vector<std::size_t> capacities;
+    for (const auto &trace : truth_intersection_traces) {
+        capacities.push_back(trace.size());
+    }
+
+    vecmem::data::jagged_vector_buffer<
+        navigation::detail::candidate_record<intersection_t>>
+        recorded_intersections_buffer(capacities, *dev_mr, host_mr,
+                                      vecmem::data::buffer_type::resizable);
+    cuda_cpy.setup(recorded_intersections_buffer);
+    auto recorded_intersections_view =
+        vecmem::get_data(recorded_intersections_buffer);
+
+    // Run the navigation validation test on device
+    navigation_validation_device<bfield_t, detector_t, intersection_record_t>(
+        det_view, cfg, field_data, navigation_cache_buffer,
+        truth_intersection_traces_view, recorded_intersections_view);
+
+    // Get the result back to the host and pass it on to the checking
+    vecmem::jagged_vector<navigation::detail::candidate_record<intersection_t>>
+        recorded_intersections(host_mr);
+    cuda_cpy(recorded_intersections_buffer, recorded_intersections);
+
+    return recorded_intersections;
+}
+
+/// @brief Test class that runs the navigation validation for a given detector
+/// on device.
+///
+/// @note The lifetime of the detector needs to be guaranteed outside this class
+template <typename detector_t, template <typename> class scan_type>
+class navigation_validation : public test::fixture_base<> {
+
+    using scalar_t = typename detector_t::scalar_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using free_track_parameters_t = free_track_parameters<algebra_t>;
+    using trajectory_type = typename scan_type<algebra_t>::trajectory_type;
+    using intersection_trace_t = typename scan_type<
+        algebra_t>::template intersection_trace_type<detector_t>;
+
+    /// Switch between rays and helices
+    static constexpr auto k_use_rays{
+        std::is_same_v<detail::ray<algebra_t>, trajectory_type>};
+
+    public:
+    using fixture_type = test::fixture_base<>;
+    using config = detray::test::navigation_validation_config;
+
+    explicit navigation_validation(
+        const detector_t &det, const typename detector_t::name_map &names,
+        const config &cfg = {},
+        const typename detector_t::geometry_context gctx = {})
+        : m_cfg{cfg}, m_gctx{gctx}, m_det{det}, m_names{names} {
+
+        if (!m_cfg.whiteboard()) {
+            throw std::invalid_argument("No white board was passed to " +
+                                        m_cfg.name() + " test");
+        }
+
+        // Use ray or helix
+        const std::string det_name{m_det.name(m_names)};
+        m_truth_data_name = k_use_rays ? det_name + "_ray_scan_for_cuda"
+                                       : det_name + "_helix_scan_for_cuda";
+
+        // Pin the data onto the whiteboard
+        if (io::file_exists(m_cfg.intersection_file()) &&
+            io::file_exists(m_cfg.track_param_file())) {
+
+            // Name clash: Choose alternative name
+            if (m_cfg.whiteboard()->exists(m_truth_data_name)) {
+                m_truth_data_name = io::alt_file_name(m_truth_data_name);
+            }
+
+            std::vector<intersection_trace_t> intersection_traces;
+
+            std::cout << "INFO: Reading data from file..." << std::endl;
+
+            // Fill the intersection traces from file
+            detray::detector_scanner::read(m_cfg.intersection_file(),
+                                           m_cfg.track_param_file(),
+                                           intersection_traces);
+
+            m_cfg.whiteboard()->add(m_truth_data_name,
+                                    std::move(intersection_traces));
+        } else {
+            // File names were configured, but not found
+            if (!m_cfg.intersection_file().empty() ||
+                !m_cfg.track_param_file().empty()) {
+                std::cout << "WARNING: Data files do not exist" << std::endl;
+            }
+        }
+
+        // Check that data is ready
+        if (!m_cfg.whiteboard()->exists(m_truth_data_name)) {
+            throw std::invalid_argument(
+                "Data for navigation check is not on the whiteboard");
+        }
+    }
+
+    /// Run the check
+    void TestBody() override {
+        using namespace detray;
+        using namespace navigation;
+
+        // Runge-Kutta stepper
+        using hom_bfield_t = bfield::const_field_t;
+        using bfield_view_t =
+            std::conditional_t<k_use_rays, navigation_validator::empty_bfield,
+                               hom_bfield_t::view_t>;
+        using bfield_t =
+            std::conditional_t<k_use_rays, navigation_validator::empty_bfield,
+                               hom_bfield_t>;
+
+        bfield_t b_field{};
+        if constexpr (!k_use_rays) {
+            b_field = bfield::create_const_field(m_cfg.B_vector());
+        }
+
+        // Fetch the truth data
+        const auto &truth_intersection_traces =
+            m_cfg.whiteboard()->template get<std::vector<intersection_trace_t>>(
+                m_truth_data_name);
+
+        std::size_t n_test_tracks{
+            std::min(m_cfg.n_tracks(), truth_intersection_traces.size())};
+        std::cout << "\nINFO: Running device navigation validation on: "
+                  << m_det.name(m_names) << "...\n"
+                  << std::endl;
+
+        // Run the propagation on device and record the navigation data
+        auto recorded_intersections = run_navigation_validation<bfield_view_t>(
+            &m_host_mr, &m_dev_mr, m_det, m_cfg.propagation(), b_field,
+            truth_intersection_traces);
+
+        // Collect some statistics
+        std::size_t n_tracks{0u}, n_miss{0u}, n_fatal{0u};
+
+        EXPECT_EQ(recorded_intersections.size(),
+                  truth_intersection_traces.size());
+
+        for (std::size_t i = 0u; i < truth_intersection_traces.size(); ++i) {
+            const auto &truth_trace = truth_intersection_traces[i];
+            const auto &recorded_trace = recorded_intersections[i];
+
+            if (n_tracks >= m_cfg.n_tracks()) {
+                break;
+            }
+
+            // Get the original test trajectory (ray or helix)
+            const auto &trck_param = truth_trace.front().track_param;
+            trajectory_type test_traj = get_parametrized_trajectory(trck_param);
+
+            // Recorded only the start position, which added by default
+            bool success{true};
+            if (truth_trace.size() == 1) {
+                // Propagation did not succeed
+                success = false;
+                ++n_fatal;
+            } else {
+                // Compare truth and recorded data elementwise
+                success &= navigation_validator::compare_traces(
+                    truth_trace, recorded_trace, test_traj, n_tracks,
+                    n_test_tracks);
+
+                if (not success) {
+                    // Count mismatches
+                    ++n_miss;
+                }
+            }
+
+            if (not success) {
+                detector_scanner::display_error(
+                    m_gctx, m_det, m_names, m_cfg.name(), test_traj,
+                    truth_trace, m_cfg.svg_style(), n_tracks, n_test_tracks,
+                    recorded_trace);
+            }
+
+            EXPECT_TRUE(success);
+
+            ++n_tracks;
+        }
+
+        // Calculate and display the result
+        navigation_validator::print_efficiency(n_tracks, n_miss, n_fatal);
+    }
+
+    private:
+    /// @returns either the helix or ray corresponding to the input track
+    /// parameters @param track
+    trajectory_type get_parametrized_trajectory(
+        const free_track_parameters_t &track) {
+        std::unique_ptr<trajectory_type> test_traj{nullptr};
+        if constexpr (k_use_rays) {
+            test_traj = std::make_unique<trajectory_type>(track);
+        } else {
+            test_traj =
+                std::make_unique<trajectory_type>(track, &(m_cfg.B_vector()));
+        }
+        return *(test_traj.release());
+    }
+
+    /// Vecmem memory resource for the host allocations
+    vecmem::host_memory_resource m_host_mr{};
+    /// Vecmem memory resource for the device allocations
+    vecmem::cuda::device_memory_resource m_dev_mr{};
+    /// The configuration of this test
+    config m_cfg;
+    /// Name of the truth data collection
+    std::string m_truth_data_name{""};
+    /// The geometry context to check
+    typename detector_t::geometry_context m_gctx{};
+    /// The detector to be checked
+    const detector_t &m_det;
+    /// Volume names
+    const typename detector_t::name_map &m_names;
+};
+
+template <typename detector_t>
+using straight_line_navigation =
+    navigation_validation<detector_t, detray::ray_scan>;
+
+template <typename detector_t>
+using helix_navigation = navigation_validation<detector_t, detray::helix_scan>;
+
+}  // namespace detray::cuda

--- a/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
@@ -1,0 +1,101 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/detectors/bfield.hpp"
+#include "detray/detectors/build_telescope_detector.hpp"
+#include "detray/test/detail/register_checks.hpp"
+#include "detray/test/detail/whiteboard.hpp"
+#include "detray/test/detector_scan.hpp"
+#include "navigation_validation.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+
+// GTest include
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <limits>
+
+using namespace detray;
+
+int main(int argc, char **argv) {
+
+    using namespace detray;
+
+    // Filter out the google test flags
+    ::testing::InitGoogleTest(&argc, argv);
+
+    //
+    // Telescope detector configuration
+    //
+    using tel_detector_t = detector<telescope_metadata<rectangle2D>>;
+    using scalar_t = typename tel_detector_t::scalar_type;
+
+    tel_det_config<rectangle2D> tel_cfg{20.f * unit<scalar_t>::mm,
+                                        20.f * unit<scalar_t>::mm};
+    tel_cfg.n_surfaces(10u).length(500.f * unit<scalar_t>::mm);
+
+    vecmem::host_memory_resource host_mr;
+
+    const auto [tel_det, tel_names] =
+        build_telescope_detector(host_mr, tel_cfg);
+
+    auto white_board = std::make_shared<test::whiteboard>();
+
+    // Navigation link consistency, discovered by ray intersection
+    test::ray_scan<tel_detector_t>::config cfg_ray_scan{};
+    cfg_ray_scan.name("telescope_detector_ray_scan_for_cuda");
+    cfg_ray_scan.whiteboard(white_board);
+    cfg_ray_scan.track_generator().n_tracks(1000u);
+    cfg_ray_scan.track_generator().origin({0.f, 0.f, -0.05f});
+    cfg_ray_scan.track_generator().theta_range(constant<scalar_t>::pi_4,
+                                               constant<scalar_t>::pi_2);
+
+    detail::register_checks<test::ray_scan>(tel_det, tel_names, cfg_ray_scan);
+
+    // Comparison of straight line navigation with ray scan
+    detray::cuda::straight_line_navigation<tel_detector_t>::config
+        cfg_str_nav{};
+    cfg_str_nav.name("telescope_detector_straight_line_navigation_cuda");
+    cfg_str_nav.whiteboard(white_board);
+    auto mask_tolerance = cfg_ray_scan.mask_tolerance();
+    cfg_str_nav.propagation().navigation.min_mask_tolerance = mask_tolerance[0];
+    cfg_str_nav.propagation().navigation.max_mask_tolerance = mask_tolerance[1];
+
+    detail::register_checks<detray::cuda::straight_line_navigation>(
+        tel_det, tel_names, cfg_str_nav);
+
+    // Navigation link consistency, discovered by helix intersection
+    test::helix_scan<tel_detector_t>::config cfg_hel_scan{};
+    cfg_hel_scan.name("telescope_detector_helix_scan_for_cuda");
+    cfg_hel_scan.whiteboard(white_board);
+    // Let the Newton algorithm dynamically choose tol. based on approx. error
+    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
+                                 detray::detail::invalid_value<scalar_t>()});
+    cfg_hel_scan.track_generator().n_tracks(1000u);
+    cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().origin({0.f, 0.f, -0.05f});
+    cfg_hel_scan.track_generator().theta_range(constant<scalar_t>::pi_4,
+                                               constant<scalar_t>::pi_2);
+
+    detail::register_checks<test::helix_scan>(tel_det, tel_names, cfg_hel_scan);
+
+    // Comparison of navigation in a constant B-field with helix
+    detray::cuda::helix_navigation<tel_detector_t>::config cfg_hel_nav{};
+    cfg_hel_nav.name("telescope_detector_helix_navigation_cuda");
+    cfg_hel_nav.whiteboard(white_board);
+
+    detail::register_checks<detray::cuda::helix_navigation>(tel_det, tel_names,
+                                                            cfg_hel_nav);
+
+    // Run the checks
+    return RUN_ALL_TESTS();
+}

--- a/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
@@ -1,0 +1,104 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/detectors/bfield.hpp"
+#include "detray/detectors/build_toy_detector.hpp"
+#include "detray/test/detail/register_checks.hpp"
+#include "detray/test/detail/whiteboard.hpp"
+#include "detray/test/detector_scan.hpp"
+#include "navigation_validation.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+
+// GTest include
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <limits>
+
+using namespace detray;
+
+int main(int argc, char **argv) {
+
+    using namespace detray;
+
+    // Filter out the google test flags
+    ::testing::InitGoogleTest(&argc, argv);
+
+    using toy_detector_t = detector<toy_metadata>;
+    using scalar_t = typename toy_detector_t::scalar_type;
+
+    //
+    // Toy detector configuration
+    //
+    toy_det_config<scalar_t> toy_cfg{};
+    toy_cfg.n_brl_layers(4u).n_edc_layers(7u);
+
+    // Build the geometry
+    vecmem::host_memory_resource host_mr;
+    auto [toy_det, toy_names] = build_toy_detector(host_mr, toy_cfg);
+
+    auto white_board = std::make_shared<test::whiteboard>();
+
+    // Navigation link consistency, discovered by ray intersection
+    test::ray_scan<toy_detector_t>::config cfg_ray_scan{};
+    cfg_ray_scan.name("toy_detector_ray_scan_for_cuda");
+    cfg_ray_scan.whiteboard(white_board);
+    cfg_ray_scan.track_generator().n_tracks(1000u);
+
+    detail::register_checks<test::ray_scan>(toy_det, toy_names, cfg_ray_scan);
+
+    // Comparison of straight line navigation with ray scan
+    detray::cuda::straight_line_navigation<toy_detector_t>::config
+        cfg_str_nav{};
+    cfg_str_nav.name("toy_detector_straight_line_navigation_cuda");
+    /*cfg_str_nav.intersection_file(toy_det.name(toy_names) +
+                                  "_ray_scan_intersections.csv");
+    cfg_str_nav.track_param_file(toy_det.name(toy_names) +
+                                 "_ray_scan_track_parameters.csv");*/
+    cfg_str_nav.whiteboard(white_board);
+    cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
+    auto mask_tolerance = cfg_ray_scan.mask_tolerance();
+    cfg_str_nav.propagation().navigation.min_mask_tolerance = mask_tolerance[0];
+    cfg_str_nav.propagation().navigation.max_mask_tolerance = mask_tolerance[1];
+
+    detail::register_checks<detray::cuda::straight_line_navigation>(
+        toy_det, toy_names, cfg_str_nav);
+
+    // Navigation link consistency, discovered by helix intersection
+    test::helix_scan<toy_detector_t>::config cfg_hel_scan{};
+    cfg_hel_scan.name("toy_detector_helix_scan_for_cuda");
+    cfg_hel_scan.whiteboard(white_board);
+    // Let the Newton algorithm dynamically choose tol. based on approx. error
+    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
+                                 detray::detail::invalid_value<scalar_t>()});
+    cfg_hel_scan.track_generator().n_tracks(1000u);
+    cfg_hel_scan.track_generator().eta_range(-4.f, 4.f);
+    cfg_hel_scan.track_generator().p_T(1.f * unit<scalar_t>::GeV);
+
+    detail::register_checks<test::helix_scan>(toy_det, toy_names, cfg_hel_scan);
+
+    // Comparison of navigation in a constant B-field with helix
+    detray::cuda::helix_navigation<toy_detector_t>::config cfg_hel_nav{};
+    cfg_hel_nav.name("toy_detector_helix_navigation_cuda");
+    /*cfg_hel_nav.intersection_file(toy_det.name(toy_names) +
+                                  "_helix_scan_intersections.csv");
+    cfg_hel_nav.track_param_file(toy_det.name(toy_names) +
+                                 "_helix_scan_track_parameters.csv");*/
+    cfg_hel_nav.whiteboard(white_board);
+    cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
+
+    detail::register_checks<detray::cuda::helix_navigation>(toy_det, toy_names,
+                                                            cfg_hel_nav);
+
+    // Run the checks
+    return RUN_ALL_TESTS();
+}

--- a/tests/integration_tests/device/cuda/wire_chamber_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/wire_chamber_navigation_validation.cpp
@@ -1,0 +1,97 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/detectors/bfield.hpp"
+#include "detray/detectors/create_wire_chamber.hpp"
+#include "detray/test/detail/register_checks.hpp"
+#include "detray/test/detail/whiteboard.hpp"
+#include "detray/test/detector_scan.hpp"
+#include "navigation_validation.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+
+// GTest include
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <limits>
+
+using namespace detray;
+
+int main(int argc, char **argv) {
+
+    using namespace detray;
+
+    // Filter out the google test flags
+    ::testing::InitGoogleTest(&argc, argv);
+
+    //
+    // Wire Chamber configuration
+    //
+    vecmem::host_memory_resource host_mr;
+
+    using wire_chamber_t = detector<>;
+    using scalar_t = typename wire_chamber_t::scalar_type;
+
+    wire_chamber_config wire_chamber_cfg{};
+    wire_chamber_cfg.half_z(500.f * unit<scalar>::mm);
+
+    auto [det, names] = create_wire_chamber(host_mr, wire_chamber_cfg);
+
+    auto white_board = std::make_shared<test::whiteboard>();
+
+    // Navigation link consistency, discovered by ray intersection
+    test::ray_scan<wire_chamber_t>::config cfg_ray_scan{};
+    cfg_ray_scan.name("wire_chamber_ray_scan_for_cuda");
+    cfg_ray_scan.whiteboard(white_board);
+    cfg_ray_scan.track_generator().n_tracks(1000u);
+
+    detail::register_checks<test::ray_scan>(det, names, cfg_ray_scan);
+
+    // Comparison of straight line navigation with ray scan
+    detray::cuda::straight_line_navigation<wire_chamber_t>::config
+        cfg_str_nav{};
+    cfg_str_nav.name("wire_chamber_straight_line_navigation_cuda");
+    cfg_str_nav.whiteboard(white_board);
+    cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
+    auto mask_tolerance = cfg_ray_scan.mask_tolerance();
+    cfg_str_nav.propagation().navigation.min_mask_tolerance = mask_tolerance[0];
+    cfg_str_nav.propagation().navigation.max_mask_tolerance = mask_tolerance[1];
+
+    detail::register_checks<detray::cuda::straight_line_navigation>(
+        det, names, cfg_str_nav);
+
+    // Navigation link consistency, discovered by helix intersection
+    test::helix_scan<wire_chamber_t>::config cfg_hel_scan{};
+    cfg_hel_scan.name("wire_chamber_helix_scan_for_cuda");
+    cfg_hel_scan.whiteboard(white_board);
+    // Let the Newton algorithm dynamically choose tol. based on approx. error
+    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
+                                 detray::detail::invalid_value<scalar_t>()});
+    cfg_hel_scan.track_generator().n_tracks(1000u);
+    cfg_hel_scan.track_generator().eta_range(-1.f, 1.f);
+    // TODO: Fails for smaller momenta
+    cfg_hel_scan.track_generator().p_T(5.f * unit<scalar_t>::GeV);
+
+    detail::register_checks<test::helix_scan>(det, names, cfg_hel_scan);
+
+    // Comparison of navigation in a constant B-field with helix
+    detray::cuda::helix_navigation<wire_chamber_t>::config cfg_hel_nav{};
+    cfg_hel_nav.name("wire_chamber_helix_navigation_cuda");
+    cfg_hel_nav.whiteboard(white_board);
+    cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
+
+    detail::register_checks<detray::cuda::helix_navigation>(det, names,
+                                                            cfg_hel_nav);
+
+    // Run the checks
+    return RUN_ALL_TESTS();
+}

--- a/tests/tools/include/detray/validation/detector_material_scan.hpp
+++ b/tests/tools/include/detray/validation/detector_material_scan.hpp
@@ -77,13 +77,13 @@ class material_scan : public test::fixture_base<> {
         auto ray_generator = track_generator_t(m_cfg.track_generator());
 
         // Csv output file
-        std::string file_name{m_cfg.name() + "_" + m_names.at(0)};
+        std::string file_name{m_cfg.name() + "_" + m_det.name(m_names)};
         detray::io::file_handle outfile{
             file_name, ".csv",
             std::ios::out | std::ios::binary | std::ios::trunc};
         *outfile << "eta,phi,mat_sX0,mat_sL0,mat_tX0,mat_tL0" << std::endl;
 
-        std::cout << "INFO: Running material scan on: " << m_names.at(0)
+        std::cout << "INFO: Running material scan on: " << m_det.name(m_names)
                   << "\n(" << ray_generator.size() << " rays) ...\n"
                   << std::endl;
 

--- a/tests/tools/src/detector_display.cpp
+++ b/tests/tools/src/detector_display.cpp
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
         detray::volume_graph graph(det);
 
         detray::io::file_handle stream{
-            path / (names.at(0) + "_volume_graph.dot"),
+            path / (det.name(names) + "_volume_graph.dot"),
             std::ios::out | std::ios::trunc};
         *stream << graph.to_dot_string();
     }

--- a/tests/tools/src/detector_validation.cpp
+++ b/tests/tools/src/detector_validation.cpp
@@ -32,7 +32,7 @@
 namespace po = boost::program_options;
 using namespace detray;
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
 
     // Use the most general type to be able to read in all detector files
     using detector_t = detray::detector<>;
@@ -211,23 +211,22 @@ int main(int argc, char **argv) {
 
     const auto [det, names] =
         detray::io::read_detector<detector_t>(host_mr, reader_cfg);
+    const std::string& det_name = det.name(names);
 
     // Create the whiteboard for data transfer between the steps
     auto white_board = std::make_shared<test::whiteboard>();
-    ray_scan_cfg.name(names.at(0) + "_ray_scan");
+    ray_scan_cfg.name(det_name + "_ray_scan");
     ray_scan_cfg.whiteboard(white_board);
-    ray_scan_cfg.intersection_file(names.at(0) + "_ray_scan_intersections.csv");
-    ray_scan_cfg.track_param_file(names.at(0) +
-                                  "_ray_scan_track_parameters.csv");
+    ray_scan_cfg.intersection_file(det_name + "_ray_scan_intersections.csv");
+    ray_scan_cfg.track_param_file(det_name + "_ray_scan_track_parameters.csv");
 
-    hel_scan_cfg.name(names.at(0) + "_helix_scan");
+    hel_scan_cfg.name(det_name + "_helix_scan");
     hel_scan_cfg.whiteboard(white_board);
     // Let the Newton algorithm dynamically choose tol. based on approx. error
     hel_scan_cfg.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
                                  detray::detail::invalid_value<scalar_t>()});
-    hel_scan_cfg.intersection_file(names.at(0) +
-                                   "_helix_scan_intersections.csv");
-    hel_scan_cfg.track_param_file(names.at(0) +
+    hel_scan_cfg.intersection_file(det_name + "_helix_scan_intersections.csv");
+    hel_scan_cfg.track_param_file(det_name +
                                   "_helix_scan_track_parameters.csv");
 
     str_nav_cfg.whiteboard(white_board);
@@ -238,17 +237,17 @@ int main(int argc, char **argv) {
         det, names, con_chk_cfg);
 
     // Navigation link consistency, discovered by ray intersection
-    ray_scan_cfg.name(names.at(0) + "_ray_scan");
+    ray_scan_cfg.name(det_name + "_ray_scan");
     detray::detail::register_checks<detray::test::ray_scan>(det, names,
                                                             ray_scan_cfg);
 
     // Navigation link consistency, discovered by helix intersection
-    hel_scan_cfg.name(names.at(0) + "_helix_scan");
+    hel_scan_cfg.name(det_name + "_helix_scan");
     detray::detail::register_checks<detray::test::helix_scan>(det, names,
                                                               hel_scan_cfg);
 
     // Comparision of straight line navigation with ray scan
-    str_nav_cfg.name(names.at(0) + "_straight_line_navigation");
+    str_nav_cfg.name(det_name + "_straight_line_navigation");
     // Ensure that the same mask tolerance is used
     auto mask_tolerance = ray_scan_cfg.mask_tolerance();
     str_nav_cfg.propagation().navigation.min_mask_tolerance = mask_tolerance[0];
@@ -257,7 +256,7 @@ int main(int argc, char **argv) {
         det, names, str_nav_cfg);
 
     // Comparision of navigation in a constant B-field with helix
-    hel_nav_cfg.name(names.at(0) + "_helix_navigation");
+    hel_nav_cfg.name(det_name + "_helix_navigation");
     detray::detail::register_checks<detray::test::helix_navigation>(
         det, names, hel_nav_cfg);
 

--- a/tests/tools/src/detector_validation.cpp
+++ b/tests/tools/src/detector_validation.cpp
@@ -93,7 +93,7 @@ int main(int argc, char** argv) {
     // General options
     if (vm.count("write_volume_graph")) {
         con_chk_cfg.write_graph(true);
-        throw std::invalid_argument("Writing of voume graph not implemented");
+        throw std::invalid_argument("Writing of volume graph not implemented");
     }
     if (vm.count("write_scan_data")) {
         ray_scan_cfg.write_intersections(true);
@@ -241,11 +241,6 @@ int main(int argc, char** argv) {
     detray::detail::register_checks<detray::test::ray_scan>(det, names,
                                                             ray_scan_cfg);
 
-    // Navigation link consistency, discovered by helix intersection
-    hel_scan_cfg.name(det_name + "_helix_scan");
-    detray::detail::register_checks<detray::test::helix_scan>(det, names,
-                                                              hel_scan_cfg);
-
     // Comparision of straight line navigation with ray scan
     str_nav_cfg.name(det_name + "_straight_line_navigation");
     // Ensure that the same mask tolerance is used
@@ -254,6 +249,11 @@ int main(int argc, char** argv) {
     str_nav_cfg.propagation().navigation.max_mask_tolerance = mask_tolerance[1];
     detray::detail::register_checks<detray::test::straight_line_navigation>(
         det, names, str_nav_cfg);
+
+    // Navigation link consistency, discovered by helix intersection
+    hel_scan_cfg.name(det_name + "_helix_scan");
+    detray::detail::register_checks<detray::test::helix_scan>(det, names,
+                                                              hel_scan_cfg);
 
     // Comparision of navigation in a constant B-field with helix
     hel_nav_cfg.name(det_name + "_helix_navigation");

--- a/tests/unit_tests/cpu/navigation/navigator.cpp
+++ b/tests/unit_tests/cpu/navigation/navigator.cpp
@@ -271,7 +271,7 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
             // The status is: exited
             ASSERT_EQ(navigation.status(), status::e_on_target);
             // Switch to next volume leads out of the detector world -> exit
-            ASSERT_TRUE(detail::is_invalid_value(navigation.volume()));
+            ASSERT_TRUE(detray::detail::is_invalid_value(navigation.volume()));
             // We know we went out of the detector
             ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
         } else {
@@ -429,7 +429,7 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
             // The status is: exited
             ASSERT_EQ(navigation.status(), status::e_on_target);
             // Switch to next volume leads out of the detector world -> exit
-            ASSERT_TRUE(detail::is_invalid_value(navigation.volume()));
+            ASSERT_TRUE(detray::detail::is_invalid_value(navigation.volume()));
             // We know we went out of the detector
             ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
         } else {

--- a/tests/unit_tests/svgtools/intersections.cpp
+++ b/tests/unit_tests/svgtools/intersections.cpp
@@ -13,6 +13,7 @@
 #include "detray/plugins/svgtools/writer.hpp"
 #include "detray/simulation/event_generator/track_generators.hpp"
 #include "detray/test/utils/detector_scanner.hpp"
+#include "detray/test/utils/svg_display.hpp"
 #include "detray/tracks/tracks.hpp"
 
 // Vecmem include(s)
@@ -78,8 +79,10 @@ GTEST_TEST(svgtools, intersections) {
             "test_svgtools_intersection_record" + std::to_string(index);
 
         // Drawing the intersections.
-        const auto svg_ir = il.draw_intersections(name, intersection_record,
-                                                  test_ray.dir(), view);
+        auto intersections =
+            detray::detail::transcribe_intersections(intersection_record);
+        const auto svg_ir =
+            il.draw_intersections(name, intersections, test_ray.dir(), view);
 
         detray::svgtools::write_svg(name, {axes, svg_det, svg_ir});
 

--- a/tests/unit_tests/svgtools/trajectories.cpp
+++ b/tests/unit_tests/svgtools/trajectories.cpp
@@ -14,6 +14,7 @@
 #include "detray/plugins/svgtools/illustrator.hpp"
 #include "detray/plugins/svgtools/writer.hpp"
 #include "detray/test/utils/detector_scanner.hpp"
+#include "detray/test/utils/svg_display.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -73,8 +74,9 @@ GTEST_TEST(svgtools, trajectories) {
     const auto svg_ray = il.draw_trajectory("trajectory", ray, 500.f, view);
 
     // Draw the intersections.
+    auto ray_intersections = detray::detail::transcribe_intersections(ray_ir);
     const auto svg_ray_ir =
-        il.draw_intersections("record", ray_ir, ray.dir(), view);
+        il.draw_intersections("record", ray_intersections, ray.dir(), view);
 
     detray::svgtools::write_svg("test_svgtools_ray",
                                 {svg_volumes, svg_ray, svg_ray_ir});
@@ -94,8 +96,10 @@ GTEST_TEST(svgtools, trajectories) {
     const auto svg_helix = il.draw_trajectory("trajectory", helix, 500.f, view);
 
     // Draw the intersections.
+    auto helix_intersections =
+        detray::detail::transcribe_intersections(helix_ir);
     const auto svg_helix_ir =
-        il.draw_intersections("record", helix_ir, helix.dir(), view);
+        il.draw_intersections("record", helix_intersections, helix.dir(), view);
 
     detray::svgtools::write_svg("test_svgtools_helix",
                                 {svg_volumes, svg_helix, svg_helix_ir});

--- a/tests/unit_tests/svgtools/web.cpp
+++ b/tests/unit_tests/svgtools/web.cpp
@@ -13,6 +13,7 @@
 #include "detray/plugins/svgtools/utils/groups.hpp"
 #include "detray/plugins/svgtools/writer.hpp"
 #include "detray/test/utils/detector_scanner.hpp"
+#include "detray/test/utils/svg_display.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -93,8 +94,10 @@ GTEST_TEST(svgtools, web) {
             il.draw_trajectory(name + "_trajectory", helix, view);
 
         // Draw the intersection record.
+        auto helix_intersections =
+            detray::detail::transcribe_intersections(helix_ir);
         const auto svg_helix_ir = il.draw_intersections(
-            name + "_record", helix_ir, helix.dir(), view);
+            name + "_record", helix_intersections, helix.dir(), view);
 
         // We one the trajectory and intersection record to be considered as one
         // svg. Thus we group them together before adding the group to the svg

--- a/tutorials/src/cpu/detector/detector_ray_scan.cpp
+++ b/tutorials/src/cpu/detector/detector_ray_scan.cpp
@@ -70,8 +70,8 @@ int main() {
         1.f * detray::unit<detray::scalar>::GeV);
 
     // Run the check
-    std::cout << "\nScanning " << names.at(0) << " (" << ray_generator.size()
-              << " rays) ...\n"
+    std::cout << "\nScanning " << det.name(names) << " ("
+              << ray_generator.size() << " rays) ...\n"
               << std::endl;
 
     bool success = true;
@@ -85,9 +85,13 @@ int main() {
             intersection_trace, start_index, adj_mat_scan, obj_hashes);
 
         if (!check_result) {
+            // Empty navigation trace
+            using intersection_trace_t = decltype(intersection_trace);
+
             detray::detector_scanner::display_error(
                 gctx, det, names, "ray_scan_tutorial", ray, intersection_trace,
-                svg_style, n_rays, ray_generator.size());
+                svg_style, n_rays, ray_generator.size(),
+                intersection_trace_t{});
         }
         success &= check_result;
 

--- a/tutorials/src/cpu/propagation/navigation_inspection.cpp
+++ b/tutorials/src/cpu/propagation/navigation_inspection.cpp
@@ -108,7 +108,7 @@ int main() {
                          << "found in vol: "
                          << intersection_trace[intr_idx].vol_idx << ",\n\t"
                          << intersection_trace[intr_idx].intersection;
-            debug_stream << "\nnavig.:\t" << obj_tracer[intr_idx];
+            debug_stream << "\nnavig.:\t" << obj_tracer[intr_idx].intersection;
         }
         std::cout << debug_stream.str() << std::endl;
 


### PR DESCRIPTION
Run the navigation validation on device with data that was gathered during navigation run on the host. This adds a navigation state view so that memory allocations needed for the navigation inspectors can be handed through. The navigation object tracer, which records data whenever the navigator finds an object of given type, now also records the global track position and direction. This can now be written to file as well, and compared between host and device. 

In order to display the new truth and recorded intersections traces, the svg code had to be adapted a little. The CUDA navigation validation is run in the CI now, however, I did not know how to get the truth data there, so I recreate it, but with less statistics.

I also discovered that the current estimation of the maximum number of candidates has a bug, which I fixed by using a functor to query the every acceleration structure according to the link the volume provides.