### PR TITLE
feat: check distance to surface edge in navigation validation

### DIFF
--- a/core/include/detray/builders/detail/portal_accessor.hpp
+++ b/core/include/detray/builders/detail/portal_accessor.hpp
@@ -42,8 +42,8 @@ auto get_cylinder_portals(const detector_volume<detector_t> &vol) {
 
         if (name == "cylinder2D" || name == "concentric_cylinder2D") {
             radii[pt_desc] = pt.boundary(cylinder2D::e_r);
-            z_pos[pt_desc] = pt.boundary(cylinder2D::e_n_half_z);
-            z_pos[pt_desc] = pt.boundary(cylinder2D::e_p_half_z);
+            z_pos[pt_desc] = pt.boundary(cylinder2D::e_lower_z);
+            z_pos[pt_desc] = pt.boundary(cylinder2D::e_upper_z);
         } else {
             radii[pt_desc] = pt.boundary(ring2D::e_inner_r);
             radii[pt_desc] = pt.boundary(ring2D::e_outer_r);

--- a/core/include/detray/builders/grid_factory.hpp
+++ b/core/include/detray/builders/grid_factory.hpp
@@ -184,7 +184,7 @@ class grid_factory {
 
         return new_grid<local_frame>(
             {-constant<scalar_type>::pi, constant<scalar_type>::pi,
-             b_values[boundary::e_n_half_z], b_values[boundary::e_p_half_z]},
+             b_values[boundary::e_lower_z], b_values[boundary::e_upper_z]},
             {n_bins[e_rphi_axis], n_bins[e_z_axis]}, bin_capacities,
             {bin_edges[e_rphi_axis], bin_edges[e_z_axis]},
             types::list<rphi_bounds, z_bounds>{},
@@ -226,7 +226,7 @@ class grid_factory {
 
         return new_grid<local_frame>(
             {-constant<scalar_type>::pi, constant<scalar_type>::pi,
-             b_values[boundary::e_n_half_z], b_values[boundary::e_p_half_z]},
+             b_values[boundary::e_lower_z], b_values[boundary::e_upper_z]},
             {n_bins[e_rphi_axis], n_bins[e_z_axis]}, bin_capacities,
             {bin_edges[e_rphi_axis], bin_edges[e_z_axis]},
             types::list<rphi_bounds, z_bounds>{},

--- a/core/include/detray/builders/material_map_generator.hpp
+++ b/core/include/detray/builders/material_map_generator.hpp
@@ -38,8 +38,8 @@ inline std::vector<material_slab<scalar_t>> generate_cyl_mat(
     ts.reserve(nbins);
 
     // Make sure the cylinder bounds are centered around zero
-    const scalar_t length{math::fabs(bounds[cylinder2D::e_p_half_z] -
-                                     bounds[cylinder2D::e_n_half_z])};
+    const scalar_t length{math::fabs(bounds[cylinder2D::e_upper_z] -
+                                     bounds[cylinder2D::e_lower_z])};
     scalar_t z{-0.5f * length};
     const scalar_t z_step{length / static_cast<scalar_t>(nbins - 1u)};
     for (std::size_t n = 0u; n < nbins; ++n) {

--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -45,6 +45,18 @@ struct surface_kernels {
         }
     };
 
+    /// A functor that checks if a local point @param loc_p is within the
+    /// surface mask with tolerance @param tol
+    struct is_inside {
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline bool operator()(
+            const mask_group_t& mask_group, const index_t& index,
+            const point3_type& loc_p, const scalar_type tol) const {
+
+            return mask_group[index].is_inside(loc_p, tol);
+        }
+    };
+
     /// A functor to run the mask self check. Puts error messages into @param os
     struct mask_self_check {
         template <typename mask_group_t, typename index_t>
@@ -277,6 +289,18 @@ struct surface_kernels {
                 std::numeric_limits<scalar_t>::epsilon()) const {
 
             return mask_group[index].local_min_bounds(env);
+        }
+    };
+
+    /// A functor to get the minimum distance to any surface boundary.
+    struct min_dist_to_boundary {
+
+        template <typename mask_group_t, typename index_t, typename point_t>
+        DETRAY_HOST_DEVICE inline auto operator()(
+            const mask_group_t& mask_group, const index_t& index,
+            const point_t& loc_p) const {
+
+            return mask_group[index].min_dist_to_boundary(loc_p);
         }
     };
 

--- a/core/include/detray/geometry/shapes/annulus2D.hpp
+++ b/core/include/detray/geometry/shapes/annulus2D.hpp
@@ -25,7 +25,7 @@
 
 namespace detray {
 
-/// @brief Geometrical shape of a stereo annulus that is used for the itk
+/// @brief Geometrical shape of a stereo annulus that is used for the ITk
 /// strip endcaps.
 ///
 /// The stereo annulus is defined in two different(!) polar coordinate systems
@@ -60,6 +60,10 @@ class annulus2D {
         e_size = 7u,
     };
 
+    /// Container definition for the shape boundary values
+    template <typename scalar_t>
+    using bounds_type = darray<scalar_t, boundaries::e_size>;
+
     /// Local coordinate frame ( focal system )
     template <typename algebra_t>
     using local_frame_type = polar2D<algebra_t>;
@@ -68,54 +72,99 @@ class annulus2D {
     static constexpr std::size_t dim{2u};
 
     /// @returns the stereo angle calculated from the mask @param bounds .
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE darray<scalar_t, 8> stereo_angle(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         // Half stereo angle (phi_s / 2) (y points in the long strip direction)
         return 2.f * math::atan(bounds[e_shift_y] / bounds[e_shift_x]);
     }
 
-    /// @brief Check boundary values for a local point.
-    ///
-    /// @note the point is expected to be given in local coordinates by the
-    /// caller. For the annulus shape, the local coordinate system of the
-    /// strips is used.
-    ///
-    /// @param bounds the boundary values for this shape
-    /// @param loc_p the point to be checked in the local coordinate system
-    /// @param tol dynamic tolerance determined by caller
-    ///
-    /// @return true if the local point lies within the given boundaries.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM, typename point_t,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline auto check_boundaries(
-        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
-        const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
-
-        // The two quantities to check: r^2 in beam system, phi in focal system:
-
+    /// @returns The phi position in relative to the average phi of the annulus.
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline scalar_t get_phi_rel(
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p) const {
         // Rotate by avr phi in the focal system (this is usually zero)
-        const scalar_t phi_strp = loc_p[1] - bounds[e_average_phi];
+        return loc_p[1] - bounds[e_average_phi];
+    }
 
-        // Check phi boundaries, which are well def. in focal frame
-        const scalar_t phi_tol = detail::phi_tolerance(tol, loc_p[0]);
-        const auto phi_check =
-            !((phi_strp < (bounds[e_min_phi_rel] - phi_tol)) or
-              (phi_strp > (bounds[e_max_phi_rel] + phi_tol)));
+    /// @returns The squared radial position in the beam frame.
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline scalar_t get_r2_beam_frame(
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p) const {
 
-        // Now go to beam frame to check r boundaries. Use the origin
+        // Go to beam frame to check r boundaries. Use the origin
         // shift in polar coordinates for that
         // TODO: Put shift in r-phi into the bounds?
         const point_t shift_xy = {-bounds[e_shift_x], -bounds[e_shift_y], 0.f};
         const scalar_t shift_r = getter::perp(shift_xy);
         const scalar_t shift_phi = getter::phi(shift_xy);
 
-        const scalar_t r_mod2 =
-            shift_r * shift_r + loc_p[0] * loc_p[0] +
-            2.f * shift_r * loc_p[0] * math::cos(phi_strp - shift_phi);
+        return shift_r * shift_r + loc_p[0] * loc_p[0] +
+               2.f * shift_r * loc_p[0] *
+                   math::cos(get_phi_rel(bounds, loc_p) - shift_phi);
+    }
+
+    /// @brief Find the minimum distance to any boundary.
+    ///
+    /// @note the point is expected to be given in local coordinates by the
+    /// caller. For the annulus shape, the local coordinate system of the
+    /// strips is used (focal system).
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param loc_p the point to be checked in the local coordinate system
+    ///
+    /// @return the minimum distance.
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline scalar_t min_dist_to_boundary(
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p) const {
+        // The two quantities to check: r^2 in beam system, phi in focal system:
+
+        // Rotate by avr phi in the focal system (this is usually zero)
+        const scalar_t phi_rel_focal = get_phi_rel(bounds, loc_p);
+
+        // Check phi boundaries, which are well def. in focal frame
+        const scalar_t min_phi_dist =
+            math::min(math::fabs(phi_rel_focal - bounds[e_min_phi_rel]),
+                      math::fabs(bounds[e_max_phi_rel] - phi_rel_focal));
+
+        const auto r_beam = math::sqrt(get_r2_beam_frame(bounds, loc_p));
+
+        const scalar_t min_r_dist =
+            math::min(math::fabs(r_beam - bounds[e_min_r]),
+                      math::fabs(bounds[e_max_r] - r_beam));
+
+        // Compare the radius with the chord
+        return math::min(min_r_dist,
+                         2.f * loc_p[0] * math::sin(0.5f * min_phi_dist));
+    }
+
+    /// @brief Check boundary values for a local point.
+    ///
+    /// @note the point is expected to be given in local coordinates by the
+    /// caller. For the annulus shape, the local coordinate system of the
+    /// strips is used (focal system).
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param loc_p the point to be checked in the local coordinate system
+    /// @param tol dynamic tolerance determined by caller
+    ///
+    /// @return true if the local point lies within the given boundaries.
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p,
+        const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
+        // The two quantities to check: r^2 in beam system, phi in focal system:
+
+        // Rotate by avr phi in the focal system (this is usually zero)
+        const scalar_t phi_focal = get_phi_rel(bounds, loc_p);
+
+        // Check phi boundaries, which are well def. in focal frame
+        const scalar_t phi_tol = detail::phi_tolerance(tol, loc_p[0]);
+        const auto phi_check =
+            !((phi_focal < (bounds[e_min_phi_rel] - phi_tol)) or
+              (phi_focal > (bounds[e_max_phi_rel] + phi_tol)));
+
+        const auto r_beam2 = get_r2_beam_frame(bounds, loc_p);
 
         // Apply tolerances as squares: 0 <= a, 0 <= b: a^2 <= b^2 <=> a <= b
         const scalar_t minR_tol = bounds[e_min_r] - tol;
@@ -123,8 +172,8 @@ class annulus2D {
 
         assert(detail::all_of(minR_tol >= scalar_t(0.f)));
 
-        return ((r_mod2 >= (minR_tol * minR_tol)) &&
-                (r_mod2 <= (maxR_tol * maxR_tol))) &&
+        return ((r_beam2 >= (minR_tol * minR_tol)) &&
+                (r_beam2 <= (maxR_tol * maxR_tol))) &&
                phi_check;
     }
 
@@ -135,11 +184,9 @@ class annulus2D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the stereo annulus area on the plane.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t measure(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return area(bounds);
     }
 
@@ -150,11 +197,9 @@ class annulus2D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the stereo annulus area.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t area(
-        const bounds_t<scalar_t, kDIM> &) const {
+        const bounds_type<scalar_t> &) const {
         return detail::invalid_value<scalar_t>();
     }
 
@@ -168,14 +213,13 @@ class annulus2D {
     /// @returns and array of coordinates that contains the lower point (first
     /// three values) and the upper point (latter three values).
     // @TODO: this is a terrible approximation: restrict to annulus corners
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE darray<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM> &bounds,
-        const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
+    template <typename algebra_t>
+    DETRAY_HOST_DEVICE darray<dscalar<algebra_t>, 6> local_min_bounds(
+        const bounds_type<dscalar<algebra_t>> &bounds,
+        const dscalar<algebra_t> env =
+            std::numeric_limits<dscalar<algebra_t>>::epsilon()) const {
 
+        using scalar_t = dscalar<algebra_t>;
         using point_t = dpoint2D<algebra_t>;
 
         assert(env > 0.f);
@@ -224,11 +268,9 @@ class annulus2D {
     ///
     /// @returns an array of coordinates that contains the lower point (first
     /// four values) and the upper point (latter four values).
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE darray<scalar_t, 8> corners(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
 
         // Calculate the r-coordinate of a point in the strip system from the
         // circle arc radius (e.g. min_r) and the phi position in the strip
@@ -271,12 +313,11 @@ class annulus2D {
     /// @returns the shapes centroid in local cartesian coordinates
     /// @note the caluculated centroid position is only an approximation
     /// (centroid of the four corner points)!
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename algebra_t>
     DETRAY_HOST_DEVICE dpoint3D<algebra_t> centroid(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<dscalar<algebra_t>> &bounds) const {
+
+        using scalar_t = dscalar<algebra_t>;
 
         // Strip polar system
         const auto crns = corners(bounds);
@@ -294,12 +335,13 @@ class annulus2D {
     /// @param n_seg is the number of line segments
     ///
     /// @return a generated list of vertices
-    template <typename point2_t, typename point3_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST dvector<point3_t> vertices(
-        const bounds_t<scalar_t, kDIM> &bounds, dindex n_seg) const {
+    template <typename algebra_t>
+    DETRAY_HOST dvector<dpoint3D<algebra_t>> vertices(
+        const bounds_type<dscalar<algebra_t>> &bounds, dindex n_seg) const {
+
+        using scalar_t = dscalar<algebra_t>;
+        using point2_t = dpoint2D<algebra_t>;
+        using point3_t = dpoint3D<algebra_t>;
 
         scalar_t min_r = bounds[e_min_r];
         scalar_t max_r = bounds[e_max_r];
@@ -382,11 +424,9 @@ class annulus2D {
     /// @param os output stream for error messages
     ///
     /// @return true if the bounds are consistent.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST constexpr bool check_consistency(
-        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+        const bounds_type<scalar_t> &bounds, std::ostream &os) const {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 

--- a/core/include/detray/geometry/shapes/concentric_cylinder2D.hpp
+++ b/core/include/detray/geometry/shapes/concentric_cylinder2D.hpp
@@ -32,10 +32,14 @@ class concentric_cylinder2D {
 
     enum boundaries : unsigned int {
         e_r = 0u,
-        e_n_half_z = 1u,
-        e_p_half_z = 2u,
+        e_lower_z = 1u,
+        e_upper_z = 2u,
         e_size = 3u,
     };
+
+    /// Container definition for the shape boundary values
+    template <typename scalar_t>
+    using bounds_type = darray<scalar_t, boundaries::e_size>;
 
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
@@ -43,6 +47,23 @@ class concentric_cylinder2D {
 
     /// Dimension of the local coordinate system
     static constexpr std::size_t dim{2u};
+
+    /// @brief Find the minimum distance to any boundary.
+    ///
+    /// @note the point is expected to be given in local coordinates by the
+    /// caller.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param loc_p the point to be checked in the local coordinate system
+    ///
+    /// @return the minimum distance.
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline scalar_t min_dist_to_boundary(
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p) const {
+
+        return math::min(math::fabs(loc_p[1] - bounds[e_lower_z]),
+                         math::fabs(bounds[e_upper_z] - loc_p[1]));
+    }
 
     /// @brief Check boundary values for a local point.
     ///
@@ -59,15 +80,13 @@ class concentric_cylinder2D {
     /// @param tol dynamic tolerance determined by caller
     ///
     /// @return true if the local point lies within the given boundaries.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM, typename point_t,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t, typename point_t>
     DETRAY_HOST_DEVICE inline auto check_boundaries(
-        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
-        return (bounds[e_n_half_z] - tol <= loc_p[1] and
-                loc_p[1] <= bounds[e_p_half_z] + tol);
+        return (bounds[e_lower_z] - tol <= loc_p[1] and
+                loc_p[1] <= bounds[e_upper_z] + tol);
     }
 
     /// @brief Measure of the shape: Area
@@ -75,11 +94,9 @@ class concentric_cylinder2D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the cylinder area on the cylinder of radius r.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t measure(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return area(bounds);
     }
 
@@ -88,13 +105,11 @@ class concentric_cylinder2D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the cylinder area.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t area(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return 2.f * constant<scalar_t>::pi * bounds[e_r] *
-               (bounds[e_p_half_z] - bounds[e_n_half_z]);
+               (bounds[e_upper_z] - bounds[e_lower_z]);
     }
 
     /// @brief Lower and upper point for minimal axis aligned bounding box.
@@ -106,28 +121,24 @@ class concentric_cylinder2D {
     ///
     /// @returns an array of coordinates that contains the lower point (first
     /// three values) and the upper point (latter three values) .
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM> &bounds,
-        const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
+    template <typename algebra_t>
+    DETRAY_HOST_DEVICE inline darray<dscalar<algebra_t>, 6> local_min_bounds(
+        const bounds_type<dscalar<algebra_t>> &bounds,
+        const dscalar<algebra_t> env =
+            std::numeric_limits<dscalar<algebra_t>>::epsilon()) const {
+
         assert(env > 0.f);
-        const scalar_t xy_bound{bounds[e_r] + env};
-        return {-xy_bound, -xy_bound, bounds[e_n_half_z] - env,
-                xy_bound,  xy_bound,  bounds[e_p_half_z] + env};
+        const dscalar<algebra_t> xy_bound{bounds[e_r] + env};
+        return {-xy_bound, -xy_bound, bounds[e_lower_z] - env,
+                xy_bound,  xy_bound,  bounds[e_upper_z] + env};
     }
 
     /// @returns the shapes centroid in local cartesian coordinates
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename algebra_t>
     DETRAY_HOST_DEVICE dpoint3D<algebra_t> centroid(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<dscalar<algebra_t>> &bounds) const {
 
-        return {0.f, 0.f, 0.5f * (bounds[e_n_half_z] + bounds[e_p_half_z])};
+        return {0.f, 0.f, 0.5f * (bounds[e_lower_z] + bounds[e_upper_z])};
     }
 
     /// Generate vertices in local cartesian frame
@@ -136,12 +147,9 @@ class concentric_cylinder2D {
     /// @param n_seg is the number of line segments
     ///
     /// @return a generated list of vertices
-    template <typename point2_t, typename point3_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST dvector<point3_t> vertices(const bounds_t<scalar_t, kDIM> &,
-                                           dindex) const {
+    template <typename algebra_t>
+    DETRAY_HOST dvector<dpoint3D<algebra_t>> vertices(
+        const bounds_type<dscalar<algebra_t>> &, dindex) const {
         throw std::runtime_error(
             "Vertex generation for cylinders is not implemented");
         return {};
@@ -153,11 +161,9 @@ class concentric_cylinder2D {
     /// @param os output stream for error messages
     ///
     /// @return true if the bounds are consistent.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST constexpr bool check_consistency(
-        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+        const bounds_type<scalar_t> &bounds, std::ostream &os) const {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 
@@ -166,8 +172,8 @@ class concentric_cylinder2D {
                << std::endl;
             return false;
         }
-        if (bounds[e_n_half_z] >= bounds[e_p_half_z] or
-            math::fabs(bounds[e_n_half_z] - bounds[e_p_half_z]) < tol) {
+        if (bounds[e_lower_z] >= bounds[e_upper_z] or
+            math::fabs(bounds[e_lower_z] - bounds[e_upper_z]) < tol) {
             os << "ERROR: Neg. half length must be smaller than pos. half "
                   "length.";
             return false;

--- a/core/include/detray/geometry/shapes/cuboid3D.hpp
+++ b/core/include/detray/geometry/shapes/cuboid3D.hpp
@@ -40,12 +40,43 @@ class cuboid3D {
         e_size = 6u,
     };
 
+    /// Container definition for the shape boundary values
+    template <typename scalar_t>
+    using bounds_type = darray<scalar_t, boundaries::e_size>;
+
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = cartesian3D<algebra_t>;
 
     /// Dimension of the local coordinate system
     static constexpr std::size_t dim{3u};
+
+    /// @brief Find the minimum distance to any boundary.
+    ///
+    /// @note the point is expected to be given in local coordinates by the
+    /// caller.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param loc_p the point to be checked in the local coordinate system
+    ///
+    /// @return the minimum distance.
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline scalar_t min_dist_to_boundary(
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p) const {
+
+        const scalar_t min_x_dist =
+            math::min(math::fabs(loc_p[0] - bounds[e_min_x]),
+                      math::fabs(bounds[e_max_x] - loc_p[0]));
+        const scalar_t min_y_dist =
+            math::min(math::fabs(loc_p[1] - bounds[e_min_y]),
+                      math::fabs(bounds[e_max_y] - loc_p[1]));
+        const scalar_t min_z_dist =
+            math::min(math::fabs(loc_p[2] - bounds[e_min_z]),
+                      math::fabs(bounds[e_max_z] - loc_p[2]));
+
+        // Use the chord for the phi distance
+        return math::min(math::min(min_x_dist, min_y_dist), min_z_dist);
+    }
 
     /// @brief Check boundary values for a local point.
     ///
@@ -59,11 +90,9 @@ class cuboid3D {
     /// @param tol dynamic tolerance determined by caller
     ///
     /// @return true if the local point lies within the given boundaries.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM, typename point_t,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t, typename point_t>
     DETRAY_HOST_DEVICE inline auto check_boundaries(
-        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         return ((bounds[e_min_x] - tol) <= loc_p[0] &&
                 (bounds[e_min_y] - tol) <= loc_p[1] &&
@@ -78,11 +107,9 @@ class cuboid3D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the cuboid volume as part of global space.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t measure(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return volume(bounds);
     }
 
@@ -91,11 +118,9 @@ class cuboid3D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the cuboid volume.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t volume(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return (bounds[e_max_x] - bounds[e_min_x]) *
                (bounds[e_max_y] - bounds[e_min_y]) *
                (bounds[e_max_z] - bounds[e_min_z]);
@@ -110,15 +135,14 @@ class cuboid3D {
     ///
     /// @returns and array of coordinates that contains the lower point (first
     /// three values) and the upper point (latter three values) .
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM> &bounds,
-        const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
+    template <typename algebra_t>
+    DETRAY_HOST_DEVICE inline darray<dscalar<algebra_t>, 6> local_min_bounds(
+        const bounds_type<dscalar<algebra_t>> &bounds,
+        const dscalar<algebra_t> env =
+            std::numeric_limits<dscalar<algebra_t>>::epsilon()) const {
+
         assert(env > 0.f);
-        bounds_t<scalar_t, kDIM> o_bounds{bounds};
+        bounds_type<dscalar<algebra_t>> o_bounds{bounds};
         for (unsigned int i{0}; i < 3u; ++i) {
             o_bounds[i] -= env;
             o_bounds[i + 3u] += env;
@@ -127,12 +151,9 @@ class cuboid3D {
     }
 
     /// @returns the shapes centroid in local cartesian coordinates
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename algebra_t>
     DETRAY_HOST_DEVICE dpoint3D<algebra_t> centroid(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<dscalar<algebra_t>> &bounds) const {
 
         return 0.5f * dpoint3D<algebra_t>{bounds[e_min_x] + bounds[e_max_x],
                                           bounds[e_min_y] + bounds[e_max_y],
@@ -145,12 +166,9 @@ class cuboid3D {
     /// @param n_seg is the number of line segments
     ///
     /// @return a generated list of vertices
-    template <typename point2_t, typename point3_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST dvector<point3_t> vertices(const bounds_t<scalar_t, kDIM> &,
-                                           dindex) const {
+    template <typename algebra_t>
+    DETRAY_HOST dvector<dpoint3D<algebra_t>> vertices(
+        const bounds_type<dscalar<algebra_t>> &, dindex) const {
         throw std::runtime_error(
             "Vertex generation for cuboids is not implemented");
         return {};
@@ -162,11 +180,9 @@ class cuboid3D {
     /// @param os output stream for error messages
     ///
     /// @return true if the bounds are consistent.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST constexpr bool check_consistency(
-        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+        const bounds_type<scalar_t> &bounds, std::ostream &os) const {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 

--- a/core/include/detray/geometry/shapes/rectangle2D.hpp
+++ b/core/include/detray/geometry/shapes/rectangle2D.hpp
@@ -34,12 +34,33 @@ class rectangle2D {
         e_size = 2u,
     };
 
+    /// Container definition for the shape boundary values
+    template <typename scalar_t>
+    using bounds_type = darray<scalar_t, boundaries::e_size>;
+
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = cartesian2D<algebra_t>;
 
     /// Dimension of the local coordinate system
     static constexpr std::size_t dim{2u};
+
+    /// @brief Find the minimum distance to any boundary.
+    ///
+    /// @note the point is expected to be given in local coordinates by the
+    /// caller.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param loc_p the point to be checked in the local coordinate system
+    ///
+    /// @return the minimum distance.
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline scalar_t min_dist_to_boundary(
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p) const {
+
+        return math::min(math::fabs(math::fabs(loc_p[0]) - bounds[e_half_x]),
+                         math::fabs(math::fabs(loc_p[1]) - bounds[e_half_y]));
+    }
 
     /// @brief Check boundary values for a local point.
     ///
@@ -52,11 +73,9 @@ class rectangle2D {
     /// @param tol dynamic tolerance determined by caller
     ///
     /// @return true if the local point lies within the given boundaries.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM, typename point_t,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t, typename point_t>
     DETRAY_HOST_DEVICE inline auto check_boundaries(
-        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         return (math::fabs(loc_p[0]) <= (bounds[e_half_x] + tol) &&
                 math::fabs(loc_p[1]) <= (bounds[e_half_y] + tol));
@@ -67,11 +86,9 @@ class rectangle2D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the rectangle area on the plane
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t measure(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return area(bounds);
     }
 
@@ -80,11 +97,9 @@ class rectangle2D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the rectangle area.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t area(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return 4.f * bounds[e_half_x] * bounds[e_half_y];
     }
 
@@ -97,13 +112,13 @@ class rectangle2D {
     ///
     /// @returns an array of coordinates that contains the lower point (first
     /// three values) and the upper point (latter three values) .
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM> &bounds,
-        const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
+    template <typename algebra_t>
+    DETRAY_HOST_DEVICE inline darray<dscalar<algebra_t>, 6> local_min_bounds(
+        const bounds_type<dscalar<algebra_t>> &bounds,
+        const dscalar<algebra_t> env =
+            std::numeric_limits<dscalar<algebra_t>>::epsilon()) const {
+        using scalar_t = dscalar<algebra_t>;
+
         assert(env > 0.f);
         const scalar_t x_bound{bounds[e_half_x] + env};
         const scalar_t y_bound{bounds[e_half_y] + env};
@@ -111,12 +126,9 @@ class rectangle2D {
     }
 
     /// @returns the shapes centroid in local cartesian coordinates
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename algebra_t>
     DETRAY_HOST_DEVICE dpoint3D<algebra_t> centroid(
-        const bounds_t<scalar_t, kDIM> &) const {
+        const bounds_type<dscalar<algebra_t>> &) const {
 
         return {0.f, 0.f, 0.f};
     }
@@ -127,12 +139,13 @@ class rectangle2D {
     /// @param n_seg is the number of line segments
     ///
     /// @return a generated list of vertices
-    template <typename point2_t, typename point3_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST dvector<point3_t> vertices(
-        const bounds_t<scalar_t, kDIM> &bounds, dindex /*ignored*/) const {
+    template <typename algebra_t>
+    DETRAY_HOST dvector<dpoint3D<algebra_t>> vertices(
+        const bounds_type<dscalar<algebra_t>> &bounds,
+        dindex /*ignored*/) const {
+
+        using point3_t = dpoint3D<algebra_t>;
+
         // left hand lower corner
         point3_t lh_lc{-bounds[e_half_x], -bounds[e_half_y], 0.f};
         // right hand lower corner
@@ -141,6 +154,7 @@ class rectangle2D {
         point3_t rh_uc{bounds[e_half_x], bounds[e_half_y], 0.f};
         // left hand upper corner
         point3_t lh_uc{-bounds[e_half_x], bounds[e_half_y], 0.f};
+
         // Return the confining vertices
         return {lh_lc, rh_lc, rh_uc, lh_uc};
     }
@@ -151,11 +165,9 @@ class rectangle2D {
     /// @param os output stream for error messages
     ///
     /// @return true if the bounds are consistent.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST constexpr bool check_consistency(
-        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+        const bounds_type<scalar_t> &bounds, std::ostream &os) const {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 

--- a/core/include/detray/geometry/shapes/ring2D.hpp
+++ b/core/include/detray/geometry/shapes/ring2D.hpp
@@ -37,12 +37,33 @@ class ring2D {
         e_size = 2u,
     };
 
+    /// Container definition for the shape boundary values
+    template <typename scalar_t>
+    using bounds_type = darray<scalar_t, boundaries::e_size>;
+
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = polar2D<algebra_t>;
 
     /// Dimension of the local coordinate system
     static constexpr std::size_t dim{2u};
+
+    /// @brief Find the minimum distance to any boundary.
+    ///
+    /// @note the point is expected to be given in local coordinates by the
+    /// caller.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param loc_p the point to be checked in the local coordinate system
+    ///
+    /// @return the minimum distance.
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline scalar_t min_dist_to_boundary(
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p) const {
+
+        return math::min(math::fabs(loc_p[0] - bounds[e_inner_r]),
+                         math::fabs(bounds[e_outer_r] - loc_p[0]));
+    }
 
     /// @brief Check boundary values for a local point.
     ///
@@ -55,11 +76,9 @@ class ring2D {
     /// @param tol dynamic tolerance determined by caller
     ///
     /// @return true if the local point lies within the given boundaries.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM, typename point_t,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t, typename point_t>
     DETRAY_HOST_DEVICE inline auto check_boundaries(
-        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
         return ((loc_p[0] + tol) >= bounds[e_inner_r] &&
@@ -71,11 +90,9 @@ class ring2D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the ring area on the plane
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t measure(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return area(bounds);
     }
 
@@ -84,11 +101,9 @@ class ring2D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the ring area.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t area(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return (bounds[e_outer_r] * bounds[e_outer_r] -
                 bounds[e_inner_r] * bounds[e_inner_r]) *
                constant<scalar>::pi;
@@ -103,25 +118,21 @@ class ring2D {
     ///
     /// @returns and array of coordinates that contains the lower point (first
     /// three values) and the upper point (latter three values) .
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM> &bounds,
-        const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
+    template <typename algebra_t>
+    DETRAY_HOST_DEVICE inline darray<dscalar<algebra_t>, 6> local_min_bounds(
+        const bounds_type<dscalar<algebra_t>> &bounds,
+        const dscalar<algebra_t> env =
+            std::numeric_limits<dscalar<algebra_t>>::epsilon()) const {
+
         assert(env > 0.f);
-        const scalar_t r_bound{env + bounds[e_outer_r]};
+        const dscalar<algebra_t> r_bound{env + bounds[e_outer_r]};
         return {-r_bound, -r_bound, -env, r_bound, r_bound, env};
     }
 
     /// @returns the shapes centroid in local cartesian coordinates
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename algebra_t>
     DETRAY_HOST_DEVICE dpoint3D<algebra_t> centroid(
-        const bounds_t<scalar_t, kDIM> &) const {
+        const bounds_type<dscalar<algebra_t>> &) const {
 
         return {0.f, 0.f, 0.f};
     }
@@ -132,12 +143,9 @@ class ring2D {
     /// @param n_seg is the number of line segments
     ///
     /// @return a generated list of vertices
-    template <typename point2_t, typename point3_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST dvector<point3_t> vertices(const bounds_t<scalar_t, kDIM> &,
-                                           dindex) const {
+    template <typename algebra_t>
+    DETRAY_HOST dvector<dpoint3D<algebra_t>> vertices(
+        const bounds_type<dscalar<algebra_t>> &, dindex) const {
         throw std::runtime_error(
             "Vertex generation for rings is not implemented");
         return {};
@@ -149,11 +157,9 @@ class ring2D {
     /// @param os output stream for error messages
     ///
     /// @return true if the bounds are consistent.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST constexpr bool check_consistency(
-        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+        const bounds_type<scalar_t> &bounds, std::ostream &os) const {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 

--- a/core/include/detray/geometry/shapes/trapezoid2D.hpp
+++ b/core/include/detray/geometry/shapes/trapezoid2D.hpp
@@ -40,12 +40,44 @@ class trapezoid2D {
         e_size = 4u,
     };
 
+    /// Container definition for the shape boundary values
+    template <typename scalar_t>
+    using bounds_type = darray<scalar_t, boundaries::e_size>;
+
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = cartesian2D<algebra_t>;
 
     /// Dimension of the local coordinate system
     static constexpr std::size_t dim{2u};
+
+    /// @brief Find the minimum distance to any boundary.
+    ///
+    /// @note the point is expected to be given in local coordinates by the
+    /// caller.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param loc_p the point to be checked in the local coordinate system
+    ///
+    /// @return the minimum distance.
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline scalar_t min_dist_to_boundary(
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p) const {
+
+        // Minimum distance between loc point and line between corner points
+        const scalar_t d_y = -2.f * bounds[e_half_length_2];
+        const scalar_t d_x = bounds[e_half_length_1] - bounds[e_half_length_0];
+
+        const scalar_t denom = math::sqrt(d_y * d_y + d_x * d_x);
+        const scalar_t dist_to_line =
+            math::fabs(d_y * loc_p[0] - d_x * loc_p[1] -
+                       bounds[e_half_length_2] * (bounds[e_half_length_1] +
+                                                  bounds[e_half_length_0])) /
+            denom;
+
+        return math::min(dist_to_line, math::fabs(math::fabs(loc_p[1]) -
+                                                  bounds[e_half_length_2]));
+    }
 
     /// @brief Check boundary values for a local point.
     ///
@@ -58,11 +90,9 @@ class trapezoid2D {
     /// @param tol dynamic tolerance determined by caller
     ///
     /// @return true if the local point lies within the given boundaries.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM, typename point_t,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t, typename point_t>
     DETRAY_HOST_DEVICE inline auto check_boundaries(
-        const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         const scalar_t rel_y =
             (bounds[e_half_length_2] + loc_p[1]) * bounds[e_divisor];
@@ -78,11 +108,9 @@ class trapezoid2D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the trapezoid area on the plane
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t measure(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return area(bounds);
     }
 
@@ -91,11 +119,9 @@ class trapezoid2D {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the trapezoid area.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t area(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<scalar_t> &bounds) const {
         return 2.f * (bounds[e_half_length_0] + bounds[e_half_length_1]) *
                bounds[e_half_length_2];
     }
@@ -109,13 +135,14 @@ class trapezoid2D {
     ///
     /// @returns and array of coordinates that contains the lower point (first
     /// three values) and the upper point (latter three values) .
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline darray<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM> &bounds,
-        const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
+    template <typename algebra_t>
+    DETRAY_HOST_DEVICE inline darray<dscalar<algebra_t>, 6> local_min_bounds(
+        const bounds_type<dscalar<algebra_t>> &bounds,
+        const dscalar<algebra_t> env =
+            std::numeric_limits<dscalar<algebra_t>>::epsilon()) const {
+
+        using scalar_t = dscalar<algebra_t>;
+
         assert(env > 0.f);
         const scalar_t x_bound{
             (bounds[e_half_length_0] > bounds[e_half_length_1]
@@ -127,12 +154,11 @@ class trapezoid2D {
     }
 
     /// @returns the shapes centroid in local cartesian coordinates
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename algebra_t>
     DETRAY_HOST_DEVICE dpoint3D<algebra_t> centroid(
-        const bounds_t<scalar_t, kDIM> &bounds) const {
+        const bounds_type<dscalar<algebra_t>> &bounds) const {
+
+        using scalar_t = dscalar<algebra_t>;
 
         const scalar_t h_2{bounds[e_half_length_2]};
         const scalar_t a_2{bounds[e_half_length_1]};
@@ -150,12 +176,12 @@ class trapezoid2D {
     /// @param ls is the number of line segments
     ///
     /// @return a generated list of vertices
-    template <typename point2_t, typename point3_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST dvector<point3_t> vertices(
-        const bounds_t<scalar_t, kDIM> &bounds, dindex /*ignored*/) const {
+    template <typename algebra_t>
+    DETRAY_HOST dvector<dpoint3D<algebra_t>> vertices(
+        const bounds_type<dscalar<algebra_t>> &bounds,
+        dindex /*ignored*/) const {
+        using point3_t = dpoint3D<algebra_t>;
+
         // left hand lower corner
         point3_t lh_lc{-bounds[e_half_length_0], -bounds[e_half_length_2], 0.f};
         // right hand lower corner
@@ -164,6 +190,7 @@ class trapezoid2D {
         point3_t rh_uc{bounds[e_half_length_1], bounds[e_half_length_2], 0.f};
         // left hand upper corner
         point3_t lh_uc{-bounds[e_half_length_1], bounds[e_half_length_2], 0.f};
+
         // Return the confining vertices
         return {lh_lc, rh_lc, rh_uc, lh_uc};
     }
@@ -174,11 +201,9 @@ class trapezoid2D {
     /// @param os output stream for error messages
     ///
     /// @return true if the bounds are consistent.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST constexpr bool check_consistency(
-        const bounds_t<scalar_t, kDIM> &bounds, std::ostream &os) const {
+        const bounds_type<scalar_t> &bounds, std::ostream &os) const {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 

--- a/core/include/detray/geometry/shapes/unmasked.hpp
+++ b/core/include/detray/geometry/shapes/unmasked.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/detail/algebra.hpp"
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
@@ -29,12 +30,32 @@ class unmasked {
 
     enum boundaries : unsigned int { e_size = 1u };
 
+    /// Container definition for the shape boundary values
+    template <typename scalar_t>
+    using bounds_type = darray<scalar_t, boundaries::e_size>;
+
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>
     using local_frame_type = cartesian2D<algebra_t>;
 
     /// Dimension of the local coordinate system
     static constexpr std::size_t dim{DIM};
+
+    /// @brief Find the minimum distance to any boundary.
+    ///
+    /// @note the point is expected to be given in local coordinates by the
+    /// caller.
+    ///
+    /// @param bounds the boundary values for this shape
+    /// @param loc_p the point to be checked in the local coordinate system
+    ///
+    /// @return the minimum distance.
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline scalar_t min_dist_to_boundary(
+        const bounds_type<scalar_t>& /*bounds*/,
+        const point_t& /*loc_p*/) const {
+        return std::numeric_limits<scalar_t>::max();
+    }
 
     /// @brief Check boundary values for a local point.
     ///
@@ -43,9 +64,9 @@ class unmasked {
     /// @note the parameters are ignored
     ///
     /// @return always true
-    template <typename bounds_t, typename point_t, typename scalar_t>
-    DETRAY_HOST_DEVICE inline constexpr auto check_boundaries(
-        const bounds_t& /*bounds*/, const point_t& /*loc_p*/,
+    template <typename scalar_t, typename point_t>
+    DETRAY_HOST_DEVICE inline auto check_boundaries(
+        const bounds_type<scalar_t>& /*bounds*/, const point_t& /*loc_p*/,
         const scalar_t /*tol*/) const {
         return true;
     }
@@ -55,10 +76,9 @@ class unmasked {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns Inf.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t measure(
-        const bounds_t<scalar_t, kDIM>& bounds) const {
+        const bounds_type<scalar_t>& bounds) const {
         if constexpr (dim == 2) {
             return area(bounds);
         } else {
@@ -71,11 +91,9 @@ class unmasked {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns the stereo annulus area.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM, std::size_t D = dim,
-              std::enable_if_t<D == 2, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t area(
-        const bounds_t<scalar_t, kDIM>&) const {
+        const bounds_type<scalar_t>&) const {
         return std::numeric_limits<scalar_t>::max();
     }
 
@@ -84,11 +102,9 @@ class unmasked {
     /// @param bounds the boundary values for this shape
     ///
     /// @returns Inf.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM, std::size_t D = dim,
-              std::enable_if_t<D == 3, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t volume(
-        const bounds_t<scalar_t, kDIM>&) const {
+        const bounds_type<scalar_t>&) const {
         return std::numeric_limits<scalar_t>::max();
     }
 
@@ -101,25 +117,22 @@ class unmasked {
     ///
     /// @returns and array of coordinates that contains the lower point (first
     /// three values) and the upper point (latter three values) .
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE constexpr darray<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& /*bounds*/,
-        const scalar_t /*env*/ =
-            std::numeric_limits<scalar_t>::epsilon()) const {
+    template <typename algebra_t>
+    DETRAY_HOST_DEVICE inline darray<dscalar<algebra_t>, 6> local_min_bounds(
+        const bounds_type<dscalar<algebra_t>>& /*bounds*/,
+        const dscalar<algebra_t> /*env*/ =
+            std::numeric_limits<dscalar<algebra_t>>::epsilon()) const {
+
+        using scalar_t = dscalar<algebra_t>;
         constexpr scalar_t inv{detail::invalid_value<scalar_t>()};
+
         return {-inv, -inv, -inv, inv, inv, inv};
     }
 
     /// @returns the shapes centroid in global cartesian coordinates
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename algebra_t>
     DETRAY_HOST_DEVICE dpoint3D<algebra_t> centroid(
-        const bounds_t<scalar_t, kDIM>&) const {
+        const bounds_type<dscalar<algebra_t>>&) const {
         return {0.f, 0.f, 0.f};
     }
 
@@ -129,12 +142,9 @@ class unmasked {
     /// @param n_seg is the number of line segments
     ///
     /// @return a generated list of vertices
-    template <typename point2_t, typename point3_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST dvector<point3_t> vertices(
-        const bounds_t<scalar_t, kDIM>& bounds, dindex) const {
+    template <typename algebra_t>
+    DETRAY_HOST dvector<dpoint3D<algebra_t>> vertices(
+        const bounds_type<dscalar<algebra_t>>& bounds, dindex) const {
         return local_min_bounds(bounds);
     }
 
@@ -144,12 +154,9 @@ class unmasked {
     /// @param os output stream for error messages
     ///
     /// @return true if the bounds are consistent.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t>
     DETRAY_HOST constexpr bool check_consistency(
-        const bounds_t<scalar_t, kDIM>& /*bounds*/,
-        std::ostream& /*os*/) const {
+        const bounds_type<scalar_t>& /*bounds*/, std::ostream& /*os*/) const {
         return true;
     }
 };

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -164,6 +164,16 @@ class surface {
         return m_detector.transform_store().at(m_desc.transform(), ctx);
     }
 
+    /// @returns the mask volume link
+    template <typename point_t = point2_type,
+              std::enable_if_t<std::is_same_v<point_t, point3_type> or
+                                   std::is_same_v<point_t, point2_type>,
+                               bool> = true>
+    DETRAY_HOST_DEVICE constexpr bool is_inside(const point_t &loc_p,
+                                                const scalar_type tol) const {
+        return visit_mask<typename kernels::is_inside>(loc_p, tol);
+    }
+
     /// @returns a boundary value of the surface, according to @param index
     DETRAY_HOST_DEVICE
     constexpr scalar_type boundary(std::size_t index) const {
@@ -314,6 +324,15 @@ class surface {
             vertices[i] = transform(ctx).point_to_global(vertices[i]);
         }
         return vertices;
+    }
+
+    /// @returns the vertices in local frame with @param n_seg the number of
+    /// segments used along acrs
+    /// @note the point has to be inside the surface mask
+    template <typename point_t>
+    DETRAY_HOST constexpr auto min_dist_to_boundary(
+        const point_t &loc_p) const {
+        return visit_mask<typename kernels::min_dist_to_boundary>(loc_p);
     }
 
     /// @brief Lower and upper point for minimal axis aligned bounding box.

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -168,8 +168,8 @@ class geometry_reader {
 
             const auto z_shift{static_cast<scalar_t>(trf.translation()[2])};
 
-            mask_boundaries[concentric_cylinder2D::e_n_half_z] += z_shift;
-            mask_boundaries[concentric_cylinder2D::e_p_half_z] += z_shift;
+            mask_boundaries[concentric_cylinder2D::e_lower_z] += z_shift;
+            mask_boundaries[concentric_cylinder2D::e_upper_z] += z_shift;
 
             // Set the transform to identity afterwards
             trf = decltype(trf){};

--- a/io/include/detray/io/csv/intersection2D.hpp
+++ b/io/include/detray/io/csv/intersection2D.hpp
@@ -113,11 +113,12 @@ inline auto read_intersection2D(const std::string &file_name) {
 template <typename intersection_t>
 inline void write_intersection2D(
     const std::string &file_name,
-    const std::vector<std::vector<intersection_t>> &intersections_per_track) {
+    const std::vector<std::vector<intersection_t>> &intersections_per_track,
+    const bool replace = true) {
 
     // Don't write over existing data
     std::string inters_file_name{file_name};
-    if (io::file_exists(file_name)) {
+    if (!replace && io::file_exists(file_name)) {
         inters_file_name = io::alt_file_name(file_name);
     } else {
         // Make sure the output directories exit

--- a/io/include/detray/io/csv/track_parameters.hpp
+++ b/io/include/detray/io/csv/track_parameters.hpp
@@ -105,11 +105,12 @@ inline auto read_free_track_params(const std::string &file_name) {
 template <typename track_t>
 inline void write_free_track_params(
     const std::string &file_name,
-    const std::vector<std::vector<track_t>> &track_params_per_track) {
+    const std::vector<std::vector<track_t>> &track_params_per_track,
+    const bool replace = true) {
 
     // Don't write over existing data
     std::string trk_file_name{file_name};
-    if (io::file_exists(file_name)) {
+    if (!replace && io::file_exists(file_name)) {
         trk_file_name = io::alt_file_name(file_name);
     } else {
         // Make sure the output directories exit

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
@@ -81,8 +81,8 @@ auto inline surface(const transform_t& transform, const mask<shape_t>& m) {
     p_surface_t p_surface;
 
     const auto r = static_cast<actsvg::scalar>(m[shape_t::e_r]);
-    const auto nhz = static_cast<actsvg::scalar>(m[shape_t::e_n_half_z]);
-    const auto phz = static_cast<actsvg::scalar>(m[shape_t::e_p_half_z]);
+    const auto nhz = static_cast<actsvg::scalar>(m[shape_t::e_lower_z]);
+    const auto phz = static_cast<actsvg::scalar>(m[shape_t::e_upper_z]);
     const auto center = transform.translation();
     const auto z0 = static_cast<actsvg::scalar>(center[2]);
     auto hz = static_cast<actsvg::scalar>(0.5f * (phz - nhz));

--- a/tests/include/detray/test/cpu/detector_scan.hpp
+++ b/tests/include/detray/test/cpu/detector_scan.hpp
@@ -84,8 +84,12 @@ class detector_scan : public test::fixture_base<> {
             m_cfg.whiteboard()->template get<std::vector<intersection_trace_t>>(
                 m_cfg.name());
 
+        const std::string det_name{m_det.name(m_names)};
+        const std::string prefix{k_use_rays ? det_name + "_ray_"
+                                            : det_name + "_helix_"};
         std::ios_base::openmode io_mode = std::ios::trunc | std::ios::out;
-        detray::io::file_handle debug_file{"./detector_scan.txt", io_mode};
+        detray::io::file_handle debug_file{prefix + "_detector_scan.txt",
+                                           io_mode};
 
         std::cout << "\nINFO: Checking trace data...\n" << std::endl;
 

--- a/tests/include/detray/test/device/cuda/navigation_validation.hpp
+++ b/tests/include/detray/test/device/cuda/navigation_validation.hpp
@@ -148,6 +148,7 @@ class navigation_validation : public test::fixture_base<> {
 
     using scalar_t = typename detector_t::scalar_type;
     using algebra_t = typename detector_t::algebra_type;
+    using vector3_t = typename detector_t::vector3_type;
     using free_track_parameters_t = free_track_parameters<algebra_t>;
     using trajectory_type = typename scan_type<algebra_t>::trajectory_type;
     using intersection_trace_t = typename scan_type<
@@ -226,6 +227,8 @@ class navigation_validation : public test::fixture_base<> {
         using bfield_t =
             std::conditional_t<k_use_rays, navigation_validator::empty_bfield,
                                hom_bfield_t>;
+        using intersection_t =
+            typename intersection_trace_t::value_type::intersection_type;
 
         bfield_t b_field{};
         if constexpr (!k_use_rays) {
@@ -243,8 +246,13 @@ class navigation_validation : public test::fixture_base<> {
                   << m_det.name(m_names) << "...\n"
                   << std::endl;
 
+        const std::string det_name{m_det.name(m_names)};
+        const std::string prefix{k_use_rays ? det_name + "_ray_"
+                                            : det_name + "_helix_"};
+
         std::ios_base::openmode io_mode = std::ios::trunc | std::ios::out;
-        const std::string debug_file_name{"./navigation_validation_cuda.txt"};
+        const std::string debug_file_name{prefix +
+                                          "navigation_validation_cuda.txt"};
         detray::io::file_handle debug_file{debug_file_name, io_mode};
 
         // Run the propagation on device and record the navigation data
@@ -257,7 +265,8 @@ class navigation_validation : public test::fixture_base<> {
         std::size_t n_tracks{0u}, n_surfaces{0u}, n_miss_nav{0u},
             n_miss_truth{0u}, n_matching_error{0u}, n_fatal{0u};
 
-        std::vector<dindex> missed_sf_idx{};
+        std::vector<std::pair<trajectory_type, std::vector<intersection_t>>>
+            missed_intersections{};
 
         EXPECT_EQ(recorded_intersections.size(),
                   truth_intersection_traces.size());
@@ -279,6 +288,10 @@ class navigation_validation : public test::fixture_base<> {
             if (truth_trace.size() == 1) {
                 // Propagation did not succeed
                 success = false;
+                std::vector<intersection_t> missed_inters{};
+                missed_intersections.push_back(
+                    std::make_pair(test_traj, missed_inters));
+
                 ++n_fatal;
             } else {
                 // Compare truth and recorded data elementwise
@@ -288,10 +301,8 @@ class navigation_validation : public test::fixture_base<> {
                         truth_trace, recorded_trace, test_traj, n_tracks,
                         n_test_tracks, &(*debug_file));
 
-                for (const auto &sfi : missed_inters) {
-                    [[maybe_unused]] const auto sf =
-                        surface{m_det, sfi.sf_desc.barcode()};
-                }
+                missed_intersections.push_back(
+                    std::make_pair(test_traj, std::move(missed_inters)));
 
                 // Update statistics
                 success &= result;
@@ -322,7 +333,6 @@ class navigation_validation : public test::fixture_base<> {
                                                n_matching_error);
 
         // Print track positions for plotting
-        std::string prefix{k_use_rays ? "ray_" : "helix_"};
         const auto data_path{
             std::filesystem::path{m_cfg.track_param_file()}.parent_path()};
         const auto truth_trk_path{data_path /
@@ -331,12 +341,22 @@ class navigation_validation : public test::fixture_base<> {
                             (prefix + "navigation_track_params_cuda.csv")};
         const auto mat_path{data_path /
                             (prefix + "accumulated_material_cuda.csv")};
+        const auto missed_path{
+            data_path / (prefix + "missed_intersections_dists_cuda.csv")};
 
+        // Write the distance of the missed intersection local position
+        // to the surface boundaries to file for plotting
+        navigation_validator::write_dist_to_boundary(
+            m_det, m_names, missed_path.string(), missed_intersections);
         detector_scanner::write_tracks(truth_trk_path.string(),
                                        truth_intersection_traces);
         navigation_validator::write_tracks(trk_path.string(),
                                            recorded_intersections);
         material_validator::write_material(mat_path.string(), mat_records);
+
+        std::cout
+            << "INFO: Wrote distance to boundary of missed intersections to: "
+            << missed_path << std::endl;
         std::cout << "INFO: Wrote track states in: " << trk_path << std::endl;
         std::cout << "INFO: Wrote accumulated material in: " << mat_path
                   << std::endl;

--- a/tests/unit_tests/cpu/geometry/masks/annulus2D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/annulus2D.cpp
@@ -65,6 +65,22 @@ GTEST_TEST(detray_masks, annulus2D) {
     ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out1), 1.3f));
     ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out4), 0.9f));
 
+    ASSERT_NEAR(ann2.get_shape().min_dist_to_boundary(ann2.values(),
+                                                      toStripFrame(p2_in)),
+                2.1005f, tol);
+    ASSERT_NEAR(ann2.get_shape().min_dist_to_boundary(ann2.values(),
+                                                      toStripFrame(p2_out1)),
+                0.128932f, tol);
+    ASSERT_NEAR(ann2.get_shape().min_dist_to_boundary(ann2.values(),
+                                                      toStripFrame(p2_out2)),
+                1.55969f, tol);
+    ASSERT_NEAR(ann2.get_shape().min_dist_to_boundary(ann2.values(),
+                                                      toStripFrame(p2_out3)),
+                2.14214f, tol);
+    ASSERT_NEAR(ann2.get_shape().min_dist_to_boundary(ann2.values(),
+                                                      toStripFrame(p2_out4)),
+                0.80214f, tol);
+
     // Check area: @TODO not implemented, yet
     scalar a = ann2.area();
     ASSERT_EQ(a, ann2.measure());

--- a/tests/unit_tests/cpu/geometry/masks/cylinder.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/cylinder.cpp
@@ -35,8 +35,8 @@ GTEST_TEST(detray_masks, cylinder2D) {
     mask<cylinder2D> c{0u, r, -hz, hz};
 
     ASSERT_NEAR(c[cylinder2D::e_r], r, tol);
-    ASSERT_NEAR(c[cylinder2D::e_n_half_z], -hz, tol);
-    ASSERT_NEAR(c[cylinder2D::e_p_half_z], hz, tol);
+    ASSERT_NEAR(c[cylinder2D::e_lower_z], -hz, tol);
+    ASSERT_NEAR(c[cylinder2D::e_upper_z], hz, tol);
 
     ASSERT_TRUE(c.is_inside(p2_in));
     ASSERT_TRUE(c.is_inside(p2_edge));

--- a/tests/unit_tests/svgtools/masks.cpp
+++ b/tests/unit_tests/svgtools/masks.cpp
@@ -53,7 +53,7 @@ GTEST_TEST(svgtools, masks) {
     detray::svgtools::write_svg("test_svgtools_annulus2D", {axes, ann2D_svg});
 
     // Visualize a 2D cylinder.
-    // e_r, e_n_half_z, e_p_half_z
+    // e_r, e_lower_z, e_upper_z
     detray::mask<detray::cylinder2D> cyl2D{0u, 100.f, -10.f, 10.f};
     const auto cyl2D_proto =
         detray::svgtools::conversion::surface(transform, cyl2D);

--- a/tests/validation/python/impl/__init__.py
+++ b/tests/validation/python/impl/__init__.py
@@ -1,5 +1,5 @@
 
-from .plot_navigation_validation import read_truth_data, read_navigation_data,plot_navigation_data
+from .plot_navigation_validation import read_scan_data, read_navigation_data,plot_navigation_data
 from .plot_material_scan import read_material_data, X0_vs_eta_phi, L0_vs_eta_phi, X0_vs_eta, L0_vs_eta
 from .plot_ray_scan import read_ray_scan_data, plot_intersection_points_xy, plot_intersection_points_rz, plot_detector_scan_data
 from .plot_track_params import read_track_data, plot_track_params, compare_track_pos_xy, compare_track_pos_rz, plot_track_pos_dist, plot_track_pos_res

--- a/tests/validation/python/impl/plot_navigation_validation.py
+++ b/tests/validation/python/impl/plot_navigation_validation.py
@@ -13,7 +13,7 @@ import os
 
 
 """ Read the detector scan data from files and prepare data frames """
-def read_truth_data(inputdir, logging):
+def read_scan_data(inputdir, det_name, logging):
 
     # Input data directory
     data_dir = os.fsencode(inputdir)
@@ -26,20 +26,16 @@ def read_truth_data(inputdir, logging):
     for file in os.listdir(data_dir):
         filename = os.fsdecode(file)
 
-        if filename.find('_ray_scan_intersections') != -1:
+        if filename.find(det_name + '_ray_scan_intersections') != -1:
             ray_scan_intersections_file = inputdir + "/" + filename
             file_name = os.path.basename(ray_scan_intersections_file)
-            detector_name, sep, suffix = file_name.partition('_ray_scan_intersections')
-        elif filename.find('_ray_scan_track_parameters') != -1:
+        elif filename.find(det_name + '_ray_scan_track_parameters') != -1:
             ray_scan_track_param_file = inputdir + "/" + filename
-        elif filename.find('_helix_scan_intersections') != -1:
+        elif filename.find(det_name + '_helix_scan_intersections') != -1:
             helix_scan_intersections_file = inputdir + "/" + filename
             file_name = os.path.basename(helix_scan_intersections_file)
-            detector_name, sep, suffix = file_name.partition('_helix_scan_intersections')
-        elif filename.find('_helix_scan_track_parameters') != -1:
+        elif filename.find(det_name + '_helix_scan_track_parameters') != -1:
             helix_scan_track_param_file = inputdir + "/" + filename
-
-    detector_name = detector_name.replace('_', ' ')
 
     # Read ray scan data
     ray_scan_df = read_ray_scan_data(ray_scan_intersections_file,
@@ -49,11 +45,11 @@ def read_truth_data(inputdir, logging):
     helix_scan_df = read_ray_scan_data(helix_scan_intersections_file,
                                        helix_scan_track_param_file, logging)
 
-    return detector_name, ray_scan_df, helix_scan_df
+    return ray_scan_df, helix_scan_df
 
 
 """ Read the recorded track positions from files and prepare data frames """
-def read_navigation_data(inputdir, read_cuda, logging):
+def read_navigation_data(inputdir, det_name, read_cuda, logging):
 
     # Input data directory
     data_dir = os.fsencode(inputdir)
@@ -65,17 +61,17 @@ def read_navigation_data(inputdir, read_cuda, logging):
     for file in os.listdir(data_dir):
         filename = os.fsdecode(file)
 
-        if read_cuda and filename.find('ray_navigation_track_params_cuda') != -1:
+        if read_cuda and filename.find(det_name + '_ray_navigation_track_params_cuda') != -1:
             ray_data_cuda_file = inputdir + "/" + filename
-        elif filename.find('ray_navigation_track_params') != -1:
+        elif filename.find(det_name + '_ray_navigation_track_params') != -1:
             ray_data_file = inputdir + "/" + filename
-        elif filename.find('ray_truth_track_params') != -1:
+        elif filename.find(det_name + '_ray_truth_track_params') != -1:
             ray_truth_file = inputdir + "/" + filename
-        elif read_cuda and filename.find('helix_navigation_track_params_cuda') != -1:
+        elif read_cuda and filename.find(det_name + '_helix_navigation_track_params_cuda') != -1:
             helix_data_cuda_file = inputdir + "/" + filename
-        elif filename.find('helix_navigation_track_params') != -1:
+        elif filename.find(det_name + '_helix_navigation_track_params') != -1:
             helix_data_file = inputdir + "/" + filename
-        elif filename.find('helix_truth_track_params') != -1:
+        elif filename.find(det_name + '_helix_truth_track_params') != -1:
             helix_truth_file = inputdir + "/" + filename
 
     ray_df = read_track_data(ray_data_file, logging)

--- a/tests/validation/python/navigation_validation.py
+++ b/tests/validation/python/navigation_validation.py
@@ -5,7 +5,7 @@
 # Mozilla Public License Version 2.0
 
 # detray imports
-from impl import read_truth_data, read_navigation_data, plot_navigation_data
+from impl import read_scan_data, read_navigation_data, plot_navigation_data
 from impl import plot_track_params
 from impl import plot_detector_scan_data, plot_track_pos_dist, plot_track_pos_res
 from options import (common_options, detector_io_options,
@@ -20,6 +20,7 @@ import argparse
 import os
 import subprocess
 import sys
+import json
 
 
 def __main__():
@@ -124,6 +125,12 @@ def __main__():
 
     logging.info("Generating data plots...\n")
 
+    geo_file = open(args.geometry_file)
+    json_geo = json.loads(geo_file.read())
+
+    det_name = json_geo['header']['common']['detector']
+    logging.debug("Detector: " + det_name)
+
     # Check the data path (should have been created when running the validation)
     if not os.path.isdir(datadir):
         logging.error(f"Data directory was not found! ({args.datadir})")
@@ -132,7 +139,7 @@ def __main__():
     plot_factory = plt_factory(out_dir, logging)
 
     # Read the truth data
-    det_name, ray_scan_df, helix_scan_df = read_truth_data(datadir, logging)
+    ray_scan_df, helix_scan_df = read_scan_data(datadir, det_name, logging)
 
     plot_detector_scan_data(args, det_name, plot_factory, "ray", ray_scan_df, "ray_scan", out_format)
     plot_detector_scan_data(args, det_name, plot_factory, "helix", helix_scan_df, "helix_scan", out_format)
@@ -147,7 +154,8 @@ def __main__():
                       ray_intial_trk_df)
 
     # Read the recorded data
-    ray_nav_df, ray_truth_df, ray_nav_cuda_df, helix_nav_df, helix_truth_df, helix_nav_cuda_df = read_navigation_data(datadir, args.cuda, logging)
+    ray_nav_df, ray_truth_df, ray_nav_cuda_df, helix_nav_df, helix_truth_df, helix_nav_cuda_df = read_navigation_data(datadir, det_name, args.cuda,
+                                             logging)
 
     # Plot
     plot_navigation_data(args, det_name, plot_factory, "ray", ray_truth_df, "truth", ray_nav_df, "navigation (CPU)", out_format)

--- a/tutorials/include/detray/tutorial/my_square2D.hpp
+++ b/tutorials/include/detray/tutorial/my_square2D.hpp
@@ -31,6 +31,10 @@ class square2D {
         e_size = 1u,        // < Number of boundary values for this shape
     };
 
+    /// Container definition for the shape boundary values
+    template <typename scalar_t>
+    using bounds_type = darray<scalar_t, boundaries::e_size>;
+
     /// Local coordinate frame for boundary checks: cartesian
     template <typename algebra_t>
     using local_frame_type = cartesian2D<algebra_t>;
@@ -49,11 +53,9 @@ class square2D {
     /// @param tol dynamic tolerance determined by caller
     ///
     /// @return true if the local point lies within the given boundaries.
-    template <template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM, typename point_t,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
+    template <typename scalar_t, typename point_t>
     DETRAY_HOST_DEVICE inline auto check_boundaries(
-        const bounds_t<scalar_t, kDIM>& bounds, const point_t& loc_p,
+        const bounds_type<scalar_t> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
         return (math::abs(loc_p[0]) <= bounds[e_half_length] + tol and
                 math::abs(loc_p[1]) <= bounds[e_half_length] + tol);
@@ -68,15 +70,14 @@ class square2D {
     ///
     /// @returns and array of coordinates that contains the lower point (first
     /// three values) and the upper point (latter three values) .
-    template <typename algebra_t,
-              template <typename, std::size_t> class bounds_t,
-              typename scalar_t, std::size_t kDIM,
-              typename std::enable_if_t<kDIM == e_size, bool> = true>
-    DETRAY_HOST_DEVICE inline std::array<scalar_t, 6> local_min_bounds(
-        const bounds_t<scalar_t, kDIM>& bounds,
-        const scalar_t env = std::numeric_limits<scalar_t>::epsilon()) const {
+    template <typename algebra_t>
+    DETRAY_HOST_DEVICE inline std::array<dscalar<algebra_t>, 6>
+    local_min_bounds(
+        const bounds_type<dscalar<algebra_t>> &bounds,
+        const dscalar<algebra_t> env =
+            std::numeric_limits<dscalar<algebra_t>>::epsilon()) const {
         assert(env > 0.f);
-        const scalar_t bound{bounds[e_half_length] + env};
+        const dscalar<algebra_t> bound{bounds[e_half_length] + env};
         return {-bound, -bound, -env, bound, bound, env};
     }
 };


### PR DESCRIPTION
Simplifies the templating on the methods in the geometry shapes, renames the cylidner bounds after the transform got removed in a previous PR, and adds a method to find the minimum distance to the shape boundary for a local point that is inside. Also cleans ups some of the file naming in the navigation validation and fixes a bug in the counting of missed surfaces.

For the missed surfaces the minimum distance to boundary is written out now, along with some other additional information (e.g. eta and phi) and whether the intersection would have been inside with 0-tolerance