### PR TITLE
fix: navigation and make mask tolerance scaling configurable

### DIFF
--- a/core/include/detray/definitions/detail/math.hpp
+++ b/core/include/detray/definitions/detail/math.hpp
@@ -113,6 +113,18 @@ inline decltype(auto) copysign(T &&mag, S &&sgn) {
 
 template <typename T,
           std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) min(T &&vec) {
+    return Vc::min(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
+inline decltype(auto) max(T &&vec) {
+    return Vc::max(std::forward<T>(vec));
+}
+
+template <typename T,
+          std::enable_if_t<Vc::Traits::is_simd_vector<T>::value, bool> = true>
 inline decltype(auto) signbit(T &&vec) {
     return Vc::isnegative(std::forward<T>(vec));
 }

--- a/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
@@ -65,7 +65,7 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
                const std::array<scalar_type, 2u> mask_tolerance =
                    {detail::invalid_value<scalar_type>(),
                     detail::invalid_value<scalar_type>()},
-               const scalar_type = 0.f) const {
+               const scalar_type = 0.f, const scalar_type = 0.f) const {
 
         assert((mask_tolerance[0] == mask_tolerance[1]) &&
                "Helix intersectors use only one mask tolerance value");
@@ -194,7 +194,7 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
     DETRAY_HOST_DEVICE inline std::array<intersection_type<surface_descr_t>, 2>
     operator()(const helix_type &h, const surface_descr_t &sf_desc,
                const mask_t &mask, const transform3_type &trf,
-               const scalar_type mask_tolerance,
+               const scalar_type mask_tolerance, const scalar_type = 0.f,
                const scalar_type = 0.f) const {
         return this->operator()(h, sf_desc, mask, trf, {mask_tolerance, 0.f},
                                 0.f);

--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -58,7 +58,7 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
         const std::array<scalar_type, 2u> mask_tolerance =
             {detail::invalid_value<scalar_type>(),
              detail::invalid_value<scalar_type>()},
-        const scalar_type = 0.f) const {
+        const scalar_type = 0.f, const scalar_type = 0.f) const {
 
         assert((mask_tolerance[0] == mask_tolerance[1]) &&
                "Helix intersectors use only one mask tolerance value");
@@ -180,7 +180,7 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const helix_type &h, const surface_descr_t &sf_desc, const mask_t &mask,
         const transform3_type &trf, const scalar_type mask_tolerance,
-        const scalar_type = 0.f) const {
+        const scalar_type = 0.f, const scalar_type = 0.f) const {
         return this->operator()(h, sf_desc, mask, trf, {mask_tolerance, 0.f},
                                 0.f);
     }

--- a/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
@@ -60,7 +60,7 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
         const std::array<scalar_type, 2u> mask_tolerance =
             {detail::invalid_value<scalar_type>(),
              detail::invalid_value<scalar_type>()},
-        const scalar_type = 0.f) const {
+        const scalar_type = 0.f, const scalar_type = 0.f) const {
 
         assert((mask_tolerance[0] == mask_tolerance[1]) &&
                "Helix intersectors use only one mask tolerance value");
@@ -134,7 +134,7 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const helix_type &h, const surface_descr_t &sf_desc, const mask_t &mask,
         const transform3_type &trf, const scalar_type mask_tolerance,
-        const scalar_type = 0.f) const {
+        const scalar_type = 0.f, const scalar_type = 0.f) const {
         return this->operator()(h, sf_desc, mask, trf, {mask_tolerance, 0.f},
                                 0.f);
     }

--- a/core/include/detray/navigation/intersection/intersection.hpp
+++ b/core/include/detray/navigation/intersection/intersection.hpp
@@ -76,7 +76,8 @@ struct intersection2D {
     /// @param rhs is the left hand side intersection for comparison
     DETRAY_HOST_DEVICE
     bool_t operator==(const intersection2D &rhs) const {
-        return math::fabs(path - rhs.path) < std::numeric_limits<T>::epsilon();
+        return math::fabs(path - rhs.path) <
+               std::numeric_limits<float>::epsilon();
     }
 
     DETRAY_HOST_DEVICE

--- a/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
@@ -58,6 +58,7 @@ struct ray_concentric_cylinder_intersector {
         const transform3_type & /*trf*/,
         const std::array<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
         intersection_type<surface_descr_t> is;
@@ -114,9 +115,10 @@ struct ray_concentric_cylinder_intersector {
                 // for the r-check
                 // Tolerance: per mille of the distance
                 is.status = mask.is_inside(
-                    is.local, math::max(mask_tolerance[0],
-                                        math::min(mask_tolerance[1],
-                                                  1e-3f * math::abs(is.path))));
+                    is.local,
+                    math::max(mask_tolerance[0],
+                              math::min(mask_tolerance[1],
+                                        mask_tol_scalor * math::abs(is.path))));
 
                 // prepare some additional information in case the intersection
                 // is valid
@@ -141,7 +143,7 @@ struct ray_concentric_cylinder_intersector {
         const ray_type &ray, const surface_descr_t &sf, const mask_t &mask,
         const transform3_type &trf, const scalar_type mask_tolerance,
         const scalar_type overstep_tol = 0.f) const {
-        return this->operator()(ray, sf, mask, trf, {mask_tolerance, 0.f},
+        return this->operator()(ray, sf, mask, trf, {mask_tolerance, 0.f}, 0.f,
                                 overstep_tol);
     }
 
@@ -162,9 +164,10 @@ struct ray_concentric_cylinder_intersector {
         const mask_t &mask, const transform3_type &trf,
         const std::array<scalar_type, 2u> &mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
         sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,
-                               overstep_tol)[0];
+                               mask_tol_scalor, overstep_tol)[0];
     }
 };
 

--- a/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
@@ -66,6 +66,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
         const transform3_type &trf,
         const std::array<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
         intersection_type<surface_descr_t> is;
@@ -81,7 +82,8 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
             const scalar_type t{(qe.smaller() > overstep_tol) ? qe.smaller()
                                                               : qe.larger()};
             is = this->template build_candidate<surface_descr_t>(
-                ray, mask, trf, t, mask_tolerance, overstep_tol);
+                ray, mask, trf, t, mask_tolerance, mask_tol_scalor,
+                overstep_tol);
             is.sf_desc = sf;
         } else {
             is.status = false;
@@ -96,7 +98,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
         const ray_type &ray, const surface_descr_t &sf, const mask_t &mask,
         const transform3_type &trf, const scalar_type mask_tolerance,
         const scalar_type overstep_tol = 0.f) const {
-        return this->operator()(ray, sf, mask, trf, {mask_tolerance, 0.f},
+        return this->operator()(ray, sf, mask, trf, {mask_tolerance, 0.f}, 0.f,
                                 overstep_tol);
     }
 
@@ -116,9 +118,10 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
         const mask_t &mask, const transform3_type &trf,
         const std::array<scalar_type, 2u> &mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
         sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,
-                               overstep_tol);
+                               mask_tol_scalor, overstep_tol);
     }
 };
 

