### PR TITLE
Fix non-conformant use of iterator type aliases

### DIFF
--- a/tests/include/detray/test/common/utils/detector_scan_utils.hpp
+++ b/tests/include/detray/test/common/utils/detector_scan_utils.hpp
@@ -86,8 +86,9 @@ inline bool check_connectivity(
 
     // If the intersection trace comes from the ray gun/trace intersections
     // function it should be sorted, which is the stronger constraint
-    using records_iterator_t = decltype(trace.begin());
-    using index_t = typename records_iterator_t::difference_type;
+    using vector_t = decltype(trace);
+    using records_iterator_t = typename vector_t::iterator;
+    using index_t = typename vector_t::difference_type;
     std::function<records_iterator_t(index_t)> get_connected_record;
     if constexpr (check_sorted_trace) {
         // Get the next record


### PR DESCRIPTION
The `check_connectivity` function in the detector scan utilities header makes use of the `difference_type` typedef on the iterator of a vector, but this is not defined by the standard, and I was running into compilation errors stemming from this. The correct solution to this is to use the `std::iterator_traits` class (because an iterator can also be a raw pointer which doesn't carry any type aliases) but since we are using a vector I simply went ahead and used the
`std::vector::difference_type` definition.