### PR TITLE
ref: Record the material steps in the material tracer

### DIFF
--- a/tests/include/detray/test/common/utils/step_tracer.hpp
+++ b/tests/include/detray/test/common/utils/step_tracer.hpp
@@ -49,15 +49,22 @@ struct step_tracer : actor {
         /// Construct the vector containers with a given resource
         /// @param resource
         DETRAY_HOST
-        state(vecmem::memory_resource& resource) : m_steps(&resource) {}
+        explicit state(vecmem::memory_resource& resource)
+            : m_steps(&resource) {}
 
         /// Construct from externally provided vector for the @param steps
         DETRAY_HOST_DEVICE
-        state(vector_t<step_data_t>&& steps) : m_steps(std::move(steps)) {}
+        explicit state(vector_t<step_data_t>&& steps)
+            : m_steps(std::move(steps)) {}
 
-        /// Access to the recorded path lengths of every step along the track
+        /// Access to the recorded step data of every step along the track -
+        /// const
         DETRAY_HOST_DEVICE
         const auto& get_step_data() const { return m_steps; }
+
+        /// Move the recorded step data out of the actor
+        DETRAY_HOST
+        auto&& release_step_data() && { return std::move(m_steps); }
 
         /// Collect the data at every step
         DETRAY_HOST_DEVICE

--- a/tests/include/detray/test/cpu/navigation_validation.hpp
+++ b/tests/include/detray/test/cpu/navigation_validation.hpp
@@ -143,9 +143,11 @@ class navigation_validation : public test::fixture_base<> {
             max_pT = std::max(max_pT, track.pT(q));
 
             // Run the propagation
-            auto [success, obj_tracer, mat_trace, nav_printer, step_printer] =
+            auto [success, obj_tracer, mat_trace, mat_steps, nav_printer,
+                  step_printer] =
                 navigation_validator::record_propagation<stepper_t>(
-                    m_gctx, m_det, m_cfg.propagation(), track, b_field);
+                    m_gctx, &m_host_mr, m_det, m_cfg.propagation(), track,
+                    b_field);
 
             if (success) {
                 // The navigator does not record the initial track position,
@@ -261,6 +263,8 @@ class navigation_validation : public test::fixture_base<> {
     config m_cfg;
     /// The geometry context to check
     typename detector_t::geometry_context m_gctx{};
+    /// Vecmem memory resource for the host allocations
+    vecmem::host_memory_resource m_host_mr{};
     /// The detector to be checked
     const detector_t &m_det;
     /// Volume names

--- a/tests/include/detray/test/cpu/navigation_validation.hpp
+++ b/tests/include/detray/test/cpu/navigation_validation.hpp
@@ -143,8 +143,8 @@ class navigation_validation : public test::fixture_base<> {
             max_pT = std::max(max_pT, track.pT(q));
 
             // Run the propagation
-            auto [success, obj_tracer, mat_trace, mat_steps, nav_printer,
-                  step_printer] =
+            auto [success, obj_tracer, step_trace, mat_record, mat_trace,
+                  nav_printer, step_printer] =
                 navigation_validator::record_propagation<stepper_t>(
                     m_gctx, &m_host_mr, m_det, m_cfg.propagation(), track,
                     b_field);
@@ -193,7 +193,7 @@ class navigation_validation : public test::fixture_base<> {
             }
 
             recorded_traces.push_back(std::move(obj_tracer.object_trace));
-            mat_records.push_back(mat_trace);
+            mat_records.push_back(mat_record);
 
             EXPECT_TRUE(success) << "INFO: Wrote navigation debugging data in: "
                                  << debug_file_name;

--- a/tests/include/detray/test/device/cuda/material_validation.cu
+++ b/tests/include/detray/test/device/cuda/material_validation.cu
@@ -83,7 +83,7 @@ __global__ void material_validation_kernel(
 
     // Record the accumulated material
     assert(mat_records.size() == tracks.size());
-    mat_records.at(trk_id) = mat_tracer_state.mat_record;
+    mat_records.at(trk_id) = mat_tracer_state.get_material_record();
 }
 
 /// Launch the device kernel

--- a/tests/include/detray/test/device/cuda/material_validation.hpp
+++ b/tests/include/detray/test/device/cuda/material_validation.hpp
@@ -39,7 +39,10 @@ void material_validation_device(
         free_track_parameters<typename detector_t::algebra_type>> &tracks_view,
     vecmem::data::vector_view<
         material_validator::material_record<typename detector_t::scalar_type>>
-        &mat_records_view);
+        &mat_records_view,
+    vecmem::data::jagged_vector_view<
+        material_validator::material_params<typename detector_t::scalar_type>>
+        &mat_steps_view);
 
 /// Prepare data for device material trace run
 struct run_material_validation {
@@ -51,14 +54,14 @@ struct run_material_validation {
         vecmem::memory_resource *host_mr, vecmem::memory_resource *dev_mr,
         const detector_t &det, const propagation::config &cfg,
         const vecmem::vector<
-            free_track_parameters<typename detector_t::algebra_type>> &tracks)
-        -> vecmem::vector<material_validator::material_record<
-            typename detector_t::scalar_type>> {
+            free_track_parameters<typename detector_t::algebra_type>> &tracks,
+        const std::vector<std::size_t> &capacities) {
 
         using scalar_t = typename detector_t::scalar_type;
         using track_t =
             free_track_parameters<typename detector_t::algebra_type>;
         using material_record_t = material_validator::material_record<scalar_t>;
+        using material_params_t = material_validator::material_params<scalar_t>;
 
         // Helper object for performing memory copies (to CUDA devices)
         vecmem::cuda::copy cuda_cpy;
@@ -79,15 +82,24 @@ struct run_material_validation {
         cuda_cpy.setup(mat_records_buffer);
         auto mat_records_view = vecmem::get_data(mat_records_buffer);
 
+        // Buffer for the material parameters at every surface per track
+        vecmem::data::jagged_vector_buffer<material_params_t> mat_steps_buffer(
+            capacities, *dev_mr, host_mr, vecmem::data::buffer_type::resizable);
+        cuda_cpy.setup(mat_steps_buffer);
+        auto mat_steps_view = vecmem::get_data(mat_steps_buffer);
+
         // Run the material tracing on device
-        material_validation_device<detector_t>(det_view, cfg, tracks_view,
-                                               mat_records_view);
+        material_validation_device<detector_t>(
+            det_view, cfg, tracks_view, mat_records_view, mat_steps_view);
 
         // Get the results back to the host and pass them on to be checked
         vecmem::vector<material_record_t> mat_records(host_mr);
         cuda_cpy(mat_records_buffer, mat_records);
 
-        return mat_records;
+        vecmem::jagged_vector<material_params_t> mat_steps(host_mr);
+        cuda_cpy(mat_steps_buffer, mat_steps);
+
+        return std::make_tuple(mat_records, mat_steps);
     }
 };
 

--- a/tests/include/detray/test/device/cuda/navigation_validation.cu
+++ b/tests/include/detray/test/device/cuda/navigation_validation.cu
@@ -123,7 +123,7 @@ __global__ void navigation_validation_kernel(
 
     // Record the accumulated material
     assert(truth_intersection_traces.size() == mat_records.size());
-    mat_records.at(trk_id) = mat_tracer_state.mat_record;
+    mat_records.at(trk_id) = mat_tracer_state.get_material_record();
 }
 
 /// Launch the device kernel

--- a/tests/include/detray/test/device/cuda/navigation_validation.cu
+++ b/tests/include/detray/test/device/cuda/navigation_validation.cu
@@ -24,7 +24,10 @@ __global__ void navigation_validation_kernel(
         recorded_intersections_view,
     vecmem::data::vector_view<
         material_validator::material_record<typename detector_t::scalar_type>>
-        mat_records_view) {
+        mat_records_view,
+    vecmem::data::jagged_vector_view<
+        material_validator::material_params<typename detector_t::scalar_type>>
+        mat_steps_view) {
 
     using detector_device_t =
         detector<typename detector_t::metadata, device_container_types>;
@@ -56,7 +59,8 @@ __global__ void navigation_validation_kernel(
                   object_tracer_t>;
 
     // Propagator with pathlimit aborter
-    using material_tracer_t = material_validator::material_tracer<scalar_t>;
+    using material_tracer_t =
+        material_validator::material_tracer<scalar_t, vecmem::device_vector>;
     using actor_chain_t =
         actor_chain<tuple, pathlimit_aborter, material_tracer_t>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
@@ -70,6 +74,9 @@ __global__ void navigation_validation_kernel(
         recorded_intersections(recorded_intersections_view);
     vecmem::device_vector<typename material_tracer_t::material_record_type>
         mat_records(mat_records_view);
+    vecmem::jagged_device_vector<
+        typename material_tracer_t::material_params_type>
+        mat_steps(mat_steps_view);
 
     // Check the memory setup
     assert(truth_intersection_traces.size() ==
@@ -84,7 +91,7 @@ __global__ void navigation_validation_kernel(
 
     // Create the actor states
     pathlimit_aborter::state aborter_state{cfg.stepping.path_limit};
-    typename material_tracer_t::state mat_tracer_state{};
+    typename material_tracer_t::state mat_tracer_state{mat_steps.at(trk_id)};
     auto actor_states = ::detray::tie(aborter_state, mat_tracer_state);
 
     // Get the initial track parameters
@@ -132,7 +139,10 @@ void navigation_validation_device(
         &recorded_intersections_view,
     vecmem::data::vector_view<
         material_validator::material_record<typename detector_t::scalar_type>>
-        &mat_records_view) {
+        &mat_records_view,
+    vecmem::data::jagged_vector_view<
+        material_validator::material_params<typename detector_t::scalar_type>>
+        &mat_steps_view) {
 
     constexpr int thread_dim = 2 * WARP_SIZE;
     int block_dim = truth_intersection_traces_view.size() / thread_dim + 1;
@@ -141,7 +151,7 @@ void navigation_validation_device(
     navigation_validation_kernel<bfield_t, detector_t, intersection_record_t>
         <<<block_dim, thread_dim>>>(
             det_view, cfg, field_data, truth_intersection_traces_view,
-            recorded_intersections_view, mat_records_view);
+            recorded_intersections_view, mat_records_view, mat_steps_view);
 
     // cuda error check
     DETRAY_CUDA_ERROR_CHECK(cudaGetLastError());
@@ -162,6 +172,8 @@ void navigation_validation_device(
             typename detray::intersection_record<                              \
                 detector<METADATA>>::intersection_type>> &,                    \
         vecmem::data::vector_view<material_validator::material_record<         \
+            typename detector<METADATA>::scalar_type>> &,                      \
+        vecmem::data::jagged_vector_view<material_validator::material_params<  \
             typename detector<METADATA>::scalar_type>> &);                     \
                                                                                \
     template void navigation_validation_device<                                \
@@ -175,6 +187,8 @@ void navigation_validation_device(
             typename detray::intersection_record<                              \
                 detector<METADATA>>::intersection_type>> &,                    \
         vecmem::data::vector_view<material_validator::material_record<         \
+            typename detector<METADATA>::scalar_type>> &,                      \
+        vecmem::data::jagged_vector_view<material_validator::material_params<  \
             typename detector<METADATA>::scalar_type>> &);
 
 DECLARE_NAVIGATION_VALIDATION(default_metadata)


### PR DESCRIPTION
Also record the material steps in the material tracer for host and device. For the device material tracer, the number of surfaces that are encountered per track is currently guessed, as this information is not available in that test.
 
The PR also adds the step tracer to the host-side ```record_propagation``` function, which now runs the object tracer, the step tracer and the material tracer. For the device-side propagation recording, the number of steps that each track takes has to be determined first, before the step tracer will be added there.