### PR TITLE
Add back the full jacobian to the base stepper

### DIFF
--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -104,7 +104,7 @@ struct parameter_transporter : actor {
         // Current Surface
         const auto sf = navigation.get_surface();
 
-        // Covariance is transported only when the previous surface is the
+        // Covariance is transported only when the previous surface is an
         // actual tracking surface. (i.e. This disables the covariance transport
         // from curvilinear frame)
         if (stepping._prev_sf_id != detail::invalid_value<dindex>()) {
@@ -113,7 +113,7 @@ struct parameter_transporter : actor {
             tracking_surface<detector_type> prev_sf{navigation.detector(),
                                                     stepping._prev_sf_id};
 
-            bound_to_free_matrix<algebra_t> bound_to_free_jacobian =
+            const bound_to_free_matrix<algebra_t> bound_to_free_jacobian =
                 prev_sf.bound_to_free_jacobian(ctx, stepping._bound_params);
 
             stepping._full_jacobian =

--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -19,27 +19,25 @@ namespace detray {
 template <typename algebra_t>
 struct parameter_transporter : actor {
 
-    // Bound matrix type
-    using bound_matrix_t = bound_matrix<algebra_t>;
+    /// @name Type definitions for the struct
+    /// @{
+
+    // Transformation matching this struct
+    using transform3_type = dtransform3D<algebra_t>;
+    // scalar_type
+    using scalar_type = dscalar<algebra_t>;
     // Matrix actor
     using matrix_operator = dmatrix_operator<algebra_t>;
+    // 2D matrix type
+    template <std::size_t ROWS, std::size_t COLS>
+    using matrix_type = dmatrix<algebra_t, ROWS, COLS>;
+    // bound matrix type
+    using bound_matrix_t = bound_matrix<algebra_t>;
+    /// @}
 
     struct state {};
 
-    struct full_jacobian_kernel {
-
-        /// @name Type definitions for the struct
-        /// @{
-
-        // Transformation matching this struct
-        using transform3_type = dtransform3D<algebra_t>;
-        // scalar_type
-        using scalar_type = dscalar<algebra_t>;
-        // 2D matrix type
-        template <std::size_t ROWS, std::size_t COLS>
-        using matrix_type = dmatrix<algebra_t, ROWS, COLS>;
-
-        /// @}
+    struct get_full_jacobian_kernel {
 
         template <typename mask_group_t, typename index_t,
                   typename propagator_state_t>
@@ -47,7 +45,7 @@ struct parameter_transporter : actor {
             const mask_group_t& /*mask_group*/, const index_t& /*index*/,
             const transform3_type& trf3,
             const bound_to_free_matrix<algebra_t>& bound_to_free_jacobian,
-            propagator_state_t& propagation) {
+            const propagator_state_t& propagation) const {
 
             using frame_t = typename mask_group_t::value_type::shape::
                 template local_frame_type<algebra_t>;
@@ -69,7 +67,8 @@ struct parameter_transporter : actor {
                 jacobian_engine_t::free_to_bound_jacobian(trf3, free_params);
 
             // Transport jacobian in free coordinate
-            free_matrix_t& free_transport_jacobian = stepping._jac_transport;
+            const free_matrix_t& free_transport_jacobian =
+                stepping._jac_transport;
 
             // Path correction factor
             free_matrix_t path_correction = jacobian_engine_t::path_correction(
@@ -87,43 +86,8 @@ struct parameter_transporter : actor {
     };
 
     template <typename propagator_state_t>
-    DETRAY_HOST_DEVICE inline bound_matrix_t get_full_jacobian(
-        propagator_state_t& propagation) const {
-        const auto& stepping = propagation._stepping;
-        const auto& navigation = propagation._navigation;
-
-        using detector_type = typename propagator_state_t::detector_type;
-        using geo_cxt_t = typename detector_type::geometry_context;
-        const geo_cxt_t ctx{};
-
-        // Current Surface
-        const auto sf = navigation.get_surface();
-
-        bound_to_free_matrix<algebra_t> bound_to_free_jacobian =
-            matrix_operator().template zero<e_free_size, e_bound_size>();
-
-        if (stepping._prev_sf_id != detail::invalid_value<dindex>()) {
-
-            // Previous surface
-            tracking_surface<detector_type> prev_sf{navigation.detector(),
-                                                    stepping._prev_sf_id};
-
-            bound_to_free_jacobian = prev_sf.bound_to_free_jacobian(
-                ctx, propagation._stepping._bound_params);
-        }
-
-        return sf.template visit_mask<full_jacobian_kernel>(
-            sf.transform(ctx), bound_to_free_jacobian, propagation);
-    }
-
-    template <typename propagator_state_t>
     DETRAY_HOST_DEVICE void operator()(state& /*actor_state*/,
                                        propagator_state_t& propagation) const {
-
-        using detector_type = typename propagator_state_t::detector_type;
-        using geo_cxt_t = typename detector_type::geometry_context;
-        const geo_cxt_t ctx{};
-
         auto& stepping = propagation._stepping;
         const auto& navigation = propagation._navigation;
 
@@ -133,25 +97,44 @@ struct parameter_transporter : actor {
             return;
         }
 
-        const bound_matrix_t full_jacobian = get_full_jacobian(propagation);
+        using detector_type = typename propagator_state_t::detector_type;
+        using geo_cxt_t = typename detector_type::geometry_context;
+        const geo_cxt_t ctx{};
 
-        // Calculate surface-to-surface covariance transport
-        const bound_matrix_t new_cov =
-            full_jacobian * stepping._bound_params.covariance() *
-            matrix_operator().transpose(full_jacobian);
-
-        // Current surface
+        // Current Surface
         const auto sf = navigation.get_surface();
+
+        // Covariance is transported only when the previous surface is the
+        // actual tracking surface. (i.e. This disables the covariance transport
+        // from curvilinear frame)
+        if (stepping._prev_sf_id != detail::invalid_value<dindex>()) {
+
+            // Previous surface
+            tracking_surface<detector_type> prev_sf{navigation.detector(),
+                                                    stepping._prev_sf_id};
+
+            bound_to_free_matrix<algebra_t> bound_to_free_jacobian =
+                prev_sf.bound_to_free_jacobian(ctx, stepping._bound_params);
+
+            stepping._full_jacobian =
+                sf.template visit_mask<get_full_jacobian_kernel>(
+                    sf.transform(ctx), bound_to_free_jacobian, propagation);
+
+            // Calculate surface-to-surface covariance transport
+            const bound_matrix_t new_cov =
+                stepping._full_jacobian * stepping._bound_params.covariance() *
+                matrix_operator().transpose(stepping._full_jacobian);
+            stepping._bound_params.set_covariance(new_cov);
+        }
 
         // Convert free to bound vector
         stepping._bound_params.set_parameter_vector(
             sf.free_to_bound_vector(ctx, stepping()));
 
-        stepping._bound_params.set_covariance(new_cov);
-
         // Set surface link
-        stepping._bound_params.set_surface_link(
-            navigation.get_surface().barcode());
+        stepping._bound_params.set_surface_link(sf.barcode());
+
+        return;
     }
 };  // namespace detray
 

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -106,6 +106,10 @@ class base_stepper {
         /// free track parameter
         free_track_parameters_type _track;
 
+        /// Full jacobian
+        bound_matrix_type _full_jacobian =
+            matrix_operator().template identity<e_bound_size, e_bound_size>();
+
         /// jacobian transport matrix
         free_matrix_type _jac_transport =
             matrix_operator().template identity<e_free_size, e_free_size>();

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -437,13 +437,7 @@ struct bound_getter : actor {
             actor_state.m_path_length = stepping._path_length;
             actor_state.m_abs_path_length = stepping._abs_path_length;
             actor_state.m_param_destination = stepping._bound_params;
-
-            // Change the bound parameter to the initial state to calculate the
-            // full jacobian
-            propagation._stepping._bound_params = actor_state.m_param_departure;
-            actor_state.m_jacobi =
-                parameter_transporter<algebra_type>().get_full_jacobian(
-                    propagation);
+            actor_state.m_jacobi = stepping._full_jacobian;
 
             // Stop navigation if the destination surface found
             propagation._heartbeat &= navigation.exit();


### PR DESCRIPTION
I found that full jacobian is required in smoother in Kalman Fitter :skull_and_crossbones: 
Roll back #832
