### PR TITLE
Mark dependencies as system libraries

### DIFF
--- a/extern/actsvg/CMakeLists.txt
+++ b/extern/actsvg/CMakeLists.txt
@@ -21,9 +21,16 @@ set( DETRAY_ACTSVG_GIT_REPOSITORY "https://github.com/acts-project/actsvg.git"
    CACHE STRING "Git repository to take actsvg from" )
 set( DETRAY_ACTSVG_GIT_TAG "v0.4.45" CACHE STRING "Version of actsvg to build" )
 mark_as_advanced( DETRAY_ACTSVG_GIT_REPOSITORY DETRAY_ACTSVG_GIT_TAG )
-FetchContent_Declare( actsvg
-   GIT_REPOSITORY "${DETRAY_ACTSVG_GIT_REPOSITORY}"
-   GIT_TAG "${DETRAY_ACTSVG_GIT_TAG}" )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(DETRAY_ACTSVG_SOURCE_FULL "GIT_REPOSITORY;${DETRAY_ACTSVG_GIT_REPOSITORY};GIT_TAG;${DETRAY_ACTSVG_GIT_TAG};SYSTEM")
+else()
+   set(DETRAY_ACTSVG_SOURCE_FULL "GIT_REPOSITORY;${DETRAY_ACTSVG_GIT_REPOSITORY};GIT_TAG;${DETRAY_ACTSVG_GIT_TAG}")
+endif()
+mark_as_advanced( DETRAY_ACTSVG_SOURCE_FULL )
+
+FetchContent_Declare( actsvg ${DETRAY_ACTSVG_SOURCE_FULL} )
 
 # Make sure the web plugin of ACTSVG is built
 set(ACTSVG_BUILD_WEB ON CACHE BOOL "Build the web plugin of ACTSVG")

--- a/extern/algebra-plugins/CMakeLists.txt
+++ b/extern/algebra-plugins/CMakeLists.txt
@@ -21,7 +21,16 @@ set( DETRAY_ALGEBRA_PLUGINS_SOURCE
    "URL;https://github.com/acts-project/algebra-plugins/archive/refs/tags/v0.25.0.tar.gz;URL_MD5;8201744f8b2a8ff7fbcf21bd1b4549b9"
    CACHE STRING "Source for Algebra Plugins, when built as part of this project" )
 mark_as_advanced(DETRAY_ALGEBRA_PLUGINS_SOURCE)
