### PR TITLE
Migrate static strings to `std::string_view`

### DIFF
--- a/core/include/detray/builders/surface_factory.hpp
+++ b/core/include/detray/builders/surface_factory.hpp
@@ -165,7 +165,7 @@ class surface_factory : public surface_factory_interface<detector_t> {
 
             throw std::invalid_argument(
                 "ERROR: Cannot match shape type to mask ID: Found " +
-                mask_shape_t::name + " at mask id " +
+                std::string(mask_shape_t::name) + " at mask id " +
                 std::to_string(static_cast<std::size_t>(mask_id)));
 
         } else {

--- a/core/include/detray/geometry/mask.hpp
+++ b/core/include/detray/geometry/mask.hpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <ostream>
 #include <sstream>
+#include <string>
 #include <vector>
 
 namespace detray {
@@ -256,7 +257,7 @@ class mask {
     DETRAY_HOST
     auto to_string() const -> std::string {
         std::stringstream ss;
-        ss << shape::name;
+        ss << std::string(shape::name);
         for (const auto& v : _values) {
             ss << ", " << v;
         }

--- a/core/include/detray/geometry/shapes/annulus2D.hpp
+++ b/core/include/detray/geometry/shapes/annulus2D.hpp
@@ -21,7 +21,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
-#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -46,7 +46,7 @@ namespace detray {
 class annulus2D {
     public:
     /// The name for this shape
-    inline static const std::string name = "(stereo) annulus2D";
+    static constexpr std::string_view name = "(stereo) annulus2D";
 
     /// Names for the mask boundary values
     enum boundaries : unsigned int {

--- a/core/include/detray/geometry/shapes/concentric_cylinder2D.hpp
+++ b/core/include/detray/geometry/shapes/concentric_cylinder2D.hpp
@@ -18,7 +18,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
-#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -28,7 +28,7 @@ namespace detray {
 class concentric_cylinder2D {
     public:
     /// The name for this shape
-    inline static const std::string name = "concentric_cylinder2D";
+    static constexpr std::string_view name = "concentric_cylinder2D";
 
     enum boundaries : unsigned int {
         e_r = 0u,

--- a/core/include/detray/geometry/shapes/cuboid3D.hpp
+++ b/core/include/detray/geometry/shapes/cuboid3D.hpp
@@ -17,7 +17,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
-#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -28,7 +28,7 @@ namespace detray {
 class cuboid3D {
     public:
     /// The name for this shape
-    inline static const std::string name = "cuboid3D";
+    static constexpr std::string_view name = "cuboid3D";
 
     enum boundaries : unsigned int {
         e_min_x = 0u,

--- a/core/include/detray/geometry/shapes/cylinder2D.hpp
+++ b/core/include/detray/geometry/shapes/cylinder2D.hpp
@@ -18,7 +18,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
-#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -28,7 +28,7 @@ namespace detray {
 class cylinder2D {
     public:
     /// The name for this shape
-    inline static const std::string name = "cylinder2D";
+    static constexpr std::string_view name = "cylinder2D";
 
     enum boundaries : unsigned int {
         e_r = 0u,

--- a/core/include/detray/geometry/shapes/cylinder3D.hpp
+++ b/core/include/detray/geometry/shapes/cylinder3D.hpp
@@ -19,7 +19,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
-#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -29,7 +29,7 @@ namespace detray {
 class cylinder3D {
     public:
     /// The name for this shape
-    inline static const std::string name = "cylinder3D";
+    static constexpr std::string_view name = "cylinder3D";
 
     enum boundaries : unsigned int {
         e_min_r = 0u,

--- a/core/include/detray/geometry/shapes/line.hpp
+++ b/core/include/detray/geometry/shapes/line.hpp
@@ -18,6 +18,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
+#include <string_view>
 #include <type_traits>
 
 namespace detray {
@@ -35,7 +36,7 @@ template <bool kSquareCrossSect = false>
 class line {
     public:
     /// The name for this shape
-    inline static const std::string name = "line";
+    static constexpr std::string_view name = "line";
 
     /// Geometrical cross section of the line
     static constexpr bool square_cross_sect = kSquareCrossSect;

--- a/core/include/detray/geometry/shapes/rectangle2D.hpp
+++ b/core/include/detray/geometry/shapes/rectangle2D.hpp
@@ -16,7 +16,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
-#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -26,7 +26,7 @@ namespace detray {
 class rectangle2D {
     public:
     /// The name for this shape
-    inline static const std::string name = "rectangle2D";
+    static constexpr std::string_view name = "rectangle2D";
 
     enum boundaries : unsigned int {
         e_half_x = 0u,

--- a/core/include/detray/geometry/shapes/ring2D.hpp
+++ b/core/include/detray/geometry/shapes/ring2D.hpp
@@ -18,7 +18,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
-#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -29,7 +29,7 @@ namespace detray {
 class ring2D {
     public:
     /// The name for this shape
-    inline static const std::string name = "ring2D";
+    static constexpr std::string_view name = "ring2D";
 
     enum boundaries : unsigned int {
         e_inner_r = 0u,

--- a/core/include/detray/geometry/shapes/single3D.hpp
+++ b/core/include/detray/geometry/shapes/single3D.hpp
@@ -17,7 +17,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
-#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -29,7 +29,7 @@ template <unsigned int kCheckIndex = 0u>
 class single3D {
     public:
     /// The name for this shape
-    inline static const std::string name = "single3D";
+    static constexpr std::string_view name = "single3D";
 
     enum boundaries : unsigned int {
         e_lower = 0u,

--- a/core/include/detray/geometry/shapes/trapezoid2D.hpp
+++ b/core/include/detray/geometry/shapes/trapezoid2D.hpp
@@ -17,7 +17,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
-#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -30,7 +30,7 @@ namespace detray {
 class trapezoid2D {
     public:
     /// The name for this shape
-    inline static const std::string name = "trapezoid2D";
+    static constexpr std::string_view name = "trapezoid2D";
 
     enum boundaries : unsigned int {
         e_half_length_0 = 0u,

--- a/core/include/detray/geometry/shapes/unbounded.hpp
+++ b/core/include/detray/geometry/shapes/unbounded.hpp
@@ -12,12 +12,14 @@
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/utils/string_view_concat.hpp"
 
 // System include(s)
 #include <array>
 #include <limits>
 #include <ostream>
 #include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -32,8 +34,11 @@ class unbounded {
     template <typename scalar_t>
     using bounds_type = darray<scalar_t, boundaries::e_size>;
 
+    /// Convenience member to construct the name
+    static constexpr std::string_view name_prefix = "unbounded ";
+
     /// The name for this shape
-    inline static const std::string name = "unbounded " + shape::name;
+    static constexpr string_view_concat2 name{name_prefix, shape::name};
 
     /// Local coordinate frame for boundary checks
     template <typename algebra_t>

--- a/core/include/detray/geometry/shapes/unmasked.hpp
+++ b/core/include/detray/geometry/shapes/unmasked.hpp
@@ -17,7 +17,7 @@
 // System include(s)
 #include <limits>
 #include <ostream>
-#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -26,7 +26,7 @@ template <std::size_t DIM = 2>
 class unmasked {
     public:
     /// The name for this shape
-    inline static const std::string name = "unmasked";
+    static constexpr std::string_view name = "unmasked";
 
     enum boundaries : unsigned int { e_size = 1u };
 

--- a/core/include/detray/utils/string_view_concat.hpp
+++ b/core/include/detray/utils/string_view_concat.hpp
@@ -1,0 +1,20 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace detray {
+/// @brief Convenience class to statically concatenate two string views.
+struct string_view_concat2 {
+    std::string_view s1, s2;
+
+    operator std::string() const { return std::string(s1) + std::string(s2); }
+};
+}  // namespace detray

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -20,7 +20,7 @@
 #include <algorithm>
 #include <cassert>
 #include <map>
-#include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -47,7 +47,7 @@ class geometry_reader {
 
     public:
     /// Tag the reader as "geometry"
-    inline static const std::string tag = "geometry";
+    static constexpr std::string_view tag = "geometry";
 
     /// Convert a detector @param det from its io payload @param det_data
     /// and add the volume names to @param name_map

--- a/io/include/detray/io/common/geometry_writer.hpp
+++ b/io/include/detray/io/common/geometry_writer.hpp
@@ -29,7 +29,7 @@ class geometry_writer {
 
     public:
     /// Tag the writer as "geometry"
-    inline static const std::string tag = "geometry";
+    static constexpr std::string_view tag = "geometry";
 
     /// Convert the header information into its payload
     template <typename detector_t>

--- a/io/include/detray/io/common/homogeneous_material_reader.hpp
+++ b/io/include/detray/io/common/homogeneous_material_reader.hpp
@@ -20,7 +20,7 @@
 
 // System include(s)
 #include <memory>
-#include <string>
+#include <string_view>
 #include <vector>
 
 namespace detray::io {
@@ -34,7 +34,7 @@ class homogeneous_material_reader {
 
     public:
     /// Tag the reader as "homogeneous material"
-    inline static const std::string tag = "homogeneous_material";
+    static constexpr std::string_view tag = "homogeneous_material";
 
     /// Convert the detector material @param det_mat_data from its IO
     /// payload

--- a/io/include/detray/io/common/homogeneous_material_writer.hpp
+++ b/io/include/detray/io/common/homogeneous_material_writer.hpp
@@ -19,7 +19,6 @@
 #include "detray/utils/type_list.hpp"
 
 // System include(s)
-#include <string>
 #include <string_view>
 
 namespace detray::io {
@@ -29,7 +28,7 @@ class homogeneous_material_writer {
 
     public:
     /// Tag the writer as "homogeneous_material"
-    inline static const std::string tag = "homogeneous_material";
+    static constexpr std::string_view tag = "homogeneous_material";
 
     /// Convert the header information into its payload
     template <class detector_t>

--- a/io/include/detray/io/common/material_map_reader.hpp
+++ b/io/include/detray/io/common/material_map_reader.hpp
@@ -20,6 +20,7 @@
 // System include(s)
 #include <memory>
 #include <stdexcept>
+#include <string_view>
 #include <vector>
 
 namespace detray::io {
@@ -36,7 +37,7 @@ class material_map_reader {
     using bin_index_type = axis::multi_bin<dim>;
 
     /// Tag the reader as "material_maps"
-    inline static const std::string tag = "material_maps";
+    static constexpr std::string_view tag = "material_maps";
 
     /// Convert the material grids @param grids_data from their IO
     /// payload

--- a/io/include/detray/io/common/material_map_writer.hpp
+++ b/io/include/detray/io/common/material_map_writer.hpp
@@ -15,7 +15,7 @@
 #include "detray/materials/material_slab.hpp"
 
 // System include(s)
-#include <string>
+#include <string_view>
 
 namespace detray::io {
 
@@ -28,7 +28,7 @@ class material_map_writer : public detail::grid_writer {
 
     public:
     /// Tag the writer as "material_map"
-    inline static const std::string tag = "material_maps";
+    static constexpr std::string_view tag = "material_maps";
 
     /// Same constructors for this class as for base_type
     using base_type::base_type;

--- a/io/include/detray/io/common/surface_grid_reader.hpp
+++ b/io/include/detray/io/common/surface_grid_reader.hpp
@@ -14,7 +14,7 @@
 #include "detray/io/frontend/payloads.hpp"
 
 // System include(s)
-#include <string>
+#include <string_view>
 
 namespace detray::io {
 
@@ -31,7 +31,7 @@ class surface_grid_reader
 
     public:
     /// Tag the reader as "surface_grids"
-    inline static const std::string tag = "surface_grids";
+    static constexpr std::string_view tag = "surface_grids";
 
     /// Same constructors for this class as for base_type
     using base_type::base_type;

--- a/io/include/detray/io/common/surface_grid_writer.hpp
+++ b/io/include/detray/io/common/surface_grid_writer.hpp
@@ -13,7 +13,7 @@
 #include "detray/io/frontend/payloads.hpp"
 
 // System include(s)
-#include <string>
+#include <string_view>
 
 namespace detray::io {
 
@@ -25,7 +25,7 @@ class surface_grid_writer : public detail::grid_writer {
 
     public:
     /// Tag the writer as "surface_grids"
-    inline static const std::string tag = "surface_grids";
+    static constexpr std::string_view tag = "surface_grids";
 
     /// Same constructors for this class as for base_type
     using base_type::base_type;

--- a/io/include/detray/io/frontend/detail/io_metadata.hpp
+++ b/io/include/detray/io/frontend/detail/io_metadata.hpp
@@ -18,6 +18,7 @@
 #include <locale>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 namespace detray::io::detail {
 
@@ -46,6 +47,6 @@ inline std::string get_detray_version() {
     return "detray - " + std::string(detray::version);
 }
 
-inline static const std::string minimal_io_version{"detray - 0.52.0"};
+static constexpr std::string_view minimal_io_version = "detray - 0.52.0";
 
 }  // namespace detray::io::detail

--- a/io/include/detray/io/json/json_writer.hpp
+++ b/io/include/detray/io/json/json_writer.hpp
@@ -60,7 +60,7 @@ class json_writer final : public writer_interface<detector_t> {
         }
 
         // Create a new file
-        std::string file_stem{det_name + "_" + io_backend::tag};
+        std::string file_stem{det_name + "_" + std::string(io_backend::tag)};
         io::file_handle file{file_path / file_stem, this->m_file_extension,
                              mode};
 

--- a/tests/include/detray/test/cpu/material_validation.hpp
+++ b/tests/include/detray/test/cpu/material_validation.hpp
@@ -22,13 +22,14 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace detray::test {
 
 /// Run the material validation on the host
 struct run_material_validation {
 
-    inline static const std::string name{"cpu"};
+    static constexpr std::string_view name{"cpu"};
 
     template <typename detector_t>
     auto operator()(
@@ -159,8 +160,9 @@ class material_validation_impl : public test::fixture_base<> {
 
         // Print accumulated material per track
         std::filesystem::path mat_path{m_cfg.material_file()};
-        auto file_name{m_det.name(m_names) + "_" + material_validator_t::name +
-                       "_" + mat_path.stem().string() +
+        auto file_name{m_det.name(m_names) + "_" +
+                       std::string(material_validator_t::name) + "_" +
+                       mat_path.stem().string() +
                        mat_path.extension().string()};
 
         material_validator::write_material(mat_path.replace_filename(file_name),

--- a/tests/include/detray/test/device/cuda/material_validation.hpp
+++ b/tests/include/detray/test/device/cuda/material_validation.hpp
@@ -21,6 +21,9 @@
 #include <vecmem/memory/memory_resource.hpp>
 #include <vecmem/utils/cuda/copy.hpp>
 
+// System include
+#include <string_view>
+
 namespace detray::cuda {
 
 /// Launch the material validation kernel
@@ -43,7 +46,7 @@ void material_validation_device(
 /// Prepare data for device material trace run
 struct run_material_validation {
 
-    inline static const std::string name{"cuda"};
+    static constexpr std::string_view name = "cuda";
 
     template <typename detector_t>
     auto operator()(

--- a/tests/unit_tests/cpu/geometry/masks/unbounded.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/unbounded.cpp
@@ -47,7 +47,8 @@ GTEST_TEST(detray_masks, unbounded) {
         "incorrect local frame");
 
     // Test static members
-    EXPECT_TRUE(unbounded_t::name == "unbounded rectangle2D");
+    EXPECT_TRUE(std::string(unbounded_t::name) ==
+                std::string("unbounded rectangle2D"));
 
     // Test boundary check
     typename mask<unbounded_t>::point3_type p2 = {0.5f, -9.f, 0.f};

--- a/tutorials/include/detray/tutorial/my_square2D.hpp
+++ b/tutorials/include/detray/tutorial/my_square2D.hpp
@@ -13,7 +13,7 @@
 
 // System include(s)
 #include <limits>
-#include <string>
+#include <string_view>
 
 namespace detray::tutorial {
 
@@ -24,7 +24,7 @@ namespace detray::tutorial {
 class square2D {
     public:
     /// The name for this shape
-    inline static const std::string name = "square2D";
+    static constexpr std::string_view name = "square2D";
 
     enum boundaries : unsigned int {
         e_half_length = 0,  // < boundary value: the half length of the square


### PR DESCRIPTION
You wouldn't guess it, but it's yet another case of NVCC not liking detray code. As usual, detray hasn't actually done anything wrong, but some code in detray is leading to segmentation faults in targets built from translation units compiled with NVCC.

The reason this happens is that detray make extensive use of names and tags in the form `inline static const std::string`. This is perfectly legal, but the mechanics of this mean that the compiler has to inject some code at the start of the program which takes the string literals and stores them in memory. This is because the compiler is not allowed to simply put the strings in the `.data` section of the object, they have to be properly constructed and they have to live in `.bss`. In the meanwhile, the `inline` keyword requires the linker to deduplicate the string across translation units _and_ to make the requisite updates to the initialization code. I suspect that this is where things are going wrong, because the initialization code is throwing a segmentation fault.

Note that for whatever reason, the old code works fine in C++17 mode, but breaks in C++20 mode. I have tried to create a minimal reproducer for the CUDA team, but I haven't managed so far.

This commit replaces the `inline static const std::string` types with `static constexpr std::string_view` types, which fix this issue and should also work a bit better (e.g. they are constexpr, allowing more optimization to happen, and they don't need construction).