### PR TITLE
Fixes for failing unit tests

### DIFF
--- a/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
@@ -196,8 +196,8 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
                const mask_t &mask, const transform3_type &trf,
                const scalar_type mask_tolerance, const scalar_type = 0.f,
                const scalar_type = 0.f) const {
-        return this->operator()(h, sf_desc, mask, trf, {mask_tolerance, 0.f},
-                                0.f);
+        return this->operator()(h, sf_desc, mask, trf,
+                                {mask_tolerance, mask_tolerance}, 0.f);
     }
 
     /// Tolerance for convergence

--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -181,8 +181,8 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
         const helix_type &h, const surface_descr_t &sf_desc, const mask_t &mask,
         const transform3_type &trf, const scalar_type mask_tolerance,
         const scalar_type = 0.f, const scalar_type = 0.f) const {
-        return this->operator()(h, sf_desc, mask, trf, {mask_tolerance, 0.f},
-                                0.f);
+        return this->operator()(h, sf_desc, mask, trf,
+                                {mask_tolerance, mask_tolerance}, 0.f);
     }
 
     /// Tolerance for convergence

--- a/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
@@ -135,8 +135,8 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
         const helix_type &h, const surface_descr_t &sf_desc, const mask_t &mask,
         const transform3_type &trf, const scalar_type mask_tolerance,
         const scalar_type = 0.f, const scalar_type = 0.f) const {
-        return this->operator()(h, sf_desc, mask, trf, {mask_tolerance, 0.f},
-                                0.f);
+        return this->operator()(h, sf_desc, mask, trf,
+                                {mask_tolerance, mask_tolerance}, 0.f);
     }
 
     /// Tolerance for convergence

--- a/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
@@ -177,10 +177,6 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, false> {
                     const scalar_type mask_tol_scalor,
                     const scalar_type overstep_tol) const {
 
-        assert((mask_tolerance[0] <= mask_tolerance[1]) &&
-               "Minimal mask tolerance needs to be smaller or equal maximal "
-               "mask tolerance");
-
         intersection_type<surface_descr_t> is;
 
         // Construct the candidate only when needed

--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -57,10 +57,6 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, false> {
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
-        assert((mask_tolerance[0] <= mask_tolerance[1]) &&
-               "Minimal mask tolerance needs to be smaller or equal maximal "
-               "mask tolerance");
-
         intersection_type<surface_descr_t> is;
 
         // line direction

--- a/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
@@ -61,10 +61,6 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
-        assert((mask_tolerance[0] <= mask_tolerance[1]) &&
-               "Minimal mask tolerance needs to be smaller or equal maximal "
-               "mask tolerance");
-
         intersection_type<surface_descr_t> is;
 
         // Retrieve the surface normal & translation (context resolved)

--- a/tests/unit_tests/svgtools/trajectories.cpp
+++ b/tests/unit_tests/svgtools/trajectories.cpp
@@ -88,7 +88,8 @@ GTEST_TEST(svgtools, trajectories) {
               0.f * detray::unit<detray::scalar>::T,
               1.f * detray::unit<detray::scalar>::T};
 
-    const detray::detail::helix<algebra_t> helix(ori, 0.f, dir, -8.f, &B);
+    const detray::detail::helix<algebra_t> helix(
+        ori, 0.f, detray::vector::normalize(dir), -8.f, &B);
     const auto helix_ir =
         detray::detector_scanner::run<detray::helix_scan>(gctx, det, helix);
 


### PR DESCRIPTION
`tests/unit_tests/svgtools/trajectories.cpp`.
Normalized the dir vector before passing it to the constructor of helix

`core/include/detray/navigation/intersection/helix_*_intersector.hpp`
Fixed the calling of intersectors with one tolerance value

`core/include/detray/navigation/intersection/ray_*_intersector.hpp`
Removed the "Minimal mask tolerance needs to be smaller or equal maximal mask tolerance" assertion