### PR TITLE
fix: implement DETRAY_SVG_DISPLAY cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 option( DETRAY_EIGEN_PLUGIN "Build Eigen math plugin" ON )
 option( DETRAY_SMATRIX_PLUGIN "Build ROOT/SMatrix math plugin" OFF )
 option( DETRAY_VC_PLUGIN "Build Vc based math plugin" ON )
-option( DETRAY_SVG_DISPLAY "Build ActSVG display module" OFF)
+option( DETRAY_SVG_DISPLAY "Build ActSVG display module" ON)
 option( DETRAY_BUILD_SYCL "Build the SYCL sources included in detray" OFF )
 option( DETRAY_BUILD_CUDA "Build the CUDA sources included in detray"
    ${DETRAY_BUILD_CUDA_DEFAULT} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 option( DETRAY_EIGEN_PLUGIN "Build Eigen math plugin" ON )
 option( DETRAY_SMATRIX_PLUGIN "Build ROOT/SMatrix math plugin" OFF )
 option( DETRAY_VC_PLUGIN "Build Vc based math plugin" ON )
-option( DETRAY_SVG_DISPLAY "Build ActSVG display module" ON)
+option( DETRAY_SVG_DISPLAY "Build ActSVG display module" OFF)
 option( DETRAY_BUILD_SYCL "Build the SYCL sources included in detray" OFF )
 option( DETRAY_BUILD_CUDA "Build the CUDA sources included in detray"
    ${DETRAY_BUILD_CUDA_DEFAULT} )
@@ -64,6 +64,10 @@ option( DETRAY_BUILD_TUTORIALS "Build the tutorial executables of Detray"
    ON )
 option( DETRAY_FAIL_ON_WARNINGS
    "Make the build fail on compiler/linker warnings" FALSE )
+
+if ( ( BUILD_TESTING AND DETRAY_BUILD_TESTING ) OR DETRAY_BUILD_TUTORIALS )
+   set( DETRAY_SVG_DISPLAY ON )
+endif()
 
 # Clean up.
 unset( DETRAY_BUILD_CUDA_DEFAULT )

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -6,4 +6,7 @@
 
 # Add all subdirectories.
 add_subdirectory( algebra )
-add_subdirectory( svgtools )
+
+if ( DETRAY_SVG_DISPLAY )
+  add_subdirectory( svgtools )
+endif()

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -8,10 +8,7 @@
 add_subdirectory( covfie )
 add_subdirectory( cpu )
 add_subdirectory( io )
-
-if ( DETRAY_SVG_DISPLAY )
-   add_subdirectory( svgtools )
-endif()
+add_subdirectory( svgtools )
 
 # Set up all of the "device" tests.
 if( DETRAY_BUILD_CUDA OR DETRAY_BUILD_SYCL )

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -8,7 +8,10 @@
 add_subdirectory( covfie )
 add_subdirectory( cpu )
 add_subdirectory( io )
-add_subdirectory( svgtools )
+
+if ( DETRAY_SVG_DISPLAY )
+   add_subdirectory( svgtools )
+endif()
 
 # Set up all of the "device" tests.
 if( DETRAY_BUILD_CUDA OR DETRAY_BUILD_SYCL )


### PR DESCRIPTION
Updated the CMake flag DETRAY_SVG_DISPLAY to build SVG tools only when it is enabled. Previously, this option had no effect. Additionally, DETRAY_SVG_DISPLAY is now enabled by default.