### PR TITLE
ref: Count the number of missed surfaces in navigation validation

### DIFF
--- a/tests/include/detray/test/common/utils/detector_scanner.hpp
+++ b/tests/include/detray/test/common/utils/detector_scanner.hpp
@@ -171,36 +171,54 @@ inline auto run(const typename detector_t::geometry_context gctx,
 
 /// Write the @param intersection_traces to file
 template <typename detector_t>
-inline auto write(
+inline auto write_intersections(
     const std::string &intersection_file_name,
-    const std::string &track_param_file_name,
     const std::vector<std::vector<intersection_record<detector_t>>>
         &intersection_traces) {
 
     using record_t = intersection_record<detector_t>;
     using intersection_t = typename record_t::intersection_type;
-    using track_param_t = typename record_t::track_parameter_type;
 
     std::vector<std::vector<intersection_t>> intersections{};
-    std::vector<std::vector<track_param_t>> track_params{};
 
     // Split data
     for (const auto &trace : intersection_traces) {
 
         intersections.push_back({});
-        track_params.push_back({});
-
         intersections.back().reserve(trace.size());
-        track_params.back().reserve(trace.size());
 
         for (const auto &record : trace) {
             intersections.back().push_back(record.intersection);
-            track_params.back().push_back(record.track_param);
         }
     }
 
     // Write to file
     io::csv::write_intersection2D(intersection_file_name, intersections);
+}
+
+/// Write the @param intersection_traces to file
+template <typename detector_t>
+inline auto write_tracks(
+    const std::string &track_param_file_name,
+    const std::vector<std::vector<intersection_record<detector_t>>>
+        &intersection_traces) {
+
+    using record_t = intersection_record<detector_t>;
+    using track_param_t = typename record_t::track_parameter_type;
+
+    std::vector<std::vector<track_param_t>> track_params{};
+
+    // Split data
+    for (const auto &trace : intersection_traces) {
+        track_params.push_back({});
+        track_params.back().reserve(trace.size());
+
+        for (const auto &record : trace) {
+            track_params.back().push_back(record.track_param);
+        }
+    }
+
+    // Write to file
     io::csv::write_free_track_params(track_param_file_name, track_params);
 }
 

--- a/tests/include/detray/test/common/utils/svg_display.hpp
+++ b/tests/include/detray/test/common/utils/svg_display.hpp
@@ -156,7 +156,8 @@ inline void svg_display(const typename detector_t::geometry_context gctx,
         path / (outfile + "_" + vol_zr_svg._id + "_" + traj_name),
         {zr_axis, vol_zr_svg, svg_traj});
 
-    std::cout << "INFO: Wrote debugging data in: " << path << "\n" << std::endl;
+    std::cout << "INFO: Wrote svgs for debugging in: " << path << "\n"
+              << std::endl;
 }
 
 }  // namespace detray::detail

