### PR TITLE
Fix typo in getting material

### DIFF
--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -112,7 +112,7 @@ struct surface_kernels {
             const point2_type& loc_p) const {
 
             return detail::material_accessor::get(mat_group, idx, loc_p)
-                .get_maerial();
+                .get_material();
         }
     };
 


### PR DESCRIPTION
Fixed typo in the call. This was throwing an error when I tried to get the material properties at a surface.