### PR TITLE
fix: navigation status update

### DIFF
--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -696,7 +696,8 @@ class navigator {
 
         // Check whether the track reached the current candidate. Might be a
         // portal, in which case the navigation needs to be re-initialized
-        if (navigation.is_on_object(*navigation.next(), cfg)) {
+        if (!navigation.is_exhausted() &&
+            navigation.is_on_object(*navigation.next(), cfg)) {
             // Set the next object that we want to reach (this function is only
             // called once the cache has been updated to a full trust state).
             // Might lead to exhausted cache.


### PR DESCRIPTION
Only check "on surface" if the cache is not exhausted (in this case ```navgiation.next()``` is not valid). This should fix a bug in traccc where the navigator does not find any candidates in a fresh init, but does not abort because the status update reads random data