### PR TITLE
ref: Remove distiction between free vector and free track parameters

### DIFF
--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -32,7 +32,7 @@ struct surface_kernels {
     using point3_type = dpoint3D<algebra_t>;
     using vector3_type = dvector3D<algebra_t>;
     using transform3_type = dtransform3D<algebra_t>;
-    using free_vector_type = free_vector<algebra_t>;
+    using free_param_type = free_track_parameters<algebra_t>;
     using bound_vector_type = bound_vector<algebra_t>;
     using free_matrix_type = free_matrix<algebra_t>;
 
@@ -217,11 +217,11 @@ struct surface_kernels {
         DETRAY_HOST_DEVICE inline bound_vector_type operator()(
             const mask_group_t& /*mask_group*/, const index_t& /*index*/,
             const transform3_type& trf3,
-            const free_vector_type& free_vec) const {
+            const free_param_type& free_params) const {
 
             using frame_t = typename mask_group_t::value_type::local_frame_type;
 
-            return detail::free_to_bound_vector<frame_t>(trf3, free_vec);
+            return detail::free_to_bound_vector<frame_t>(trf3, free_params);
         }
     };
 
@@ -229,7 +229,7 @@ struct surface_kernels {
     struct bound_to_free_vector {
 
         template <typename mask_group_t, typename index_t>
-        DETRAY_HOST_DEVICE inline free_vector_type operator()(
+        DETRAY_HOST_DEVICE inline free_param_type operator()(
             const mask_group_t& mask_group, const index_t& index,
             const transform3_type& trf3,
             const bound_vector_type& bound_vec) const {
@@ -246,12 +246,12 @@ struct surface_kernels {
         DETRAY_HOST_DEVICE inline auto operator()(
             const mask_group_t& /*mask_group*/, const index_t& /*index*/,
             const transform3_type& trf3,
-            const free_vector_type& free_vec) const {
+            const free_param_type& free_params) const {
 
             using frame_t = typename mask_group_t::value_type::local_frame_type;
 
             return detail::jacobian_engine<frame_t>::free_to_bound_jacobian(
-                trf3, free_vec);
+                trf3, free_params);
         }
     };
 

--- a/core/include/detray/geometry/mask.hpp
+++ b/core/include/detray/geometry/mask.hpp
@@ -272,8 +272,8 @@ class mask {
     }
 
     private:
-    shape _shape;
-    mask_values _values;
+    shape _shape{};
+    mask_values _values{};
     links_type _volume_link{std::numeric_limits<links_type>::max()};
 };
 

--- a/core/include/detray/geometry/tracking_surface.hpp
+++ b/core/include/detray/geometry/tracking_surface.hpp
@@ -38,7 +38,7 @@ class tracking_surface {
 
     using kernels = detail::surface_kernels<typename detector_t::algebra_type>;
     /// Vector type for track parameters in global coordinates
-    using free_vector_type = typename kernels::free_vector_type;
+    using free_param_type = typename kernels::free_param_type;
     /// Vector type for track parameters in local (bound) coordinates
     using bound_vector_type = typename kernels::bound_vector_type;
 
@@ -271,9 +271,9 @@ class tracking_surface {
     /// @returns the track parametrization projected onto the surface (bound)
     DETRAY_HOST_DEVICE
     constexpr auto free_to_bound_vector(
-        const context &ctx, const free_vector_type &free_vec) const {
+        const context &ctx, const free_param_type &free_params) const {
         return visit_mask<typename kernels::free_to_bound_vector>(
-            transform(ctx), free_vec);
+            transform(ctx), free_params);
     }
 
     /// @returns the global track parametrization from a bound representation
@@ -287,10 +287,10 @@ class tracking_surface {
     /// @returns the jacobian to go from a free to a bound track parametrization
     DETRAY_HOST_DEVICE
     constexpr auto free_to_bound_jacobian(
-        const context &ctx, const free_vector_type &free_vec) const {
+        const context &ctx, const free_param_type &free_params) const {
         return this
             ->template visit_mask<typename kernels::free_to_bound_jacobian>(
-                transform(ctx), free_vec);
+                transform(ctx), free_params);
     }
 
     /// @returns the jacobian to go from a bound to a free track parametrization

--- a/core/include/detray/navigation/detail/helix.hpp
+++ b/core/include/detray/navigation/detail/helix.hpp
@@ -14,9 +14,8 @@
 
 // Project include(s).
 #include "detray/definitions/detail/math.hpp"
-#include "detray/definitions/units.hpp"
-#include "detray/tracks/detail/track_helper.hpp"
-#include "detray/tracks/tracks.hpp"
+#include "detray/tracks/free_track_parameters.hpp"
+#include "detray/utils/invalid_values.hpp"
 #include "detray/utils/matrix_helper.hpp"
 
 // System include(s).
@@ -41,16 +40,12 @@ class helix {
 
     /// Free track parameters
     using free_track_parameters_type = free_track_parameters<algebra_t>;
-    using free_vector_type = typename free_track_parameters_type::vector_type;
 
     /// 2D Matrix type
     template <std::size_t ROWS, std::size_t COLS>
     using matrix_type = dmatrix<algebra_t, ROWS, COLS>;
     using free_matrix_t = free_matrix<algebra_t>;
     using mat_helper = matrix_helper<matrix_operator>;
-
-    // Track helper
-    using track_helper = detail::track_helper<matrix_operator>;
 
     DETRAY_HOST_DEVICE
     helix() = delete;
@@ -115,15 +110,10 @@ class helix {
     }
 
     DETRAY_HOST_DEVICE
-    helix(const free_vector_type &free_vec, vector3_type const *const mag_field)
-        : helix(track_helper().pos(free_vec), track_helper().time(free_vec),
-                track_helper().dir(free_vec), track_helper().qop(free_vec),
-                mag_field) {}
-
-    DETRAY_HOST_DEVICE
     helix(const free_track_parameters_type &track,
           vector3_type const *const mag_field)
-        : helix(track.vector(), mag_field) {}
+        : helix(track.pos(), track.time(), track.dir(), track.qop(),
+                mag_field) {}
 
     /// @returns the radius of helix
     DETRAY_HOST_DEVICE

--- a/core/include/detray/navigation/detail/ray.hpp
+++ b/core/include/detray/navigation/detail/ray.hpp
@@ -8,10 +8,7 @@
 #pragma once
 
 // Project include(s).
-#include "detray/definitions/detail/math.hpp"
-#include "detray/definitions/units.hpp"
-#include "detray/tracks/detail/track_helper.hpp"
-#include "detray/tracks/tracks.hpp"
+#include "detray/tracks/free_track_parameters.hpp"
 
 // System include(s).
 #include <ostream>
@@ -31,10 +28,6 @@ class ray {
     using free_track_parameters_type = free_track_parameters<algebra_t>;
     using free_vector_type = typename free_track_parameters_type::vector_type;
 
-    // Track helper
-    using matrix_operator = dmatrix_operator<algebra_t>;
-    using track_helper = detail::track_helper<matrix_operator>;
-
     ray() = default;
 
     /// Parametrized constructor that complies with track interface
@@ -48,15 +41,8 @@ class ray {
     /// Parametrized constructor that complies with track interface
     ///
     /// @param track the track state that should be approximated
-    DETRAY_HOST_DEVICE ray(const free_vector_type &free_vec)
-        : ray(track_helper().pos(free_vec), track_helper().time(free_vec),
-              track_helper().dir(free_vec), track_helper().qop(free_vec)) {}
-
-    /// Parametrized constructor that complies with track interface
-    ///
-    /// @param track the track state that should be approximated
     DETRAY_HOST_DEVICE ray(const free_track_parameters_type &track)
-        : ray(track.vector()) {}
+        : ray(track.pos(), 0.f, track.dir(), 0.f) {}
 
     /// @returns position on the ray (compatible with tracks/intersectors)
     DETRAY_HOST_DEVICE point3_type pos() const { return _pos; }

--- a/core/include/detray/navigation/intersection/bounding_box/cuboid_intersector.hpp
+++ b/core/include/detray/navigation/intersection/bounding_box/cuboid_intersector.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/navigation/detail/ray.hpp"
+#include "detray/utils/invalid_values.hpp"
 
 namespace detray {
 

--- a/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/cylindrical2D.hpp"
 #include "detray/navigation/detail/ray.hpp"
 #include "detray/navigation/intersection/intersection.hpp"

--- a/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/cylindrical2D.hpp"
 #include "detray/navigation/detail/ray.hpp"
 #include "detray/navigation/intersection/intersection.hpp"

--- a/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/concentric_cylindrical2D.hpp"
 #include "detray/geometry/coordinates/cylindrical2D.hpp"
 #include "detray/navigation/detail/ray.hpp"

--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/line2D.hpp"
 #include "detray/navigation/detail/ray.hpp"
 #include "detray/navigation/intersection/intersection.hpp"

--- a/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/cartesian2D.hpp"
 #include "detray/geometry/coordinates/polar2D.hpp"
 #include "detray/navigation/detail/ray.hpp"

--- a/core/include/detray/propagator/actors/parameter_resetter.hpp
+++ b/core/include/detray/propagator/actors/parameter_resetter.hpp
@@ -43,8 +43,8 @@ struct parameter_resetter : actor {
             using jacobian_engine = detail::jacobian_engine<frame_t>;
 
             // Reset the free vector
-            stepping().set_vector(detail::bound_to_free_vector(
-                trf3, mask, stepping._bound_params.vector()));
+            stepping() = detail::bound_to_free_vector(
+                trf3, mask, stepping._bound_params.vector());
 
             // Reset the path length
             stepping._s = 0;

--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -62,15 +62,15 @@ struct parameter_transporter : actor {
             auto& stepping = propagation._stepping;
 
             // Free vector
-            const auto& free_vec = stepping().vector();
+            const auto& free_params = stepping();
 
             // Convert free to bound vector
             stepping._bound_params.set_vector(
-                detail::free_to_bound_vector<frame_t>(trf3, free_vec));
+                detail::free_to_bound_vector<frame_t>(trf3, free_params));
 
             // Free to bound jacobian at the destination surface
             const free_to_bound_matrix_t free_to_bound_jacobian =
-                jacobian_engine_t::free_to_bound_jacobian(trf3, free_vec);
+                jacobian_engine_t::free_to_bound_jacobian(trf3, free_params);
 
             // Transport jacobian in free coordinate
             free_matrix_t& free_transport_jacobian = stepping._jac_transport;

--- a/core/include/detray/propagator/detail/jacobian_engine.hpp
+++ b/core/include/detray/propagator/detail/jacobian_engine.hpp
@@ -71,11 +71,11 @@ struct jacobian_engine {
         const scalar_type sin_phi{math::sin(phi)};
 
         // Global position and direction
-        const free_vector<algebra_type> free_vec =
+        const free_track_parameters<algebra_type> free_params =
             bound_to_free_vector(trf3, mask, bound_vec);
 
-        const vector3_type pos = track_helper().pos(free_vec);
-        const vector3_type dir = track_helper().dir(free_vec);
+        const vector3_type pos = free_params.pos();
+        const vector3_type dir = free_params.dir();
 
         // Set d(x,y,z)/d(loc0, loc1)
         jacobian_t::set_bound_pos_to_free_pos_derivative(jac_to_global, trf3,
@@ -109,15 +109,15 @@ struct jacobian_engine {
     DETRAY_HOST_DEVICE
     static inline free_to_bound_matrix_type free_to_bound_jacobian(
         const transform3_type& trf3,
-        const free_vector<algebra_type>& free_vec) {
+        const free_track_parameters<algebra_type>& free_params) {
 
         // Declare jacobian for bound to free coordinate transform
         free_to_bound_matrix_type jac_to_local =
             matrix_operator().template zero<e_bound_size, e_free_size>();
 
         // Global position and direction
-        const vector3_type pos = track_helper().pos(free_vec);
-        const vector3_type dir = track_helper().dir(free_vec);
+        const vector3_type pos = free_params.pos();
+        const vector3_type dir = free_params.dir();
 
         const scalar_type theta{getter::theta(dir)};
         const scalar_type phi{getter::phi(dir)};

--- a/core/include/detray/tracks/detail/track_helper.hpp
+++ b/core/include/detray/tracks/detail/track_helper.hpp
@@ -33,47 +33,11 @@ struct track_helper {
     using array_type = typename matrix_operator::template array_type<N>;
     /// 3-element "vector" type
     using vector3 = array_type<3>;
-    /// Point in 3D space
-    using point3_type = vector3;
     /// Point in 2D space
     using point2 = array_type<2>;
 
     /// Track vector types
     using bound_vector = matrix_type<e_bound_size, 1>;
-    using free_vector = matrix_type<e_free_size, 1>;
-
-    DETRAY_HOST_DEVICE
-    inline point3_type pos(const free_vector& free_vec) const {
-        return {matrix_operator().element(free_vec, e_free_pos0, 0u),
-                matrix_operator().element(free_vec, e_free_pos1, 0u),
-                matrix_operator().element(free_vec, e_free_pos2, 0u)};
-    }
-
-    DETRAY_HOST_DEVICE
-    inline void set_pos(free_vector& free_vec, const point3_type& pos) {
-        matrix_operator().element(free_vec, e_free_pos0, 0u) = pos[0];
-        matrix_operator().element(free_vec, e_free_pos1, 0u) = pos[1];
-        matrix_operator().element(free_vec, e_free_pos2, 0u) = pos[2];
-    }
-
-    DETRAY_HOST_DEVICE
-    inline vector3 dir(const free_vector& free_vec) const {
-        return {matrix_operator().element(free_vec, e_free_dir0, 0u),
-                matrix_operator().element(free_vec, e_free_dir1, 0u),
-                matrix_operator().element(free_vec, e_free_dir2, 0u)};
-    }
-
-    DETRAY_HOST_DEVICE
-    inline void set_dir(free_vector& free_vec, const vector3& dir) {
-        matrix_operator().element(free_vec, e_free_dir0, 0u) = dir[0];
-        matrix_operator().element(free_vec, e_free_dir1, 0u) = dir[1];
-        matrix_operator().element(free_vec, e_free_dir2, 0u) = dir[2];
-    }
-
-    DETRAY_HOST_DEVICE
-    inline void set_qop(free_vector& free_vec, const scalar_type& qop) {
-        matrix_operator().element(free_vec, e_free_qoverp, 0u) = qop;
-    }
 
     DETRAY_HOST_DEVICE
     inline void set_qop(bound_vector& bound_vec, const scalar_type& qop) {
@@ -99,24 +63,11 @@ struct track_helper {
     }
 
     DETRAY_HOST_DEVICE
-    inline scalar_type p(const free_vector& free_vec,
-                         const scalar_type q) const {
-        assert(qop(free_vec) != 0.f);
-        assert(q * qop(free_vec) > 0.f);
-        return q / qop(free_vec);
-    }
-
-    DETRAY_HOST_DEVICE
     inline scalar_type p(const bound_vector& bound_vec,
                          const scalar_type q) const {
         assert(qop(bound_vec) != 0.f);
         assert(q * qop(bound_vec) > 0.f);
         return q / qop(bound_vec);
-    }
-
-    DETRAY_HOST_DEVICE
-    inline vector3 mom(const free_vector& free_vec, const scalar_type q) const {
-        return p(free_vec, q) * dir(free_vec);
     }
 
     DETRAY_HOST_DEVICE
@@ -126,21 +77,8 @@ struct track_helper {
     }
 
     DETRAY_HOST_DEVICE
-    inline scalar_type qop(const free_vector& free_vec) const {
-        return matrix_operator().element(free_vec, e_free_qoverp, 0u);
-    }
-
-    DETRAY_HOST_DEVICE
     inline scalar_type qop(const bound_vector& bound_vec) const {
         return matrix_operator().element(bound_vec, e_bound_qoverp, 0u);
-    }
-
-    DETRAY_HOST_DEVICE
-    inline scalar_type qopT(const free_vector& free_vec) const {
-        const auto dir = this->dir(free_vec);
-        assert(getter::perp(dir) != 0.f);
-        return matrix_operator().element(free_vec, e_free_qoverp, 0u) /
-               getter::perp(dir);
     }
 
     DETRAY_HOST_DEVICE
@@ -154,12 +92,6 @@ struct track_helper {
     }
 
     DETRAY_HOST_DEVICE
-    inline scalar_type qopz(const free_vector& free_vec) const {
-        const auto dir = this->dir(free_vec);
-        return matrix_operator().element(free_vec, e_free_qoverp, 0u) / dir[2];
-    }
-
-    DETRAY_HOST_DEVICE
     inline scalar_type qopz(const bound_vector& bound_vec) const {
         const scalar_type theta{
             matrix_operator().element(bound_vec, e_bound_theta, 0u)};
@@ -167,11 +99,6 @@ struct track_helper {
         assert(cosTheta != 0.f);
         return matrix_operator().element(bound_vec, e_bound_qoverp, 0u) /
                cosTheta;
-    }
-
-    DETRAY_HOST_DEVICE
-    inline scalar_type time(const free_vector& free_vec) const {
-        return matrix_operator().element(free_vec, e_free_time, 0u);
     }
 
     DETRAY_HOST_DEVICE

--- a/core/include/detray/tracks/detail/transform_track_parameters.hpp
+++ b/core/include/detray/tracks/detail/transform_track_parameters.hpp
@@ -10,57 +10,31 @@
 // Project include(s).
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/track_parametrization.hpp"
-#include "detray/tracks/bound_track_parameters.hpp"
 #include "detray/tracks/detail/track_helper.hpp"
 #include "detray/tracks/free_track_parameters.hpp"
 
 namespace detray::detail {
 
-/// This method transforms from a bound position to a point in the global
-/// 3D cartesian frame
-template <typename transform3_t, typename mask_t>
-DETRAY_HOST_DEVICE inline auto bound_to_free_position(
-    const transform3_t& trf, const mask_t& mask,
-    const typename mask_t::point2_type& p,
-    const typename mask_t::vector3_type& dir) {
-
-    using local_frame_t = typename mask_t::local_frame_type;
-
-    return local_frame_t::local_to_global(trf, mask, p, dir);
-}
-
-/// This method transforms from a global 3D cartesian position to a 2D bound
-/// position in the given local coordinate frame
-template <typename local_frame_t>
-DETRAY_HOST_DEVICE inline auto free_to_bound_position(
-    const dtransform3D<typename local_frame_t::algebra_type>& trf,
-    const dpoint3D<typename local_frame_t::algebra_type>& p,
-    const dvector3D<typename local_frame_t::algebra_type>& dir) {
-
-    static_assert(
-        std::is_same_v<typename local_frame_t::loc_point,
-                       dpoint2D<typename local_frame_t::algebra_type>>,
-        "Cannot define a bound position on this shape");
-
-    return local_frame_t::global_to_local(trf, p, dir);
-}
-
+/// Transform a free track parameter vector to a bound track parameter vector
+///
+/// @param trf3 transform of the surface the bound vector should be defined on
+/// @param free_param the free track parameters to be transformed
+///
+/// @returns the bound track parameter vector
 template <typename local_frame_t>
 DETRAY_HOST_DEVICE inline auto free_to_bound_vector(
     const dtransform3D<typename local_frame_t::algebra_type>& trf3,
-    const free_vector<typename local_frame_t::algebra_type>& free_vec) {
+    const free_parameters_vector<typename local_frame_t::algebra_type>&
+        free_vec) {
 
     // Matrix operator
     using algebra_t = typename local_frame_t::algebra_type;
     using matrix_operator = dmatrix_operator<algebra_t>;
-    // Track helper
-    using track_helper = detail::track_helper<matrix_operator>;
 
-    const auto pos = track_helper().pos(free_vec);
-    const auto dir = track_helper().dir(free_vec);
+    const auto pos = free_vec.pos();
+    const auto dir = free_vec.dir();
 
-    const auto bound_local =
-        free_to_bound_position<local_frame_t>(trf3, pos, dir);
+    const auto bound_local = local_frame_t::global_to_local(trf3, pos, dir);
 
     bound_vector<algebra_t> bound_vec;
     matrix_operator().element(bound_vec, e_bound_loc0, 0u) = bound_local[0];
@@ -69,14 +43,19 @@ DETRAY_HOST_DEVICE inline auto free_to_bound_vector(
     matrix_operator().element(bound_vec, e_bound_phi, 0u) = getter::phi(dir);
     matrix_operator().element(bound_vec, e_bound_theta, 0u) =
         getter::theta(dir);
-    matrix_operator().element(bound_vec, e_bound_time, 0u) =
-        matrix_operator().element(free_vec, e_free_time, 0u);
-    matrix_operator().element(bound_vec, e_bound_qoverp, 0u) =
-        matrix_operator().element(free_vec, e_free_qoverp, 0u);
+    matrix_operator().element(bound_vec, e_bound_time, 0u) = free_vec.time();
+    matrix_operator().element(bound_vec, e_bound_qoverp, 0u) = free_vec.qop();
 
     return bound_vec;
 }
 
+/// Transform a bound track parameter vector to a free track parameter vector
+///
+/// @param trf3 transform of the surface the bound parameters are defined on
+/// @param mask the mask of the surface the bound parameters are defined on
+/// @param bound_vec the bound track vector to be transformed
+///
+/// @returns the free track parameter vector
 template <typename mask_t>
 DETRAY_HOST_DEVICE inline auto bound_to_free_vector(
     const dtransform3D<typename mask_t::algebra_type>& trf3, const mask_t& mask,
@@ -84,6 +63,7 @@ DETRAY_HOST_DEVICE inline auto bound_to_free_vector(
 
     // Matrix operator
     using algebra_t = typename mask_t::algebra_type;
+    using local_frame_t = typename mask_t::local_frame_type;
     using matrix_operator = dmatrix_operator<algebra_t>;
     // Track helper
     using track_helper = detail::track_helper<matrix_operator>;
@@ -92,19 +72,17 @@ DETRAY_HOST_DEVICE inline auto bound_to_free_vector(
 
     const auto dir = track_helper().dir(bound_vec);
 
-    const auto pos = bound_to_free_position(trf3, mask, bound_local, dir);
+    const auto pos =
+        local_frame_t::local_to_global(trf3, mask, bound_local, dir);
 
-    free_vector<algebra_t> free_vec;
-    matrix_operator().element(free_vec, e_free_pos0, 0u) = pos[0];
-    matrix_operator().element(free_vec, e_free_pos1, 0u) = pos[1];
-    matrix_operator().element(free_vec, e_free_pos2, 0u) = pos[2];
-    matrix_operator().element(free_vec, e_free_time, 0u) =
-        matrix_operator().element(bound_vec, e_bound_time, 0u);
-    matrix_operator().element(free_vec, e_free_dir0, 0u) = dir[0];
-    matrix_operator().element(free_vec, e_free_dir1, 0u) = dir[1];
-    matrix_operator().element(free_vec, e_free_dir2, 0u) = dir[2];
-    matrix_operator().element(free_vec, e_free_qoverp, 0u) =
-        matrix_operator().element(bound_vec, e_bound_qoverp, 0u);
+    // The free vector constructor expects momentum and charge, so set the
+    // values explicitly instead
+    free_parameters_vector<algebra_t> free_vec{};
+
+    free_vec.set_pos(pos);
+    free_vec.set_time(track_helper().time(bound_vec));
+    free_vec.set_dir(dir);
+    free_vec.set_qop(track_helper().qop(bound_vec));
 
     return free_vec;
 }

--- a/core/include/detray/tracks/free_track_parameters.hpp
+++ b/core/include/detray/tracks/free_track_parameters.hpp
@@ -9,15 +9,14 @@
 
 // Project include(s).
 #include "detray/definitions/detail/algebra.hpp"
+#include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/track_parametrization.hpp"
-#include "detray/definitions/units.hpp"
-#include "detray/tracks/detail/track_helper.hpp"
 
 namespace detray {
 
 template <typename algebra_t>
-struct free_track_parameters {
+struct free_parameters_vector {
 
     /// @name Type definitions for the struct
     /// @{
@@ -25,50 +24,44 @@ struct free_track_parameters {
     using scalar_type = dscalar<algebra_t>;
     using point3_type = dpoint3D<algebra_t>;
     using vector3_type = dvector3D<algebra_t>;
-    using transform3_type = dtransform3D<algebra_t>;
     using matrix_operator = dmatrix_operator<algebra_t>;
 
-    // Shorthand vector/matrix types related to free track parameters.
+    // Shorthand vector type related to free track parameters.
     using vector_type = free_vector<algebra_t>;
-
-    // Track helper
-    using track_helper = detail::track_helper<matrix_operator>;
 
     /// @}
 
-    DETRAY_HOST_DEVICE
-    free_track_parameters()
-        : m_vector(matrix_operator().template zero<e_free_size, 1>()){};
+    /// Default constructor
+    free_parameters_vector() = default;
 
+    /// Construct from a 6-dim vector of parameters
     DETRAY_HOST_DEVICE
-    free_track_parameters(const vector_type& vec) : m_vector(vec) {}
+    explicit free_parameters_vector(const vector_type& vec) : m_vector(vec) {}
 
+    /// Construct from single parameters
+    ///
+    /// @param pos the global position
+    /// @param time the time
+    /// @param mom the global track momentum 3-vector
+    /// @param q the particle charge
     DETRAY_HOST_DEVICE
-    free_track_parameters(const point3_type& pos, const scalar_type time,
-                          const vector3_type& mom, const scalar_type q) {
+    free_parameters_vector(const point3_type& pos, const scalar_type time,
+                           const vector3_type& mom, const scalar_type q) {
 
-        matrix_operator().element(m_vector, e_free_pos0, 0u) = pos[0];
-        matrix_operator().element(m_vector, e_free_pos1, 0u) = pos[1];
-        matrix_operator().element(m_vector, e_free_pos2, 0u) = pos[2];
+        matrix_operator().set_block(m_vector, pos, e_free_pos0, 0u);
         matrix_operator().element(m_vector, e_free_time, 0u) = time;
 
         scalar_type p = getter::norm(mom);
         auto mom_norm = vector::normalize(mom);
-        matrix_operator().element(m_vector, e_free_dir0, 0u) = mom_norm[0];
-        matrix_operator().element(m_vector, e_free_dir1, 0u) = mom_norm[1];
-        matrix_operator().element(m_vector, e_free_dir2, 0u) = mom_norm[2];
+        matrix_operator().set_block(m_vector, mom_norm, e_free_dir0, 0u);
         matrix_operator().element(m_vector, e_free_qoverp, 0u) = q / p;
     }
 
-    /** @param rhs is the left hand side params for comparison
-     **/
+    /// @param rhs is the left hand side params for comparison
     DETRAY_HOST_DEVICE
-    bool operator==(const free_track_parameters& rhs) const {
+    bool operator==(const free_parameters_vector& rhs) const {
         for (unsigned int i = 0u; i < e_free_size; i++) {
-            const auto lhs_val = matrix_operator().element(m_vector, i, 0u);
-            const auto rhs_val = matrix_operator().element(rhs.vector(), i, 0u);
-
-            if (math::fabs(lhs_val - rhs_val) >
+            if (math::fabs((*this)[i] - rhs[i]) >
                 std::numeric_limits<scalar_type>::epsilon()) {
                 return false;
             }
@@ -77,61 +70,110 @@ struct free_track_parameters {
         return true;
     }
 
+    /// Convenience access to the track parameters - const
     DETRAY_HOST_DEVICE
-    const vector_type& vector() const { return m_vector; }
+    scalar_type operator[](std::size_t i) const {
+        return matrix_operator().element(m_vector, static_cast<unsigned int>(i),
+                                         0u);
+    }
 
+    /// Convenience access to the track parameters - non-const
     DETRAY_HOST_DEVICE
-    void set_vector(const vector_type& v) { m_vector = v; }
+    scalar_type& operator[](std::size_t i) {
+        return matrix_operator().element(m_vector, static_cast<unsigned int>(i),
+                                         0u);
+    }
 
+    /// @returns the global track position
     DETRAY_HOST_DEVICE
-    point3_type pos() const { return track_helper().pos(m_vector); }
+    point3_type pos() const {
+        return {matrix_operator().element(m_vector, e_free_pos0, 0u),
+                matrix_operator().element(m_vector, e_free_pos1, 0u),
+                matrix_operator().element(m_vector, e_free_pos2, 0u)};
+    }
 
+    /// Set the global track position
     DETRAY_HOST_DEVICE
     void set_pos(const vector3_type& pos) {
-        track_helper().set_pos(m_vector, pos);
+        matrix_operator().set_block(m_vector, pos, e_free_pos0, 0u);
     }
 
+    /// @returns the normalized, global track direction
     DETRAY_HOST_DEVICE
-    vector3_type dir() const { return track_helper().dir(m_vector); }
+    vector3_type dir() const {
+        return {matrix_operator().element(m_vector, e_free_dir0, 0u),
+                matrix_operator().element(m_vector, e_free_dir1, 0u),
+                matrix_operator().element(m_vector, e_free_dir2, 0u)};
+    }
 
+    /// Set the global track direction
+    /// @note Must be normalized!
     DETRAY_HOST_DEVICE
     void set_dir(const vector3_type& dir) {
-        track_helper().set_dir(m_vector, dir);
+        matrix_operator().set_block(m_vector, dir, e_free_dir0, 0u);
     }
 
+    /// @returns the time
     DETRAY_HOST_DEVICE
-    scalar_type time() const { return track_helper().time(m_vector); }
+    scalar_type time() const {
+        return matrix_operator().element(m_vector, e_free_time, 0u);
+    }
 
+    /// Set the time
     DETRAY_HOST_DEVICE
-    scalar_type qop() const { return track_helper().qop(m_vector); }
+    void set_time(const scalar_type t) {
+        assert(0.f <= t);
+        matrix_operator().element(m_vector, e_free_time, 0u) = t;
+    }
 
+    /// @returns the q/p value
+    DETRAY_HOST_DEVICE
+    scalar_type qop() const {
+        return matrix_operator().element(m_vector, e_free_qoverp, 0u);
+    }
+
+    /// Set the q/p value
     DETRAY_HOST_DEVICE
     void set_qop(const scalar_type qop) {
-        track_helper().set_qop(m_vector, qop);
+        matrix_operator().element(m_vector, e_free_qoverp, 0u) = qop;
     }
 
+    /// @returns the q/p_T value
     DETRAY_HOST_DEVICE
-    scalar_type qopT() const { return track_helper().qopT(m_vector); }
+    scalar_type qopT() const {
+        const auto dir = this->dir();
+        assert(getter::perp(dir) != 0.f);
+        return matrix_operator().element(m_vector, e_free_qoverp, 0u) /
+               getter::perp(dir);
+    }
 
+    /// @returns the q/p_z value
     DETRAY_HOST_DEVICE
-    scalar_type qopz() const { return track_helper().qopz(m_vector); }
+    scalar_type qopz() const {
+        const auto dir = this->dir();
+        return matrix_operator().element(m_vector, e_free_qoverp, 0u) / dir[2];
+    }
 
+    /// @returns the absolute momentum
     DETRAY_HOST_DEVICE
     scalar_type p(const scalar_type q) const {
-        return track_helper().p(m_vector, q);
+        assert(qop() != 0.f);
+        assert(q * qop() > 0.f);
+        return q / qop();
     }
 
+    /// @returns the global momentum 3-vector
     DETRAY_HOST_DEVICE
-    vector3_type mom(const scalar_type q) const {
-        return track_helper().mom(m_vector, q);
-    }
+    vector3_type mom(const scalar_type q) const { return p(q) * dir(); }
 
+    /// @returns the transverse momentum
     DETRAY_HOST_DEVICE
     scalar_type pT(const scalar_type q) const {
         assert(this->qop() != 0.f);
         return math::fabs(q / this->qop() * getter::perp(this->dir()));
     }
 
+    /// @returns the absolute momentum z-component
     DETRAY_HOST_DEVICE
     scalar_type pz(const scalar_type q) const {
         assert(this->qop() != 0.f);
@@ -141,5 +183,9 @@ struct free_track_parameters {
     private:
     vector_type m_vector = matrix_operator().template zero<e_free_size, 1>();
 };
+
+/// The free track parameters consist only of the parameter vector
+template <typename algebra_t>
+using free_track_parameters = free_parameters_vector<algebra_t>;
 
 }  // namespace detray

--- a/core/include/detray/utils/curvilinear_frame.hpp
+++ b/core/include/detray/utils/curvilinear_frame.hpp
@@ -38,7 +38,7 @@ struct curvilinear_frame {
 
         m_trf = transform3_type(t, z, x);
         m_bound_vec = detail::free_to_bound_vector<cartesian2D<algebra_t>>(
-            m_trf, free_params.vector());
+            m_trf, free_params);
     }
 
     DETRAY_HOST_DEVICE

--- a/tests/integration_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/integration_tests/cpu/propagator/covariance_transport.cpp
@@ -170,12 +170,8 @@ class detray_propagation_HelixCovarianceTransportValidation
         const bound_matrix_t& bound_cov_0 = bound_params.covariance();
 
         // Free vector at the departure surface
-        const auto free_vec_0 =
+        const auto free_trk_0 =
             detail::bound_to_free_vector(trf_0, mask_0, bound_vec_0);
-
-        // Free track at the departure surface
-        free_track_parameters<algebra_type> free_trk_0;
-        free_trk_0.set_vector(free_vec_0);
 
         // Helix from the departure surface
         detail::helix<algebra_type> hlx(free_trk_0, &B);
@@ -235,13 +231,12 @@ class detray_propagation_HelixCovarianceTransportValidation
 
         // Free-to-bound jacobian at the destination surface
         const free_to_bound_matrix_t free_to_bound_jacobi =
-            destination_jacobian_engine::free_to_bound_jacobian(
-                trf_1, free_trk_1.vector());
+            destination_jacobian_engine::free_to_bound_jacobian(trf_1,
+                                                                free_trk_1);
 
         // Bound vector at the destination surface
         const bound_vector_t bound_vec_1 =
-            detail::free_to_bound_vector<destination_frame>(
-                trf_1, free_trk_1.vector());
+            detail::free_to_bound_vector<destination_frame>(trf_1, free_trk_1);
 
         // Full jacobian
         const bound_matrix_t full_jacobi = free_to_bound_jacobi *
@@ -295,8 +290,7 @@ TYPED_TEST(detray_propagation_HelixCovarianceTransportValidation,
 
     // Set the initial bound vector
     bound_vector<algebra_t> bound_vec_0 = detail::free_to_bound_vector<
-        typename TestFixture::first_local_frame_type>(trfs[0],
-                                                      free_trk.vector());
+        typename TestFixture::first_local_frame_type>(trfs[0], free_trk);
 
     // Set the initial bound covariance
     typename bound_track_parameters<algebra_t>::covariance_type bound_cov_0 =

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -655,8 +655,7 @@ bound_track_parameters<algebra_type> get_initial_parameter(
     const free_track_parameters<algebra_type> free_par(pos, 0, dir, hlx._qop);
 
     const auto bound_vec =
-        tracking_surface{det, departure_sf}.free_to_bound_vector(
-            {}, free_par.vector());
+        tracking_surface{det, departure_sf}.free_to_bound_vector({}, free_par);
 
     bound_track_parameters<algebra_type> ret;
     ret.set_surface_link(geometry::barcode{0u});
@@ -1025,7 +1024,7 @@ get_displaced_bound_vector_helix(
                                                            hlx._qop);
     auto new_bound_vec =
         tracking_surface{det, destination_sf}.free_to_bound_vector(
-            {}, new_free_par.vector());
+            {}, new_free_par);
 
     // phi needs to be wrapped w.r.t. phi of the reference vector
     wrap_angles(dvec, new_bound_vec);
@@ -1101,8 +1100,8 @@ void evaluate_jacobian_difference_helix(
 
     // Get free to bound Jacobi
     const auto free_to_bound_jacobi =
-        tracking_surface{det, destination_sf}.free_to_bound_jacobian(
-            {}, free_par.vector());
+        tracking_surface{det, destination_sf}.free_to_bound_jacobian({},
+                                                                     free_par);
 
     // Get full Jacobi
     const auto reference_jacobian = free_to_bound_jacobi * correction_term *
@@ -1110,8 +1109,8 @@ void evaluate_jacobian_difference_helix(
 
     // Get bound vector
     const auto bound_vec =
-        tracking_surface{det, destination_sf}.free_to_bound_vector(
-            {}, free_par.vector());
+        tracking_surface{det, destination_sf}.free_to_bound_vector({},
+                                                                   free_par);
 
     /******************************
      *  Numerical differentiation

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -83,14 +83,10 @@ struct helix_inspector : actor {
         const auto sf = tracking_surface{*navigation.detector(),
                                          stepping._bound_params.surface_link()};
 
-        const auto free_vec =
+        const free_track_parameters<algebra_t> free_params =
             sf.bound_to_free_vector(ctx, stepping._bound_params.vector());
 
-        const auto last_pos =
-            detail::track_helper<matrix_operator>().pos(free_vec);
-
-        free_track_parameters<algebra_t> free_params;
-        free_params.set_vector(free_vec);
+        const auto last_pos = free_params.pos();
 
         const auto bvec =
             stepping._magnetic_field.at(last_pos[0], last_pos[1], last_pos[2]);

--- a/tests/unit_tests/cpu/propagator/jacobian_cartesian.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_cartesian.cpp
@@ -50,11 +50,11 @@ GTEST_TEST(detray_propagator, jacobian_cartesian2D) {
     // Free track parameter
     const free_track_parameters<algebra_t> free_params(global1, time, mom,
                                                        charge);
-    const auto free_vec1 = free_params.vector();
 
     const auto bound_vec =
-        detail::free_to_bound_vector<cartesian2D<algebra_t>>(trf, free_vec1);
-    const auto free_vec2 = detail::bound_to_free_vector(trf, rect, bound_vec);
+        detail::free_to_bound_vector<cartesian2D<algebra_t>>(trf, free_params);
+    const auto free_params2 =
+        detail::bound_to_free_vector(trf, rect, bound_vec);
 
     const matrix_operator m;
 
@@ -70,13 +70,12 @@ GTEST_TEST(detray_propagator, jacobian_cartesian2D) {
 
     // Check if the same free vector is obtained
     for (unsigned int i = 0u; i < 8u; i++) {
-        ASSERT_NEAR(m.element(free_vec1, i, 0u), m.element(free_vec2, i, 0u),
-                    isclose);
+        ASSERT_NEAR(free_params[i], free_params2[i], isclose);
     }
 
     // Test Jacobian transformation
     const bound_matrix<algebra_t> J =
-        jac_engine::free_to_bound_jacobian(trf, free_vec1) *
+        jac_engine::free_to_bound_jacobian(trf, free_params) *
         jac_engine::bound_to_free_jacobian(trf, rect, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {

--- a/tests/unit_tests/cpu/propagator/jacobian_cylindrical.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_cylindrical.cpp
@@ -55,11 +55,11 @@ GTEST_TEST(detray_propagator, jacobian_cylindrical2D) {
     // Free track parameter
     const free_track_parameters<algebra_t> free_params(global1, time, mom,
                                                        charge);
-    const auto free_vec1 = free_params.vector();
 
     const auto bound_vec =
-        detail::free_to_bound_vector<cylindrical2D<algebra_t>>(trf, free_vec1);
-    const auto free_vec2 = detail::bound_to_free_vector(trf, cyl, bound_vec);
+        detail::free_to_bound_vector<cylindrical2D<algebra_t>>(trf,
+                                                               free_params);
+    const auto free_params2 = detail::bound_to_free_vector(trf, cyl, bound_vec);
 
     const matrix_operator m;
 
@@ -76,13 +76,12 @@ GTEST_TEST(detray_propagator, jacobian_cylindrical2D) {
 
     // Check if the same free vector is obtained
     for (unsigned int i = 0u; i < 8u; i++) {
-        ASSERT_NEAR(m.element(free_vec1, i, 0u), m.element(free_vec2, i, 0u),
-                    isclose);
+        ASSERT_NEAR(free_params[i], free_params2[i], isclose);
     }
 
     // Test Jacobian transformation
     const bound_matrix<algebra_t> J =
-        jac_engine::free_to_bound_jacobian(trf, free_vec1) *
+        jac_engine::free_to_bound_jacobian(trf, free_params) *
         jac_engine::bound_to_free_jacobian(trf, cyl, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {

--- a/tests/unit_tests/cpu/propagator/jacobian_line.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_line.cpp
@@ -52,11 +52,10 @@ GTEST_TEST(detray_propagator, jacobian_line2D_case1) {
     // Free track parameter
     const free_track_parameters<algebra_t> free_params(global1, time, mom,
                                                        charge);
-    const auto free_vec1 = free_params.vector();
 
     const auto bound_vec =
-        detail::free_to_bound_vector<line2D<algebra_t>>(trf, free_vec1);
-    const auto free_vec2 = detail::bound_to_free_vector(trf, ln, bound_vec);
+        detail::free_to_bound_vector<line2D<algebra_t>>(trf, free_params);
+    const auto free_params2 = detail::bound_to_free_vector(trf, ln, bound_vec);
 
     const matrix_operator m;
 
@@ -72,13 +71,12 @@ GTEST_TEST(detray_propagator, jacobian_line2D_case1) {
 
     // Check if the same free vector is obtained
     for (unsigned int i = 0u; i < 8u; i++) {
-        ASSERT_NEAR(m.element(free_vec1, i, 0u), m.element(free_vec2, i, 0u),
-                    isclose);
+        ASSERT_NEAR(free_params[i], free_params2[i], isclose);
     }
 
     // Test Jacobian transformation
     const bound_matrix<algebra_t> J =
-        jac_engine::free_to_bound_jacobian(trf, free_vec1) *
+        jac_engine::free_to_bound_jacobian(trf, free_params) *
         jac_engine::bound_to_free_jacobian(trf, ln, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {
@@ -110,18 +108,18 @@ GTEST_TEST(detray_coordinates, jacobian_line2D_case2) {
 
     const point2 bound1 = {1.f, 2.f};
 
-    const point3 global = detail::bound_to_free_position(trf, ln, bound1, d);
+    const point3 global =
+        line2D<algebra_t>::local_to_global(trf, ln, bound1, d);
 
     // Free track parameter
     const free_track_parameters<algebra_t> free_params(global, time, mom,
                                                        charge);
-    const auto free_vec = free_params.vector();
     const auto bound_vec =
-        detail::free_to_bound_vector<line2D<algebra_t>>(trf, free_vec);
+        detail::free_to_bound_vector<line2D<algebra_t>>(trf, free_params);
 
     // Test Jacobian transformation
     const bound_matrix<algebra_t> J =
-        jac_engine::free_to_bound_jacobian(trf, free_vec) *
+        jac_engine::free_to_bound_jacobian(trf, free_params) *
         jac_engine::bound_to_free_jacobian(trf, ln, bound_vec);
 
     const matrix_operator m;

--- a/tests/unit_tests/cpu/propagator/jacobian_polar.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_polar.cpp
@@ -50,11 +50,9 @@ GTEST_TEST(detray_propagator, jacobian_polar2D) {
     // Free track parameter
     const free_track_parameters<algebra_t> free_params(global1, time, mom,
                                                        charge);
-    const auto free_vec1 = free_params.vector();
-
     const auto bound_vec =
-        detail::free_to_bound_vector<polar2D<algebra_t>>(trf, free_vec1);
-    const auto free_vec2 = detail::bound_to_free_vector(trf, rng, bound_vec);
+        detail::free_to_bound_vector<polar2D<algebra_t>>(trf, free_params);
+    const auto free_params2 = detail::bound_to_free_vector(trf, rng, bound_vec);
 
     const matrix_operator m;
 
@@ -70,13 +68,12 @@ GTEST_TEST(detray_propagator, jacobian_polar2D) {
 
     // Check if the same free vector is obtained
     for (unsigned int i = 0u; i < 8u; i++) {
-        ASSERT_NEAR(m.element(free_vec1, i, 0u), m.element(free_vec2, i, 0u),
-                    isclose);
+        ASSERT_NEAR(free_params[i], free_params2[i], isclose);
     }
 
     // Test Jacobian transformation
     const bound_matrix<algebra_t> J =
-        jac_engine::free_to_bound_jacobian(trf, free_vec1) *
+        jac_engine::free_to_bound_jacobian(trf, free_params) *
         jac_engine::bound_to_free_jacobian(trf, rng, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {

--- a/tests/unit_tests/cpu/propagator/rk_stepper.cpp
+++ b/tests/unit_tests/cpu/propagator/rk_stepper.cpp
@@ -120,7 +120,7 @@ GTEST_TEST(detray_propagator, rk_stepper) {
     for (auto track : uniform_track_generator<free_track_parameters<algebra_t>>(
              phi_steps, theta_steps, p_mag)) {
         // Generate track state used for propagation with constrained step size
-        free_track_parameters c_track(track);
+        free_track_parameters<algebra_t> c_track(track);
 
         // helix trajectory
         detail::helix helix(track, &B);
@@ -225,7 +225,7 @@ TEST(detray_propagator, rk_stepper_inhomogeneous_bfield) {
     for (auto track : uniform_track_generator<free_track_parameters<algebra_t>>(
              phi_steps, theta_steps, p_mag)) {
         // Generate track state used for propagation with constrained step size
-        free_track_parameters c_track(track);
+        free_track_parameters<algebra_t> c_track(track);
 
         // RK Stepping into forward direction
         prop_state<rk_stepper_t<bfield_t>::state, nav_state> propagation{

--- a/tests/unit_tests/cpu/tracks/free_track_parameters.cpp
+++ b/tests/unit_tests/cpu/tracks/free_track_parameters.cpp
@@ -43,23 +43,16 @@ GTEST_TEST(detray_tracks, free_track_parameters) {
 
     // first constructor
     free_track_parameters<algebra_t> free_param1(free_vec);
-    EXPECT_NEAR(free_param1.pos()[0],
-                getter::element(free_vec, e_free_pos0, 0u), tol);
-    EXPECT_NEAR(free_param1.pos()[1],
-                getter::element(free_vec, e_free_pos1, 0u), tol);
-    EXPECT_NEAR(free_param1.pos()[2],
-                getter::element(free_vec, e_free_pos2, 0u), tol);
-    EXPECT_NEAR(free_param1.dir()[0],
-                getter::element(free_vec, e_free_dir0, 0u), tol);
-    EXPECT_NEAR(free_param1.dir()[1],
-                getter::element(free_vec, e_free_dir1, 0u), tol);
-    EXPECT_NEAR(free_param1.dir()[2],
-                getter::element(free_vec, e_free_dir2, 0u), tol);
+    EXPECT_NEAR(free_param1.pos()[0], pos[0], tol);
+    EXPECT_NEAR(free_param1.pos()[1], pos[1], tol);
+    EXPECT_NEAR(free_param1.pos()[2], pos[2], tol);
+    EXPECT_NEAR(free_param1.dir()[0], mom[0] / getter::norm(mom), tol);
+    EXPECT_NEAR(free_param1.dir()[1], mom[1] / getter::norm(mom), tol);
+    EXPECT_NEAR(free_param1.dir()[2], mom[2] / getter::norm(mom), tol);
+    EXPECT_NEAR(free_param1.time(), time, tol);
+    EXPECT_NEAR(free_param1.qop(), charge / getter::norm(mom), tol);
+
     EXPECT_NEAR(getter::norm(free_param1.mom(charge)), getter::norm(mom), tol);
-    EXPECT_NEAR(free_param1.time(), getter::element(free_vec, e_free_time, 0u),
-                tol);
-    EXPECT_NEAR(free_param1.qop(), getter::element(free_vec, e_free_qoverp, 0u),
-                tol);
     EXPECT_NEAR(free_param1.pT(charge),
                 std::sqrt(std::pow(mom[0], 2.f) + std::pow(mom[1], 2.f)), tol);
     EXPECT_NEAR(free_param1.qopT(), charge / free_param1.pT(charge), tol);
@@ -80,9 +73,10 @@ GTEST_TEST(detray_tracks, free_track_parameters) {
     EXPECT_NEAR(free_param2.dir()[0], mom[0] / getter::norm(mom), tol);
     EXPECT_NEAR(free_param2.dir()[1], mom[1] / getter::norm(mom), tol);
     EXPECT_NEAR(free_param2.dir()[2], mom[2] / getter::norm(mom), tol);
-    EXPECT_NEAR(getter::norm(free_param2.mom(charge)), getter::norm(mom), tol);
     EXPECT_NEAR(free_param2.time(), time, tol);
     EXPECT_NEAR(free_param2.qop(), charge / getter::norm(mom), tol);
+
+    EXPECT_NEAR(getter::norm(free_param2.mom(charge)), getter::norm(mom), tol);
     EXPECT_NEAR(free_param2.pT(charge),
                 std::sqrt(std::pow(mom[0], 2.f) + std::pow(mom[1], 2.f)), tol);
     EXPECT_NEAR(free_param2.mom(charge)[0],
@@ -94,6 +88,23 @@ GTEST_TEST(detray_tracks, free_track_parameters) {
 
     EXPECT_TRUE(free_param2 == free_param1);
 
-    free_param2.set_qop(0.634f);
-    EXPECT_FLOAT_EQ(static_cast<float>(free_param2.qop()), 0.634f);
+    // Test the setters and subscript operator
+    pos = {1.f, 2.f, 3.f};
+    time = 0.5f;
+    const auto dir{vector::normalize(vector3{40.f, 50.f, 60.f})};
+    const scalar qop{0.634f};
+
+    free_param2.set_pos(pos);
+    free_param2.set_dir(dir);
+    free_param2.set_time(time);
+    free_param2.set_qop(qop);
+
+    EXPECT_NEAR(free_param2[e_free_pos0], pos[0], tol);
+    EXPECT_NEAR(free_param2[e_free_pos1], pos[1], tol);
+    EXPECT_NEAR(free_param2[e_free_pos2], pos[2], tol);
+    EXPECT_NEAR(free_param2[e_free_time], time, tol);
+    EXPECT_NEAR(free_param2[e_free_dir0], dir[0], tol);
+    EXPECT_NEAR(free_param2[e_free_dir1], dir[1], tol);
+    EXPECT_NEAR(free_param2[e_free_dir2], dir[2], tol);
+    EXPECT_NEAR(free_param2[e_free_qoverp], qop, tol);
 }


### PR DESCRIPTION
The free vector and the free track parameters are pretty much the same now, so let's use the classes public interface to access the data. This leads to some code simplifications in the track helper and the single parameter access

Also fixed a bug, where the CUDA code would not compile due to missing initializers on the mask values.