### PR TITLE
annulus2D.hpp: fixed typo that was leading to crashes in some unit tests

### DIFF
--- a/core/include/detray/geometry/shapes/annulus2D.hpp
+++ b/core/include/detray/geometry/shapes/annulus2D.hpp
@@ -118,7 +118,7 @@ class annulus2D {
         const scalar_t minR_tol = bounds[e_min_r] - tol;
         const scalar_t maxR_tol = bounds[e_max_r] + tol;
 
-        assert(!detail::any_of(minR_tol >= scalar_t(0.f)));
+        assert(detail::all_of(minR_tol >= scalar_t(0.f)));
 
         return ((r_mod2 >= (minR_tol * minR_tol)) &&
                 (r_mod2 <= (maxR_tol * maxR_tol))) &&


### PR DESCRIPTION
Here are a few unit tests affected by this problem:
- `detray_unit_test_cuda_array`
- `detray_unit_test_cuda_eigen`

and here is the error I was getting:
```
[ RUN      ] mask_store_cuda.mask_store
detray_unit_test_cuda_array: /home/tsulaia/detray/src/core/include/detray/geometry/shapes/annulus2D.hpp:121: auto detray::annulus2D::check_boundaries(const bounds_t<scalar_t, kDIM>&, const point_t&, scalar_t) const [with bounds_t = std::array; scalar_t = double; long unsigned int kDIM = 7; point_t = std::array<double, 3>; typename std::enable_if<(kDIM == detray::annulus2D::e_size), bool>::type <anonymous> = true]: Assertion `!detail::any_of(minR_tol >= scalar_t(0.f))' failed.
```