### PR TITLE
Remove the member variable of `jac_to_global` from base stepper

### DIFF
--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -21,7 +21,28 @@ struct parameter_transporter : actor {
 
     struct state {};
 
-    /// Mask store visitor
+    /// bound to free jacobian from previous surface
+    struct bound_to_free_jacobian_kernel {
+
+        // Transformation matching this struct
+        using transform3_type = dtransform3D<algebra_t>;
+
+        template <typename mask_group_t, typename index_t,
+                  typename propagator_state_t>
+        DETRAY_HOST_DEVICE inline bound_to_free_matrix<algebra_t> operator()(
+            const mask_group_t& mask_group, const index_t& index,
+            const transform3_type& trf3, propagator_state_t& propagation) {
+
+            using frame_t = typename mask_group_t::value_type::shape::
+                template local_frame_type<algebra_t>;
+
+            using jacobian_engine_t = detail::jacobian_engine<frame_t>;
+
+            return jacobian_engine_t::bound_to_free_jacobian(
+                trf3, mask_group[index], propagation._stepping._bound_params);
+        }
+    };
+
     struct kernel {
 
         /// @name Type definitions for the struct
@@ -43,7 +64,9 @@ struct parameter_transporter : actor {
                   typename propagator_state_t>
         DETRAY_HOST_DEVICE inline void operator()(
             const mask_group_t& /*mask_group*/, const index_t& /*index*/,
-            const transform3_type& trf3, propagator_state_t& propagation) {
+            const transform3_type& trf3,
+            const bound_to_free_matrix<algebra_t>& bound_to_free_jacobian,
+            propagator_state_t& propagation) {
 
             using frame_t = typename mask_group_t::value_type::shape::
                 template local_frame_type<algebra_t>;
@@ -51,8 +74,6 @@ struct parameter_transporter : actor {
             using jacobian_engine_t = detail::jacobian_engine<frame_t>;
 
             using bound_matrix_t = bound_matrix<algebra_t>;
-            using bound_to_free_matrix_t =
-                typename jacobian_engine_t::bound_to_free_matrix_type;
 
             using free_matrix_t = free_matrix<algebra_t>;
             using free_to_bound_matrix_t =
@@ -85,10 +106,6 @@ struct parameter_transporter : actor {
                     .template identity<e_free_size, e_free_size>() +
                 path_correction;
 
-            // Bound to free jacobian at the departure surface
-            const bound_to_free_matrix_t& bound_to_free_jacobian =
-                stepping._jac_to_global;
-
             stepping._full_jacobian = free_to_bound_jacobian * correction_term *
                                       free_transport_jacobian *
                                       bound_to_free_jacobian;
@@ -105,6 +122,7 @@ struct parameter_transporter : actor {
     template <typename propagator_state_t>
     DETRAY_HOST_DEVICE void operator()(state& /*actor_state*/,
                                        propagator_state_t& propagation) const {
+        auto& stepping = propagation._stepping;
         const auto& navigation = propagation._navigation;
 
         // Do covariance transport when the track is on surface
@@ -113,17 +131,33 @@ struct parameter_transporter : actor {
             return;
         }
 
-        using geo_cxt_t =
-            typename propagator_state_t::detector_type::geometry_context;
+        using matrix_operator = dmatrix_operator<algebra_t>;
+        using detector_type = typename propagator_state_t::detector_type;
+        using geo_cxt_t = typename detector_type::geometry_context;
         const geo_cxt_t ctx{};
 
-        // Surface
+        // Current Surface
         const auto sf = navigation.get_surface();
 
-        sf.template visit_mask<kernel>(sf.transform(ctx), propagation);
+        bound_to_free_matrix<algebra_t> bound_to_free_jacobian =
+            matrix_operator().template zero<e_free_size, e_bound_size>();
+
+        if (stepping._prev_sf_id != detail::invalid_value<dindex>()) {
+
+            // Previous surface
+            tracking_surface<detector_type> prev_sf{navigation.detector(),
+                                                    stepping._prev_sf_id};
+
+            bound_to_free_jacobian =
+                prev_sf.template visit_mask<bound_to_free_jacobian_kernel>(
+                    prev_sf.transform(ctx), propagation);
+        }
+
+        sf.template visit_mask<kernel>(sf.transform(ctx),
+                                       bound_to_free_jacobian, propagation);
 
         // Set surface link
-        propagation._stepping._bound_params.set_surface_link(sf.barcode());
+        stepping._bound_params.set_surface_link(sf.barcode());
     }
 };  // namespace detray
 


### PR DESCRIPTION
This also gives some boost in the event throughput

```
Main

CUDA unsync propagation/8   34369115636 ns   34355170928 ns            1 TracksPropagated=1.86289/s
CUDA unsync propagation/16     3289075 ns      3288918 ns          200 TracksPropagated=77.8371k/s
CUDA unsync propagation/32     4034031 ns      4033801 ns          173 TracksPropagated=253.855k/s
CUDA unsync propagation/64     5552317 ns      5552233 ns          124 TracksPropagated=737.721k/s
CUDA unsync propagation/128   12789134 ns     12789108 ns           54 TracksPropagated=1.28109M/s
CUDA unsync propagation/256   45228177 ns     45226861 ns           16 TracksPropagated=1.44905M/s
CUDA sync propagation/8        2092650 ns      2092419 ns          331 TracksPropagated=30.5866k/s
CUDA sync propagation/16       3308820 ns      3308826 ns          214 TracksPropagated=77.3688k/s
CUDA sync propagation/32       4082296 ns      4081955 ns          171 TracksPropagated=250.86k/s
CUDA sync propagation/64       5606346 ns      5606231 ns          123 TracksPropagated=730.616k/s
CUDA sync propagation/128     12890556 ns     12890330 ns           54 TracksPropagated=1.27103M/s
CUDA sync propagation/256     45122773 ns     45121536 ns           16 TracksPropagated=1.45243M/s

PR

CUDA unsync propagation/8   34369514205 ns   34366671308 ns            1 TracksPropagated=1.86227/s
CUDA unsync propagation/16     3150501 ns      3150404 ns          183 TracksPropagated=81.2594k/s
CUDA unsync propagation/32     3881827 ns      3881778 ns          180 TracksPropagated=263.797k/s
CUDA unsync propagation/64     4972935 ns      4972827 ns          139 TracksPropagated=823.676k/s
CUDA unsync propagation/128   11461089 ns     11460440 ns           60 TracksPropagated=1.42961M/s
CUDA unsync propagation/256   40707142 ns     40704544 ns           17 TracksPropagated=1.61004M/s
CUDA sync propagation/8        2017469 ns      2017485 ns          344 TracksPropagated=31.7227k/s
CUDA sync propagation/16       3198663 ns      3198392 ns          221 TracksPropagated=80.0402k/s
CUDA sync propagation/32       3917954 ns      3917836 ns          178 TracksPropagated=261.369k/s
CUDA sync propagation/64       4996937 ns      4996657 ns          138 TracksPropagated=819.748k/s
CUDA sync propagation/128     11514485 ns     11514296 ns           60 TracksPropagated=1.42293M/s
CUDA sync propagation/256     40804114 ns     40800854 ns           17 TracksPropagated=1.60624M/s
```