### PR TITLE
Add workflow for continous benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,17 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  detray_benchmark_job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: >
+          curl -X POST --fail
+          -F token=${{ secrets.DETRAY_BENCHMARK_TRIGGER_TOKEN }}
+          -F ref=master
+          --form variables[MERGE_TIME]="$(date '+%Y-%m-%d_%H:%M:%S')"
+          --form variables[SOURCE_SHA]="${{ github.sha }}"
+          https://gitlab.cern.ch/api/v4/projects/190570/trigger/pipeline

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ export DETRAY_BFIELD_FILE="${PWD}/odd-bfield_v0_9_0.cvf"
 | DETRAY_VC_PLUGIN | Build Vc based math plugin | ON |
 | DETRAY_SVG_DISPLAY | Build ActSVG display module | OFF |
 
-## Benchmark Monitoring
+## Continuous benchmark
 
-Work in Progress ...
+Monitoring the propagation speed with the toy geometry
+
+<img src="https://gitlab.cern.ch/acts/detray-benchmark/-/raw/master/plots/array_data.png?ref_type=heads" width="500" height="500" /> 


### PR DESCRIPTION
Adding workflow for detray continous benchmark in conjuntion with #787. (Based on @paulgessinger 's suggestion)

Whenever a PR is merged, the CI triggers the workflow [detray-benchmark](https://gitlab.cern.ch/beyeo/detray-benchmark) to run the propagation benchmark and push the results with plots.
