### PR TITLE
ref: Estimate phi tolerance from chord

### DIFF
--- a/core/include/detray/geometry/detail/shape_utils.hpp
+++ b/core/include/detray/geometry/detail/shape_utils.hpp
@@ -1,0 +1,24 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+namespace detray::detail {
+
+/// Generate phi tolerance from distance tolerance
+///
+/// @param tol is the distance tolerance in mm
+/// @param radius is the radius of the shape
+///
+/// @return the opening angle of a chord the size of tol (= 2*arcsin(c/(2r)))
+/// using a small angle approximation
+template <typename scalar_t>
+inline constexpr scalar_t phi_tolerance(scalar_t tol, scalar_t radius) {
+    return tol / radius;
+}
+
+}  // namespace detray::detail

--- a/core/include/detray/geometry/shapes/annulus2D.hpp
+++ b/core/include/detray/geometry/shapes/annulus2D.hpp
@@ -15,6 +15,7 @@
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/polar2D.hpp"
+#include "detray/geometry/detail/shape_utils.hpp"
 #include "detray/geometry/detail/vertexing.hpp"
 
 // System include(s)
@@ -100,8 +101,10 @@ class annulus2D {
         const scalar_t phi_strp = loc_p[1] - bounds[e_average_phi];
 
         // Check phi boundaries, which are well def. in focal frame
-        const auto phi_check = !((phi_strp < (bounds[e_min_phi_rel] - tol)) or
-                                 (phi_strp > (bounds[e_max_phi_rel] + tol)));
+        const scalar_t phi_tol = detail::phi_tolerance(tol, loc_p[0]);
+        const auto phi_check =
+            !((phi_strp < (bounds[e_min_phi_rel] - phi_tol)) or
+              (phi_strp > (bounds[e_max_phi_rel] + phi_tol)));
 
         // Now go to beam frame to check r boundaries. Use the origin
         // shift in polar coordinates for that

--- a/core/include/detray/geometry/shapes/cylinder3D.hpp
+++ b/core/include/detray/geometry/shapes/cylinder3D.hpp
@@ -14,6 +14,7 @@
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/cylindrical3D.hpp"
+#include "detray/geometry/detail/shape_utils.hpp"
 
 // System include(s)
 #include <limits>
@@ -65,11 +66,14 @@ class cylinder3D {
     DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_t<scalar_t, kDIM> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
+
+        const scalar_t phi_tol = detail::phi_tolerance(tol, loc_p[0]);
+
         return ((bounds[e_min_r] - tol) <= loc_p[0] &&
-                (bounds[e_min_phi] - tol) <= loc_p[1] &&
+                (bounds[e_min_phi] - phi_tol) <= loc_p[1] &&
                 (bounds[e_min_z] - tol) <= loc_p[2] &&
                 loc_p[0] <= (bounds[e_max_r] + tol) &&
-                loc_p[1] <= (bounds[e_max_phi] + tol) &&
+                loc_p[1] <= (bounds[e_max_phi] + phi_tol) &&
                 loc_p[2] <= (bounds[e_max_z] + tol));
     }
 

--- a/tests/unit_tests/cpu/geometry/masks/annulus2D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/annulus2D.cpp
@@ -63,7 +63,7 @@ GTEST_TEST(detray_masks, annulus2D) {
     ASSERT_FALSE(ann2.is_inside(toStripFrame(p2_out4)));
     // Move outside point inside using a tolerance
     ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out1), 1.3f));
-    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out4), 0.07f));
+    ASSERT_TRUE(ann2.is_inside(toStripFrame(p2_out4), 0.9f));
 
     // Check area: @TODO not implemented, yet
     scalar a = ann2.area();


### PR DESCRIPTION
Interpret the mask tolerance parameter in inside/outside check for phi angles as the opening angle that corresponds to a chord of the length of the tolerance. Since the phi tolerance is always small, the calculation can be done with a small angle approximation and is relatively cheap.