### PR TITLE
ref: Replace logic operators

### DIFF
--- a/core/include/detray/builders/detail/associator.hpp
+++ b/core/include/detray/builders/detail/associator.hpp
@@ -50,7 +50,7 @@ struct center_of_gravity_rectangle {
             max_l1 = math::max(b[1], max_l1);
         }
 
-        if (cgs[0] >= min_l0 and cgs[0] < max_l0 and cgs[1] >= min_l1 and
+        if (cgs[0] >= min_l0 && cgs[0] < max_l0 && cgs[1] >= min_l1 &&
             cgs[1] < max_l1) {
             return true;
         }
@@ -86,8 +86,8 @@ struct center_of_gravity_generic {
         for (i = 0u, j = num_points - 1u; i < num_points; j = i++) {
             const auto &pi = bin_contour[i];
             const auto &pj = bin_contour[j];
-            if ((((pi[1] <= cgs[1]) and (cgs[1] < pj[1])) or
-                 ((pj[1] <= cgs[1]) and (cgs[1] < pi[1]))) and
+            if ((((pi[1] <= cgs[1]) && (cgs[1] < pj[1])) ||
+                 ((pj[1] <= cgs[1]) && (cgs[1] < pi[1]))) &&
                 (cgs[0] <
                  (pj[0] - pi[0]) * (cgs[1] - pi[1]) / (pj[1] - pi[1]) + pi[0]))
                 inside = !inside;
@@ -123,7 +123,7 @@ struct edges_intersect_generic {
                 double s = ((pi[1] - pk[1]) * (pj[0] - pi[0]) -
                             (pi[0] - pk[0]) * (pj[1] - pi[1])) /
                            d;
-                if (r >= 0.f and r <= 1.f and s >= 0.f and s <= 1.f) {
+                if (r >= 0.f && r <= 1.f && s >= 0.f && s <= 1.f) {
                     return true;
                 }
             }

--- a/core/include/detray/builders/detail/bin_association.hpp
+++ b/core/include/detray/builders/detail/bin_association.hpp
@@ -99,7 +99,7 @@ static inline void bin_association(const context_t & /*context*/,
                     // Usually one mask per surface, but design allows - a
                     // single association  is sufficient though
                     for (auto &vertices : vertices_per_masks) {
-                        if (not vertices.empty()) {
+                        if (!vertices.empty()) {
                             // Create a surface contour
                             std::vector<point2_t> surface_contour;
                             surface_contour.reserve(vertices.size());
@@ -108,7 +108,7 @@ static inline void bin_association(const context_t & /*context*/,
                                 surface_contour.push_back({vg[0], vg[1]});
                             }
                             // The association has worked
-                            if (cgs_assoc(bin_contour, surface_contour) or
+                            if (cgs_assoc(bin_contour, surface_contour) ||
                                 edges_assoc(bin_contour, surface_contour)) {
                                 grid.template populate<attach<>>({bin_0, bin_1},
                                                                  sf);
@@ -172,7 +172,7 @@ static inline void bin_association(const context_t & /*context*/,
 
                     for (auto &vertices : vertices_per_masks) {
 
-                        if (not vertices.empty()) {
+                        if (!vertices.empty()) {
                             // Create a surface contour
                             std::vector<point2_t> surface_contour;
                             surface_contour.reserve(vertices.size());
@@ -210,7 +210,7 @@ static inline void bin_association(const context_t & /*context*/,
                             }
                             // Check for phi wrapping
                             std::vector<std::vector<point2_t>> surface_contours;
-                            if (phi_max - phi_min > constant<scalar>::pi and
+                            if (phi_max - phi_min > constant<scalar>::pi &&
                                 phi_max * phi_min < 0.) {
                                 s_c_neg.push_back(
                                     {z_max_neg, -constant<scalar>::pi});
@@ -228,7 +228,7 @@ static inline void bin_association(const context_t & /*context*/,
                             // Check the association (with potential splits)
                             bool associated = false;
                             for (const auto &s_c : surface_contours) {
-                                if (cgs_assoc(bin_contour, s_c) or
+                                if (cgs_assoc(bin_contour, s_c) ||
                                     edges_assoc(bin_contour, s_c)) {
                                     associated = true;
                                     break;

--- a/core/include/detray/builders/detail/volume_connector.hpp
+++ b/core/include/detray/builders/detail/volume_connector.hpp
@@ -63,7 +63,7 @@ void connect_cylindrical_volumes(
         }
         seed_map[volume_index] = 1;
 
-        if (seed[0] < axis_r.bins() and seed[1] < axis_z.bins()) {
+        if (seed[0] < axis_r.bins() && seed[1] < axis_z.bins()) {
             seeds.push_back(seed);
         }
     };
@@ -110,17 +110,17 @@ void connect_cylindrical_volumes(
             //  1 - Left walk up
             // First peek to the to the left for portal desitnations
             dindex last_portal_dest =
-                (running_bin[1] > 0 and running_bin[1] < axis_r.bins())
+                (running_bin[1] > 0 && running_bin[1] < axis_r.bins())
                     ? volume_grid.bin(running_bin[0], running_bin[1] + peek)
                     : dindex_invalid;
-            while ((ref == test) and ++running_bin[0] < axis_r.bins()) {
+            while ((ref == test) && ++running_bin[0] < axis_r.bins()) {
                 high = axis_r.borders(running_bin[0]);
                 test = (seed[0] + 1 < axis_r.bins())
                            ? volume_grid.bin(running_bin[0], running_bin[1])
                            : dindex_invalid;
                 // Peek outside and see if the portal destination has changed
                 dindex portal_dest =
-                    (running_bin[1] > 0 and running_bin[1] < axis_r.bins())
+                    (running_bin[1] > 0 && running_bin[1] < axis_r.bins())
                         ? volume_grid.bin(running_bin[0], running_bin[1] + peek)
                         : dindex_invalid;
                 if (portal_dest != last_portal_dest) {
@@ -181,7 +181,7 @@ void connect_cylindrical_volumes(
                     : dindex_invalid;
 
             // Seed setting loop as well
-            while (ref == test and (++running_bin[1]) < axis_z.bins()) {
+            while (ref == test && (++running_bin[1]) < axis_z.bins()) {
                 high = axis_z.borders(running_bin[1]);
                 test = volume_grid.bin(running_bin[0], running_bin[1]);
                 // Peek outside and see if the portal destination has changed
@@ -191,7 +191,7 @@ void connect_cylindrical_volumes(
                         : dindex_invalid;
                 if (portal_dest != last_portal_dest) {
                     // Record the boundary
-                    if (not walk_only) {
+                    if (!walk_only) {
                         portals_info.push_back(
                             {{low[0], high[0]}, last_portal_dest});
                         last_added = {running_bin[0], running_bin[1] - 1};
@@ -200,7 +200,7 @@ void connect_cylindrical_volumes(
                     low = high;
                     last_portal_dest = portal_dest;
                     // That's a new seed right here, except for last one
-                    if (running_bin[1] < axis_z.bins() and add_seed) {
+                    if (running_bin[1] < axis_z.bins() && add_seed) {
                         add_new_seed({running_bin[0] + peek, running_bin[1]},
                                      portal_dest);
                     }
@@ -209,7 +209,7 @@ void connect_cylindrical_volumes(
             }
             // By this we undo the overstepping (see above)
             high = axis_z.borders(--running_bin[1]);
-            if (not walk_only and last_added != running_bin) {
+            if (!walk_only && last_added != running_bin) {
                 portals_info.push_back({{low[0], high[1]}, last_portal_dest});
             }
             // The new bin position after walk
@@ -251,7 +251,7 @@ void connect_cylindrical_volumes(
             using portal_t = typename detector_t::surface_type;
             using volume_link_t = typename portal_t::volume_link_type;
             // Fill in the left side portals
-            if (not portals_info.empty()) {
+            if (!portals_info.empty()) {
                 // The portal transfrom is given from the left
                 typename detector_t::vector3_type _translation{
                     0., 0., volume_bounds[bound_index]};
@@ -302,7 +302,7 @@ void connect_cylindrical_volumes(
             using portal_t = typename detector_t::surface_type;
             using volume_link_t = typename portal_t::volume_link_type;
             // Fill in the upper side portals
-            if (not portals_info.empty()) {
+            if (!portals_info.empty()) {
                 // Get the mask context group and fill it
                 constexpr auto cylinder_id =
                     detector_t::masks::id::e_portal_cylinder3;

--- a/core/include/detray/builders/grid_builder.hpp
+++ b/core/include/detray/builders/grid_builder.hpp
@@ -155,8 +155,8 @@ class grid_builder : public volume_decorator<detector_t> {
             std::vector<surface_desc_t> surfaces{};
             for (auto &sf_desc : vol.surfaces()) {
 
-                if (sf_desc.is_sensitive() or
-                    (m_add_passives and sf_desc.is_passive())) {
+                if (sf_desc.is_sensitive() ||
+                    (m_add_passives && sf_desc.is_passive())) {
                     surfaces.push_back(sf_desc);
                 }
             }

--- a/core/include/detray/builders/homogeneous_material_factory.hpp
+++ b/core/include/detray/builders/homogeneous_material_factory.hpp
@@ -172,7 +172,7 @@ class homogeneous_material_factory final
         const dindex n_surfaces{static_cast<dindex>(m_links.size())};
 
         // Need exactly one material per surface
-        assert(m_indices.empty() or (m_indices.size() == n_surfaces));
+        assert(m_indices.empty() || (m_indices.size() == n_surfaces));
         assert(m_links.size() == n_surfaces);
         assert(m_materials.size() == n_surfaces);
         assert(m_thickness.size() == n_surfaces);
@@ -266,7 +266,7 @@ class homogeneous_material_factory final
 
         // If no concrete surface ordering was passed, use index sequence
         // and add the materials to the trailing elements in the surfaces cont.
-        if (m_indices.empty() or
+        if (m_indices.empty() ||
             std::find(m_indices.begin(), m_indices.end(),
                       detail::invalid_value<std::size_t>()) !=
                 m_indices.end()) {

--- a/core/include/detray/core/detail/multi_store.hpp
+++ b/core/include/detray/core/detail/multi_store.hpp
@@ -81,9 +81,9 @@ class multi_store {
 
     /// Construct with a specific vecmem memory resource @param resource
     /// (host-side only)
-    template <typename allocator_t = vecmem::memory_resource,
-              std::enable_if_t<not detail::is_device_view_v<allocator_t>,
-                               bool> = true>
+    template <
+        typename allocator_t = vecmem::memory_resource,
+        std::enable_if_t<!detail::is_device_view_v<allocator_t>, bool> = true>
     DETRAY_HOST explicit multi_store(allocator_t &resource)
         : m_tuple_container(resource) {}
 

--- a/core/include/detray/core/detail/single_store.hpp
+++ b/core/include/detray/core/detail/single_store.hpp
@@ -62,9 +62,9 @@ class single_store {
 
     /// Construct with a specific memory resource @param resource
     /// (host-side only)
-    template <typename allocator_t = vecmem::memory_resource,
-              std::enable_if_t<not detail::is_device_view_v<allocator_t>,
-                               bool> = true>
+    template <
+        typename allocator_t = vecmem::memory_resource,
+        std::enable_if_t<!detail::is_device_view_v<allocator_t>, bool> = true>
     DETRAY_HOST explicit single_store(allocator_t &resource)
         : m_container(&resource) {}
 

--- a/core/include/detray/core/detail/surface_lookup.hpp
+++ b/core/include/detray/core/detail/surface_lookup.hpp
@@ -89,9 +89,9 @@ class surface_lookup {
 
     /// Construct with a specific memory resource @param resource
     /// (host-side only)
-    template <typename allocator_t = vecmem::memory_resource,
-              std::enable_if_t<not detail::is_device_view_v<allocator_t>,
-                               bool> = true>
+    template <
+        typename allocator_t = vecmem::memory_resource,
+        std::enable_if_t<!detail::is_device_view_v<allocator_t>, bool> = true>
     DETRAY_HOST explicit surface_lookup(allocator_t &resource)
         : m_container(&resource) {}
 

--- a/core/include/detray/core/detail/tuple_container.hpp
+++ b/core/include/detray/core/detail/tuple_container.hpp
@@ -54,7 +54,7 @@ class tuple_container {
     /// Construct with a specific vecmem memory resource @param resource
     /// (host-side only)
     template <typename allocator_t = vecmem::memory_resource,
-              std::enable_if_t<not is_device_view_v<allocator_t>, bool> = true>
+              std::enable_if_t<!is_device_view_v<allocator_t>, bool> = true>
     DETRAY_HOST explicit tuple_container(allocator_t &resource)
         : _tuple(Ts(&resource)...) {}
 
@@ -204,7 +204,7 @@ class tuple_container {
                                     std::forward<Args>(As)...);
         }
         // If there is no matching ID, return default output
-        if constexpr (not std::is_same_v<
+        if constexpr (!std::is_same_v<
                           std::invoke_result_t<
                               functor_t,
                               const detail::tuple_element_t<0, tuple_type> &,

--- a/core/include/detray/geometry/mask.hpp
+++ b/core/include/detray/geometry/mask.hpp
@@ -246,7 +246,7 @@ class mask {
 
         const bool result = _shape.check_consistency(_values, os);
 
-        if (not result) {
+        if (!result) {
             os << to_string();
         }
 

--- a/core/include/detray/geometry/shapes/annulus2D.hpp
+++ b/core/include/detray/geometry/shapes/annulus2D.hpp
@@ -161,7 +161,7 @@ class annulus2D {
         // Check phi boundaries, which are well def. in focal frame
         const scalar_t phi_tol = detail::phi_tolerance(tol, loc_p[0]);
         const auto phi_check =
-            !((phi_focal < (bounds[e_min_phi_rel] - phi_tol)) or
+            !((phi_focal < (bounds[e_min_phi_rel] - phi_tol)) ||
               (phi_focal > (bounds[e_max_phi_rel] + phi_tol)));
 
         const auto r_beam2 = get_r2_beam_frame(bounds, loc_p);
@@ -430,25 +430,25 @@ class annulus2D {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 
-        if (math::signbit(bounds[e_min_r]) or bounds[e_max_r] < tol) {
+        if (math::signbit(bounds[e_min_r]) || bounds[e_max_r] < tol) {
             os << "ERROR: Radial bounds must be in the range [0, numeric_max)";
             return false;
         }
-        if (bounds[e_min_r] >= bounds[e_max_r] or
+        if (bounds[e_min_r] >= bounds[e_max_r] ||
             math::fabs(bounds[e_min_r] - bounds[e_max_r]) < tol) {
             os << "ERROR: Min radius must be smaller than max radius.";
             return false;
         }
-        if ((bounds[e_min_phi_rel] < -constant<scalar_t>::pi or
-             bounds[e_min_phi_rel] > constant<scalar_t>::pi) or
-            (bounds[e_max_phi_rel] < -constant<scalar_t>::pi or
-             bounds[e_max_phi_rel] > constant<scalar_t>::pi) or
-            (bounds[e_average_phi] < -constant<scalar_t>::pi or
+        if ((bounds[e_min_phi_rel] < -constant<scalar_t>::pi ||
+             bounds[e_min_phi_rel] > constant<scalar_t>::pi) ||
+            (bounds[e_max_phi_rel] < -constant<scalar_t>::pi ||
+             bounds[e_max_phi_rel] > constant<scalar_t>::pi) ||
+            (bounds[e_average_phi] < -constant<scalar_t>::pi ||
              bounds[e_average_phi] > constant<scalar_t>::pi)) {
             os << "ERROR: Angles must map onto [-pi, pi] range.";
             return false;
         }
-        if (bounds[e_min_phi_rel] >= bounds[e_max_phi_rel] or
+        if (bounds[e_min_phi_rel] >= bounds[e_max_phi_rel] ||
             math::fabs(bounds[e_min_phi_rel] - bounds[e_max_phi_rel]) < tol) {
             os << "ERROR: Min relative angle must be smaller than max relative "
                   "angle.";

--- a/core/include/detray/geometry/shapes/concentric_cylinder2D.hpp
+++ b/core/include/detray/geometry/shapes/concentric_cylinder2D.hpp
@@ -85,7 +85,7 @@ class concentric_cylinder2D {
         const bounds_type<scalar_t> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
 
-        return (bounds[e_lower_z] - tol <= loc_p[1] and
+        return (bounds[e_lower_z] - tol <= loc_p[1] &&
                 loc_p[1] <= bounds[e_upper_z] + tol);
     }
 
@@ -172,7 +172,7 @@ class concentric_cylinder2D {
                << std::endl;
             return false;
         }
-        if (bounds[e_lower_z] >= bounds[e_upper_z] or
+        if (bounds[e_lower_z] >= bounds[e_upper_z] ||
             math::fabs(bounds[e_lower_z] - bounds[e_upper_z]) < tol) {
             os << "ERROR: Neg. half length must be smaller than pos. half "
                   "length.";

--- a/core/include/detray/geometry/shapes/cuboid3D.hpp
+++ b/core/include/detray/geometry/shapes/cuboid3D.hpp
@@ -186,17 +186,17 @@ class cuboid3D {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 
-        if (bounds[e_min_x] >= bounds[e_max_x] or
+        if (bounds[e_min_x] >= bounds[e_max_x] ||
             math::fabs(bounds[e_min_x] - bounds[e_max_x]) < tol) {
             os << "ERROR: Min x must be smaller than max x.";
             return false;
         }
-        if (bounds[e_min_y] >= bounds[e_max_y] or
+        if (bounds[e_min_y] >= bounds[e_max_y] ||
             math::fabs(bounds[e_min_y] - bounds[e_max_y]) < tol) {
             os << "ERROR: Min y must be smaller than max y.";
             return false;
         }
-        if (bounds[e_min_z] >= bounds[e_max_z] or
+        if (bounds[e_min_z] >= bounds[e_max_z] ||
             math::fabs(bounds[e_min_z] - bounds[e_max_z]) < tol) {
             os << "ERROR: Min z must be smaller than max z.";
             return false;

--- a/core/include/detray/geometry/shapes/cylinder2D.hpp
+++ b/core/include/detray/geometry/shapes/cylinder2D.hpp
@@ -172,7 +172,7 @@ class cylinder2D {
                << std::endl;
             return false;
         }
-        if (bounds[e_lower_z] >= bounds[e_upper_z] or
+        if (bounds[e_lower_z] >= bounds[e_upper_z] ||
             math::fabs(bounds[e_lower_z] - bounds[e_upper_z]) < tol) {
             os << "ERROR: Neg. half length must be smaller than pos. half "
                   "length.";

--- a/core/include/detray/geometry/shapes/cylinder3D.hpp
+++ b/core/include/detray/geometry/shapes/cylinder3D.hpp
@@ -196,12 +196,12 @@ class cylinder3D {
                << std::endl;
             return false;
         }
-        if (bounds[e_min_r] >= bounds[e_max_r] or
+        if (bounds[e_min_r] >= bounds[e_max_r] ||
             math::fabs(bounds[e_min_r] - bounds[e_max_r]) < tol) {
             os << "ERROR: Min Radius must be smaller than max Radius.";
             return false;
         }
-        if (bounds[e_min_z] >= bounds[e_max_z] or
+        if (bounds[e_min_z] >= bounds[e_max_z] ||
             math::fabs(bounds[e_min_z] - bounds[e_max_z]) < tol) {
             os << "ERROR: Min z must be smaller than max z.";
             return false;

--- a/core/include/detray/geometry/shapes/rectangle2D.hpp
+++ b/core/include/detray/geometry/shapes/rectangle2D.hpp
@@ -171,7 +171,7 @@ class rectangle2D {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 
-        if (bounds[e_half_x] < tol or bounds[e_half_y] < tol) {
+        if (bounds[e_half_x] < tol || bounds[e_half_y] < tol) {
             os << "ERROR: Half lengths must be in the range (0, numeric_max)"
                << std::endl;
             return false;

--- a/core/include/detray/geometry/shapes/ring2D.hpp
+++ b/core/include/detray/geometry/shapes/ring2D.hpp
@@ -163,12 +163,12 @@ class ring2D {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 
-        if (math::signbit(bounds[e_inner_r]) or bounds[e_outer_r] < tol) {
+        if (math::signbit(bounds[e_inner_r]) || bounds[e_outer_r] < tol) {
             os << "ERROR: Radius must be in the range [0, numeric_max)"
                << std::endl;
             return false;
         }
-        if (bounds[e_inner_r] >= bounds[e_outer_r] or
+        if (bounds[e_inner_r] >= bounds[e_outer_r] ||
             math::fabs(bounds[e_inner_r] - bounds[e_outer_r]) < tol) {
             os << "ERROR: Inner radius must be smaller outer radius.";
             return false;

--- a/core/include/detray/geometry/shapes/single3D.hpp
+++ b/core/include/detray/geometry/shapes/single3D.hpp
@@ -80,7 +80,7 @@ class single3D {
     DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_type<scalar_t> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
-        return (bounds[e_lower] - tol <= loc_p[kCheckIndex] and
+        return (bounds[e_lower] - tol <= loc_p[kCheckIndex] &&
                 loc_p[kCheckIndex] <= bounds[e_upper] + tol);
     }
 

--- a/core/include/detray/geometry/shapes/trapezoid2D.hpp
+++ b/core/include/detray/geometry/shapes/trapezoid2D.hpp
@@ -207,7 +207,7 @@ class trapezoid2D {
 
         constexpr auto tol{10.f * std::numeric_limits<scalar_t>::epsilon()};
 
-        if (bounds[e_half_length_0] < tol or bounds[e_half_length_1] < tol) {
+        if (bounds[e_half_length_0] < tol || bounds[e_half_length_1] < tol) {
             os << "ERROR: Half length in x must be in the range (0, "
                   "numeric_max)"
                << std::endl;

--- a/core/include/detray/geometry/tracking_surface.hpp
+++ b/core/include/detray/geometry/tracking_surface.hpp
@@ -86,7 +86,7 @@ class tracking_surface {
     /// @param rhs is the right hand side to be compared to
     DETRAY_HOST_DEVICE
     constexpr auto operator==(const tracking_surface &rhs) const -> bool {
-        return (&m_detector == &(rhs.m_detector) and m_desc == rhs.m_desc);
+        return (&m_detector == &(rhs.m_detector) && m_desc == rhs.m_desc);
     }
 
     /// @returns the surface barcode
@@ -169,7 +169,7 @@ class tracking_surface {
 
     /// @returns the mask volume link
     template <typename point_t = point2_type,
-              std::enable_if_t<std::is_same_v<point_t, point3_type> or
+              std::enable_if_t<std::is_same_v<point_t, point3_type> ||
                                    std::is_same_v<point_t, point2_type>,
                                bool> = true>
     DETRAY_HOST_DEVICE constexpr bool is_inside(const point_t &loc_p,
@@ -200,7 +200,7 @@ class tracking_surface {
     /// @returns the surface normal in global coordinates at a given bound/local
     /// position @param p
     template <typename point_t = point2_type,
-              std::enable_if_t<std::is_same_v<point_t, point3_type> or
+              std::enable_if_t<std::is_same_v<point_t, point3_type> ||
                                    std::is_same_v<point_t, point2_type>,
                                bool> = true>
     DETRAY_HOST_DEVICE constexpr auto normal(const context &ctx,
@@ -213,7 +213,7 @@ class tracking_surface {
     /// @param p and a global direction @param dir
     /// @note The direction has to be normalized
     template <typename point_t = point2_type,
-              std::enable_if_t<std::is_same_v<point_t, point3_type> or
+              std::enable_if_t<std::is_same_v<point_t, point3_type> ||
                                    std::is_same_v<point_t, point2_type>,
                                bool> = true>
     DETRAY_HOST_DEVICE constexpr auto cos_angle(const context &ctx,
@@ -410,7 +410,7 @@ class tracking_surface {
             return false;
         }
         // Only check, if there is material in the detector
-        if (not m_detector.material_store().all_empty()) {
+        if (!m_detector.material_store().all_empty()) {
             if (has_material() && m_desc.material().is_invalid_index()) {
                 os << "ERROR: Surface does not have valid material link:\n"
                    << *this << std::endl;
@@ -418,7 +418,7 @@ class tracking_surface {
             }
         }
         // Check the mask boundaries
-        if (not visit_mask<typename kernels::mask_self_check>(os)) {
+        if (!visit_mask<typename kernels::mask_self_check>(os)) {
             os << "\nSurface: " << *this << std::endl;
             return false;
         }

--- a/core/include/detray/geometry/tracking_volume.hpp
+++ b/core/include/detray/geometry/tracking_volume.hpp
@@ -71,7 +71,7 @@ class tracking_volume {
     /// @param rhs is the right hand side to be compared to
     DETRAY_HOST_DEVICE
     constexpr auto operator==(const tracking_volume &rhs) const -> bool {
-        return (&m_detector == &(rhs.m_detector) and m_desc == rhs.m_desc);
+        return (&m_detector == &(rhs.m_detector) && m_desc == rhs.m_desc);
     }
 
     /// @returns the volume shape id, e.g. 'cylinder'.
@@ -184,7 +184,7 @@ class tracking_volume {
 
         // Check if this volume holds such a collection and, if so, add max
         // number of candidates that we can expect from it
-        if (not link.is_invalid()) {
+        if (!link.is_invalid()) {
             const unsigned int n_max{
                 m_detector.accelerator_store()
                     .template visit<detail::n_candidates_getter>(link)};
@@ -287,7 +287,7 @@ class tracking_volume {
         std::stringstream warnigns{};
         for (std::size_t i = 1u; i < acc_link.size(); ++i) {
             // An acceleration data structure link was set, but is invalid
-            if (!acc_link[i].is_invalid_id() and
+            if (!acc_link[i].is_invalid_id() &&
                 acc_link[i].is_invalid_index()) {
                 suspicious_links = true;
                 warnigns << "Link to acceleration data structure "
@@ -338,7 +338,7 @@ class tracking_volume {
             static_cast<typename descr_t::object_id>(I)>()};
 
         // Only visit, if object type is contained in volume
-        if (not link.is_invalid()) {
+        if (!link.is_invalid()) {
             // Run over the surfaces in a single acceleration data structure
             // and apply the functor to the resulting neighborhood
             m_detector.accelerator_store().template visit<functor_t>(

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -87,7 +87,7 @@ struct regular {
     dindex bin(scalar v) const {
         int ibin = static_cast<int>((v - min) / (max - min) *
                                     static_cast<scalar>(n_bins));
-        if (ibin >= 0 and ibin < static_cast<int>(n_bins)) {
+        if (ibin >= 0 && ibin < static_cast<int>(n_bins)) {
             return static_cast<dindex>(ibin);
         } else {
             if (ibin < 0) {
@@ -272,7 +272,7 @@ struct circular {
     dindex bin(scalar v) const {
         int ibin = static_cast<int>((v - min) / (max - min) *
                                     static_cast<scalar>(n_bins));
-        if (ibin >= 0 and ibin < static_cast<int>(n_bins)) {
+        if (ibin >= 0 && ibin < static_cast<int>(n_bins)) {
             return static_cast<dindex>(ibin);
         } else {
             if (ibin < 0) {
@@ -384,7 +384,7 @@ struct circular {
     DETRAY_HOST_DEVICE
     dindex remap(dindex ibin, int shood) const {
         int opt_bin = static_cast<int>(ibin) + shood;
-        if (opt_bin >= 0 and opt_bin < static_cast<int>(n_bins)) {
+        if (opt_bin >= 0 && opt_bin < static_cast<int>(n_bins)) {
             return static_cast<dindex>(opt_bin);
         }
         if (opt_bin < 0) {
@@ -501,7 +501,7 @@ struct irregular {
         int ibin = static_cast<int>(
             std::lower_bound(boundaries.begin(), boundaries.end(), v) -
             boundaries.begin());
-        if (ibin > 0 and ibin < static_cast<int>(boundaries.size())) {
+        if (ibin > 0 && ibin < static_cast<int>(boundaries.size())) {
             return static_cast<dindex>(--ibin);
         } else {
             if (ibin == 0) {

--- a/core/include/detray/materials/interaction.hpp
+++ b/core/include/detray/materials/interaction.hpp
@@ -238,7 +238,7 @@ struct interaction {
         // computations
 
         // if electron or positron
-        if ((ptc.pdg_num() == 11) or (ptc.pdg_num() == -11)) {
+        if ((ptc.pdg_num() == 11) || (ptc.pdg_num() == -11)) {
             //@todo (Beomki): Not sure if we need this function. At least we
             // need to find the reference for this equation
             return theta0RossiGreisen(xOverX0, momentumInv, rq.m_q2OverBeta2);

--- a/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
@@ -136,7 +136,7 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
                 // f(s) = ((h.pos(s) - sc) x sz)^2 - r^2 == 0
                 // Run the iteration on s
                 std::size_t n_tries{0u};
-                while (math::fabs(s - s_prev) > convergence_tolerance and
+                while (math::fabs(s - s_prev) > convergence_tolerance &&
                        n_tries < max_n_tries) {
 
                     // f'(s) = 2 * ( (h.pos(s) - sc) x sz) * (h.dir(s) x sz) )

--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -109,7 +109,7 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
 
             // Run the iteration on s
             std::size_t n_tries{0u};
-            while (math::fabs(s - s_prev) > convergence_tolerance and
+            while (math::fabs(s - s_prev) > convergence_tolerance &&
                    n_tries < max_n_tries) {
 
                 // track direction

--- a/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
@@ -92,7 +92,7 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
             // f(s) = sn * (h.pos(s) - st) == 0
             // Run the iteration on s
             std::size_t n_tries{0u};
-            while (math::fabs(s - s_prev) > convergence_tolerance and
+            while (math::fabs(s - s_prev) > convergence_tolerance &&
                    n_tries < max_n_tries) {
                 // f'(s) = sn * h.dir(s)
                 denom = vector::dot(sn, h.dir(s));

--- a/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
@@ -99,13 +99,13 @@ struct ray_concentric_cylinder_intersector {
 
             // Chose the index, take the smaller positive one
             const unsigned int cindex =
-                (t01[0] < t01[1] and t01[0] > overstep_tolerance)
+                (t01[0] < t01[1] && t01[0] > overstep_tolerance)
                     ? 0u
-                    : (t01[0] < overstep_tolerance and
+                    : (t01[0] < overstep_tolerance &&
                                t01[1] > overstep_tolerance
                            ? 1u
                            : 0u);
-            if (t01[0] > overstep_tolerance or t01[1] > overstep_tolerance) {
+            if (t01[0] > overstep_tolerance || t01[1] > overstep_tolerance) {
 
                 const point3_type p3 = candidates[cindex];
                 const scalar_type phi{getter::phi(p3)};

--- a/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
@@ -77,7 +77,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
         const auto qe = this->solve_intersection(ray, mask, trf);
 
         // Find the closest valid intersection
-        if (qe.solutions() > 0 and qe.larger() > overstep_tol) {
+        if (qe.solutions() > 0 && qe.larger() > overstep_tol) {
             // Only the closest intersection that is outside the overstepping
             // tolerance is needed
             const scalar_type t{(qe.smaller() > overstep_tol) ? qe.smaller()

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
@@ -70,7 +70,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
         const auto qe = this->solve_intersection(ray, mask, trf);
 
         // None of the cylinders has a valid intersection
-        if (detray::detail::all_of(qe.solutions() <= 0) or
+        if (detray::detail::all_of(qe.solutions() <= 0) ||
             detray::detail::all_of(qe.larger() <= overstep_tol)) {
             is.status = decltype(is.status)(false);
             return is;

--- a/core/include/detray/navigation/intersection/soa/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_plane_intersector.hpp
@@ -80,7 +80,7 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, true> {
 
         // Check if we divided by zero
         const auto check_sum = is.path.sum();
-        if (!std::isnan(check_sum) and !std::isinf(check_sum)) {
+        if (!std::isnan(check_sum) && !std::isinf(check_sum)) {
 
             const point3_type p3 = ro + is.path * rd;
             is.local = mask.to_local_frame(trf, p3, rd);

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -290,7 +290,7 @@ class navigator {
         /// (cannot be used when not on surface) - const
         DETRAY_HOST_DEVICE
         inline auto get_surface() const {
-            assert(is_on_module() or is_on_portal());
+            assert(is_on_module() || is_on_portal());
             return tracking_surface<detector_type>{*m_detector, barcode()};
         }
 
@@ -383,7 +383,7 @@ class navigator {
         DETRAY_HOST_DEVICE
         inline auto is_complete() const -> bool {
             // Normal exit for this navigation?
-            return m_status == navigation::status::e_on_target and !m_heartbeat;
+            return m_status == navigation::status::e_on_target && !m_heartbeat;
         }
 
         /// Navigation state that cannot be recovered from. Leave the other
@@ -460,8 +460,8 @@ class navigator {
             [[maybe_unused]] const point3_type &track_pos,
             [[maybe_unused]] const vector3_type &track_dir,
             [[maybe_unused]] const char *message) {
-            if constexpr (not std::is_same_v<inspector_t,
-                                             navigation::void_inspector>) {
+            if constexpr (!std::is_same_v<inspector_t,
+                                          navigation::void_inspector>) {
                 m_inspector(*this, cfg, track_pos, track_dir, message);
             }
         }
@@ -614,7 +614,7 @@ class navigator {
         navigation.m_heartbeat &= init(propagation, cfg);
 
         // Sanity check: Should never be the case after complete update call
-        if (navigation.trust_level() != navigation::trust_level::e_full or
+        if (navigation.trust_level() != navigation::trust_level::e_full ||
             navigation.is_exhausted()) {
             navigation.abort();
         }
@@ -650,7 +650,7 @@ class navigator {
              navigation.trust_level() == navigation::trust_level::e_high)) {
 
             // Update next candidate: If not reachable, 'high trust' is broken
-            if (not update_candidate(*navigation.next(), track, det, cfg)) {
+            if (!update_candidate(*navigation.next(), track, det, cfg)) {
                 navigation.m_status = navigation::status::e_unknown;
                 navigation.set_fair_trust();
             } else {
@@ -664,7 +664,7 @@ class navigator {
                 // The work is done if: the track has not reached a surface yet
                 // or trust is gone (portal was reached or the cache is broken).
                 if (navigation.status() ==
-                        navigation::status::e_towards_object or
+                        navigation::status::e_towards_object ||
                     navigation.trust_level() ==
                         navigation::trust_level::e_no_trust) {
                     return;
@@ -689,7 +689,7 @@ class navigator {
 
             for (auto &candidate : navigation) {
                 // Disregard this candidate if it is not reachable
-                if (not update_candidate(candidate, track, det, cfg)) {
+                if (!update_candidate(candidate, track, det, cfg)) {
                     // Forcefully set dist to numeric max for sorting
                     candidate.path = std::numeric_limits<scalar_type>::max();
                 }

--- a/core/include/detray/navigation/volume_graph.hpp
+++ b/core/include/detray/navigation/volume_graph.hpp
@@ -354,7 +354,7 @@ class volume_graph {
         node_queue.push(&(first_node));
 
         // Visit adjacent nodes and check current one
-        while (not node_queue.empty()) {
+        while (!node_queue.empty()) {
             // Inspect
             current = node_queue.front();
             if (visited[current->index()]) {
@@ -373,7 +373,7 @@ class volume_graph {
     edge_generator::iterator(current->index(), edg_link, _edges)) { dindex nbr
     = edg.to();
                     // If not leaving world and if not visited, enqueue the node
-                    if ((nbr != dindex_invalid and nbr > 0) and not
+                    if ((nbr != dindex_invalid && nbr > 0) && not
     visited[nbr]) { node_queue.push(&(_nodes[nbr]));
                     }
                 }
@@ -401,7 +401,7 @@ class volume_graph {
                     degr > 1 ? "\t\t\t\t(" + std::to_string(degr) + "x)" : "";
 
                 // Edge that leads out of the detector world
-                if (i == dim - 1u and degr != 0u) {
+                if (i == dim - 1u && degr != 0u) {
                     stream << "    -> leaving world " + n_occur << std::endl;
                 } else {
                     stream << "    -> " << std::to_string(i) + "\t" + n_occur

--- a/core/include/detray/propagator/actor_chain.hpp
+++ b/core/include/detray/propagator/actor_chain.hpp
@@ -57,7 +57,7 @@ class actor_chain {
     DETRAY_HOST_DEVICE inline void run(const actor_t &actr,
                                        actor_states_t &states,
                                        propagator_state_t &p_state) const {
-        if constexpr (not typename actor_t::is_comp_actor()) {
+        if constexpr (!typename actor_t::is_comp_actor()) {
             actr(detail::get<typename actor_t::state &>(states), p_state);
         } else {
             actr(states, p_state);

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -87,8 +87,8 @@ struct target_aborter : actor {
 
         // In case the propagation starts on a module, make sure to not abort
         // directly
-        if (navigation.is_on_module() and
-            (navigation.barcode() == abrt_state._target_surface) and
+        if (navigation.is_on_module() &&
+            (navigation.barcode() == abrt_state._target_surface) &&
             (stepping.path_length() > 0.f)) {
             prop_state._heartbeat &= navigation.abort();
         }

--- a/core/include/detray/propagator/base_actor.hpp
+++ b/core/include/detray/propagator/base_actor.hpp
@@ -95,7 +95,7 @@ class composite_actor final : public actor_impl_t {
                                           actor_impl_state_t &actor_state,
                                           propagator_state_t &p_state) const {
         // Two cases: observer is a simple actor or a composite actor
-        if constexpr (not typename observer_t::is_comp_actor()) {
+        if constexpr (!typename observer_t::is_comp_actor()) {
             observer(detail::get<typename observer_t::state &>(states),
                      actor_state, p_state);
         } else {

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -213,8 +213,8 @@ class base_stepper {
         DETRAY_HOST_DEVICE
         inline void run_inspector([[maybe_unused]] const stepping::config &cfg,
                                   [[maybe_unused]] const char *message) {
-            if constexpr (not std::is_same_v<inspector_t,
-                                             stepping::void_inspector>) {
+            if constexpr (!std::is_same_v<inspector_t,
+                                          stepping::void_inspector>) {
                 _inspector(*this, cfg, message);
             }
         }

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -295,7 +295,7 @@ struct propagator {
         }
 
         propagation.debug_stream << "surface: " << std::setw(14);
-        if (navigation.is_on_portal() or navigation.is_on_module()) {
+        if (navigation.is_on_portal() || navigation.is_on_module()) {
             propagation.debug_stream << navigation.barcode();
         } else {
             propagation.debug_stream << "undefined";

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -146,8 +146,8 @@ class rk_stepper final
             [[maybe_unused]] const stepping::config& cfg,
             [[maybe_unused]] const char* message,
             [[maybe_unused]] Args&&... args) {
-            if constexpr (not std::is_same_v<inspector_t,
-                                             stepping::void_inspector>) {
+            if constexpr (!std::is_same_v<inspector_t,
+                                          stepping::void_inspector>) {
                 this->_inspector(*this, cfg, message,
                                  std::forward<Args>(args)...);
             }

--- a/core/include/detray/utils/bounding_volume.hpp
+++ b/core/include/detray/utils/bounding_volume.hpp
@@ -244,12 +244,12 @@ class axis_aligned_bounding_volume {
             (m_mask[cuboid3D::e_max_z] - m_mask[cuboid3D::e_min_z])};
 
         // Cannot handle 'inv' propagation through the calculation for now
-        if (detail::is_invalid_value(scalor_x) or
-            detail::is_invalid_value(scalor_y) or
+        if (detail::is_invalid_value(scalor_x) ||
+            detail::is_invalid_value(scalor_y) ||
             detail::is_invalid_value(scalor_z)) {
             // If the box was infinite to begin with, it stays that way
-            assert(detail::is_invalid_value(scalor_x) and
-                   detail::is_invalid_value(scalor_y) and
+            assert(detail::is_invalid_value(scalor_x) &&
+                   detail::is_invalid_value(scalor_y) &&
                    detail::is_invalid_value(scalor_z));
 
             return *this;

--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -60,7 +60,7 @@ struct surface_checker {
         std::stringstream err_stream{};
         err_stream << "VOLUME \"" << print_volume_name(vol, names) << "\":\n";
 
-        if (not sf.self_check(err_stream)) {
+        if (!sf.self_check(err_stream)) {
             throw std::invalid_argument(err_stream.str());
         }
 
@@ -238,7 +238,7 @@ inline void check_empty(const detector_t &det, const bool verbose) {
     auto find_volumes =
         [](const typename detector_t::volume_finder &vf) -> bool {
         for (const auto &v : vf.all()) {
-            if (not detail::is_invalid_value(v)) {
+            if (!detail::is_invalid_value(v)) {
                 return true;
             }
         }
@@ -258,7 +258,7 @@ inline void check_empty(const detector_t &det, const bool verbose) {
     if (det.mask_store().all_empty()) {
         throw std::runtime_error("ERROR: No masks in detector");
     }
-    if (not find_portals()) {
+    if (!find_portals()) {
         throw std::runtime_error("ERROR: No portals in detector");
     }
 
@@ -287,7 +287,7 @@ inline void check_empty(const detector_t &det, const bool verbose) {
     }
 
     // Check volume search data structure
-    if (not find_volumes(det.volume_search_grid())) {
+    if (!find_volumes(det.volume_search_grid())) {
         std::cout << "WARNING: No entries in volume finder\n" << std::endl;
     }
 }
@@ -306,7 +306,7 @@ inline bool check_consistency(const detector_t &det, const bool verbose = false,
         err_stream << "VOLUME \"" << print_volume_name(vol, names) << "\":\n";
 
         // Check that nothing is obviously broken
-        if (not vol.self_check(err_stream)) {
+        if (!vol.self_check(err_stream)) {
             throw std::invalid_argument(err_stream.str());
         }
 
@@ -336,7 +336,7 @@ inline bool check_consistency(const detector_t &det, const bool verbose = false,
         err_stream << "VOLUME \"" << print_volume_name(vol, names) << "\":\n";
 
         // Check that nothing is obviously broken
-        if (not sf.self_check(err_stream)) {
+        if (!sf.self_check(err_stream)) {
             err_stream << "\nat surface no. " << std::to_string(idx);
             throw std::invalid_argument(err_stream.str());
         }
@@ -356,7 +356,7 @@ inline bool check_consistency(const detector_t &det, const bool verbose = false,
         vol.template visit_surfaces<detail::surface_checker>(
             sf_desc, is_registered, det);
 
-        if (not is_registered) {
+        if (!is_registered) {
             err_stream << "ERROR: Found surface that is not part of its "
                        << "volume's navigation acceleration data structures:\n"
                        << "Surface: " << sf;

--- a/core/include/detray/utils/inspectors.hpp
+++ b/core/include/detray/utils/inspectors.hpp
@@ -215,7 +215,7 @@ struct print_inspector {
             debug_stream << ", glob: [r:" << getter::perp(pos)
                          << ", z:" << pos[2] << "]" << std::endl;
         }
-        if (not state.candidates().empty()) {
+        if (!state.candidates().empty()) {
             debug_stream << "=> next: ";
             if (state.is_exhausted()) {
                 debug_stream << "exhausted" << std::endl;
@@ -248,7 +248,7 @@ struct print_inspector {
         };
 
         debug_stream << "current object\t\t\t";
-        if (state.is_on_portal() or state.is_on_module() or
+        if (state.is_on_portal() || state.is_on_module() ||
             state.status() == status::e_on_target) {
             debug_stream << state.barcode() << std::endl;
         } else {

--- a/core/include/detray/utils/ranges/iota.hpp
+++ b/core/include/detray/utils/ranges/iota.hpp
@@ -101,10 +101,9 @@ class iota_view : public detray::ranges::view_interface<iota_view<incr_t>> {
     constexpr iota_view() = default;
 
     /// Construct from just a @param start value to represent a single value seq
-    template <
-        typename deduced_incr_t,
-        std::enable_if_t<not detray::detail::is_interval_v<deduced_incr_t>,
-                         bool> = true>
+    template <typename deduced_incr_t,
+              std::enable_if_t<!detray::detail::is_interval_v<deduced_incr_t>,
+                               bool> = true>
     DETRAY_HOST_DEVICE constexpr explicit iota_view(deduced_incr_t &&start)
         : m_start{start},
           m_end{static_cast<std::decay_t<deduced_incr_t>>(start + 1)} {}
@@ -180,10 +179,9 @@ struct iota : public detray::ranges::iota_view<incr_t> {
         : base_type(std::forward<deduced_incr_t>(start),
                     std::forward<deduced_incr_t>(end)) {}
 
-    template <
-        typename deduced_incr_t,
-        std::enable_if_t<not detray::detail::is_interval_v<deduced_incr_t>,
-                         bool> = true>
+    template <typename deduced_incr_t,
+              std::enable_if_t<!detray::detail::is_interval_v<deduced_incr_t>,
+                               bool> = true>
     DETRAY_HOST_DEVICE constexpr explicit iota(deduced_incr_t &&start)
         : base_type(std::forward<deduced_incr_t>(start)) {}
 };
@@ -202,7 +200,7 @@ DETRAY_HOST_DEVICE iota(deduced_incr_t &&start, deduced_incr_t &&end)
     ->iota<detray::detail::remove_cvref_t<deduced_incr_t>>;
 
 template <typename deduced_incr_t,
-          std::enable_if_t<not detray::detail::is_interval_v<deduced_incr_t>,
+          std::enable_if_t<!detray::detail::is_interval_v<deduced_incr_t>,
                            bool> = true>
 DETRAY_HOST_DEVICE iota(deduced_incr_t &&start)
     ->iota<detray::detail::remove_cvref_t<deduced_incr_t>>;

--- a/core/include/detray/utils/ranges/ranges.hpp
+++ b/core/include/detray/utils/ranges/ranges.hpp
@@ -110,10 +110,10 @@ struct range : public std::false_type {
 template <class R>
 struct range<R,
              std::enable_if_t<
-                 (std::is_class_v<detray::ranges::iterator_t<R>> or
+                 (std::is_class_v<detray::ranges::iterator_t<R>> ||
                   std::is_pointer_v<detray::ranges::iterator_t<
-                      R>>)and(std::is_class_v<detray::ranges::sentinel_t<R>> or
-                              std::is_pointer_v<detray::ranges::sentinel_t<R>>),
+                      R>>)&&(std::is_class_v<detray::ranges::sentinel_t<R>> ||
+                             std::is_pointer_v<detray::ranges::sentinel_t<R>>),
                  void>> : public std::true_type {};
 
 // Range
@@ -148,23 +148,23 @@ inline constexpr bool random_access_iterator_v =
 
 // Range categories
 template <class R>
-inline constexpr bool input_range_v = detray::ranges::range_v<R>and
+inline constexpr bool input_range_v = detray::ranges::range_v<R>&&
     input_iterator_v<detray::ranges::iterator_t<R>>;
 
 template <class R>
-inline constexpr bool output_range_v = detray::ranges::range_v<R>and
+inline constexpr bool output_range_v = detray::ranges::range_v<R>&&
     output_iterator_v<detray::ranges::iterator_t<R>>;
 
 template <class R>
-inline constexpr bool forward_range_v = detray::ranges::range_v<R>and
+inline constexpr bool forward_range_v = detray::ranges::range_v<R>&&
     forward_iterator_v<detray::ranges::iterator_t<R>>;
 
 template <class R>
-inline constexpr bool bidirectional_range_v = detray::ranges::range_v<R>and
+inline constexpr bool bidirectional_range_v = detray::ranges::range_v<R>&&
     bidirectional_iterator_v<detray::ranges::iterator_t<R>>;
 
 template <class R>
-inline constexpr bool random_access_range_v = detray::ranges::range_v<R>and
+inline constexpr bool random_access_range_v = detray::ranges::range_v<R>&&
     random_access_iterator_v<detray::ranges::iterator_t<R>>;
 
 // Contiguous iterator trait is only available in c++20
@@ -180,8 +180,8 @@ inline constexpr bool disable_sized_range = false;
 /// @brief A function 'size' is implemented for the range @tparam R
 template <class R>
 inline constexpr bool sized_range =
-    not ranges::disable_sized_range<detray::detail::remove_cvref_t<R>> and
-    (detray::ranges::range_v<R> and
+    !ranges::disable_sized_range<detray::detail::remove_cvref_t<R>> &&
+    (detray::ranges::range_v<R> &&
      std::is_integral_v<detray::ranges::range_size_t<R>>);
 
 /// @see https://en.cppreference.com/w/cpp/ranges/borrowed_range
@@ -249,7 +249,7 @@ class view_interface : public base_view {
 
     DETRAY_HOST_DEVICE
     constexpr explicit operator bool() const {
-        return not detray::ranges::empty(cast_impl());
+        return !detray::ranges::empty(cast_impl());
     }
 
     /// @note requires contiguous range (not yet modelled)
@@ -279,7 +279,7 @@ class view_interface : public base_view {
               std::enable_if_t<detray::ranges::forward_range_v<R>, bool> = true>
     DETRAY_HOST_DEVICE constexpr decltype(auto) front() const {
         const auto bg = detray::ranges::begin(cast_impl());
-        assert(not empty());
+        assert(!empty());
         return *bg;
     }
 
@@ -288,7 +288,7 @@ class view_interface : public base_view {
               std::enable_if_t<detray::ranges::forward_range_v<R>, bool> = true>
     DETRAY_HOST_DEVICE constexpr decltype(auto) front() {
         const auto bg = detray::ranges::begin(cast_impl());
-        assert(not empty());
+        assert(!empty());
         return *bg;
     }
 
@@ -298,7 +298,7 @@ class view_interface : public base_view {
         std::enable_if_t<detray::ranges::bidirectional_range_v<R>, bool> = true>
     DETRAY_HOST_DEVICE constexpr decltype(auto) back() const {
         auto sentinel = detray::ranges::end(cast_impl());
-        assert(not empty());
+        assert(!empty());
         return *(--sentinel);
     }
 
@@ -308,7 +308,7 @@ class view_interface : public base_view {
         std::enable_if_t<detray::ranges::bidirectional_range_v<R>, bool> = true>
     DETRAY_HOST_DEVICE constexpr decltype(auto) back() {
         auto sentinel = detray::ranges::end(cast_impl());
-        assert(not empty());
+        assert(!empty());
         return *(--sentinel);
     }
 
@@ -341,11 +341,11 @@ class view_interface : public base_view {
 /// @{
 template <typename R>
 inline constexpr bool enable_view =
-    std::is_base_of_v<base_view, R> or std::is_base_of_v<view_interface<R>, R>;
+    std::is_base_of_v<base_view, R> || std::is_base_of_v<view_interface<R>, R>;
 
 template <class R>
-inline constexpr bool view = detray::ranges::range_v<R>and std::is_object_v<R>&&
-    std::is_move_constructible_v<R>and enable_view<R>;
+inline constexpr bool view = detray::ranges::range_v<R>&& std::is_object_v<R>&&
+    std::is_move_constructible_v<R>&& enable_view<R>;
 
 template <class R>
 inline constexpr bool viewable_range =

--- a/core/include/detray/utils/ranges/static_join.hpp
+++ b/core/include/detray/utils/ranges/static_join.hpp
@@ -219,7 +219,7 @@ struct static_join_iterator {
         // Switch to next range in the collection
         constexpr std::size_t max_idx{
             sizeof(iterator_coll_t) / sizeof(iterator_t) - 1u};
-        if ((m_iter == (*m_ends)[m_idx]) and (m_idx < max_idx)) {
+        if ((m_iter == (*m_ends)[m_idx]) && (m_idx < max_idx)) {
             ++m_idx;
             m_iter = (*m_begins)[m_idx];
         }

--- a/core/include/detray/utils/type_registry.hpp
+++ b/core/include/detray/utils/type_registry.hpp
@@ -137,8 +137,8 @@ class type_registry {
     template <typename object_t, typename first_t = empty_type,
               typename... remaining_types>
     DETRAY_HOST_DEVICE static constexpr ID unroll_ids() {
-        if constexpr (not std::is_same_v<first_t, empty_type> and
-                      not std::is_same_v<object_t, first_t>) {
+        if constexpr (!std::is_same_v<first_t, empty_type> &&
+                      !std::is_same_v<object_t, first_t>) {
             return unroll_ids<object_t, remaining_types...>();
         }
         if constexpr (std::is_same_v<object_t, first_t>) {

--- a/core/include/detray/utils/type_traits.hpp
+++ b/core/include/detray/utils/type_traits.hpp
@@ -52,8 +52,7 @@ template <typename container_t>
 struct get_value_type<
     container_t,
     std::enable_if_t<
-        not std::is_same_v<typename remove_cvref_t<container_t>::value_type,
-                           void>,
+        !std::is_same_v<typename remove_cvref_t<container_t>::value_type, void>,
         void>> {
     using type = typename remove_cvref_t<container_t>::value_type;
 };
@@ -71,11 +70,11 @@ struct is_interval : public std::false_type {};
 template <typename TYPE>
 struct is_interval<
     TYPE,
-    std::enable_if_t<not std::is_arithmetic_v<std::remove_reference_t<TYPE>> and
+    std::enable_if_t<!std::is_arithmetic_v<std::remove_reference_t<TYPE>> &&
                          std::is_arithmetic_v<std::remove_reference_t<decltype(
                              detray::detail::get<0>(std::declval<TYPE>()))>>,
                      void>,
-    std::enable_if_t<not std::is_arithmetic_v<std::remove_reference_t<TYPE>> and
+    std::enable_if_t<!std::is_arithmetic_v<std::remove_reference_t<TYPE>> &&
                          std::is_arithmetic_v<std::remove_reference_t<decltype(
                              detray::detail::get<1>(std::declval<TYPE>()))>>,
                      void>> : public std::true_type {};
@@ -114,7 +113,7 @@ struct get_type_pos {
     /// @note Returns the position of the type counted from the back!
     template <typename first_t, typename... remaining_types>
     DETRAY_HOST_DEVICE static inline constexpr std::size_t type_pos_back() {
-        if constexpr (not std::is_same_v<T, first_t>) {
+        if constexpr (!std::is_same_v<T, first_t>) {
             return type_pos_back<remaining_types...>();
         }
         if constexpr (std::is_same_v<T, first_t>) {

--- a/io/include/detray/io/common/detail/basic_converter.hpp
+++ b/io/include/detray/io/common/detail/basic_converter.hpp
@@ -32,8 +32,8 @@ inline single_link_payload convert(const std::size_t idx) {
     return link_data;
 }
 
-/// Convert a typed link with a type id @param id and and index
-/// @param idx into its io payload
+/// Convert a typed link with a type id @param id and index @param idx into its
+/// io payload
 template <typename type_id>
 inline typed_link_payload<type_id> convert(const type_id id,
                                            const std::size_t idx) {

--- a/io/include/detray/io/common/detail/grid_reader.hpp
+++ b/io/include/detray/io/common/detail/grid_reader.hpp
@@ -201,7 +201,7 @@ class grid_reader {
     /// @param det_builder gather the grid data and build the final volume
     template <typename detector_t, typename bounds_ts, typename binning_ts,
               typename content_t,
-              std::enable_if_t<types::size<bounds_ts> == dim and
+              std::enable_if_t<types::size<bounds_ts> == dim &&
                                    types::size<binning_ts> == dim,
                                bool> = true>
     static void convert(
@@ -283,7 +283,7 @@ class grid_reader {
     /// @brief End of recursion: build the grid from the @param grid_data
     template <typename detector_t, typename local_frame_t, typename content_t,
               typename... bounds_ts, typename... binning_ts,
-              std::enable_if_t<sizeof...(bounds_ts) == dim and
+              std::enable_if_t<sizeof...(bounds_ts) == dim &&
                                    sizeof...(binning_ts) == dim,
                                bool> = true>
     static void convert(

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -206,7 +206,7 @@ class geometry_reader {
         // Shape index of surface data found
         if (shape_id == I) {
             // Test wether this shape exists in detector
-            if constexpr (not std::is_same_v<shape_t, void>) {
+            if constexpr (!std::is_same_v<shape_t, void>) {
                 return std::make_shared<surface_factory<detector_t, shape_t>>();
             }
         }

--- a/io/include/detray/io/common/geometry_writer.hpp
+++ b/io/include/detray/io/common/geometry_writer.hpp
@@ -152,7 +152,7 @@ class geometry_writer {
         // and is handled automatically during detector building
         for (unsigned int i = 1u; i < link.size(); ++i) {
             const auto& l = link[i];
-            if (not l.is_invalid()) {
+            if (!l.is_invalid()) {
                 const auto aclp = det.accelerator_store()
                                       .template visit<get_acc_link_payload>(l);
                 vol_data.acc_links->push_back(aclp);

--- a/io/include/detray/io/common/homogeneous_material_writer.hpp
+++ b/io/include/detray/io/common/homogeneous_material_writer.hpp
@@ -112,7 +112,7 @@ class homogeneous_material_writer {
                 mslp.index_in_coll = slab_idx++;
                 mv_data.mat_slabs.push_back(mslp);
             } else if (mslp.type == material_type::rod) {
-                if (not mv_data.mat_rods.has_value()) {
+                if (!mv_data.mat_rods.has_value()) {
                     mv_data.mat_rods.emplace();
                 }
                 mslp.index_in_coll = rod_idx++;
@@ -169,7 +169,7 @@ class homogeneous_material_writer {
             constexpr bool is_rod =
                 std::is_same_v<material_t, material_rod<scalar_t>>;
 
-            if constexpr (is_slab or is_rod) {
+            if constexpr (is_slab || is_rod) {
                 return homogeneous_material_writer::convert(
                     material_group[index], sf_index);
             } else {

--- a/io/include/detray/io/common/material_map_writer.hpp
+++ b/io/include/detray/io/common/material_map_writer.hpp
@@ -67,7 +67,7 @@ class material_map_writer : public detail::grid_writer {
 
                 const auto& mat_link = sf_desc.material();
                 // Don't look at empty links
-                if (mat_link.is_invalid() or
+                if (mat_link.is_invalid() ||
                     mat_link.id() == detector_t::materials::id::e_none) {
                     continue;
                 }

--- a/io/include/detray/io/covfie/read_bfield.hpp
+++ b/io/include/detray/io/covfie/read_bfield.hpp
@@ -39,7 +39,7 @@ inline bool check_covfie_file(const std::string& file_name) {
 template <typename bfield_t>
 inline bfield_t read_bfield(const std::string& file_name) {
 
-    if (not check_covfie_file(file_name)) {
+    if (!check_covfie_file(file_name)) {
         throw std::runtime_error("Not a valid covfie file: " + file_name);
     }
 

--- a/io/include/detray/io/frontend/detail/type_traits.hpp
+++ b/io/include/detray/io/frontend/detail/type_traits.hpp
@@ -79,7 +79,7 @@ struct has_homogeneous_material : public std::false_type {};
 
 template <class detector_t>
 struct has_homogeneous_material<
-    detector_t, std::enable_if_t<has_material_slabs_v<detector_t> or
+    detector_t, std::enable_if_t<has_material_slabs_v<detector_t> ||
                                      has_material_rods_v<detector_t>,
                                  void>> : public std::true_type {};
 

--- a/io/include/detray/io/json/json_geometry_io.hpp
+++ b/io/include/detray/io/json/json_geometry_io.hpp
@@ -37,7 +37,7 @@ inline void to_json(nlohmann::ordered_json& j, const geo_header_payload& h) {
 inline void from_json(const nlohmann::ordered_json& j, geo_header_payload& h) {
     h.common = j["common"];
 
-    if (j.find("volume_count") != j.end() and
+    if (j.find("volume_count") != j.end() &&
         j.find("surface_count") != j.end()) {
         h.sub_header.emplace();
         auto& geo_sub_header = h.sub_header.value();
@@ -100,7 +100,7 @@ inline void to_json(nlohmann::ordered_json& j, const volume_payload& v) {
         sjson.push_back(s);
     }
     j["surfaces"] = sjson;
-    if (v.acc_links.has_value() and !v.acc_links.value().empty()) {
+    if (v.acc_links.has_value() && !v.acc_links.value().empty()) {
         nlohmann::ordered_json ljson;
         for (const auto& al : v.acc_links.value()) {
             ljson.push_back(al);
@@ -128,7 +128,7 @@ inline void from_json(const nlohmann::ordered_json& j, volume_payload& v) {
 }
 
 inline void to_json(nlohmann::ordered_json& j, const detector_payload& d) {
-    if (not d.volumes.empty()) {
+    if (!d.volumes.empty()) {
         nlohmann::ordered_json jvolumes;
         for (const auto& v : d.volumes) {
             jvolumes.push_back(v);

--- a/io/include/detray/io/json/json_grids_io.hpp
+++ b/io/include/detray/io/json/json_grids_io.hpp
@@ -120,7 +120,7 @@ inline void from_json(const nlohmann::ordered_json& j,
 template <typename content_t, typename grid_id_t>
 inline void to_json(nlohmann::ordered_json& j,
                     const detector_grids_payload<content_t, grid_id_t>& d) {
-    if (not d.grids.empty()) {
+    if (!d.grids.empty()) {
 
         // Collection of volumes with their grid content
         nlohmann::ordered_json jgrids;

--- a/io/include/detray/io/json/json_material_io.hpp
+++ b/io/include/detray/io/json/json_material_io.hpp
@@ -35,7 +35,7 @@ inline void from_json(const nlohmann::ordered_json& j,
                       homogeneous_material_header_payload& h) {
     h.common = j["common"];
 
-    if (j.find("slab_count") != j.end() and j.find("rod_count") != j.end()) {
+    if (j.find("slab_count") != j.end() && j.find("rod_count") != j.end()) {
         h.sub_header.emplace();
         auto& mat_sub_header = h.sub_header.value();
         mat_sub_header.n_slabs = j["slab_count"];
@@ -76,14 +76,14 @@ inline void to_json(nlohmann::ordered_json& j,
                     const material_volume_payload& mv) {
     j["volume_link"] = mv.volume_link;
 
-    if (not mv.mat_slabs.empty()) {
+    if (!mv.mat_slabs.empty()) {
         nlohmann::ordered_json jmats;
         for (const auto& m : mv.mat_slabs) {
             jmats.push_back(m);
         }
         j["material_slabs"] = jmats;
     }
-    if (mv.mat_rods.has_value() and not mv.mat_rods->empty()) {
+    if (mv.mat_rods.has_value() && !mv.mat_rods->empty()) {
         nlohmann::ordered_json jmats;
         for (const auto& m : mv.mat_rods.value()) {
             jmats.push_back(m);
@@ -113,7 +113,7 @@ inline void from_json(const nlohmann::ordered_json& j,
 
 inline void to_json(nlohmann::ordered_json& j,
                     const detector_homogeneous_material_payload& d) {
-    if (not d.volumes.empty()) {
+    if (!d.volumes.empty()) {
         nlohmann::ordered_json jmats;
         for (const auto& m : d.volumes) {
             jmats.push_back(m);

--- a/io/include/detray/io/json/json_writer.hpp
+++ b/io/include/detray/io/json/json_writer.hpp
@@ -46,16 +46,16 @@ class json_writer final : public writer_interface<detector_t> {
         const std::ios_base::openmode mode = std::ios::out | std::ios::binary,
         const std::filesystem::path &file_path = {"./"}) override {
         // Assert output stream
-        assert(((mode == std::ios_base::out) or
-                (mode == (std::ios_base::out | std::ios_base::binary)) or
-                (mode == (std::ios_base::out | std::ios_base::trunc)) or
+        assert(((mode == std::ios_base::out) ||
+                (mode == (std::ios_base::out | std::ios_base::binary)) ||
+                (mode == (std::ios_base::out | std::ios_base::trunc)) ||
                 (mode == (std::ios_base::out | std::ios_base::trunc |
                           std::ios_base::binary))) &&
                "Illegal file mode for json writer");
 
         // By convention the name of the detector is the first element
         std::string det_name = "";
-        if (not names.empty()) {
+        if (!names.empty()) {
             det_name = names.at(0);
         }
 

--- a/io/include/detray/io/utils/create_path.hpp
+++ b/io/include/detray/io/utils/create_path.hpp
@@ -36,7 +36,7 @@ inline std::string alt_file_name(const std::string& name) {
         // File stem already comes with a number, simply update it
         if (n > 2u) {
             std::size_t pos{file_stem.rfind(delim)};
-            if (pos == std::string::npos or (pos + 1 == file_stem.size())) {
+            if (pos == std::string::npos || (pos + 1 == file_stem.size())) {
                 throw std::runtime_error("Malformed file name");
             }
 

--- a/io/include/detray/io/utils/file_handle.hpp
+++ b/io/include/detray/io/utils/file_handle.hpp
@@ -78,7 +78,7 @@ class file_handle final {
             }
 
             std::filesystem::path file_path{file_name + extension};
-            if (not std::filesystem::exists(file_path)) {
+            if (!std::filesystem::exists(file_path)) {
                 throw std::invalid_argument(
                     "Could not open file: File does not exist: " + file_name +
                     extension);

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
@@ -190,7 +190,7 @@ std::vector<std::vector<std::size_t>> get_bin_association(
     const auto& link =
         vol_desc.template accel_link<geo_object_ids::e_sensitive>();
 
-    if (not link.is_invalid()) {
+    if (!link.is_invalid()) {
         return det.accelerator_store()
             .template visit<detail::bin_association_getter>(link, vol_desc,
                                                             search_window);

--- a/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
@@ -510,7 +510,7 @@ class illustrator {
         ret._tag = "g";
         ret._id = prefix;
 
-        if (not intersections.empty()) {
+        if (!intersections.empty()) {
 
             // Draw intersections with landmark style
             auto p_ir = svgtools::conversion::intersection(

--- a/tests/include/detray/test/common/utils/detector_scan_utils.hpp
+++ b/tests/include/detray/test/common/utils/detector_scan_utils.hpp
@@ -109,7 +109,7 @@ inline bool check_connectivity(
             return find_if(
                 trace.begin(), trace.end(),
                 [&](const std::pair<entry_type, entry_type> &rec) -> bool {
-                    return (std::get<1>(rec.first) == current_volume) or
+                    return (std::get<1>(rec.first) == current_volume) ||
                            (std::get<1>(rec.second) == current_volume);
                 });
         };
@@ -144,7 +144,7 @@ inline bool check_connectivity(
 
         // Don't search this key again -> only one potential key with current
         // index left
-        if constexpr (not check_sorted_trace) {
+        if constexpr (!check_sorted_trace) {
             trace.erase(record);
         }
 
@@ -266,7 +266,7 @@ inline auto trace_intersections(const record_container &intersection_records,
         const record rec{intersection_records.at(0u)};
 
         // No exit potal
-        if (not rec.is_portal()) {
+        if (!rec.is_portal()) {
             const std::string sf_type{rec.is_sensitive() ? "sensitive"
                                                          : "passive"};
 
@@ -294,12 +294,12 @@ inline auto trace_intersections(const record_container &intersection_records,
         // If the current record is not a portal, add an entry to the module
         // trace and continue in more fine-grained steps (sensitive/passive
         // surfaces do not come in pairs)
-        if (not current_rec.is_portal()) {
+        if (!current_rec.is_portal()) {
             // Check that the surface was found in the volume it claims to
             // belong to
             const bool is_in_volume =
                 (current_rec.volume_idx() ==
-                 current_rec.surface_volume_idx()) and
+                 current_rec.surface_volume_idx()) &&
                 (current_rec.surface_volume_idx() == current_vol);
             if (is_in_volume) {
                 module_trace.emplace_back(current_rec.surface_idx(),
@@ -336,24 +336,24 @@ inline auto trace_intersections(const record_container &intersection_records,
             next_rec.volume_idx() == next_rec.surface_volume_idx();
         // Is this doublet connected via a valid portal intersection?
         const bool is_valid =
-            (current_rec.inters() == next_rec.inters()) and
-            (current_rec.volume_idx() == next_rec.volume_link()) and
+            (current_rec.inters() == next_rec.inters()) &&
+            (current_rec.volume_idx() == next_rec.volume_link()) &&
             (next_rec.volume_idx() == current_rec.volume_link());
         // Is this indeed a portal crossing, i.e. changing volumes?
         const bool is_self_link =
             current_rec.volume_idx() == next_rec.volume_idx();
         // Is the record doublet we picked made up of a portal and a module?
         const bool is_mixed =
-            (current_rec.is_portal() and not next_rec.is_portal()) or
-            (next_rec.is_portal() and not current_rec.is_portal());
+            (current_rec.is_portal() && !next_rec.is_portal()) ||
+            (next_rec.is_portal() && !current_rec.is_portal());
 
-        if (not is_in_volume) {
+        if (!is_in_volume) {
             record_stream << "\n(!!) Surface outside of its volume (Found: "
                           << next_rec.volume_idx()
                           << ", belongs in: " << next_rec.surface_volume_idx()
                           << ")" << std::endl;
         }
-        if (not is_valid) {
+        if (!is_valid) {
             record_stream << "\n(!!) Not a valid portal crossing ("
                           << current_rec.volume_idx() << " <-> "
                           << next_rec.volume_idx() << "):\nPortals are not "
@@ -371,7 +371,7 @@ inline auto trace_intersections(const record_container &intersection_records,
                           << " this portal crossing is not a portal!"
                           << std::endl;
         }
-        if (is_in_volume and is_valid and not is_self_link and not is_mixed) {
+        if (is_in_volume && is_valid && !is_self_link && !is_mixed) {
 
             // Insert into portal trace
             trace_entry lower{current_rec.surface_idx(),
@@ -413,7 +413,7 @@ inline auto trace_intersections(const record_container &intersection_records,
 
     // Look at the last entry, which is a single portal
     const record rec_back{intersection_records.back()};
-    if (not rec_back.is_portal()) {
+    if (!rec_back.is_portal()) {
         err_stream << "We don't leave the detector by portal!";
         print_err(err_stream);
     } else {
@@ -681,7 +681,7 @@ inline std::string print_adj(const dvector<dindex> &adjacency_matrix) {
                 degr > 1 ? "\t\t\t\t(" + std::to_string(degr) + "x)" : "";
 
             // Edge that leads out of the detector world
-            if (j == dim - 1 and degr != 0) {
+            if (j == dim - 1 && degr != 0) {
                 out_stream << "    -> leaving world " + n_occur << std::endl;
             } else {
                 out_stream << "    -> " << std::to_string(j) + "\t" + n_occur

--- a/tests/include/detray/test/common/utils/hash_tree.hpp
+++ b/tests/include/detray/test/common/utils/hash_tree.hpp
@@ -163,7 +163,7 @@ class hash_tree {
         }
         dindex n_level = n_prev_level / 2u;
         // Need dummy leaf node for next level?
-        if (n_level % 2u != 0u and n_level > 1u) {
+        if (n_level % 2u != 0u && n_level > 1u) {
             _tree.emplace_back(0);
             n_level++;
         }

--- a/tests/include/detray/test/common/utils/svg_display.hpp
+++ b/tests/include/detray/test/common/utils/svg_display.hpp
@@ -93,7 +93,7 @@ auto draw_intersection_and_traj_svg(
                                           traj.dir(0.f), view, gctx);
 
     // Draw an approximation of the trajectory with the recorded intersections
-    if (not recorded_intersections.empty()) {
+    if (!recorded_intersections.empty()) {
         svg_traj.add_object(il.draw_intersections_and_trajectory(
             traj_name, recorded_intersections, traj, view,
             truth_intersections.back().path, gctx));
@@ -118,7 +118,7 @@ inline void svg_display(const typename detector_t::geometry_context gctx,
 
     // Gather all volumes that need to be displayed
     auto volumes = get_volume_indices(truth_trace);
-    if (not recorded_trace.empty()) {
+    if (!recorded_trace.empty()) {
         const auto more_volumes = get_volume_indices(truth_trace);
         volumes.insert(more_volumes.begin(), more_volumes.end());
     }

--- a/tests/include/detray/test/cpu/detector_scan.hpp
+++ b/tests/include/detray/test/cpu/detector_scan.hpp
@@ -113,7 +113,7 @@ class detector_scan : public test::fixture_base<> {
                 intersection_trace, start_index, adj_mat_scan, obj_hashes);
 
             // Display the detector, track and intersections for debugging
-            if (not success) {
+            if (!success) {
                 detector_scanner::display_error(
                     m_gctx, m_det, m_names, m_cfg.name(), test_traj,
                     intersection_trace, m_cfg.svg_style(), n_tracks, n_helices,

--- a/tests/include/detray/test/cpu/navigation_validation.hpp
+++ b/tests/include/detray/test/cpu/navigation_validation.hpp
@@ -178,7 +178,7 @@ class navigation_validation : public test::fixture_base<> {
                     std::make_pair(test_traj, missed_inters));
             }
 
-            if (not success) {
+            if (!success) {
                 // Write debug info to file
                 *debug_file << "TEST TRACK " << n_tracks << ":\n\n"
                             << nav_printer.to_string()

--- a/tests/include/detray/test/cpu/toy_detector_test.hpp
+++ b/tests/include/detray/test/cpu/toy_detector_test.hpp
@@ -359,7 +359,7 @@ inline bool toy_detector_test(
                     .template get<accel_ids::e_brute_force>()[link[0].index()];
 
             // This means no grids, all surfaces are in the brute force method
-            if (not has_grids) {
+            if (!has_grids) {
                 const auto full_range = darray<dindex, 2>{
                     sf_range[0], math::max(pt_range[1], sf_range[1])};
                 test_finder(bf_finder, vol_itr->index(), full_range);
@@ -367,7 +367,7 @@ inline bool toy_detector_test(
                 test_finder(bf_finder, vol_itr->index(), pt_range);
 
                 // Test the module search if grids were filled
-                if (not link[1].is_invalid()) {
+                if (!link[1].is_invalid()) {
                     if (link[1].id() == accel_ids::e_cylinder2_grid) {
                         const auto& cyl_grid = accel_store.template get<
                             accel_ids::e_cylinder2_grid>()[link[1].index()];

--- a/tests/include/detray/test/device/cuda/navigation_validation.hpp
+++ b/tests/include/detray/test/device/cuda/navigation_validation.hpp
@@ -317,7 +317,7 @@ class navigation_validation : public test::fixture_base<> {
                 n_matching_error += n_error;
             }
 
-            if (not success) {
+            if (!success) {
                 detector_scanner::display_error(
                     m_gctx, m_det, m_names, m_cfg.name(), test_traj,
                     truth_trace, m_cfg.svg_style(), n_tracks, n_test_tracks,

--- a/tests/integration_tests/cpu/builders/grid_builder.cpp
+++ b/tests/integration_tests/cpu/builders/grid_builder.cpp
@@ -170,7 +170,7 @@ GTEST_TEST(detray_builders, decorator_grid_builder) {
         d.accelerator_store()
             .template get<detector_t::accel::id::e_brute_force>()[0];
     for (const auto& sf : bf_finder.all()) {
-        EXPECT_TRUE((sf.id() == surface_id::e_portal) or
+        EXPECT_TRUE((sf.id() == surface_id::e_portal) ||
                     (sf.id() == surface_id::e_passive));
         EXPECT_EQ(sf.volume(), 0u);
     }

--- a/tests/integration_tests/cpu/builders/homogeneous_material_builder.cpp
+++ b/tests/integration_tests/cpu/builders/homogeneous_material_builder.cpp
@@ -168,7 +168,7 @@ GTEST_TEST(detray_builders, decorator_homogeneous_material_builder) {
 
     for (const auto &mat_slab :
          d.material_store().template get<material_id::e_slab>()) {
-        EXPECT_TRUE(mat_slab.get_material() == silicon<scalar>() or
+        EXPECT_TRUE(mat_slab.get_material() == silicon<scalar>() ||
                     mat_slab.get_material() == tungsten<scalar>());
     }
 }

--- a/tests/integration_tests/cpu/builders/material_map_builder.cpp
+++ b/tests/integration_tests/cpu/builders/material_map_builder.cpp
@@ -243,7 +243,7 @@ GTEST_TEST(detray_builders, decorator_material_map_builder) {
         EXPECT_EQ(z_axis.nbins(), 10u);
 
         for (const auto& mat_slab : cyl_mat_grid.all()) {
-            EXPECT_TRUE(mat_slab.get_material() == silicon<scalar>() or
+            EXPECT_TRUE(mat_slab.get_material() == silicon<scalar>() ||
                         mat_slab.get_material() == gold<scalar>());
         }
     }

--- a/tests/integration_tests/io/io_json_detector_roundtrip.cpp
+++ b/tests/integration_tests/io/io_json_detector_roundtrip.cpp
@@ -48,7 +48,7 @@ bool compare_files(const std::string& file_name1, const std::string& file_name2,
     std::size_t i{1u};
     while (std::getline(*file1, line1)) {
         if (std::getline(*file2, line2)) {
-            if (skip < i and line1 != line2) {
+            if (skip < i && line1 != line2) {
                 std::cout << "In line " << i << ":" << std::endl
                           << line1 << std::endl
                           << line2 << std::endl;

--- a/tests/tools/src/cpu/detector_display.cpp
+++ b/tests/tools/src/cpu/detector_display.cpp
@@ -127,7 +127,7 @@ int main(int argc, char** argv) {
     const actsvg::views::z_phi zphi;
 
     // Display the volumes
-    if (not volumes.empty()) {
+    if (!volumes.empty()) {
         const auto [vol_xy_svg, xy_sheets] = il.draw_volumes(volumes, xy, gctx);
         detray::svgtools::write_svg(path / vol_xy_svg._id,
                                     {xy_axis, vol_xy_svg});
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
     }
 
     // Display the surfaces
-    if (not surfaces.empty()) {
+    if (!surfaces.empty()) {
         const auto [sf_xy_svg, mat_xy_svg] =
             il.draw_surfaces(surfaces, xy, gctx);
         detray::svgtools::write_svg(path / sf_xy_svg._id, {xy_axis, sf_xy_svg});
@@ -168,7 +168,7 @@ int main(int argc, char** argv) {
     }
 
     // If nothing was specified, display the whole detector
-    if (volumes.empty() and surfaces.empty()) {
+    if (volumes.empty() && surfaces.empty()) {
         const auto det_xy_svg = il.draw_detector(xy, gctx);
         detray::svgtools::write_svg(path / det_xy_svg._id,
                                     {xy_axis, det_xy_svg});

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -193,7 +193,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     bool heartbeat_z2 = navigator_z2.init(propgation_z2);
     bool heartbeat_x = navigator_x.init(propgation_x);
 
-    while (heartbeat_z1 and heartbeat_z2 and heartbeat_x) {
+    while (heartbeat_z1 && heartbeat_z2 && heartbeat_x) {
 
         // check that all propagation flows are still running
         EXPECT_TRUE(heartbeat_z1);

--- a/tests/unit_tests/cpu/navigation/navigator.cpp
+++ b/tests/unit_tests/cpu/navigation/navigator.cpp
@@ -50,7 +50,7 @@ inline void check_towards_surface(state_t &state, dindex vol_id,
     ASSERT_EQ(state.n_candidates(), n_candidates);
     // the portal is still the next object, since we did not step
     ASSERT_EQ(state.next_surface().index(), next_id);
-    ASSERT_TRUE((state.trust_level() == navigation::trust_level::e_full) or
+    ASSERT_TRUE((state.trust_level() == navigation::trust_level::e_full) ||
                 (state.trust_level() == navigation::trust_level::e_high));
 }
 
@@ -61,7 +61,7 @@ inline void check_on_surface(state_t &state, dindex vol_id,
                              dindex next_id) {
     // The status is: on surface/towards surface if the next candidate is
     // immediately updated and set in the same update call
-    ASSERT_TRUE(state.status() == navigation::status::e_on_module or
+    ASSERT_TRUE(state.status() == navigation::status::e_on_module ||
                 state.status() == navigation::status::e_on_portal);
     // Points towards next candidate
     ASSERT_TRUE(std::abs(state()) >= 1.f * unit<scalar>::um);

--- a/tests/unit_tests/cpu/propagator/actor_chain.cpp
+++ b/tests/unit_tests/cpu/propagator/actor_chain.cpp
@@ -77,7 +77,7 @@ struct example_actor : detray::actor {
     /// Observing actor implementation to printer: do nothing
     template <
         typename subj_state_t, typename propagator_state_t,
-        std::enable_if_t<not std::is_same_v<subj_state_t, state>, bool> = true>
+        std::enable_if_t<!std::is_same_v<subj_state_t, state>, bool> = true>
     void operator()(state & /*example_state*/,
                     const subj_state_t & /*subject_state*/,
                     const propagator_state_t & /*p_state*/) const {}

--- a/tests/unit_tests/cpu/simulation/detector_scanner.cpp
+++ b/tests/unit_tests/cpu/simulation/detector_scanner.cpp
@@ -88,7 +88,7 @@ GTEST_TEST(detray_simulation, detector_scanner) {
                 // Intersection record at portal bound might be flipped
                 // (the portals overlap completely)
                 if (expected[n_tracks][i].vol_idx ==
-                        intersection_trace[i + 1u].vol_idx and
+                        intersection_trace[i + 1u].vol_idx &&
                     expected[n_tracks][i + 1u].vol_idx ==
                         intersection_trace[i].vol_idx) {
                     // Have already checked the next record

--- a/tests/unit_tests/cpu/utils/hash_tree.cpp
+++ b/tests/unit_tests/cpu/utils/hash_tree.cpp
@@ -34,7 +34,7 @@ void test_hash(std::size_t first_child, std::size_t n_prev_level,
     std::size_t n_level =
         static_cast<std::size_t>(0.5f * static_cast<float>(n_prev_level));
     // Need dummy leaf node for next level?
-    if (n_level % 2u != 0u and n_level > 1u) {
+    if (n_level % 2u != 0u && n_level > 1u) {
         digests.push_back(0);
         n_level++;
     }

--- a/tests/unit_tests/cpu/utils/ranges.cpp
+++ b/tests/unit_tests/cpu/utils/ranges.cpp
@@ -32,26 +32,26 @@ GTEST_TEST(detray_utils, ranges) {
     //
     // std::vector
     static_assert(detray::ranges::range_v<dvector<float>>);
-    static_assert(not detray::ranges::view<dvector<float>>);
+    static_assert(!detray::ranges::view<dvector<float>>);
     static_assert(detray::ranges::random_access_range_v<dvector<float>>);
     static_assert(detray::ranges::common_range<dvector<float>>);
 
     // std::array
     static_assert(detray::ranges::range_v<darray<float, 1>>);
-    static_assert(not detray::ranges::view<darray<float, 1>>);
+    static_assert(!detray::ranges::view<darray<float, 1>>);
     static_assert(detray::ranges::random_access_range_v<darray<float, 1>>);
     static_assert(detray::ranges::common_range<darray<float, 1>>);
 
     // std::map
     static_assert(detray::ranges::range_v<dmap<int, float>>);
-    static_assert(not detray::ranges::view<dmap<int, float>>);
+    static_assert(!detray::ranges::view<dmap<int, float>>);
     static_assert(detray::ranges::bidirectional_range_v<dmap<int, float>>);
-    static_assert(not detray::ranges::random_access_range_v<dmap<int, float>>);
+    static_assert(!detray::ranges::random_access_range_v<dmap<int, float>>);
     static_assert(detray::ranges::common_range<dmap<int, float>>);
 
     // std::tuple
-    static_assert(not detray::ranges::range_v<dtuple<int, float>>);
-    static_assert(not detray::ranges::view<dtuple<int, float>>);
+    static_assert(!detray::ranges::range_v<dtuple<int, float>>);
+    static_assert(!detray::ranges::view<dtuple<int, float>>);
 
     //
     // vecmem containers
@@ -59,21 +59,20 @@ GTEST_TEST(detray_utils, ranges) {
 
     // vecmem::device_vector
     static_assert(detray::ranges::range_v<vecmem::device_vector<float>>);
-    static_assert(not detray::ranges::view<vecmem::device_vector<float>>);
+    static_assert(!detray::ranges::view<vecmem::device_vector<float>>);
     static_assert(
         detray::ranges::random_access_range_v<vecmem::device_vector<float>>);
     static_assert(detray::ranges::common_range<vecmem::device_vector<float>>);
 
     // vecmem::jagged_vector
     static_assert(detray::ranges::range_v<djagged_vector<float>>);
-    static_assert(not detray::ranges::view<djagged_vector<float>>);
+    static_assert(!detray::ranges::view<djagged_vector<float>>);
     static_assert(detray::ranges::random_access_range_v<djagged_vector<float>>);
     static_assert(detray::ranges::common_range<djagged_vector<float>>);
 
     // vecmem::jagged_device_vector
     static_assert(detray::ranges::range_v<vecmem::jagged_device_vector<float>>);
-    static_assert(
-        not detray::ranges::view<vecmem::jagged_device_vector<float>>);
+    static_assert(!detray::ranges::view<vecmem::jagged_device_vector<float>>);
     static_assert(detray::ranges::random_access_range_v<
                   vecmem::jagged_device_vector<float>>);
     static_assert(
@@ -85,17 +84,17 @@ GTEST_TEST(detray_utils, ranges) {
 
     // std::forward_list
     static_assert(detray::ranges::range_v<std::forward_list<float>>);
-    static_assert(not detray::ranges::view<std::forward_list<float>>);
+    static_assert(!detray::ranges::view<std::forward_list<float>>);
     static_assert(detray::ranges::forward_range_v<std::forward_list<float>>);
     static_assert(
-        not detray::ranges::bidirectional_range_v<std::forward_list<float>>);
+        !detray::ranges::bidirectional_range_v<std::forward_list<float>>);
     static_assert(detray::ranges::common_range<std::forward_list<float>>);
 
     // std::list
     static_assert(detray::ranges::range_v<std::list<float>>);
-    static_assert(not detray::ranges::view<std::list<float>>);
+    static_assert(!detray::ranges::view<std::list<float>>);
     static_assert(detray::ranges::bidirectional_range_v<std::list<float>>);
-    static_assert(not detray::ranges::random_access_range_v<std::list<float>>);
+    static_assert(!detray::ranges::random_access_range_v<std::list<float>>);
     static_assert(detray::ranges::common_range<std::list<float>>);
 }
 
@@ -199,7 +198,7 @@ GTEST_TEST(detray_utils, ranges_iota_single) {
     static_assert(detray::ranges::range_v<decltype(seq)>);
     static_assert(detray::ranges::view<decltype(seq)>);
     static_assert(detray::ranges::bidirectional_range_v<decltype(seq)>);
-    static_assert(not detray::ranges::random_access_range_v<decltype(seq)>);
+    static_assert(!detray::ranges::random_access_range_v<decltype(seq)>);
 
     // Test prerequisits for LagacyIterator
     static_assert(
@@ -229,7 +228,7 @@ GTEST_TEST(detray_utils, ranges_iota_interval) {
     static_assert(detray::ranges::view<decltype(seq)>);
     static_assert(std::is_copy_assignable_v<decltype(seq)>);
     static_assert(detray::ranges::bidirectional_range_v<decltype(seq)>);
-    static_assert(not detray::ranges::random_access_range_v<decltype(seq)>);
+    static_assert(!detray::ranges::random_access_range_v<decltype(seq)>);
 
     // Test prerequisits for LagacyIterator
     static_assert(
@@ -265,7 +264,7 @@ GTEST_TEST(detray_utils, ranges_cartesian_product_trivial) {
     static_assert(detray::ranges::view<decltype(cp)>);
     static_assert(std::is_copy_assignable_v<decltype(cp)>);
     static_assert(detray::ranges::bidirectional_range_v<decltype(cp)>);
-    static_assert(not detray::ranges::random_access_range_v<decltype(cp)>);
+    static_assert(!detray::ranges::random_access_range_v<decltype(cp)>);
 
     // Test prerequisits for LagacyIterator
     static_assert(
@@ -301,7 +300,7 @@ GTEST_TEST(detray_utils, ranges_cartesian_product) {
     static_assert(detray::ranges::view<decltype(cp)>);
     static_assert(std::is_copy_assignable_v<decltype(cp)>);
     static_assert(detray::ranges::bidirectional_range_v<decltype(cp)>);
-    static_assert(not detray::ranges::random_access_range_v<decltype(cp)>);
+    static_assert(!detray::ranges::random_access_range_v<decltype(cp)>);
 
     // Test prerequisits for LagacyIterator
     static_assert(
@@ -576,7 +575,7 @@ GTEST_TEST(detray_utils, ranges_subrange_iota) {
 
     // Check iterator category
     static_assert(detray::ranges::bidirectional_range_v<decltype(iota_sr)>);
-    static_assert(not detray::ranges::random_access_range_v<decltype(iota_sr)>);
+    static_assert(!detray::ranges::random_access_range_v<decltype(iota_sr)>);
 
     std::size_t i{4u};
     for (const auto v : iota_sr) {
@@ -631,10 +630,9 @@ GTEST_TEST(detray_utils, ranges_pick_joined_sequence) {
 
     // Check iterator category
     static_assert(detray::ranges::bidirectional_range_v<decltype(indices)>);
-    static_assert(not detray::ranges::random_access_range_v<decltype(indices)>);
+    static_assert(!detray::ranges::random_access_range_v<decltype(indices)>);
     static_assert(detray::ranges::bidirectional_range_v<decltype(selected)>);
-    static_assert(
-        not detray::ranges::random_access_range_v<decltype(selected)>);
+    static_assert(!detray::ranges::random_access_range_v<decltype(selected)>);
 
     // Test inherited member functions
     const auto [i, v] = selected[2];

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
@@ -116,7 +116,7 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
 }
 
 // Equality operator in complete populator does not work correctly in CUDA
-// (not constexpr)
+// (!constexpr)
 /*TEST(grids_cuda, grid2_complete_populator) {
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.cu
@@ -264,7 +264,7 @@ __global__ void grid_collection_test_kernel(
     vecmem::device_vector<std::array<dindex, 3>> result_bins(result_bins_view);
 
     // test the grid axes of the second grid in the collection
-    if (threadIdx.x == 0 and threadIdx.y == 0 and threadIdx.z == 0) {
+    if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
         const auto& axis_r =
             device_coll[blockIdx.x].template get_axis<axis::label::e_r>();
         const auto& axis_phi =

--- a/tutorials/include/detray/tutorial/my_square2D.hpp
+++ b/tutorials/include/detray/tutorial/my_square2D.hpp
@@ -57,7 +57,7 @@ class square2D {
     DETRAY_HOST_DEVICE inline auto check_boundaries(
         const bounds_type<scalar_t> &bounds, const point_t &loc_p,
         const scalar_t tol = std::numeric_limits<scalar_t>::epsilon()) const {
-        return (math::fabs(loc_p[0]) <= bounds[e_half_length] + tol and
+        return (math::fabs(loc_p[0]) <= bounds[e_half_length] + tol &&
                 math::fabs(loc_p[1]) <= bounds[e_half_length] + tol);
     }
 

--- a/tutorials/src/cpu/propagation/define_an_actor.cpp
+++ b/tutorials/src/cpu/propagation/define_an_actor.cpp
@@ -77,7 +77,7 @@ struct example_actor : detray::actor {
     /// Observing actor implementation to printer: do nothing
     template <
         typename subj_state_t, typename propagator_state_t,
-        std::enable_if_t<not std::is_same_v<subj_state_t, state>, bool> = true>
+        std::enable_if_t<!std::is_same_v<subj_state_t, state>, bool> = true>
     void operator()(state & /*example_state*/,
                     const subj_state_t & /*subject_state*/,
                     const propagator_state_t & /*p_state*/) const {}

--- a/utils/include/detray/simulation/event_generator/uniform_track_generator.hpp
+++ b/utils/include/detray/simulation/event_generator/uniform_track_generator.hpp
@@ -78,13 +78,13 @@ class uniform_track_generator
         /// @returns whether we reached end of angle space
         DETRAY_HOST_DEVICE
         constexpr bool operator==(const iterator& rhs) const {
-            return rhs.i_phi == i_phi and rhs.i_theta == i_theta;
+            return rhs.i_phi == i_phi && rhs.i_theta == i_theta;
         }
 
         /// @returns whether we reached end of angle space
         DETRAY_HOST_DEVICE
         constexpr bool operator!=(const iterator& rhs) const {
-            return not(*this == rhs);
+            return !(*this == rhs);
         }
 
         /// Iterate through angle space according to given step sizes.

--- a/utils/include/detray/simulation/random_scatterer.hpp
+++ b/utils/include/detray/simulation/random_scatterer.hpp
@@ -136,7 +136,7 @@ struct random_scatterer : actor {
 
         auto& navigation = prop_state._navigation;
 
-        if (not navigation.is_on_module()) {
+        if (!navigation.is_on_module()) {
             return;
         }
 


### PR DESCRIPTION
Replace logic operators "and", "or" and "not", because not all compilers know them