--- a/tests/include/detray/test/cpu/detector_scan.hpp
+++ b/tests/include/detray/test/cpu/detector_scan.hpp
@@ -195,9 +195,11 @@ class detector_scan : public test::fixture_base<> {
 
         // Csv output
         if (!data_files_exist && m_cfg.write_intersections()) {
-            detector_scanner::write(m_cfg.intersection_file(),
-                                    m_cfg.track_param_file(),
-                                    intersection_traces);
+            detector_scanner::write_tracks(m_cfg.track_param_file(),
+                                           intersection_traces);
+            detector_scanner::write_intersections(m_cfg.intersection_file(),
+                                                  intersection_traces);
+
             std::cout << "  ->Wrote  " << intersection_traces.size()
                       << " intersection traces to file" << std::endl;
         }

--- a/tests/validation/python/impl/__init__.py
+++ b/tests/validation/python/impl/__init__.py
@@ -1,4 +1,5 @@
 
-from .plot_material_scan import X0_vs_eta_phi, L0_vs_eta_phi, X0_vs_eta, L0_vs_eta, read_material_data
-from .plot_ray_scan import read_scan_data, plot_intersection_points_xy, plot_intersection_points_rz
-from .plot_track_positions import read_navigation_data, compare_track_pos_xy, compare_track_pos_rz, plot_track_pos_dist, plot_track_pos_res
+from .plot_navigation_validation import read_truth_data, read_navigation_data,plot_navigation_data
+from .plot_material_scan import read_material_data, X0_vs_eta_phi, L0_vs_eta_phi, X0_vs_eta, L0_vs_eta
+from .plot_ray_scan import read_ray_scan_data, plot_intersection_points_xy, plot_intersection_points_rz, plot_detector_scan_data
+from .plot_track_positions import read_track_data, compare_track_pos_xy, compare_track_pos_rz, plot_track_pos_dist, plot_track_pos_res

--- a/tests/validation/python/impl/plot_navigation_validation.py
+++ b/tests/validation/python/impl/plot_navigation_validation.py
@@ -4,15 +4,16 @@
 #
 # Mozilla Public License Version 2.0
 
-from .plot_ray_scan import intersection_points_xy, intersection_points_rz
+from .plot_ray_scan import read_ray_scan_data, plot_intersection_points_xy, plot_intersection_points_rz
+from .plot_track_positions import read_track_data, compare_track_pos_xy, compare_track_pos_rz, plot_track_pos_dist, plot_track_pos_res
 
 # python includes
 import pandas as pd
 import os
 
 
-""" Read the navigation data from files and prepare data frames """
-def read_navigation_data(inputdir, logging):
+""" Read the detector scan data from files and prepare data frames """
+def read_truth_data(inputdir, logging):
 
     # Input data directory
     data_dir = os.fsencode(inputdir)
@@ -26,49 +27,90 @@ def read_navigation_data(inputdir, logging):
         filename = os.fsdecode(file)
 
         if filename.find('_ray_scan_intersections') != -1:
-            detector_name = ray_scan_intersections_file.removesuffix('_ray_scan_intersections.csv')
             ray_scan_intersections_file = inputdir + "/" + filename
+            file_name = os.path.basename(ray_scan_intersections_file)
+            detector_name, sep, suffix = file_name.partition('_ray_scan_intersections')
         elif filename.find('_ray_scan_track_parameters') != -1:
             ray_scan_track_param_file = inputdir + "/" + filename
         elif filename.find('_helix_scan_intersections') != -1:
-            detector_name = helix_scan_intersections_file.removesuffix('_helix_scan_intersections.csv')
             helix_scan_intersections_file = inputdir + "/" + filename
+            file_name = os.path.basename(helix_scan_intersections_file)
+            detector_name, sep, suffix = file_name.partition('_helix_scan_intersections')
         elif filename.find('_helix_scan_track_parameters') != -1:
             helix_scan_track_param_file = inputdir + "/" + filename
 
     detector_name = detector_name.replace('_', ' ')
 
     # Read ray scan data
-    if ray_scan_intersections_file:
-        ray_inters_df = pd.read_csv(ray_scan_intersections_file)
-        ray_trk_param_df = pd.read_csv(ray_scan_track_param_file)
-        ray_scan_df = pd.concat([ray_inters_df, ray_trk_param_df], axis=1)
-
-        logging.debug(ray_scan_df)
-    else:
-        logging.warning("Could not find ray scan data: " + ray_scan_intersections_file)
-        ray_scan_df = pd.DataFrame({})
+    ray_scan_df = read_ray_scan_data(ray_scan_intersections_file,
+                                     ray_scan_track_param_file, logging)
 
     # Read helix scan data
-    if helix_scan_intersections_file:
-        helix_inters_df = pd.read_csv(helix_scan_intersections_file)
-        helix_trk_param_df = pd.read_csv(helix_scan_track_param_file)
-        helix_scan_df = pd.concat([helix_inters_df, helix_trk_param_df], axis=1)
-
-        logging.debug(helix_scan_df)
-    else:
-        logging.warning("Could not find helix scan data" + helix_scan_intersections_file)
-        helix_scan_df = pd.DataFrame({})
+    helix_scan_df = read_ray_scan_data(helix_scan_intersections_file,
+                                       helix_scan_track_param_file, logging)
 
     return detector_name, ray_scan_df, helix_scan_df
 
 
+""" Read the recorded track positions from files and prepare data frames """
+def read_navigation_data(inputdir, read_cuda, logging):
+
+    # Input data directory
+    data_dir = os.fsencode(inputdir)
+
+    ray_truth_file = ray_data_file = ray_data_cuda_file = ""
+    helix_truth_file = helix_data_file = helix_data_cuda_file = ""
+
+    # Find the data files by naming convention
+    for file in os.listdir(data_dir):
+        filename = os.fsdecode(file)
+
+        if read_cuda and filename.find('ray_navigation_track_params_cuda') != -1:
+            ray_data_cuda_file = inputdir + "/" + filename
+        elif filename.find('ray_navigation_track_params') != -1:
+            ray_data_file = inputdir + "/" + filename
+        elif filename.find('ray_truth_track_params') != -1:
+            ray_truth_file = inputdir + "/" + filename
+        elif read_cuda and filename.find('helix_navigation_track_params_cuda') != -1:
+            helix_data_cuda_file = inputdir + "/" + filename
+        elif filename.find('helix_navigation_track_params') != -1:
+            helix_data_file = inputdir + "/" + filename
+        elif filename.find('helix_truth_track_params') != -1:
+            helix_truth_file = inputdir + "/" + filename
+
+    ray_df = read_track_data(ray_data_file, logging)
+    ray_truth_df = read_track_data(ray_truth_file, logging)
+    helix_df = read_track_data(helix_data_file, logging)
+    helix_truth_df = read_track_data(helix_truth_file, logging)
+
+    ray_cuda_df = helix_cuda_df = pd.DataFrame({})
+    if read_cuda:
+        ray_cuda_df = read_track_data(ray_data_cuda_file, logging)
+        helix_cuda_df = read_track_data(helix_data_cuda_file, logging)
+
+    return ray_df, ray_truth_df, ray_cuda_df, helix_df, helix_truth_df, helix_cuda_df
+
 
 """ Plot the data gathered during the navigaiton validation """
-def plot_navigation_data(args, detector_name, plot_factory, df_truth, data_name, out_format = "png"):
+def plot_navigation_data(args, det_name, plot_factory, data_type, df_truth, truth_name, df_ref, ref_name, out_format = "png"):
 
-    # Plot truth scan
-    intersection_points_xy(args, df_truth, detector_name,
-                                        data_name, plot_factory, out_format)
-    intersection_points_rz(args, df_truth, detector_name,
-                                        data_name, plot_factory, out_format)
+    # xy
+    compare_track_pos_xy(args, det_name, data_type, plot_factory, out_format,
+                         df_truth, truth_name, 'r',
+                         df_ref, ref_name, 'darkgrey')
+    # rz
+    compare_track_pos_rz(args, det_name, data_type, plot_factory, out_format,
+                         df_truth, truth_name, 'r',
+                         df_ref, ref_name, 'darkgrey')
+
+    # Absolut distance
+    plot_track_pos_dist(args, det_name, data_type, plot_factory, out_format,
+                        df_truth, truth_name, df_ref, ref_name)
+
+    # Residuals
+    plot_track_pos_res(args, det_name, data_type, plot_factory, out_format,
+                       df_truth, truth_name, df_ref, ref_name, 'x')
+    plot_track_pos_res(args, det_name, data_type, plot_factory, out_format,
+                       df_truth, truth_name, df_ref, ref_name, 'y')
+    plot_track_pos_res(args, det_name, data_type, plot_factory, out_format,
+                       df_truth, truth_name, df_ref, ref_name, 'z')

--- a/tests/validation/python/impl/plot_ray_scan.py
+++ b/tests/validation/python/impl/plot_ray_scan.py
@@ -12,60 +12,22 @@ import numpy as np
 import pandas as pd
 import os
 
+
 """ Read the detector scan data from files and prepare data frames """
-def read_scan_data(inputdir, logging):
-
-    # Input data directory
-    data_dir = os.fsencode(inputdir)
-
-    detector_name = "default_detector"
-    ray_scan_intersections_file = ray_scan_track_param_file = ""
-    helix_scan_intersections_file = helix_scan_track_param_file = ""
-
-    # Find the data files by naming convention
-    for file in os.listdir(data_dir):
-        filename = os.fsdecode(file)
-
-        if filename.find('_ray_scan_intersections') != -1:
-            ray_scan_intersections_file = inputdir + "/" + filename
-            file_name = os.path.basename(ray_scan_intersections_file)
-            detector_name = file_name.removesuffix('_ray_scan_intersections.csv')
-        elif filename.find('_ray_scan_track_parameters') != -1:
-            ray_scan_track_param_file = inputdir + "/" + filename
-        elif filename.find('_helix_scan_intersections') != -1:
-            helix_scan_intersections_file = inputdir + "/" + filename
-            file_name = os.path.basename(helix_scan_intersections_file)
-            detector_name = file_name.removesuffix('_helix_scan_intersections.csv')
-        elif filename.find('_helix_scan_track_parameters') != -1:
-            helix_scan_track_param_file = inputdir + "/" + filename
-
-    detector_name = detector_name.replace('_', ' ')
-
-    # Read scan data
-    def read_data(intersection_file, track_param_file):
-        if intersection_file:
-            inters_df = pd.read_csv(intersection_file,
+def read_ray_scan_data(intersection_file, track_param_file, logging):
+    if intersection_file:
+        inters_df = pd.read_csv(intersection_file,
+                                float_precision='round_trip')
+        trk_param_df = pd.read_csv(track_param_file,
                                     float_precision='round_trip')
-            trk_param_df = pd.read_csv(track_param_file,
-                                       float_precision='round_trip')
-            scan_df = pd.concat([inters_df, trk_param_df], axis=1)
+        scan_df = pd.concat([inters_df, trk_param_df], axis=1)
 
-            logging.debug(scan_df)
-        else:
-            logging.warning("Could not find scan data: " + intersection_file)
-            scan_df = pd.DataFrame({})
+        logging.debug(scan_df)
+    else:
+        logging.warning("Could not find ray scan data: " + intersection_file)
+        scan_df = pd.DataFrame({})
 
-        return scan_df
-
-    # Read ray scan data
-    ray_scan_df = read_data(ray_scan_intersections_file,
-                            ray_scan_track_param_file)
-
-    # Read helix scan data
-    helix_scan_df = read_data(helix_scan_intersections_file,
-                            helix_scan_track_param_file)
-
-    return detector_name, ray_scan_df, helix_scan_df
+    return scan_df
 
 
 """ Plot the intersection points of the detector with the rays - xy view """
@@ -203,3 +165,13 @@ def plot_intersection_points_rz(opts, df, detector, scan_type, plotFactory,  out
 
     detector_name = detector.replace(' ', '_')
     plotFactory.write_plot(hist_data, f"{detector_name}_{scan_type}_scan_rz",  out_format)
+
+
+""" Plot the data gathered during the navigaiton validation """
+def plot_detector_scan_data(args, det_name, plot_factory, data_type, df, name, out_format = "png"):
+
+    # Plot truth scan
+    plot_intersection_points_xy(args, df, det_name,
+                                name, plot_factory, out_format)
+    plot_intersection_points_rz(args, df, det_name,
+                                name, plot_factory, out_format)


### PR DESCRIPTION
Instead of returning as soon as a difference in the intersection traces between truth and navigation is found, the validation now counts all differences, in case there were multiple surfaces missed. For every missed surface, a dummy record is inserted, so that the resulting track states that are written out have the same number of elements, allowing to plot residuals easily, where the missed surfaces appear as outlier values. The python scripts have been adapted to plot truth vs. navigation track position residuals, including optional outlier cuts. The reporting of errors and statistics of missed surfaces has been improved and the option to do a Gaussian fit has been added to the plotting of the residuals.

The *surface finding efficiency* is quoted as result now, which is defined as the number of surfaces discovered by the navigator vs the total number of surfaces found by the Newton algorithm.