### PR TITLE
Add missing eta range in SYCL propagator test

### DIFF
--- a/tests/integration_tests/device/sycl/propagator.sycl
+++ b/tests/integration_tests/device/sycl/propagator.sycl
@@ -49,6 +49,7 @@ TEST_P(SyclPropConstBFieldMng, propagator) {
     propagator_test_config cfg{};
     cfg.track_generator.phi_steps(20u).theta_steps(20u);
     cfg.track_generator.p_tot(10.f * unit<scalar_t>::GeV);
+    cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
     // Configuration for non-z-aligned B-fields
     cfg.propagation.navigation.overstep_tolerance = std::get<0>(GetParam());
@@ -90,6 +91,7 @@ TEST_P(SyclPropConstBFieldCpy, propagator) {
     propagator_test_config cfg{};
     cfg.track_generator.phi_steps(20u).theta_steps(20u);
     cfg.track_generator.p_tot(10.f * unit<scalar_t>::GeV);
+    cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
     // Configuration for non-z-aligned B-fields
     cfg.propagation.navigation.overstep_tolerance = std::get<0>(GetParam());


### PR DESCRIPTION
The CI for #771 has been failing mysteriously, and I have found that this is actually due to the fact that the SYCL propagator tests are missing a configuration parameter limiting the eta range to [-3, 3] like the other propagator tests have. This commit adds this missing range and seems to fix the CI bug.