### PR TITLE
feat: allow to read material map boundaries

### DIFF
--- a/core/include/detray/builders/grid_factory.hpp
+++ b/core/include/detray/builders/grid_factory.hpp
@@ -105,7 +105,7 @@ class grid_factory {
         auto b_values = grid_bounds.values();
         // Overwrite the mask values if axis spans are provided
         if (!axis_spans[0].empty()) {
-            b_values[boundary::e_min_r] = axis_spans[0][0];
+            b_values[boundary::e_min_r] = axis_spans[0].at(0);
             b_values[boundary::e_max_r] = axis_spans[0][1];
         }
         scalar_type min_phi = b_values[boundary::e_average_phi] -

--- a/core/include/detray/builders/grid_factory.hpp
+++ b/core/include/detray/builders/grid_factory.hpp
@@ -104,7 +104,7 @@ class grid_factory {
 
         auto b_values = grid_bounds.values();
         // Overwrite the mask values if axis spans are provided
-        if (axis_spans[0].size() > 1) {
+        if (!axis_spans[0].empty()) {
             b_values[boundary::e_min_r] = axis_spans[0][0];
             b_values[boundary::e_max_r] = axis_spans[0][1];
         }

--- a/core/include/detray/builders/grid_factory.hpp
+++ b/core/include/detray/builders/grid_factory.hpp
@@ -104,17 +104,19 @@ class grid_factory {
 
         auto b_values = grid_bounds.values();
         // Overwrite the mask values if axis spans are provided
-        if (!axis_spans[0].empty()) {
-            b_values[boundary::e_min_r] = axis_spans[0].at(0);
-            b_values[boundary::e_max_r] = axis_spans[0][1];
+        if (!axis_spans[0UL].empty()) {
+            assert(axis_spans[0UL].size() == 2UL);
+            b_values[boundary::e_min_r] = axis_spans[0UL].at(0UL);
+            b_values[boundary::e_max_r] = axis_spans[0UL].at(1UL);
         }
         scalar_type min_phi = b_values[boundary::e_average_phi] -
                               b_values[boundary::e_min_phi_rel];
         scalar_type max_phi = b_values[boundary::e_average_phi] +
                               b_values[boundary::e_max_phi_rel];
-        if (axis_spans[1].size() > 1) {
-            min_phi = axis_spans[1][0];
-            max_phi = axis_spans[1][1];
+        if (!axis_spans[1UL].empty()) {
+            assert(axis_spans[1UL].size() == 2UL);
+            min_phi = axis_spans[1UL].at(0UL);
+            max_phi = axis_spans[1UL].at(1UL);
         }
 
         return new_grid<local_frame>(
@@ -157,17 +159,20 @@ class grid_factory {
 
         // Overwrite the mask values if axis spans are provided
         auto b_values = grid_bounds.values();
-        if (axis_spans[0].size() > 1) {
-            b_values[boundary::e_min_x] = axis_spans[0][0];
-            b_values[boundary::e_max_x] = axis_spans[0][1];
+        if (!axis_spans[0UL].empty()) {
+            assert(axis_spans[0UL].size() == 2UL);
+            b_values[boundary::e_min_x] = axis_spans[0UL].at(0UL);
+            b_values[boundary::e_max_x] = axis_spans[0UL].at(1UL);
         }
-        if (axis_spans[1].size() > 1) {
-            b_values[boundary::e_min_y] = axis_spans[1][0];
-            b_values[boundary::e_max_y] = axis_spans[1][1];
+        if (!axis_spans[1UL].empty()) {
+            assert(axis_spans[1UL].size() == 2UL);
+            b_values[boundary::e_min_y] = axis_spans[1UL].at(0UL);
+            b_values[boundary::e_max_y] = axis_spans[1UL].at(1UL);
         }
-        if (axis_spans[2].size() > 1) {
-            b_values[boundary::e_min_z] = axis_spans[2][0];
-            b_values[boundary::e_max_z] = axis_spans[2][1];
+        if (!axis_spans[2UL].empty()) {
+            assert(axis_spans[2UL].size() == 2UL);
+            b_values[boundary::e_min_z] = axis_spans[2UL].at(0UL);
+            b_values[boundary::e_max_z] = axis_spans[2UL].at(1UL);
         }
 
         return new_grid<local_frame>(
@@ -214,17 +219,11 @@ class grid_factory {
         constexpr auto e_z_axis = static_cast<dindex>(axes_t::label1);
 
         auto b_values = grid_bounds.values();
-        scalar_type min_phi = -constant<scalar_type>::pi;
-        scalar_type max_phi = constant<scalar_type>::pi;
-        if (axis_spans[0].size() > 1) {
-            min_phi = axis_spans[0][0];
-            max_phi = axis_spans[0][1];
+        if (!axis_spans[1UL].empty()) {
+            assert(axis_spans[1UL].size() == 2UL);
+            b_values[boundary::e_lower_z] = axis_spans[1UL].at(0UL);
+            b_values[boundary::e_upper_z] = axis_spans[1UL].at(1UL);
         }
-        if (axis_spans[1].size() > 1) {
-            b_values[boundary::e_n_half_z] = axis_spans[1][0];
-            b_values[boundary::e_p_half_z] = axis_spans[1][1];
-        }
-
         return new_grid<local_frame>(
             {-constant<scalar_type>::pi, constant<scalar_type>::pi,
              b_values[boundary::e_lower_z], b_values[boundary::e_upper_z]},
@@ -267,19 +266,14 @@ class grid_factory {
         constexpr auto e_z_axis = static_cast<dindex>(axes_t::label1);
 
         auto b_values = grid_bounds.values();
-        scalar_type min_phi = -constant<scalar_type>::pi;
-        scalar_type max_phi = constant<scalar_type>::pi;
-        if (axis_spans[0].size() > 1) {
-            min_phi = axis_spans[0][0];
-            max_phi = axis_spans[0][1];
-        }
-        if (axis_spans[1].size() > 1) {            
-            b_values[boundary::e_n_half_z] = axis_spans[1][0];
-            b_values[boundary::e_p_half_z] = axis_spans[1][1];
+        if (!axis_spans[1UL].empty()) {
+            assert(axis_spans[1UL].size() == 2UL);
+            b_values[boundary::e_lower_z] = axis_spans[1UL].at(0UL);
+            b_values[boundary::e_upper_z] = axis_spans[1UL].at(1UL);
         }
 
         return new_grid<local_frame>(
-            {min_phi, max_phi, b_values[boundary::e_n_half_z],
+            {-constant<scalar_type>::pi, constant<scalar_type>::pi,
              b_values[boundary::e_lower_z], b_values[boundary::e_upper_z]},
             {n_bins[e_rphi_axis], n_bins[e_z_axis]}, bin_capacities,
             {bin_edges[e_rphi_axis], bin_edges[e_z_axis]},
@@ -323,19 +317,22 @@ class grid_factory {
 
         auto b_values = grid_bounds.values();
         // Overwrite the mask values if axis spans are provided
-        if (axis_spans[0].size() > 1) {
-            b_values[boundary::e_min_r] = axis_spans[0][0];
-            b_values[boundary::e_max_r] = axis_spans[0][1];
+        if (!axis_spans[0UL].empty()) {
+            assert(axis_spans[0UL].size() == 2UL);
+            b_values[boundary::e_min_r] = axis_spans[0UL].at(0UL);
+            b_values[boundary::e_max_r] = axis_spans[0UL].at(1UL);
         }
         scalar_type min_phi = -constant<scalar_type>::pi;
         scalar_type max_phi = constant<scalar_type>::pi;
-        if (axis_spans[1].size() > 1) {
-            min_phi = axis_spans[1][0];
-            max_phi = axis_spans[1][1];
+        if (!axis_spans[1UL].empty()) {
+            assert(axis_spans[1UL].size() == 2UL);
+            min_phi = axis_spans[1UL].at(0UL);
+            max_phi = axis_spans[1UL].at(1UL);
         }
-        if (axis_spans[2].size() > 1) {
-            b_values[boundary::e_min_z] = axis_spans[2][0];
-            b_values[boundary::e_max_z] = axis_spans[2][1];
+        if (!axis_spans[2UL].empty()) {
+            assert(axis_spans[2UL].size() == 2UL);
+            b_values[boundary::e_min_z] = axis_spans[2UL].at(0UL);
+            b_values[boundary::e_max_z] = axis_spans[2UL].at(1UL);
         }
 
         return new_grid<local_frame>(
@@ -381,20 +378,15 @@ class grid_factory {
 
         auto b_values = grid_bounds.values();
         // Overwrite the mask values if axis spans are provided
-        if (axis_spans[0].size() > 1) {
-            b_values[boundary::e_inner_r] = axis_spans[0][0];
-            b_values[boundary::e_outer_r] = axis_spans[0][1];
-        }
-        scalar_type min_phi = -constant<scalar_type>::pi;
-        scalar_type max_phi = constant<scalar_type>::pi;
-        if (axis_spans[1].size() > 1) {
-            min_phi = axis_spans[1][0];
-            max_phi = axis_spans[1][1];
+        if (!axis_spans[0UL].empty()) {
+            assert(axis_spans[0UL].size() == 2UL);
+            b_values[boundary::e_inner_r] = axis_spans[0UL].at(0UL);
+            b_values[boundary::e_outer_r] = axis_spans[0UL].at(1UL);
         }
 
         return new_grid<local_frame>(
             {b_values[boundary::e_inner_r], b_values[boundary::e_outer_r],
-             min_phi, max_phi},
+             -constant<scalar_type>::pi, constant<scalar_type>::pi},
             {n_bins[e_r_axis], n_bins[e_phi_axis]}, bin_capacities,
             {bin_edges[e_r_axis], bin_edges[e_phi_axis]},
             types::list<r_bounds, phi_bounds>{},
@@ -429,11 +421,13 @@ class grid_factory {
 
         auto b_values = grid_bounds.values();
         // Overwrite the mask values if axis spans are provided
-        if (axis_spans[0].size() > 1) {
-            b_values[boundary::e_half_x] = axis_spans[0][1];
+        if (!axis_spans[0UL].empty()) {
+            assert(axis_spans[0UL].size() == 2UL);
+            b_values[boundary::e_half_x] = axis_spans[0UL].at(1UL);
         }
-        if (axis_spans[1].size() > 1) {
-            b_values[boundary::e_half_y] = axis_spans[1][1];
+        if (!axis_spans[1UL].empty()) {
+            assert(axis_spans[1UL].size() == 2UL);
+            b_values[boundary::e_half_y] = axis_spans[1UL].at(1UL);
         }
 
         return new_grid<local_frame>(
@@ -473,11 +467,13 @@ class grid_factory {
 
         auto b_values = grid_bounds.values();
         // Overwrite the mask values if axis spans are provided
-        if (axis_spans[0].size() > 1) {
-            b_values[boundary::e_half_length_1] = axis_spans[0][1];
+        if (!axis_spans[0UL].empty()) {
+            assert(axis_spans[0UL].size() == 2UL);
+            b_values[boundary::e_half_length_1] = axis_spans[0UL].at(1UL);
         }
-        if (axis_spans[1].size() > 1) {
-            b_values[boundary::e_half_length_2] = axis_spans[1][1];
+        if (!axis_spans[1UL].empty()) {
+            assert(axis_spans[1UL].size() == 2UL);
+            b_values[boundary::e_half_length_2] = axis_spans[1UL].at(1UL);
         }
 
         return new_grid<local_frame>({-b_values[boundary::e_half_length_1],

--- a/core/include/detray/builders/material_map_builder.hpp
+++ b/core/include/detray/builders/material_map_builder.hpp
@@ -124,11 +124,18 @@ class material_map_builder : public volume_decorator<detector_t> {
             }
 
             // Construct and append the material map for a given surface shape
+            std::array<std::vector<scalar_type>, DIM> axis_spans{};
+            auto axis_spans_itr = m_axis_spans.find(sf_idx - 1u);
+            if (axis_spans_itr != m_axis_spans.end()) {
+                axis_spans = axis_spans_itr->second;
+            }
+
+            // Construct and append the material map for a given surface shape
             auto sf = surface{det, sf_desc};
             [[maybe_unused]] auto [mat_id, mat_idx] = sf.template visit_mask<
                 detail::add_sf_material_map<materials_t>>(
                 m_factory, m_bin_data.at(sf_idx - 1u), m_n_bins.at(sf_idx - 1u),
-                m_axis_spans.at(sf_idx - 1u), det.material_store());
+                axis_spans, det.material_store());
 
             // Make sure the linking was precomputed correctly
             assert(mat_id == sf_desc.material().id());

--- a/core/include/detray/builders/material_map_builder.hpp
+++ b/core/include/detray/builders/material_map_builder.hpp
@@ -87,7 +87,8 @@ class material_map_builder : public volume_decorator<detector_t> {
         auto mat_factory = std::dynamic_pointer_cast<
             material_map_factory<detector_t, axis::multi_bin<DIM>>>(sf_factory);
         if (mat_factory) {
-            (*mat_factory)(this->surfaces(), m_bin_data, m_n_bins);
+            (*mat_factory)(this->surfaces(), m_bin_data, m_n_bins,
+                           m_axis_spans);
         }
         auto mat_generator =
             std::dynamic_pointer_cast<material_map_generator<detector_t>>(
@@ -102,8 +103,9 @@ class material_map_builder : public volume_decorator<detector_t> {
 
     /// Add the volume and the material maps to the detector @param det
     DETRAY_HOST
-    auto build(detector_t& det, typename detector_t::geometry_context ctx = {})
-        -> typename detector_t::volume_type* override {
+    auto build(detector_t& det,
+               typename detector_t::geometry_context ctx = {}) ->
+        typename detector_t::volume_type* override {
 
         // Ensure the material links are correct BEFORE the surfaces are built
         // and potentially added to an acceleration data structure
@@ -127,7 +129,7 @@ class material_map_builder : public volume_decorator<detector_t> {
             [[maybe_unused]] auto [mat_id, mat_idx] = sf.template visit_mask<
                 detail::add_sf_material_map<materials_t>>(
                 m_factory, m_bin_data.at(sf_idx - 1u), m_n_bins.at(sf_idx - 1u),
-                det.material_store());
+                m_axis_spans.at(sf_idx - 1u), det.material_store());
 
             // Make sure the linking was precomputed correctly
             assert(mat_id == sf_desc.material().id());
@@ -189,6 +191,8 @@ class material_map_builder : public volume_decorator<detector_t> {
     std::map<dindex, std::vector<bin_data_type>> m_bin_data;
     /// Number of bins for the material grid axes
     std::map<dindex, std::array<std::size_t, DIM>> m_n_bins{};
+    /// The Axis spans for the material grid axes
+    std::map<dindex, std::array<std::vector<scalar_type>, DIM>> m_axis_spans{};
     /// Helper to generate empty grids
     mat_map_factory_t m_factory{};
 };
@@ -211,13 +215,16 @@ template <typename materials_t>
 struct add_sf_material_map {
 
     template <typename coll_t, typename index_t, typename mat_factory_t,
-              typename bin_data_t, std::size_t DIM, typename material_store_t>
+              typename bin_data_t, std::size_t DIM, typename material_store_t,
+              typename scalar_t>
     DETRAY_HOST inline std::pair<typename materials_t::id, dindex> operator()(
         [[maybe_unused]] const coll_t& coll,
         [[maybe_unused]] const index_t& index,
         [[maybe_unused]] const mat_factory_t& mat_factory,
         [[maybe_unused]] std::vector<bin_data_t>& bin_data,
         [[maybe_unused]] const std::array<std::size_t, DIM>& n_bins,
+        [[maybe_unused]] const std::array<std::vector<scalar_t>, DIM>&
+            axis_spans,
         [[maybe_unused]] material_store_t& mat_store) const {
 
         using mask_shape_t = typename coll_t::value_type::shape;
@@ -230,7 +237,8 @@ struct add_sf_material_map {
         if constexpr (!is_line && mask_shape_t::dim == DIM) {
             // Map a grid onto the surface mask
             const auto& sf_mask = coll[index];
-            auto mat_grid = mat_factory.new_grid(sf_mask, n_bins);
+            auto mat_grid =
+                mat_factory.new_grid(sf_mask, n_bins, {}, {}, axis_spans);
 
             // The detector only knows the non-owning grid types
             using non_owning_t =

--- a/core/include/detray/builders/material_map_builder.hpp
+++ b/core/include/detray/builders/material_map_builder.hpp
@@ -103,9 +103,8 @@ class material_map_builder : public volume_decorator<detector_t> {
 
     /// Add the volume and the material maps to the detector @param det
     DETRAY_HOST
-    auto build(detector_t& det,
-               typename detector_t::geometry_context ctx = {}) ->
-        typename detector_t::volume_type* override {
+    auto build(detector_t& det, typename detector_t::geometry_context ctx = {})
+        -> typename detector_t::volume_type* override {
 
         // Ensure the material links are correct BEFORE the surfaces are built
         // and potentially added to an acceleration data structure

--- a/core/include/detray/builders/material_map_factory.hpp
+++ b/core/include/detray/builders/material_map_factory.hpp
@@ -66,6 +66,7 @@ class material_map_factory final : public factory_decorator<detector_t> {
 
         // Need exactly one material per surface
         assert(m_n_bins.size() == n_surfaces);
+        assert(m_axis_spans.size() == n_surfaces);
         assert(m_materials.size() == n_surfaces);
         assert(m_thickness.size() == n_surfaces);
 
@@ -98,17 +99,20 @@ class material_map_factory final : public factory_decorator<detector_t> {
     ///
     /// @param id the identifier for thr type of material map
     /// @param n_bins the number of bins for the material grid axes
+    /// @param axis_spans the axis ranges for the material grid axes
     /// @param mat_data contains the material data
     /// @param indices local bin indices in the same order as the material data
     DETRAY_HOST
     void add_material(material_id id, data_type &&mat_data,
                       std::vector<std::size_t> &&n_bins,
+                      std::vector<std::vector<scalar_type>> &&axis_spans,
                       std::vector<index_type> &&indices) {
 
         auto [sf_index, mat, thickness] = mat_data.get_data();
 
         m_links[sf_index] = std::make_pair(id, std::move(indices));
         m_n_bins[sf_index] = std::move(n_bins);
+        m_axis_spans[sf_index] = std::move(axis_spans);
         m_materials[sf_index] = std::move(mat);
         m_thickness[sf_index] = std::move(thickness);
     }
@@ -118,6 +122,7 @@ class material_map_factory final : public factory_decorator<detector_t> {
     auto clear() -> void override {
         m_links.clear();
         m_n_bins.clear();
+        m_axis_spans.clear();
         m_materials.clear();
         m_thickness.clear();
     }
@@ -139,7 +144,8 @@ class material_map_factory final : public factory_decorator<detector_t> {
     DETRAY_HOST auto operator()(
         typename detector_t::surface_lookup_container &surfaces,
         std::map<dindex, std::vector<bin_data_t>> &material_map,
-        std::map<dindex, std::array<std::size_t, N>> &n_bins) {
+        std::map<dindex, std::array<std::size_t, N>> &n_bins,
+        std::map<dindex, std::array<std::vector<scalar_type>, N>> &axis_spans) {
 
         using link_t = typename detector_t::surface_type::material_link;
 
@@ -160,6 +166,11 @@ class material_map_factory final : public factory_decorator<detector_t> {
             n_bins[sf_idx] = {};
             std::copy_n(m_n_bins.at(sf_idx).begin(), N,
                         n_bins.at(sf_idx).begin());
+
+            // Copy the axis spans to the builder
+            axis_spans[sf_idx] = {};
+            std::copy_n(m_axis_spans.at(sf_idx).begin(), N,
+                        axis_spans.at(sf_idx).begin());
 
             // Combine the material slab with its local bin index
             for (const auto [j, mat] : detray::views::enumerate(materials)) {
@@ -189,6 +200,8 @@ class material_map_factory final : public factory_decorator<detector_t> {
         m_links{};
     /// Number of bins for the material grid axes
     std::map<std::size_t, std::vector<std::size_t>> m_n_bins{};
+    /// Axis ranges for the material grid axes
+    std::map<std::size_t, std::vector<std::vector<scalar_type>>> m_axis_spans{};
     /// Material thickness per surface
     std::map<std::size_t, std::vector<scalar_type>> m_thickness{};
     /// The pre-computed material to be wrapped in a slab per surface material

--- a/core/include/detray/builders/material_map_factory.hpp
+++ b/core/include/detray/builders/material_map_factory.hpp
@@ -167,10 +167,14 @@ class material_map_factory final : public factory_decorator<detector_t> {
             std::copy_n(m_n_bins.at(sf_idx).begin(), N,
                         n_bins.at(sf_idx).begin());
 
-            // Copy the axis spans to the builder
-            axis_spans[sf_idx] = {};
-            std::copy_n(m_axis_spans.at(sf_idx).begin(), N,
-                        axis_spans.at(sf_idx).begin());
+            // Copy the axis spans to the builder (if present)
+            axis_spans[sf_idx] = std::array<std::vector<scalar_type>, N>{};
+            for (std::size_t in = 0; in < N; ++in) {
+                if (m_axis_spans.at(sf_idx).size() > in) {
+                    axis_spans.at(sf_idx).at(in) =
+                        m_axis_spans.at(sf_idx).at(in);
+                }
+            }
 
             // Combine the material slab with its local bin index
             for (const auto [j, mat] : detray::views::enumerate(materials)) {

--- a/io/include/detray/io/common/material_map_reader.hpp
+++ b/io/include/detray/io/common/material_map_reader.hpp
@@ -85,6 +85,13 @@ class material_map_reader {
                     n_bins.push_back(axis_data.bins);
                 }
 
+                // Get the axis spans
+                std::vector<std::vector<scalar_t>> axis_spans = {};
+                for (const auto &axis_data : grid_data.axes) {
+                    axis_spans.push_back(
+                        {axis_data.edges.front(), axis_data.edges.back()});
+                }
+
                 // Get the local bin indices and the material parametrization
                 std::vector<bin_index_type> loc_bins{};
                 mat_data_t mat_data{
@@ -111,9 +118,9 @@ class material_map_reader {
                     }
                 }
 
-                mat_factory->add_material(map_id, std::move(mat_data),
-                                          std::move(n_bins),
-                                          std::move(loc_bins));
+                mat_factory->add_material(
+                    map_id, std::move(mat_data), std::move(n_bins),
+                    std::move(axis_spans), std::move(loc_bins));
             }
 
             // Add the material maps to the volume

--- a/io/include/detray/io/common/material_map_reader.hpp
+++ b/io/include/detray/io/common/material_map_reader.hpp
@@ -89,7 +89,8 @@ class material_map_reader {
                 std::vector<std::vector<scalar_t>> axis_spans = {};
                 for (const auto &axis_data : grid_data.axes) {
                     axis_spans.push_back(
-                        {axis_data.edges.front(), axis_data.edges.back()});
+                        {static_cast<scalar_t>(axis_data.edges.front()),
+                         static_cast<scalar_t>(axis_data.edges.back())});
                 }
 
                 // Get the local bin indices and the material parametrization

--- a/tests/integration_tests/cpu/builders/material_map_builder.cpp
+++ b/tests/integration_tests/cpu/builders/material_map_builder.cpp
@@ -50,7 +50,7 @@ auto add_material_data(const material_factory_t& mat_factory, mat_id id,
     typename material_factory_t::element_type::data_type mat_data{sf_index};
     std::vector<bin_index_t> m_bins{};
     std::vector<std::size_t> n_bins{5u, 10u};
-    std::vector<std::vector<scalar_t>> a_spans = {};
+    std::vector<std::vector<scalar_t>> axis_spans = {};
 
     // Add material for every bin
     for (auto [i, j] : detray::views::cartesian_product{
@@ -61,7 +61,7 @@ auto add_material_data(const material_factory_t& mat_factory, mat_id id,
     }
 
     mat_factory->add_material(id, std::move(mat_data), std::move(n_bins),
-                              std::move(a_spans), std::move(m_bins));
+                              std::move(axis_spans), std::move(m_bins));
 }
 
 }  // anonymous namespace

--- a/tests/integration_tests/cpu/builders/material_map_builder.cpp
+++ b/tests/integration_tests/cpu/builders/material_map_builder.cpp
@@ -50,6 +50,7 @@ auto add_material_data(const material_factory_t& mat_factory, mat_id id,
     typename material_factory_t::element_type::data_type mat_data{sf_index};
     std::vector<bin_index_t> m_bins{};
     std::vector<std::size_t> n_bins{5u, 10u};
+    std::vector<std::vector<scalar_t>> a_spans = {};
 
     // Add material for every bin
     for (auto [i, j] : detray::views::cartesian_product{
@@ -60,7 +61,7 @@ auto add_material_data(const material_factory_t& mat_factory, mat_id id,
     }
 
     mat_factory->add_material(id, std::move(mat_data), std::move(n_bins),
-                              std::move(m_bins));
+                              std::move(a_spans), std::move(m_bins));
 }
 
 }  // anonymous namespace

--- a/tests/unit_tests/cpu/builders/material_map_builder.cpp
+++ b/tests/unit_tests/cpu/builders/material_map_builder.cpp
@@ -50,7 +50,7 @@ auto add_material_data(const material_factory_t& mat_factory, mat_id id,
     typename material_factory_t::element_type::data_type mat_data{sf_index};
     std::vector<bin_index_t> m_bins{};
     std::vector<std::size_t> n_bins{5u, 10u};
-    std::vector<std::vector<scalar_t>> a_spans = {};
+    std::vector<std::vector<scalar_t>> axis_spans = {};
 
     // Add material for every bin
     for (auto [i, j] : detray::views::cartesian_product{
@@ -61,7 +61,7 @@ auto add_material_data(const material_factory_t& mat_factory, mat_id id,
     }
 
     mat_factory->add_material(id, std::move(mat_data), std::move(n_bins),
-                              std::move(a_spans), std::move(m_bins));
+                              std::move(axis_spans), std::move(m_bins));
 }
 
 }  // anonymous namespace

--- a/tests/unit_tests/cpu/builders/material_map_builder.cpp
+++ b/tests/unit_tests/cpu/builders/material_map_builder.cpp
@@ -50,6 +50,7 @@ auto add_material_data(const material_factory_t& mat_factory, mat_id id,
     typename material_factory_t::element_type::data_type mat_data{sf_index};
     std::vector<bin_index_t> m_bins{};
     std::vector<std::size_t> n_bins{5u, 10u};
+    std::vector<std::vector<scalar_t>> a_spans = {};
 
     // Add material for every bin
     for (auto [i, j] : detray::views::cartesian_product{
@@ -60,7 +61,7 @@ auto add_material_data(const material_factory_t& mat_factory, mat_id id,
     }
 
     mat_factory->add_material(id, std::move(mat_data), std::move(n_bins),
-                              std::move(m_bins));
+                              std::move(a_spans), std::move(m_bins));
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
This PR allows to read in the map bounds and overwrite the mask boundaries. This gives a very nice result now between ACTS and detray material even for portal material.

![Screenshot 2024-06-11 at 15 29 54](https://github.com/acts-project/detray/assets/26623879/718f7638-6a0f-4eb2-9086-23b68b2b4e78)
