### PR TITLE
ref: Harmonize cmake warnings with ACTS and switch false warnings off

### DIFF
--- a/cmake/detray-compiler-options-cpp.cmake
+++ b/cmake/detray-compiler-options-cpp.cmake
@@ -30,6 +30,9 @@ if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR
    detray_add_flag(CMAKE_CXX_FLAGS "-Wextra")
    detray_add_flag(CMAKE_CXX_FLAGS "-Wshadow")
    detray_add_flag(CMAKE_CXX_FLAGS "-Wunused-local-typedefs")
+   detray_add_flag(CMAKE_CXX_FLAGS "-Wzero-as-null-pointer-constant")
+   detray_add_flag(CMAKE_CXX_FLAGS "-Wnull-dereference")
+   detray_add_flag(CMAKE_CXX_FLAGS "-Wold-style-cast")
    detray_add_flag(CMAKE_CXX_FLAGS "-pedantic")
    # No implicit single to double conversions from floating point literals
    detray_add_flag(CMAKE_CXX_FLAGS "-Wconversion")

--- a/core/include/detray/builders/detector_builder.hpp
+++ b/core/include/detray/builders/detector_builder.hpp
@@ -80,6 +80,7 @@ class detector_builder {
     DETRAY_HOST auto decorate(
         const volume_builder_interface<detector_type>* v_builder)
         -> builder_t* {
+        assert(v_builder != nullptr);
 
         return decorate<builder_t>(v_builder->vol_index());
     }

--- a/core/include/detray/builders/grid_builder.hpp
+++ b/core/include/detray/builders/grid_builder.hpp
@@ -40,10 +40,6 @@ class grid_builder : public volume_decorator<detector_t> {
     using detector_type = detector_t;
     using value_type = typename detector_type::surface_type;
 
-    /// Use the grid builder stand-alone
-    DETRAY_HOST
-    grid_builder() : volume_decorator<detector_t>(nullptr) {}
-
     /// Decorate a volume with a grid
     DETRAY_HOST
     explicit grid_builder(

--- a/core/include/detray/builders/grid_factory.hpp
+++ b/core/include/detray/builders/grid_factory.hpp
@@ -316,6 +316,7 @@ class grid_factory {
         constexpr auto e_z_axis = static_cast<dindex>(axes_t::label2);
 
         auto b_values = grid_bounds.values();
+
         // Overwrite the mask values if axis spans are provided
         if (!axis_spans[0UL].empty()) {
             assert(axis_spans[0UL].size() == 2UL);

--- a/core/include/detray/builders/material_map_builder.hpp
+++ b/core/include/detray/builders/material_map_builder.hpp
@@ -9,7 +9,6 @@
 
 // Project include(s).
 #include "detray/builders/bin_fillers.hpp"
-#include "detray/builders/grid_factory.hpp"
 #include "detray/builders/material_map_factory.hpp"
 #include "detray/builders/material_map_generator.hpp"
 #include "detray/builders/surface_factory_interface.hpp"

--- a/core/include/detray/builders/material_map_generator.hpp
+++ b/core/include/detray/builders/material_map_generator.hpp
@@ -12,6 +12,8 @@
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/geometry/detail/surface_kernels.hpp"
+#include "detray/geometry/shapes/cylinder2D.hpp"
+#include "detray/geometry/shapes/ring2D.hpp"
 #include "detray/materials/material.hpp"
 #include "detray/materials/material_slab.hpp"
 #include "detray/materials/predefined_materials.hpp"

--- a/core/include/detray/builders/surface_factory_interface.hpp
+++ b/core/include/detray/builders/surface_factory_interface.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -159,7 +159,9 @@ class factory_decorator : public surface_factory_interface<detector_t> {
     DETRAY_HOST
     explicit factory_decorator(
         std::unique_ptr<surface_factory_interface<detector_t>> factory)
-        : m_factory(std::move(factory)) {}
+        : m_factory(std::move(factory)) {
+        assert(m_factory != nullptr);
+    }
 
     /// @returns access to the underlying factory - const
     DETRAY_HOST

--- a/core/include/detray/builders/volume_builder_interface.hpp
+++ b/core/include/detray/builders/volume_builder_interface.hpp
@@ -112,7 +112,9 @@ class volume_decorator : public volume_builder_interface<detector_t> {
     DETRAY_HOST
     explicit volume_decorator(
         std::unique_ptr<volume_builder_interface<detector_t>> vol_builder)
-        : m_builder(std::move(vol_builder)) {}
+        : m_builder(std::move(vol_builder)) {
+        assert(m_builder != nullptr);
+    }
 
     DETRAY_HOST
     auto operator()() -> typename detector_t::volume_type & override {

--- a/io/include/detray/io/common/detail/grid_reader.hpp
+++ b/io/include/detray/io/common/detail/grid_reader.hpp
@@ -329,9 +329,11 @@ class grid_reader {
             using builder_t = grid_builder_t<detector_t, grid_t, bin_filler_t,
                                              grid_factory_type<grid_t>>;
 
-            auto v_builder =
+            auto vgr_builder =
                 det_builder.template decorate<builder_t>(volume_idx);
-            auto vgr_builder = dynamic_cast<builder_t *>(v_builder);
+            if (!vgr_builder) {
+                throw std::runtime_error("Grid decoration failed");
+            }
 
             // Initialize the grid axes
             std::vector<std::size_t> n_bins_per_axis{};

--- a/tests/benchmarks/cpu/benchmark_propagator.cpp
+++ b/tests/benchmarks/cpu/benchmark_propagator.cpp
@@ -6,7 +6,6 @@
  */
 
 // Project include(s).
-#include "detray/builders/grid_factory.hpp"
 #include "detray/definitions/detail/algebra.hpp"
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/indexing.hpp"

--- a/tests/include/detray/test/common/detail/register_checks.hpp
+++ b/tests/include/detray/test/common/detail/register_checks.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,9 @@
 // GTest include(s)
 #include <gtest/gtest.h>
 
+// System include(s)
+#include <source_location>
+
 namespace detray::detail {
 
 template <template <typename> class check_t, typename detector_t,
@@ -18,12 +21,21 @@ void register_checks(const detector_t &det,
                      const typename detector_t::name_map &vol_names,
                      const config_t &cfg = {},
                      const typename detector_t::geometry_context gctx = {}) {
-    ::testing::RegisterTest(
-        "detray_validation", cfg.name().c_str(), nullptr, cfg.name().c_str(),
-        __FILE__, __LINE__,
-        [&]() -> typename check_t<detector_t>::fixture_type * {
-            return new check_t<detector_t>(det, vol_names, cfg, gctx);
-        });
+
+    const char *test_name = cfg.name().c_str();
+    if (!test_name) {
+        throw std::invalid_argument("Invalid test name");
+    }
+
+    const std::source_location src_loc{};
+
+    ::testing::RegisterTest("detray_validation", test_name, nullptr, test_name,
+                            src_loc.file_name(), src_loc.line(),
+                            [&det, &vol_names, &cfg, &gctx]() ->
+                            typename check_t<detector_t>::fixture_type * {
+                                return new check_t<detector_t>(det, vol_names,
+                                                               cfg, gctx);
+                            });
 }
 
 }  // namespace detray::detail

--- a/tests/integration_tests/cpu/CMakeLists.txt
+++ b/tests/integration_tests/cpu/CMakeLists.txt
@@ -78,7 +78,7 @@ detray_add_integration_test(jacobian_validation
                             "propagator/jacobian_validation.cpp"
                             LINK_LIBRARIES GTest::gtest GTest::gtest_main 
                             Boost::program_options detray::test_common
-                            detray::core_array detray::utils)
+                            detray::core_array detray::utils detray::tools)
 
 set_tests_properties(detray_integration_test_jacobian_validation PROPERTIES DEPENDS
    "detray_unit_test_cpu;detray_unit_test_cpu_arraydetray_integration_test_telescope_detector")

--- a/tests/integration_tests/cpu/builders/homogeneous_material_builder.cpp
+++ b/tests/integration_tests/cpu/builders/homogeneous_material_builder.cpp
@@ -199,6 +199,8 @@ GTEST_TEST(detray_builders, detector_builder_with_material) {
         det_builder.template decorate<homogeneous_material_builder<detector_t>>(
             vbuilder->vol_index());
 
+    assert(mv_builder != nullptr);
+
     typename detector_t::point3_type t{0.f, 0.f, 20.f};
     mv_builder->add_volume_placement(t);
 

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -26,7 +26,7 @@
 #include <gtest/gtest.h>
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s).
 #include <filesystem>

--- a/tests/tools/include/detray/options/boost_program_options.hpp
+++ b/tests/tools/include/detray/options/boost_program_options.hpp
@@ -1,0 +1,15 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// This header is used to disable GCC warnings that occur in the boost program
+// options header (boost/program_options/detail/value_semantic.hpp)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#include <boost/program_options.hpp>
+#pragma GCC diagnostic pop

--- a/tests/tools/include/detray/options/detector_io_options.hpp
+++ b/tests/tools/include/detray/options/detector_io_options.hpp
@@ -13,7 +13,7 @@
 #include "detray/options/options_handling.hpp"
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <stdexcept>

--- a/tests/tools/include/detray/options/options_handling.hpp
+++ b/tests/tools/include/detray/options/options_handling.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <iostream>

--- a/tests/tools/include/detray/options/parse_options.hpp
+++ b/tests/tools/include/detray/options/parse_options.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s).
 #include <cstdlib>
@@ -31,6 +31,10 @@ auto parse_options(boost::program_options::options_description& desc, int argc,
                    char* argv[], CONFIGS&... cfgs) {
 
     static_assert(sizeof...(CONFIGS) > 0, "No commandline options configured");
+
+    if (!argv) {
+        throw std::invalid_argument("Invalid command line arguments passed");
+    }
 
     desc.add_options()("help", "Produce help message");
 

--- a/tests/tools/include/detray/options/propagation_options.hpp
+++ b/tests/tools/include/detray/options/propagation_options.hpp
@@ -12,11 +12,10 @@
 #include "detray/propagator/propagation_config.hpp"
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <stdexcept>
-#include <string>
 
 namespace detray::options {
 

--- a/tests/tools/include/detray/options/toy_detector_options.hpp
+++ b/tests/tools/include/detray/options/toy_detector_options.hpp
@@ -12,7 +12,7 @@
 #include "detray/options/options_handling.hpp"
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <stdexcept>

--- a/tests/tools/include/detray/options/track_generator_options.hpp
+++ b/tests/tools/include/detray/options/track_generator_options.hpp
@@ -13,7 +13,7 @@
 #include "detray/simulation/event_generator/uniform_track_generator_config.hpp"
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <stdexcept>

--- a/tests/tools/include/detray/options/wire_chamber_options.hpp
+++ b/tests/tools/include/detray/options/wire_chamber_options.hpp
@@ -12,7 +12,7 @@
 #include "detray/options/options_handling.hpp"
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <string>

--- a/tests/tools/src/cpu/detector_display.cpp
+++ b/tests/tools/src/cpu/detector_display.cpp
@@ -22,7 +22,7 @@
 #include "actsvg/core.hpp"
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <filesystem>
@@ -31,6 +31,7 @@
 #include <string>
 
 namespace po = boost::program_options;
+
 using namespace detray;
 
 int main(int argc, char** argv) {

--- a/tests/tools/src/cpu/detector_validation.cpp
+++ b/tests/tools/src/cpu/detector_validation.cpp
@@ -26,7 +26,7 @@
 #include <gtest/gtest.h>
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <sstream>
@@ -34,6 +34,7 @@
 #include <string>
 
 namespace po = boost::program_options;
+
 using namespace detray;
 
 int main(int argc, char** argv) {

--- a/tests/tools/src/cpu/generate_telescope_detector.cpp
+++ b/tests/tools/src/cpu/generate_telescope_detector.cpp
@@ -18,9 +18,10 @@
 #include <vecmem/memory/host_memory_resource.hpp>
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 namespace po = boost::program_options;
+
 using namespace detray;
 
 namespace {

--- a/tests/tools/src/cpu/generate_toy_detector.cpp
+++ b/tests/tools/src/cpu/generate_toy_detector.cpp
@@ -17,13 +17,13 @@
 #include <vecmem/memory/host_memory_resource.hpp>
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 namespace po = boost::program_options;
 
-int main(int argc, char **argv) {
+using namespace detray;
 
-    using namespace detray;
+int main(int argc, char **argv) {
 
     // Configuration
     detray::toy_det_config toy_cfg{};

--- a/tests/tools/src/cpu/generate_wire_chamber.cpp
+++ b/tests/tools/src/cpu/generate_wire_chamber.cpp
@@ -17,12 +17,13 @@
 #include <vecmem/memory/host_memory_resource.hpp>
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
+
+namespace po = boost::program_options;
+
+using namespace detray;
 
 int main(int argc, char **argv) {
-
-    namespace po = boost::program_options;
-    using namespace detray;
 
     // Options parsing
     po::options_description desc("\nWire chamber generation options");

--- a/tests/tools/src/cpu/material_validation.cpp
+++ b/tests/tools/src/cpu/material_validation.cpp
@@ -25,7 +25,7 @@
 #include <gtest/gtest.h>
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <sstream>
@@ -33,6 +33,7 @@
 #include <string>
 
 namespace po = boost::program_options;
+
 using namespace detray;
 
 int main(int argc, char **argv) {

--- a/tests/tools/src/cuda/detector_validation_cuda.cpp
+++ b/tests/tools/src/cuda/detector_validation_cuda.cpp
@@ -25,7 +25,7 @@
 #include <gtest/gtest.h>
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <sstream>
@@ -33,6 +33,7 @@
 #include <string>
 
 namespace po = boost::program_options;
+
 using namespace detray;
 
 int main(int argc, char** argv) {

--- a/tests/tools/src/cuda/material_validation_cuda.cpp
+++ b/tests/tools/src/cuda/material_validation_cuda.cpp
@@ -25,7 +25,7 @@
 #include <gtest/gtest.h>
 
 // Boost
-#include <boost/program_options.hpp>
+#include "detray/options/boost_program_options.hpp"
 
 // System include(s)
 #include <sstream>
@@ -33,6 +33,7 @@
 #include <string>
 
 namespace po = boost::program_options;
+
 using namespace detray;
 
 int main(int argc, char **argv) {

--- a/tests/unit_tests/cpu/builders/homogeneous_material_builder.cpp
+++ b/tests/unit_tests/cpu/builders/homogeneous_material_builder.cpp
@@ -42,7 +42,7 @@ constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
 }  // anonymous namespace
 
 /// Unittest: Test the construction of a collection of materials
-TEST(detray_builders, homogeneous_material_builder) {
+TEST(detray_builders, homogeneous_material_factory) {
 
     using transform3 = typename detector_t::transform3_type;
     using material_id = typename detector_t::materials::id;

--- a/utils/include/detray/detectors/build_telescope_detector.hpp
+++ b/utils/include/detray/detectors/build_telescope_detector.hpp
@@ -224,6 +224,10 @@ inline auto build_telescope_detector(
                 .template decorate<homogeneous_material_builder<detector_t>>(
                     v_builder);
 
+        if (!vm_builder) {
+            throw std::runtime_error("Surface material decoration failed");
+        }
+
         auto tel_mat_generator =
             std::make_shared<homogeneous_material_generator<detector_t>>(
                 std::move(tel_generator), cfg.material_config());
@@ -251,7 +255,11 @@ inline auto build_telescope_detector(
         auto full_v_builder = det_builder.template decorate<
             homogeneous_volume_material_builder<detector_t>>(vm_builder);
 
-        full_v_builder->set_material(cfg.volume_material());
+        if (full_v_builder) {
+            full_v_builder->set_material(cfg.volume_material());
+        } else {
+            throw std::runtime_error("Volume material decoration failed");
+        }
     }
 
     // Build and return the detector

--- a/utils/include/detray/detectors/build_toy_detector.hpp
+++ b/utils/include/detray/detectors/build_toy_detector.hpp
@@ -339,6 +339,10 @@ volume_builder_interface<detector_t> *decorate_material(
                     v_builder);
     }
 
+    if (!vm_builder) {
+        throw std::runtime_error("Material decoration failed");
+    }
+
     return vm_builder;
 }
 
@@ -508,8 +512,11 @@ inline void add_cylinder_grid(detector_builder_t &det_builder,
     const auto &barrel_cfg{cfg.barrel_config()};
     const scalar_t h_z{barrel_cfg.half_length()};
 
-    auto v_builder = det_builder.template decorate<grid_builder_t>(vol_index);
-    auto vgr_builder = dynamic_cast<grid_builder_t *>(v_builder);
+    auto vgr_builder = det_builder.template decorate<grid_builder_t>(vol_index);
+
+    if (!vgr_builder) {
+        throw std::runtime_error("Grid decoration failed");
+    }
 
     vgr_builder->set_type(detector_t::geo_obj_ids::e_sensitive);
     vgr_builder->init_grid(
@@ -540,8 +547,11 @@ inline void add_disc_grid(detector_builder_t &det_builder, toy_det_config &cfg,
     const scalar_t inner_r{cfg.beampipe_vol_radius()};
     const scalar_t outer_r{cfg.outer_radius()};
 
-    auto v_builder = det_builder.template decorate<grid_builder_t>(vol_index);
-    auto vgr_builder = dynamic_cast<grid_builder_t *>(v_builder);
+    auto vgr_builder = det_builder.template decorate<grid_builder_t>(vol_index);
+
+    if (!vgr_builder) {
+        throw std::runtime_error("Grid decoration failed");
+    }
 
     vgr_builder->set_type(detector_t::geo_obj_ids::e_sensitive);
     vgr_builder->init_grid(

--- a/utils/include/detray/detectors/create_wire_chamber.hpp
+++ b/utils/include/detray/detectors/create_wire_chamber.hpp
@@ -420,7 +420,11 @@ inline auto create_wire_chamber(vecmem::memory_resource &resource,
         using cyl_grid_t =
             typename detector_t::accelerator_container::template get_type<
                 grid_id>;
-        auto gbuilder = grid_builder<detector_t, cyl_grid_t>{};
+        // Empty volume builder as placeholder
+        auto vbuilder =
+            std::make_unique<volume_builder<detector_t>>(volume_id::e_cylinder);
+        auto gbuilder =
+            grid_builder<detector_t, cyl_grid_t>{std::move(vbuilder)};
 
         // The portal portals are at the end of the portal range by construction
         auto vol = tracking_volume{det, vol_desc};


### PR DESCRIPTION
Add missing warnings to detray so that they can be caught before integration into ACTS. One null-dereference warning that happens in a boost header gets ignored using pragmas