### PR TITLE
Update surface kernel to accept string_view.

### DIFF
--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -42,7 +42,7 @@ struct surface_kernels {
         DETRAY_HOST inline std::string operator()(const mask_group_t&,
                                                   const index_t&) const {
 
-            return mask_group_t::value_type::shape::name;
+            return std::string(mask_group_t::value_type::shape::name);
         }
     };
 

--- a/tests/unit_tests/cpu/geometry/tracking_surface.cpp
+++ b/tests/unit_tests/cpu/geometry/tracking_surface.cpp
@@ -112,6 +112,7 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
     ASSERT_EQ(disc.index(), 1u);
     ASSERT_EQ(disc.id(), surface_id::e_portal);
     ASSERT_EQ(disc.shape_id(), detector_t::masks::id::e_portal_ring2);
+    ASSERT_EQ(disc.shape_name(), "ring2D");
     ASSERT_FALSE(disc.is_sensitive());
     ASSERT_FALSE(disc.is_passive());
     ASSERT_TRUE(disc.is_portal());


### PR DESCRIPTION
I'm guessing this function was missed as part of #756, but essentially without the proposed change you get a compiler error due to the attempted automatic conversion between a `string_view` (from the surface) and a `string` that the function is attempting to return.

This just swaps that, and updates a unit test to catch it.
If you remove the fix and build the tests, you should be able to see the initial error.

I assume this is a fairly isolated change, but my knowledge of detray is as a user rather than developer, so hopefully I've not missed anything.