### PR TITLE
ref: speedup device CI builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 build_cuda:
   tags: [docker]
   stage: build
-  image: gitlab-registry.cern.ch/acts/machines/ubuntu2204_cuda:latest
+  image: ghcr.io/acts-project/ubuntu2204_cuda:56
   artifacts:
     paths:
       - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ build_cuda:
         -DDETRAY_BUILD_TUTORIALS=ON
         -DDETRAY_BUILD_HOST=OFF
         -DDETRAY_FAIL_ON_WARNINGS=ON
-      - cmake --build build
+      - cmake --build build -- -j 2
 
 
 test_cuda:


### PR DESCRIPTION
Go back to old docker image source, and instead add multithreaded CUDA ci-bridge build.