### PR TITLE
ref: make protected member variables private and add the excplicit keyword to constructors

### DIFF
--- a/core/include/detray/builders/cuboid_portal_generator.hpp
+++ b/core/include/detray/builders/cuboid_portal_generator.hpp
@@ -105,7 +105,7 @@ class cuboid_portal_generator final
         assert(n_surfaces != 0u);
 
         // The surfaces container is prefilled with other surfaces
-        dindex surfaces_offset = static_cast<dindex>(n_surfaces);
+        auto surfaces_offset{static_cast<dindex>(n_surfaces)};
 
         // Fetch the position in the mask tuple for the rectangle portals
         constexpr auto rectangle_id{detector_t::masks::id::e_portal_rectangle2};

--- a/core/include/detray/builders/detector_builder.hpp
+++ b/core/include/detray/builders/detector_builder.hpp
@@ -147,7 +147,7 @@ class detector_builder {
         return m_vol_finder;
     }
 
-    protected:
+    private:
     /// Data structure that holds a volume builder for every detector volume
     volume_data_t<std::unique_ptr<volume_builder_interface<detector_type>>>
         m_volumes{};

--- a/core/include/detray/builders/grid_builder.hpp
+++ b/core/include/detray/builders/grid_builder.hpp
@@ -46,13 +46,13 @@ class grid_builder : public volume_decorator<detector_t> {
 
     /// Decorate a volume with a grid
     DETRAY_HOST
-    grid_builder(
+    explicit grid_builder(
         std::unique_ptr<volume_builder_interface<detector_t>> vol_builder)
         : volume_decorator<detector_t>(std::move(vol_builder)) {
         // The grid builder provides an acceleration structure to the
         // volume, so don't add sensitive surfaces to the brute force method
-        if (this->m_builder) {
-            this->m_builder->has_accel(true);
+        if (this->get_builder()) {
+            this->has_accel(true);
         }
     }
 
@@ -197,7 +197,7 @@ class grid_builder : public volume_decorator<detector_t> {
     DETRAY_HOST
     auto &get() { return m_grid; }
 
-    protected:
+    private:
     link_id_t m_id{link_id_t::e_sensitive};
     grid_factory_t m_factory{};
     typename grid_t::template type<true> m_grid{};

--- a/core/include/detray/builders/homogeneous_material_builder.hpp
+++ b/core/include/detray/builders/homogeneous_material_builder.hpp
@@ -33,7 +33,7 @@ class homogeneous_material_builder final : public volume_decorator<detector_t> {
 
     /// @param vol_builder volume builder that should be decorated with material
     DETRAY_HOST
-    homogeneous_material_builder(
+    explicit homogeneous_material_builder(
         std::unique_ptr<volume_builder_interface<detector_t>> vol_builder)
         : volume_decorator<detector_t>(std::move(vol_builder)) {}
 
@@ -97,7 +97,7 @@ class homogeneous_material_builder final : public volume_decorator<detector_t> {
         return volume_decorator<detector_t>::build(det, ctx);
     }
 
-    protected:
+    private:
     // Material container for this volume
     typename detector_t::material_container m_materials{};
 };

--- a/core/include/detray/builders/homogeneous_material_factory.hpp
+++ b/core/include/detray/builders/homogeneous_material_factory.hpp
@@ -34,7 +34,7 @@ class material_data {
     /// @param sf_idx the index of the surface this material belongs to, needs
     ///               to be passed only if a special oredering must be observed
     DETRAY_HOST
-    constexpr material_data(
+    explicit constexpr material_data(
         const std::size_t sf_idx = detail::invalid_value<std::size_t>())
         : m_sf_index{sf_idx}, m_mat{}, m_thickness{} {}
 
@@ -159,7 +159,7 @@ class homogeneous_material_factory final
     /// Factory with surfaces potentially already filled or empty placeholder
     /// that will not be used.
     DETRAY_HOST
-    homogeneous_material_factory(
+    explicit homogeneous_material_factory(
         std::unique_ptr<surface_factory_interface<detector_t>> sf_factory =
             std::make_unique<placeholder_factory_t>())
         : base_factory(std::move(sf_factory)) {}
@@ -312,7 +312,7 @@ class homogeneous_material_factory final
         }
     }
 
-    protected:
+    private:
     /// Material links of surfaces
     std::vector<std::pair<material_id, dindex>> m_links{};
     /// Position of the material in the detector material collection

--- a/core/include/detray/builders/homogeneous_material_generator.hpp
+++ b/core/include/detray/builders/homogeneous_material_generator.hpp
@@ -104,7 +104,7 @@ class homogeneous_material_generator final
         -> dindex_range override {
 
         auto [lower, upper] =
-            (*this->m_factory)(volume, surfaces, transforms, masks, ctx);
+            (*this->get_factory())(volume, surfaces, transforms, masks, ctx);
 
         m_surface_range = {lower, upper};
 

--- a/core/include/detray/builders/homogeneous_volume_material_builder.hpp
+++ b/core/include/detray/builders/homogeneous_volume_material_builder.hpp
@@ -34,7 +34,7 @@ class homogeneous_volume_material_builder final
     /// @param vol_builder volume builder that should be decorated with volume
     /// material
     DETRAY_HOST
-    homogeneous_volume_material_builder(
+    explicit homogeneous_volume_material_builder(
         std::unique_ptr<volume_builder_interface<detector_t>> vol_builder)
         : volume_decorator<detector_t>(std::move(vol_builder)) {}
 
@@ -74,7 +74,7 @@ class homogeneous_volume_material_builder final
         return vol;
     }
 
-    protected:
+    private:
     // Material for this volume
     material<scalar_type> m_volume_material{};
 };

--- a/core/include/detray/builders/material_map_builder.hpp
+++ b/core/include/detray/builders/material_map_builder.hpp
@@ -43,7 +43,7 @@ struct add_sf_material_map;
 template <typename detector_t, std::size_t DIM = 2u,
           typename mat_map_factory_t =
               material_grid_factory<typename detector_t::scalar_type>>
-class material_map_builder : public volume_decorator<detector_t> {
+class material_map_builder final : public volume_decorator<detector_t> {
     using materials_t = typename detector_t::materials;
 
     public:
@@ -56,7 +56,7 @@ class material_map_builder : public volume_decorator<detector_t> {
     /// @param vol_builder volume builder that should be decorated with material
     /// maps
     DETRAY_HOST
-    material_map_builder(
+    explicit material_map_builder(
         std::unique_ptr<volume_builder_interface<detector_t>> vol_builder)
         : volume_decorator<detector_t>(std::move(vol_builder)) {}
 
@@ -66,12 +66,6 @@ class material_map_builder : public volume_decorator<detector_t> {
     auto data() const -> const std::map<dindex, std::vector<bin_data_type>>& {
         return m_bin_data;
     }
-
-    /// Not needed for material maps builder
-    DETRAY_HOST void init_grid(const std::vector<scalar_type>&,
-                               const std::vector<std::size_t>&,
-                               const std::vector<std::vector<scalar_type>>& = {
-                                   {}}) {}
 
     /// Overwrite, to add material maps in addition to surfaces
     /// @{

--- a/core/include/detray/builders/material_map_factory.hpp
+++ b/core/include/detray/builders/material_map_factory.hpp
@@ -52,7 +52,7 @@ class material_map_factory final : public factory_decorator<detector_t> {
     /// Factory with surfaces potentially already filled or empty placeholder
     /// that will not be used.
     DETRAY_HOST
-    material_map_factory(
+    explicit material_map_factory(
         std::unique_ptr<surface_factory_interface<detector_t>> sf_factory =
             std::make_unique<placeholder_factory_t>())
         : base_factory(std::move(sf_factory)) {}
@@ -198,7 +198,7 @@ class material_map_factory final : public factory_decorator<detector_t> {
         }
     }
 
-    protected:
+    private:
     /// Type and position(s) of the material in the detector material collection
     std::map<std::size_t, std::pair<material_id, std::vector<index_type>>>
         m_links{};

--- a/core/include/detray/builders/material_map_generator.hpp
+++ b/core/include/detray/builders/material_map_generator.hpp
@@ -171,7 +171,7 @@ class material_map_generator final : public factory_decorator<detector_t> {
         -> dindex_range override {
 
         auto [lower, upper] =
-            (*this->m_factory)(volume, surfaces, transforms, masks, ctx);
+            (*this->get_factory())(volume, surfaces, transforms, masks, ctx);
 
         m_surface_range = {lower, upper};
 

--- a/core/include/detray/builders/surface_factory_interface.hpp
+++ b/core/include/detray/builders/surface_factory_interface.hpp
@@ -157,11 +157,11 @@ class factory_decorator : public surface_factory_interface<detector_t> {
 
     public:
     DETRAY_HOST
-    factory_decorator(
+    explicit factory_decorator(
         std::unique_ptr<surface_factory_interface<detector_t>> factory)
         : m_factory(std::move(factory)) {}
 
-    /// @returns access to the underlying factory
+    /// @returns access to the underlying factory - const
     DETRAY_HOST
     const surface_factory_interface<detector_t> *get_factory() const {
         return m_factory.get();
@@ -197,6 +197,14 @@ class factory_decorator : public surface_factory_interface<detector_t> {
     /// @}
 
     protected:
+    /// @returns access to the underlying factory - non-const
+    DETRAY_HOST
+    surface_factory_interface<detector_t> *get_factory() {
+        return m_factory.get();
+    }
+
+    private:
+    /// Wrapped surface factory that new functionalit is added to by decoration
     std::unique_ptr<surface_factory_interface<detector_t>> m_factory;
 };
 

--- a/core/include/detray/builders/volume_builder.hpp
+++ b/core/include/detray/builders/volume_builder.hpp
@@ -266,6 +266,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
         det._volumes.push_back(m_volume);
     }
 
+    private:
     /// Whether the volume will get an acceleration structure
     bool m_has_accel{false};
 

--- a/core/include/detray/builders/volume_builder_interface.hpp
+++ b/core/include/detray/builders/volume_builder_interface.hpp
@@ -110,7 +110,7 @@ class volume_decorator : public volume_builder_interface<detector_t> {
     using array_type = typename detector_t::template array_type<T, N>;
 
     DETRAY_HOST
-    volume_decorator(
+    explicit volume_decorator(
         std::unique_ptr<volume_builder_interface<detector_t>> vol_builder)
         : m_builder(std::move(vol_builder)) {}
 
@@ -170,6 +170,11 @@ class volume_decorator : public volume_builder_interface<detector_t> {
     /// @}
 
     protected:
+    /// Access to underlying builder
+    /// @{
+    volume_builder_interface<detector_t> *get_builder() {
+        return m_builder.get();
+    }
     typename detector_t::surface_lookup_container &surfaces() override {
         return m_builder->surfaces();
     }
@@ -179,7 +184,9 @@ class volume_decorator : public volume_builder_interface<detector_t> {
     typename detector_t::mask_container &masks() override {
         return m_builder->masks();
     }
+    /// @}
 
+    private:
     std::unique_ptr<volume_builder_interface<detector_t>> m_builder;
 };
 

--- a/core/include/detray/core/detail/single_store.hpp
+++ b/core/include/detray/core/detail/single_store.hpp
@@ -73,14 +73,14 @@ class single_store {
     template <typename allocator_t = vecmem::memory_resource,
               typename C = container_t<T>,
               std::enable_if_t<std::is_same_v<C, std::vector<T>>, bool> = true>
-    DETRAY_HOST explicit single_store(allocator_t &resource, const T &arg)
+    DETRAY_HOST single_store(allocator_t &resource, const T &arg)
         : m_container(&resource, arg) {}
 
     /// Construct from the container @param view . Mainly used device-side.
     template <typename container_view_t,
               std::enable_if_t<detail::is_device_view_v<container_view_t>,
                                bool> = true>
-    DETRAY_HOST_DEVICE single_store(container_view_t &view)
+    DETRAY_HOST_DEVICE explicit single_store(container_view_t &view)
         : m_container(view) {}
 
     /// @returns a pointer to the underlying container - const

--- a/core/include/detray/core/detail/surface_lookup.hpp
+++ b/core/include/detray/core/detail/surface_lookup.hpp
@@ -110,7 +110,7 @@ class surface_lookup {
     template <typename container_view_t,
               std::enable_if_t<detail::is_device_view_v<container_view_t>,
                                bool> = true>
-    DETRAY_HOST_DEVICE surface_lookup(container_view_t &view)
+    DETRAY_HOST_DEVICE explicit surface_lookup(container_view_t &view)
         : m_container(view) {}
 
     /// @returns the size of the underlying container

--- a/core/include/detray/core/detail/tuple_container.hpp
+++ b/core/include/detray/core/detail/tuple_container.hpp
@@ -44,9 +44,9 @@ class tuple_container {
     /// Empty container - default alloc
     constexpr tuple_container() = default;
     /// Move constructor
-    constexpr tuple_container(tuple_container &&) = default;
+    constexpr tuple_container(tuple_container &&) noexcept = default;
     /// Move assignment operator
-    constexpr tuple_container &operator=(tuple_container &&) = default;
+    constexpr tuple_container &operator=(tuple_container &&) noexcept = default;
 
     /// Copy construct from element types
     constexpr explicit tuple_container(const Ts &... args) : _tuple(args...) {}
@@ -64,14 +64,13 @@ class tuple_container {
         typename allocator_t = vecmem::memory_resource,
         typename T = tuple_t<Ts...>,
         std::enable_if_t<std::is_same_v<T, std::tuple<Ts...>>, bool> = true>
-    DETRAY_HOST explicit tuple_container(allocator_t &resource,
-                                         const Ts &... args)
+    DETRAY_HOST tuple_container(allocator_t &resource, const Ts &... args)
         : _tuple(std::allocator_arg, resource, args...) {}
 
     /// Construct from the container @param view type. Mainly used device-side.
     template <typename tuple_view_t,
               std::enable_if_t<is_device_view_v<tuple_view_t>, bool> = true>
-    DETRAY_HOST_DEVICE tuple_container(tuple_view_t &view)
+    DETRAY_HOST_DEVICE explicit tuple_container(tuple_view_t &view)
         : _tuple(
               unroll_views(view, std::make_index_sequence<sizeof...(Ts)>{})) {}
 

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -166,10 +166,10 @@ class detector {
     /// @{
 
     /// Move constructor
-    detector(detector &&) = default;
+    detector(detector &&) noexcept = default;
 
     /// Move assignment
-    detector &operator=(detector &&) = default;
+    detector &operator=(detector &&) noexcept = default;
 
     /// Default construction
     /// @param resource memory resource for the allocation of members

--- a/core/include/detray/definitions/detail/containers.hpp
+++ b/core/include/detray/definitions/detail/containers.hpp
@@ -103,7 +103,9 @@ DETRAY_HOST_DEVICE void call_reserve(T& obj, std::size_t newsize) {
 }
 
 template <typename T, std::enable_if_t<!(has_reserve<T>::value), bool> = true>
-DETRAY_HOST_DEVICE void call_reserve(T& /*obj*/, std::size_t /*newsize*/) {}
+DETRAY_HOST_DEVICE void call_reserve(T& /*obj*/, std::size_t /*newsize*/) {
+    /*Not defined*/
+}
 /// @}
 
 }  // namespace detail

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -50,7 +50,7 @@ struct regular {
 
     /** Constructor with vecmem memory resource **/
     DETRAY_HOST
-    regular(vecmem::memory_resource & /*resource*/)
+    explicit regular(vecmem::memory_resource & /*resource*/)
         : n_bins(detail::invalid_value<dindex>()),
           min(static_cast<scalar>(0.)),
           max(static_cast<scalar>(n_bins)) {}
@@ -70,7 +70,7 @@ struct regular {
     template <
         typename axis_data_t,
         std::enable_if_t<!std::is_same_v<regular, axis_data_t>, bool> = true>
-    DETRAY_HOST_DEVICE regular(const axis_data_t &axis_data)
+    DETRAY_HOST_DEVICE explicit regular(const axis_data_t &axis_data)
         : n_bins(axis_data.n_bins), min(axis_data.min), max(axis_data.max) {}
 
     /** Return the number of bins */
@@ -235,7 +235,7 @@ struct circular {
 
     /** Constructor with vecmem memory resource **/
     DETRAY_HOST
-    circular(vecmem::memory_resource & /*resource*/)
+    explicit circular(vecmem::memory_resource & /*resource*/)
         : n_bins(detail::invalid_value<dindex>()),
           min(static_cast<scalar>(0.)),
           max(static_cast<scalar>(n_bins)) {}
@@ -255,7 +255,7 @@ struct circular {
     template <
         typename axis_data_t,
         std::enable_if_t<!std::is_same_v<circular, axis_data_t>, bool> = true>
-    DETRAY_HOST_DEVICE circular(const axis_data_t &axis_data)
+    DETRAY_HOST_DEVICE explicit circular(const axis_data_t &axis_data)
         : n_bins(axis_data.n_bins), min(axis_data.min), max(axis_data.max) {}
 
     /** Return the number of bins */
@@ -446,7 +446,7 @@ struct irregular {
 
     /** Constructor with vecmem memory resource **/
     DETRAY_HOST
-    irregular(vecmem::memory_resource &resource)
+    explicit irregular(vecmem::memory_resource &resource)
         : n_bins(detail::invalid_value<dindex>()),
           min(0.f),
           max(static_cast<scalar>(n_bins)),
@@ -480,7 +480,7 @@ struct irregular {
     template <
         typename axis_data_t,
         std::enable_if_t<!std::is_same_v<irregular, axis_data_t>, bool> = true>
-    DETRAY_HOST_DEVICE irregular(const axis_data_t &axis_data)
+    DETRAY_HOST_DEVICE explicit irregular(const axis_data_t &axis_data)
         : n_bins(axis_data.n_bins),
           min(axis_data.min),
           max(axis_data.max),
@@ -636,7 +636,7 @@ struct axis_data<axis_t, scalar_t,
         typename other_scalar_t,
         std::enable_if_t<detail::is_same_nc<scalar_t, other_scalar_t>::value,
                          bool> = true>
-    DETRAY_HOST_DEVICE axis_data(
+    DETRAY_HOST_DEVICE explicit axis_data(
         const axis_data<axis_t, other_scalar_t, void> &parent)
         : n_bins(parent.n_bins), min(parent.min), max(parent.max) {}
 
@@ -662,7 +662,7 @@ struct axis_data<axis_t, scalar_t,
         typename other_scalar_t,
         std::enable_if_t<detail::is_same_nc<scalar_t, other_scalar_t>::value,
                          bool> = true>
-    DETRAY_HOST_DEVICE axis_data(
+    DETRAY_HOST_DEVICE explicit axis_data(
         const axis_data<axis_t, other_scalar_t, void> &parent)
         : n_bins(parent.n_bins),
           min(parent.min),

--- a/core/include/detray/grids/populator.hpp
+++ b/core/include/detray/grids/populator.hpp
@@ -40,7 +40,8 @@ template <template <typename...> class vector_t = dvector,
           typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1u>
 struct replace_populator {
     DETRAY_HOST_DEVICE
-    replace_populator(const value_t invalid = detail::invalid_value<value_t>())
+    explicit replace_populator(
+        const value_t invalid = detail::invalid_value<value_t>())
         : m_invalid(invalid) {}
 
     value_t m_invalid;
@@ -114,7 +115,8 @@ template <template <typename...> class vector_t = dvector,
           typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1u>
 struct complete_populator {
     DETRAY_HOST_DEVICE
-    complete_populator(const value_t invalid = detail::invalid_value<value_t>())
+    explicit complete_populator(
+        const value_t invalid = detail::invalid_value<value_t>())
         : m_invalid(invalid) {}
 
     value_t m_invalid;
@@ -204,7 +206,8 @@ template <template <typename...> class vector_t = dvector,
           typename value_t = dindex, bool kSORT = false, unsigned int kDIM = 1u>
 struct attach_populator {
     DETRAY_HOST_DEVICE
-    attach_populator(const value_t invalid = detail::invalid_value<value_t>())
+    explicit attach_populator(
+        const value_t invalid = detail::invalid_value<value_t>())
         : m_invalid(invalid) {}
 
     value_t m_invalid;

--- a/core/include/detray/materials/material.hpp
+++ b/core/include/detray/materials/material.hpp
@@ -36,6 +36,7 @@ struct material {
 
     constexpr material() = default;
 
+    /// Construct from material parameters
     DETRAY_HOST_DEVICE
     constexpr material(const scalar_type x0, const scalar_type l0,
                        const scalar_type ar, const scalar_type z,
@@ -50,6 +51,7 @@ struct material {
         m_molar_rho = mass_to_molar_density(ar, mass_rho);
     }
 
+    /// Construct from material parameters with density effect data
     DETRAY_HOST_DEVICE
     constexpr material(const scalar_type x0, const scalar_type l0,
                        const scalar_type ar, const scalar_type z,
@@ -190,10 +192,33 @@ struct material {
         return os;
     }
 
+    /// @returns true if density effect data is present
     DETRAY_HOST_DEVICE
     bool has_density_effect_data() const { return m_has_density_effect_data; }
 
     protected:
+    /// Set the radition length.
+    DETRAY_HOST_DEVICE
+    constexpr void set_X0(scalar_type x0) { m_x0 = x0; }
+    /// Set the nuclear interaction length.
+    DETRAY_HOST_DEVICE
+    constexpr void set_L0(scalar_type l0) { m_l0 = l0; }
+    /// Set the relative atomic mass.
+    DETRAY_HOST_DEVICE
+    constexpr void set_Ar(scalar_type ar) { m_ar = ar; }
+    /// Set the nuclear charge number.
+    DETRAY_HOST_DEVICE
+    constexpr void set_Z(scalar_type z) { m_z = z; }
+    /// Set the mass density.
+    DETRAY_HOST_DEVICE
+    constexpr void set_mass_density(scalar_type mass_rho) {
+        m_mass_rho = mass_rho;
+    }
+    /// Set the molar density.
+    DETRAY_HOST_DEVICE
+    constexpr void set_molar_density(scalar_type molar_rho) {
+        m_molar_rho = molar_rho;
+    }
     DETRAY_HOST_DEVICE
     /// @return [mass_density / A]
     constexpr scalar_type mass_to_molar_density(double ar, double mass_rho) {
@@ -206,6 +231,7 @@ struct material {
         return static_cast<scalar_type>(mass_rho / molar_mass);
     }
 
+    private:
     // Material properties
     scalar_type m_x0 = detail::invalid_value<scalar_type>();
     scalar_type m_l0 = detail::invalid_value<scalar_type>();

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -43,7 +43,7 @@ struct material_rod {
 
     /// Boolean operator
     DETRAY_HOST_DEVICE
-    constexpr operator bool() const {
+    constexpr explicit operator bool() const {
         if (m_radius <= std::numeric_limits<scalar_type>::epsilon() ||
             m_material == vacuum<scalar_type>() || m_material.Z() == 0 ||
             m_material.mass_density() == 0) {

--- a/core/include/detray/materials/mixture.hpp
+++ b/core/include/detray/materials/mixture.hpp
@@ -36,7 +36,7 @@ struct mixture
             return ((M.Ar() * M.fraction()) + ...);
         };
 
-        this->m_ar = std::apply(sum_Ar, std::tuple<material_types...>());
+        this->set_Ar(std::apply(sum_Ar, std::tuple<material_types...>()));
 
         // Compute effective atomic number
         // Zeff = Z0 * ratio0 + Z1 * ratio1 + ...
@@ -44,14 +44,15 @@ struct mixture
             return ((M.Z() * M.fraction()) + ...);
         };
 
-        this->m_z = std::apply(sum_Z, std::tuple<material_types...>());
+        this->set_Z(std::apply(sum_Z, std::tuple<material_types...>()));
 
         // Get averaged mass density
         auto sum_rho = [](material_types... M) constexpr->decltype(auto) {
             return ((M.mass_density() * M.fraction()) + ...);
         };
 
-        this->m_mass_rho = std::apply(sum_rho, std::tuple<material_types...>());
+        this->set_mass_density(
+            std::apply(sum_rho, std::tuple<material_types...>()));
 
         // Compute effective radiation length (X0)
         // reference:
@@ -64,8 +65,8 @@ struct mixture
             [](material_types... M) constexpr->decltype(auto) {
             return ((M.fraction() / M.X0()) + ...);
         };
-        this->m_x0 =
-            1.f / std::apply(sum_rho_over_X0, std::tuple<material_types...>());
+        this->set_X0(
+            1.f / std::apply(sum_rho_over_X0, std::tuple<material_types...>()));
 
         // Compute effective nuclear radiation length
         // Follow the same equation of effective X0
@@ -74,12 +75,12 @@ struct mixture
             return ((M.fraction() / M.L0()) + ...);
         };
 
-        this->m_l0 =
-            1.f / std::apply(sum_rho_over_L0, std::tuple<material_types...>());
+        this->set_L0(
+            1.f / std::apply(sum_rho_over_L0, std::tuple<material_types...>()));
 
         // Compute molar density
-        this->m_molar_rho =
-            this->mass_to_molar_density(this->m_ar, this->m_mass_rho);
+        this->set_molar_density(
+            this->mass_to_molar_density(this->Ar(), this->mass_density()));
 
         // @TODO: Calculate density effect data as well if exist?
     }

--- a/core/include/detray/navigation/accelerators/brute_force_finder.hpp
+++ b/core/include/detray/navigation/accelerators/brute_force_finder.hpp
@@ -119,7 +119,7 @@ class brute_force_collection {
     template <typename coll_view_t,
               typename std::enable_if_t<detail::is_device_view_v<coll_view_t>,
                                         bool> = true>
-    DETRAY_HOST_DEVICE brute_force_collection(coll_view_t& view)
+    DETRAY_HOST_DEVICE explicit brute_force_collection(coll_view_t& view)
         : m_offsets(detail::get<0>(view.m_view)),
           m_surfaces(detail::get<1>(view.m_view)) {}
 

--- a/core/include/detray/navigation/detail/ray.hpp
+++ b/core/include/detray/navigation/detail/ray.hpp
@@ -41,7 +41,7 @@ class ray {
     /// Parametrized constructor that complies with track interface
     ///
     /// @param track the track state that should be approximated
-    DETRAY_HOST_DEVICE ray(const free_track_parameters_type &track)
+    DETRAY_HOST_DEVICE explicit ray(const free_track_parameters_type &track)
         : ray(track.pos(), 0.f, track.dir(), 0.f) {}
 
     /// @returns position on the ray (compatible with tracks/intersectors)

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -68,7 +68,9 @@ struct void_inspector {
 
     template <typename state_t>
     DETRAY_HOST_DEVICE void operator()(const state_t & /*ignored*/,
-                                       const char * /*ignored*/) {}
+                                       const char * /*ignored*/) {
+        /*Do nothing*/
+    }
 };
 
 }  // namespace navigation
@@ -179,7 +181,7 @@ class navigator {
         /// Default constructor
         state() = default;
 
-        state(const detector_type &det) : m_detector(&det) {}
+        explicit state(const detector_type &det) : m_detector(&det) {}
 
         /// Constructor with memory resource
         DETRAY_HOST

--- a/core/include/detray/navigation/volume_graph.hpp
+++ b/core/include/detray/navigation/volume_graph.hpp
@@ -36,6 +36,7 @@ struct void_node_inspector {
 template <typename node_t>
 struct void_actor {
     void operator()(const node_t & /*n*/, const dindex_range & /*edge_range*/) {
+        /*Do nothing*/
     }
 };
 
@@ -83,7 +84,7 @@ class volume_graph {
         struct node {
 
             /// Constructor from a detectors volume and surface collections
-            node(const tracking_volume<detector_t> &volume)
+            explicit node(const tracking_volume<detector_t> &volume)
                 : m_idx(volume.index()) {
                 // @TODO: Remove duplicates from multiple placements of surfaces
                 volume.template visit_surfaces<node_builder>(m_half_edges);
@@ -312,7 +313,7 @@ class volume_graph {
     /// @param det provides: geometry volumes that become the graph nodes,
     /// surfaces which are needed to index the correct masks and the
     /// masks that link to volumes and become graph edges.
-    volume_graph(const detector_t &det)
+    explicit volume_graph(const detector_t &det)
         : _nodes(det.volumes(), det), _edges(det.mask_store()), _adj_matrix{0} {
         build();
     }

--- a/core/include/detray/propagator/actor_chain.hpp
+++ b/core/include/detray/propagator/actor_chain.hpp
@@ -95,6 +95,7 @@ class actor_chain<> {
     template <typename actor_states_t, typename propagator_state_t>
     DETRAY_HOST_DEVICE void operator()(actor_states_t & /*states*/,
                                        propagator_state_t & /*p_state*/) const {
+        /*Do nothing*/
     }
 };
 

--- a/core/include/detray/propagator/base_actor.hpp
+++ b/core/include/detray/propagator/base_actor.hpp
@@ -72,7 +72,8 @@ class composite_actor final : public actor_impl_t {
         if constexpr (std::is_same_v<subj_state_t, typename actor::state>) {
             actor_type::operator()(actor_state, p_state);
         } else {
-            actor_type::operator()(actor_state, p_state, subject_state);
+            actor_type::operator()(actor_state, p_state,
+                                   std::forward<subj_state_t>(subject_state));
         }
 
         // ... then run the observers on the updated state

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -28,7 +28,9 @@ namespace stepping {
 struct void_inspector {
     template <typename state_t>
     DETRAY_HOST_DEVICE constexpr void operator()(const state_t & /*ignored*/,
-                                                 const char * /*ignored*/) {}
+                                                 const char * /*ignored*/) {
+        /*Do nothing*/
+    }
 };
 
 }  // namespace stepping
@@ -61,7 +63,7 @@ class base_stepper {
 
         /// Sets track parameters.
         DETRAY_HOST_DEVICE
-        state(const free_track_parameters_type &free_params)
+        explicit state(const free_track_parameters_type &free_params)
             : _track(free_params) {
 
             curvilinear_frame<algebra_t> cf(free_params);

--- a/core/include/detray/propagator/constrained_step.hpp
+++ b/core/include/detray/propagator/constrained_step.hpp
@@ -49,7 +49,9 @@ struct unconstrained_step {
 
     /// Register a new @param step_size constraint
     template <step::constraint type>
-    DETRAY_HOST_DEVICE constexpr void set(const scalar /*step_size*/) const {}
+    DETRAY_HOST_DEVICE constexpr void set(const scalar /*step_size*/) const {
+        /*Do nothing*/
+    }
 
     /// @returns the current step size constraint
     template <step::constraint type = step::constraint::e_all>
@@ -60,7 +62,9 @@ struct unconstrained_step {
 
     /// Remove constraints
     template <step::constraint type = step::constraint::e_actor>
-    DETRAY_HOST_DEVICE constexpr void release() const {}
+    DETRAY_HOST_DEVICE constexpr void release() const {
+        /*Do nothing*/
+    }
 };
 
 /// Struct that can be configured with a number of different step sizes by other

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -41,14 +41,10 @@ class line_stepper final
     struct state : public base_type::state {
         static constexpr const stepping::id id = stepping::id::e_linear;
 
-        DETRAY_HOST_DEVICE
-        state(const free_track_parameters_type& t) : base_type::state(t) {}
+        using base_state = typename base_type::state;
 
-        template <typename detector_t>
-        DETRAY_HOST_DEVICE state(
-            const bound_track_parameters_type& bound_params,
-            const detector_t& det)
-            : base_type::state(bound_params, det) {}
+        /// Import base class constructors
+        using base_state::base_state;
 
         /// Update the track state in a straight line.
         DETRAY_HOST_DEVICE

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -52,8 +52,7 @@ class rk_stepper final
     template <std::size_t ROWS, std::size_t COLS>
     using matrix_type = dmatrix<algebra_t, ROWS, COLS>;
 
-    DETRAY_HOST_DEVICE
-    rk_stepper() {}
+    rk_stepper() = default;
 
     struct state : public base_type::state {
 

--- a/core/include/detray/utils/grid/detail/axis.hpp
+++ b/core/include/detray/utils/grid/detail/axis.hpp
@@ -247,7 +247,7 @@ class multi_axis {
 
     /// Construct containers using a specific memory resources
     template <bool owner = is_owning, std::enable_if_t<owner, bool> = true>
-    DETRAY_HOST multi_axis(vecmem::memory_resource &resource)
+    DETRAY_HOST explicit multi_axis(vecmem::memory_resource &resource)
         : m_edge_offsets(&resource), m_edges(&resource) {}
 
     /// Construct from containers - move
@@ -274,7 +274,7 @@ class multi_axis {
     template <typename view_t,
               typename std::enable_if_t<
                   detray::detail::is_device_view_v<view_t>, bool> = true>
-    DETRAY_HOST_DEVICE multi_axis(const view_t &view)
+    DETRAY_HOST_DEVICE explicit multi_axis(const view_t &view)
         : m_edge_offsets(detray::detail::get<0>(view.m_view)),
           m_edges(detray::detail::get<1>(view.m_view)) {}
 

--- a/core/include/detray/utils/grid/detail/bin_storage.hpp
+++ b/core/include/detray/utils/grid/detail/bin_storage.hpp
@@ -47,23 +47,23 @@ class bin_storage : public detray::ranges::view_interface<
     /// Default constructor
     bin_storage() = default;
     /// Copy constructor
-    bin_storage(const bin_storage&) = default;
+    bin_storage(const bin_storage&) noexcept = default;
     /// Move constructor
-    bin_storage(bin_storage&&) = default;
+    bin_storage(bin_storage&&) noexcept = default;
 
     /// Copy assignment
-    bin_storage& operator=(const bin_storage&) = default;
+    bin_storage& operator=(const bin_storage&) noexcept = default;
     /// Move assignment
-    bin_storage& operator=(bin_storage&&) = default;
+    bin_storage& operator=(bin_storage&&) noexcept = default;
 
     /// Construct containers using a memory resources
     template <bool owner = is_owning, std::enable_if_t<owner, bool> = true>
-    DETRAY_HOST bin_storage(vecmem::memory_resource& resource)
+    DETRAY_HOST explicit bin_storage(vecmem::memory_resource& resource)
         : m_bin_data(&resource) {}
 
     /// Construct grid data from containers - move
     template <bool owner = is_owning, std::enable_if_t<owner, bool> = true>
-    DETRAY_HOST_DEVICE bin_storage(bin_container_type&& bin_data)
+    DETRAY_HOST_DEVICE explicit bin_storage(bin_container_type&& bin_data)
         : m_bin_data(std::move(bin_data)) {}
 
     /// Construct the non-owning type from the @param offset into the global
@@ -84,7 +84,8 @@ class bin_storage : public detray::ranges::view_interface<
     template <typename view_t,
               typename std::enable_if_t<detail::is_device_view_v<view_t>,
                                         bool> = true>
-    DETRAY_HOST_DEVICE bin_storage(const view_t& view) : m_bin_data(view) {}
+    DETRAY_HOST_DEVICE explicit bin_storage(const view_t& view)
+        : m_bin_data(view) {}
 
     /// begin and end of the bin range
     /// @{
@@ -142,19 +143,21 @@ struct dynamic_bin_container {
 
     constexpr dynamic_bin_container() = default;
     DETRAY_HOST
-    dynamic_bin_container(vecmem::memory_resource* resource)
+    explicit dynamic_bin_container(vecmem::memory_resource* resource)
         : bins{resource}, entries{resource} {}
     dynamic_bin_container(const dynamic_bin_container& other) = default;
     dynamic_bin_container(dynamic_bin_container&& other) = default;
 
-    dynamic_bin_container& operator=(const dynamic_bin_container&) = default;
-    dynamic_bin_container& operator=(dynamic_bin_container&&) = default;
+    dynamic_bin_container& operator=(const dynamic_bin_container&) noexcept =
+        default;
+    dynamic_bin_container& operator=(dynamic_bin_container&&) noexcept =
+        default;
 
     /// Device-side construction from a vecmem based view type
     template <typename view_t,
               typename std::enable_if_t<detail::is_device_view_v<view_t>,
                                         bool> = true>
-    DETRAY_HOST_DEVICE dynamic_bin_container(view_t& view)
+    DETRAY_HOST_DEVICE explicit dynamic_bin_container(view_t& view)
         : bins(detail::get<0>(view.m_view)),
           entries(detail::get<1>(view.m_view)) {}
 
@@ -324,18 +327,18 @@ class bin_storage<is_owning, detray::bins::dynamic_array<entry_t>, containers>
     /// Default constructor
     bin_storage() = default;
     /// Copy constructor
-    bin_storage(const bin_storage&) = default;
+    bin_storage(const bin_storage&) noexcept = default;
     /// Move constructor
-    bin_storage(bin_storage&&) = default;
+    bin_storage(bin_storage&&) noexcept = default;
 
     /// Construct containers using a memory resources
     template <bool owner = is_owning, std::enable_if_t<owner, bool> = true>
-    DETRAY_HOST bin_storage(vecmem::memory_resource& resource)
+    DETRAY_HOST explicit bin_storage(vecmem::memory_resource& resource)
         : m_bin_data(&resource), m_entry_data(&resource) {}
 
     /// Construct grid data from containers - move
     template <bool owner = is_owning, std::enable_if_t<owner, bool> = true>
-    DETRAY_HOST_DEVICE bin_storage(bin_container_type&& bin_data)
+    DETRAY_HOST_DEVICE explicit bin_storage(bin_container_type&& bin_data)
         : m_bin_data(std::move(bin_data.bins)),
           m_entry_data(std::move(bin_data.entries)) {}
 
@@ -353,14 +356,14 @@ class bin_storage<is_owning, detray::bins::dynamic_array<entry_t>, containers>
     template <typename view_t,
               typename std::enable_if_t<detail::is_device_view_v<view_t>,
                                         bool> = true>
-    DETRAY_HOST_DEVICE bin_storage(const view_t& view)
+    DETRAY_HOST_DEVICE explicit bin_storage(const view_t& view)
         : m_bin_data(detray::detail::get<0>(view.m_view)),
           m_entry_data(detray::detail::get<1>(view.m_view)) {}
 
     /// Copy assignment
-    bin_storage& operator=(const bin_storage&) = default;
+    bin_storage& operator=(const bin_storage&) noexcept = default;
     /// Move assignment
-    bin_storage& operator=(bin_storage&&) = default;
+    bin_storage& operator=(bin_storage&&) noexcept = default;
 
     const bin_range_t& bin_data() const { return m_bin_data; }
     const entry_range_t& entry_data() const { return m_entry_data; }

--- a/core/include/detray/utils/grid/detail/bin_view.hpp
+++ b/core/include/detray/utils/grid/detail/bin_view.hpp
@@ -59,7 +59,7 @@ struct bin_view : public detray::ranges::view_interface<bin_view<grid_t>> {
 
     /// Copy constructor
     DETRAY_HOST_DEVICE
-    constexpr bin_view(const bin_view &other)
+    constexpr explicit bin_view(const bin_view &other)
         : m_grid{other.m_grid}, m_bin_indexer{other.m_bin_indexer} {}
 
     /// Default destructor

--- a/core/include/detray/utils/grid/detail/grid_bins.hpp
+++ b/core/include/detray/utils/grid/detail/grid_bins.hpp
@@ -72,7 +72,7 @@ class static_array
     DETRAY_HOST_DEVICE constexpr static_array() { init(); };
     constexpr static_array(const static_array& other) = default;
     constexpr static_array(static_array&& other) = default;
-    static_array& operator=(const static_array& other) = default;
+    static_array& operator=(const static_array& other) noexcept = default;
 
     /// @returns view iterator over bin content in start or end position
     /// @{

--- a/core/include/detray/utils/grid/grid.hpp
+++ b/core/include/detray/utils/grid/grid.hpp
@@ -129,7 +129,7 @@ class grid_impl {
     template <typename grid_view_t,
               typename std::enable_if_t<detail::is_device_view_v<grid_view_t>,
                                         bool> = true>
-    DETRAY_HOST_DEVICE grid_impl(grid_view_t &view)
+    DETRAY_HOST_DEVICE explicit grid_impl(grid_view_t &view)
         : m_bins(detray::detail::get<0>(view.m_view)),
           m_axes(detray::detail::get<1>(view.m_view)) {}
 

--- a/core/include/detray/utils/grid/grid_collection.hpp
+++ b/core/include/detray/utils/grid/grid_collection.hpp
@@ -74,7 +74,7 @@ class grid_collection<
 
         constexpr iterator(const iterator &other) = default;
         constexpr iterator(iterator &&other) = default;
-        constexpr iterator &operator=(const iterator &rhs) = default;
+        constexpr iterator &operator=(const iterator &rhs) noexcept = default;
 
         /// @returns true if grid indices are the same
         DETRAY_HOST_DEVICE
@@ -163,7 +163,7 @@ class grid_collection<
     template <typename coll_view_t,
               typename std::enable_if_t<detail::is_device_view_v<coll_view_t>,
                                         bool> = true>
-    DETRAY_HOST_DEVICE grid_collection(coll_view_t &view)
+    DETRAY_HOST_DEVICE explicit grid_collection(coll_view_t &view)
         : m_bin_offsets(detail::get<0>(view.m_view)),
           m_bins(detail::get<1>(view.m_view)),
           m_bin_edge_offsets(detail::get<2>(view.m_view)),

--- a/core/include/detray/utils/grid/populators.hpp
+++ b/core/include/detray/utils/grid/populators.hpp
@@ -31,11 +31,12 @@ struct replace {
     /// @param content new content to be added
     template <typename bin_t, typename content_t>
     DETRAY_HOST_DEVICE void operator()(bin_t &&bin, content_t &&entry) const {
-        bin.init(std::forward<content_t>(entry));
+        std::forward<bin_t>(bin).init(std::forward<content_t>(entry));
 
         // Optionally sort the bin content
         if constexpr (kSORT) {
-            detray::detail::sequential_sort(bin.begin(), bin.end());
+            detray::detail::sequential_sort(std::forward<bin_t>(bin).begin(),
+                                            std::forward<bin_t>(bin).end());
         }
     }
 };
@@ -52,11 +53,12 @@ struct attach {
     /// @param content new content to be added
     template <typename bin_t, typename entry_t>
     DETRAY_HOST_DEVICE void operator()(bin_t &&bin, entry_t &&entry) const {
-        bin.push_back(std::forward<entry_t>(entry));
+        std::forward<bin_t>(bin).push_back(std::forward<entry_t>(entry));
 
         // Optionally sort the bin content
         if constexpr (kSORT) {
-            detray::detail::sequential_sort(bin.begin(), bin.end());
+            detray::detail::sequential_sort(std::forward<bin_t>(bin).begin(),
+                                            std::forward<bin_t>(bin).end());
         }
     }
 };
@@ -74,13 +76,15 @@ struct complete {
     /// @param content new content to be added
     template <typename bin_t, typename entry_t>
     DETRAY_HOST_DEVICE void operator()(bin_t &&bin, entry_t &&entry) const {
-        for (dindex i{bin.size()}; i < bin.capacity(); ++i) {
-            bin.push_back(std::forward<entry_t>(entry));
+        for (dindex i{std::forward<bin_t>(bin).size()};
+             i < std::forward<bin_t>(bin).capacity(); ++i) {
+            std::forward<bin_t>(bin).push_back(std::forward<entry_t>(entry));
         }
 
         // Optionally sort the bin content
         if constexpr (kSORT) {
-            detray::detail::sequential_sort(bin.begin(), bin.end());
+            detray::detail::sequential_sort(std::forward<bin_t>(bin).begin(),
+                                            std::forward<bin_t>(bin).end());
         }
     }
 };

--- a/core/include/detray/utils/inspectors.hpp
+++ b/core/include/detray/utils/inspectors.hpp
@@ -132,7 +132,7 @@ struct object_tracer {
         dvector_view<candidate_record_t> &view)
         : object_trace(view) {}
 
-    // record all object id the navigator encounters
+    // Record all objects the navigator encounters
     vector_t<candidate_record_t> object_trace;
     dindex current_vol{dindex_invalid};
     const scalar_t inv_pos{detray::detail::invalid_value<scalar_t>()};

--- a/core/include/detray/utils/ranges/cartesian_product.hpp
+++ b/core/include/detray/utils/ranges/cartesian_product.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -49,22 +49,6 @@ struct cartesian_product_view : public detray::ranges::view_interface<
         range_ts... ranges)
         : m_begins(detray::ranges::begin(ranges)...),
           m_ends(detray::ranges::end(ranges)...) {}
-
-    /// Copy constructor
-    DETRAY_HOST_DEVICE
-    constexpr cartesian_product_view(const cartesian_product_view &other)
-        : m_begins{other.m_begins}, m_ends{other.m_ends} {}
-
-    /// Default destructor
-    ~cartesian_product_view() = default;
-
-    /// Copy assignment operator
-    DETRAY_HOST_DEVICE
-    cartesian_product_view &operator=(const cartesian_product_view &other) {
-        m_begins = other.m_begins;
-        m_ends = other.m_ends;
-        return *this;
-    }
 
     /// @returns start position of range - const
     DETRAY_HOST_DEVICE
@@ -149,22 +133,6 @@ struct cartesian_product_iterator {
     constexpr cartesian_product_iterator(detray::tuple<iterator_ts...> begins,
                                          detray::tuple<iterator_ts...> ends)
         : m_begins(begins), m_ends(ends), m_itrs(begins) {}
-
-    /// Copy constructor
-    DETRAY_HOST_DEVICE
-    cartesian_product_iterator(const cartesian_product_iterator &other)
-        : m_begins{other.m_begins},
-          m_ends{other.m_ends},
-          m_itrs{other.m_itrs} {}
-
-    /// Copy assignment operator
-    DETRAY_HOST_DEVICE
-    cartesian_product_iterator &operator=(
-        const cartesian_product_iterator &other) {
-        m_begins = other.m_begins;
-        m_ends = other.m_ends;
-        return *this;
-    }
 
     /// @returns true if the last range iterators are equal.
     DETRAY_HOST_DEVICE constexpr bool operator==(

--- a/core/include/detray/utils/ranges/empty.hpp
+++ b/core/include/detray/utils/ranges/empty.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -24,20 +24,6 @@ class empty_view : public detray::ranges::view_interface<empty_view<value_t>> {
     public:
     /// Iterator category: bidirectional
     using iterator_t = value_t*;
-
-    /// Default constructor
-    constexpr empty_view() = default;
-
-    /// Copy constructor
-    DETRAY_HOST_DEVICE
-    constexpr empty_view(const empty_view&) {}
-
-    /// Default destructor
-    DETRAY_HOST_DEVICE ~empty_view() {}
-
-    /// Copy assignment operator - does nothing
-    DETRAY_HOST_DEVICE
-    constexpr empty_view& operator=(const empty_view&){};
 
     /// @returns @c nullptr
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/ranges/enumerate.hpp
+++ b/core/include/detray/utils/ranges/enumerate.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -50,7 +50,7 @@ class enumerate_view : public detray::ranges::view_interface<
         using iterator_category =
             typename std::iterator_traits<range_itr_t>::iterator_category;
 
-        iterator() = default;
+        constexpr iterator() = default;
 
         DETRAY_HOST_DEVICE
         iterator(range_itr_t iter, incr_t offset = 0)
@@ -190,22 +190,6 @@ class enumerate_view : public detray::ranges::view_interface<
         : m_begin{detray::ranges::begin(std::forward<range_t>(rng)), start},
           m_end{detray::ranges::end(std::forward<range_t>(rng)),
                 start + static_cast<dindex>(rng.size())} {}
-
-    /// Copy constructor
-    DETRAY_HOST_DEVICE
-    constexpr enumerate_view(const enumerate_view &other)
-        : m_begin{other.m_begin}, m_end{other.m_end} {}
-
-    /// Default destructor
-    DETRAY_HOST_DEVICE ~enumerate_view() {}
-
-    /// Copy assignment operator
-    DETRAY_HOST_DEVICE
-    enumerate_view &operator=(const enumerate_view &other) {
-        m_begin = other.m_begin;
-        m_end = other.m_end;
-        return *this;
-    }
 
     /// @return start position of range on container.
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/ranges/iota.hpp
+++ b/core/include/detray/utils/ranges/iota.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -40,12 +40,6 @@ class iota_view : public detray::ranges::view_interface<iota_view<incr_t>> {
         using pointer = incr_t *;
         using reference = incr_t &;
         using iterator_category = detray::ranges::bidirectional_iterator_tag;
-
-        /// Default construction only works if incr_t is default constructible
-        constexpr iterator() = default;
-        constexpr iterator(const iterator &other) = default;
-        constexpr iterator(iterator &&other) = default;
-        constexpr iterator &operator=(const iterator &rhs) = default;
 
         /// Parametrized Constructor
         DETRAY_HOST_DEVICE constexpr explicit iterator(incr_t i) : m_i{i} {}
@@ -105,43 +99,24 @@ class iota_view : public detray::ranges::view_interface<iota_view<incr_t>> {
               std::enable_if_t<!detray::detail::is_interval_v<deduced_incr_t>,
                                bool> = true>
     DETRAY_HOST_DEVICE constexpr explicit iota_view(deduced_incr_t &&start)
-        : m_start{start},
-          m_end{static_cast<std::decay_t<deduced_incr_t>>(start + 1)} {}
+        : m_start{std::forward<deduced_incr_t>(start)},
+          m_end{static_cast<std::decay_t<deduced_incr_t>>(
+              std::forward<deduced_incr_t>(start) + 1)} {}
 
     /// Construct from an @param interval that defines start and end values.
     template <typename interval_t,
               std::enable_if_t<detray::detail::is_interval_v<interval_t>,
                                bool> = true>
     DETRAY_HOST_DEVICE constexpr explicit iota_view(interval_t &&interval)
-        : m_start{detray::detail::get<0>(interval)},
-          m_end{detray::detail::get<1>(interval)} {}
+        : m_start{detray::detail::get<0>(std::forward<interval_t>(interval))},
+          m_end{detray::detail::get<1>(std::forward<interval_t>(interval))} {}
 
     /// Construct from a @param start start and @param end value.
     template <typename deduced_incr_t>
     DETRAY_HOST_DEVICE constexpr iota_view(deduced_incr_t &&start,
                                            deduced_incr_t &&end)
-        : m_start{start}, m_end{end} {}
-
-    /// Copy constructor
-    DETRAY_HOST_DEVICE
-    constexpr iota_view(const iota_view &other)
-        : m_start{other.m_start}, m_end{other.m_end} {}
-
-    /// MOve constructor
-    DETRAY_HOST_DEVICE
-    constexpr iota_view(iota_view &&other)
-        : m_start{std::move(other.m_start)}, m_end{std::move(other.m_end)} {}
-
-    /// Default destructor
-    DETRAY_HOST_DEVICE ~iota_view() {}
-
-    /// Copy assignment operator
-    DETRAY_HOST_DEVICE
-    iota_view &operator=(const iota_view &other) {
-        m_start = other.m_start;
-        m_end = other.m_end;
-        return *this;
-    }
+        : m_start{std::forward<deduced_incr_t>(start)},
+          m_end{std::forward<deduced_incr_t>(end)} {}
 
     /// @return start position of range on container.
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/ranges/join.hpp
+++ b/core/include/detray/utils/ranges/join.hpp
@@ -61,22 +61,6 @@ struct join_view : public detray::ranges::view_interface<join_view<range_t>> {
         : m_begin{detray::ranges::begin(std::forward<R>(ranges))},
           m_end{detray::ranges::end(std::forward<R>(ranges))} {}
 
-    /// Copy constructor
-    DETRAY_HOST_DEVICE
-    constexpr join_view(const join_view &other)
-        : m_begin{other.m_begin}, m_end{other.m_end} {}
-
-    /// Default destructor
-    ~join_view() = default;
-
-    /// Copy assignment operator
-    DETRAY_HOST_DEVICE
-    join_view &operator=(const join_view &other) {
-        m_begin = other.m_begin;
-        m_end = other.m_end;
-        return *this;
-    }
-
     /// @return start position of range - const
     DETRAY_HOST_DEVICE
     constexpr auto begin() const -> iterator_t { return {m_begin, m_end}; }

--- a/core/include/detray/utils/ranges/pick.hpp
+++ b/core/include/detray/utils/ranges/pick.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -160,7 +160,7 @@ class pick_view : public detray::ranges::view_interface<
     using iterator_t = iterator;
 
     /// Default constructor
-    pick_view() = default;
+    constexpr pick_view() = default;
 
     /// Construct from a @param range that will be enumerated beginning at 0
     template <
@@ -172,27 +172,6 @@ class pick_view : public detray::ranges::view_interface<
           m_range_end{detray::ranges::end(std::forward<range_t>(range))},
           m_seq_begin{detray::ranges::cbegin(std::forward<sequence_t>(seq))},
           m_seq_end{detray::ranges::cend(std::forward<sequence_t>(seq))} {}
-
-    /// Copy constructor
-    DETRAY_HOST_DEVICE
-    constexpr pick_view(const pick_view &other)
-        : m_range_begin{other.m_range_begin},
-          m_range_end{other.m_range_end},
-          m_seq_begin{other.m_seq_begin},
-          m_seq_end{other.m_seq_end} {}
-
-    /// Default destructor
-    DETRAY_HOST_DEVICE ~pick_view() {}
-
-    /// Copy assignment operator
-    DETRAY_HOST_DEVICE
-    pick_view &operator=(const pick_view &other) {
-        m_range_begin = other.m_range_begin;
-        m_range_end = other.m_range_end;
-        m_seq_begin = other.m_seq_begin;
-        m_seq_end = other.m_seq_end;
-        return *this;
-    }
 
     /// @return start position of range on container.
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/ranges/pointer.hpp
+++ b/core/include/detray/utils/ranges/pointer.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,24 +34,6 @@ class pointer_view
     /// Construct iterator from the single @param value - copy
     DETRAY_HOST_DEVICE constexpr explicit pointer_view(value_t& value)
         : m_value{&value} {}
-
-    /// Copy constructor
-    DETRAY_HOST_DEVICE
-    constexpr pointer_view(const pointer_view& other)
-        : m_value{other.m_value} {}
-
-    /// Move constructor for the pointer view
-    constexpr pointer_view(pointer_view&& other) = default;
-
-    /// Default destructor
-    ~pointer_view() = default;
-
-    /// Copy assignment operator
-    DETRAY_HOST_DEVICE
-    pointer_view& operator=(const pointer_view& other) {
-        m_value = other.m_value;
-        return *this;
-    }
 
     /// @return the pointer value
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/ranges/ranges.hpp
+++ b/core/include/detray/utils/ranges/ranges.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/include/detray/utils/ranges/single.hpp
+++ b/core/include/detray/utils/ranges/single.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,7 +31,7 @@ class single_view
     using iterator_t = value_t*;
 
     /// Default constructor
-    single_view() = default;
+    constexpr single_view() = default;
 
     /// Construct iterator from the single @param value - copy
     DETRAY_HOST_DEVICE constexpr explicit single_view(const value_t& value)
@@ -45,23 +45,6 @@ class single_view
     template <class... Args>
     DETRAY_HOST_DEVICE constexpr single_view(std::in_place_t, Args&&... args)
         : m_value{std::in_place, std::forward<Args>(args)...} {}
-
-    /// Copy constructor
-    DETRAY_HOST_DEVICE
-    constexpr single_view(const single_view& other) : m_value{other.m_value} {}
-
-    /// Move constructor for the single view
-    constexpr single_view(single_view&& other) = default;
-
-    /// Default destructor
-    ~single_view() = default;
-
-    /// Copy assignment operator
-    DETRAY_HOST_DEVICE
-    single_view& operator=(const single_view& other) {
-        m_value = other.m_value;
-        return *this;
-    }
 
     /// @return the single value
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/ranges/static_join.hpp
+++ b/core/include/detray/utils/ranges/static_join.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -64,22 +64,6 @@ struct static_join_view
         const ranges_t &... ranges)
         : m_begins{detray::ranges::cbegin(ranges)...},
           m_ends{detray::ranges::cend(ranges)...} {}
-
-    /// Copy constructor
-    DETRAY_HOST_DEVICE
-    constexpr static_join_view(const static_join_view &other)
-        : m_begins{other.m_begins}, m_ends{other.m_ends} {}
-
-    /// Default destructor
-    DETRAY_HOST_DEVICE ~static_join_view() {}
-
-    /// Copy assignment operator
-    DETRAY_HOST_DEVICE
-    static_join_view &operator=(const static_join_view &other) {
-        m_begins = other.m_begins;
-        m_ends = other.m_ends;
-        return *this;
-    }
 
     /// @return start position of range - const
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/ranges/subrange.hpp
+++ b/core/include/detray/utils/ranges/subrange.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,7 +33,7 @@ class subrange : public detray::ranges::view_interface<subrange<range_t>> {
     using difference_t = typename detray::ranges::range_difference_t<range_t>;
 
     /// Default constructor
-    subrange() = default;
+    constexpr subrange() = default;
 
     /// Construct from an @param start and @param end iterator pair.
     DETRAY_HOST_DEVICE constexpr subrange(iterator_t start, iterator_t end)
@@ -43,7 +43,7 @@ class subrange : public detray::ranges::view_interface<subrange<range_t>> {
     template <
         typename deduced_range_t,
         std::enable_if_t<detray::ranges::range_v<deduced_range_t>, bool> = true>
-    DETRAY_HOST_DEVICE constexpr subrange(deduced_range_t &&range)
+    DETRAY_HOST_DEVICE constexpr explicit subrange(deduced_range_t &&range)
         : m_begin{detray::ranges::begin(range)},
           m_end{detray::ranges::end(range)} {}
 
@@ -75,23 +75,6 @@ class subrange : public detray::ranges::view_interface<subrange<range_t>> {
           m_end{detray::ranges::next(
               detray::ranges::begin(range),
               static_cast<difference_t>(detray::detail::get<1>(pos)))} {}
-
-    /// Copy constructor
-    constexpr subrange(const subrange &other) = default;
-
-    /// Move constructor
-    constexpr subrange(subrange &&other) = default;
-
-    /// Default destructor
-    ~subrange() = default;
-
-    /// Copy assignment operator
-    DETRAY_HOST_DEVICE
-    subrange &operator=(const subrange &other) {
-        m_begin = other.m_begin;
-        m_end = other.m_end;
-        return *this;
-    };
 
     /// @return start position of range.
     DETRAY_HOST_DEVICE

--- a/io/include/detray/io/frontend/reader_interface.hpp
+++ b/io/include/detray/io/frontend/reader_interface.hpp
@@ -9,7 +9,6 @@
 
 // Project include(s)
 #include "detray/builders/detector_builder.hpp"
-#include "detray/io/frontend/payloads.hpp"
 
 // System include(s)
 #include <filesystem>
@@ -28,10 +27,13 @@ class reader_interface {
     reader_interface() = delete;
 
     /// Only accept files with a fixed @param extension
-    reader_interface(const std::string& ext) : m_file_extension{ext} {}
+    explicit reader_interface(const std::string& ext) : m_file_extension{ext} {}
 
     /// Default destructor
     virtual ~reader_interface() = default;
+
+    /// @returns the file extension
+    const std::string& file_extension() const { return m_file_extension; }
 
     /// Reads the respective detector component from file. Since the detector
     /// does not keep the volume names, the name map is also passed and
@@ -40,7 +42,7 @@ class reader_interface {
         detector_builder<typename detector_t::metadata, volume_builder>&,
         typename detector_t::name_map&, const std::string&) = 0;
 
-    protected:
+    private:
     /// Extension that matches the file format of the respective reader
     std::string m_file_extension;
 };

--- a/io/include/detray/io/frontend/writer_interface.hpp
+++ b/io/include/detray/io/frontend/writer_interface.hpp
@@ -9,7 +9,6 @@
 
 // Project include(s)
 #include "detray/builders/detector_builder.hpp"
-#include "detray/io/frontend/payloads.hpp"
 
 // System include(s)
 #include <filesystem>
@@ -28,10 +27,13 @@ class writer_interface {
     writer_interface() = delete;
 
     /// File gets created with a fixed @param extension
-    writer_interface(const std::string& ext) : m_file_extension{ext} {}
+    explicit writer_interface(const std::string& ext) : m_file_extension{ext} {}
 
     /// Default destructor
     virtual ~writer_interface() = default;
+
+    /// @returns the file extension
+    const std::string& file_extension() const { return m_file_extension; }
 
     /// Writes the respective detector component to file. Since the detector
     /// does not provide the volume names, the name map is also passed.
@@ -41,7 +43,7 @@ class writer_interface {
                               const std::ios_base::openmode,
                               const std::filesystem::path&) = 0;
 
-    protected:
+    private:
     /// Extension that matches the file format of the respective writer
     std::string m_file_extension;
 };

--- a/io/include/detray/io/json/json_writer.hpp
+++ b/io/include/detray/io/json/json_writer.hpp
@@ -61,7 +61,7 @@ class json_writer final : public writer_interface<detector_t> {
 
         // Create a new file
         std::string file_stem{det_name + "_" + std::string(io_backend::tag)};
-        io::file_handle file{file_path / file_stem, this->m_file_extension,
+        io::file_handle file{file_path / file_stem, this->file_extension(),
                              mode};
 
         // Write some general information
@@ -75,7 +75,7 @@ class json_writer final : public writer_interface<detector_t> {
         // Write to file
         *file << std::setw(4) << out_json << std::endl;
 
-        return file_stem + this->m_file_extension;
+        return file_stem + this->file_extension();
     }
 };
 

--- a/tests/include/detray/test/common/utils/material_validation_utils.hpp
+++ b/tests/include/detray/test/common/utils/material_validation_utils.hpp
@@ -215,12 +215,13 @@ inline auto record_material(
     typename material_tracer_t::state mat_tracer_state{};
 
     auto actor_states =
-        std::tie(pathlimit_aborter_state, transporter_state, resetter_state,
-                 interactor_state, mat_tracer_state);
+        detray::tie(pathlimit_aborter_state, transporter_state, resetter_state,
+                    interactor_state, mat_tracer_state);
+
+    typename propagator_t::state propagation{track, det};
 
     // Run the propagation
-    bool success =
-        prop.propagate(typename propagator_t::state{track, det}, actor_states);
+    bool success = prop.propagate(propagation, actor_states);
 
     return std::make_tuple(success, std::move(mat_tracer_state.mat_record));
 }

--- a/tests/include/detray/test/common/utils/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/common/utils/navigation_validation_utils.hpp
@@ -72,7 +72,7 @@ inline auto record_propagation(
     // Build actor and propagator states
     pathlimit_aborter::state pathlimit_aborter_state{cfg.stepping.path_limit};
     typename material_tracer_t::state mat_tracer_state{};
-    auto actor_states = std::tie(pathlimit_aborter_state, mat_tracer_state);
+    auto actor_states = detray::tie(pathlimit_aborter_state, mat_tracer_state);
 
     std::unique_ptr<typename propagator_t::state> propagation{nullptr};
     if constexpr (std::is_same_v<bfield_t, empty_bfield>) {

--- a/tests/include/detray/test/device/cuda/material_validation.cu
+++ b/tests/include/detray/test/device/cuda/material_validation.cu
@@ -73,11 +73,11 @@ __global__ void material_validation_kernel(
 
     // Run propagation
     navigation::void_inspector::view_type void_view{};
-    p.propagate(
-        typename propagator_t::state(tracks[trk_id], det, trk_id,
-                                     typename navigator_t::state::view_type{
-                                         navigation_cache_view, void_view}),
-        actor_states);
+    typename propagator_t::state propagation(
+        tracks[trk_id], det, trk_id,
+        typename navigator_t::state::view_type{navigation_cache_view,
+                                               void_view});
+    p.propagate(propagation, actor_states);
 
     // Record the accumulated material
     assert(mat_records.size() == tracks.size());

--- a/tests/include/detray/test/device/cuda/navigation_validation.cu
+++ b/tests/include/detray/test/device/cuda/navigation_validation.cu
@@ -108,19 +108,19 @@ __global__ void navigation_validation_kernel(
 
     // Run propagation
     if constexpr (is_no_bfield) {
-        p.propagate(typename propagator_t::state(
-                        track, det, trk_id,
-                        typename navigator_t::state::view_type{
-                            navigation_cache_view,
-                            recorded_intersections_view.ptr()[trk_id]}),
-                    actor_states);
+        typename propagator_t::state propagation(
+            track, det, trk_id,
+            typename navigator_t::state::view_type{
+                navigation_cache_view,
+                recorded_intersections_view.ptr()[trk_id]});
+        p.propagate(propagation, actor_states);
     } else {
-        p.propagate(typename propagator_t::state(
-                        track, field_data, det, trk_id,
-                        typename navigator_t::state::view_type{
-                            navigation_cache_view,
-                            recorded_intersections_view.ptr()[trk_id]}),
-                    actor_states);
+        typename propagator_t::state propagation(
+            track, field_data, det, trk_id,
+            typename navigator_t::state::view_type{
+                navigation_cache_view,
+                recorded_intersections_view.ptr()[trk_id]});
+        p.propagate(propagation, actor_states);
     }
 
     // Record the accumulated material

--- a/tests/integration_tests/cpu/material/material_interaction.cpp
+++ b/tests/integration_tests/cpu/material/material_interaction.cpp
@@ -100,8 +100,8 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
     parameter_resetter<algebra_t>::state parameter_resetter_state{};
 
     // Create actor states tuples
-    auto actor_states = std::tie(aborter_state, bound_updater, interactor_state,
-                                 parameter_resetter_state);
+    auto actor_states = detray::tie(aborter_state, bound_updater,
+                                    interactor_state, parameter_resetter_state);
 
     propagator_t::state state(bound_param, det);
     state.do_debug = true;
@@ -186,7 +186,7 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
         next_surface_aborter::state next_surface_aborter_state{
             0.1f * unit<scalar>::mm};
 
-        auto alt_actor_states = std::tie(
+        auto alt_actor_states = detray::tie(
             alt_aborter_state, bound_updater, next_surface_aborter_state,
             interactor_state, parameter_resetter_state);
 
@@ -280,8 +280,9 @@ GTEST_TEST(detray_material, telescope_geometry_scattering_angle) {
         parameter_resetter<algebra_t>::state parameter_resetter_state{};
 
         // Create actor states tuples
-        auto actor_states = std::tie(aborter_state, bound_updater,
-                                     simulator_state, parameter_resetter_state);
+        auto actor_states =
+            detray::tie(aborter_state, bound_updater, simulator_state,
+                        parameter_resetter_state);
 
         propagator_t::state state(bound_param, det);
         state.do_debug = true;
@@ -383,7 +384,7 @@ GTEST_TEST(detray_material, telescope_geometry_volume_material) {
         propagator_t::state state(bound_param, const_bfield, det);
 
         pathlimit_aborter::state abrt_state{path_limit};
-        auto actor_states = std::tie(abrt_state);
+        auto actor_states = detray::tie(abrt_state);
 
         p.propagate(state, actor_states);
 

--- a/tests/integration_tests/cpu/propagator/guided_navigator.cpp
+++ b/tests/integration_tests/cpu/propagator/guided_navigator.cpp
@@ -82,7 +82,7 @@ GTEST_TEST(detray_navigation, guided_navigator) {
     propagator_t::state guided_state(track, b_field, telescope_det);
 
     // Propagate
-    p.propagate(guided_state, std::tie(pathlimit));
+    p.propagate(guided_state, detray::tie(pathlimit));
 
     auto &nav_state = guided_state._navigation;
     auto &debug_printer = nav_state.inspector().template get<print_inspector>();

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -476,7 +476,7 @@ bound_getter<algebra_type>::state evaluate_bound_param(
     bound_getter_state.m_min_path_length = detector_length * 0.75f;
     parameter_resetter<algebra_type>::state resetter_state{};
     auto actor_states =
-        std::tie(transporter_state, bound_getter_state, resetter_state);
+        detray::tie(transporter_state, bound_getter_state, resetter_state);
 
     // Init propagator states for the reference track
     typename propagator_t::state state(initial_param, field, det);
@@ -528,7 +528,7 @@ bound_param_vector_type get_displaced_bound_vector(
     bound_getter_state.m_min_path_length = detector_length * 0.75f;
 
     auto actor_states =
-        std::tie(transporter_state, bound_getter_state, resetter_state);
+        detray::tie(transporter_state, bound_getter_state, resetter_state);
     dstate.set_particle(ptc);
     dstate._stepping
         .template set_constraint<detray::step::constraint::e_accuracy>(

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -229,14 +229,14 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
 
         // Create actor states tuples
         auto actor_states =
-            std::tie(helix_insp_state, unlimted_aborter_state,
-                     transporter_state, interactor_state, resetter_state);
+            detray::tie(helix_insp_state, unlimted_aborter_state,
+                        transporter_state, interactor_state, resetter_state);
         auto sync_actor_states =
-            std::tie(helix_insp_state, unlimted_aborter_state,
-                     transporter_state, interactor_state, resetter_state);
+            detray::tie(helix_insp_state, unlimted_aborter_state,
+                        transporter_state, interactor_state, resetter_state);
         auto lim_actor_states =
-            std::tie(helix_insp_state, pathlimit_aborter_state,
-                     transporter_state, interactor_state, resetter_state);
+            detray::tie(helix_insp_state, pathlimit_aborter_state,
+                        transporter_state, interactor_state, resetter_state);
 
         // Init propagator states
         propagator_t::state state(track, bfield, det);
@@ -269,9 +269,9 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
         // Compare the navigation status vector between propagate and
         // propagate_sync function
         const auto nav_status =
-            std::get<helix_inspector::state&>(actor_states)._nav_status;
+            detray::get<helix_inspector::state&>(actor_states)._nav_status;
         const auto sync_nav_status =
-            std::get<helix_inspector::state&>(sync_actor_states)._nav_status;
+            detray::get<helix_inspector::state&>(sync_actor_states)._nav_status;
         ASSERT_TRUE(nav_status.size() > 0);
         ASSERT_TRUE(nav_status == sync_nav_status);
     }
@@ -324,11 +324,12 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
         parameter_resetter<algebra_t>::state resetter_state{};
 
         // Create actor states tuples
-        auto actor_states = std::tie(unlimted_aborter_state, transporter_state,
-                                     interactor_state, resetter_state);
+        auto actor_states =
+            detray::tie(unlimted_aborter_state, transporter_state,
+                        interactor_state, resetter_state);
         auto lim_actor_states =
-            std::tie(pathlimit_aborter_state, transporter_state,
-                     interactor_state, resetter_state);
+            detray::tie(pathlimit_aborter_state, transporter_state,
+                        interactor_state, resetter_state);
 
         // Init propagator states
         propagator_t::state state(track, bfield, det);

--- a/tests/unit_tests/cpu/propagator/actor_chain.cpp
+++ b/tests/unit_tests/cpu/propagator/actor_chain.cpp
@@ -121,7 +121,7 @@ GTEST_TEST(detray_propagator, actor_chain) {
     print_actor::state printer_state{};
 
     // Aggregate actor states to be able to pass them through the chain
-    auto actor_states = std::tie(example_state, printer_state);
+    auto actor_states = detray::tie(example_state, printer_state);
 
     // Propagator state
     struct empty_prop_state {};

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -97,7 +97,7 @@ GTEST_TEST(detray_propagator, covariance_transport) {
     propagator_t::state propagation(bound_param0, det);
 
     // Run propagator
-    p.propagate(propagation, std::tie(bound_updater, rst));
+    p.propagate(propagation, detray::tie(bound_updater, rst));
 
     // Bound state after one turn propagation
     const auto& bound_param1 = propagation._stepping._bound_params;

--- a/utils/include/detray/detectors/build_telescope_detector.hpp
+++ b/utils/include/detray/detectors/build_telescope_detector.hpp
@@ -58,7 +58,7 @@ struct tel_det_config {
     template <
         typename... Args,
         std::enable_if_t<(std::is_same_v<Args, scalar> || ...), bool> = true>
-    tel_det_config(Args &&... args)
+    explicit tel_det_config(Args &&... args)
         : tel_det_config(mask<mask_shape_t>{0u, std::forward<Args>(args)...}) {}
 
     /// Mask of the test surfaces
@@ -172,8 +172,9 @@ template <typename mask_shape_t = rectangle2D,
           typename trajectory_t = detail::ray<ALGEBRA_PLUGIN<detray::scalar>>>
 inline auto build_telescope_detector(
     vecmem::memory_resource &resource,
-    const tel_det_config<mask_shape_t, trajectory_t> &cfg = {
-        20.f * unit<scalar>::mm, 20.f * unit<scalar>::mm}) {
+    const tel_det_config<mask_shape_t, trajectory_t> &cfg =
+        tel_det_config<mask_shape_t, trajectory_t>{20.f * unit<scalar>::mm,
+                                                   20.f * unit<scalar>::mm}) {
 
     using builder_t =
         detector_builder<telescope_metadata<mask_shape_t>, volume_builder>;

--- a/utils/include/detray/detectors/build_toy_detector.hpp
+++ b/utils/include/detray/detectors/build_toy_detector.hpp
@@ -566,7 +566,7 @@ inline void get_volume_extent(
     if (cfg.use_material_maps()) {
         // Retrieve the underlying portal factory
         auto decorator =
-            std::dynamic_pointer_cast<factory_decorator<detector_t>>(
+            std::dynamic_pointer_cast<const factory_decorator<detector_t>>(
                 sf_factory);
         cyl_factory =
             dynamic_cast<const cylinder_portal_generator<detector_t> *>(

--- a/utils/include/detray/detectors/factories/barrel_generator.hpp
+++ b/utils/include/detray/detectors/factories/barrel_generator.hpp
@@ -122,7 +122,7 @@ class barrel_generator final : public surface_factory_interface<detector_t> {
     /// This is a surface generator, no external surface data needed
     /// @{
     DETRAY_HOST
-    void clear() override{};
+    void clear() override{/*Do nothing*/};
     DETRAY_HOST
     void push_back(surface_data<detector_t> &&) override { /*Do nothing*/
     }

--- a/utils/include/detray/detectors/factories/endcap_generator.hpp
+++ b/utils/include/detray/detectors/factories/endcap_generator.hpp
@@ -152,7 +152,7 @@ class endcap_generator final : public surface_factory_interface<detector_t> {
     /// This is a surface generator, no external surface data needed
     /// @{
     DETRAY_HOST
-    void clear() override{};
+    void clear() override{/*Do nothing*/};
     DETRAY_HOST
     void push_back(surface_data<detector_t> &&) override { /*Do nothing*/
     }

--- a/utils/include/detray/simulation/event_generator/random_numbers.hpp
+++ b/utils/include/detray/simulation/event_generator/random_numbers.hpp
@@ -38,16 +38,16 @@ struct random_numbers {
 
     /// Different seed @param s for every instance
     DETRAY_HOST
-    random_numbers(seed_type s) : m_seeds{s}, m_engine{m_seeds} {}
+    explicit random_numbers(seed_type s) : m_seeds{s}, m_engine{m_seeds} {}
 
     /// More entropy in seeds from collection @param s
     DETRAY_HOST
-    random_numbers(const std::vector<seed_type>& s)
+    explicit random_numbers(const std::vector<seed_type>& s)
         : m_seeds{s.begin(), s.end()}, m_engine{m_seeds} {}
 
     /// Copy constructor
     DETRAY_HOST
-    random_numbers(random_numbers&& other)
+    random_numbers(random_numbers&& other) noexcept
         : m_engine(std::move(other.m_engine)) {}
 
     /// Generate random numbers in a given range

--- a/utils/include/detray/simulation/event_generator/random_track_generator.hpp
+++ b/utils/include/detray/simulation/event_generator/random_track_generator.hpp
@@ -145,7 +145,7 @@ class random_track_generator
 
     /// Construct from external configuration
     DETRAY_HOST_DEVICE
-    constexpr random_track_generator(const configuration& cfg)
+    explicit constexpr random_track_generator(const configuration& cfg)
         : m_gen{generator_t(cfg.seed())}, m_cfg(cfg) {}
 
     /// Paramtetrized constructor for quick construction of simple tasks
@@ -169,7 +169,7 @@ class random_track_generator
 
     /// Move constructor
     DETRAY_HOST_DEVICE
-    random_track_generator(random_track_generator&& other)
+    random_track_generator(random_track_generator&& other) noexcept
         : m_gen(std::move(other.m_gen)), m_cfg(std::move(other.m_cfg)) {}
 
     /// Access the configuration

--- a/utils/include/detray/simulation/event_generator/uniform_track_generator.hpp
+++ b/utils/include/detray/simulation/event_generator/uniform_track_generator.hpp
@@ -193,7 +193,7 @@ class uniform_track_generator
 
     /// Construct from external configuration @param cfg
     DETRAY_HOST_DEVICE
-    constexpr uniform_track_generator(configuration cfg)
+    explicit constexpr uniform_track_generator(configuration cfg)
         : m_gen{generator_t(cfg.seed())}, m_cfg{cfg} {}
 
     /// Paramtetrized constructor for quick construction of simple tasks
@@ -219,7 +219,7 @@ class uniform_track_generator
 
     /// Move constructor
     DETRAY_HOST_DEVICE
-    uniform_track_generator(uniform_track_generator&& other)
+    uniform_track_generator(uniform_track_generator&& other) noexcept
         : m_gen(std::move(other.m_gen)), m_cfg(std::move(other.m_cfg)) {}
 
     /// Copy assignment operator
@@ -227,6 +227,7 @@ class uniform_track_generator
     constexpr uniform_track_generator& operator=(
         const uniform_track_generator& other) {
         m_cfg = other.m_cfg;
+        m_gen = std::move(other.m_gen);
         return *this;
     }
 

--- a/utils/include/detray/simulation/random_scatterer.hpp
+++ b/utils/include/detray/simulation/random_scatterer.hpp
@@ -56,7 +56,7 @@ struct random_scatterer : actor {
         /// Constructor with seed
         ///
         /// @param sd the seed number
-        state(const uint_fast64_t sd = 0u) { generator.seed(sd); }
+        explicit state(const uint_fast64_t sd = 0u) { generator.seed(sd); }
 
         void set_seed(const uint_fast64_t sd) { generator.seed(sd); }
     };


### PR DESCRIPTION
Some general code cleanup:
- make protected member variables private and use getters and setter instead (better encapsulation -> less opportunity for derived classes to change data)
- add ```excplicit``` keyword to many constructors to prevent confusing implicit conversions
- correctly forward arguments that are universal references

This resulted in some further small refactoring:

In the propagator, I removed the universal reference completely, since the actor states are just a tuple of references and added an overload, which is easier to read. This meant, I had to use ```detray::tie```  and ```detray::get``` for the actor states.

In the multistore, I collapsed the copy and move versions of the insert methods to one implementation

For the ranges implementation I was finally able to remove all of the explicit copy/move constructor and assignment operators.