### PR TITLE
ref: Use relative error in material comparison and improve material plots

### DIFF
--- a/tests/include/detray/test/common/material_validation_config.hpp
+++ b/tests/include/detray/test/common/material_validation_config.hpp
@@ -38,6 +38,8 @@ struct material_validation_config : public test::fixture_base<>::configuration {
     std::string m_material_file{"navigation_material_trace.csv"};
     /// The maximal number of test tracks to run
     std::size_t m_n_tracks{detray::detail::invalid_value<std::size_t>()};
+    /// Allowed relative discrepancy between truth and navigation material
+    scalar_type m_rel_error{0.001f};
 
     /// Getters
     /// @{
@@ -49,6 +51,7 @@ struct material_validation_config : public test::fixture_base<>::configuration {
     }
     const std::string &material_file() const { return m_material_file; }
     std::size_t n_tracks() const { return m_n_tracks; }
+    scalar_type relative_error() const { return m_rel_error; }
     /// @}
 
     /// Setters
@@ -76,6 +79,11 @@ struct material_validation_config : public test::fixture_base<>::configuration {
     }
     material_validation_config &n_tracks(std::size_t n) {
         m_n_tracks = n;
+        return *this;
+    }
+    material_validation_config &relative_error(scalar_type re) {
+        assert(re > 0.f);
+        m_rel_error = re;
         return *this;
     }
     /// @}

--- a/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
@@ -112,7 +112,10 @@ int main(int argc, char **argv) {
     test::material_validation<toy_detector_t>::config mat_val_cfg{};
     mat_val_cfg.name("toy_detector_material_validaiton");
     mat_val_cfg.whiteboard(white_board);
-    mat_val_cfg.tol(1.5e-6f);  // < Reduce tolerance for single precision tests
+    // Reduce tolerance for single precision tests
+    if constexpr (std::is_same_v<scalar_t, float>) {
+        mat_val_cfg.relative_error(1.5e-6f);
+    }
     mat_val_cfg.propagation() = cfg_str_nav.propagation();
 
     // @TODO: Put material maps on all portals

--- a/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
@@ -112,7 +112,10 @@ int main(int argc, char **argv) {
     test::material_validation<wire_chamber_t>::config mat_val_cfg{};
     mat_val_cfg.name("wire_chamber_material_validaiton");
     mat_val_cfg.whiteboard(white_board);
-    mat_val_cfg.tol(5e-3f);  // < Reduce tolerance for single precision tests
+    // Reduce tolerance for single precision tests
+    if constexpr (std::is_same_v<scalar_t, float>) {
+        mat_val_cfg.relative_error(130.f);
+    }
     mat_val_cfg.propagation() = cfg_str_nav.propagation();
 
     detail::register_checks<test::material_validation>(det, names, mat_val_cfg);

--- a/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
     mat_scan_cfg.name("toy_detector_material_scan_for_cuda");
     mat_scan_cfg.whiteboard(white_board);
     mat_scan_cfg.track_generator().uniform_eta(true).eta_range(-4.f, 4.f);
-    mat_scan_cfg.track_generator().phi_steps(10).eta_steps(100);
+    mat_scan_cfg.track_generator().phi_steps(100).eta_steps(100);
 
     // Record the material using a ray scan
     detail::register_checks<test::material_scan>(toy_det, toy_names,
@@ -117,8 +117,8 @@ int main(int argc, char **argv) {
     mat_val_cfg.tol(1e-6f);  // < Reduce tolerance for single precision tests
     mat_val_cfg.propagation() = cfg_str_nav.propagation();
 
-    /*detail::register_checks<detray::cuda::material_validation>(toy_det,
-       toy_names, mat_val_cfg);*/
+    detail::register_checks<detray::cuda::material_validation>(
+        toy_det, toy_names, mat_val_cfg);
 
     // Run the material validation - Homogeneous material
     toy_cfg.use_material_maps(false);

--- a/tests/integration_tests/device/cuda/wire_chamber_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/wire_chamber_navigation_validation.cpp
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
     cfg_hel_scan.track_generator().n_tracks(1000u);
     cfg_hel_scan.track_generator().eta_range(-1.f, 1.f);
     // TODO: Fails for smaller momenta
-    cfg_hel_scan.track_generator().p_T(5.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_T(4.f * unit<scalar_t>::GeV);
 
     detail::register_checks<test::helix_scan>(det, names, cfg_hel_scan);
 
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
     detray::cuda::helix_navigation<wire_chamber_t>::config cfg_hel_nav{};
     cfg_hel_nav.name("wire_chamber_helix_navigation_cuda");
     cfg_hel_nav.whiteboard(white_board);
-    cfg_hel_nav.propagation().navigation.min_mask_tolerance *= 0.9f;
+    cfg_hel_nav.propagation().navigation.min_mask_tolerance *= 12.f;
     cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
 
     detail::register_checks<detray::cuda::helix_navigation>(det, names,
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
     mat_scan_cfg.name("wire_chamber_material_scan_for_cuda");
     mat_scan_cfg.whiteboard(white_board);
     mat_scan_cfg.track_generator().uniform_eta(true).eta_range(-1.f, 1.f);
-    mat_scan_cfg.track_generator().phi_steps(10).eta_steps(100);
+    mat_scan_cfg.track_generator().phi_steps(100).eta_steps(100);
 
     // Record the material using a ray scan
     detail::register_checks<test::material_scan>(det, names, mat_scan_cfg);
@@ -118,7 +118,10 @@ int main(int argc, char **argv) {
     mat_val_cfg.name("wire_chamber_material_validaiton_cuda");
     mat_val_cfg.whiteboard(white_board);
     mat_val_cfg.device_mr(&dev_mr);
-    mat_val_cfg.tol(5e-3f);  // < Reduce tolerance for single precision tests
+    // Reduce tolerance for single precision tests
+    if constexpr (std::is_same_v<scalar_t, float>) {
+        mat_val_cfg.relative_error(130.f);
+    }
     mat_val_cfg.propagation() = cfg_str_nav.propagation();
 
     detail::register_checks<detray::cuda::material_validation>(det, names,

--- a/tests/tools/src/cpu/material_validation.cpp
+++ b/tests/tools/src/cpu/material_validation.cpp
@@ -47,8 +47,8 @@ int main(int argc, char **argv) {
     po::options_description desc("\ndetray material validation options");
 
     desc.add_options()(
-        "tol", boost::program_options::value<float>()->default_value(1e-4f),
-        "Tolerance for comparing the material traces");
+        "tol", boost::program_options::value<float>()->default_value(1.f),
+        "Tolerance for comparing the material traces [%]");
 
     // Configs to be filled
     detray::io::detector_reader_config reader_cfg{};
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 
     // General options
     if (vm.count("tol")) {
-        mat_val_cfg.tol(vm["tol"].as<float>());
+        mat_val_cfg.relative_error(vm["tol"].as<float>() / 100.f);
     }
 
     vecmem::host_memory_resource host_mr;

--- a/tests/tools/src/cuda/material_validation_cuda.cpp
+++ b/tests/tools/src/cuda/material_validation_cuda.cpp
@@ -47,8 +47,8 @@ int main(int argc, char **argv) {
     po::options_description desc("\ndetray CUDA material validation options");
 
     desc.add_options()(
-        "tol", boost::program_options::value<float>()->default_value(1e-4f),
-        "Tolerance for comparing the material traces");
+        "tol", boost::program_options::value<float>()->default_value(1.f),
+        "Tolerance for comparing the material traces [%]");
 
     // Configs to be filled
     detray::io::detector_reader_config reader_cfg{};
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 
     // General options
     if (vm.count("tol")) {
-        mat_val_cfg.tol(vm["tol"].as<float>());
+        mat_val_cfg.relative_error(vm["tol"].as<float>() / 100.f);
     }
 
     /// Vecmem memory resource for the device allocations
@@ -74,12 +74,14 @@ int main(int argc, char **argv) {
     auto white_board = std::make_shared<test::whiteboard>();
 
     // Print the detector's material as recorded by a ray scan
+    mat_val_cfg.name("material_validation_for_cuda");
     mat_scan_cfg.whiteboard(white_board);
     mat_scan_cfg.track_generator().uniform_eta(true);
     detray::detail::register_checks<test::material_scan>(det, names,
                                                          mat_scan_cfg);
 
     // Now trace the material during navigation and compare
+    mat_val_cfg.name("material_validation_cuda");
     mat_val_cfg.whiteboard(white_board);
     mat_val_cfg.device_mr(&dev_mr);
 

--- a/tests/validation/python/impl/plot_material_scan.py
+++ b/tests/validation/python/impl/plot_material_scan.py
@@ -34,11 +34,14 @@ def read_material_data(inputdir, logging, det_name, read_cuda):
         elif read_cuda and filename.find(det_name + '_cuda_navigation_material_trace') != -1:
             cuda_material_trace_file = inputdir + "/" + filename
 
-    df_scan = pd.read_csv(material_scan_file)
-    df_cpu_trace = pd.read_csv(cpu_material_trace_file)
+    df_scan = pd.read_csv(material_scan_file,
+                               float_precision='round_trip')
+    df_cpu_trace = pd.read_csv(cpu_material_trace_file,
+                               float_precision='round_trip')
     df_cuda_trace = pd.DataFrame({})
     if read_cuda:
-        df_cuda_trace = pd.read_csv(cuda_material_trace_file)
+        df_cuda_trace = pd.read_csv(cuda_material_trace_file,
+                               float_precision='round_trip')
 
     return df_scan, df_cpu_trace, df_cuda_trace
 
@@ -61,6 +64,21 @@ def get_n_bins(df):
     return xBinning, yBinning
 
 
+""" Calculate the binwise errors: Standard Error on the Mean """
+def get_errors(df, n, name):
+    # Number of entries per bin
+    errors = []
+    # Iterate over data per bin
+    for i in range(0, n):
+        # Project the next n rows of the data frame (the bin content is the 
+        # mean of the material along phi)
+        bin_data = df.iloc[i * n:(i + 1) * n]
+        # Caluculate the error on the mean: stddev/sqrt(n)
+        errors.append(np.std(bin_data[name], axis=0) / math.sqrt(n))
+
+    return errors
+
+
 """ Plot the material thickenss vs phi and eta in units of X_0 """
 def X0_vs_eta_phi(df, label, detector, plotFactory,  out_format =  "pdf"):
 
@@ -77,6 +95,7 @@ def X0_vs_eta_phi(df, label, detector, plotFactory,  out_format =  "pdf"):
                             yLabel = r'$\phi\,\mathrm{[rad]}$',
                             zLabel = r'thickness / $X_0$',
                             xBins = xBinning, yBins = yBinning,
+                            figsize  = (9, 7),
                             showStats = False)
 
     plotFactory.write_plot(hist_data, detector + "_" + label + "_t_X0_map",  out_format)
@@ -91,6 +110,7 @@ def X0_vs_eta_phi(df, label, detector, plotFactory,  out_format =  "pdf"):
                             yLabel = r'$\phi\,\mathrm{[rad]}$',
                             zLabel = r'path length / $X_0$',
                             xBins = xBinning, yBins = yBinning,
+                            figsize  = (9, 7),
                             showStats = False)
 
     plotFactory.write_plot(hist_data, detector + "_" + label + "_s_X0_map",  out_format)
@@ -112,6 +132,7 @@ def L0_vs_eta_phi(df, label, detector, plotFactory,  out_format =  "pdf"):
                             yLabel = r'$\phi\,\mathrm{[rad]}$',
                             zLabel = r'thickness / $\Lambda_0$',
                             xBins = xBinning, yBins = yBinning,
+                            figsize  = (9, 7),
                             showStats = False)
 
     plotFactory.write_plot(hist_data, detector + "_" + label + "_t_L0_map",  out_format)
@@ -126,6 +147,7 @@ def L0_vs_eta_phi(df, label, detector, plotFactory,  out_format =  "pdf"):
                             yLabel = r'$\phi\,\mathrm{[rad]}$',
                             zLabel = r'path length / $\Lambda_0$',
                             xBins = xBinning, yBins = yBinning,
+                            figsize  = (9, 7),
                             showStats = False)
 
     plotFactory.write_plot(hist_data, detector + "_" + label + "_s_L0_map",  out_format)
@@ -133,85 +155,152 @@ def L0_vs_eta_phi(df, label, detector, plotFactory,  out_format =  "pdf"):
 
 """ Plot the material thickness in units of X_0 vs eta """
 def X0_vs_eta(df, label, detector, plotFactory,  out_format =  "pdf"):
+    # Where to place the legend box
+    box_anchor_x = 1.02
+    box_anchor_y = 1.145
 
     # Histogram bin edges
     xBinning, yBinning = get_n_bins(df)
     lgd_ops = plotting.get_legend_options()
     lgd_ops._replace(loc = 'upper center')
 
-    phi_normalization = len(yBinning) - 1
+    # Same number of entries in every bin as per uniform ray scan
+    n_phi = len(yBinning) - 1
 
     hist_data = plotFactory.hist1D(
                             x      = df['eta'],
-                            w      = df['mat_tX0'] / phi_normalization,
+                            w      = df['mat_tX0'] / n_phi,
+                            errors = get_errors(df, n_phi, 'mat_tX0'),
                             normalize = False,
                             label  = rf'{detector}',
                             xLabel = r'$\eta$',
                             yLabel = r'thickness / $X_0$',
                             bins = xBinning,
                             showStats = False,
+                            figsize  = (9, 7),
                             lgd_ops = lgd_ops)
 
-    # Move the legend ouside plo
-    hist_data.lgd.set_bbox_to_anchor((0.825, 1.15))
+    # Move the legend ouside plot
+    hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(hist_data, detector + "_" + label + "_t_X0",  out_format)
 
     hist_data = plotFactory.hist1D(
                             x      = df['eta'],
-                            w      = df['mat_sX0'] / phi_normalization,
+                            w      = df['mat_sX0'] / n_phi,
+                            errors = get_errors(df, n_phi, 'mat_sX0'),
                             normalize = False,
                             label  = rf'{detector}',
                             xLabel = r'$\eta$',
                             yLabel = r'path length / $X_0$',
                             bins = xBinning,
                             showStats = False,
+                            figsize  = (9, 7),
                             lgd_ops = lgd_ops)
 
-    # Move the legend ouside plo
-    hist_data.lgd.set_bbox_to_anchor((0.825, 1.15))
+    # Move the legend ouside plot
+    hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(hist_data, detector + "_" + label + "_s_X0",  out_format)
 
 
 """ Plot the material thickness in units of L_0 vs eta """
 def L0_vs_eta(df, label, detector, plotFactory,  out_format =  "pdf"):
+    # Where to place the legend box
+    box_anchor_x = 1.02
+    box_anchor_y = 1.145
 
     # Histogram bin edges
     xBinning, yBinning = get_n_bins(df)
     lgd_ops = plotting.get_legend_options()
     lgd_ops._replace(loc = 'upper center')
 
-    phi_normalization = len(yBinning) - 1
+    # Same number of entries in every bin as per uniform ray scan
+    n_phi = len(yBinning) - 1
 
     hist_data = plotFactory.hist1D(
                             x      = df['eta'],
-                            w      = df['mat_tL0'] / phi_normalization,
+                            w      = df['mat_tL0'] / n_phi,
+                            errors = get_errors(df, n_phi, 'mat_tL0'),
                             normalize = False,
                             label  = rf'{detector}',
                             xLabel = r'$\eta$',
                             yLabel = r'thickness / $\Lambda_0$',
                             bins = xBinning,
                             showStats = False,
+                            figsize  = (9, 7),
                             lgd_ops = lgd_ops)
 
-    # Move the legend ouside plo
-    hist_data.lgd.set_bbox_to_anchor((0.825, 1.15))
+    # Move the legend ouside plot
+    hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(hist_data, detector + "_" + label + "_t_L0",  out_format)
 
     hist_data = plotFactory.hist1D(
                             x      = df['eta'],
-                            w      = df['mat_sL0'] / phi_normalization,
+                            w      = df['mat_sL0'] / n_phi,
+                            errors = get_errors(df, n_phi, 'mat_sL0'),
                             normalize = False,
                             label  = rf'{detector}',
                             xLabel = r'$\eta$',
                             yLabel = r'path length / $\Lambda_0$',
                             bins = xBinning,
                             showStats = False,
+                            figsize  = (9, 7),
                             lgd_ops = lgd_ops)
 
-    # Move the legend ouside plo
-    hist_data.lgd.set_bbox_to_anchor((0.825, 1.15))
+    # Move the legend ouside plot
+    hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
 
     plotFactory.write_plot(hist_data, detector + "_" + label + "_s_L0",  out_format)
+
+
+""" Compare two material distributions """
+def compare_mat(df_truth, df_rec, label, detector, plotFactory, out_format =  "pdf"):
+    # Where to place the legend box
+    box_anchor_x = 1.02
+    box_anchor_y = 1.29
+
+    # Histogram bin edges
+    xBinning, yBinning = get_n_bins(df_truth)
+    lgd_ops = plotting.get_legend_options()
+    lgd_ops._replace(loc = 'upper center')
+
+    # Same number of entries in every bin as per uniform ray scan
+    n_phi = len(yBinning) - 1
+
+    truth_data = plotFactory.hist1D(
+                            x      = df_truth['eta'],
+                            w      = df_truth['mat_sX0'] / n_phi,
+                            errors = get_errors(df_truth, n_phi, 'mat_sX0'),
+                            normalize = False,
+                            label  = rf'{detector}: scan',
+                            xLabel = r'$\eta$',
+                            yLabel = r'path length / $X_0$',
+                            bins = xBinning,
+                            showStats = False,
+                            figsize  = (10, 10),
+                            layout = 'tight',
+                            lgd_ops = lgd_ops)
+
+    # Move the legend ouside plot
+    truth_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
+
+    # Add recorded data for comparison
+    rec_data = plotFactory.add_plot(
+                            oldHist   = truth_data,
+                            x         = df_rec['eta'].to_numpy(dtype = np.double),
+                            w         = df_rec['mat_sX0'] / n_phi,
+                            errors    = get_errors(df_rec, n_phi, 'mat_sX0'),
+                            normalize = False,
+                            label     = rf'{detector}: navigator')
+
+    # Add a ratio plot to hist_data
+    ratio_data = plotFactory.add_ratio(
+                        nom        = truth_data,
+                        denom      = rec_data,
+                        label      = 'scan/navigation',
+                        setLog     = False,
+                        showErrors = True)
+
+    plotFactory.write_plot(ratio_data, detector + "_" + label + "_comparison_s_X0",  out_format)

--- a/tests/validation/python/impl/plot_navigation_validation.py
+++ b/tests/validation/python/impl/plot_navigation_validation.py
@@ -91,11 +91,11 @@ def read_navigation_data(inputdir, det_name, momentum, read_cuda, logging):
 def plot_navigation_data(args, det_name, plot_factory, data_type, df_truth, truth_name, df_ref, ref_name, out_format = "png"):
 
     # xy
-    compare_track_pos_xy(args, det_name, data_type, plot_factory, out_format,
+    compare_track_pos_xy(args, det_name, data_type, plot_factory, "png",
                          df_truth, truth_name, 'r',
                          df_ref, ref_name, 'darkgrey')
     # rz
-    compare_track_pos_rz(args, det_name, data_type, plot_factory, out_format,
+    compare_track_pos_rz(args, det_name, data_type, plot_factory, "png",
                          df_truth, truth_name, 'r',
                          df_ref, ref_name, 'darkgrey')
 

--- a/tests/validation/python/impl/plot_track_params.py
+++ b/tests/validation/python/impl/plot_track_params.py
@@ -45,6 +45,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                      bins    = 4,
                                      xLabel  = r'$q\,\mathrm{[e]}$',
                                      lgd_ops = lgd_ops,
+                                     figsize  = (8.5, 8.5),
                                      ax_formatter = ScalarFormatter())
 
     # For this plot, move the legend ouside
@@ -64,6 +65,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                      xLabel  = r'$p_{tot}\,\mathrm{[GeV]}$',
                                      lgd_ops = lgd_ops,
                                      setLog  = True,
+                                     figsize  = (8.5, 8.5),
                                      ax_formatter = ScalarFormatter())
 
     p_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
@@ -80,6 +82,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                       bins    = 100,
                                       xLabel  = r'$p_{T}\,\mathrm{[GeV]}$',
                                       lgd_ops = lgd_ops,
+                                      figsize  = (8.5, 8.5),
                                       ax_formatter = ScalarFormatter())
 
     pT_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
@@ -94,6 +97,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                      bins    = 100,
                                      xLabel  = r'$x\,\mathrm{[mm]}$',
                                      lgd_ops = lgd_ops,
+                                     figsize  = (8.5, 8.5),
                                      ax_formatter = ScalarFormatter())
 
     x_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
@@ -108,6 +112,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                      bins    = 100,
                                      xLabel  = r'$y\,\mathrm{[mm]}$',
                                      lgd_ops = lgd_ops,
+                                     figsize  = (8.5, 8.5),
                                      ax_formatter = ScalarFormatter())
 
     y_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
@@ -121,6 +126,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                      bins    = 100,
                                      xLabel  = r'$z\,\mathrm{[mm]}$',
                                      lgd_ops = lgd_ops,
+                                     figsize  = (8.5, 8.5),
                                      ax_formatter = ScalarFormatter())
 
     z_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
@@ -136,6 +142,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                         bins    = 100,
                                         xLabel  = r'$\varphi\,\mathrm{[rad]}$',
                                         lgd_ops = lgd_ops,
+                                        figsize  = (8.5, 8.5),
                                         ax_formatter = ScalarFormatter())
 
     dir_phi_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
@@ -151,6 +158,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                              bins    = 100,
                                              xLabel  = r'$\theta\,\mathrm{[rad]}$',
                                              lgd_ops = lgd_ops,
+                                             figsize  = (8.5, 8.5),
                                              ax_formatter = ScalarFormatter())
 
     dir_theta_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
