### PR TITLE
Fix C++20 bug in axis constructor

### DIFF
--- a/core/include/detray/utils/grid/detail/axis.hpp
+++ b/core/include/detray/utils/grid/detail/axis.hpp
@@ -31,9 +31,7 @@ namespace detray::axis {
 
 /// @brief Multi-bin: contains bin indices from multiple axes
 template <std::size_t DIM, typename index_t = dindex>
-struct multi_bin : public dmulti_index<index_t, DIM> {
-    constexpr multi_bin() = default;
-};
+struct multi_bin : public dmulti_index<index_t, DIM> {};
 
 /// @brief Helper to tie two bin indices to a range.
 /// @note Cannot use dindex_range for signed integer bin indices.


### PR DESCRIPTION
For reasons that I cannot fully explain, the default `multi_bin` constructor introduces a compiler error in C++20. This commit removes that constructor which seems to repair the situation.