### PR TITLE
Remove `_full_jacobian` from base stepper

### DIFF
--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -19,31 +19,14 @@ namespace detray {
 template <typename algebra_t>
 struct parameter_transporter : actor {
 
+    // Bound matrix type
+    using bound_matrix_t = bound_matrix<algebra_t>;
+    // Matrix actor
+    using matrix_operator = dmatrix_operator<algebra_t>;
+
     struct state {};
 
-    /// bound to free jacobian from previous surface
-    struct bound_to_free_jacobian_kernel {
-
-        // Transformation matching this struct
-        using transform3_type = dtransform3D<algebra_t>;
-
-        template <typename mask_group_t, typename index_t,
-                  typename propagator_state_t>
-        DETRAY_HOST_DEVICE inline bound_to_free_matrix<algebra_t> operator()(
-            const mask_group_t& mask_group, const index_t& index,
-            const transform3_type& trf3, propagator_state_t& propagation) {
-
-            using frame_t = typename mask_group_t::value_type::shape::
-                template local_frame_type<algebra_t>;
-
-            using jacobian_engine_t = detail::jacobian_engine<frame_t>;
-
-            return jacobian_engine_t::bound_to_free_jacobian(
-                trf3, mask_group[index], propagation._stepping._bound_params);
-        }
-    };
-
-    struct kernel {
+    struct full_jacobian_kernel {
 
         /// @name Type definitions for the struct
         /// @{
@@ -52,8 +35,6 @@ struct parameter_transporter : actor {
         using transform3_type = dtransform3D<algebra_t>;
         // scalar_type
         using scalar_type = dscalar<algebra_t>;
-        // Matrix actor
-        using matrix_operator = dmatrix_operator<algebra_t>;
         // 2D matrix type
         template <std::size_t ROWS, std::size_t COLS>
         using matrix_type = dmatrix<algebra_t, ROWS, COLS>;
@@ -62,7 +43,7 @@ struct parameter_transporter : actor {
 
         template <typename mask_group_t, typename index_t,
                   typename propagator_state_t>
-        DETRAY_HOST_DEVICE inline void operator()(
+        DETRAY_HOST_DEVICE inline bound_matrix_t operator()(
             const mask_group_t& /*mask_group*/, const index_t& /*index*/,
             const transform3_type& trf3,
             const bound_to_free_matrix<algebra_t>& bound_to_free_jacobian,
@@ -73,8 +54,6 @@ struct parameter_transporter : actor {
 
             using jacobian_engine_t = detail::jacobian_engine<frame_t>;
 
-            using bound_matrix_t = bound_matrix<algebra_t>;
-
             using free_matrix_t = free_matrix<algebra_t>;
             using free_to_bound_matrix_t =
                 typename jacobian_engine_t::free_to_bound_matrix_type;
@@ -84,10 +63,6 @@ struct parameter_transporter : actor {
 
             // Free vector
             const auto& free_params = stepping();
-
-            // Convert free to bound vector
-            stepping._bound_params.set_parameter_vector(
-                detail::free_to_bound_vector<frame_t>(trf3, free_params));
 
             // Free to bound jacobian at the destination surface
             const free_to_bound_matrix_t free_to_bound_jacobian =
@@ -106,32 +81,17 @@ struct parameter_transporter : actor {
                     .template identity<e_free_size, e_free_size>() +
                 path_correction;
 
-            stepping._full_jacobian = free_to_bound_jacobian * correction_term *
-                                      free_transport_jacobian *
-                                      bound_to_free_jacobian;
-
-            bound_matrix_t new_cov =
-                stepping._full_jacobian * stepping._bound_params.covariance() *
-                matrix_operator().transpose(stepping._full_jacobian);
-
-            // Calculate surface-to-surface covariance transport
-            stepping._bound_params.set_covariance(new_cov);
+            return free_to_bound_jacobian * correction_term *
+                   free_transport_jacobian * bound_to_free_jacobian;
         }
     };
 
     template <typename propagator_state_t>
-    DETRAY_HOST_DEVICE void operator()(state& /*actor_state*/,
-                                       propagator_state_t& propagation) const {
-        auto& stepping = propagation._stepping;
+    DETRAY_HOST_DEVICE inline bound_matrix_t get_full_jacobian(
+        propagator_state_t& propagation) const {
+        const auto& stepping = propagation._stepping;
         const auto& navigation = propagation._navigation;
 
-        // Do covariance transport when the track is on surface
-        if (!(navigation.is_on_sensitive() ||
-              navigation.encountered_sf_material())) {
-            return;
-        }
-
-        using matrix_operator = dmatrix_operator<algebra_t>;
         using detector_type = typename propagator_state_t::detector_type;
         using geo_cxt_t = typename detector_type::geometry_context;
         const geo_cxt_t ctx{};
@@ -148,16 +108,50 @@ struct parameter_transporter : actor {
             tracking_surface<detector_type> prev_sf{navigation.detector(),
                                                     stepping._prev_sf_id};
 
-            bound_to_free_jacobian =
-                prev_sf.template visit_mask<bound_to_free_jacobian_kernel>(
-                    prev_sf.transform(ctx), propagation);
+            bound_to_free_jacobian = prev_sf.bound_to_free_jacobian(
+                ctx, propagation._stepping._bound_params);
         }
 
-        sf.template visit_mask<kernel>(sf.transform(ctx),
-                                       bound_to_free_jacobian, propagation);
+        return sf.template visit_mask<full_jacobian_kernel>(
+            sf.transform(ctx), bound_to_free_jacobian, propagation);
+    }
+
+    template <typename propagator_state_t>
+    DETRAY_HOST_DEVICE void operator()(state& /*actor_state*/,
+                                       propagator_state_t& propagation) const {
+
+        using detector_type = typename propagator_state_t::detector_type;
+        using geo_cxt_t = typename detector_type::geometry_context;
+        const geo_cxt_t ctx{};
+
+        auto& stepping = propagation._stepping;
+        const auto& navigation = propagation._navigation;
+
+        // Do covariance transport when the track is on surface
+        if (!(navigation.is_on_sensitive() ||
+              navigation.encountered_sf_material())) {
+            return;
+        }
+
+        const bound_matrix_t full_jacobian = get_full_jacobian(propagation);
+
+        // Calculate surface-to-surface covariance transport
+        const bound_matrix_t new_cov =
+            full_jacobian * stepping._bound_params.covariance() *
+            matrix_operator().transpose(full_jacobian);
+
+        // Current surface
+        const auto sf = navigation.get_surface();
+
+        // Convert free to bound vector
+        stepping._bound_params.set_parameter_vector(
+            sf.free_to_bound_vector(ctx, stepping()));
+
+        stepping._bound_params.set_covariance(new_cov);
 
         // Set surface link
-        stepping._bound_params.set_surface_link(sf.barcode());
+        stepping._bound_params.set_surface_link(
+            navigation.get_surface().barcode());
     }
 };  // namespace detray
 

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -106,10 +106,6 @@ class base_stepper {
         /// free track parameter
         free_track_parameters_type _track;
 
-        /// Full jacobian
-        bound_matrix_type _full_jacobian =
-            matrix_operator().template identity<e_bound_size, e_bound_size>();
-
         /// jacobian transport matrix
         free_matrix_type _jac_transport =
             matrix_operator().template identity<e_free_size, e_free_size>();

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -437,7 +437,13 @@ struct bound_getter : actor {
             actor_state.m_path_length = stepping._path_length;
             actor_state.m_abs_path_length = stepping._abs_path_length;
             actor_state.m_param_destination = stepping._bound_params;
-            actor_state.m_jacobi = stepping._full_jacobian;
+
+            // Change the bound parameter to the initial state to calculate the
+            // full jacobian
+            propagation._stepping._bound_params = actor_state.m_param_departure;
+            actor_state.m_jacobi =
+                parameter_transporter<algebra_type>().get_full_jacobian(
+                    propagation);
 
             // Stop navigation if the destination surface found
             propagation._heartbeat &= navigation.exit();


### PR DESCRIPTION
The PR removes the _full_jacobian from the base stepper.
I had to split the parameter_transport operator into two functions to make it work with jacobian_validation test.


The performance is improved slightly:

Main

```
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
CUDA unsync propagation/8      2139250 ns      2139123 ns          266 TracksPropagated=29.9188k/s
CUDA unsync propagation/16     3162398 ns      3162309 ns          219 TracksPropagated=80.9535k/s
CUDA unsync propagation/32     3989859 ns      3989710 ns          174 TracksPropagated=256.66k/s
CUDA unsync propagation/64     5023091 ns      5022813 ns          138 TracksPropagated=815.479k/s
CUDA unsync propagation/128   11542654 ns     11541598 ns           60 TracksPropagated=1.41956M/s
CUDA unsync propagation/256   40331589 ns     40330407 ns           17 TracksPropagated=1.62498M/s
CUDA sync propagation/8        2103464 ns      2103411 ns          329 TracksPropagated=30.4268k/s
CUDA sync propagation/16       3188313 ns      3188082 ns          219 TracksPropagated=80.2991k/s
CUDA sync propagation/32       4018884 ns      4018790 ns          174 TracksPropagated=254.803k/s
CUDA sync propagation/64       5077063 ns      5076936 ns          135 TracksPropagated=806.786k/s
CUDA sync propagation/128     11621492 ns     11621185 ns           59 TracksPropagated=1.40984M/s
CUDA sync propagation/256     40868906 ns     40867001 ns           17 TracksPropagated=1.60364M/s
```

PR

```
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
CUDA unsync propagation/8   33818441294 ns   33815892218 ns            1 TracksPropagated=1.8926/s
CUDA unsync propagation/16     3093877 ns      3093738 ns          184 TracksPropagated=82.7478k/s
CUDA unsync propagation/32     3919884 ns      3919738 ns          177 TracksPropagated=261.242k/s
CUDA unsync propagation/64     4791991 ns      4791790 ns          142 TracksPropagated=854.795k/s
CUDA unsync propagation/128   11155984 ns     11155452 ns           63 TracksPropagated=1.4687M/s
CUDA unsync propagation/256   39361889 ns     39359983 ns           18 TracksPropagated=1.66504M/s
CUDA sync propagation/8        2065692 ns      2065608 ns          335 TracksPropagated=30.9836k/s
CUDA sync propagation/16       3111323 ns      3111089 ns          224 TracksPropagated=82.2863k/s
CUDA sync propagation/32       3969601 ns      3969425 ns          179 TracksPropagated=257.972k/s
CUDA sync propagation/64       4978605 ns      4978415 ns          139 TracksPropagated=822.752k/s
CUDA sync propagation/128     11225573 ns     11225494 ns           61 TracksPropagated=1.45953M/s
CUDA sync propagation/256     39701109 ns     39699952 ns           18 TracksPropagated=1.65078M/s
```