--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -54,6 +54,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, false> {
         const transform3_type &trf,
         const std::array<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
         assert((mask_tolerance[0] <= mask_tolerance[1]) &&
@@ -107,9 +108,10 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, false> {
             is.local = mask.to_local_frame(trf, m, _d);
             // Tolerance: per mille of the distance
             is.status = mask.is_inside(
-                is.local, math::max(mask_tolerance[0],
-                                    math::min(mask_tolerance[1],
-                                              1e-3f * math::fabs(is.path))));
+                is.local,
+                math::max(mask_tolerance[0],
+                          math::min(mask_tolerance[1],
+                                    mask_tol_scalor * math::fabs(is.path))));
 
             // prepare some additional information in case the intersection
             // is valid
@@ -131,7 +133,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, false> {
         const ray_type &ray, const surface_descr_t &sf, const mask_t &mask,
         const transform3_type &trf, const scalar_type mask_tolerance,
         const scalar_type overstep_tol = 0.f) const {
-        return this->operator()(ray, sf, mask, trf, {mask_tolerance, 0.f},
+        return this->operator()(ray, sf, mask, trf, {mask_tolerance, 0.f}, 0.f,
                                 overstep_tol);
     }
 
@@ -151,10 +153,11 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, false> {
         const mask_t &mask, const transform3_type &trf,
         const std::array<scalar_type, 2u> &mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
         sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,
-                               overstep_tol);
+                               mask_tol_scalor, overstep_tol);
     }
 };
 

