### PR TITLE
feat: Add additional track posistion and residual plots

### DIFF
--- a/tests/include/detray/test/common/utils/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/common/utils/navigation_validation_utils.hpp
@@ -12,6 +12,7 @@
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/actors/aborters.hpp"
 #include "detray/propagator/propagator.hpp"
+#include "detray/tracks/free_track_parameters.hpp"
 #include "detray/utils/inspectors.hpp"
 
 // System include(s)
@@ -171,6 +172,30 @@ bool compare_traces(const truth_trace_t &truth_trace,
     }
 
     return true;
+}
+
+/// Write the track positions of a trace @param intersection_traces to a csv
+/// file to the path @param track_param_file_name
+template <typename record_t>
+auto write_tracks(const std::string &track_param_file_name,
+                  const dvector<dvector<record_t>> &intersection_traces) {
+    using track_param_t =
+        free_track_parameters<typename record_t::algebra_type>;
+
+    std::vector<std::vector<track_param_t>> track_params{};
+
+    for (const auto &trace : intersection_traces) {
+
+        track_params.push_back({});
+        track_params.back().reserve(trace.size());
+
+        for (const auto &record : trace) {
+            track_params.back().push_back({record.pos, 0.f, record.dir, -1.f});
+        }
+    }
+
+    // Write to file
+    io::csv::write_free_track_params(track_param_file_name, track_params);
 }
 
 /// Calculate and print the navigation efficiency

