### PR TITLE
ref: Update to new actsvg version and fix some bugs

### DIFF
--- a/extern/actsvg/CMakeLists.txt
+++ b/extern/actsvg/CMakeLists.txt
@@ -19,7 +19,7 @@ message( STATUS "Building actsvg as part of the Detray project" )
 # Declare where to get Actsvg from.
 set( DETRAY_ACTSVG_GIT_REPOSITORY "https://github.com/acts-project/actsvg.git"
    CACHE STRING "Git repository to take actsvg from" )
-set( DETRAY_ACTSVG_GIT_TAG "v0.4.42" CACHE STRING "Version of actsvg to build" )
+set( DETRAY_ACTSVG_GIT_TAG "v0.4.44" CACHE STRING "Version of actsvg to build" )
 mark_as_advanced( DETRAY_ACTSVG_GIT_REPOSITORY DETRAY_ACTSVG_GIT_TAG )
 FetchContent_Declare( actsvg
    GIT_REPOSITORY "${DETRAY_ACTSVG_GIT_REPOSITORY}"

--- a/plugins/svgtools/include/detray/plugins/svgtools/utils/surface_kernels.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/utils/surface_kernels.hpp
@@ -132,21 +132,33 @@ struct link_start_getter {
         return mask.to_global_frame(transform, point3_t{r, phi, 0.f});
     }
 
-    // Calculates the (optimal) link starting point for cylinders (2D).
-    template <
-        typename transform_t, typename shape_t,
-        std::enable_if_t<std::is_same_v<shape_t, cylinder2D> ||
-                             std::is_same_v<shape_t, concentric_cylinder2D>,
-                         bool> = true>
-    auto inline link_start(const detray::mask<shape_t>& mask,
+    // Calculates the (optimal) link starting point for concentric cylinders
+    template <typename transform_t>
+    auto inline link_start(const detray::mask<concentric_cylinder2D>& mask,
                            const transform_t& transform) const {
-        using mask_t = detray::mask<shape_t>;
+        using mask_t = detray::mask<concentric_cylinder2D>;
         using point3_t = typename mask_t::point3_type;
         using scalar_t = typename mask_t::scalar_type;
 
-        const scalar_t r{mask[shape_t::e_r]};
+        const scalar_t r{mask[concentric_cylinder2D::e_r]};
         const scalar_t phi{detray::constant<scalar_t>::pi_2};
-        // Shift the center to the actual cylider bounds
+        // Shift the center to the actual cylinder bounds
+        const scalar_t z{mask.centroid()[2]};
+
+        return mask.to_global_frame(transform, point3_t{phi, z, r});
+    }
+
+    // Calculates the (optimal) link starting point for cylinders (2D).
+    template <typename transform_t>
+    auto inline link_start(const detray::mask<cylinder2D>& mask,
+                           const transform_t& transform) const {
+        using mask_t = detray::mask<cylinder2D>;
+        using point3_t = typename mask_t::point3_type;
+        using scalar_t = typename mask_t::scalar_type;
+
+        const scalar_t r{mask[cylinder2D::e_r]};
+        const scalar_t phi{detray::constant<scalar_t>::pi_2};
+        // Shift the center to the actual cylinder bounds
         const scalar_t z{mask.centroid()[2]};
 
         return mask.to_global_frame(transform, point3_t{r * phi, z, r});
@@ -162,8 +174,7 @@ struct link_start_getter {
         using point3_t = typename mask_t::point3_type;
         using scalar_t = typename mask_t::scalar_type;
 
-        const scalar_t r{0.5f *
-                         (mask[shape_t::e_min_r] + mask[shape_t::e_max_r])};
+        const scalar_t r{mask[shape_t::e_max_r]};
         const scalar_t phi{
             0.5f * (mask[shape_t::e_max_phi] + mask[shape_t::e_max_phi])};
         const scalar_t z{mask.centroid()[2]};

--- a/tests/tools/src/cpu/generate_telescope_detector.cpp
+++ b/tests/tools/src/cpu/generate_telescope_detector.cpp
@@ -27,6 +27,33 @@ namespace {
 
 /// Generate and write a telescope detector, given the commandline variables
 /// and a configuration for the detector writer @param writer_cfg
+template <typename mask_shape_t, typename value_t, typename trajectory_t>
+void write_telecope(const po::variables_map &vm,
+                    io::detector_writer_config &writer_cfg,
+                    std::vector<value_t> &mask_params,
+                    const trajectory_t &traj) {
+
+    using detector_t = detector<telescope_metadata<mask_shape_t>>;
+    using scalar_t = typename detector_t::scalar_type;
+
+    detray::tel_det_config<mask_shape_t, trajectory_t> tel_cfg{mask_params,
+                                                               traj};
+
+    tel_cfg.n_surfaces(vm["modules"].as<unsigned int>());
+    tel_cfg.length(vm["length"].as<scalar_t>());
+    tel_cfg.mat_thickness(vm["thickness"].as<scalar_t>());
+    tel_cfg.envelope(vm["envelope"].as<scalar_t>());
+
+    // Build the detector
+    vecmem::host_memory_resource host_mr;
+    auto [tel_det, tel_names] = build_telescope_detector(host_mr, tel_cfg);
+
+    // Write to file
+    detray::io::write_detector(tel_det, tel_names, writer_cfg);
+}
+
+/// Generate and write a telescope detector, given the commandline variables
+/// and a configuration for the detector writer @param writer_cfg
 template <typename mask_shape_t, typename value_t>
 void write_telecope(const po::variables_map &vm,
                     io::detector_writer_config &writer_cfg,
@@ -35,30 +62,41 @@ void write_telecope(const po::variables_map &vm,
     using detector_t = detector<telescope_metadata<mask_shape_t>>;
     using scalar_t = typename detector_t::scalar_type;
     using algebra_t = typename detector_t::algebra_type;
+    using vector3_t = dvector3D<algebra_t>;
 
-    detray::tel_det_config<mask_shape_t> tel_cfg{mask_params};
-
-    tel_cfg.n_surfaces(vm["modules"].as<unsigned int>());
-    tel_cfg.length(vm["length"].as<scalar_t>());
-    tel_cfg.mat_thickness(vm["thickness"].as<scalar_t>());
-
+    // Construct the pilot track
     std::string direction{vm["direction"].as<std::string>()};
-    detray::detail::ray<algebra_t> r{};
+    vector3_t dir;
     if (direction == "x") {
-        r.set_dir({1.f, 0.f, 0.f});
+        dir = {1.f, 0.f, 0.f};
     } else if (direction == "y") {
-        r.set_dir({0.f, 1.f, 0.f});
+        dir = {{0.f, 1.f, 0.f}};
     } else if (direction == "z") {
-        r.set_dir({0.f, 0.f, 1.f});
+        dir = {0.f, 0.f, 1.f};
     }
-    tel_cfg.pilot_track(r);
 
-    // Build the detector
-    vecmem::host_memory_resource host_mr;
-    auto [tel_det, tel_names] = build_telescope_detector(host_mr, tel_cfg);
+    if (!vm.count("b_field")) {
+        detray::detail::ray<algebra_t> r{};
+        r.set_dir(dir);
 
-    // Write to file
-    detray::io::write_detector(tel_det, tel_names, writer_cfg);
+        write_telecope<mask_shape_t>(vm, writer_cfg, mask_params, r);
+    } else {
+        const auto b_field = vm["b_field"].as<std::vector<scalar_t>>();
+        if (b_field.size() == 3u) {
+            vector3_t B{b_field[0] * unit<scalar_t>::T,
+                        b_field[1] * unit<scalar_t>::T,
+                        b_field[2] * unit<scalar_t>::T};
+
+            const auto p{vm["p"].as<scalar_t>() * unit<scalar_t>::GeV};
+            detray::detail::helix<algebra_t> h{
+                {0.f, 0.f, 0.f}, 0.f, dir, 1.f / p, &B};
+
+            write_telecope<mask_shape_t>(vm, writer_cfg, mask_params, h);
+        } else {
+            throw std::invalid_argument(
+                "B-field vector has to have three entries");
+        }
+    }
 }
 
 }  // anonymous namespace
@@ -86,8 +124,16 @@ int main(int argc, char **argv) {
         "thickness",
         po::value<scalar_t>()->default_value(1.f * unit<scalar_t>::mm),
         "thickness of the module silicon material")(
+        "envelope",
+        po::value<scalar_t>()->default_value(100.f * unit<scalar_t>::um),
+        "minimal distance between sensitive surfaces and portals")(
         "direction", po::value<std::string>()->default_value("z"),
-        "direction of the telescope in global frame [x, y, z]");
+        "direction of the telescope in global frame [x, y, z]")(
+        "b_field",
+        boost::program_options::value<std::vector<scalar_t>>()->multitoken(),
+        "B field vector for a pilot helix [T]")(
+        "p", po::value<scalar_t>()->default_value(10.f * unit<scalar_t>::GeV),
+        "Total momentum of the pilot track [GeV]");
 
     // Configuration
     detray::io::detector_writer_config writer_cfg{};


### PR DESCRIPTION
New actsvg version that should allow to display the material maps correctly. Also fixes a bug in the arrow generation for portal links on concentric cylinders and adds more options to tool that generates telescope detectors along helices 