### PR TITLE
Make ACTSVG setup CMake variable less Explicit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,12 +128,10 @@ if( DETRAY_SETUP_ALGEBRA_PLUGINS )
 endif()
 
 # Set up ACTSVG for displaying
-option( DETRAY_SETUP_ACTSVG
-   "Set up the actsvg target(s) explicitly" ${DETRAY_SVG_DISPLAY} )
 option( DETRAY_USE_SYSTEM_ACTSVG
    "Pick up an existing installation of actsvg from the build environment"
    ${DETRAY_USE_SYSTEM_LIBS} )
-if( DETRAY_SETUP_ACTSVG )
+if ( DETRAY_SVG_DISPLAY )
    if( DETRAY_USE_SYSTEM_ACTSVG )
       find_package( actsvg REQUIRED COMPONENTS core meta )
    else()


### PR DESCRIPTION
It seems there is an UB in CMake config.

```
cmake ../detray -DDETRAY_BUILD_CUDA=ON -DCMAKE_BUILD_TYPE=Release
cmake ../detray -DDETRAY_BUILD_BENCHMARKS=ON
```
The first command runs OK but when I run the second one right after the first one I see the following error:

```
-- Detecting CUDA compile features - done
-- Configuring done (8.6s)
CMake Error at plugins/svgtools/CMakeLists.txt:17 (target_link_libraries):
  The link interface of target "detray_svgtools" contains:

    actsvg::core

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.



-- Generating done (0.6s)
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

I think it is because the `set` commmand does not use `CACHE`