### PR TITLE
oneAPI 2024.1.0 Support, main branch (2024.05.15.)

### DIFF
--- a/core/include/detray/builders/cuboid_portal_generator.hpp
+++ b/core/include/detray/builders/cuboid_portal_generator.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,6 +11,7 @@
 #include "detray/builders/surface_factory_interface.hpp"
 #include "detray/core/detail/data_context.hpp"
 #include "detray/definitions/detail/indexing.hpp"
+#include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/geometry.hpp"
 #include "detray/geometry/shapes/cuboid3D.hpp"
@@ -138,9 +139,9 @@ class cuboid_portal_generator final
 
         // Get the half lengths for the rectangle sides and translation
         const point3_t h_lengths = 0.5f * (box_max - box_min);
-        const scalar_type h_x{math::abs(h_lengths[0])};
-        const scalar_type h_y{math::abs(h_lengths[1])};
-        const scalar_type h_z{math::abs(h_lengths[2])};
+        const scalar_type h_x{math::fabs(h_lengths[0])};
+        const scalar_type h_y{math::fabs(h_lengths[1])};
+        const scalar_type h_z{math::fabs(h_lengths[2])};
 
         // Volume links for the portal descriptors and the masks
         const dindex volume_idx{volume.index()};

--- a/core/include/detray/geometry/shapes/annulus2D.hpp
+++ b/core/include/detray/geometry/shapes/annulus2D.hpp
@@ -392,7 +392,7 @@ class annulus2D {
             return false;
         }
         if (bounds[e_min_r] >= bounds[e_max_r] or
-            math::abs(bounds[e_min_r] - bounds[e_max_r]) < tol) {
+            math::fabs(bounds[e_min_r] - bounds[e_max_r]) < tol) {
             os << "ERROR: Min radius must be smaller than max radius.";
             return false;
         }
