### PR TITLE
fix: Remove compiler/linker warnings

### DIFF
--- a/core/include/detray/builders/grid_builder.hpp
+++ b/core/include/detray/builders/grid_builder.hpp
@@ -82,7 +82,7 @@ class grid_builder : public volume_decorator<detector_t> {
         const std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
             &bin_capacities = {},
         const std::array<std::vector<scalar_type>, grid_t::dim> &ax_bin_edges =
-            {{}}) {
+            std::array<std::vector<scalar_type>, grid_t::dim>()) {
 
         static_assert(
             std::is_same_v<typename grid_shape_t::template local_frame_type<
@@ -100,7 +100,8 @@ class grid_builder : public volume_decorator<detector_t> {
         const std::vector<std::size_t> &n_bins,
         const std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
             &bin_capacities = {},
-        const std::vector<std::vector<scalar_type>> &ax_bin_edges = {{}}) {
+        const std::vector<std::vector<scalar_type>> &ax_bin_edges =
+            std::vector<std::vector<scalar_type>>()) {
 
         m_grid = m_factory.template new_grid<grid_t>(
             spans, n_bins, bin_capacities, ax_bin_edges);

--- a/core/include/detray/builders/grid_factory.hpp
+++ b/core/include/detray/builders/grid_factory.hpp
@@ -81,14 +81,14 @@ class grid_factory {
         typename phi_binning = axis::regular<host_container_types, scalar_type>,
         std::enable_if_t<std::is_enum_v<decltype(r_bounds::label)>, bool> =
             true>
-    auto new_grid(
-        const mask<annulus2D> &grid_bounds,
-        const std::array<std::size_t, 2UL> n_bins,
-        const std::vector<std::pair<loc_bin_index<annulus2D>, dindex>>
-            &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {{}},
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans = {
-            {}}) const {
+    auto new_grid(const mask<annulus2D> &grid_bounds,
+                  const std::array<std::size_t, 2UL> n_bins,
+                  const std::vector<std::pair<loc_bin_index<annulus2D>, dindex>>
+                      &bin_capacities = {},
+                  const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
+                      std::array<std::vector<scalar_type>, 2UL>(),
+                  const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
+                      std::array<std::vector<scalar_type>, 2UL>()) const {
 
         static_assert(
             std::is_same_v<phi_bounds, axis::circular<>>,
@@ -140,14 +140,14 @@ class grid_factory {
         typename z_binning = axis::regular<host_container_types, scalar_type>,
         std::enable_if_t<std::is_enum_v<decltype(x_bounds::label)>, bool> =
             true>
-    auto new_grid(
-        const mask<cuboid3D> &grid_bounds,
-        const std::array<std::size_t, 3UL> n_bins,
-        const std::vector<std::pair<loc_bin_index<cuboid3D>, dindex>>
-            &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 3UL> &bin_edges = {{}},
-        const std::array<std::vector<scalar_type>, 3UL> &axis_spans = {
-            {}}) const {
+    auto new_grid(const mask<cuboid3D> &grid_bounds,
+                  const std::array<std::size_t, 3UL> n_bins,
+                  const std::vector<std::pair<loc_bin_index<cuboid3D>, dindex>>
+                      &bin_capacities = {},
+                  const std::array<std::vector<scalar_type>, 3UL> &bin_edges =
+                      std::array<std::vector<scalar_type>, 3UL>(),
+                  const std::array<std::vector<scalar_type>, 3UL> &axis_spans =
+                      std::array<std::vector<scalar_type>, 3UL>()) const {
         // Axes boundaries and local indices
         using boundary = cuboid3D::boundaries;
         using axes_t = axes<cuboid3D>::template type<algebra_t>;
@@ -202,9 +202,10 @@ class grid_factory {
         const std::array<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<cylinder2D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {{}},
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans = {
-            {}}) const {
+        const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
+            std::array<std::vector<scalar_type>, 2UL>(),
+        const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
+            std::array<std::vector<scalar_type>, 2UL>()) const {
 
         static_assert(
             std::is_same_v<rphi_bounds, axis::circular<axis::label::e_rphi>>,
@@ -244,14 +245,15 @@ class grid_factory {
         typename z_binning = axis::regular<host_container_types, scalar_type>,
         std::enable_if_t<std::is_enum_v<decltype(rphi_bounds::label)>, bool> =
             true>
-    auto new_grid(
-        const mask<concentric_cylinder2D> &grid_bounds,
-        const std::array<std::size_t, 2UL> n_bins,
-        const std::vector<std::pair<loc_bin_index<concentric_cylinder2D>,
-                                    dindex>> &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {{}},
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans = {
-            {}}) const {
+    auto new_grid(const mask<concentric_cylinder2D> &grid_bounds,
+                  const std::array<std::size_t, 2UL> n_bins,
+                  const std::vector<
+                      std::pair<loc_bin_index<concentric_cylinder2D>, dindex>>
+                      &bin_capacities = {},
+                  const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
+                      std::array<std::vector<scalar_type>, 2UL>(),
+                  const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
+                      std::array<std::vector<scalar_type>, 2UL>()) const {
 
         static_assert(
             std::is_same_v<rphi_bounds, axis::circular<axis::label::e_rphi>>,
@@ -298,9 +300,10 @@ class grid_factory {
         const std::array<std::size_t, 3UL> n_bins,
         const std::vector<std::pair<loc_bin_index<cylinder3D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 3UL> &bin_edges = {{}},
-        const std::array<std::vector<scalar_type>, 3UL> &axis_spans = {
-            {}}) const {
+        const std::array<std::vector<scalar_type>, 3UL> &bin_edges =
+            std::array<std::vector<scalar_type>, 3UL>(),
+        const std::array<std::vector<scalar_type>, 3UL> &axis_spans =
+            std::array<std::vector<scalar_type>, 3UL>()) const {
 
         static_assert(
             std::is_same_v<phi_bounds, axis::circular<>>,
@@ -357,14 +360,14 @@ class grid_factory {
         typename phi_binning = axis::regular<host_container_types, scalar_type>,
         std::enable_if_t<std::is_enum_v<decltype(r_bounds::label)>, bool> =
             true>
-    auto new_grid(
-        const mask<ring2D> &grid_bounds,
-        const std::array<std::size_t, 2UL> n_bins,
-        const std::vector<std::pair<loc_bin_index<ring2D>, dindex>>
-            &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {{}},
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans = {
-            {}}) const {
+    auto new_grid(const mask<ring2D> &grid_bounds,
+                  const std::array<std::size_t, 2UL> n_bins,
+                  const std::vector<std::pair<loc_bin_index<ring2D>, dindex>>
+                      &bin_capacities = {},
+                  const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
+                      std::array<std::vector<scalar_type>, 2UL>(),
+                  const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
+                      std::array<std::vector<scalar_type>, 2UL>()) const {
 
         static_assert(std::is_same_v<phi_bounds, axis::circular<>>,
                       "Phi axis bounds need to be circular for ring shape");
@@ -409,9 +412,10 @@ class grid_factory {
         const std::array<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<rectangle2D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {{}},
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans = {
-            {}}) const {
+        const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
+            std::array<std::vector<scalar_type>, 2UL>(),
+        const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
+            std::array<std::vector<scalar_type>, 2UL>()) const {
         // Axes boundaries and local indices
         using boundary = rectangle2D::boundaries;
         using axes_t = axes<rectangle2D>::template type<algebra_t>;
@@ -455,9 +459,10 @@ class grid_factory {
         const std::array<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<trapezoid2D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges = {{}},
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans = {
-            {}}) const {
+        const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
+            std::array<std::vector<scalar_type>, 2UL>(),
+        const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
+            std::array<std::vector<scalar_type>, 2UL>()) const {
         // Axes boundaries and local indices
         using boundary = trapezoid2D::boundaries;
         using axes_t = axes<trapezoid2D>::template type<algebra_t>;

--- a/core/include/detray/geometry/mask.hpp
+++ b/core/include/detray/geometry/mask.hpp
@@ -60,7 +60,9 @@ class mask {
 
     /// Constructor from single mask boundary values @param args and
     /// volume link @param link
-    template <typename... Args>
+    template <typename... Args,
+              std::enable_if_t<(sizeof...(Args) == shape::boundaries::e_size),
+                               bool> = true>
     DETRAY_HOST_DEVICE explicit constexpr mask(const links_type& link,
                                                Args&&... args)
         : _values({{std::forward<Args>(args)...}}), _volume_link(link) {}

--- a/core/include/detray/utils/curvilinear_frame.hpp
+++ b/core/include/detray/utils/curvilinear_frame.hpp
@@ -47,8 +47,8 @@ struct curvilinear_frame {
             m_trf, mask<rectangle2D>{}, m_bound_vec);
     }
 
-    transform3_type m_trf;
-    bound_vector_type m_bound_vec;
+    transform3_type m_trf{};
+    bound_vector_type m_bound_vec{};
 
 };  // curvilinear frame
 

--- a/tests/include/detray/test/utils/prefill_detector.hpp
+++ b/tests/include/detray/test/utils/prefill_detector.hpp
@@ -70,7 +70,7 @@ void prefill_detector(detector_t& d,
     point3 t2{2.f, 0.f, 0.f};
     trfs.emplace_back(ctx, t2);
     masks.template emplace_back<mask_id::e_trapezoid2>(empty_ctx, 0u, 1.f, 2.f,
-                                                       3.f);
+                                                       3.f, 1.f / 6.f);
     materials.template emplace_back<material_id::e_rod>(
         empty_ctx, detray::aluminium<scalar_t>(), 4.f);
 

--- a/tests/unit_tests/cpu/core/mask_store.cpp
+++ b/tests/unit_tests/cpu/core/mask_store.cpp
@@ -69,7 +69,7 @@ GTEST_TEST(detray_core, static_mask_store) {
     store.emplace_back<mask_ids::e_cylinder3>(empty_context{}, 0u, 1.f, 1.5f,
                                               2.0f);
     store.emplace_back<mask_ids::e_trapezoid2>(empty_context{}, 0u, 0.5f, 1.5f,
-                                               4.0f);
+                                               4.0f, 1.f / 8.f);
     store.emplace_back<mask_ids::e_rectangle2>(empty_context{}, 0u, 1.0f, 2.0f);
     store.emplace_back<mask_ids::e_rectangle2>(empty_context{}, 0u, 2.0f, 1.0f);
     store.emplace_back<mask_ids::e_rectangle2>(empty_context{}, 0u, 10.0f,

--- a/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
@@ -104,7 +104,7 @@ GTEST_TEST(detray_intersection, intersection_kernel_ray) {
     mask_container_t mask_store(host_mr);
 
     const rectangle_t rect{0u, 10.f, 10.f};
-    const trapezoid_t trap{0u, 10.f, 20.f, 30.f};
+    const trapezoid_t trap{0u, 10.f, 20.f, 30.f, 1.f / 60.f};
     const annulus_t annl{0u, 15.f, 55.f, 0.75f, 1.95f, 0.f, 2.f, -2.f};
     const cylinder_t cyl{0u, 5.f, -10.f, 10.f};
     const cylinder_portal_t cyl_portal{0u, 1.f, 0.f, 1000.f};
@@ -244,7 +244,7 @@ GTEST_TEST(detray_intersection, intersection_kernel_helix) {
     mask_container_t mask_store(host_mr);
 
     const rectangle_t rect{0u, 10.f, 10.f};
-    const trapezoid_t trap{0u, 10.f, 20.f, 30.f};
+    const trapezoid_t trap{0u, 10.f, 20.f, 30.f, 1.f / 60.f};
     const annulus_t annl{0u, 15.f, 55.f, 0.75f, 1.95f, 0.f, 2.f, -2.f};
     mask_store.template push_back<e_rectangle2>(rect, empty_context{});
     mask_store.template push_back<e_trapezoid2>(trap, empty_context{});

--- a/tests/unit_tests/device/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda.cpp
@@ -35,7 +35,7 @@ TEST(mask_store_cuda, mask_store) {
 
     store.template emplace_back<e_rectangle2>(empty_context{}, 0u, 1.0f, 2.0f);
     store.template emplace_back<e_trapezoid2>(empty_context{}, 0u, 0.5f, 1.5f,
-                                              4.0f);
+                                              4.0f, 1.f / 8.f);
     store.template emplace_back<e_ring2>(empty_context{}, 0u, 1.0f, 10.0f);
     store.template emplace_back<e_cylinder2>(empty_context{}, 0u, 1.f, 0.5f,
                                              2.0f);

--- a/tests/unit_tests/svgtools/masks.cpp
+++ b/tests/unit_tests/svgtools/masks.cpp
@@ -82,7 +82,8 @@ GTEST_TEST(svgtools, masks) {
 
     // Visualize a 2D trapezoid.
     // e_half_length_0, e_half_length_1, e_half_length_2, e_divisor
-    detray::mask<detray::trapezoid2D> tra2D{0u, 100.f, 50.f, 200.f};
+    detray::mask<detray::trapezoid2D> tra2D{0u, 100.f, 50.f, 200.f,
+                                            1.f / 400.f};
     const auto tra2D_proto =
         detray::svgtools::conversion::surface(transform, tra2D);
     const auto tra2D_svg = actsvg::display::surface("", tra2D_proto, view);


### PR DESCRIPTION
Changes the default parameters in the grid builder infrastructure to circumvent a spurious null-dereference warning. Also mandates a certain number of value to initialize a mask, in order to remove is-uninitialized warnings (unsuccessfully). But it helped uncovering a few spots where trapezoid masks are not initialized corretly