### PR TITLE
Remove the covariance matrix from the free track parameters

### DIFF
--- a/core/include/detray/definitions/track_parametrization.hpp
+++ b/core/include/detray/definitions/track_parametrization.hpp
@@ -62,9 +62,6 @@ enum free_indices : unsigned int {
     e_free_size,
 };
 
-// Track parameter type
-enum class parameter_type : int { e_free = 0, e_bound = 1 };
-
 /// Vector type for free track parametrization
 template <typename algebra_t>
 using free_vector =

--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -85,33 +85,17 @@ struct parameter_transporter : actor {
                     .template identity<e_free_size, e_free_size>() +
                 path_correction;
 
+            // Bound to free jacobian at the departure surface
+            const bound_to_free_matrix_t& bound_to_free_jacobian =
+                stepping._jac_to_global;
+
+            stepping._full_jacobian = free_to_bound_jacobian * correction_term *
+                                      free_transport_jacobian *
+                                      bound_to_free_jacobian;
+
             bound_matrix_t new_cov =
-                matrix_operator().template zero<e_bound_size, e_bound_size>();
-
-            if (propagation.param_type() == parameter_type::e_free) {
-
-                const matrix_type<e_bound_size, e_free_size> full_jacobian =
-                    free_to_bound_jacobian * correction_term *
-                    free_transport_jacobian;
-
-                new_cov = full_jacobian * stepping().covariance() *
-                          matrix_operator().transpose(full_jacobian);
-
-                propagation.set_param_type(parameter_type::e_bound);
-
-            } else if (propagation.param_type() == parameter_type::e_bound) {
-                // Bound to free jacobian at the departure surface
-                const bound_to_free_matrix_t& bound_to_free_jacobian =
-                    stepping._jac_to_global;
-
-                stepping._full_jacobian =
-                    free_to_bound_jacobian * correction_term *
-                    free_transport_jacobian * bound_to_free_jacobian;
-
-                new_cov = stepping._full_jacobian *
-                          stepping._bound_params.covariance() *
-                          matrix_operator().transpose(stepping._full_jacobian);
-            }
+                stepping._full_jacobian * stepping._bound_params.covariance() *
+                matrix_operator().transpose(stepping._full_jacobian);
 
             // Calculate surface-to-surface covariance transport
             stepping._bound_params.set_covariance(new_cov);

--- a/core/include/detray/tracks/bound_track_parameters.hpp
+++ b/core/include/detray/tracks/bound_track_parameters.hpp
@@ -132,7 +132,7 @@ struct bound_track_parameters {
 
     DETRAY_HOST_DEVICE
     void set_qop(const scalar_type qop) {
-        matrix_operator().element(m_vector, e_bound_qoverp, 0u) = qop;
+        track_helper().set_qop(m_vector, qop);
     }
 
     DETRAY_HOST_DEVICE

--- a/core/include/detray/tracks/detail/track_helper.hpp
+++ b/core/include/detray/tracks/detail/track_helper.hpp
@@ -71,6 +71,16 @@ struct track_helper {
     }
 
     DETRAY_HOST_DEVICE
+    inline void set_qop(free_vector& free_vec, const scalar_type& qop) {
+        matrix_operator().element(free_vec, e_free_qoverp, 0u) = qop;
+    }
+
+    DETRAY_HOST_DEVICE
+    inline void set_qop(bound_vector& bound_vec, const scalar_type& qop) {
+        matrix_operator().element(bound_vec, e_bound_qoverp, 0u) = qop;
+    }
+
+    DETRAY_HOST_DEVICE
     inline point2 bound_local(const bound_vector& bound_vec) const {
         return {matrix_operator().element(bound_vec, e_bound_loc0, 0u),
                 matrix_operator().element(bound_vec, e_bound_loc1, 0u)};

--- a/core/include/detray/tracks/free_track_parameters.hpp
+++ b/core/include/detray/tracks/free_track_parameters.hpp
@@ -30,7 +30,6 @@ struct free_track_parameters {
 
     // Shorthand vector/matrix types related to free track parameters.
     using vector_type = free_vector<algebra_t>;
-    using covariance_type = free_matrix<algebra_t>;
 
     // Track helper
     using track_helper = detail::track_helper<matrix_operator>;
@@ -39,13 +38,10 @@ struct free_track_parameters {
 
     DETRAY_HOST_DEVICE
     free_track_parameters()
-        : m_vector(matrix_operator().template zero<e_free_size, 1>()),
-          m_covariance(
-              matrix_operator().template zero<e_free_size, e_free_size>()){};
+        : m_vector(matrix_operator().template zero<e_free_size, 1>()){};
 
     DETRAY_HOST_DEVICE
-    free_track_parameters(const vector_type& vec, const covariance_type& cov)
-        : m_vector(vec), m_covariance(cov) {}
+    free_track_parameters(const vector_type& vec) : m_vector(vec) {}
 
     DETRAY_HOST_DEVICE
     free_track_parameters(const point3_type& pos, const scalar_type time,
@@ -77,19 +73,7 @@ struct free_track_parameters {
                 return false;
             }
         }
-        for (unsigned int i = 0u; i < e_free_size; i++) {
-            for (unsigned int j = 0u; j < e_free_size; j++) {
-                const auto lhs_val =
-                    matrix_operator().element(m_covariance, i, j);
-                const auto rhs_val =
-                    matrix_operator().element(rhs.covariance(), i, j);
 
-                if (math::fabs(lhs_val - rhs_val) >
-                    std::numeric_limits<scalar_type>::epsilon()) {
-                    return false;
-                }
-            }
-        }
         return true;
     }
 
@@ -98,12 +82,6 @@ struct free_track_parameters {
 
     DETRAY_HOST_DEVICE
     void set_vector(const vector_type& v) { m_vector = v; }
-
-    DETRAY_HOST_DEVICE
-    const covariance_type& covariance() const { return m_covariance; }
-
-    DETRAY_HOST_DEVICE
-    void set_covariance(const covariance_type& c) { m_covariance = c; }
 
     DETRAY_HOST_DEVICE
     point3_type pos() const { return track_helper().pos(m_vector); }
@@ -129,7 +107,7 @@ struct free_track_parameters {
 
     DETRAY_HOST_DEVICE
     void set_qop(const scalar_type qop) {
-        matrix_operator().element(m_vector, e_free_qoverp, 0u) = qop;
+        track_helper().set_qop(m_vector, qop);
     }
 
     DETRAY_HOST_DEVICE
@@ -162,8 +140,6 @@ struct free_track_parameters {
 
     private:
     vector_type m_vector = matrix_operator().template zero<e_free_size, 1>();
-    covariance_type m_covariance =
-        matrix_operator().template zero<e_free_size, e_free_size>();
 };
 
 }  // namespace detray

--- a/core/include/detray/utils/curvilinear_frame.hpp
+++ b/core/include/detray/utils/curvilinear_frame.hpp
@@ -1,0 +1,55 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/geometry/coordinates/cartesian2D.hpp"
+#include "detray/geometry/mask.hpp"
+#include "detray/geometry/shapes/rectangle2D.hpp"
+#include "detray/propagator/detail/jacobian_engine.hpp"
+#include "detray/tracks/detail/track_helper.hpp"
+#include "detray/utils/unit_vectors.hpp"
+
+namespace detray {
+
+template <typename algebra_t>
+struct curvilinear_frame {
+
+    using transform3_type = dtransform3D<algebra_t>;
+    using vector3 = typename transform3_type::vector3;
+    using unit_vectors_type = unit_vectors<vector3>;
+    using bound_to_free_matrix_type = bound_to_free_matrix<algebra_t>;
+    using bound_vector_type = bound_vector<algebra_t>;
+    using jacobian_engine_type =
+        detail::jacobian_engine<cartesian2D<algebra_t>>;
+    using free_track_parameters_type = free_track_parameters<algebra_t>;
+
+    DETRAY_HOST_DEVICE
+    curvilinear_frame(const free_track_parameters_type& free_params) {
+
+        const auto t = free_params.pos();
+        const auto z = free_params.dir();
+        const auto x = unit_vectors_type().make_curvilinear_unit_u(z);
+
+        m_trf = transform3_type(t, z, x);
+        m_bound_vec = detail::free_to_bound_vector<cartesian2D<algebra_t>>(
+            m_trf, free_params.vector());
+    }
+
+    DETRAY_HOST_DEVICE
+    bound_to_free_matrix_type bound_to_free_jacobian() const {
+        return jacobian_engine_type().bound_to_free_jacobian(
+            m_trf, mask<rectangle2D>{}, m_bound_vec);
+    }
+
+    transform3_type m_trf;
+    bound_vector_type m_bound_vec;
+
+};  // curvilinear frame
+
+}  // namespace detray

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -70,12 +70,12 @@ struct helix_inspector : actor {
 
         inspector_state._nav_status.push_back(navigation.status());
 
-        if (prop_state.param_type() == parameter_type::e_free) {
+        // Nothing has happened yet (first call of actor chain)
+        if (stepping.path_length() < tol || stepping._s < tol) {
             return;
         }
 
-        // Nothing has happened yet (first call of actor chain)
-        if (stepping.path_length() < tol || stepping._s < tol) {
+        if (stepping._bound_params.surface_link().is_invalid()) {
             return;
         }
 

--- a/tests/unit_tests/cpu/CMakeLists.txt
+++ b/tests/unit_tests/cpu/CMakeLists.txt
@@ -92,6 +92,7 @@ macro(detray_add_cpu_test algebra)
       "utils/grids/populators.cpp"
       "utils/grids/serializers.cpp"
       "utils/bounding_volume.cpp"
+      "utils/curvilinear_frame.cpp"
       "utils/axis_rotation.cpp"
       "utils/matrix_helper.cpp"
       "utils/quadratic_equation.cpp"

--- a/tests/unit_tests/cpu/tracks/bound_track_parameters.cpp
+++ b/tests/unit_tests/cpu/tracks/bound_track_parameters.cpp
@@ -128,4 +128,7 @@ GTEST_TEST(detray_tracks, bound_track_parameters) {
 
     EXPECT_TRUE(!(bound_param2 == bound_param1));
     EXPECT_TRUE(bound_param2 == bound_param3);
+
+    bound_param2.set_qop(0.127f);
+    EXPECT_FLOAT_EQ(static_cast<float>(bound_param2.qop()), 0.127f);
 }

--- a/tests/unit_tests/cpu/tracks/free_track_parameters.cpp
+++ b/tests/unit_tests/cpu/tracks/free_track_parameters.cpp
@@ -41,11 +41,8 @@ GTEST_TEST(detray_tracks, free_track_parameters) {
     getter::element(free_vec, e_free_dir2, 0u) = mom[2] / getter::norm(mom);
     getter::element(free_vec, e_free_qoverp, 0u) = charge / getter::norm(mom);
 
-    typename free_track_parameters<algebra_t>::covariance_type free_cov =
-        matrix_operator().template zero<e_free_size, e_free_size>();
-
     // first constructor
-    free_track_parameters<algebra_t> free_param1(free_vec, free_cov);
+    free_track_parameters<algebra_t> free_param1(free_vec);
     EXPECT_NEAR(free_param1.pos()[0],
                 getter::element(free_vec, e_free_pos0, 0u), tol);
     EXPECT_NEAR(free_param1.pos()[1],
@@ -96,4 +93,7 @@ GTEST_TEST(detray_tracks, free_track_parameters) {
                 free_param2.p(charge) * free_param2.dir()[2], tol);
 
     EXPECT_TRUE(free_param2 == free_param1);
+
+    free_param2.set_qop(0.634f);
+    EXPECT_FLOAT_EQ(static_cast<float>(free_param2.qop()), 0.634f);
 }

--- a/tests/unit_tests/cpu/utils/curvilinear_frame.cpp
+++ b/tests/unit_tests/cpu/utils/curvilinear_frame.cpp
@@ -1,0 +1,87 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/utils/curvilinear_frame.hpp"
+
+#include "detray/test/common/types.hpp"
+
+// Google Test include(s)
+#include <gtest/gtest.h>
+
+using namespace detray;
+using transform3 = test::transform3;
+using vector3 = typename transform3::vector3;
+using algebra_t = test::algebra;
+using point3 = test::point3;
+
+GTEST_TEST(detray_utils, curvilinear_frame) {
+
+    constexpr const scalar tolerance = 1e-5f;
+
+    point3 pos = {4.f, 10.f, 2.f};
+    scalar time = 0.1f;
+    vector3 mom = {10.f, 20.f, 30.f};
+    constexpr scalar charge = -1.f;
+
+    free_track_parameters<algebra_t> free_params(pos, time, mom, charge);
+
+    curvilinear_frame<algebra_t> cf(free_params);
+
+    const auto bound_vec = cf.m_bound_vec;
+
+    const auto phi = getter::phi(mom);
+    const auto theta = getter::theta(mom);
+
+    EXPECT_NEAR(getter::element(bound_vec, e_bound_loc0, 0u), 0.f, tolerance);
+    EXPECT_NEAR(getter::element(bound_vec, e_bound_loc1, 0u), 0.f, tolerance);
+    EXPECT_NEAR(getter::element(bound_vec, e_bound_phi, 0u), phi, tolerance);
+    EXPECT_NEAR(getter::element(bound_vec, e_bound_theta, 0u), theta,
+                tolerance);
+    EXPECT_NEAR(getter::element(bound_vec, e_bound_qoverp, 0u),
+                charge / getter::norm(mom), tolerance);
+
+    const auto unit_p = vector::normalize(mom);
+    const auto trf_x = cf.m_trf.x();
+    const auto trf_y = cf.m_trf.y();
+    const auto trf_z = cf.m_trf.z();
+    const auto trf_t = cf.m_trf.translation();
+
+    // local x axis transform does not have global z components
+    EXPECT_NEAR(trf_x[2], 0.f, tolerance);
+
+    // local z axis of transform = track direction
+    EXPECT_NEAR(unit_p[0], trf_z[0], tolerance);
+    EXPECT_NEAR(unit_p[1], trf_z[1], tolerance);
+    EXPECT_NEAR(unit_p[2], trf_z[2], tolerance);
+
+    // translation of transform = track position
+    EXPECT_NEAR(pos[0], trf_t[0], tolerance);
+    EXPECT_NEAR(pos[1], trf_t[1], tolerance);
+    EXPECT_NEAR(pos[2], trf_t[2], tolerance);
+
+    // Top-left components of the jacobian
+    const auto jac = cf.bound_to_free_jacobian();
+    EXPECT_NEAR(getter::element(jac, 0u, 0u), trf_x[0u], tolerance);
+    EXPECT_NEAR(getter::element(jac, 1u, 0u), trf_x[1u], tolerance);
+    EXPECT_NEAR(getter::element(jac, 2u, 0u), trf_x[2u], tolerance);
+    EXPECT_NEAR(getter::element(jac, 0u, 1u), trf_y[0u], tolerance);
+    EXPECT_NEAR(getter::element(jac, 1u, 1u), trf_y[1u], tolerance);
+    EXPECT_NEAR(getter::element(jac, 2u, 1u), trf_y[2u], tolerance);
+
+    EXPECT_NEAR(getter::element(jac, e_free_dir0, e_bound_phi),
+                -math::sin(phi) * math::sin(theta), tolerance);
+    EXPECT_NEAR(getter::element(jac, e_free_dir0, e_bound_theta),
+                math::cos(phi) * math::cos(theta), tolerance);
+    EXPECT_NEAR(getter::element(jac, e_free_dir1, e_bound_phi),
+                math::cos(phi) * math::sin(theta), tolerance);
+    EXPECT_NEAR(getter::element(jac, e_free_dir1, e_bound_theta),
+                math::sin(phi) * math::cos(theta), tolerance);
+    EXPECT_NEAR(getter::element(jac, e_free_dir2, e_bound_phi), 0, tolerance);
+    EXPECT_NEAR(getter::element(jac, e_free_dir2, e_bound_theta),
+                -math::sin(theta), tolerance);
+}


### PR DESCRIPTION
The covariance of free track parameter of steppers is removed.  

The free covariance is required when the state is constructed with free track parameter, however, constructing stepper state with free parameter covariance does not make sense to me. Covariance transport is also disabled when the stepper state is created with free vector. 