@@ -406,7 +406,7 @@ class annulus2D {
             return false;
         }
         if (bounds[e_min_phi_rel] >= bounds[e_max_phi_rel] or
-            math::abs(bounds[e_min_phi_rel] - bounds[e_max_phi_rel]) < tol) {
+            math::fabs(bounds[e_min_phi_rel] - bounds[e_max_phi_rel]) < tol) {
             os << "ERROR: Min relative angle must be smaller than max relative "
                   "angle.";
             return false;

--- a/core/include/detray/geometry/shapes/concentric_cylinder2D.hpp
+++ b/core/include/detray/geometry/shapes/concentric_cylinder2D.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/indexing.hpp"
+#include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/concentric_cylindrical2D.hpp"
@@ -166,7 +167,7 @@ class concentric_cylinder2D {
             return false;
         }
         if (bounds[e_n_half_z] >= bounds[e_p_half_z] or
-            math::abs(bounds[e_n_half_z] - bounds[e_p_half_z]) < tol) {
+            math::fabs(bounds[e_n_half_z] - bounds[e_p_half_z]) < tol) {
             os << "ERROR: Neg. half length must be smaller than pos. half "
                   "length.";
             return false;

--- a/core/include/detray/geometry/shapes/cuboid3D.hpp
+++ b/core/include/detray/geometry/shapes/cuboid3D.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/indexing.hpp"
+#include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/geometry/coordinates/cartesian3D.hpp"
 
@@ -170,17 +171,17 @@ class cuboid3D {
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 
         if (bounds[e_min_x] >= bounds[e_max_x] or
-            math::abs(bounds[e_min_x] - bounds[e_max_x]) < tol) {
+            math::fabs(bounds[e_min_x] - bounds[e_max_x]) < tol) {
             os << "ERROR: Min x must be smaller than max x.";
             return false;
         }
         if (bounds[e_min_y] >= bounds[e_max_y] or
-            math::abs(bounds[e_min_y] - bounds[e_max_y]) < tol) {
+            math::fabs(bounds[e_min_y] - bounds[e_max_y]) < tol) {
             os << "ERROR: Min y must be smaller than max y.";
             return false;
         }
         if (bounds[e_min_z] >= bounds[e_max_z] or
-            math::abs(bounds[e_min_z] - bounds[e_max_z]) < tol) {
+            math::fabs(bounds[e_min_z] - bounds[e_max_z]) < tol) {
             os << "ERROR: Min z must be smaller than max z.";
             return false;
         }

--- a/core/include/detray/geometry/shapes/cylinder2D.hpp
+++ b/core/include/detray/geometry/shapes/cylinder2D.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/indexing.hpp"
+#include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/cylindrical2D.hpp"
@@ -166,7 +167,7 @@ class cylinder2D {
             return false;
         }
         if (bounds[e_n_half_z] >= bounds[e_p_half_z] or
-            math::abs(bounds[e_n_half_z] - bounds[e_p_half_z]) < tol) {
+            math::fabs(bounds[e_n_half_z] - bounds[e_p_half_z]) < tol) {
             os << "ERROR: Neg. half length must be smaller than pos. half "
                   "length.";
             return false;

--- a/core/include/detray/geometry/shapes/cylinder3D.hpp
+++ b/core/include/detray/geometry/shapes/cylinder3D.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/indexing.hpp"
+#include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/cylindrical3D.hpp"
@@ -173,12 +174,12 @@ class cylinder3D {
             return false;
         }
         if (bounds[e_min_r] >= bounds[e_max_r] or
-            math::abs(bounds[e_min_r] - bounds[e_max_r]) < tol) {
+            math::fabs(bounds[e_min_r] - bounds[e_max_r]) < tol) {
             os << "ERROR: Min Radius must be smaller than max Radius.";
             return false;
         }
         if (bounds[e_min_z] >= bounds[e_max_z] or
-            math::abs(bounds[e_min_z] - bounds[e_max_z]) < tol) {
+            math::fabs(bounds[e_min_z] - bounds[e_max_z]) < tol) {
             os << "ERROR: Min z must be smaller than max z.";
             return false;
         }

--- a/core/include/detray/geometry/shapes/line.hpp
+++ b/core/include/detray/geometry/shapes/line.hpp
@@ -81,11 +81,11 @@ class line {
         // size and (2) the distance to the point of closest approach on thw
         // line from the line center is less than the half line length
         if constexpr (square_cross_sect) {
-            return (math::abs(loc_p[0] * math::cos(loc_p[2])) <=
+            return (math::fabs(loc_p[0] * math::cos(loc_p[2])) <=
                         bounds[e_cross_section] + tol &&
-                    math::abs(loc_p[0] * math::sin(loc_p[2])) <=
+                    math::fabs(loc_p[0] * math::sin(loc_p[2])) <=
                         bounds[e_cross_section] + tol &&
-                    math::abs(loc_p[1]) <= bounds[e_half_z] + tol);
+                    math::fabs(loc_p[1]) <= bounds[e_half_z] + tol);
 
         }
         // For a circular cross section (e.g. straw tube), we check if (1) the
@@ -93,8 +93,8 @@ class line {
         // of closest approach on the line from the line center is less than the
         // line half length
         else {
-            return (math::abs(loc_p[0]) <= bounds[e_cross_section] + tol &&
-                    math::abs(loc_p[1]) <= bounds[e_half_z] + tol);
+            return (math::fabs(loc_p[0]) <= bounds[e_cross_section] + tol &&
+                    math::fabs(loc_p[1]) <= bounds[e_half_z] + tol);
         }
     }
 

--- a/core/include/detray/geometry/shapes/rectangle2D.hpp
+++ b/core/include/detray/geometry/shapes/rectangle2D.hpp
@@ -58,8 +58,8 @@ class rectangle2D {
     DETRAY_HOST_DEVICE inline bool check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
-        return (math::abs(loc_p[0]) <= bounds[e_half_x] + tol and
-                math::abs(loc_p[1]) <= bounds[e_half_y] + tol);
+        return (math::fabs(loc_p[0]) <= bounds[e_half_x] + tol and
+                math::fabs(loc_p[1]) <= bounds[e_half_y] + tol);
     }
 
     /// @brief Measure of the shape: Area

--- a/core/include/detray/geometry/shapes/ring2D.hpp
+++ b/core/include/detray/geometry/shapes/ring2D.hpp
@@ -163,7 +163,7 @@ class ring2D {
             return false;
         }
         if (bounds[e_inner_r] >= bounds[e_outer_r] or
-            math::abs(bounds[e_inner_r] - bounds[e_outer_r]) < tol) {
+            math::fabs(bounds[e_inner_r] - bounds[e_outer_r]) < tol) {
             os << "ERROR: Inner radius must be smaller outer radius.";
             return false;
         }

--- a/core/include/detray/geometry/shapes/single3D.hpp
+++ b/core/include/detray/geometry/shapes/single3D.hpp
@@ -88,7 +88,7 @@ class single3D {
               typename std::enable_if_t<kDIM == e_size, bool> = true>
     DETRAY_HOST_DEVICE constexpr scalar_t area(
         const bounds_t<scalar_t, kDIM> &bounds) const {
-        return math::abs(bounds[e_upper] - bounds[e_lower]);
+        return math::fabs(bounds[e_upper] - bounds[e_lower]);
     }
 
     /// @brief Lower and upper point for minimal axis aligned bounding box.

--- a/core/include/detray/geometry/shapes/trapezoid2D.hpp
+++ b/core/include/detray/geometry/shapes/trapezoid2D.hpp
@@ -66,11 +66,11 @@ class trapezoid2D {
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         const scalar_t rel_y{(bounds[e_half_length_2] + loc_p[1]) *
                              bounds[e_divisor]};
-        return (math::abs(loc_p[0]) <= bounds[e_half_length_0] +
-                                           rel_y * (bounds[e_half_length_1] -
-                                                    bounds[e_half_length_0]) +
-                                           tol and
-                math::abs(loc_p[1]) <= bounds[e_half_length_2] + tol);
+        return (math::fabs(loc_p[0]) <= bounds[e_half_length_0] +
+                                            rel_y * (bounds[e_half_length_1] -
+                                                     bounds[e_half_length_0]) +
+                                            tol and
+                math::fabs(loc_p[1]) <= bounds[e_half_length_2] + tol);
     }
 
     /// @brief Measure of the shape: Area
@@ -195,7 +195,7 @@ class trapezoid2D {
             return false;
         }
         const auto div{1.f / (2.f * bounds[e_half_length_2])};
-        if (math::abs(bounds[e_divisor] - div) > tol) {
+        if (math::fabs(bounds[e_divisor] - div) > tol) {
             os << "ERROR: Divisor incorrect. Should be: " << div << std::endl;
             return false;
         }

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -10,6 +10,7 @@
 
 // Project include(s)
 #include "detray/definitions/detail/indexing.hpp"
+#include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/geometry.hpp"
 #include "detray/geometry/barcode.hpp"
@@ -205,7 +206,7 @@ class surface {
                                                 const vector3_type &dir,
                                                 const point_t &p) const
         -> scalar_type {
-        return math::abs(vector::dot(dir, normal(ctx, p)));
+        return math::fabs(vector::dot(dir, normal(ctx, p)));
     }
 
     /// @returns the material parameters at the local position @param loc_p

--- a/core/include/detray/materials/detail/relativistic_quantities.hpp
+++ b/core/include/detray/materials/detail/relativistic_quantities.hpp
@@ -53,7 +53,7 @@ struct relativistic_quantities {
         m_q2OverBeta2 = q * q + (mass * qOverP) * (mass * qOverP);
         // 1/p = q/(qp) = (q/p)/q
         const scalar_type mOverP{
-            mass * ((q == 0.f) ? math::abs(qOverP / q) : math::abs(qOverP))};
+            mass * ((q == 0.f) ? math::fabs(qOverP / q) : math::fabs(qOverP))};
         const scalar_type pOverM{1.f / mOverP};
         // beta² = p²/E² = p²/(m² + p²) = 1/(1 + (m/p)²)
         m_beta2 = 1.f / (1.f + mOverP * mOverP);

--- a/core/include/detray/materials/interaction.hpp
+++ b/core/include/detray/materials/interaction.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -173,7 +173,7 @@ struct interaction {
         const scalar_type qOverP, const scalar_type q) const {
 
         // 1/p = q/(pq) = (q/p)/q
-        const scalar_type momentumInv{math::abs(qOverP / q)};
+        const scalar_type momentumInv{math::fabs(qOverP / q)};
         // q²/beta²; a smart compiler should be able to remove the unused
         // computations
         const relativistic_quantities rq(m, qOverP, q);

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -71,7 +71,7 @@ struct material_rod {
     DETRAY_HOST_DEVICE constexpr scalar_type path_segment(
         const scalar_type cos_inc_angle, const scalar_type approach) const {
         // Assume that is.local[0] is radial distance of line intersector
-        if (math::abs(approach) > m_radius) {
+        if (math::fabs(approach) > m_radius) {
             return 0.f;
         }
 

--- a/core/include/detray/navigation/intersection/intersection.hpp
+++ b/core/include/detray/navigation/intersection/intersection.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -79,19 +79,19 @@ struct intersection2D {
     /// @param rhs is the right hand side intersection for comparison
     DETRAY_HOST_DEVICE
     bool operator<(const intersection2D &rhs) const {
-        return (math::abs(path) < math::abs(rhs.path));
+        return (math::fabs(path) < math::fabs(rhs.path));
     }
 
     /// @param rhs is the left hand side intersection for comparison
     DETRAY_HOST_DEVICE
     bool operator>(const intersection2D &rhs) const {
-        return (math::abs(path) > math::abs(rhs.path));
+        return (math::fabs(path) > math::fabs(rhs.path));
     }
 
     /// @param rhs is the left hand side intersection for comparison
     DETRAY_HOST_DEVICE
     bool operator==(const intersection2D &rhs) const {
-        return math::abs(path - rhs.path) <
+        return math::fabs(path - rhs.path) <
                std::numeric_limits<float>::epsilon();
     }
 

--- a/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -191,7 +191,7 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
             is.status = mask.is_inside(
                 is.local, math::max(mask_tolerance[0],
                                     math::min(mask_tolerance[1],
-                                              1e-3f * math::abs(is.path))));
+                                              1e-3f * math::fabs(is.path))));
 
             // prepare some additional information in case the intersection
             // is valid

--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -109,7 +109,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t> {
             is.status = mask.is_inside(
                 is.local, math::max(mask_tolerance[0],
                                     math::min(mask_tolerance[1],
-                                              1e-3f * math::abs(is.path))));
+                                              1e-3f * math::fabs(is.path))));
 
             // prepare some additional information in case the intersection
             // is valid
@@ -122,7 +122,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t> {
                 is.volume_link = mask.volume_link();
 
                 // Get incidence angle
-                is.cos_incidence_angle = math::abs(zd);
+                is.cos_incidence_angle = math::fabs(zd);
             }
         }
         return is;

--- a/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
@@ -86,9 +86,10 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
                 is.local = mask.to_local_frame(trf, p3, ray.dir());
                 // Tolerance: per mille of the distance
                 is.status = mask.is_inside(
-                    is.local, math::max(mask_tolerance[0],
-                                        math::min(mask_tolerance[1],
-                                                  1e-3f * math::abs(is.path))));
+                    is.local,
+                    math::max(mask_tolerance[0],
+                              math::min(mask_tolerance[1],
+                                        1e-3f * math::fabs(is.path))));
 
                 // prepare some additional information in case the intersection
                 // is valid
@@ -101,7 +102,7 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
                     is.volume_link = mask.volume_link();
 
                     // Get incidene angle
-                    is.cos_incidence_angle = math::abs(denom);
+                    is.cos_incidence_angle = math::fabs(denom);
                 }
             }
         } else {

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -413,7 +413,7 @@ class navigator {
         DETRAY_HOST_DEVICE inline auto is_on_object(
             const intersection_type &candidate,
             const navigation::config<scalar_type> &cfg) const -> bool {
-            return (math::abs(candidate.path) < cfg.on_surface_tolerance);
+            return (math::fabs(candidate.path) < cfg.on_surface_tolerance);
         }
 
         /// @returns next object that we want to reach (current target)

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -51,7 +51,7 @@ struct pathlimit_aborter : actor {
 
         const scalar step_limit =
             abrt_state.path_limit() -
-            math::abs(prop_state._stepping._abs_path_length);
+            math::fabs(prop_state._stepping._abs_path_length);
 
         // Check the path limit
         if (step_limit <= 0.f) {

--- a/core/include/detray/propagator/constrained_step.hpp
+++ b/core/include/detray/propagator/constrained_step.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -74,7 +74,7 @@ struct constrained_step {
         std::enable_if_t<not(type == step::constraint::e_all), bool> = true>
     DETRAY_HOST_DEVICE void set(const scalar step_size) {
         _constraints[type] =
-            math::min(_constraints[type], math::abs(step_size));
+            math::min(_constraints[type], math::fabs(step_size));
     }
 
     /// @returns the current step size constraint for a given type or overall

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -46,7 +46,7 @@ detray::rk_stepper<magnetic_field_t, algebra_t, constraint_t, policy_t,
 
     // Update path length
     this->_path_length += h;
-    this->_abs_path_length += math::abs(h);
+    this->_abs_path_length += math::fabs(h);
     this->_s += h;
 }
 
@@ -765,8 +765,8 @@ DETRAY_HOST_DEVICE bool detray::rk_stepper<
     stepping.set_direction(step_dir);
 
     // Check constraints
-    if (math::abs(stepping._step_size) >
-        math::abs(
+    if (math::fabs(stepping._step_size) >
+        math::fabs(
             stepping.constraints().template size<>(stepping.direction()))) {
 
         // Run inspection before step size is cut

--- a/core/include/detray/utils/invalid_values.hpp
+++ b/core/include/detray/utils/invalid_values.hpp
@@ -39,7 +39,11 @@ template <typename T,
 DETRAY_HOST_DEVICE inline constexpr bool is_invalid_value(
     const T value) noexcept {
     if constexpr (std::is_signed_v<T>) {
-        return (math::abs(value) == detail::invalid_value<T>());
+        if constexpr (std::is_floating_point_v<T>) {
+            return (math::fabs(value) == detail::invalid_value<T>());
+        } else {
+            return (math::abs(value) == detail::invalid_value<T>());
+        }
     } else {
         return (value == detail::invalid_value<T>());
     }

--- a/core/include/detray/utils/quadratic_equation.hpp
+++ b/core/include/detray/utils/quadratic_equation.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2023 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -38,8 +38,8 @@ class quadratic_equation {
         const scalar_t a, const scalar_t b, const scalar_t c,
         const scalar_t tolerance = std::numeric_limits<scalar_t>::epsilon()) {
         // linear case
-        if (math::abs(a) <= tolerance) {
-            if (math::abs(b) <= tolerance) {
+        if (math::fabs(a) <= tolerance) {
+            if (math::fabs(b) <= tolerance) {
                 m_solutions = 0;
             } else {
                 m_solutions = 1;


### PR DESCRIPTION
Switched from using `sycl::abs` to `sycl::fabs` for floating point types. With oneAPI 2024.1.0 this became mandatory, as `sycl::abs` only works for integers according to the SYCL standard.

At the same time switched to `std::fabs` for all non-SYCL platforms as well, as using `fabs` is generally a good idea there as well. 🤔

And yes, we'll desperately need to introduce a oneAPI 2024.1.0 based CI test soon. Otherwise that build will break sooner than later...