### PR TITLE
fix: suggest parentheses around comparison in operand of '|' warning

### DIFF
--- a/core/include/detray/utils/bit_encoder.hpp
+++ b/core/include/detray/utils/bit_encoder.hpp
@@ -35,8 +35,7 @@ class bit_encoder {
     template <value_t... masks>
     DETRAY_HOST_DEVICE static constexpr bool is_invalid(value_t v) noexcept {
         // All bits set to one in the range of a given mask defined as invalid
-        auto x = (v & masks) == masks;
-        return (x | ...);
+        return (((v & masks) == masks) || ...);
     }
 
     /// @returns the masked bits from the encoded value as value of the same

--- a/core/include/detray/utils/bit_encoder.hpp
+++ b/core/include/detray/utils/bit_encoder.hpp
@@ -35,7 +35,8 @@ class bit_encoder {
     template <value_t... masks>
     DETRAY_HOST_DEVICE static constexpr bool is_invalid(value_t v) noexcept {
         // All bits set to one in the range of a given mask defined as invalid
-        return (((v & masks) == masks) | ...);
+        auto x = (v & masks) == masks;
+        return (x | ...);
     }
 
     /// @returns the masked bits from the encoded value as value of the same


### PR DESCRIPTION
Fix `suggest parentheses around comparison in operand of '|' [-Werror=parentheses]` which occures when detray is included in ACTS (CI linux-nodeps centos8-lcg100-gcc10 fails)