--- a/tests/include/detray/test/device/cuda/navigation_validation.cu
+++ b/tests/include/detray/test/device/cuda/navigation_validation.cu
@@ -90,9 +90,12 @@ __global__ void navigation_validation_kernel(
 
     // Save the initial intersection, since it is not recorded by the
     // object tracer
+    assert(recorded_intersections.at(trk_id).empty());
     recorded_intersections.at(trk_id).push_back(
         {track.pos(), track.dir(),
          truth_intersection_traces[trk_id].front().intersection});
+    // Did the insertion of an element work?
+    assert(recorded_intersections.at(trk_id).size() == 1);
 
     // Run propagation
     if constexpr (is_no_bfield) {

--- a/tests/tools/src/cpu/detector_validation.cpp
+++ b/tests/tools/src/cpu/detector_validation.cpp
@@ -121,12 +121,17 @@ int main(int argc, char** argv) {
 
     // Comparison of straight line navigation with ray scan
     str_nav_cfg.name(det_name + "_straight_line_navigation");
+    // Number of tracks to check
+    str_nav_cfg.n_tracks(ray_scan_cfg.track_generator().n_tracks());
     // Ensure that the same mask tolerance is used
     auto mask_tolerance = ray_scan_cfg.mask_tolerance();
     str_nav_cfg.propagation().navigation.min_mask_tolerance =
         static_cast<float>(mask_tolerance[0]);
     str_nav_cfg.propagation().navigation.max_mask_tolerance =
         static_cast<float>(mask_tolerance[1]);
+    str_nav_cfg.intersection_file(ray_scan_cfg.intersection_file());
+    str_nav_cfg.track_param_file(ray_scan_cfg.track_param_file());
+
     detray::detail::register_checks<detray::test::straight_line_navigation>(
         det, names, str_nav_cfg);
 
@@ -136,6 +141,11 @@ int main(int argc, char** argv) {
 
     // Comparison of navigation in a constant B-field with helix
     hel_nav_cfg.name(det_name + "_helix_navigation");
+    // Number of tracks to check
+    hel_nav_cfg.n_tracks(hel_scan_cfg.track_generator().n_tracks());
+    hel_nav_cfg.intersection_file(hel_scan_cfg.intersection_file());
+    hel_nav_cfg.track_param_file(hel_scan_cfg.track_param_file());
+
     detray::detail::register_checks<detray::test::helix_navigation>(
         det, names, hel_nav_cfg);
 

--- a/tests/tools/src/cuda/detector_validation_cuda.cpp
+++ b/tests/tools/src/cuda/detector_validation_cuda.cpp
@@ -106,12 +106,17 @@ int main(int argc, char** argv) {
 
     // Comparison of straight line navigation with ray scan
     str_nav_cfg.name(det_name + "_straight_line_navigation_cuda");
+    // Number of tracks to check
+    str_nav_cfg.n_tracks(ray_scan_cfg.track_generator().n_tracks());
     // Ensure that the same mask tolerance is used
     auto mask_tolerance = ray_scan_cfg.mask_tolerance();
     str_nav_cfg.propagation().navigation.min_mask_tolerance =
         static_cast<float>(mask_tolerance[0]);
     str_nav_cfg.propagation().navigation.max_mask_tolerance =
         static_cast<float>(mask_tolerance[1]);
+    str_nav_cfg.intersection_file(ray_scan_cfg.intersection_file());
+    str_nav_cfg.track_param_file(ray_scan_cfg.track_param_file());
+
     detray::detail::register_checks<detray::cuda::straight_line_navigation>(
         det, names, str_nav_cfg);
 
@@ -121,6 +126,11 @@ int main(int argc, char** argv) {
 
     // Comparison of navigation in a constant B-field with helix
     hel_nav_cfg.name(det_name + "_helix_navigation_cuda");
+    // Number of tracks to check
+    hel_nav_cfg.n_tracks(hel_scan_cfg.track_generator().n_tracks());
+    hel_nav_cfg.intersection_file(hel_scan_cfg.intersection_file());
+    hel_nav_cfg.track_param_file(hel_scan_cfg.track_param_file());
+
     detray::detail::register_checks<detray::cuda::helix_navigation>(
         det, names, hel_nav_cfg);
 

--- a/tests/validation/python/impl/__init__.py
+++ b/tests/validation/python/impl/__init__.py
@@ -1,4 +1,4 @@
 
 from .plot_material_scan import X0_vs_eta_phi, L0_vs_eta_phi, X0_vs_eta, L0_vs_eta
-from .plot_ray_scan import intersection_points_xy, intersection_points_rz
-from .plot_navigation_validation import read_navigation_data, plot_navigation_data
+from .plot_ray_scan import read_scan_data, plot_intersection_points_xy, plot_intersection_points_rz
+from .plot_track_positions import read_navigation_data, compare_track_pos_xy, compare_track_pos_rz, plot_track_pos_dist, plot_track_pos_res

--- a/tests/validation/python/impl/plot_track_positions.py
+++ b/tests/validation/python/impl/plot_track_positions.py
@@ -1,0 +1,239 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# detray includes
+import plotting
+
+# python includes
+import numpy as np
+import pandas as pd
+import os
+
+
+""" Read the recorded track positions from files and prepare data frames """
+def read_navigation_data(inputdir, read_cuda, logging):
+
+    # Input data directory
+    data_dir = os.fsencode(inputdir)
+
+    ray_data_file = ray_data_cuda_file = ""
+    helix_data_file = helix_data_cuda_file = ""
+
+    # Find the data files by naming convention
+    for file in os.listdir(data_dir):
+        filename = os.fsdecode(file)
+
+        if read_cuda and filename.find('ray_navigation_track_pos_cuda.') != -1:
+            ray_data_cuda_file = inputdir + "/" + filename
+        elif filename.find('ray_navigation_track_pos.') != -1:
+            ray_data_file = inputdir + "/" + filename
+        elif read_cuda and filename.find('helix_navigation_track_pos_cuda.') != -1:
+            helix_data_cuda_file = inputdir + "/" + filename
+        elif filename.find('helix_navigation_track_pos.') != -1:
+            helix_data_file = inputdir + "/" + filename
+
+    # Read navigation data
+    def read_data(file):
+        if file:
+            # Preserve floating point precision
+            df = pd.read_csv(file, float_precision='round_trip')
+            logging.debug(df)
+        else:
+            logging.warning("Could not find navigation data file: " + file)
+            df = pd.DataFrame({})
+
+        return df
+
+    ray_df = read_data(ray_data_file)
+    ray_cuda_df = read_data(ray_data_cuda_file)
+    helix_df = read_data(helix_data_file)
+    helix_cuda_df = read_data(helix_data_cuda_file)
+
+    return ray_df, ray_cuda_df, helix_df, helix_cuda_df
+
+
+""" Plot the track positions of two data sources - rz view """
+def compare_track_pos_xy(opts, detector, scan_type, plotFactory, out_format,
+                         df1, label1, color1, df2, label2, color2):
+
+    n_rays = np.max(df1['track_id']) + 1
+    tracks = "rays" if scan_type == "ray" else "helices"
+
+    # Reduce data to the requested z-range (50mm tolerance)
+    min_z = opts.z_range[0]
+    max_z = opts.z_range[1]
+    assert min_z < max_z, "xy plotting range: min z must be smaller that max z"
+    pos_range = lambda data: ((data['z'] > min_z) & (data['z'] < max_z))
+
+    first_x, first_y = plotting.filter_data(
+                                         data      = df1,
+                                         filter    = pos_range,
+                                         variables = ['x', 'y'])
+
+    second_x, second_y = plotting.filter_data(
+                                         data      = df2,
+                                         filter    = pos_range,
+                                         variables = ['x', 'y'])
+
+    # Plot the xy coordinates of the filtered track positions
+    lgd_ops = plotting.legend_options('upper center', 4, 0.4, 0.005)
+    hist_data = plotFactory.scatter(
+                            figsize = (8, 8),
+                            x       = first_x,
+                            y       = first_y,
+                            xLabel  = r'$x\,\mathrm{[mm]}$',
+                            yLabel  = r'$y\,\mathrm{[mm]}$',
+                            label   = label1,
+                            color   = color1,
+                            alpha   = 1.,
+                            showStats = lambda x, y: f"{n_rays} {tracks}",
+                            lgd_ops = lgd_ops)
+
+    # Compare agaist second data set
+    plotFactory.highlight_region(hist_data, second_x, second_y, color2, label2)
+
+    # Refine legend
+    hist_data.lgd.legend_handles[0].set_visible(False)
+    for handle in hist_data.lgd.legend_handles[1:]:
+        handle.set_sizes([40])
+
+    # For this plot, move the legend ouside
+    hist_data.lgd.set_bbox_to_anchor((0.5, 1.11))
+
+    # Adjust spacing in box
+    for vpack in hist_data.lgd._legend_handle_box.get_children()[:1]:
+        for hpack in vpack.get_children():
+            hpack.get_children()[0].set_width(0)
+
+    detector_name = detector.replace(' ', '_')
+    l1 = label1.replace(' ', '_').replace("(", "").replace(")", "")
+    l2 = label2.replace(' ', '_').replace("(", "").replace(")", "")
+
+    # Need a very high dpi to reach a good coverage of the individual points
+    plotFactory.write_plot(
+                        hist_data,
+                        f"{detector_name}_{scan_type}_track_pos_{l1}_{l2}_xy",
+                        out_format, dpi = 600)
+
+
+""" Plot the track positions of two data sources - rz view """
+def compare_track_pos_rz(opts, detector, scan_type, plotFactory, out_format,
+                         df1, label1, color1, df2, label2, color2):
+
+    n_rays = np.max(df1['track_id']) + 1
+    tracks =  "rays" if scan_type == "ray" else "helices"
+
+    first_x, first_y, first_z = plotting.filter_data(
+                                                data      = df1,
+                                                variables = ['x', 'y', 'z'])
+
+    second_x, second_y, second_z = plotting.filter_data(
+                                                data      = df2,
+                                                variables = ['x', 'y', 'z'])
+
+    # Plot the xy coordinates of the filtered intersections points
+    lgd_ops = plotting.legend_options('upper center', 4, 0.8, 0.005)
+    hist_data = plotFactory.scatter(
+                            figsize = (12, 6),
+                            x      = first_z,
+                            y      = np.hypot(first_x, first_y),
+                            xLabel = r'$z\,\mathrm{[mm]}$',
+                            yLabel = r'$r\,\mathrm{[mm]}$',
+                            label  = label1,
+                            color  = color1,
+                            alpha   = 1.,
+                            showStats = lambda x, y: f"{n_rays} {tracks}",
+                            lgd_ops = lgd_ops)
+
+    # Compare agaist second data set
+    plotFactory.highlight_region(hist_data, second_z, np.hypot(second_x, second_y), color2, label2)
+
+    # Refine legend
+    hist_data.lgd.legend_handles[0].set_visible(False)
+    for handle in hist_data.lgd.legend_handles[1:]:
+        handle.set_sizes([40])
+
+    # For this plot, move the legend ouside
+    hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+
+    # Adjust spacing in box
+    for vpack in hist_data.lgd._legend_handle_box.get_children()[:1]:
+        for hpack in vpack.get_children():
+            hpack.get_children()[0].set_width(0)
+
+    detector_name = detector.replace(' ', '_')
+    l1 = label1.replace(' ', '_').replace("(", "").replace(")", "")
+    l2 = label2.replace(' ', '_').replace("(", "").replace(")", "")
+
+    # Need a very high dpi to reach a good coverage of the individual points
+    plotFactory.write_plot(
+                        hist_data,
+                        f"{detector_name}_{scan_type}_track_pos_{l1}_{l2}_rz",
+                        out_format, dpi = 600)
+
+
+""" Plot the absolute track positions distance """
+def plot_track_pos_dist(opts, detector, scan_type, plotFactory, out_format,
+                        df1, label1, df2, label2):
+
+    n_rays = np.max(df1['track_id']) + 1
+    tracks =  "rays" if scan_type == "ray" else "helices"
+
+    dist = np.sqrt(np.square(df1['x'] - df2['x']) +
+                   np.square(df1['y'] - df2['y']) +
+                   np.square(df1['z'] - df2['z']))
+
+    # Plot the xy coordinates of the filtered intersections points
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    hist_data = plotFactory.hist1D(x       = dist,
+                                   bins    = 100,
+                                   xLabel  = r'$d\,\mathrm{[mm]}$',
+                                   setLog  = True,
+                                   lgd_ops = lgd_ops)
+
+    # Adjust spacing in box
+    hist_data.lgd.legend_handles[0].set_visible(False)
+    for vpack in hist_data.lgd._legend_handle_box.get_children()[:1]:
+        for hpack in vpack.get_children():
+            hpack.get_children()[0].set_width(0)
+
+    detector_name = detector.replace(' ', '_')
+    l1 = label1.replace(' ', '_').replace("(", "").replace(")", "")
+    l2 = label2.replace(' ', '_').replace("(", "").replace(")", "")
+    plotFactory.write_plot(hist_data,
+                           f"{detector_name}_{scan_type}_dist_{l1}_{l2}",
+                           out_format)
+
+
+""" Plot the track position residual for the given variable """
+def plot_track_pos_res(opts, detector, scan_type, plotFactory, out_format,
+                       df1, label1, df2, label2, var):
+
+    n_rays = np.max(df1['track_id']) + 1
+    tracks =  "rays" if scan_type == "ray" else "helices"
+
+    res = df1[var] - df2[var]
+
+    # Plot the xy coordinates of the filtered intersections points
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    hist_data = plotFactory.hist1D(x       = res,
+                                   bins    = 100,
+                                   xLabel  = r'$\mathrm{res}' + rf'\,{var}' + r'\,\mathrm{[mm]}$',
+                                   setLog  = True,
+                                   lgd_ops = lgd_ops)
+
+    # Adjust spacing in box
+    hist_data.lgd.legend_handles[0].set_visible(False)
+    for vpack in hist_data.lgd._legend_handle_box.get_children()[:1]:
+        for hpack in vpack.get_children():
+            hpack.get_children()[0].set_width(0)
+
+    detector_name = detector.replace(' ', '_')
+    l1 = label1.replace(' ', '_').replace("(", "").replace(")", "")
+    l2 = label2.replace(' ', '_').replace("(", "").replace(")", "")
+    plotFactory.write_plot(hist_data,
+                           f"{detector_name}_{scan_type}_res_{var}_{l1}_{l2}",
+                           out_format)

--- a/tests/validation/python/plotting/plot_helpers.py
+++ b/tests/validation/python/plotting/plot_helpers.py
@@ -5,6 +5,7 @@
 # Mozilla Public License Version 2.0
 
 from collections import namedtuple
+import numpy as np
 
 #-------------------------------------------------------------------------------
 # Common helpers for plotting measurement data
@@ -17,13 +18,13 @@ def filter_data(data, filter = lambda df: [], variables = []):
     # Get global data
     if len(filter(data)) == 0:
         for var in variables:
-            dataColl.append(data[var].to_numpy())
+            dataColl.append(data[var].to_numpy(dtype = np.double))
 
     # Filtered data
     else:
         filtered = data.loc[filter]
         for var in variables:
-            dataColl.append(filtered[var].to_numpy())
+            dataColl.append(filtered[var].to_numpy(dtype = np.double))
 
     return tuple(dataColl)
 

--- a/tests/validation/python/plotting/pyplot_factory.py
+++ b/tests/validation/python/plotting/pyplot_factory.py
@@ -98,12 +98,13 @@ class pyplot_factory():
         scale = 1./len(x) if normalize else 1.
 
         # Fill data
-        data, bins, hist = ax.hist(x, weights = w,
-                                   range = (xMin, xMax),
-                                   bins = bins,
-                                   label=f"{label}  ({len(x)} entries)",
-                                   histtype  ='stepfilled',
-                                   density = normalize,
+        data, bins, hist = ax.hist(x,
+                                   weights   = w,
+                                   range     = (xMin, xMax),
+                                   bins      = bins,
+                                   label     = f"{label}  ({len(x)} entries)",
+                                   histtype  = 'stepfilled',
+                                   density   = normalize,
                                    facecolor = mcolors.to_rgba(color, alpha),
                                    edgecolor = color)
 
@@ -219,7 +220,7 @@ class pyplot_factory():
 
 
     """ Create a 2D scatter plot """
-    def scatter(self, x, y, 
+    def scatter(self, x, y,
                 xLabel = "", yLabel = "", title = "", label = "",
                 color  = 'tab:blue', alpha = 1,
                 figsize   = (8, 6), 
@@ -254,9 +255,11 @@ class pyplot_factory():
     def highlight_region(self, plotData, x, y, color, label = ""):
 
         if label == "":
-            plotData.ax.scatter(x, y, c = color, s = 0.1)
+            plotData.ax.scatter(x, y, c = color, alpha = 1, s = 0.1,
+                                rasterized=True)
         else:
-            plotData.ax.scatter(x, y, c = color, s = 0.1, label=label)
+            plotData.ax.scatter(x, y, c = color, alpha = 1, s = 0.1,
+                                label=label, rasterized=True)
 
             # Update legend
             lgd = plotData.lgd
@@ -269,13 +272,13 @@ class pyplot_factory():
 
     """ Safe a plot to disk """
     def write_plot(self, plot_data, name = "plot", file_format = "svg",
-                   outPrefix = ""):
+                   outPrefix = "", dpi = 450):
         if (outPrefix == ""):
             fileName = self.outputPrefix + name + "." + file_format
         else:
             fileName = outPrefix + name + "." + file_format
 
-        plot_data.fig.savefig(fileName, dpi=150)
+        plot_data.fig.savefig(fileName, dpi=dpi)
         plt.close(plot_data.fig)
 
 

--- a/utils/include/detray/simulation/event_generator/uniform_track_generator_config.hpp
+++ b/utils/include/detray/simulation/event_generator/uniform_track_generator_config.hpp
@@ -159,6 +159,9 @@ struct uniform_track_generator_config {
 
     /// Getters
     /// @{
+    DETRAY_HOST_DEVICE constexpr std::size_t n_tracks() const {
+        return phi_steps() * theta_steps();
+    }
     DETRAY_HOST_DEVICE constexpr std::array<scalar, 2> phi_range() const {
         return m_phi_range;
     }
@@ -193,12 +196,11 @@ inline std::ostream& operator<<(std::ostream& out,
                                 const uniform_track_generator_config& cfg) {
     const auto& ori = cfg.origin();
     const auto& phi_range = cfg.phi_range();
-    const std::size_t n_tracks{cfg.phi_steps() * cfg.theta_steps()};
 
     // General
     out << "\nUnform track generator\n"
         << "----------------------------\n"
-        << "  No. tracks            : " << n_tracks << "\n"
+        << "  No. tracks            : " << cfg.n_tracks() << "\n"
         << "    -> phi steps        : " << cfg.phi_steps() << "\n"
         << "    -> theta/eta steps  : " << cfg.theta_steps() << "\n"
         << "  Charge                : "


### PR DESCRIPTION
Added a method to write the track positions and directions that were recorded whenever the navigation has reached a surface to csv. The csv file is read back into the python plotting tools where 2D track position and residual plots are prepared from them (e.g. host vs. device). I moved the csv IO functionality in python into the same files where the corresponding plotting functions are defined.

Also fixed the selection of the number of tracks to check in the validation tools and made sure that the python code is handling the data in double precision, so that the minute residuals between host and device code become visible at all (but only when removing the fast math option for CUDA and even then, it is quantized to multiples of the machine epsilon)