-FetchContent_Declare(AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE})
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(DETRAY_ALGEBRA_PLUGINS_SOURCE_FULL "${DETRAY_ALGEBRA_PLUGINS_SOURCE};SYSTEM")
+else()
+   set(DETRAY_ALGEBRA_PLUGINS_SOURCE_FULL "${DETRAY_ALGEBRA_PLUGINS_SOURCE}")
+endif()
+mark_as_advanced( DETRAY_ALGEBRA_PLUGINS_SOURCE_FULL )
+
+FetchContent_Declare(AlgebraPlugins ${DETRAY_ALGEBRA_PLUGINS_SOURCE_FULL})
 
 # Options used in the build of Algebra Plugins.
 set(ALGEBRA_PLUGINS_BUILD_TESTING FALSE CACHE BOOL

--- a/extern/benchmark/CMakeLists.txt
+++ b/extern/benchmark/CMakeLists.txt
@@ -21,7 +21,16 @@ set(DETRAY_BENCHMARK_SOURCE
    "URL;https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz;URL_MD5;7b93dd03670665684f1b2e9b70ad17fe"
    CACHE STRING "Source for Google Benchmark, when built as part of this project")
 mark_as_advanced(DETRAY_BENCHMARK_SOURCE)
-FetchContent_Declare(Benchmark ${DETRAY_BENCHMARK_SOURCE})
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(DETRAY_BENCHMARK_SOURCE_FULL "${DETRAY_BENCHMARK_SOURCE};SYSTEM")
+else()
+   set(DETRAY_BENCHMARK_SOURCE_FULL "${DETRAY_BENCHMARK_SOURCE}")
+endif()
+mark_as_advanced( DETRAY_BENCHMARK_SOURCE_FULL )
+
+FetchContent_Declare(Benchmark ${DETRAY_BENCHMARK_SOURCE_FULL})
 
 # Options used in the build of Google Benchmark.
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Turn off the tests in Google Benchmark")

--- a/extern/covfie/CMakeLists.txt
+++ b/extern/covfie/CMakeLists.txt
@@ -21,7 +21,16 @@ set( DETRAY_COVFIE_SOURCE
    "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.9.0.tar.gz;URL_MD5;b310712c6dd1acc8104c734086f40fc0"
    CACHE STRING "Source for covfie, when built as part of this project" )
 mark_as_advanced( DETRAY_COVFIE_SOURCE )
-FetchContent_Declare( covfie ${DETRAY_COVFIE_SOURCE} )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(DETRAY_COVFIE_SOURCE_FULL "${DETRAY_COVFIE_SOURCE};SYSTEM")
+else()
+   set(DETRAY_COVFIE_SOURCE_FULL "${DETRAY_COVFIE_SOURCE}")
+endif()
+mark_as_advanced( DETRAY_COVFIE_SOURCE_FULL )
+
+FetchContent_Declare( covfie ${DETRAY_COVFIE_SOURCE_FULL} )
 
 # Options used for covfie.
 set( COVFIE_BUILD_EXAMPLES OFF CACHE BOOL "Build covfie examples")

--- a/extern/dfelibs/CMakeLists.txt
+++ b/extern/dfelibs/CMakeLists.txt
@@ -21,7 +21,16 @@ set( DETRAY_DFELIBS_SOURCE
    "URL;https://github.com/acts-project/dfelibs/archive/refs/tags/v20211029.tar.gz;URL_MD5;87fb09c5a11b98250f5e266e9cd501ea"
    CACHE STRING "Source for dfelibs, when built as part of this project" )
 mark_as_advanced( DETRAY_DFELIBS_SOURCE )
-FetchContent_Declare( dfelibs ${DETRAY_DFELIBS_SOURCE} )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(DETRAY_DFELIBS_SOURCE_FULL "${DETRAY_DFELIBS_SOURCE};SYSTEM")
+else()
+   set(DETRAY_DFELIBS_SOURCE_FULL "${DETRAY_DFELIBS_SOURCE}")
+endif()
+mark_as_advanced( DETRAY_DFELIBS_SOURCE_FULL )
+
+FetchContent_Declare( dfelibs ${DETRAY_DFELIBS_SOURCE_FULL} )
 
 # Options used in the build of dfelibs.
 set( dfelibs_BUILD_EXAMPLES FALSE CACHE BOOL

--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -21,7 +21,16 @@ set( DETRAY_GOOGLETEST_SOURCE
    "URL;https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz;URL_MD5;c8340a482851ef6a3fe618a082304cfc"
    CACHE STRING "Source for GoogleTest, when built as part of this project" )
 mark_as_advanced( DETRAY_GOOGLETEST_SOURCE )
-FetchContent_Declare( GoogleTest ${DETRAY_GOOGLETEST_SOURCE} )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(DETRAY_GOOGLETEST_SOURCE_FULL "${DETRAY_GOOGLETEST_SOURCE};SYSTEM")
+else()
+   set(DETRAY_GOOGLETEST_SOURCE_FULL "${DETRAY_GOOGLETEST_SOURCE}")
+endif()
+mark_as_advanced( DETRAY_GOOGLETEST_SOURCE_FULL )
+
+FetchContent_Declare( GoogleTest ${DETRAY_GOOGLETEST_SOURCE_FULL} )
 
 # Options used in the build of GoogleTest.
 set( BUILD_GMOCK TRUE CACHE BOOL "Turn off the build of GMock" )

--- a/extern/nlohmann_json/CMakeLists.txt
+++ b/extern/nlohmann_json/CMakeLists.txt
@@ -19,9 +19,16 @@ message( STATUS "Building nlohmann_json as part of the detray project" )
 set( DETRAY_NLOHMANN_JSON_GIT_TAG "v3.11.3" CACHE STRING "Version of nlohmann_json to build" )
 set( DETRAY_NLOHMANN_JSON_SHA1 "2074caa675f8097d9b03c0f4976ffc3410170937" CACHE STRING "SHA1 hash of the downloaded zip" )
 mark_as_advanced( DETRAY_NLOHMANN_JSON_GIT_REPOSITORY DETRAY_NLOHMANN_JSON_GIT_TAG )
-FetchContent_Declare( nlohmann_json
-   URL "https://github.com/nlohmann/json/archive/refs/tags/${DETRAY_NLOHMANN_JSON_GIT_TAG}.tar.gz"
-   URL_HASH SHA1=${DETRAY_NLOHMANN_JSON_SHA1})
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(DETRAY_NLOHMANN_JSON_SOURCE_FULL "URL;https://github.com/nlohmann/json/archive/refs/tags/${DETRAY_NLOHMANN_JSON_GIT_TAG}.tar.gz;URL_HASH;SHA1=${DETRAY_NLOHMANN_JSON_SHA1};SYSTEM")
+else()
+   set(DETRAY_NLOHMANN_JSON_SOURCE_FULL "URL;https://github.com/nlohmann/json/archive/refs/tags/${DETRAY_NLOHMANN_JSON_GIT_TAG}.tar.gz;URL_HASH;SHA1=${DETRAY_NLOHMANN_JSON_SHA1}")
+endif()
+mark_as_advanced( DETRAY_NLOHMANN_JSON_SOURCE_FULL )
+
+FetchContent_Declare( nlohmann_json ${DETRAY_NLOHMANN_JSON_SOURCE_FULL})
 
 # Now set up its build.
 set(JSON_BuildTests OFF CACHE INTERNAL "")

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -21,7 +21,16 @@ set( DETRAY_VECMEM_SOURCE
    "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.4.0.tar.gz;URL_MD5;af5434e34ca9c084678c2c043441f174"
    CACHE STRING "Source for VecMem, when built as part of this project" )
 mark_as_advanced( DETRAY_VECMEM_SOURCE )
-FetchContent_Declare( VecMem ${DETRAY_VECMEM_SOURCE} )
+
+# Mark the import as a system library on modern CMake versions
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+   set(DETRAY_VECMEM_SOURCE_FULL "${DETRAY_VECMEM_SOURCE};SYSTEM")
+else()
+   set(DETRAY_VECMEM_SOURCE_FULL "${DETRAY_VECMEM_SOURCE}")
+endif()
+mark_as_advanced( DETRAY_VECMEM_SOURCE_FULL )
+
+FetchContent_Declare( VecMem ${DETRAY_VECMEM_SOURCE_FULL} )
 
 # Options used in the build of VecMem.
 set( VECMEM_BUILD_TESTING FALSE CACHE BOOL


### PR DESCRIPTION
This commit allows us to mark dependencies as system libraries on CMake versions 3.25 and later, reducing the volume of compiler warnings.