### PR TITLE
ref: add momentum information to file names and finalize plots

### DIFF
--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/intersection.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/intersection.hpp
@@ -26,6 +26,7 @@ inline auto intersection(const detector_t& detector,
                              styling::svg_default::intersection_style) {
 
     using point3_t = typename detector_t::point3_type;
+    using point2_t = typename detector_t::point2_type;
     using p_intersection_t = svgtools::meta::proto::intersection<point3_t>;
     p_intersection_t p_ir;
 
@@ -36,7 +37,8 @@ inline auto intersection(const detector_t& detector,
             continue;
         }
 
-        const auto position = sf.local_to_global(gctx, intr.local, dir);
+        const point2_t bound{intr.local[0], intr.local[1]};
+        const auto position = sf.bound_to_global(gctx, bound, dir);
         const auto p_lm = svgtools::conversion::landmark(position, style);
 
         p_ir._landmarks.push_back(p_lm);

--- a/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
@@ -439,6 +439,8 @@ class illustrator {
 
         auto p_ir = svgtools::conversion::intersection(
             _detector, intersections, dir, gctx, _style._intersection_style);
+        // The first intersection sits in the origin by convention
+        p_ir._landmarks.front()._position = {0.f, 0.f, 0.f};
 
         return svgtools::meta::display::intersection(prefix, p_ir, view);
     }
@@ -512,6 +514,8 @@ class illustrator {
             auto p_ir = svgtools::conversion::intersection(
                 _detector, intersections, trajectory.dir(0.f), gctx,
                 _style._landmark_style);
+            // The first intersection sits in the origin by convention
+            p_ir._landmarks.front()._position = {0.f, 0.f, 0.f};
 
             ret.add_object(svgtools::meta::display::intersection(
                 prefix + "_record", p_ir, view));

--- a/tests/include/detray/test/common/detector_scan_config.hpp
+++ b/tests/include/detray/test/common/detector_scan_config.hpp
@@ -33,8 +33,8 @@ struct detector_scan_config : public test::fixture_base<>::configuration {
     /// Save results for later use in downstream tests
     std::shared_ptr<test::whiteboard> m_white_board;
     /// Name of the input file, containing the complete ray scan traces
-    std::string m_intersection_file{"truth_intersections.csv"};
-    std::string m_track_param_file{"truth_trk_parameters.csv"};
+    std::string m_intersection_file{"truth_intersections"};
+    std::string m_track_param_file{"truth_trk_parameters"};
     /// Mask tolerance for the intersectors
     std::array<scalar_type, 2> m_mask_tol{
         std::numeric_limits<float>::epsilon(),

--- a/tests/include/detray/test/cpu/detector_scan.hpp
+++ b/tests/include/detray/test/cpu/detector_scan.hpp
@@ -166,18 +166,26 @@ class detector_scan : public test::fixture_base<> {
         const std::size_t n_helices{trk_state_generator.size()};
         intersection_traces.reserve(n_helices);
 
-        const bool data_files_exist{
-            io::file_exists(m_cfg.intersection_file()) &&
-            io::file_exists(m_cfg.track_param_file())};
+        const auto pT_range = m_cfg.track_generator().mom_range();
+        std::string mometum_str{std::to_string(pT_range[0]) + "_" +
+                                std::to_string(pT_range[1])};
+
+        std::string track_param_file_name{m_cfg.track_param_file() + "_" +
+                                          mometum_str + "GeV.csv"};
+
+        std::string intersection_file_name{m_cfg.intersection_file() + "_" +
+                                           mometum_str + "GeV.csv"};
+
+        const bool data_files_exist{io::file_exists(intersection_file_name) &&
+                                    io::file_exists(track_param_file_name)};
 
         if (data_files_exist) {
 
             std::cout << "INFO: Reading data from file..." << std::endl;
 
             // Fill the intersection traces from file
-            detector_scanner::read(m_cfg.intersection_file(),
-                                   m_cfg.track_param_file(),
-                                   intersection_traces);
+            detector_scanner::read(intersection_file_name,
+                                   track_param_file_name, intersection_traces);
         } else {
 
             std::cout << "INFO: Generating trace data..." << std::endl;
@@ -200,9 +208,9 @@ class detector_scan : public test::fixture_base<> {
 
         // Csv output
         if (!data_files_exist && m_cfg.write_intersections()) {
-            detector_scanner::write_tracks(m_cfg.track_param_file(),
+            detector_scanner::write_tracks(track_param_file_name,
                                            intersection_traces);
-            detector_scanner::write_intersections(m_cfg.intersection_file(),
+            detector_scanner::write_intersections(intersection_file_name,
                                                   intersection_traces);
 
             std::cout << "  ->Wrote  " << intersection_traces.size()

--- a/tests/include/detray/test/cpu/navigation_validation.hpp
+++ b/tests/include/detray/test/cpu/navigation_validation.hpp
@@ -124,6 +124,8 @@ class navigation_validation : public test::fixture_base<> {
         std::vector<std::pair<trajectory_type, std::vector<intersection_t>>>
             missed_intersections{};
 
+        scalar_t min_pT{std::numeric_limits<scalar_t>::max()};
+        scalar_t max_pT{-std::numeric_limits<scalar_t>::max()};
         for (auto &truth_trace : truth_traces) {
 
             if (n_tracks >= m_cfg.n_tracks()) {
@@ -135,6 +137,8 @@ class navigation_validation : public test::fixture_base<> {
             const auto &start = truth_trace.front();
             const auto &track = start.track_param;
             trajectory_type test_traj = get_parametrized_trajectory(track);
+            min_pT = std::min(min_pT, track.pT());
+            max_pT = std::max(max_pT, track.pT());
 
             // Run the propagation
             auto [success, obj_tracer, mat_trace, nav_printer, step_printer] =
@@ -202,15 +206,20 @@ class navigation_validation : public test::fixture_base<> {
                                                n_matching_error);
 
         // Print track positions for plotting
+        std::string mometum_str{std::to_string(min_pT) + "_" +
+                                std::to_string(max_pT)};
+
         const auto data_path{
             std::filesystem::path{m_cfg.track_param_file()}.parent_path()};
-        const auto truth_trk_path{data_path /
-                                  (prefix + "truth_track_params.csv")};
-        const auto trk_path{data_path /
-                            (prefix + "navigation_track_params.csv")};
-        const auto mat_path{data_path / (prefix + "accumulated_material.csv")};
-        const auto missed_path{data_path /
-                               (prefix + "missed_intersections_dists.csv")};
+        const auto truth_trk_path{data_path / (prefix + "truth_track_params_" +
+                                               mometum_str + "GeV.csv")};
+        const auto trk_path{data_path / (prefix + "navigation_track_params_" +
+                                         mometum_str + "GeV.csv")};
+        const auto mat_path{data_path / (prefix + "accumulated_material_" +
+                                         mometum_str + "GeV.csv")};
+        const auto missed_path{
+            data_path /
+            (prefix + "missed_intersections_dists_" + mometum_str + "GeV.csv")};
 
         // Write the distance of the missed intersection local position
         // to the surface boundaries to file for plotting

--- a/tests/include/detray/test/device/cuda/navigation_validation.hpp
+++ b/tests/include/detray/test/device/cuda/navigation_validation.hpp
@@ -271,6 +271,8 @@ class navigation_validation : public test::fixture_base<> {
         EXPECT_EQ(recorded_intersections.size(),
                   truth_intersection_traces.size());
 
+        scalar_t min_pT{std::numeric_limits<scalar_t>::max()};
+        scalar_t max_pT{-std::numeric_limits<scalar_t>::max()};
         for (std::size_t i = 0u; i < truth_intersection_traces.size(); ++i) {
             auto &truth_trace = truth_intersection_traces[i];
             auto &recorded_trace = recorded_intersections[i];
@@ -282,6 +284,8 @@ class navigation_validation : public test::fixture_base<> {
             // Get the original test trajectory (ray or helix)
             const auto &trck_param = truth_trace.front().track_param;
             trajectory_type test_traj = get_parametrized_trajectory(trck_param);
+            min_pT = std::min(min_pT, trck_param.pT());
+            max_pT = std::max(max_pT, trck_param.pT());
 
             // Recorded only the start position, which added by default
             bool success{true};
@@ -333,16 +337,22 @@ class navigation_validation : public test::fixture_base<> {
                                                n_matching_error);
 
         // Print track positions for plotting
+        std::string mometum_str{std::to_string(min_pT) + "_" +
+                                std::to_string(max_pT)};
+
         const auto data_path{
             std::filesystem::path{m_cfg.track_param_file()}.parent_path()};
-        const auto truth_trk_path{data_path /
-                                  (prefix + "truth_track_params_cuda.csv")};
+        const auto truth_trk_path{
+            data_path /
+            (prefix + "truth_track_params_cuda_" + mometum_str + "GeV.csv")};
         const auto trk_path{data_path /
-                            (prefix + "navigation_track_params_cuda.csv")};
-        const auto mat_path{data_path /
-                            (prefix + "accumulated_material_cuda.csv")};
-        const auto missed_path{
-            data_path / (prefix + "missed_intersections_dists_cuda.csv")};
+                            (prefix + "navigation_track_params_cuda_" +
+                             mometum_str + "GeV.csv")};
+        const auto mat_path{data_path / (prefix + "accumulated_material_cuda_" +
+                                         mometum_str + "GeV.csv")};
+        const auto missed_path{data_path /
+                               (prefix + "missed_intersections_dists_cuda_" +
+                                mometum_str + "GeV.csv")};
 
         // Write the distance of the missed intersection local position
         // to the surface boundaries to file for plotting

--- a/tests/tools/include/detray/options/propagation_options.hpp
+++ b/tests/tools/include/detray/options/propagation_options.hpp
@@ -166,7 +166,7 @@ void configure_options<detray::stepping::config>(
     }
     if (!vm["path_limit"].defaulted()) {
         const float path_limit{vm["path_limit"].as<float>()};
-        assert(path_limit <= 0.f);
+        assert(path_limit > 0.f);
 
         cfg.path_limit = path_limit * unit<float>::m;
     }

--- a/tests/tools/src/cpu/detector_validation.cpp
+++ b/tests/tools/src/cpu/detector_validation.cpp
@@ -94,19 +94,16 @@ int main(int argc, char** argv) {
     const std::string file_prefix{data_dir + "/" + det_name};
     ray_scan_cfg.name(det_name + "_ray_scan");
     ray_scan_cfg.whiteboard(white_board);
-    ray_scan_cfg.intersection_file(file_prefix + "_ray_scan_intersections.csv");
-    ray_scan_cfg.track_param_file(file_prefix +
-                                  "_ray_scan_track_parameters.csv");
+    ray_scan_cfg.intersection_file(file_prefix + "_ray_scan_intersections");
+    ray_scan_cfg.track_param_file(file_prefix + "_ray_scan_track_parameters");
 
     hel_scan_cfg.name(det_name + "_helix_scan");
     hel_scan_cfg.whiteboard(white_board);
     // Let the Newton algorithm dynamically choose tol. based on approx. error
     hel_scan_cfg.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
                                  detray::detail::invalid_value<scalar_t>()});
-    hel_scan_cfg.intersection_file(file_prefix +
-                                   "_helix_scan_intersections.csv");
-    hel_scan_cfg.track_param_file(file_prefix +
-                                  "_helix_scan_track_parameters.csv");
+    hel_scan_cfg.intersection_file(file_prefix + "_helix_scan_intersections");
+    hel_scan_cfg.track_param_file(file_prefix + "_helix_scan_track_parameters");
 
     str_nav_cfg.whiteboard(white_board);
     hel_nav_cfg.whiteboard(white_board);

--- a/tests/tools/src/cpu/generate_toy_detector.cpp
+++ b/tests/tools/src/cpu/generate_toy_detector.cpp
@@ -42,7 +42,8 @@ int main(int argc, char **argv) {
 
     // Make sure material is written to file, if it was requested
     writer_cfg.write_material(vm.count("homogeneous_material") ||
-                              vm.count("material_maps"));
+                              vm.count("material_maps") ||
+                              vm.count("write_material"));
 
     // Build the geometry
     vecmem::host_memory_resource host_mr;

--- a/tests/tools/src/cuda/detector_validation_cuda.cpp
+++ b/tests/tools/src/cuda/detector_validation_cuda.cpp
@@ -83,19 +83,16 @@ int main(int argc, char** argv) {
     const std::string file_prefix{data_dir + "/" + det_name};
     ray_scan_cfg.name(det_name + "_ray_scan_for_cuda");
     ray_scan_cfg.whiteboard(white_board);
-    ray_scan_cfg.intersection_file(file_prefix + "_ray_scan_intersections.csv");
-    ray_scan_cfg.track_param_file(file_prefix +
-                                  "_ray_scan_track_parameters.csv");
+    ray_scan_cfg.intersection_file(file_prefix + "_ray_scan_intersections");
+    ray_scan_cfg.track_param_file(file_prefix + "_ray_scan_track_parameters");
 
     hel_scan_cfg.name(det_name + "_helix_scan_for_cuda");
     hel_scan_cfg.whiteboard(white_board);
     // Let the Newton algorithm dynamically choose tol. based on approx. error
     hel_scan_cfg.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
                                  detray::detail::invalid_value<scalar_t>()});
-    hel_scan_cfg.intersection_file(file_prefix +
-                                   "_helix_scan_intersections.csv");
-    hel_scan_cfg.track_param_file(file_prefix +
-                                  "_helix_scan_track_parameters.csv");
+    hel_scan_cfg.intersection_file(file_prefix + "_helix_scan_intersections");
+    hel_scan_cfg.track_param_file(file_prefix + "_helix_scan_track_parameters");
 
     str_nav_cfg.whiteboard(white_board);
     hel_nav_cfg.whiteboard(white_board);

--- a/tests/validation/python/impl/plot_navigation_validation.py
+++ b/tests/validation/python/impl/plot_navigation_validation.py
@@ -13,7 +13,7 @@ import os
 
 
 """ Read the detector scan data from files and prepare data frames """
-def read_scan_data(inputdir, det_name, logging):
+def read_scan_data(inputdir, det_name, momentum, logging):
 
     # Input data directory
     data_dir = os.fsencode(inputdir)
@@ -26,15 +26,15 @@ def read_scan_data(inputdir, det_name, logging):
     for file in os.listdir(data_dir):
         filename = os.fsdecode(file)
 
-        if filename.find(det_name + '_ray_scan_intersections') != -1:
+        if filename.find(det_name + '_ray_scan_intersections_' + momentum) != -1:
             ray_scan_intersections_file = inputdir + "/" + filename
             file_name = os.path.basename(ray_scan_intersections_file)
-        elif filename.find(det_name + '_ray_scan_track_parameters') != -1:
+        elif filename.find(det_name + '_ray_scan_track_parameters_' + momentum) != -1:
             ray_scan_track_param_file = inputdir + "/" + filename
-        elif filename.find(det_name + '_helix_scan_intersections') != -1:
+        elif filename.find(det_name + '_helix_scan_intersections_' + momentum) != -1:
             helix_scan_intersections_file = inputdir + "/" + filename
             file_name = os.path.basename(helix_scan_intersections_file)
-        elif filename.find(det_name + '_helix_scan_track_parameters') != -1:
+        elif filename.find(det_name + '_helix_scan_track_parameters_' + momentum) != -1:
             helix_scan_track_param_file = inputdir + "/" + filename
 
     # Read ray scan data
@@ -49,7 +49,7 @@ def read_scan_data(inputdir, det_name, logging):
 
 
 """ Read the recorded track positions from files and prepare data frames """
-def read_navigation_data(inputdir, det_name, read_cuda, logging):
+def read_navigation_data(inputdir, det_name, momentum, read_cuda, logging):
 
     # Input data directory
     data_dir = os.fsencode(inputdir)
@@ -61,17 +61,17 @@ def read_navigation_data(inputdir, det_name, read_cuda, logging):
     for file in os.listdir(data_dir):
         filename = os.fsdecode(file)
 
-        if read_cuda and filename.find(det_name + '_ray_navigation_track_params_cuda') != -1:
+        if read_cuda and filename.find(det_name + '_ray_navigation_track_params_cuda_' + momentum) != -1:
             ray_data_cuda_file = inputdir + "/" + filename
-        elif filename.find(det_name + '_ray_navigation_track_params') != -1:
+        elif filename.find(det_name + '_ray_navigation_track_params_' + momentum) != -1:
             ray_data_file = inputdir + "/" + filename
-        elif filename.find(det_name + '_ray_truth_track_params') != -1:
+        elif filename.find(det_name + '_ray_truth_track_params_' + momentum) != -1:
             ray_truth_file = inputdir + "/" + filename
-        elif read_cuda and filename.find(det_name + '_helix_navigation_track_params_cuda') != -1:
+        elif read_cuda and filename.find(det_name + '_helix_navigation_track_params_cuda_' + momentum) != -1:
             helix_data_cuda_file = inputdir + "/" + filename
-        elif filename.find(det_name + '_helix_navigation_track_params') != -1:
+        elif filename.find(det_name + '_helix_navigation_track_params_' + momentum) != -1:
             helix_data_file = inputdir + "/" + filename
-        elif filename.find(det_name + '_helix_truth_track_params') != -1:
+        elif filename.find(det_name + '_helix_truth_track_params_' + momentum) != -1:
             helix_truth_file = inputdir + "/" + filename
 
     ray_df = read_track_data(ray_data_file, logging)

--- a/tests/validation/python/impl/plot_ray_scan.py
+++ b/tests/validation/python/impl/plot_ray_scan.py
@@ -52,7 +52,7 @@ def plot_intersection_points_xy(opts, df, detector, scan_type, plotFactory,  out
     # Plot the xy coordinates of the filtered intersections points
     lgd_ops = plotting.legend_options('upper center', 4, 0.4, 0.005)
     hist_data = plotFactory.scatter(
-                            figsize = (8, 8),
+                            figsize = (10, 10),
                             x       = senstive_x,
                             y       = senstive_y,
                             xLabel  = r'$x\,\mathrm{[mm]}$',
@@ -82,13 +82,16 @@ def plot_intersection_points_xy(opts, df, detector, scan_type, plotFactory,  out
         plotFactory.highlight_region(hist_data, passive_x, passive_y, 'C2',    \
                                      "passives")
 
+    # Set aspect ratio
+    hist_data.ax.set_aspect('equal')
+
     # Refine legend
     hist_data.lgd.legend_handles[0].set_visible(False)
     for handle in hist_data.lgd.legend_handles[1:]:
         handle.set_sizes([40])
 
     # For this plot, move the legend ouside
-    hist_data.lgd.set_bbox_to_anchor((0.5, 1.11))
+    hist_data.lgd.set_bbox_to_anchor((0.5, 1.095))
 
     # Adjust spacing in box
     for vpack in hist_data.lgd._legend_handle_box.get_children()[:1]:
@@ -153,10 +156,10 @@ def plot_intersection_points_rz(opts, df, detector, scan_type, plotFactory,  out
     # Refine legend
     hist_data.lgd.legend_handles[0].set_visible(False)
     for handle in hist_data.lgd.legend_handles[1:]:
-        handle.set_sizes([40])
+        handle.set_sizes([45])
 
     # For this plot, move the legend ouside
-    hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    hist_data.lgd.set_bbox_to_anchor((0.5, 1.165))
 
     # Adjust spacing in box
     for vpack in hist_data.lgd._legend_handle_box.get_children()[:1]:
@@ -172,6 +175,6 @@ def plot_detector_scan_data(args, det_name, plot_factory, data_type, df, name, o
 
     # Plot truth scan
     plot_intersection_points_xy(args, df, det_name,
-                                name, plot_factory, out_format)
+                                data_type, plot_factory, out_format)
     plot_intersection_points_rz(args, df, det_name,
-                                name, plot_factory, out_format)
+                                data_type, plot_factory, out_format)

--- a/tests/validation/python/impl/plot_track_params.py
+++ b/tests/validation/python/impl/plot_track_params.py
@@ -35,6 +35,9 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
     detector_name = detector.replace(' ', '_')
     n_tracks = len(df['track_id'])
     tracks =  "rays" if track_type == "ray" else "helices"
+    # Where to place the legend box
+    box_anchor_x = 1.02
+    box_anchor_y = 1.245
 
     # Plot the charge
     lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
@@ -45,7 +48,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                      ax_formatter = ScalarFormatter())
 
     # For this plot, move the legend ouside
-    q_hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    q_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(q_hist_data,
                            f"{detector_name}_{track_type}_charge_dist",
@@ -60,9 +63,10 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                      bins    = 100,
                                      xLabel  = r'$p_{tot}\,\mathrm{[GeV]}$',
                                      lgd_ops = lgd_ops,
+                                     setLog  = True,
                                      ax_formatter = ScalarFormatter())
 
-    p_hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    p_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(p_hist_data,
                            f"{detector_name}_{track_type}_p_dist",
@@ -78,7 +82,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                       lgd_ops = lgd_ops,
                                       ax_formatter = ScalarFormatter())
 
-    pT_hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    pT_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(pT_hist_data,
                            f"{detector_name}_{track_type}_pT_dist",
@@ -87,12 +91,12 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
     # Plot the x-origin
     lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
     x_hist_data = plotFactory.hist1D(x      = df['x'],
-                                      bins    = 100,
-                                      xLabel  = r'$x\,\mathrm{[mm]}$',
-                                      lgd_ops = lgd_ops,
-                                      ax_formatter = ScalarFormatter())
+                                     bins    = 100,
+                                     xLabel  = r'$x\,\mathrm{[mm]}$',
+                                     lgd_ops = lgd_ops,
+                                     ax_formatter = ScalarFormatter())
 
-    x_hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    x_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(x_hist_data,
                            f"{detector_name}_{track_type}_x_origin",
@@ -101,12 +105,12 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
     # Plot the y-origin
     lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
     y_hist_data = plotFactory.hist1D(x      = df['y'],
-                                      bins    = 100,
-                                      xLabel  = r'$y\,\mathrm{[mm]}$',
-                                      lgd_ops = lgd_ops,
-                                      ax_formatter = ScalarFormatter())
+                                     bins    = 100,
+                                     xLabel  = r'$y\,\mathrm{[mm]}$',
+                                     lgd_ops = lgd_ops,
+                                     ax_formatter = ScalarFormatter())
 
-    y_hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    y_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(y_hist_data,
                            f"{detector_name}_{track_type}_y_origin",
@@ -114,12 +118,12 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
     # Plot the z-origin
     lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
     z_hist_data = plotFactory.hist1D(x      = df['z'],
-                                      bins    = 100,
-                                      xLabel  = r'$z\,\mathrm{[mm]}$',
-                                      lgd_ops = lgd_ops,
-                                      ax_formatter = ScalarFormatter())
+                                     bins    = 100,
+                                     xLabel  = r'$z\,\mathrm{[mm]}$',
+                                     lgd_ops = lgd_ops,
+                                     ax_formatter = ScalarFormatter())
 
-    z_hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    z_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(z_hist_data,
                            f"{detector_name}_{track_type}_z_origin",
@@ -134,7 +138,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                         lgd_ops = lgd_ops,
                                         ax_formatter = ScalarFormatter())
 
-    dir_phi_hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    dir_phi_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(dir_phi_hist_data,
                            f"{detector_name}_{track_type}_dir_phi",
@@ -149,7 +153,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                              lgd_ops = lgd_ops,
                                              ax_formatter = ScalarFormatter())
 
-    dir_theta_hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    dir_theta_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(dir_theta_hist_data,
                            f"{detector_name}_{track_type}_dir_theta",
@@ -164,7 +168,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                            lgd_ops = lgd_ops,
                                            ax_formatter = ScalarFormatter())
 
-    dir_eta_hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    dir_eta_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(dir_eta_hist_data,
                            f"{detector_name}_{track_type}_dir_eta",
@@ -197,7 +201,7 @@ def compare_track_pos_xy(opts, detector, scan_type, plotFactory, out_format,
     # Plot the xy coordinates of the filtered track positions
     lgd_ops = plotting.legend_options('upper center', 4, 0.4, 0.005)
     hist_data = plotFactory.scatter(
-                            figsize = (8, 8),
+                            figsize = (10, 10),
                             x       = first_x,
                             y       = first_y,
                             xLabel  = r'$x\,\mathrm{[mm]}$',
@@ -212,7 +216,7 @@ def compare_track_pos_xy(opts, detector, scan_type, plotFactory, out_format,
     plotFactory.highlight_region(hist_data, second_x, second_y, color2, label2)
 
     # For this plot, move the legend ouside
-    hist_data.lgd.set_bbox_to_anchor((0.5, 1.11))
+    hist_data.lgd.set_bbox_to_anchor((0.5, 1.095))
 
     detector_name = detector.replace(' ', '_')
     l1 = label1.replace(' ', '_').replace("(", "").replace(")", "")
@@ -258,7 +262,7 @@ def compare_track_pos_rz(opts, detector, scan_type, plotFactory, out_format,
     plotFactory.highlight_region(hist_data, second_z, np.hypot(second_x, second_y), color2, label2)
 
     # For this plot, move the legend ouside
-    hist_data.lgd.set_bbox_to_anchor((0.5, 1.15))
+    hist_data.lgd.set_bbox_to_anchor((0.5, 1.168))
 
     detector_name = detector.replace(' ', '_')
     l1 = label1.replace(' ', '_').replace("(", "").replace(")", "")
@@ -277,6 +281,9 @@ def plot_track_pos_dist(opts, detector, scan_type, plotFactory, out_format,
 
     n_tracks = np.max(df1['track_id']) + 1
     tracks =  "rays" if scan_type == "ray" else "helices"
+    # Where to place the legend box
+    box_anchor_x = 1.02
+    box_anchor_y = 1.24
 
     dist = np.sqrt(np.square(df1['x'] - df2['x']) +
                    np.square(df1['y'] - df2['y']) +
@@ -303,6 +310,8 @@ def plot_track_pos_dist(opts, detector, scan_type, plotFactory, out_format,
                                    setLog  = True,
                                    lgd_ops = lgd_ops)
 
+    hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
+
     detector_name = detector.replace(' ', '_')
     l1 = label1.replace(' ', '_').replace("(", "").replace(")", "")
     l2 = label2.replace(' ', '_').replace("(", "").replace(")", "")
@@ -317,6 +326,9 @@ def plot_track_pos_res(opts, detector, scan_type, plotFactory, out_format,
 
     n_tracks = np.max(df1['track_id']) + 1
     tracks =  "rays" if scan_type == "ray" else "helices"
+    # Where to place the legend box
+    box_anchor_x = 1.02
+    box_anchor_y = 1.285
 
     res = df1[var] - df2[var]
 
@@ -324,6 +336,7 @@ def plot_track_pos_res(opts, detector, scan_type, plotFactory, out_format,
     filter_res = np.absolute(res) < opts.outlier 
     filtered_res = res[filter_res]
 
+    uOut = oOut = int(0)
     if not np.all(filter_res == True):
         print(f"\nRemoved outliers ({var}):")
         for i, r in enumerate(res):
@@ -331,22 +344,29 @@ def plot_track_pos_res(opts, detector, scan_type, plotFactory, out_format,
                 track_id = (df1['track_id'].to_numpy())[i]
                 print(f"track {track_id}: {df1[var][i]} - {df2[var][i]} = {r}")
 
+                if r < 0.:
+                    uOut = uOut + 1
+                else:
+                    oOut = oOut + 1
+
 
     # Plot the xy coordinates of the filtered intersections points
-    lgd_ops = plotting.legend_options('upper right', 4, 0.8, 0.005)
-    hist_data = plotFactory.hist1D(x       = filtered_res,
-                                   bins    = 100,
-                                   xLabel  = r'$\mathrm{res}' + rf'\,{var}' + r'\,\mathrm{[mm]}$',
-                                   setLog  = False,
-                                   lgd_ops = lgd_ops)
-
+    lgd_ops = plotting.legend_options('upper right', 4, 0.01, 0.0005)
+    hist_data = plotFactory.hist1D(x        = filtered_res,
+                                   figsize  = (9, 9),
+                                   bins     = 100,
+                                   xLabel   = r'$\mathrm{res}' + rf'\,{var}' + r'\,\mathrm{[mm]}$',
+                                   setLog   = False,
+                                   lgd_ops  = lgd_ops,
+                                   uOutlier = uOut,
+                                   oOutlier = oOut)
 
     mu, sig = plotFactory.fit_gaussian(hist_data)
     if mu is None or sig is None:
         print(rf"WARNING: fit failed (res ({tracks}): {label1} - {label2} )")
 
     # Move the legend ouside plo
-    hist_data.lgd.set_bbox_to_anchor((1.02, 1.281))
+    hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     detector_name = detector.replace(' ', '_')
     l1 = label1.replace(' ', '_').replace("(", "").replace(")", "")

--- a/tests/validation/python/navigation_validation.py
+++ b/tests/validation/python/navigation_validation.py
@@ -140,7 +140,7 @@ def __main__():
     plot_factory = plt_factory(out_dir, logging)
 
     # Read the truth data
-    ray_scan_df, helix_scan_df = read_scan_data(datadir, det_name, logging)
+    ray_scan_df, helix_scan_df = read_scan_data(datadir, det_name, str(args.transverse_momentum), logging)
 
     plot_detector_scan_data(args, det_name, plot_factory, "ray", ray_scan_df, "ray_scan", out_format)
     plot_detector_scan_data(args, det_name, plot_factory, "helix", helix_scan_df, "helix_scan", out_format)
@@ -155,7 +155,7 @@ def __main__():
                       ray_intial_trk_df)
 
     # Read the recorded data
-    ray_nav_df, ray_truth_df, ray_nav_cuda_df, helix_nav_df, helix_truth_df, helix_nav_cuda_df = read_navigation_data(datadir, det_name, args.cuda,
+    ray_nav_df, ray_truth_df, ray_nav_cuda_df, helix_nav_df, helix_truth_df, helix_nav_cuda_df = read_navigation_data(datadir, det_name, str(args.transverse_momentum), args.cuda,
                                              logging)
 
     # Plot


### PR DESCRIPTION
Adds the momentum range to the data file names that are generated during the navigation validation, so that the validation can be run for different momenta automatically. Also cleans up the corresponding plots (font sizes etc.)

Fixes a bug, where in the svg the intersection positions on concentric cylinders were not displayed correctly after reading them back in from file, since the files only safe the bound coordinates. Therefore, the ```bound_to_global``` method is now used in the illustrator to get the correct positions, setting the first intersection always into the origin by convention (this is a dummy record that captures the initial track parameters).