### PR TITLE
fix: path creation

### DIFF
--- a/io/include/detray/io/csv/intersection2D.hpp
+++ b/io/include/detray/io/csv/intersection2D.hpp
@@ -18,6 +18,7 @@
 
 // System include(s).
 #include <cstdint>
+#include <filesystem>
 
 namespace detray::io::csv {
 
@@ -120,7 +121,7 @@ inline void write_intersection2D(
         inters_file_name = io::alt_file_name(file_name);
     } else {
         // Make sure the output directories exit
-        io::create_path(inters_file_name);
+        io::create_path(std::filesystem::path{inters_file_name}.parent_path());
     }
 
     dfe::NamedTupleCsvWriter<io::csv::intersection2D> inters_writer(

--- a/io/include/detray/io/csv/track_parameters.hpp
+++ b/io/include/detray/io/csv/track_parameters.hpp
@@ -16,6 +16,9 @@
 #include <dfe/dfe_io_dsv.hpp>
 #include <dfe/dfe_namedtuple.hpp>
 
+// System include(s)
+#include <filesystem>
+
 namespace detray::io::csv {
 
 /// Type to read the data of free track parameters
@@ -110,7 +113,7 @@ inline void write_free_track_params(
         trk_file_name = io::alt_file_name(file_name);
     } else {
         // Make sure the output directories exit
-        io::create_path(trk_file_name);
+        io::create_path(std::filesystem::path{trk_file_name}.parent_path());
     }
 
     dfe::NamedTupleCsvWriter<io::csv::free_track_parameters> track_param_writer(

--- a/io/include/detray/io/utils/create_path.hpp
+++ b/io/include/detray/io/utils/create_path.hpp
@@ -71,9 +71,8 @@ inline std::string alt_file_name(const std::string& name) {
 inline auto create_path(const std::string& outdir) {
 
     auto path = std::filesystem::path(outdir);
-    path = std::filesystem::is_directory(path) ? path : path.parent_path();
 
-    if (!std::filesystem::exists(path)) {
+    if (!path.empty() && !std::filesystem::exists(path)) {
         if (std::error_code err;
             !std::filesystem::create_directories(path, err)) {
             throw std::runtime_error(err.message());


### PR DESCRIPTION
The ```is_directory``` call does not seem to work as expected, so only actual directory paths must be passed to ```create_path```.