@@ -166,6 +174,7 @@ def plot_track_params(opts, detector, track_type, plotFactory, out_format,
                                            bins    = 100,
                                            xLabel  = r'$\eta$',
                                            lgd_ops = lgd_ops,
+                                           figsize  = (8.5, 8.5),
                                            ax_formatter = ScalarFormatter())
 
     dir_eta_hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
@@ -308,6 +317,7 @@ def plot_track_pos_dist(opts, detector, scan_type, plotFactory, out_format,
                                    bins    = 100,
                                    xLabel  = r'$d\,\mathrm{[mm]}$',
                                    setLog  = True,
+                                   figsize  = (8.5, 8.5),
                                    lgd_ops = lgd_ops)
 
     hist_data.lgd.set_bbox_to_anchor((box_anchor_x, box_anchor_y))
@@ -328,7 +338,7 @@ def plot_track_pos_res(opts, detector, scan_type, plotFactory, out_format,
     tracks =  "rays" if scan_type == "ray" else "helices"
     # Where to place the legend box
     box_anchor_x = 1.02
-    box_anchor_y = 1.285
+    box_anchor_y = 1.28
 
     res = df1[var] - df2[var]
 

--- a/tests/validation/python/material_validation.py
+++ b/tests/validation/python/material_validation.py
@@ -43,8 +43,8 @@ def __main__():
                         help=("Directoy containing the data files"),
                         default = "./validation_data/material", type=str)
     parser.add_argument("--tolerance", "-t",
-                        help=("Tolerance for material comparisons"),
-                        default = 0.0001, type=float)
+                        help=("Tolerance for material comparisons [%]"),
+                        default = 1, type=float)
     parser.add_argument("--cuda",
                         help=("Run the CUDA material validation."),
                         action="store_true", default=False)
