### PR TITLE
CI: Run debug unittests

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -107,6 +107,12 @@ jobs:
         cd build
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
         ctest --output-on-failure
+    - name: Unit Test
+      if: "matrix.BUILD_TYPE == 'Debug'"
+      run: |
+        cd build
+        source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
+        ctest -R detray_unit_test_. -E ._eigen --output-on-failure
 
   # Containerised build jobs.
   device-container:


### PR DESCRIPTION
Run the host unit tests in debug build in the CI. The integration tests are still not run, as it would likely take quite long. Furthermore, the Eigen builds are excluded from this, since they result in a timeout of the CI