### PR TITLE
ref: Add material maps to all portals in toy detector and harmonize with material scan

### DIFF
--- a/tests/include/detray/test/common/utils/material_validation_utils.hpp
+++ b/tests/include/detray/test/common/utils/material_validation_utils.hpp
@@ -127,6 +127,14 @@ struct material_tracer : detray::actor {
 
         const auto &navigation = prop_state._navigation;
 
+        // Record the initial track direction
+        vector3_t glob_dir = prop_state._stepping().dir();
+        if (detray::detail::is_invalid_value(tracer.mat_record.eta) &&
+            detray::detail::is_invalid_value(tracer.mat_record.phi)) {
+            tracer.mat_record.eta = getter::eta(glob_dir);
+            tracer.mat_record.phi = getter::phi(glob_dir);
+        }
+
         // Only count material if navigator encountered it
         if (!navigation.encountered_sf_material()) {
             return;
@@ -139,7 +147,6 @@ struct material_tracer : detray::actor {
         const auto sf = navigation.get_surface();
 
         // Track direction and bound position on current surface
-        vector3_t glob_dir{};
         point2_t loc_pos{};
 
         // Get the local track position from the bound track parameters,
@@ -149,7 +156,6 @@ struct material_tracer : detray::actor {
                           typename propagator_state_t::actor_chain_type::
                               state>) {
             const auto &track_param = prop_state._stepping._bound_params;
-            glob_dir = track_param.dir();
             loc_pos = track_param.bound_local();
         } else {
             const auto &track_param = prop_state._stepping();
@@ -167,14 +173,6 @@ struct material_tracer : detray::actor {
         const scalar_t ml0{mat_params.mat_L0};
 
         // Fill the material record
-
-        // Record the initial track direction
-        if (detray::detail::is_invalid_value(tracer.mat_record.eta) &&
-            detray::detail::is_invalid_value(tracer.mat_record.phi)) {
-            tracer.mat_record.eta = getter::eta(glob_dir);
-            tracer.mat_record.phi = getter::phi(glob_dir);
-        }
-
         if (mx0 > 0.f) {
             tracer.mat_record.sX0 += seg / mx0;
             tracer.mat_record.tX0 += t / mx0;

--- a/tests/include/detray/test/cpu/material_validation.hpp
+++ b/tests/include/detray/test/cpu/material_validation.hpp
@@ -89,8 +89,8 @@ class material_validation_impl : public test::fixture_base<> {
         }
 
         // Name of the material scan data collection
-        m_scan_data_name = "material_scan_" + m_det.name(m_names);
-        m_track_data_name = "material_scan_tracks_" + m_det.name(m_names);
+        m_scan_data_name = m_det.name(m_names) + "_material_scan";
+        m_track_data_name = m_det.name(m_names) + "_material_scan_tracks";
 
         // Check that data is available in memory
         if (!m_cfg.whiteboard()->exists(m_scan_data_name)) {
@@ -159,8 +159,8 @@ class material_validation_impl : public test::fixture_base<> {
 
         // Print accumulated material per track
         std::filesystem::path mat_path{m_cfg.material_file()};
-        auto file_name{material_validator_t::name + "_" +
-                       mat_path.stem().string() + "_" + m_det.name(m_names) +
+        auto file_name{m_det.name(m_names) + "_" + material_validator_t::name +
+                       "_" + mat_path.stem().string() +
                        mat_path.extension().string()};
 
         material_validator::write_material(mat_path.replace_filename(file_name),

--- a/tests/include/detray/test/cpu/toy_detector_test.hpp
+++ b/tests/include/detray/test/cpu/toy_detector_test.hpp
@@ -168,8 +168,8 @@ inline bool toy_detector_test(
         EXPECT_FALSE(has_hom_material);
         EXPECT_EQ(
             materials.template size<material_ids::e_concentric_cylinder2_map>(),
-            21u);
-        EXPECT_EQ(materials.template size<material_ids::e_disc2_map>(), 20u);
+            54u);
+        EXPECT_EQ(materials.template size<material_ids::e_disc2_map>(), 58u);
     }
 
     // Check the surface source links

--- a/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
@@ -111,12 +111,12 @@ int main(int argc, char **argv) {
     test::material_validation<toy_detector_t>::config mat_val_cfg{};
     mat_val_cfg.name("toy_detector_material_validaiton");
     mat_val_cfg.whiteboard(white_board);
-    mat_val_cfg.tol(1e-6f);  // < Reduce tolerance for single precision tests
+    mat_val_cfg.tol(1.5e-6f);  // < Reduce tolerance for single precision tests
     mat_val_cfg.propagation() = cfg_str_nav.propagation();
 
     // @TODO: Put material maps on all portals
-    /*detail::register_checks<test::material_validation>(toy_det, toy_names,
-                                                            mat_val_cfg);*/
+    detail::register_checks<test::material_validation>(toy_det, toy_names,
+                                                       mat_val_cfg);
 
     // Run the material validation - Homogeneous material
     toy_cfg.use_material_maps(false);

--- a/tests/tools/src/cpu/generate_toy_detector.cpp
+++ b/tests/tools/src/cpu/generate_toy_detector.cpp
@@ -40,6 +40,10 @@ int main(int argc, char **argv) {
     po::variables_map vm =
         detray::options::parse_options(desc, argc, argv, toy_cfg, writer_cfg);
 
+    // Make sure material is written to file, if it was requested
+    writer_cfg.write_material(vm.count("homogeneous_material") ||
+                              vm.count("material_maps"));
+
     // Build the geometry
     vecmem::host_memory_resource host_mr;
     auto [toy_det, toy_names] = build_toy_detector(host_mr, toy_cfg);

--- a/tests/validation/python/impl/plot_material_scan.py
+++ b/tests/validation/python/impl/plot_material_scan.py
@@ -15,29 +15,32 @@ import pandas as pd
 
 
 """ Read the material scan data from file and prepare data frame """
-def read_material_data(inputdir, logging):
+def read_material_data(inputdir, logging, det_name, read_cuda):
 
     # Input data directory
     data_dir = os.fsencode(inputdir)
 
     detector_name = "default_detector"
-    material_scan_file = ""
+    material_scan_file = cpu_material_trace_file = cuda_material_trace_file = ""
 
     # Find the data files by naming convention
     for file in os.listdir(data_dir):
         filename = os.fsdecode(file)
 
-        if filename.find('material_scan_') != -1:
+        if filename.find(det_name + '_material_scan') != -1:
             material_scan_file = inputdir + "/" + filename
-            file_name = os.path.basename(material_scan_file)
-            detector_name = file_name.removeprefix('material_scan_ ')
-            detector_name = detector_name.removesuffix('.csv')
+        elif filename.find(det_name + '_cpu_navigation_material_trace') != -1:
+            cpu_material_trace_file = inputdir + "/" + filename
+        elif read_cuda and filename.find(det_name + '_cuda_navigation_material_trace') != -1:
+            cuda_material_trace_file = inputdir + "/" + filename
 
-    detector_name = detector_name.replace('_', ' ')
+    df_scan = pd.read_csv(material_scan_file)
+    df_cpu_trace = pd.read_csv(cpu_material_trace_file)
+    df_cuda_trace = pd.DataFrame({})
+    if read_cuda:
+        df_cuda_trace = pd.read_csv(cuda_material_trace_file)
 
-    df = pd.read_csv(material_scan_file)
-
-    return detector_name, df
+    return df_scan, df_cpu_trace, df_cuda_trace
 
 
 """ Calculate edges of bins to plot the mateiral data """
@@ -59,7 +62,7 @@ def get_n_bins(df):
 
 
 """ Plot the material thickenss vs phi and eta in units of X_0 """
-def X0_vs_eta_phi(df, detector, plotFactory,  out_format =  "pdf"):
+def X0_vs_eta_phi(df, label, detector, plotFactory,  out_format =  "pdf"):
 
     # Histogram bin edges
     xBinning, yBinning = get_n_bins(df)
@@ -76,7 +79,7 @@ def X0_vs_eta_phi(df, detector, plotFactory,  out_format =  "pdf"):
                             xBins = xBinning, yBins = yBinning,
                             showStats = False)
 
-    plotFactory.write_plot(hist_data, "t_X0_map",  out_format)
+    plotFactory.write_plot(hist_data, detector + "_" + label + "_t_X0_map",  out_format)
 
     # Plot path length through material of the respective ray in units of X_0
     hist_data = plotFactory.hist2D(
@@ -90,11 +93,11 @@ def X0_vs_eta_phi(df, detector, plotFactory,  out_format =  "pdf"):
                             xBins = xBinning, yBins = yBinning,
                             showStats = False)
 
-    plotFactory.write_plot(hist_data, "s_X0_map",  out_format)
+    plotFactory.write_plot(hist_data, detector + "_" + label + "_s_X0_map",  out_format)
 
 
 """ Plot the material thickenss vs phi and eta in units of L_0 """
-def L0_vs_eta_phi(df, detector, plotFactory,  out_format =  "pdf"):
+def L0_vs_eta_phi(df, label, detector, plotFactory,  out_format =  "pdf"):
 
     # Histogram bin edges
     xBinning, yBinning = get_n_bins(df)
@@ -111,7 +114,7 @@ def L0_vs_eta_phi(df, detector, plotFactory,  out_format =  "pdf"):
                             xBins = xBinning, yBins = yBinning,
                             showStats = False)
 
-    plotFactory.write_plot(hist_data, "t_L0_map",  out_format)
+    plotFactory.write_plot(hist_data, detector + "_" + label + "_t_L0_map",  out_format)
 
     # Plot path length through material of the respective ray in units of L_0
     hist_data = plotFactory.hist2D(
@@ -125,11 +128,11 @@ def L0_vs_eta_phi(df, detector, plotFactory,  out_format =  "pdf"):
                             xBins = xBinning, yBins = yBinning,
                             showStats = False)
 
-    plotFactory.write_plot(hist_data, "s_L0_map",  out_format)
+    plotFactory.write_plot(hist_data, detector + "_" + label + "_s_L0_map",  out_format)
 
 
 """ Plot the material thickness in units of X_0 vs eta """
-def X0_vs_eta(df, detector, plotFactory,  out_format =  "pdf"):
+def X0_vs_eta(df, label, detector, plotFactory,  out_format =  "pdf"):
 
     # Histogram bin edges
     xBinning, yBinning = get_n_bins(df)
@@ -152,7 +155,7 @@ def X0_vs_eta(df, detector, plotFactory,  out_format =  "pdf"):
     # Move the legend ouside plo
     hist_data.lgd.set_bbox_to_anchor((0.825, 1.15))
 
-    plotFactory.write_plot(hist_data, "t_X0",  out_format)
+    plotFactory.write_plot(hist_data, detector + "_" + label + "_t_X0",  out_format)
 
     hist_data = plotFactory.hist1D(
                             x      = df['eta'],
@@ -168,11 +171,11 @@ def X0_vs_eta(df, detector, plotFactory,  out_format =  "pdf"):
     # Move the legend ouside plo
     hist_data.lgd.set_bbox_to_anchor((0.825, 1.15))
 
-    plotFactory.write_plot(hist_data, "s_X0",  out_format)
+    plotFactory.write_plot(hist_data, detector + "_" + label + "_s_X0",  out_format)
 
 
 """ Plot the material thickness in units of L_0 vs eta """
-def L0_vs_eta(df, detector, plotFactory,  out_format =  "pdf"):
+def L0_vs_eta(df, label, detector, plotFactory,  out_format =  "pdf"):
 
     # Histogram bin edges
     xBinning, yBinning = get_n_bins(df)
@@ -195,7 +198,7 @@ def L0_vs_eta(df, detector, plotFactory,  out_format =  "pdf"):
     # Move the legend ouside plo
     hist_data.lgd.set_bbox_to_anchor((0.825, 1.15))
 
-    plotFactory.write_plot(hist_data, "t_L0",  out_format)
+    plotFactory.write_plot(hist_data, detector + "_" + label + "_t_L0",  out_format)
 
     hist_data = plotFactory.hist1D(
                             x      = df['eta'],
@@ -211,4 +214,4 @@ def L0_vs_eta(df, detector, plotFactory,  out_format =  "pdf"):
     # Move the legend ouside plo
     hist_data.lgd.set_bbox_to_anchor((0.825, 1.15))
 
-    plotFactory.write_plot(hist_data, "s_L0",  out_format)
+    plotFactory.write_plot(hist_data, detector + "_" + label + "_s_L0",  out_format)

--- a/tests/validation/python/material_validation.py
+++ b/tests/validation/python/material_validation.py
@@ -8,12 +8,18 @@
 from impl import plot_material_scan as mat_plotter
 from impl import read_material_data
 from plotting import pyplot_factory as plt_factory
-from options import common_options, plotting_options
-from options import parse_common_options, parse_plotting_options
+from options import (common_options, detector_io_options,
+                     uniform_track_generator_options, propagation_options,
+                     plotting_options)
+from options import (parse_common_options, parse_detector_io_options, 
+                     parse_plotting_options)
 
 # python includes
 import argparse
-
+import json
+import os
+import subprocess
+import sys
 
 def __main__():
 
@@ -21,28 +27,132 @@ def __main__():
 
     descr = "Detray Material Validation"
 
-    common_parser = common_options(descr)
-    plotting_parser = plotting_options()
+    # Define options
+    parent_parsers = [common_options(descr),
+                      detector_io_options(),
+                      uniform_track_generator_options(),
+                      propagation_options(),
+                      plotting_options()]
 
-    parser = argparse.ArgumentParser(description = descr, parents=[common_parser, plotting_parser])
+    parser = argparse.ArgumentParser(description=descr, parents=parent_parsers)
+
+    parser.add_argument("--bindir", "-bin",
+                        help=("Directoy containing the validation executables"),
+                        default = "./bin", type=str)
+    parser.add_argument("--datadir", "-data",
+                        help=("Directoy containing the data files"),
+                        default = "./validation_data/material", type=str)
+    parser.add_argument("--tolerance", "-t",
+                        help=("Tolerance for material comparisons"),
+                        default = 0.0001, type=float)
+    parser.add_argument("--cuda",
+                        help=("Run the CUDA material validation."),
+                        action="store_true", default=False)
+    parser.add_argument("--sycl",
+                        help=("Run the SYCL material validation."),
+                        action="store_true", default=False)
 
     args = parser.parse_args()
 
     logging = parse_common_options(args, descr)
-    input_dir, out_dir, out_format = parse_plotting_options(args, logging)
+    parse_detector_io_options(args, logging)
+    in_dir, out_dir, out_format = parse_plotting_options(args, logging)
+
+    # IO path for data files
+    datadir = args.datadir.strip("/")
+
+    # Check bin path
+    bindir = args.bindir.strip("/")
+    cpu_validation = bindir + "/detray_material_validation"
+    cuda_validation = bindir + "/detray_material_validation_cuda"
+
+    if not os.path.isdir(bindir) or not os.path.isfile(cpu_validation):
+        logging.error(f"Material validation binaries were not found! ({args.bindir})")
+        sys.exit(1)
+
+#------------------------------------------------------------------------run
+
+    # Pass on the options for the validation tools
+    args_list = ["--geometry_file", args.geometry_file,
+                 "--material_file", args.material_file,
+                 "--phi_steps", str(args.phi_steps),
+                 "--eta_steps", str(args.eta_steps),
+                 "--eta_range", str(args.eta_range[0]), str(args.eta_range[1]),
+                 "--tol", str(args.tolerance),
+                 "--min_mask_tolerance", str(args.min_mask_tol),
+                 "--max_mask_tolerance", str(args.max_mask_tol),
+                 "--overstep_tolerance", str(args.overstep_tol),
+                 "--path_tolerance", str(args.path_tol),
+                 "--rk-tolerance", str(args.rk_error_tol),
+                 "--path_limit", str(args.path_limit),
+                 "--search_window", str(args.search_window[0]),
+                 str(args.search_window[1])]
+
+    if args.grid_file:
+        args_list = args_list + ["--grid_file", args.grid_file]
+
+    # Run the host validation and produce the truth data
+    logging.debug("Running CPU material validation")
+    subprocess.run([cpu_validation] + args_list)
+
+    # Run the device validation (if it has been built)
+    if args.cuda and os.path.isfile(cuda_validation):
+        logging.debug("Running CUDA material validation")
+        subprocess.run([cuda_validation] + args_list)
+
+    elif args.cuda:
+        logging.error("Could not find CUDA material validation executable")
+
+    if args.sycl:
+        logging.error("SYCL material validation is not implemented")
 
 #------------------------------------------------------------------------plot
 
-    detector_name, df = read_material_data(input_dir, logging)
+    logging.info("Generating data plots...\n")
 
-    plot_factory = plt_factory(out_dir + "material_", logging)
+    geo_file = open(args.geometry_file)
+    json_geo = json.loads(geo_file.read())
+
+    det_name = json_geo['header']['common']['detector']
+    logging.debug("Detector: " + det_name)
+
+    df_scan, df_cpu, df_cuda = read_material_data(in_dir, logging, det_name,
+                                                  args.cuda)
+
+    plot_factory = plt_factory(out_dir, logging)
 
     # The histograms are not re-weighted (if the rays are not evenly distributed
     # the material in some bins might be artificially high)!
-    mat_plotter.X0_vs_eta_phi(df, detector_name, plot_factory, out_format)
-    mat_plotter.L0_vs_eta_phi(df, detector_name, plot_factory, out_format)
-    mat_plotter.X0_vs_eta(df, detector_name, plot_factory, out_format)
-    mat_plotter.L0_vs_eta(df, detector_name, plot_factory, out_format)
+    mat_plotter.X0_vs_eta_phi(df_scan, "material_scan", det_name,
+                              plot_factory, out_format)
+    mat_plotter.L0_vs_eta_phi(df_scan, "material_scan", det_name,
+                              plot_factory, out_format)
+    mat_plotter.X0_vs_eta(df_scan, "material_scan", det_name,
+                              plot_factory, out_format)
+    mat_plotter.L0_vs_eta(df_scan, "material_scan", det_name,
+                              plot_factory, out_format)
+
+    # Navigaiton material Traces
+    # CPU
+    mat_plotter.X0_vs_eta_phi(df_cpu, "cpu_material_trace", det_name,
+                              plot_factory, out_format)
+    mat_plotter.L0_vs_eta_phi(df_cpu, "cpu_material_trace", det_name,
+                              plot_factory, out_format)
+    mat_plotter.X0_vs_eta(df_cpu, "cpu_material_trace", det_name,
+                          plot_factory, out_format)
+    mat_plotter.L0_vs_eta(df_cpu, "cpu_material_trace", det_name,
+                          plot_factory, out_format)
+
+    # CUDA
+    if args.cuda:
+        mat_plotter.X0_vs_eta_phi(df_cuda, "cuda_material_trace", det_name,
+                                plot_factory, out_format)
+        mat_plotter.L0_vs_eta_phi(df_cuda, "cuda_material_trace", det_name,
+                                plot_factory, out_format)
+        mat_plotter.X0_vs_eta(df_cuda, "cuda_material_trace", det_name,
+                              plot_factory, out_format)
+        mat_plotter.L0_vs_eta(df_cuda, "cuda_material_trace", det_name,
+                              plot_factory, out_format)
 
 #-------------------------------------------------------------------------------
 

--- a/tests/validation/python/navigation_validation.py
+++ b/tests/validation/python/navigation_validation.py
@@ -8,7 +8,7 @@
 from impl import read_truth_data, read_navigation_data, plot_navigation_data
 from impl import plot_detector_scan_data, plot_track_pos_dist, plot_track_pos_res
 from options import (common_options, detector_io_options,
-                     track_generator_options, propagation_options,
+                     random_track_generator_options, propagation_options,
                      plotting_options)
 from options import (parse_common_options, parse_detector_io_options, 
                      parse_plotting_options)
@@ -30,7 +30,7 @@ def __main__():
     # Define options
     parent_parsers = [common_options(descr),
                       detector_io_options(),
-                      track_generator_options(),
+                      random_track_generator_options(),
                       propagation_options(),
                       plotting_options()]
 
@@ -63,6 +63,7 @@ def __main__():
 
     # Parse options
     args = parser.parse_args()
+
     logging = parse_common_options(args, descr)
     parse_detector_io_options(args, logging)
     in_dir, out_dir, out_format = parse_plotting_options(args, logging)

--- a/tests/validation/python/options/__init__.py
+++ b/tests/validation/python/options/__init__.py
@@ -3,4 +3,4 @@ from .common_options import common_options, parse_common_options
 from .plotting_options import plotting_options, parse_plotting_options
 from .detector_io_options import detector_io_options, parse_detector_io_options
 from .propagation_options import propagation_options
-from .track_generator_options import track_generator_options
+from .track_generator_options import random_track_generator_options, uniform_track_generator_options

--- a/tests/validation/python/options/track_generator_options.py
+++ b/tests/validation/python/options/track_generator_options.py
@@ -11,7 +11,7 @@ import argparse
 #-------------------------------------------------------------------------------
 
 """ Parent parser that contains propagation options """
-def track_generator_options():
+def random_track_generator_options():
 
     parser = argparse.ArgumentParser(add_help=False)
 
@@ -27,5 +27,28 @@ def track_generator_options():
                         default = [-4, 4], type=float)
 
     return parser
+
+
+""" Parent parser that contains propagation options """
+def uniform_track_generator_options():
+
+    parser = argparse.ArgumentParser(add_help=False)
+
+    # Navigation options
+    parser.add_argument("--phi_steps", "-n_phi",
+                        help=("Number steps in phi"),
+                        default = 50, type=int)
+    parser.add_argument("--eta_steps", "-n_eta",
+                        help=("Number steps in eta"),
+                        default = 50, type=int)
+    parser.add_argument("--transverse-momentum", "-p_T",
+                        help=("Transverse momentum of the test particle [GeV]"),
+                        default = 10, type=float)
+    parser.add_argument("--eta_range", "-eta", nargs=2,
+                        help=("Eta range of generated tracks"),
+                        default = [-4, 4], type=float)
+
+    return parser
+
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This PR decorates all portals in the toy detector with material maps, not just the volumes that contain sensitive surfaces and teaches the material scan to skip the exit portals the way the navigator would. In particular, the world portal is skipped now. 

Also activated the material map validation integration test for the toy detector in the CI, as this works correctly now and added a little bit of plotting.