@@ -143,6 +143,10 @@ def __main__():
     mat_plotter.L0_vs_eta(df_cpu, "cpu_material_trace", det_name,
                           plot_factory, out_format)
 
+    # Comparison between scan and navigator trace in sX0
+    mat_plotter.compare_mat(df_scan, df_cpu, "cpu_material", det_name,
+                            plot_factory, out_format)
+
     # CUDA
     if args.cuda:
         mat_plotter.X0_vs_eta_phi(df_cuda, "cuda_material_trace", det_name,
@@ -153,6 +157,8 @@ def __main__():
                               plot_factory, out_format)
         mat_plotter.L0_vs_eta(df_cuda, "cuda_material_trace", det_name,
                               plot_factory, out_format)
+        mat_plotter.compare_mat(df_scan, df_cuda, "cuda_material", det_name,
+                                plot_factory, out_format)
 
 #-------------------------------------------------------------------------------
 

--- a/tests/validation/python/navigation_validation.py
+++ b/tests/validation/python/navigation_validation.py
@@ -142,8 +142,8 @@ def __main__():
     # Read the truth data
     ray_scan_df, helix_scan_df = read_scan_data(datadir, det_name, str(args.transverse_momentum), logging)
 
-    plot_detector_scan_data(args, det_name, plot_factory, "ray", ray_scan_df, "ray_scan", out_format)
-    plot_detector_scan_data(args, det_name, plot_factory, "helix", helix_scan_df, "helix_scan", out_format)
+    plot_detector_scan_data(args, det_name, plot_factory, "ray", ray_scan_df, "ray_scan", "png")
+    plot_detector_scan_data(args, det_name, plot_factory, "helix", helix_scan_df, "helix_scan", "png")
 
     # Plot distributions of track parameter values
     # Only take initial track parameters from generator


### PR DESCRIPTION
Switches to realtive error checking for the material traces and cleans up material plots. Also adds a comparision plot between the material scan data and the navigaiton material traces. The large scatter plots are for now always returned as pngs