--- a/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
@@ -58,6 +58,7 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {
         const transform3_type &trf,
         const std::array<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
         assert((mask_tolerance[0] <= mask_tolerance[1]) &&
@@ -86,10 +87,10 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {
                 is.local = mask.to_local_frame(trf, p3, ray.dir());
                 // Tolerance: per mille of the distance
                 is.status = mask.is_inside(
-                    is.local,
-                    math::max(mask_tolerance[0],
-                              math::min(mask_tolerance[1],
-                                        1e-3f * math::fabs(is.path))));
+                    is.local, math::max(mask_tolerance[0],
+                                        math::min(mask_tolerance[1],
+                                                  mask_tol_scalor *
+                                                      math::fabs(is.path))));
 
                 // prepare some additional information in case the intersection
                 // is valid
@@ -115,7 +116,7 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {
         const ray_type &ray, const surface_descr_t &sf, const mask_t &mask,
         const transform3_type &trf, const scalar_type mask_tolerance,
         const scalar_type overstep_tol = 0.f) const {
-        return this->operator()(ray, sf, mask, trf, {mask_tolerance, 0.f},
+        return this->operator()(ray, sf, mask, trf, {mask_tolerance, 0.f}, 0.f,
                                 overstep_tol);
     }
 
@@ -136,9 +137,10 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {
         const mask_t &mask, const transform3_type &trf,
         const std::array<scalar_type, 2u> &mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
         sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,
-                               overstep_tol);
+                               mask_tol_scalor, overstep_tol);
     }
 };
 

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
@@ -59,7 +59,8 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const detail::ray<other_algebra_t> &ray, const surface_descr_t &sf,
         const mask_t &mask, const transform3_type &trf,
-        const scalar_type mask_tolerance = 0.f,
+        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
         intersection_type<surface_descr_t> is;
@@ -83,7 +84,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
         t(!valid_smaller) = qe.larger();
 
         is = this->template build_candidate<surface_descr_t>(
-            ray, mask, trf, t, mask_tolerance, overstep_tol);
+            ray, mask, trf, t, mask_tolerance, mask_tol_scalor, overstep_tol);
         is.sf_desc = sf;
 
         return is;
@@ -103,10 +104,12 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
     DETRAY_HOST_DEVICE inline void update(
         const detail::ray<other_algebra_t> &ray,
         intersection_type<surface_descr_t> &sfi, const mask_t &mask,
-        const transform3_type &trf, const scalar_type mask_tolerance = 0.f,
+        const transform3_type &trf,
+        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
         sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,
-                               overstep_tol);
+                               mask_tol_scalor, overstep_tol);
     }
 };
 

--- a/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
@@ -55,7 +55,8 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, true> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const detail::ray<other_algebra_t> &ray, const surface_descr_t &sf,
         const mask_t &mask, const transform3_type &trf,
-        const scalar_type mask_tolerance = 0.f,
+        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
         intersection_type<surface_descr_t> is;
@@ -98,7 +99,11 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, true> {
         // point of closest approach on the track
         const point3_type m = ro + rd * is.path;
         is.local = mask.to_local_frame(trf, m, rd);
-        is.status = mask.is_inside(is.local, mask_tolerance);
+        is.status = mask.is_inside(
+            is.local,
+            math::max(mask_tolerance[0],
+                      math::min(mask_tolerance[1],
+                                mask_tol_scalor * math::fabs(is.path))));
 
         // Early return, in case all intersections are invalid
         if (detray::detail::none_of(is.status)) {
@@ -133,10 +138,12 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, true> {
     DETRAY_HOST_DEVICE inline void update(
         const detail::ray<other_algebra_t> &ray,
         intersection_type<surface_descr_t> &sfi, const mask_t &mask,
-        const transform3_type &trf, const scalar_type mask_tolerance = 0.f,
+        const transform3_type &trf,
+        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
         sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,
-                               overstep_tol);
+                               mask_tol_scalor, overstep_tol);
     }
 };
 

