### PR TITLE
ref: Move the transform index onto the barcode

### DIFF
--- a/core/include/detray/geometry/detail/surface_descriptor.hpp
+++ b/core/include/detray/geometry/detail/surface_descriptor.hpp
@@ -56,11 +56,11 @@ class surface_descriptor {
     constexpr surface_descriptor(transform_link &&trf, mask_link &&mask,
                                  material_link &&material, dindex volume,
                                  surface_id sf_id)
-        : _mask(std::move(mask)),
-          _material(std::move(material)),
-          _trf(std::move(trf)) {
+        : m_mask(std::move(mask)), m_material(std::move(material)) {
 
-        m_barcode = geometry::barcode{}.set_volume(volume).set_id(sf_id);
+        m_barcode =
+            geometry::barcode{}.set_volume(volume).set_id(sf_id).set_transform(
+                trf);
     }
 
     /// Constructor with full arguments - copy semantics
@@ -76,8 +76,10 @@ class surface_descriptor {
                                  const mask_link &mask,
                                  const material_link &material,
                                  const dindex volume, const surface_id sf_id)
-        : _mask(mask), _material(material), _trf(trf) {
-        m_barcode = geometry::barcode{}.set_volume(volume).set_id(sf_id);
+        : m_mask(mask), m_material(material) {
+        m_barcode =
+            geometry::barcode{}.set_volume(volume).set_id(sf_id).set_transform(
+                trf);
     }
 
     constexpr surface_descriptor() = default;
@@ -89,8 +91,8 @@ class surface_descriptor {
     /// @param rhs is the right hand side to be compared to
     DETRAY_HOST_DEVICE
     constexpr auto operator==(const surface_descriptor &rhs) const -> bool {
-        return (_mask == rhs._mask and _material == rhs._material and
-                _trf == rhs._trf and m_barcode == rhs.m_barcode);
+        return (m_mask == rhs.m_mask && m_material == rhs.m_material &&
+                m_barcode == rhs.m_barcode);
     }
 
     /// Sets a new surface barcode
@@ -133,36 +135,38 @@ class surface_descriptor {
     ///
     /// @param offset update the position when move into new collection
     DETRAY_HOST
-    auto update_transform(dindex offset) -> void { _trf += offset; }
+    auto update_transform(dindex offset) -> void {
+        m_barcode.set_transform(transform() + offset);
+    }
 
     /// @return the transform index
     DETRAY_HOST_DEVICE
-    constexpr auto transform() const -> const transform_link & { return _trf; }
+    constexpr auto transform() const -> dindex { return m_barcode.transform(); }
 
     /// Update the mask link
     ///
     /// @param offset update the position when move into new collection
     DETRAY_HOST
-    auto update_mask(dindex offset) -> void { _mask += offset; }
+    auto update_mask(dindex offset) -> void { m_mask += offset; }
 
     /// @return the mask link
     DETRAY_HOST_DEVICE
-    constexpr auto mask() const -> const mask_link & { return _mask; }
+    constexpr auto mask() const -> const mask_link & { return m_mask; }
 
     /// Update the material link
     ///
     /// @param offset update the position when move into new collection
     DETRAY_HOST
-    auto update_material(dindex offset) -> void { _material += offset; }
+    auto update_material(dindex offset) -> void { m_material += offset; }
 
     /// Access to the material
     DETRAY_HOST_DEVICE
-    constexpr auto material() -> material_link & { return _material; }
+    constexpr auto material() -> material_link & { return m_material; }
 
     /// @return the material link
     DETRAY_HOST_DEVICE
     constexpr auto material() const -> const material_link & {
-        return _material;
+        return m_material;
     }
 
     /// @returns true if the surface is a senstive detector module.
@@ -188,17 +192,15 @@ class surface_descriptor {
     friend std::ostream &operator<<(std::ostream &os,
                                     const surface_descriptor &sf) {
         os << sf.m_barcode;
-        os << " | trf.: " << sf._trf;
-        os << " | mask: " << sf._mask;
-        os << " | mat.: " << sf._material;
+        os << " | mask: " << sf.m_mask;
+        os << " | mat.: " << sf.m_material;
         return os;
     }
 
     private:
     geometry::barcode m_barcode{};
-    mask_link _mask{};
-    material_link _material{};
-    transform_link_t _trf{};
+    mask_link m_mask{};
+    material_link m_material{};
 };
 
 }  // namespace detray

--- a/tests/integration_tests/cpu/propagator/guided_navigator.cpp
+++ b/tests/integration_tests/cpu/propagator/guided_navigator.cpp
@@ -101,6 +101,8 @@ GTEST_TEST(detray_navigation, guided_navigator) {
         const auto &candidate = obj_tracer[i].intersection;
         auto bcd = geometry::barcode{};
         bcd.set_volume(0u).set_index(sf_sequence[i]);
+        // The first transform in the detector belongs to the volume
+        bcd.set_transform(sf_sequence[i] + 1);
         bcd.set_id((i == 11u) ? surface_id::e_portal : surface_id::e_sensitive);
         EXPECT_TRUE(candidate.sf_desc.barcode() == bcd)
             << "error at intersection on surface:\n"

--- a/tests/unit_tests/cpu/geometry/barcode.cpp
+++ b/tests/unit_tests/cpu/geometry/barcode.cpp
@@ -21,18 +21,21 @@ GTEST_TEST(detray_geometry, barcode) {
     // Check a empty barcode
     EXPECT_EQ(bcd.volume(), static_cast<dindex>((1UL << 12) - 1UL));
     EXPECT_EQ(bcd.id(), static_cast<surface_id>((1UL << 4) - 1UL));
-    EXPECT_EQ(bcd.index(), static_cast<dindex>((1UL << 40) - 1UL));
-    EXPECT_EQ(bcd.extra(), static_cast<dindex>((1UL << 8) - 1UL));
+    EXPECT_EQ(bcd.index(), static_cast<dindex>((1UL << 21) - 1UL));
+    EXPECT_EQ(bcd.transform(), static_cast<dindex>((1UL << 21) - 1UL));
+    EXPECT_EQ(bcd.extra(), static_cast<dindex>((1UL << 6) - 1UL));
 
     bcd.set_volume(2UL)
         .set_id(surface_id::e_passive)
         .set_index(42UL)
+        .set_transform(11UL)
         .set_extra(24UL);
 
     // Check the values after setting them
     EXPECT_EQ(bcd.volume(), 2UL);
     EXPECT_EQ(bcd.id(), surface_id::e_passive);
     EXPECT_EQ(bcd.index(), 42UL);
+    EXPECT_EQ(bcd.transform(), 11UL);
     EXPECT_EQ(bcd.extra(), 24UL);
 
     // Check invalid barcode
@@ -41,14 +44,22 @@ GTEST_TEST(detray_geometry, barcode) {
     EXPECT_TRUE(bcd.is_invalid());
     bcd.set_volume(2UL);
     EXPECT_FALSE(bcd.is_invalid());
+
     bcd.set_id(static_cast<surface_id>((1UL << 4) - 1UL));
     EXPECT_TRUE(bcd.is_invalid());
     bcd.set_id(surface_id::e_passive);
     EXPECT_FALSE(bcd.is_invalid());
-    bcd.set_index((1UL << 40) - 1UL);
+
+    bcd.set_index((1UL << 21) - 1UL);
     EXPECT_TRUE(bcd.is_invalid());
     bcd.set_index(42UL);
     EXPECT_FALSE(bcd.is_invalid());
-    bcd.set_extra((1UL << 8) - 1UL);
+
+    bcd.set_transform((1UL << 21) - 1UL);
+    EXPECT_TRUE(bcd.is_invalid());
+    bcd.set_transform(11UL);
+    EXPECT_FALSE(bcd.is_invalid());
+
+    bcd.set_extra((1UL << 6) - 1UL);
     EXPECT_FALSE(bcd.is_invalid());
 }

--- a/tests/unit_tests/cpu/navigation/brute_force_finder.cpp
+++ b/tests/unit_tests/cpu/navigation/brute_force_finder.cpp
@@ -52,9 +52,12 @@ GTEST_TEST(detray_navigation, brute_force_collection) {
     // surface direction
     vector3 direction{0.f, 0.f, 1.f};
 
-    auto surfaces1 = test::planes_along_direction(distances1, direction);
-    auto surfaces2 = test::planes_along_direction(distances2, direction);
-    auto surfaces3 = test::planes_along_direction(distances3, direction);
+    auto [surfaces1, transforms1] =
+        test::planes_along_direction(distances1, direction);
+    auto [surfaces2, transforms2] =
+        test::planes_along_direction(distances2, direction);
+    auto [surfaces3, transforms3] =
+        test::planes_along_direction(distances3, direction);
 
     brute_force_collection<typename decltype(surfaces1)::value_type>
         sf_collection(&host_mr);


### PR DESCRIPTION
Removes the transform index as a separate index in the surface descriptor and adds it to the barcode. If it turns out not to be needed in the SoA layout, it will eventually be removed altogether. 
Some of the benchmark code used to put the transform directly into the descriptor, which was now changed, so that the transforms are passed in a separate collection