### PR TITLE
fix: Allow different track charges in navigation validation

### DIFF
--- a/core/include/detray/navigation/detail/helix.hpp
+++ b/core/include/detray/navigation/detail/helix.hpp
@@ -170,12 +170,6 @@ class helix {
     DETRAY_HOST_DEVICE
     scalar_type qop() const { return _qop; }
 
-    /// @return charge of helix
-    DETRAY_HOST_DEVICE
-    constexpr scalar_type charge() const {
-        return math::signbit(qop()) ? -1.f : 1.f;
-    }
-
     DETRAY_HOST_DEVICE
     auto b_field() const { return _mag_field; }
 

--- a/core/include/detray/navigation/detail/ray.hpp
+++ b/core/include/detray/navigation/detail/ray.hpp
@@ -67,9 +67,9 @@ class ray {
     /// @param dir new direction of the ray
     DETRAY_HOST_DEVICE void set_dir(vector3_type dir) { _dir = dir; }
 
-    /// @return charge 1
+    /// @returns the q over p value: Zero for ray
     DETRAY_HOST_DEVICE
-    constexpr scalar_type charge() const { return 1.f; }
+    constexpr scalar_type qop() const { return 0.f; }
 
     /// Print
     DETRAY_HOST

--- a/core/include/detray/tracks/bound_track_parameters.hpp
+++ b/core/include/detray/tracks/bound_track_parameters.hpp
@@ -217,6 +217,7 @@ struct bound_parameters_vector {
     DETRAY_HOST_DEVICE
     scalar_type pT(const scalar_type q) const {
         assert(qop() != 0.f);
+        assert(q * qop() > 0.f);
         return math::fabs(q / qop() * getter::perp(dir()));
     }
 
@@ -224,6 +225,7 @@ struct bound_parameters_vector {
     DETRAY_HOST_DEVICE
     scalar_type pz(const scalar_type q) const {
         assert(qop() != 0.f);
+        assert(q * qop() > 0.f);
         return math::fabs(q / qop() * dir()[2]);
     }
 

--- a/core/include/detray/tracks/free_track_parameters.hpp
+++ b/core/include/detray/tracks/free_track_parameters.hpp
@@ -169,6 +169,7 @@ struct free_parameters_vector {
     DETRAY_HOST_DEVICE
     scalar_type pT(const scalar_type q) const {
         assert(this->qop() != 0.f);
+        assert(q * qop() > 0.f);
         return math::fabs(q / this->qop() * getter::perp(this->dir()));
     }
 
@@ -176,6 +177,7 @@ struct free_parameters_vector {
     DETRAY_HOST_DEVICE
     scalar_type pz(const scalar_type q) const {
         assert(this->qop() != 0.f);
+        assert(q * qop() > 0.f);
         return math::fabs(q / this->qop() * this->dir()[2]);
     }
 

--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -113,19 +113,38 @@ namespace detail {
 /// Record of a surface intersection along a track
 template <typename intersetion_t>
 struct candidate_record {
-
     using algebra_type = typename intersetion_t::algebra_type;
     using scalar_type = dscalar<algebra_type>;
     using point3_type = dpoint3D<algebra_type>;
     using vector3_type = dvector3D<algebra_type>;
     using intersection_type = intersetion_t;
 
+    constexpr candidate_record() = default;
+
+    /// The particle charge is not known in the navigation, but might be
+    /// provided in a different context
+    DETRAY_HOST_DEVICE
+    constexpr candidate_record(
+        const point3_type &position, const vector3_type &direction,
+        const intersection_type &intr,
+        const scalar_type q = detray::detail::invalid_value<scalar_type>(),
+        const scalar_type p = detray::detail::invalid_value<scalar_type>())
+        : pos{position},
+          dir{direction},
+          intersection{intr},
+          charge{q},
+          p_mag{p} {}
+
     /// Current global track position
-    point3_type pos;
+    point3_type pos{};
     /// Current global track direction
-    vector3_type dir;
+    vector3_type dir{};
     /// The intersection result
-    intersetion_t intersection;
+    intersetion_t intersection{};
+    /// Charge hypothesis of the particle (invalid value if not known)
+    scalar_type charge{detray::detail::invalid_value<scalar_type>()};
+    /// Current momentum magnitude of the particle (invalid value if not known)
+    scalar_type p_mag{detray::detail::invalid_value<scalar_type>()};
 };
 
 }  // namespace detail

--- a/tests/include/detray/test/utils/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/utils/navigation_validation_utils.hpp
@@ -339,10 +339,11 @@ auto compare_traces(truth_trace_t &truth_trace,
 template <typename record_t>
 auto write_tracks(const std::string &track_param_file_name,
                   const dvector<dvector<record_t>> &intersection_traces) {
-    using track_param_t =
-        free_track_parameters<typename record_t::algebra_type>;
+    using algebra_t = typename record_t::algebra_type;
+    using scalar_t = dscalar<algebra_t>;
+    using track_param_t = free_track_parameters<algebra_t>;
 
-    std::vector<std::vector<track_param_t>> track_params{};
+    std::vector<std::vector<std::pair<scalar_t, track_param_t>>> track_params{};
 
     for (const auto &trace : intersection_traces) {
 
@@ -350,7 +351,9 @@ auto write_tracks(const std::string &track_param_file_name,
         track_params.back().reserve(trace.size());
 
         for (const auto &record : trace) {
-            track_params.back().push_back({record.pos, 0.f, record.dir, -1.f});
+            track_params.back().emplace_back(
+                record.charge,
+                track_param_t{record.pos, 0.f, record.dir, record.charge});
         }
     }
 


### PR DESCRIPTION
Even though the track generator can be configured with any charge, the navigation validation can only be run with q=1 to avoid possible inconsistencies when the trace data is dumped into csv files. This has been fixed by passing the charge as an additional parameter. 

Additionally, the ```charge``` getters have been removed from the test trajectories (helix and ray), because it is actually unknown there and should not be guessed to be one.