--- a/core/include/detray/navigation/intersection_kernel.hpp
+++ b/core/include/detray/navigation/intersection_kernel.hpp
@@ -47,6 +47,7 @@ struct intersection_initialize {
         const transform_container_t &contextual_transforms,
         const std::array<scalar_t, 2u> &mask_tolerance =
             {0.f, 1.f * unit<scalar_t>::mm},
+        const scalar_t mask_tol_scalor = 0.f,
         const scalar_t overstep_tol = 0.f) const {
 
         using mask_t = typename mask_group_t::value_type;
@@ -60,7 +61,8 @@ struct intersection_initialize {
 
             if (place_in_collection(
                     intersector_t<typename mask_t::shape, algebra_t>{}(
-                        traj, surface, mask, ctf, mask_tolerance, overstep_tol),
+                        traj, surface, mask, ctf, mask_tolerance,
+                        mask_tol_scalor, overstep_tol),
                     is_container)) {
                 return;
             };
@@ -130,6 +132,7 @@ struct intersection_update {
         const transform_container_t &contextual_transforms,
         const std::array<scalar_t, 2u> &mask_tolerance =
             {0.f, 1.f * unit<scalar_t>::mm},
+        const scalar_t mask_tol_scalor = 0.f,
         const scalar_t overstep_tol = 0.f) const {
 
         using mask_t = typename mask_group_t::value_type;
@@ -142,7 +145,8 @@ struct intersection_update {
              detray::ranges::subrange(mask_group, mask_range)) {
 
             intersector_t<typename mask_t::shape, algebra_t>{}.update(
-                traj, sfi, mask, ctf, mask_tolerance, overstep_tol);
+                traj, sfi, mask, ctf, mask_tolerance, mask_tol_scalor,
+                overstep_tol);
 
             if (sfi.status) {
                 return true;

--- a/core/include/detray/navigation/intersector.hpp
+++ b/core/include/detray/navigation/intersector.hpp
@@ -36,10 +36,11 @@ struct intersector {
         const mask_t &mask, const transform3_type &trf,
         const std::array<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
+        const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
         return ray_intersector_type{}(ray, sf, mask, trf, mask_tolerance,
-                                      overstep_tol);
+                                      mask_tol_scalor, overstep_tol);
     }
 
     /// @returns the intersection(s) between a surface and the helix @param h
@@ -49,7 +50,7 @@ struct intersector {
         const mask_t &mask, const transform3_type &trf,
         const std::array<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
-        const scalar_type = 0.f) const {
+        const scalar_type = 0.f, const scalar_type = 0.f) const {
 
         return helix_intersector_type{}(h, sf, mask, trf, mask_tolerance);
     }

--- a/core/include/detray/navigation/navigation_config.hpp
+++ b/core/include/detray/navigation/navigation_config.hpp
@@ -33,6 +33,8 @@ struct config {
     float min_mask_tolerance{1e-5f * unit<float>::mm};
     /// Maximal tolerance: loose tolerance when still far away from surface
     float max_mask_tolerance{1.f * unit<float>::mm};
+    /// Scale factor on the path used for the mask tolerance calculation
+    float mask_tolerance_scalor{1e-2f};
     ///@}
     /// Maximal absolute path distance for a track to be considered 'on surface'
     float path_tolerance{1.f * unit<float>::um};
@@ -51,6 +53,7 @@ inline std::ostream& operator<<(std::ostream& out,
         << cfg.min_mask_tolerance / detray::unit<float>::mm << " [mm]\n"
         << "  Max. mask tolerance   : "
         << cfg.max_mask_tolerance / detray::unit<float>::mm << " [mm]\n"
+        << "  Mask tolerance scalor : " << cfg.mask_tolerance_scalor << "\n"
         << "  Path tolerance        : "
         << cfg.path_tolerance / detray::unit<float>::um << " [um]\n"
         << "  Overstep tolerance    : "

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -198,11 +198,15 @@ class navigator {
 
         /// @return start position of valid candidate range.
         DETRAY_HOST_DEVICE
-        constexpr auto begin() -> candidate_itr_t { return m_next; }
+        constexpr auto begin() -> candidate_itr_t {
+            return (is_on_module() || is_on_portal()) ? m_next - 1 : m_next;
+        }
 
         /// @return start position of the valid candidate range - const
         DETRAY_HOST_DEVICE
-        constexpr auto begin() const -> const_candidate_itr_t { return m_next; }
+        constexpr auto begin() const -> const_candidate_itr_t {
+            return (is_on_module() || is_on_portal()) ? current() : next();
+        }
 
         /// @return sentinel of the valid candidate range.
         DETRAY_HOST_DEVICE
@@ -243,15 +247,11 @@ class navigator {
 
         /// @returns next object that we want to reach (current target) - const
         DETRAY_HOST_DEVICE
-        inline auto next() const -> const const_candidate_itr_t & {
-            return m_next;
-        }
+        inline auto next() const -> const_candidate_itr_t { return m_next; }
 
         /// @returns last valid candidate (by position in the cache) - const
         DETRAY_HOST_DEVICE
-        inline auto last() const -> const const_candidate_itr_t & {
-            return m_last;
-        }
+        inline auto last() const -> const_candidate_itr_t { return m_last; }
 
         /// @returns the navigation inspector
         DETRAY_HOST
@@ -418,6 +418,7 @@ class navigator {
         }
 
         /// @returns next object that we want to reach (current target)
+        /// @note must be lvalue to update the iterator position correctly
         DETRAY_HOST_DEVICE
         inline auto next() -> candidate_itr_t & { return m_next; }
 

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -129,6 +129,7 @@ class navigator {
             const detector_type &det, const track_t &track,
             vector_type<intersection_type> &candidates,
             const std::array<scalar_type, 2> mask_tol,
+            const scalar_type mask_tol_scalor,
             const scalar_type overstep_tol) const {
 
             const auto sf = surface{det, sf_descr};
@@ -137,7 +138,7 @@ class navigator {
                 candidates, detail::ray(track), sf_descr, det.transform_store(),
                 sf.is_portal() ? std::array<scalar_type, 2>{0.f, 0.f}
                                : mask_tol,
-                overstep_tol);
+                mask_tol_scalor, overstep_tol);
         }
     };
 
@@ -524,6 +525,7 @@ class navigator {
             track, cfg, *det, track, navigation.candidates(),
             std::array<scalar_type, 2u>{cfg.min_mask_tolerance,
                                         cfg.max_mask_tolerance},
+            static_cast<scalar_type>(cfg.mask_tolerance_scalor),
             static_cast<scalar_type>(cfg.overstep_tolerance));
 
         // Sort all candidates and pick the closest one
@@ -784,6 +786,7 @@ class navigator {
             sf.is_portal() ? std::array<scalar_type, 2>{0.f, 0.f}
                            : std::array<scalar_type, 2>{cfg.min_mask_tolerance,
                                                         cfg.max_mask_tolerance},
+            static_cast<scalar_type>(cfg.mask_tolerance_scalor),
             static_cast<scalar_type>(cfg.overstep_tolerance));
     }
 

--- a/io/include/detray/io/csv/intersection2D.hpp
+++ b/io/include/detray/io/csv/intersection2D.hpp
@@ -26,6 +26,7 @@ struct intersection2D {
 
     unsigned int track_id = 0;
     std::uint64_t identifier = 0ul;
+    unsigned int type = 0u;
     unsigned int transform_index = 0u;
     unsigned int mask_id = 0u;
     unsigned int mask_index = 0u;
@@ -39,7 +40,7 @@ struct intersection2D {
     int direction = 0;
     int status = 0;
 
-    DFE_NAMEDTUPLE(intersection2D, track_id, identifier, transform_index,
+    DFE_NAMEDTUPLE(intersection2D, track_id, identifier, type, transform_index,
                    mask_id, mask_index, material_id, material_index, l0, l1,
                    path, cos_theta, volume_link, direction, status);
 };
@@ -117,6 +118,9 @@ inline void write_intersection2D(
     std::string inters_file_name{file_name};
     if (io::file_exists(file_name)) {
         inters_file_name = io::alt_file_name(file_name);
+    } else {
+        // Make sure the output directories exit
+        io::create_path(inters_file_name);
     }
 
     dfe::NamedTupleCsvWriter<io::csv::intersection2D> inters_writer(
@@ -135,6 +139,8 @@ inline void write_intersection2D(
 
             inters_data.track_id = track_idx;
             inters_data.identifier = inters.sf_desc.barcode().value();
+            inters_data.type =
+                static_cast<unsigned int>(inters.sf_desc.barcode().id());
             inters_data.transform_index = inters.sf_desc.transform();
             inters_data.mask_id =
                 static_cast<unsigned int>(inters.sf_desc.mask().id());

--- a/io/include/detray/io/csv/track_parameters.hpp
+++ b/io/include/detray/io/csv/track_parameters.hpp
@@ -108,6 +108,9 @@ inline void write_free_track_params(
     std::string trk_file_name{file_name};
     if (io::file_exists(file_name)) {
         trk_file_name = io::alt_file_name(file_name);
+    } else {
+        // Make sure the output directories exit
+        io::create_path(trk_file_name);
     }
 
     dfe::NamedTupleCsvWriter<io::csv::free_track_parameters> track_param_writer(

--- a/io/include/detray/io/utils/create_path.hpp
+++ b/io/include/detray/io/utils/create_path.hpp
@@ -71,6 +71,7 @@ inline std::string alt_file_name(const std::string& name) {
 inline auto create_path(const std::string& outdir) {
 
     auto path = std::filesystem::path(outdir);
+    path = std::filesystem::is_directory(path) ? path : path.parent_path();
 
     if (!std::filesystem::exists(path)) {
         if (std::error_code err;

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
@@ -160,11 +160,13 @@ auto surface_grid(const detector_t& detector, const dindex index,
         }
     }
 
-    scalar_t inner_r = *std::min_element(radii.begin(), radii.end());
-    scalar_t outer_r = *std::max_element(radii.begin(), radii.end());
+    scalar_t cyl_ref_radius{0.f};
+    if (!radii.empty()) {
+        scalar_t inner_r = *std::min_element(radii.begin(), radii.end());
+        scalar_t outer_r = *std::max_element(radii.begin(), radii.end());
 
-    scalar_t cyl_ref_radius =
-        0.5f * static_cast<actsvg::scalar>(inner_r + outer_r);
+        cyl_ref_radius = 0.5f * static_cast<actsvg::scalar>(inner_r + outer_r);
+    }
 
     return svgtools::conversion::grid(detector.accelerator_store(), link, view,
                                       cyl_ref_radius, style);

--- a/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
@@ -35,7 +35,9 @@ int main(int argc, char **argv) {
 
     tel_det_config<rectangle2D> tel_cfg{20.f * unit<scalar_t>::mm,
                                         20.f * unit<scalar_t>::mm};
-    tel_cfg.n_surfaces(10u).length(500.f * unit<scalar_t>::mm);
+    tel_cfg.n_surfaces(10u)
+        .length(500.f * unit<scalar_t>::mm)
+        .envelope(500.f * unit<scalar_t>::um);
 
     vecmem::host_memory_resource host_mr;
 
@@ -54,13 +56,10 @@ int main(int argc, char **argv) {
     cfg_ray_scan.name("telescope_detector_ray_scan");
     cfg_ray_scan.whiteboard(white_board);
     cfg_ray_scan.track_generator().n_tracks(10000u);
+    // The first surface is at z=0, so shift the track origin back
     cfg_ray_scan.track_generator().origin({0.f, 0.f, -0.05f});
-    cfg_ray_scan.track_generator().theta_range(constant<scalar_t>::pi_4,
-                                               constant<scalar_t>::pi_2);
-    // Better momentum range fails because of bug in the object tracer
-    /*cfg_ray_scan.track_generator().theta_range(0.f,
-                                               0.25f *
-       constant<scalar_t>::pi_4);*/
+    cfg_ray_scan.track_generator().theta_range(
+        0.f, 0.25f * constant<scalar_t>::pi_4);
 
     detail::register_checks<test::ray_scan>(tel_det, tel_names, cfg_ray_scan);
 
@@ -74,10 +73,9 @@ int main(int argc, char **argv) {
     cfg_hel_scan.track_generator().n_tracks(10000u);
     cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar_t>::GeV);
     cfg_hel_scan.track_generator().origin({0.f, 0.f, -0.05f});
-    cfg_hel_scan.track_generator().theta_range(constant<scalar_t>::pi_4,
-                                               constant<scalar_t>::pi_2);
-    /*cfg_hel_scan.track_generator().theta_range(0.f,
-                                               constant<scalar_t>::pi_4);*/
+    cfg_hel_scan.track_generator().theta_range(
+        0.f, 0.25f * constant<scalar_t>::pi_4);
+
     detail::register_checks<test::helix_scan>(tel_det, tel_names, cfg_hel_scan);
 
     // Comparison of straight line navigation with ray scan
@@ -97,6 +95,8 @@ int main(int argc, char **argv) {
     test::helix_navigation<tel_detector_t>::config cfg_hel_nav{};
     cfg_hel_nav.name("telescope_detector_helix_navigation");
     cfg_hel_nav.whiteboard(white_board);
+    cfg_hel_nav.propagation().navigation.overstep_tolerance =
+        -300.f * unit<float>::um;
 
     detail::register_checks<test::helix_navigation>(tel_det, tel_names,
                                                     cfg_hel_nav);

--- a/tests/tools/include/detray/options/propagation_options.hpp
+++ b/tests/tools/include/detray/options/propagation_options.hpp
@@ -38,6 +38,10 @@ void add_options<detray::navigation::config>(
         boost::program_options::value<float>()->default_value(
             cfg.max_mask_tolerance),
         "Maximum mask tolerance [mm]")(
+        "mask_tolerance_scalor",
+        boost::program_options::value<float>()->default_value(
+            cfg.mask_tolerance_scalor),
+        "Mask tolerance scaling")(
         "overstep_tolerance",
         boost::program_options::value<float>()->default_value(
             cfg.overstep_tolerance),
@@ -113,6 +117,12 @@ void configure_options<detray::navigation::config>(
         assert(mask_tol >= 0.f);
 
         cfg.max_mask_tolerance = mask_tol * unit<float>::mm;
+    }
+    if (!vm["mask_tolerance_scalor"].defaulted()) {
+        const float mask_tol_scalor{vm["mask_tolerance_scalor"].as<float>()};
+        assert(mask_tol_scalor >= 0.f);
+
+        cfg.mask_tolerance_scalor = mask_tol_scalor;
     }
     if (!vm["overstep_tolerance"].defaulted()) {
         const float overstep_tol{vm["overstep_tolerance"].as<float>()};

--- a/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
@@ -273,7 +273,7 @@ GTEST_TEST(detray_intersection, intersection_kernel_helix) {
     for (const auto [sf_idx, surface] : detray::views::enumerate(surfaces)) {
         mask_store.visit<intersection_initialize<helix_intersector>>(
             surface.mask(), sfi_helix, h, surface, transform_store,
-            std::array<scalar_t, 2>{0.f, 0.f}, scalar_t{0.f});
+            std::array<scalar_t, 2>{0.f, 0.f}, scalar_t{0.f}, scalar_t{0.f});
 
         vector3 global;
 


### PR DESCRIPTION
Makes the scale factor on the mask tolerance configurable and adds the adaptive mask tolerance to the SoA intersectors. Fixes a few bugs in the navigator:
- candidate iteration includes the current candidate if the track is on a surface (this can lead to skipping a surface in rare cases)
- the object tracer only records elements if the state has changed since the last call. This avoids double counting of candidates and allows to test the telescope detector over a proper theta range without errors
- the mask tolerance scalor was raised, which improves the navigation validation on the ODD for low momenta (0.5 GeV)
- sets the equality operator of the intersection back to single precision, since the ray scan on ACTS detectors fails on adjacent portals otherwise due to a slight floating point inaccuracy during IO
- Fixed the validation data output
- Fixes a bug in the svg output, which failed to produce min/max radii for box volumes (telescope detector)