### PR TITLE
fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ export DETRAY_BFIELD_FILE="${PWD}/odd-bfield_v0_9_0.cvf"
 
 | Option | Description | Default |
 | --- | --- | --- |
-| DETRAY_BUILD_CUDA  | Build the CUDA sources included in traccc | ON (if available) |
-| DETRAY_BUILD_SYCL  | Build the SYCL sources included in traccc | OFF |
-| DETRAY_BUILD_TESTING  | Build the (unit) tests of traccc | ON |
-| DETRAY_BUILD_TUTORIALS  | Build the examples of traccc | ON |
+| DETRAY_BUILD_CUDA  | Build the CUDA sources included in detray | ON (if available) |
+| DETRAY_BUILD_SYCL  | Build the SYCL sources included in detray | OFF |
+| DETRAY_BUILD_TESTING  | Build the (unit) tests of detray | ON |
+| DETRAY_BUILD_TUTORIALS  | Build the examples of detray | ON |
 | DETRAY_CUSTOM_SCALARTYPE | Floating point precision | double |
 | DETRAY_EIGEN_PLUGIN | Build Eigen math plugin | ON |
 | DETRAY_SMATRIX_PLUGIN | Build ROOT/SMatrix math plugin | OFF |


### PR DESCRIPTION
Changed `traccc` to `detray` in README.