### PR TITLE
feat: Randomize charge in track generators and plot track parameter distributions

### DIFF
--- a/core/include/detray/navigation/detail/helix.hpp
+++ b/core/include/detray/navigation/detail/helix.hpp
@@ -175,6 +175,12 @@ class helix {
     DETRAY_HOST_DEVICE
     scalar_type qop() const { return _qop; }
 
+    /// @return charge of helix
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type charge() const {
+        return math::signbit(qop()) ? -1.f : 1.f;
+    }
+
     DETRAY_HOST_DEVICE
     auto b_field() const { return _mag_field; }
 

--- a/core/include/detray/navigation/detail/ray.hpp
+++ b/core/include/detray/navigation/detail/ray.hpp
@@ -81,6 +81,10 @@ class ray {
     /// @param dir new direction of the ray
     DETRAY_HOST_DEVICE void set_dir(vector3_type dir) { _dir = dir; }
 
+    /// @return charge 1
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type charge() const { return 1.f; }
+
     /// Print
     DETRAY_HOST
     friend std::ostream &operator<<(std::ostream &os, const ray &r) {

--- a/io/include/detray/io/frontend/detector_writer_config.hpp
+++ b/io/include/detray/io/frontend/detector_writer_config.hpp
@@ -27,9 +27,9 @@ struct detector_writer_config {
     /// Compactify json output, if not json format this flag does nothing
     bool m_compact_io = false;
     /// Whether to write the material to file
-    bool m_write_material = false;
+    bool m_write_material = true;
     /// Whether to write the accelerator grids to file
-    bool m_write_grids = false;
+    bool m_write_grids = true;
 
     /// Getters
     /// @{

--- a/tests/include/detray/test/common/utils/detector_scanner.hpp
+++ b/tests/include/detray/test/common/utils/detector_scanner.hpp
@@ -92,7 +92,7 @@ struct brute_force_scan {
                     // Record the intersection
                     intersection_trace.push_back(
                         {{traj.pos(sfi.path), 0.f, p * traj.dir(sfi.path),
-                          -1.f},
+                          traj.charge()},
                          sf.volume(),
                          sfi});
                 }
@@ -113,11 +113,12 @@ struct brute_force_scan {
         start_intersection.volume_link =
             static_cast<nav_link_t>(first_record.vol_idx);
 
-        intersection_trace.insert(intersection_trace.begin(),
-                                  intersection_record<detector_t>{
-                                      {traj.pos(), 0.f, p * traj.dir(), -1.f},
-                                      first_record.vol_idx,
-                                      start_intersection});
+        intersection_trace.insert(
+            intersection_trace.begin(),
+            intersection_record<detector_t>{
+                {traj.pos(), 0.f, p * traj.dir(), traj.charge()},
+                first_record.vol_idx,
+                start_intersection});
 
         return intersection_trace;
     }

--- a/tests/include/detray/test/cpu/detector_scan.hpp
+++ b/tests/include/detray/test/cpu/detector_scan.hpp
@@ -40,7 +40,8 @@ class detector_scan : public test::fixture_base<> {
         algebra_t>::template intersection_trace_type<detector_t>;
     using trajectory_type = typename scan_type<algebra_t>::trajectory_type;
     using uniform_gen_t =
-        random_numbers<scalar_t, std::uniform_real_distribution<scalar_t>>;
+        detail::random_numbers<scalar_t,
+                               std::uniform_real_distribution<scalar_t>>;
     using track_generator_t =
         random_track_generator<free_track_parameters_t, uniform_gen_t>;
 

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -1579,7 +1579,7 @@ int main(int argc, char** argv) {
     // Iterate over reference (pilot) tracks for a rectangular telescope
     // geometry and Jacobian calculation
     using uniform_gen_t =
-        random_numbers<scalar, std::uniform_real_distribution<scalar>>;
+        detail::random_numbers<scalar, std::uniform_real_distribution<scalar>>;
     using trk_generator_t = random_track_generator<track_type, uniform_gen_t>;
     trk_generator_t::configuration trk_gen_cfg{};
     trk_gen_cfg.seed(mc_seed);

--- a/tests/tools/include/detray/options/detector_io_options.hpp
+++ b/tests/tools/include/detray/options/detector_io_options.hpp
@@ -81,15 +81,9 @@ void configure_options<detray::io::detector_writer_config>(
     if (!vm["outdir"].defaulted()) {
         cfg.path(vm["outdir"].as<std::string>());
     }
-    if (vm.count("compactify_json")) {
-        cfg.compactify_json(true);
-    }
-    if (vm.count("write_material")) {
-        cfg.write_material(true);
-    }
-    if (vm.count("write_grids")) {
-        cfg.write_grids(true);
-    }
+    cfg.compactify_json(vm.count("compactify_json"));
+    cfg.write_material(vm.count("write_material"));
+    cfg.write_grids(vm.count("write_grids"));
 }
 
 }  // namespace detray::options

--- a/tests/tools/include/detray/options/track_generator_options.hpp
+++ b/tests/tools/include/detray/options/track_generator_options.hpp
@@ -39,6 +39,7 @@ void add_options<uniform_track_generator_config>(
         "eta_range",
         boost::program_options::value<std::vector<float>>()->multitoken(),
         "Min, Max range of eta values for particle gun")(
+        "randomize_charge", "Randomly flip charge sign per track")(
         "origin",
         boost::program_options::value<std::vector<float>>()->multitoken(),
         "Coordintates for particle gun origin position [mm]")(
@@ -60,6 +61,7 @@ void configure_options<uniform_track_generator_config>(
 
     cfg.phi_steps(vm["phi_steps"].as<std::size_t>());
     cfg.eta_steps(vm["eta_steps"].as<std::size_t>());
+    cfg.randomize_charge(vm.count("randomize_charge"));
 
     if (vm.count("eta_range")) {
         const auto eta_range = vm["eta_range"].as<std::vector<float>>();
@@ -109,6 +111,7 @@ void add_options<random_track_generator_config>(
         "eta_range",
         boost::program_options::value<std::vector<float>>()->multitoken(),
         "Min, Max range of eta values for particle gun")(
+        "randomize_charge", "Randomly flip charge sign per track")(
         "origin",
         boost::program_options::value<std::vector<float>>()->multitoken(),
         "Coordintates for particle gun origin position")(
@@ -129,6 +132,8 @@ void configure_options<random_track_generator_config>(
     random_track_generator_config &cfg) {
 
     cfg.n_tracks(vm["n_tracks"].as<std::size_t>());
+    cfg.randomize_charge(vm.count("randomize_charge"));
+
     if (vm.count("eta_range") && vm.count("theta_range")) {
         throw std::invalid_argument(
             "Eta range and theta range cannot be specified at the same time");

--- a/tests/unit_tests/cpu/simulation/track_generators.cpp
+++ b/tests/unit_tests/cpu/simulation/track_generators.cpp
@@ -218,7 +218,8 @@ GTEST_TEST(detray_simulation, random_track_generator_uniform) {
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =
-        random_numbers<scalar_t, std::uniform_real_distribution<scalar_t>>;
+        detail::random_numbers<scalar_t,
+                               std::uniform_real_distribution<scalar_t>>;
     using trk_generator_t =
         random_track_generator<free_track_parameters<algebra_t>, uniform_gen_t>;
 
@@ -301,7 +302,7 @@ GTEST_TEST(detray_simulation, random_track_generator_normal) {
 
     // Use deterministic random number generator for testing
     using normal_gen_t =
-        random_numbers<scalar_t, std::normal_distribution<scalar_t>>;
+        detail::random_numbers<scalar_t, std::normal_distribution<scalar_t>>;
     using trk_generator_t =
         random_track_generator<free_track_parameters<algebra_t>, normal_gen_t>;
 

--- a/tests/validation/python/impl/__init__.py
+++ b/tests/validation/python/impl/__init__.py
@@ -2,4 +2,4 @@
 from .plot_navigation_validation import read_truth_data, read_navigation_data,plot_navigation_data
 from .plot_material_scan import read_material_data, X0_vs_eta_phi, L0_vs_eta_phi, X0_vs_eta, L0_vs_eta
 from .plot_ray_scan import read_ray_scan_data, plot_intersection_points_xy, plot_intersection_points_rz, plot_detector_scan_data
-from .plot_track_positions import read_track_data, compare_track_pos_xy, compare_track_pos_rz, plot_track_pos_dist, plot_track_pos_res
+from .plot_track_params import read_track_data, plot_track_params, compare_track_pos_xy, compare_track_pos_rz, plot_track_pos_dist, plot_track_pos_res

--- a/tests/validation/python/impl/plot_navigation_validation.py
+++ b/tests/validation/python/impl/plot_navigation_validation.py
@@ -5,7 +5,7 @@
 # Mozilla Public License Version 2.0
 
 from .plot_ray_scan import read_ray_scan_data, plot_intersection_points_xy, plot_intersection_points_rz
-from .plot_track_positions import read_track_data, compare_track_pos_xy, compare_track_pos_rz, plot_track_pos_dist, plot_track_pos_res
+from .plot_track_params import read_track_data, compare_track_pos_xy, compare_track_pos_rz, plot_track_pos_dist, plot_track_pos_res
 
 # python includes
 import pandas as pd

--- a/tests/validation/python/impl/plot_track_params.py
+++ b/tests/validation/python/impl/plot_track_params.py
@@ -26,6 +26,132 @@ def read_track_data(file, logging):
     return df
 
 
+""" Plot the distributions of track parameter data """
+def plot_track_params(opts, detector, track_type, plotFactory, out_format,
+                      df):
+
+    from matplotlib.ticker import ScalarFormatter
+
+    detector_name = detector.replace(' ', '_')
+    n_tracks = len(df['track_id'])
+    tracks =  "rays" if track_type == "ray" else "helices"
+
+    # Plot the charge
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    q_hist_data = plotFactory.hist1D(x       = df['q'],
+                                     bins    = 4,
+                                     xLabel  = r'$q\,\mathrm{[e]}$',
+                                     lgd_ops = lgd_ops,
+                                     ax_formatter = ScalarFormatter())
+
+    plotFactory.write_plot(q_hist_data,
+                           f"{detector_name}_{track_type}_charge_dist",
+                           out_format)
+
+    # Plot the total momentum
+    p = np.sqrt(np.square(df['px']) +  np.square(df['py']) + 
+                np.square(df['pz']))
+
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    p_hist_data = plotFactory.hist1D(x       = p,
+                                     bins    = int(n_tracks / 10),
+                                     xLabel  = r'$p_{tot}\,\mathrm{[GeV]}$',
+                                     lgd_ops = lgd_ops,
+                                     ax_formatter = ScalarFormatter())
+
+    plotFactory.write_plot(p_hist_data,
+                           f"{detector_name}_{track_type}_p_dist",
+                           out_format)
+
+    # Plot the transverse momentum
+    pT = np.sqrt(np.square(df['px']) + np.square(df['py']))
+
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    pT_hist_data = plotFactory.hist1D(x      = pT,
+                                      bins    = int(n_tracks / 10),
+                                      xLabel  = r'$p_{T}\,\mathrm{[GeV]}$',
+                                      lgd_ops = lgd_ops,
+                                      ax_formatter = ScalarFormatter())
+
+    plotFactory.write_plot(pT_hist_data,
+                           f"{detector_name}_{track_type}_pT_dist",
+                           out_format)
+
+    # Plot the x-origin
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    x_hist_data = plotFactory.hist1D(x      = df['x'],
+                                      bins    = int(n_tracks / 10),
+                                      xLabel  = r'$x\,\mathrm{[mm]}$',
+                                      lgd_ops = lgd_ops,
+                                      ax_formatter = ScalarFormatter())
+
+    plotFactory.write_plot(x_hist_data,
+                           f"{detector_name}_{track_type}_x_origin",
+                           out_format)
+
+    # Plot the y-origin
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    y_hist_data = plotFactory.hist1D(x      = df['y'],
+                                      bins    = int(n_tracks / 10),
+                                      xLabel  = r'$y\,\mathrm{[mm]}$',
+                                      lgd_ops = lgd_ops,
+                                      ax_formatter = ScalarFormatter())
+
+    plotFactory.write_plot(y_hist_data,
+                           f"{detector_name}_{track_type}_y_origin",
+                           out_format)
+    # Plot the z-origin
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    z_hist_data = plotFactory.hist1D(x      = df['z'],
+                                      bins    = int(n_tracks / 10),
+                                      xLabel  = r'$z\,\mathrm{[mm]}$',
+                                      lgd_ops = lgd_ops,
+                                      ax_formatter = ScalarFormatter())
+
+    plotFactory.write_plot(z_hist_data,
+                           f"{detector_name}_{track_type}_z_origin",
+                           out_format)
+
+    # Plot the phi angle of the track direction
+    phi = np.arctan2(df['py'], df['px'])
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    dir_phi_hist_data = plotFactory.hist1D(x      = phi,
+                                        bins    = int(n_tracks / 10),
+                                        xLabel  = r'$\varphi\,\mathrm{[rad]}$',
+                                        lgd_ops = lgd_ops,
+                                        ax_formatter = ScalarFormatter())
+
+    plotFactory.write_plot(dir_phi_hist_data,
+                           f"{detector_name}_{track_type}_dir_phi",
+                           out_format)
+
+    # Plot the theta value of the track direction
+    theta = np.arctan2(pT, df['pz'])
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    dir_theta_hist_data = plotFactory.hist1D(x      = theta,
+                                             bins    = int(n_tracks / 10),
+                                             xLabel  = r'$\theta\,\mathrm{[rad]}$',
+                                             lgd_ops = lgd_ops,
+                                             ax_formatter = ScalarFormatter())
+
+    plotFactory.write_plot(dir_theta_hist_data,
+                           f"{detector_name}_{track_type}_dir_theta",
+                           out_format)
+
+    # Plot the eta value of the track direction
+    eta = np.arctanh(df['pz'] / p)
+    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
+    dir_eta_hist_data = plotFactory.hist1D(x       = eta,
+                                           bins    = int(n_tracks / 10),
+                                           xLabel  = r'$\eta$',
+                                           lgd_ops = lgd_ops,
+                                           ax_formatter = ScalarFormatter())
+
+    plotFactory.write_plot(dir_eta_hist_data,
+                           f"{detector_name}_{track_type}_dir_eta",
+                           out_format)
+
+
 """ Plot the track positions of two data sources - rz view """
 def compare_track_pos_xy(opts, detector, scan_type, plotFactory, out_format,
                          df1, label1, color1, df2, label2, color2):
@@ -150,7 +276,7 @@ def compare_track_pos_rz(opts, detector, scan_type, plotFactory, out_format,
 def plot_track_pos_dist(opts, detector, scan_type, plotFactory, out_format,
                         df1, label1, df2, label2):
 
-    n_rays = np.max(df1['track_id']) + 1
+    n_tracks = np.max(df1['track_id']) + 1
     tracks =  "rays" if scan_type == "ray" else "helices"
 
     dist = np.sqrt(np.square(df1['x'] - df2['x']) +
@@ -173,7 +299,7 @@ def plot_track_pos_dist(opts, detector, scan_type, plotFactory, out_format,
     # Plot the xy coordinates of the filtered intersections points
     lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
     hist_data = plotFactory.hist1D(x       = filtered_dist,
-                                   bins    = 100,
+                                   bins    = int(n_tracks / 10),
                                    xLabel  = r'$d\,\mathrm{[mm]}$',
                                    setLog  = True,
                                    lgd_ops = lgd_ops)
@@ -196,7 +322,7 @@ def plot_track_pos_dist(opts, detector, scan_type, plotFactory, out_format,
 def plot_track_pos_res(opts, detector, scan_type, plotFactory, out_format,
                        df1, label1, df2, label2, var):
 
-    n_rays = np.max(df1['track_id']) + 1
+    n_tracks = np.max(df1['track_id']) + 1
     tracks =  "rays" if scan_type == "ray" else "helices"
 
     res = df1[var] - df2[var]
@@ -216,7 +342,7 @@ def plot_track_pos_res(opts, detector, scan_type, plotFactory, out_format,
     # Plot the xy coordinates of the filtered intersections points
     lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
     hist_data = plotFactory.hist1D(x       = filtered_res,
-                                   bins    = 100,
+                                   bins    = int(n_tracks / 10),
                                    xLabel  = r'$\mathrm{res}' + rf'\,{var}' + r'\,\mathrm{[mm]}$',
                                    setLog  = False,
                                    lgd_ops = lgd_ops)

--- a/tests/validation/python/navigation_validation.py
+++ b/tests/validation/python/navigation_validation.py
@@ -86,6 +86,7 @@ def __main__():
     args_list = ["--data_dir", datadir,
                  "--geometry_file", args.geometry_file,
                  "--n_tracks", str(args.n_tracks),
+                 "--randomize_charge", str(args.randomize_charge),
                  "--p_T", str(args.transverse_momentum),
                  "--eta_range", str(args.eta_range[0]), str(args.eta_range[1]),
                  "--min_mask_tolerance", str(args.min_mask_tol),

--- a/tests/validation/python/navigation_validation.py
+++ b/tests/validation/python/navigation_validation.py
@@ -6,6 +6,7 @@
 
 # detray imports
 from impl import read_truth_data, read_navigation_data, plot_navigation_data
+from impl import plot_track_params
 from impl import plot_detector_scan_data, plot_track_pos_dist, plot_track_pos_res
 from options import (common_options, detector_io_options,
                      random_track_generator_options, propagation_options,
@@ -135,6 +136,15 @@ def __main__():
 
     plot_detector_scan_data(args, det_name, plot_factory, "ray", ray_scan_df, "ray_scan", out_format)
     plot_detector_scan_data(args, det_name, plot_factory, "helix", helix_scan_df, "helix_scan", out_format)
+
+    # Plot distributions of track parameter values
+    # Only take initial track parameters from generator
+    ray_intial_trk_df = ray_scan_df.drop_duplicates(subset=['track_id'])
+    helix_intial_trk_df = helix_scan_df.drop_duplicates(subset=['track_id'])
+    plot_track_params(args, det_name, "helix", plot_factory, out_format,
+                      helix_intial_trk_df)
+    plot_track_params(args, det_name, "ray", plot_factory, out_format,
+                      ray_intial_trk_df)
 
     # Read the recorded data
     ray_nav_df, ray_truth_df, ray_nav_cuda_df, helix_nav_df, helix_truth_df, helix_nav_cuda_df = read_navigation_data(datadir, args.cuda, logging)

--- a/tests/validation/python/options/track_generator_options.py
+++ b/tests/validation/python/options/track_generator_options.py
@@ -25,6 +25,9 @@ def random_track_generator_options():
     parser.add_argument("--eta_range", "-eta", nargs=2,
                         help=("Eta range of generated tracks"),
                         default = [-4, 4], type=float)
+    parser.add_argument("--randomize_charge", "-rand_chrg",
+                        help=("Randomly flip charge sign per track"),
+                        action="store_true", default=True)
 
     return parser
 

--- a/tutorials/src/cpu/detector/detector_ray_scan.cpp
+++ b/tutorials/src/cpu/detector/detector_ray_scan.cpp
@@ -62,9 +62,8 @@ int main() {
     std::size_t n_rays{0u};
 
     // Generate a number of random rays
-    using generator_t =
-        detray::random_numbers<detray::scalar,
-                               std::uniform_real_distribution<detray::scalar>>;
+    using generator_t = detray::detail::random_numbers<
+        detray::scalar, std::uniform_real_distribution<detray::scalar>>;
     auto ray_generator = detray::random_track_generator<ray_t, generator_t>{};
     ray_generator.config().n_tracks(10000).p_T(
         1.f * detray::unit<detray::scalar>::GeV);

--- a/utils/include/detray/simulation/event_generator/random_numbers.hpp
+++ b/utils/include/detray/simulation/event_generator/random_numbers.hpp
@@ -1,0 +1,89 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/algebra.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+
+// System include(s)
+#include <array>
+#include <limits>
+#include <random>
+
+namespace detray::detail {
+
+/// Wrapper for CPU random number generatrion for the @c random_track_generator
+template <typename scalar_t = scalar,
+          typename distribution_t = std::uniform_real_distribution<scalar_t>,
+          typename engine_t = std::mt19937_64>
+struct random_numbers {
+
+    using distribution_type = distribution_t;
+    using engine_type = engine_t;
+    using seed_type = typename engine_t::result_type;
+
+    std::seed_seq m_seeds;
+    engine_t m_engine;
+
+    /// Default seed
+    DETRAY_HOST
+    random_numbers()
+        : m_seeds{random_numbers::default_seed()}, m_engine{m_seeds} {}
+
+    /// Different seed @param s for every instance
+    DETRAY_HOST
+    random_numbers(seed_type s) : m_seeds{s}, m_engine{m_seeds} {}
+
+    /// More entropy in seeds from collection @param s
+    DETRAY_HOST
+    random_numbers(const std::vector<seed_type>& s)
+        : m_seeds{s.begin(), s.end()}, m_engine{m_seeds} {}
+
+    /// Copy constructor
+    DETRAY_HOST
+    random_numbers(random_numbers&& other)
+        : m_engine(std::move(other.m_engine)) {}
+
+    /// Generate random numbers in a given range
+    DETRAY_HOST auto operator()(const std::array<scalar_t, 2> range = {
+                                    -std::numeric_limits<scalar_t>::max(),
+                                    std::numeric_limits<scalar_t>::max()}) {
+        const scalar_t min{range[0]}, max{range[1]};
+        assert(min <= max);
+
+        // Uniform
+        if constexpr (std::is_same_v<
+                          distribution_t,
+                          std::uniform_real_distribution<scalar_t>>) {
+            return distribution_t(min, max)(m_engine);
+
+            // Normal
+        } else if constexpr (std::is_same_v<
+                                 distribution_t,
+                                 std::normal_distribution<scalar_t>>) {
+            scalar_t mu{min + 0.5f * (max - min)};
+            return distribution_t(mu, 0.5f / 3.0f * (max - min))(m_engine);
+        }
+    }
+
+    /// Explicit normal distribution around a @param mean and @param stddev
+    DETRAY_HOST auto normal(const scalar_t mean, const scalar_t stddev) {
+        return std::normal_distribution<scalar_t>(mean, stddev)(m_engine);
+    }
+
+    /// 50:50 coin toss
+    DETRAY_HOST std::uint8_t coin_toss() {
+        return std::uniform_int_distribution<std::uint8_t>(0u, 1u)(m_engine);
+    }
+
+    /// Get the default seed of the engine
+    static constexpr seed_type default_seed() { return engine_t::default_seed; }
+};
+
+}  // namespace detray::detail

--- a/utils/include/detray/simulation/event_generator/random_track_generator.hpp
+++ b/utils/include/detray/simulation/event_generator/random_track_generator.hpp
@@ -36,7 +36,7 @@ namespace detray {
 /// generator, which must not be invalidated during the iteration.
 /// @note the random numbers are clamped to fit the phi/theta ranges. This can
 /// effect distribution mean etc.
-template <typename track_t, typename generator_t = random_numbers<>>
+template <typename track_t, typename generator_t = detail::random_numbers<>>
 class random_track_generator
     : public detray::ranges::view_interface<
           random_track_generator<track_t, generator_t>> {
@@ -115,7 +115,13 @@ class random_track_generator
             mom = (m_cfg.is_pT() ? 1.f / sin_theta : 1.f) * p_mag *
                   vector::normalize(mom);
 
-            return track_t{vtx, m_cfg.time(), mom, m_cfg.charge()};
+            // Randomly flip the charge sign
+            std::array<double, 2> signs{1., -1.};
+            const auto sign{static_cast<scalar>(
+                signs[m_cfg.randomize_charge() ? m_rnd_numbers.coin_toss()
+                                               : 0u])};
+
+            return track_t{vtx, m_cfg.time(), mom, sign * m_cfg.charge()};
         }
 
         /// Random number generator

--- a/utils/include/detray/simulation/event_generator/random_track_generator_config.hpp
+++ b/utils/include/detray/simulation/event_generator/random_track_generator_config.hpp
@@ -12,6 +12,7 @@
 #include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/simulation/event_generator/random_numbers.hpp"
 
 // System include(s)
 #include <algorithm>
@@ -22,69 +23,6 @@
 
 namespace detray {
 
-/// Wrapper for CPU random number generatrion for the @c random_track_generator
-template <typename scalar_t = scalar,
-          typename distribution_t = std::uniform_real_distribution<scalar_t>,
-          typename engine_t = std::mt19937_64>
-struct random_numbers {
-
-    using distribution_type = distribution_t;
-    using engine_type = engine_t;
-    using seed_type = typename engine_t::result_type;
-
-    std::seed_seq m_seeds;
-    engine_t m_engine;
-
-    /// Default seed
-    DETRAY_HOST
-    random_numbers()
-        : m_seeds{random_numbers::default_seed()}, m_engine{m_seeds} {}
-
-    /// Different seed @param s for every instance
-    DETRAY_HOST
-    random_numbers(seed_type s) : m_seeds{s}, m_engine{m_seeds} {}
-
-    /// More entropy in seeds from collection @param s
-    DETRAY_HOST
-    random_numbers(const std::vector<seed_type>& s)
-        : m_seeds{s.begin(), s.end()}, m_engine{m_seeds} {}
-
-    /// Copy constructor
-    DETRAY_HOST
-    random_numbers(random_numbers&& other)
-        : m_engine(std::move(other.m_engine)) {}
-
-    /// Generate random numbers in a given range
-    DETRAY_HOST auto operator()(const std::array<scalar_t, 2> range = {
-                                    -std::numeric_limits<scalar_t>::max(),
-                                    std::numeric_limits<scalar_t>::max()}) {
-        const scalar_t min{range[0]}, max{range[1]};
-        assert(min <= max);
-
-        // Uniform
-        if constexpr (std::is_same_v<
-                          distribution_t,
-                          std::uniform_real_distribution<scalar_t>>) {
-            return distribution_t(min, max)(m_engine);
-
-            // Normal
-        } else if constexpr (std::is_same_v<
-                                 distribution_t,
-                                 std::normal_distribution<scalar_t>>) {
-            scalar_t mu{min + 0.5f * (max - min)};
-            return distribution_t(mu, 0.5f / 3.0f * (max - min))(m_engine);
-        }
-    }
-
-    /// Explicit normal distribution around a @param mean and @param stddev
-    DETRAY_HOST auto normal(const scalar_t mean, const scalar_t stddev) {
-        return std::normal_distribution<scalar_t>(mean, stddev)(m_engine);
-    }
-
-    /// Get the default seed of the engine
-    static constexpr seed_type default_seed() { return engine_t::default_seed; }
-};
-
 /// Configuration for the random track generator
 struct random_track_generator_config {
 
@@ -94,7 +32,7 @@ struct random_track_generator_config {
     bool m_do_vtx_smearing = false;
 
     /// Monte-Carlo seed
-    seed_t m_seed{random_numbers<>::default_seed()};
+    seed_t m_seed{detail::random_numbers<>::default_seed()};
 
     /// How many tracks will be generated
     std::size_t m_n_tracks{10u};
@@ -113,6 +51,9 @@ struct random_track_generator_config {
     /// Track origin
     std::array<scalar, 3> m_origin{0.f, 0.f, 0.f},
         m_origin_stddev{0.f, 0.f, 0.f};
+
+    /// Randomly flip the charge sign?
+    bool m_randomize_charge{false};
 
     /// Time parameter and charge of the track
     scalar m_time{0.f * unit<scalar>::us}, m_charge{-1.f * unit<scalar>::e};
@@ -237,6 +178,11 @@ struct random_track_generator_config {
         m_origin_stddev = {stddev[0], stddev[1], stddev[2]};
         return *this;
     }
+    DETRAY_HOST_DEVICE
+    random_track_generator_config& randomize_charge(bool rc) {
+        m_randomize_charge = rc;
+        return *this;
+    }
     DETRAY_HOST_DEVICE random_track_generator_config& time(scalar t) {
         assert(t >= 0.f);
         m_time = t;
@@ -274,6 +220,9 @@ struct random_track_generator_config {
         return m_origin_stddev;
     }
     DETRAY_HOST_DEVICE constexpr bool is_pT() const { return m_is_pT; }
+    DETRAY_HOST_DEVICE constexpr bool randomize_charge() const {
+        return m_randomize_charge;
+    }
     DETRAY_HOST_DEVICE constexpr scalar time() const { return m_time; }
     DETRAY_HOST_DEVICE constexpr scalar charge() const { return m_charge; }
     /// @}
@@ -293,7 +242,9 @@ inline std::ostream& operator<<(std::ostream& out,
         << "----------------------------\n"
         << "  No. tracks            : " << cfg.n_tracks() << "\n"
         << "  Charge                : "
-        << cfg.charge() / detray::unit<scalar>::e << " [e]\n";
+        << cfg.charge() / detray::unit<scalar>::e << " [e]\n"
+        << "  Rand. charge          : " << std::boolalpha
+        << cfg.randomize_charge() << std::noboolalpha << "\n";
 
     // Momentum and direction
     if (cfg.is_pT()) {


### PR DESCRIPTION
Allow to randomize the charge sign in the track generators. For this, the random number generator wrapper was moved to its own header, so that it can be shared between the random and uniform track generators. The randomization can be switched on via the track generator options and the navigation trajectories (ray/helix) now returns their associated charge. Some changes to the IO options were reverted - should have no further effect besides being more intuitive.

Also adds plots for the distribution of the parameters of the tracks that are generated by the track generators and fixes the Gauss fits a little.