### PR TITLE
Replace `math::abs` with `math::fabs` where needed

### DIFF
--- a/core/include/detray/builders/cylinder_portal_generator.hpp
+++ b/core/include/detray/builders/cylinder_portal_generator.hpp
@@ -204,9 +204,9 @@ class cylinder_portal_generator final
 
         // Get the half lengths for the cylinder height and disc translation
         const point3_t h_lengths = 0.5f * (box_max - box_min);
-        const scalar h_x{math::abs(h_lengths[0])};
-        const scalar h_y{math::abs(h_lengths[1])};
-        const scalar h_z{math::abs(h_lengths[2])};
+        const scalar h_x{math::fabs(h_lengths[0])};
+        const scalar h_y{math::fabs(h_lengths[1])};
+        const scalar h_z{math::fabs(h_lengths[2])};
 
         const scalar_t outer_r_min{math::max(h_x, h_y)};
         const scalar_t mean_radius{get_mean_radius(surfaces, transforms)};

--- a/core/include/detray/geometry/coordinates/line2D.hpp
+++ b/core/include/detray/geometry/coordinates/line2D.hpp
@@ -71,7 +71,7 @@ struct line2D {
     /// the global cartesian 3D frame
     DETRAY_HOST_DEVICE static inline point3_type local_to_global(
         const transform3_type &trf, const point3_type &p) {
-        const scalar_type R = math::abs(p[0]);
+        const scalar_type R = math::fabs(p[0]);
         const point3_type local = {R * math::cos(p[2]), R * math::sin(p[2]),
                                    p[1]};
 

--- a/core/include/detray/navigation/detail/helix.hpp
+++ b/core/include/detray/navigation/detail/helix.hpp
@@ -69,12 +69,12 @@ class helix {
         // Normalized tangent vector
         _t0 = dir;
 
-        assert((math::abs(getter::norm(_t0) - 1.f) < 1e-5f) &&
+        assert((math::fabs(getter::norm(_t0) - 1.f) < 1e-5f) &&
                "The helix direction must be normalized");
 
         // Momentum
         const vector3_type mom =
-            1.f / static_cast<scalar_type>(math::abs(qop)) * _t0;
+            1.f / static_cast<scalar_type>(math::fabs(qop)) * _t0;
 
         // Normalized _h0 X _t0
         _n0 = vector::normalize(vector::cross(_h0, _t0));

--- a/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
@@ -136,7 +136,7 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
                 // f(s) = ((h.pos(s) - sc) x sz)^2 - r^2 == 0
                 // Run the iteration on s
                 std::size_t n_tries{0u};
-                while (math::abs(s - s_prev) > convergence_tolerance and
+                while (math::fabs(s - s_prev) > convergence_tolerance and
                        n_tries < max_n_tries) {
 
                     // f'(s) = 2 * ( (h.pos(s) - sc) x sz) * (h.dir(s) x sz) )

--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -109,7 +109,7 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
 
             // Run the iteration on s
             std::size_t n_tries{0u};
-            while (math::abs(s - s_prev) > convergence_tolerance and
+            while (math::fabs(s - s_prev) > convergence_tolerance and
                    n_tries < max_n_tries) {
 
                 // track direction

--- a/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
@@ -85,14 +85,14 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
             if (denom == 0.f) {
                 s = getter::norm(dist);
             }
-            s = math::abs(vector::dot(sn, dist) / denom);
+            s = math::fabs(vector::dot(sn, dist) / denom);
 
             scalar_type s_prev{0.f};
 
             // f(s) = sn * (h.pos(s) - st) == 0
             // Run the iteration on s
             std::size_t n_tries{0u};
-            while (math::abs(s - s_prev) > convergence_tolerance and
+            while (math::fabs(s - s_prev) > convergence_tolerance and
                    n_tries < max_n_tries) {
                 // f'(s) = sn * h.dir(s)
                 denom = vector::dot(sn, h.dir(s));

--- a/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
@@ -71,7 +71,7 @@ struct ray_concentric_cylinder_intersector {
         const point3_type l1 = ro + rd;
 
         // swap coorinates x/y for numerical stability
-        const bool swap_x_y = math::abs(rd[0]) < 1e-3f;
+        const bool swap_x_y = math::fabs(rd[0]) < 1e-3f;
 
         unsigned int _x = swap_x_y ? 1u : 0u;
         unsigned int _y = swap_x_y ? 0u : 1u;
@@ -115,10 +115,10 @@ struct ray_concentric_cylinder_intersector {
                 // for the r-check
                 // Tolerance: per mille of the distance
                 is.status = mask.is_inside(
-                    is.local,
-                    math::max(mask_tolerance[0],
-                              math::min(mask_tolerance[1],
-                                        mask_tol_scalor * math::abs(is.path))));
+                    is.local, math::max(mask_tolerance[0],
+                                        math::min(mask_tolerance[1],
+                                                  mask_tol_scalor *
+                                                      math::fabs(is.path))));
                 is.sf_desc = sf;
                 is.direction = !detail::signbit(is.path);
                 is.volume_link = mask.volume_link();

--- a/core/include/detray/navigation/policies.hpp
+++ b/core/include/detray/navigation/policies.hpp
@@ -73,8 +73,8 @@ struct stepper_default_policy : actor {
         auto &navigation = propagation._navigation;
 
         // Not a severe change to track state expected
-        if (math::abs(stepping.step_size()) <
-            math::abs(
+        if (math::fabs(stepping.step_size()) <
+            math::fabs(
                 stepping.constraints().template size<>(stepping.direction())) -
                 pol_state.tol) {
             // Re-evaluate only next candidate

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -118,8 +118,8 @@ class line_stepper final
         stepping.set_direction(step_dir);
 
         // Check constraints
-        if (math::abs(stepping.step_size()) >
-            math::abs(
+        if (math::fabs(stepping.step_size()) >
+            math::fabs(
                 stepping.constraints().template size<>(stepping.direction()))) {
             // Run inspection before step size is cut
             stepping.run_inspector(cfg, "Before constraint: ");

--- a/core/include/detray/tracks/bound_track_parameters.hpp
+++ b/core/include/detray/tracks/bound_track_parameters.hpp
@@ -61,7 +61,7 @@ struct bound_track_parameters {
             const auto lhs_val = matrix_operator().element(m_vector, i, 0u);
             const auto rhs_val = matrix_operator().element(rhs.vector(), i, 0u);
 
-            if (math::abs(lhs_val - rhs_val) >
+            if (math::fabs(lhs_val - rhs_val) >
                 std::numeric_limits<scalar_type>::epsilon()) {
                 return false;
             }
@@ -73,7 +73,7 @@ struct bound_track_parameters {
                 const auto rhs_val =
                     matrix_operator().element(rhs.covariance(), i, j);
 
-                if (math::abs(lhs_val - rhs_val) >
+                if (math::fabs(lhs_val - rhs_val) >
                     std::numeric_limits<scalar_type>::epsilon()) {
                     return false;
                 }
@@ -153,13 +153,13 @@ struct bound_track_parameters {
     DETRAY_HOST_DEVICE
     scalar_type pT() const {
         assert(this->qop() != 0.f);
-        return math::abs(1.f / this->qop() * getter::perp(this->dir()));
+        return math::fabs(1.f / this->qop() * getter::perp(this->dir()));
     }
 
     DETRAY_HOST_DEVICE
     scalar_type pz() const {
         assert(this->qop() != 0.f);
-        return math::abs(1.f / this->qop() * this->dir()[2]);
+        return math::fabs(1.f / this->qop() * this->dir()[2]);
     }
 
     private:

--- a/core/include/detray/tracks/free_track_parameters.hpp
+++ b/core/include/detray/tracks/free_track_parameters.hpp
@@ -72,7 +72,7 @@ struct free_track_parameters {
             const auto lhs_val = matrix_operator().element(m_vector, i, 0u);
             const auto rhs_val = matrix_operator().element(rhs.vector(), i, 0u);
 
-            if (math::abs(lhs_val - rhs_val) >
+            if (math::fabs(lhs_val - rhs_val) >
                 std::numeric_limits<scalar_type>::epsilon()) {
                 return false;
             }
@@ -84,7 +84,7 @@ struct free_track_parameters {
                 const auto rhs_val =
                     matrix_operator().element(rhs.covariance(), i, j);
 
-                if (math::abs(lhs_val - rhs_val) >
+                if (math::fabs(lhs_val - rhs_val) >
                     std::numeric_limits<scalar_type>::epsilon()) {
                     return false;
                 }
@@ -150,13 +150,13 @@ struct free_track_parameters {
     DETRAY_HOST_DEVICE
     scalar_type pT() const {
         assert(this->qop() != 0.f);
-        return math::abs(1.f / this->qop() * getter::perp(this->dir()));
+        return math::fabs(1.f / this->qop() * getter::perp(this->dir()));
     }
 
     DETRAY_HOST_DEVICE
     scalar_type pz() const {
         assert(this->qop() != 0.f);
-        return math::abs(1.f / this->qop() * this->dir()[2]);
+        return math::fabs(1.f / this->qop() * this->dir()[2]);
     }
 
     private:

--- a/core/include/detray/utils/inspectors.hpp
+++ b/core/include/detray/utils/inspectors.hpp
@@ -256,7 +256,7 @@ struct print_inspector {
         }
 
         debug_stream << "distance to next\t\t";
-        if (math::abs(state()) < static_cast<scalar>(cfg.path_tolerance)) {
+        if (math::fabs(state()) < static_cast<scalar>(cfg.path_tolerance)) {
             debug_stream << "on obj (within tol)" << std::endl;
         } else {
             debug_stream << state() << std::endl;

--- a/core/include/detray/utils/quadratic_equation.hpp
+++ b/core/include/detray/utils/quadratic_equation.hpp
@@ -106,7 +106,7 @@ class quadratic_equation<
                                  const scalar_t &c,
                                  const scalar_t &tolerance = 1e-6f) {
         // Linear case
-        auto one_sol = (math::abs(a) <= tolerance);
+        auto one_sol = (math::fabs(a) <= tolerance);
         m_solutions(one_sol) = 1.f;
         m_values[0] = -c / b;
 

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
@@ -88,7 +88,7 @@ auto inline surface(const transform_t& transform, const mask<shape_t>& m) {
     auto hz = static_cast<actsvg::scalar>(0.5f * (phz - nhz));
 
     // ACTS-like cylinder definition: symmetric around translation
-    if (math::abs(nhz - phz) <=
+    if (math::fabs(nhz - phz) <=
         std::numeric_limits<actsvg::scalar>::epsilon()) {
         p_surface._zparameters = {z0, hz};
 

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -169,8 +169,8 @@ struct ridders_derivative {
                 fac[i] = con2 * fac[i];
 
                 errt[j] =
-                    math::max(math::abs(Arr[j][q][p] - Arr[j][q - 1][p]),
-                              math::abs(Arr[j][q][p] - Arr[j][q - 1][p - 1]));
+                    math::max(math::fabs(Arr[j][q][p] - Arr[j][q - 1][p]),
+                              math::fabs(Arr[j][q][p] - Arr[j][q - 1][p - 1]));
 
                 if (errt[j] <= err[j]) {
 
@@ -184,7 +184,7 @@ struct ridders_derivative {
                             std::cout << q << " " << p << " "
                                       << getter::element(
                                              differentiated_jacobian, j, i)
-                                      << "  " << math::abs(Arr[j][q][p])
+                                      << "  " << math::fabs(Arr[j][q][p])
                                       << std::endl;
                         }
                         */
@@ -200,11 +200,11 @@ struct ridders_derivative {
                 std::cout << getter::element(differentiated_jacobian, j, i)
                           << "  " << Arr[j][p][p] << "  "
                           << Arr[j][p - 1][p - 1] << "  "
-                          << math::abs(Arr[j][p][p] - Arr[j][p - 1][p - 1])
+                          << math::fabs(Arr[j][p][p] - Arr[j][p - 1][p - 1])
                           << "  " << safe[i] * err[j] << std::endl;
             }
             */
-            if (math::abs(Arr[j][p][p] - Arr[j][p - 1][p - 1]) >=
+            if (math::fabs(Arr[j][p][p] - Arr[j][p - 1][p - 1]) >=
                 safe[i] * err[j]) {
                 complete[j] = true;
             }
@@ -1654,7 +1654,7 @@ int main(int argc, char** argv) {
         scalar overstep_tol =
             vm["overstep-tolerance-mm"].as<scalar>() * unit<scalar>::mm;
         overstep_tol =
-            -math::min(math::abs(overstep_tol), detector_length * 0.5f);
+            -math::min(math::fabs(overstep_tol), detector_length * 0.5f);
 
         tel_det_config<rect_type, detail::helix<algebra_type>> rectangle_cfg{
             rect, helix_bz};

--- a/tutorials/include/detray/tutorial/my_square2D.hpp
+++ b/tutorials/include/detray/tutorial/my_square2D.hpp
@@ -57,8 +57,8 @@ class square2D {
     DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_type<scalar_t> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
-        return (math::abs(loc_p[0]) <= bounds[e_half_length] + tol and
-                math::abs(loc_p[1]) <= bounds[e_half_length] + tol);
+        return (math::fabs(loc_p[0]) <= bounds[e_half_length] + tol and
+                math::fabs(loc_p[1]) <= bounds[e_half_length] + tol);
     }
 
     /// @brief Lower and upper point for minimal axis aligned bounding box.

--- a/utils/include/detray/detectors/factories/barrel_generator.hpp
+++ b/utils/include/detray/detectors/factories/barrel_generator.hpp
@@ -183,7 +183,7 @@ class barrel_generator final : public surface_factory_interface<detector_t> {
         const scalar_t z_start{
             -0.5f * static_cast<scalar_t>(n_z_bins - 1u) *
             (2.f * m_cfg.module_bounds().at(1) - m_cfg.z_overlap())};
-        const scalar_t z_step{(math::abs(z_start) - z_start) /
+        const scalar_t z_step{(math::fabs(z_start) - z_start) /
                               static_cast<scalar_t>(n_z_bins - 1)};
 
         // loop over the z bins


### PR DESCRIPTION
Using `std::abs` on floating point types is deprecated behaviour, and `std::fabs` should be used instead. This commit ensures that the correct function is used on floating point values.