### PR TITLE
fix: access to material parameters from tracking surface

### DIFF
--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/materials/detail/material_accessor.hpp"
+#include "detray/materials/material.hpp"
 #include "detray/propagator/detail/jacobian_engine.hpp"
 #include "detray/tracks/detail/transform_track_parameters.hpp"
 #include "detray/tracks/tracks.hpp"
@@ -111,8 +112,16 @@ struct surface_kernels {
             const mat_group_t& mat_group, const index_t& idx,
             const point2_type& loc_p) const {
 
-            return detail::material_accessor::get(mat_group, idx, loc_p)
-                .get_material();
+            using material_t = typename mat_group_t::value_type;
+
+            if constexpr (detail::is_surface_material_v<material_t>) {
+                return &(detail::material_accessor::get(mat_group, idx, loc_p)
+                             .get_material());
+            } else {
+                using scalar_t = typename material_t::scalar_type;
+                // Volume material (cannot be reached from a surface)
+                return static_cast<const material<scalar_t>*>(nullptr);
+            }
         }
     };
 

--- a/core/include/detray/geometry/detail/volume_kernels.hpp
+++ b/core/include/detray/geometry/detail/volume_kernels.hpp
@@ -22,16 +22,19 @@ struct get_material_params {
                                               const index_t &idx,
                                               const point_t &loc_p) const {
         using material_t = typename mat_group_t::value_type;
-        using scalar_t = typename material_t::scalar_type;
 
-        if constexpr (std::is_same_v<material_t, material<scalar_t>>) {
-            // Homogeneous volume material
-            return &(detail::material_accessor::get(mat_group, idx, loc_p));
-        } else if constexpr (detail::is_volume_material_v<material_t>) {
-            // Volume material maps
-            return &(detail::material_accessor::get(mat_group, idx, loc_p)
-                         .get_material());
+        if constexpr (detail::is_volume_material_v<material_t>) {
+
+            if constexpr (detail::is_hom_material_v<material_t>) {
+                // Homogeneous volume material
+                return &(detail::material_accessor::get(mat_group, idx, loc_p));
+            } else {
+                // Volume material maps
+                return &(detail::material_accessor::get(mat_group, idx, loc_p)
+                             .get_material());
+            }
         } else {
+            using scalar_t = typename material_t::scalar_type;
             // Cannot be reached for volumes
             return static_cast<const material<scalar_t> *>(nullptr);
         }

--- a/core/include/detray/geometry/tracking_surface.hpp
+++ b/core/include/detray/geometry/tracking_surface.hpp
@@ -222,9 +222,10 @@ class tracking_surface {
         return math::fabs(vector::dot(dir, normal(ctx, p)));
     }
 
-    /// @returns the material parameters at the local position @param loc_p
-    DETRAY_HOST_DEVICE constexpr material<scalar_type> material_parameters(
-        const point2_type &loc_p) const {
+    /// @returns a pointer to the material parameters at the local position
+    /// @param loc_p
+    DETRAY_HOST_DEVICE constexpr const material<scalar_type>
+        *material_parameters(const point2_type &loc_p) const {
         return visit_material<typename kernels::get_material_params>(loc_p);
     }
 

--- a/core/include/detray/geometry/tracking_volume.hpp
+++ b/core/include/detray/geometry/tracking_volume.hpp
@@ -96,7 +96,8 @@ class tracking_volume {
         return transform().translation();
     }
 
-    /// @returns the material parameters at the local position @param loc_p
+    /// @returns a pointer to the material parameters at the local position
+    /// @param loc_p
     DETRAY_HOST_DEVICE constexpr auto material_parameters(
         const point3_type &loc_p) const
         -> const detray::material<scalar_type> * {

--- a/core/include/detray/materials/material.hpp
+++ b/core/include/detray/materials/material.hpp
@@ -224,6 +224,10 @@ namespace detail {
 template <typename scalar_t>
 struct is_hom_material<material<scalar_t>, void> : public std::true_type {};
 
+// Pick the raw material type up for homogeneous volume material
+template <typename scalar_t>
+struct is_volume_material<material<scalar_t>, void> : public std::true_type {};
+
 }  // namespace detail
 
 // Macro for declaring the predefined materials (w/o Density effect data)

--- a/core/include/detray/materials/material_map.hpp
+++ b/core/include/detray/materials/material_map.hpp
@@ -44,20 +44,22 @@ struct is_material_map<
         is_grid_v<material_t> &&
             std::is_same_v<
                 typename material_t::value_type,
-                material_slab<typename material_t::value_type::scalar_type>> &&
-            (material_t::dim == 2),
+                material_slab<typename material_t::value_type::scalar_type>>,
         void>> : public std::true_type {};
 
-template <class material_t>
+// Pick the 2D material map types up for surface material maps
+template <typename material_t>
+struct is_surface_material<
+    material_t,
+    std::enable_if_t<is_material_map_v<material_t> && (material_t::dim == 2),
+                     void>> : public std::true_type {};
+
+// Pick the 3D material map types up for volume material maps
+template <typename material_t>
 struct is_volume_material<
     material_t,
-    std::enable_if_t<
-        is_grid_v<material_t> &&
-            std::is_same_v<
-                typename material_t::value_type,
-                material_slab<typename material_t::value_type::scalar_type>> &&
-            (material_t::dim == 3),
-        void>> : public std::true_type {};
+    std::enable_if_t<is_material_map_v<material_t> && (material_t::dim == 3),
+                     void>> : public std::true_type {};
 
 }  // namespace detail
 

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -122,6 +122,11 @@ namespace detail {
 template <typename scalar_t>
 struct is_hom_material<material_rod<scalar_t>, void> : public std::true_type {};
 
+// Pick the material rod type up for homogeneous surface material
+template <typename scalar_t>
+struct is_surface_material<material_rod<scalar_t>, void>
+    : public std::true_type {};
+
 }  // namespace detail
 
 }  // namespace detray

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -120,6 +120,11 @@ template <class scalar_t>
 struct is_hom_material<material_slab<scalar_t>, void> : public std::true_type {
 };
 
+// Pick the material slab type up for homogeneous surface material
+template <typename scalar_t>
+struct is_surface_material<material_slab<scalar_t>, void>
+    : public std::true_type {};
+
 }  // namespace detail
 
 }  // namespace detray

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -76,10 +76,7 @@ struct pointwise_material_interactor : actor {
             using material_t = typename mat_group_t::value_type;
 
             // Filter material types for which to do "pointwise" interactions
-            if constexpr ((detail::is_hom_material_v<material_t> &&
-                           !std::is_same_v<material_t,
-                                           material<scalar_type>>) ||
-                          detail::is_material_map_v<material_t>) {
+            if constexpr (detail::is_surface_material_v<material_t>) {
 
                 const auto mat = detail::material_accessor::get(
                     material_group, mat_index, bound_params.bound_local());

--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -153,9 +153,7 @@ struct material_checker {
     /// @param id type id of the material grid collection
     template <typename material_coll_t, typename index_t, typename id_t,
               std::enable_if_t<detail::is_material_map_v<
-                                   typename material_coll_t::value_type> ||
-                                   detail::is_volume_material_v<
-                                       typename material_coll_t::value_type>,
+                                   typename material_coll_t::value_type>,
                                bool> = true>
     DETRAY_HOST_DEVICE void operator()(const material_coll_t &material_coll,
                                        const index_t idx, const id_t id) const {

--- a/core/include/detray/utils/type_traits.hpp
+++ b/core/include/detray/utils/type_traits.hpp
@@ -160,4 +160,10 @@ struct is_volume_material : public std::false_type {};
 template <typename T>
 inline constexpr bool is_volume_material_v = is_volume_material<T>::value;
 
+template <class material_t, typename = void>
+struct is_surface_material : public std::false_type {};
+
+template <typename T>
+inline constexpr bool is_surface_material_v = is_surface_material<T>::value;
+
 }  // namespace detray::detail

--- a/io/include/detray/io/common/detail/type_info.hpp
+++ b/io/include/detray/io/common/detail/type_info.hpp
@@ -69,8 +69,7 @@ constexpr io::material_id get_id() {
 
 /// Infer the IO material id from the material type - material maps
 template <typename material_t,
-          std::enable_if_t<detray::detail::is_material_map_v<material_t> ||
-                               detray::detail::is_volume_material_v<material_t>,
+          std::enable_if_t<detray::detail::is_material_map_v<material_t>,
                            bool> = true>
 constexpr io::material_id get_id() {
 

--- a/tests/include/detray/test/common/utils/material_validation_utils.hpp
+++ b/tests/include/detray/test/common/utils/material_validation_utils.hpp
@@ -75,9 +75,7 @@ struct get_material_params {
         constexpr auto inv{detail::invalid_value<scalar_t>()};
 
         // Access homogeneous surface material or material maps
-        if constexpr ((detail::is_hom_material_v<material_t> &&
-                       !std::is_same_v<material_t, material<scalar_t>>) ||
-                      detail::is_material_map_v<material_t>) {
+        if constexpr (detail::is_surface_material_v<material_t>) {
 
             // Slab or rod
             const auto mat =

--- a/tests/unit_tests/cpu/geometry/tracking_surface.cpp
+++ b/tests/unit_tests/cpu/geometry/tracking_surface.cpp
@@ -91,7 +91,9 @@ GTEST_TEST(detray_geometry, surface) {
     using vector3_t = tracking_surface<detector_t>::vector3_type;
 
     vecmem::host_memory_resource host_mr;
-    const auto [toy_det, names] = build_toy_detector(host_mr);
+    toy_det_config toy_cfg{};
+    toy_cfg.use_material_maps(true).do_check(true);
+    const auto [toy_det, names] = build_toy_detector(host_mr, toy_cfg);
 
     auto ctx = typename detector_t::geometry_context{};
 
@@ -152,4 +154,10 @@ GTEST_TEST(detray_geometry, surface) {
     ASSERT_NEAR(global2[1], glob_pos[1], tol);
     // The bound transform assumes the point is on surface
     ASSERT_NEAR(global2[2], disc_translation[2], tol);
+
+    // Test the material
+    ASSERT_TRUE(disc.has_material());
+    const auto* mat_param = disc.material_parameters({0.f, 0.f});
+    ASSERT_TRUE(mat_param);
+    ASSERT_EQ(*mat_param, toy_cfg.mapped_material());
 }


### PR DESCRIPTION
The functor to get the material parameters was broken when a detector contains homogeneous volume material, since this returns the material parameters directly instead of as a material slab or rod.

In order to disentangle things better, this PR introduces new type traits to identify volume (material params and 3D maps) and surface material (slabs/rod and 2D maps).