### PR TITLE
ref: Use ranges algorithms

### DIFF
--- a/core/include/detray/builders/homogeneous_material_factory.hpp
+++ b/core/include/detray/builders/homogeneous_material_factory.hpp
@@ -19,7 +19,6 @@
 #include <cassert>
 #include <memory>
 #include <numeric>
-#include <ranges>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -98,12 +97,10 @@ class material_data {
     DETRAY_HOST
     void append(material_data &&other) {
         m_mat.reserve(m_mat.size() + other.m_mat.size());
-        std::ranges::move(other.m_mat.begin(), other.m_mat.end(),
-                          std::back_inserter(m_mat));
+        std::ranges::move(other.m_mat, std::back_inserter(m_mat));
 
         m_thickness.reserve(m_thickness.size() + other.m_thickness.size());
-        std::ranges::move(other.m_thickness.begin(), other.m_thickness.end(),
-                          std::back_inserter(m_thickness));
+        std::ranges::move(other.m_thickness, std::back_inserter(m_thickness));
     }
 
     /// Append new material
@@ -272,8 +269,8 @@ class homogeneous_material_factory final
         // If no concrete surface ordering was passed, use index sequence
         // and add the materials to the trailing elements in the surfaces cont.
         if (m_indices.empty() ||
-            std::find(m_indices.begin(), m_indices.end(),
-                      detail::invalid_value<std::size_t>()) !=
+            std::ranges::find(m_indices,
+                              detail::invalid_value<std::size_t>()) !=
                 m_indices.end()) {
             m_indices.resize(n_materials);
             std::iota(std::begin(m_indices), std::end(m_indices),
@@ -281,8 +278,7 @@ class homogeneous_material_factory final
         }
 
         // Correctly index the data in this factory
-        std::size_t sf_offset{
-            *std::min_element(m_indices.begin(), m_indices.end())};
+        std::size_t sf_offset{*std::ranges::min_element(m_indices)};
 
         // Add the material to the surfaces that the data links against
         for (auto [i, sf] : detray::views::pick(surfaces, m_indices)) {

--- a/core/include/detray/builders/material_map_factory.hpp
+++ b/core/include/detray/builders/material_map_factory.hpp
@@ -164,8 +164,8 @@ class material_map_factory final : public factory_decorator<detector_t> {
             // Copy the number of bins to the builder
             assert(m_n_bins.at(sf_idx).size() == N);
             n_bins[sf_idx] = {};
-            std::copy_n(m_n_bins.at(sf_idx).begin(), N,
-                        n_bins.at(sf_idx).begin());
+            std::ranges::copy_n(m_n_bins.at(sf_idx).begin(), N,
+                                n_bins.at(sf_idx).begin());
 
             // Copy the axis spans to the builder (if present)
             axis_spans[sf_idx] = std::array<std::vector<scalar_type>, N>{};

--- a/core/include/detray/builders/material_map_generator.hpp
+++ b/core/include/detray/builders/material_map_generator.hpp
@@ -230,7 +230,8 @@ class material_map_generator final : public factory_decorator<detector_t> {
             // Copy the number of bins to the builder
             assert(map_cfg.n_bins.size() == N);
             n_bins[sf_idx] = {};
-            std::copy_n(map_cfg.n_bins.begin(), N, n_bins.at(sf_idx).begin());
+            std::ranges::copy_n(map_cfg.n_bins.begin(), N,
+                                n_bins.at(sf_idx).begin());
 
             // Scale material thickness either over e.g. r- or z-bins
             const std::size_t bins = map_cfg.n_bins[map_cfg.axis_index];

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -221,7 +221,7 @@ class detector {
             _volume_finder.project(identity, p, identity.translation());
 
         // Only one entry per bin
-        dindex volume_index{*_volume_finder.search(loc_pos)};
+        dindex volume_index{_volume_finder.search(loc_pos).value()};
         return _volumes[volume_index];
     }
 
@@ -547,19 +547,6 @@ class detector {
     }
 
     ///------------------------------------------------------------------------
-
-    /// @returns the maximum number of surface candidates that any volume may
-    /// return.
-    DETRAY_HOST
-    inline auto n_max_candidates() const -> std::size_t {
-        std::vector<std::size_t> n_candidates;
-        n_candidates.reserve(_volumes.size());
-        for (const auto &vol : _volumes) {
-            n_candidates.push_back(
-                tracking_volume{*this, vol}.n_max_candidates());
-        }
-        return *std::max_element(n_candidates.begin(), n_candidates.end());
-    }
 
     private:
     /// Contains the detector sub-volumes.

--- a/core/include/detray/definitions/detail/algorithms.hpp
+++ b/core/include/detray/definitions/detail/algorithms.hpp
@@ -19,22 +19,25 @@
 namespace detray::detail {
 
 /// @brief sequential (single thread) sort function
-template <std::random_access_iterator RandomIt>
-DETRAY_HOST_DEVICE inline void sequential_sort(RandomIt first, RandomIt last) {
+template <std::random_access_iterator rand_iter_t,
+          std::sentinel_for<rand_iter_t> sentinel_t>
+DETRAY_HOST_DEVICE inline void sequential_sort(rand_iter_t first,
+                                               sentinel_t last) {
 #if defined(__CUDACC__) || defined(CL_SYCL_LANGUAGE_VERSION) || \
     defined(SYCL_LANGUAGE_VERSION)
     detray::selection_sort(first, last);
 #else
-    std::sort(first, last);
+    std::ranges::sort(first, last);
 #endif
 }
 
 /// @brief find_if implementation for host/devcie (single thread)
-template <std::random_access_iterator RandomIt, class Predicate>
-DETRAY_HOST_DEVICE inline auto find_if(RandomIt first, RandomIt last,
+template <std::random_access_iterator rand_iter_t,
+          std::sentinel_for<rand_iter_t> sentinel_t, class Predicate>
+DETRAY_HOST_DEVICE inline auto find_if(rand_iter_t first, sentinel_t last,
                                        Predicate&& comp) {
-    for (RandomIt i = first; i != last; ++i) {
-        if (comp(*i)) {
+    for (rand_iter_t i = first; i != last; ++i) {
+        if (std::forward<Predicate>(comp)(*i)) {
             return i;
         }
     }
@@ -43,26 +46,28 @@ DETRAY_HOST_DEVICE inline auto find_if(RandomIt first, RandomIt last,
 }
 
 /// @brief lower_bound implementation for host/device
-template <std::forward_iterator ForwardIt, typename Value>
-DETRAY_HOST_DEVICE inline auto lower_bound(ForwardIt first, ForwardIt last,
+template <std::forward_iterator forw_iter_t,
+          std::sentinel_for<forw_iter_t> sentinel_t, typename Value>
+DETRAY_HOST_DEVICE inline auto lower_bound(forw_iter_t first, sentinel_t last,
                                            const Value& value) {
 #if defined(__CUDACC__) || defined(CL_SYCL_LANGUAGE_VERSION) || \
     defined(SYCL_LANGUAGE_VERSION)
     return detray::lower_bound(first, last, value);
 #else
-    return std::lower_bound(first, last, value);
+    return std::ranges::lower_bound(first, last, value);
 #endif
 }
 
 /// @brief upper_bound implementation for host/device
-template <std::forward_iterator ForwardIt, typename Value>
-DETRAY_HOST_DEVICE inline auto upper_bound(ForwardIt first, ForwardIt last,
+template <std::forward_iterator forw_iter_t,
+          std::sentinel_for<forw_iter_t> sentinel_t, typename Value>
+DETRAY_HOST_DEVICE inline auto upper_bound(forw_iter_t first, sentinel_t last,
                                            const Value& value) {
 #if defined(__CUDACC__) || defined(CL_SYCL_LANGUAGE_VERSION) || \
     defined(SYCL_LANGUAGE_VERSION)
     return detray::upper_bound(first, last, value);
 #else
-    return std::upper_bound(first, last, value);
+    return std::ranges::upper_bound(first, last, value);
 #endif
 }
 

--- a/core/include/detray/geometry/tracking_volume.hpp
+++ b/core/include/detray/geometry/tracking_volume.hpp
@@ -244,7 +244,7 @@ class tracking_volume {
             return rg1[0] < rg2[0];
         };
 
-        std::sort(std::begin(sf_ranges), std::end(sf_ranges), compare_ranges);
+        std::ranges::sort(sf_ranges, compare_ranges);
 
         if ((sf_ranges.size() > 1 && sf_ranges[0][1] != sf_ranges[1][0]) ||
             (sf_ranges.size() > 2 && sf_ranges[1][1] != sf_ranges[2][0])) {

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -157,8 +157,7 @@ struct regular {
                                      nh_range[1] - nh_range[0] + 1u),
                                  nh_range[0]);
         dindex m = 0u;
-        std::for_each(sequence.begin(), sequence.end(),
-                      [&](auto &n) { n += m++; });
+        std::ranges::for_each(sequence, [&](auto &n) { n += m++; });
         return sequence;
     }
 
@@ -329,8 +328,7 @@ struct circular {
                                          nh_range[1] - nh_range[0] + 1u),
                                      nh_range[0]);
             dindex m = 0;
-            std::for_each(sequence.begin(), sequence.end(),
-                          [&](auto &n) { n += m++; });
+            std::ranges::for_each(sequence, [&](auto &n) { n += m++; });
             return sequence;
         }
         dindex vl =
@@ -339,7 +337,7 @@ struct circular {
         dindex mo = 0;
         dindex_sequence sequence(static_cast<dindex_sequence::size_type>(vl),
                                  nh_range[0]);
-        std::for_each(sequence.begin(), sequence.end(), [&](auto &n) {
+        std::ranges::for_each(sequence, [&](auto &n) {
             n += mi++;
             if (n > n_bins - 1u) {
                 n = mo++;
@@ -495,9 +493,8 @@ struct irregular {
      **/
     DETRAY_HOST_DEVICE
     dindex bin(scalar v) const {
-        int ibin = static_cast<int>(
-            std::lower_bound(boundaries.begin(), boundaries.end(), v) -
-            boundaries.begin());
+        auto ibin = static_cast<int>(std::ranges::lower_bound(boundaries, v) -
+                                     boundaries.begin());
         if (ibin > 0 && ibin < static_cast<int>(boundaries.size())) {
             return static_cast<dindex>(--ibin);
         } else {
@@ -561,8 +558,7 @@ struct irregular {
                                      nh_range[1] - nh_range[0] + 1u),
                                  nh_range[0]);
         dindex m = 0u;
-        std::for_each(sequence.begin(), sequence.end(),
-                      [&](auto &n) { n += m++; });
+        std::ranges::for_each(sequence, [&](auto &n) { n += m++; });
         return sequence;
     }
 

--- a/core/include/detray/grids/grid2.hpp
+++ b/core/include/detray/grids/grid2.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2020-2022 CERN for the benefit of the ACTS project
+ * (c) 2020-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,6 +15,9 @@
 // VecMem include(s).
 #include <vecmem/containers/data/buffer_type.hpp>
 #include <vecmem/memory/memory_resource.hpp>
+
+// System include(s)
+#include <algorithm>
 
 namespace detray {
 
@@ -124,8 +127,8 @@ class grid2 {
      *
      **/
     void shift(const typename populator_type::bare_value &offset) {
-        std::for_each(_data_serialized.begin(), _data_serialized.end(),
-                      [&](auto &ds) { _populator.shift(ds, offset); });
+        std::ranges::for_each(_data_serialized,
+                              [&](auto &ds) { _populator.shift(ds, offset); });
     }
 
     /** Fill/populate operation
@@ -282,7 +285,7 @@ class grid2 {
         }
 
         if (sort) {
-            std::sort(zone.begin(), zone.end());
+            std::ranges::sort(zone);
         }
         return zone;
     }

--- a/core/include/detray/grids/populator.hpp
+++ b/core/include/detray/grids/populator.hpp
@@ -176,8 +176,7 @@ struct complete_populator {
      **/
     DETRAY_HOST_DEVICE
     void shift(store_value &stored, const bare_value &offset) const {
-        std::for_each(stored.begin(), stored.end(),
-                      [&](auto &d) { d += offset; });
+        std::ranges::for_each(stored, [&](auto &d) { d += offset; });
     }
 
     /** Return an initialized bin value
@@ -234,7 +233,7 @@ struct attach_populator {
     void operator()(store_value &stored, bare_value &&bvalue) const {
         stored.push_back(std::move(bvalue));
         if (kSORT) {
-            std::sort(stored.begin(), stored.end());
+            std::ranges::sort(stored);
         }
     }
 
@@ -267,8 +266,7 @@ struct attach_populator {
      **/
     DETRAY_HOST_DEVICE
     void shift(store_value &stored, const bare_value &offset) const {
-        std::for_each(stored.begin(), stored.end(),
-                      [&](auto &d) { d += offset; });
+        std::ranges::for_each(stored, [&](auto &d) { d += offset; });
     }
 
     /** Return an initialized bin value

--- a/core/include/detray/materials/detail/material_accessor.hpp
+++ b/core/include/detray/materials/detail/material_accessor.hpp
@@ -36,7 +36,7 @@ requires detail::is_grid_v<typename material_coll_t::value_type>
             &loc_point) noexcept {
 
     // Find the material slab (only one entry per bin)
-    return *(material_coll[idx].search(loc_point));
+    return material_coll[idx].search(loc_point).ref();
 }
 
 }  // namespace detray::detail::material_accessor

--- a/core/include/detray/navigation/intersection/intersection.hpp
+++ b/core/include/detray/navigation/intersection/intersection.hpp
@@ -58,11 +58,20 @@ struct intersection2D {
     /// false = opposite)
     bool_t direction{true};
 
+    /// @note: Three way comparison cannot be used easily with SoA boolean masks
+    /// @{
     /// @param rhs is the right hand side intersection for comparison
     DETRAY_HOST_DEVICE
     friend constexpr bool_t operator<(const intersection2D &lhs,
                                       const intersection2D &rhs) noexcept {
         return (math::fabs(lhs.path) < math::fabs(rhs.path));
+    }
+
+    /// @param rhs is the right hand side intersection for comparison
+    DETRAY_HOST_DEVICE
+    friend constexpr bool_t operator<=(const intersection2D &lhs,
+                                       const intersection2D &rhs) noexcept {
+        return (math::fabs(lhs.path) <= math::fabs(rhs.path));
     }
 
     /// @param rhs is the left hand side intersection for comparison
@@ -71,6 +80,14 @@ struct intersection2D {
                                       const intersection2D &rhs) noexcept {
         return (math::fabs(lhs.path) > math::fabs(rhs.path));
     }
+
+    /// @param rhs is the left hand side intersection for comparison
+    DETRAY_HOST_DEVICE
+    friend constexpr bool_t operator>=(const intersection2D &lhs,
+                                       const intersection2D &rhs) noexcept {
+        return (math::fabs(lhs.path) > math::fabs(rhs.path));
+    }
+    /// @}
 
     /// @param rhs is the left hand side intersection for comparison
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/grid/detail/bin_storage.hpp
+++ b/core/include/detray/utils/grid/detail/bin_storage.hpp
@@ -246,6 +246,7 @@ class bin_storage<is_owning, detray::bins::dynamic_array<entry_t>, containers>
             std::conditional_t<std::is_same_v<bin_itr_t, const_bin_iterator_t>,
                                const entry_t*, entry_t*>;
 
+        /// Default constructor required by LegacyIterator trait
         constexpr iterator_adapter() = default;
 
         DETRAY_HOST_DEVICE
@@ -351,9 +352,9 @@ class bin_storage<is_owning, detray::bins::dynamic_array<entry_t>, containers>
         }
 
         /// Access to the bin content
-        data_ptr_t m_entry_data;
+        data_ptr_t m_entry_data{};
         /// Iterator over bin data from which to construct a bin instance
-        bin_itr_t m_itr;
+        bin_itr_t m_itr{};
     };
 
     public:

--- a/core/include/detray/utils/ranges/ranges.hpp
+++ b/core/include/detray/utils/ranges/ranges.hpp
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <concepts>
 #include <memory>
+#include <ranges>
 #include <type_traits>
 
 namespace detray::ranges {

--- a/core/include/detray/utils/ranges/single.hpp
+++ b/core/include/detray/utils/ranges/single.hpp
@@ -48,11 +48,13 @@ class single_view
 
     /// @return the single value
     DETRAY_HOST_DEVICE
-    constexpr auto operator*() const -> const value_t& { return m_value; }
+    constexpr auto value() const -> value_t { return m_value; }
 
     /// @return the single value
     DETRAY_HOST_DEVICE
-    constexpr auto operator*() -> value_t& { return m_value; }
+    constexpr auto ref() const -> const value_t& { return m_value; }
+    DETRAY_HOST_DEVICE
+    constexpr auto ref() -> value_t& { return m_value; }
 
     /// @returns value pointer.
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/sort.hpp
+++ b/core/include/detray/utils/sort.hpp
@@ -26,7 +26,7 @@ DETRAY_HOST_DEVICE inline void insertion_sort(RandomIt first, RandomIt last) {
         auto const insertion_point = detray::upper_bound(first, it, *it);
 
         // Shifting the unsorted part
-        std::rotate(insertion_point, it, it + 1);
+        std::ranges::rotate(insertion_point, it, it + 1);
     }
 }
 

--- a/io/include/detray/io/common/detail/grid_reader.hpp
+++ b/io/include/detray/io/common/detail/grid_reader.hpp
@@ -19,6 +19,7 @@
 #include "detray/utils/type_list.hpp"
 
 // System include(s)
+#include <algorithm>
 #include <queue>
 #include <stdexcept>
 #include <string>
@@ -340,8 +341,7 @@ class grid_reader {
             for (const auto &axis_data : grid_data.axes) {
                 n_bins_per_axis.push_back(axis_data.bins);
                 std::vector<scalar_t> edges{};
-                std::copy(axis_data.edges.begin(), axis_data.edges.end(),
-                          std::back_inserter(edges));
+                std::ranges::copy(axis_data.edges, std::back_inserter(edges));
                 ax_bin_edges.emplace_back(std::move(edges));
                 spans.push_back(static_cast<scalar_t>(axis_data.edges.front()));
                 spans.push_back(static_cast<scalar_t>(axis_data.edges.back()));

--- a/io/include/detray/io/common/detail/grid_writer.hpp
+++ b/io/include/detray/io/common/detail/grid_writer.hpp
@@ -71,8 +71,7 @@ class grid_writer {
             convert(gr.axes());
 
         grid_data.axes.resize(axes_data.size());
-        std::copy(std::cbegin(axes_data), std::cend(axes_data),
-                  std::begin(grid_data.axes));
+        std::ranges::copy(axes_data, std::begin(grid_data.axes));
 
         // Write the surface indices
         for (unsigned int gid = 0u; gid < gr.nbins(); ++gid) {
@@ -113,8 +112,7 @@ class grid_writer {
         } else {
             const auto& bin_edges = axis.bin_edges();
             axis_data.edges.resize(bin_edges.size());
-            std::copy(std::cbegin(bin_edges), std::cend(bin_edges),
-                      std::begin(axis_data.edges));
+            std::ranges::copy(bin_edges, std::begin(axis_data.edges));
         }
 
         return axis_data;

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -153,9 +153,8 @@ class geometry_reader {
 
         // Transcribe mask boundaries onto correct vector type
         std::vector<scalar_t> mask_boundaries;
-        std::copy(sf_data.mask.boundaries.begin(),
-                  sf_data.mask.boundaries.end(),
-                  std::back_inserter(mask_boundaries));
+        std::ranges::copy(sf_data.mask.boundaries,
+                          std::back_inserter(mask_boundaries));
 
         // If the concentric cylinder is shifted in z, discard the shift
         // and put it in the mask boundaries instead. Everything else

--- a/io/include/detray/io/common/geometry_writer.hpp
+++ b/io/include/detray/io/common/geometry_writer.hpp
@@ -95,8 +95,7 @@ class geometry_writer {
             detail::basic_converter::convert(m.volume_link());
 
         mask_data.boundaries.resize(mask_t::boundaries::e_size);
-        std::copy(std::cbegin(m.values()), std::cend(m.values()),
-                  std::begin(mask_data.boundaries));
+        std::ranges::copy(m.values(), std::begin(mask_data.boundaries));
 
         return mask_data;
     }

--- a/io/include/detray/io/frontend/detail/detector_components_writer.hpp
+++ b/io/include/detray/io/frontend/detail/detector_components_writer.hpp
@@ -58,10 +58,10 @@ class detector_components_writer final {
                "No writers registered! Need at least a geometry writer");
 
         // Call the write method on all optional writers
-        std::for_each(m_writers.begin(), m_writers.end(),
-                      [&det, &names, mode, &file_path](writer_ptr_t& writer) {
-                          writer->write(det, names, mode, file_path);
-                      });
+        std::ranges::for_each(
+            m_writers, [&det, &names, mode, &file_path](writer_ptr_t& writer) {
+                writer->write(det, names, mode, file_path);
+            });
     }
 
     private:

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
@@ -197,12 +197,12 @@ auto grid(const store_t& store, const link_t& link, const view_t& view,
         }
     }
 
-    std::transform(edges0.cbegin(), edges0.cend(),
-                   std::back_inserter(p_grid._edges_0),
-                   [](scalar_t v) { return static_cast<actsvg::scalar>(v); });
-    std::transform(edges1.cbegin(), edges1.cend(),
-                   std::back_inserter(p_grid._edges_1),
-                   [](scalar_t v) { return static_cast<actsvg::scalar>(v); });
+    std::ranges::transform(
+        edges0, std::back_inserter(p_grid._edges_0),
+        [](scalar_t v) { return static_cast<actsvg::scalar>(v); });
+    std::ranges::transform(
+        edges1, std::back_inserter(p_grid._edges_1),
+        [](scalar_t v) { return static_cast<actsvg::scalar>(v); });
 
     svgtools::styling::apply_style(p_grid, style);
 

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
@@ -33,8 +33,8 @@ inline void set_measures(
     auto cast_scalar = [](const typename mask_t::scalar_type& v) {
         return static_cast<actsvg::scalar>(v);
     };
-    std::transform(m.values().cbegin(), m.values().cend(),
-                   std::back_inserter(p_surface._measures), cast_scalar);
+    std::ranges::transform(m.values(), std::back_inserter(p_surface._measures),
+                           cast_scalar);
 }
 
 /// @brief Sets the vertices of the proto surface to be the same as the mask.

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
@@ -102,7 +102,7 @@ struct bin_association_getter {
                     }
 
                     // Remove duplicates
-                    std::sort(entries.begin(), entries.end());
+                    std::ranges::sort(entries);
                     auto last = std::unique(entries.begin(), entries.end());
                     entries.erase(last, entries.end());
 
@@ -162,8 +162,8 @@ auto surface_grid(const detector_t& detector, const dindex index,
 
     scalar_t cyl_ref_radius{0.f};
     if (!radii.empty()) {
-        scalar_t inner_r = *std::min_element(radii.begin(), radii.end());
-        scalar_t outer_r = *std::max_element(radii.begin(), radii.end());
+        scalar_t inner_r = *std::ranges::min_element(radii);
+        scalar_t outer_r = *std::ranges::max_element(radii);
 
         cyl_ref_radius = 0.5f * static_cast<actsvg::scalar>(inner_r + outer_r);
     }

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
@@ -107,7 +107,7 @@ struct material_converter {
                         bin_idx = {j, i};
                     }
 
-                    const auto& mat_slab = *(material_map.bin(bin_idx));
+                    const auto& mat_slab = material_map.bin(bin_idx).ref();
                     const auto& mat = mat_slab.get_material();
 
                     actsvg::proto::material_slab p_mat_slab;

--- a/plugins/svgtools/include/detray/plugins/svgtools/meta/display/tracking.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/meta/display/tracking.hpp
@@ -59,8 +59,8 @@ inline auto trajectory(
     auto change_view = [view](const point3_t& p) {
         return view(std::vector{p})[0];
     };
-    std::transform(p_trajectory._points.cbegin(), p_trajectory._points.cend(),
-                   std::back_inserter(points), change_view);
+    std::ranges::transform(p_trajectory._points, std::back_inserter(points),
+                           change_view);
     actsvg::svg::object ret;
     ret._tag = "g";
     ret._id = id;

--- a/tests/benchmarks/cpu/grid.cpp
+++ b/tests/benchmarks/cpu/grid.cpp
@@ -122,13 +122,13 @@ void BM_GRID_REGULAR_BIN_CAP1(benchmark::State &state) {
 
     for (auto _ : state) {
         for (const auto &p : points) {
-            benchmark::DoNotOptimize(*g2r.search(p));
+            benchmark::DoNotOptimize(g2r.search(p).value());
         }
     }
 
 #ifdef DETRAY_BENCHMARK_PRINTOUTS
     std::cout << "BM_GRID_REGULAR_BIN_CAP1:" << std::endl;
-    std::cout << *g2r.search(tp) << std::endl;
+    std::cout << g2r.search(p).value() << std::endl;
 #endif  // DETRAY_BENCHMARK_PRINTOUTS
 }
 
@@ -293,13 +293,13 @@ void BM_GRID_IRREGULAR_BIN_CAP1(benchmark::State &state) {
 
     for (auto _ : state) {
         for (const auto &p : points) {
-            benchmark::DoNotOptimize(*g2irr.search(p));
+            benchmark::DoNotOptimize(g2irr.search(p).value());
         }
     }
 
 #ifdef DETRAY_BENCHMARK_PRINTOUTS
     std::cout << "BM_GRID_IRREGULAR_BIN_CAP1:" << std::endl;
-    std::cout << *g2irr.search(tp) << std::endl;
+    std::cout << g2irr.search(tp).value() << std::endl;
 #endif  // DETRAY_BENCHMARK_PRINTOUTS
 }
 

--- a/tests/benchmarks/cpu/intersectors.cpp
+++ b/tests/benchmarks/cpu/intersectors.cpp
@@ -25,6 +25,9 @@
 // Google Benchmark include(s)
 #include <benchmark/benchmark.h>
 
+// System include(s)
+#include <algorithm>
+
 using namespace detray;
 
 static constexpr unsigned int theta_steps{2000u};
@@ -68,8 +71,7 @@ std::vector<detail::ray<algebra_s>> generate_rays() {
     ray_generator.config().theta_steps(theta_steps).phi_steps(phi_steps);
 
     std::vector<detail::ray<algebra_s>> rays;
-    std::copy(ray_generator.begin(), ray_generator.end(),
-              std::back_inserter(rays));
+    std::ranges::copy(ray_generator, std::back_inserter(rays));
 
     return rays;
 }

--- a/tests/include/detray/test/cpu/toy_detector_test.hpp
+++ b/tests/include/detray/test/cpu/toy_detector_test.hpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 // System include(s)
+#include <algorithm>
 #include <type_traits>
 
 namespace detray {
@@ -51,8 +52,7 @@ inline void test_finder(const acc_t& finder, const dindex volume_index,
     // Check if surface indices are consistent with given range of indices
     EXPECT_EQ(finder.size(), range[1] - range[0]);
     for (dindex idx : detray::views::iota(range)) {
-        EXPECT_TRUE(std::find(indices.begin(), indices.end(), idx) !=
-                    indices.end());
+        EXPECT_TRUE(std::ranges::find(indices, idx) != indices.end());
     }
 }
 

--- a/tests/include/detray/test/utils/detector_scanner.hpp
+++ b/tests/include/detray/test/utils/detector_scanner.hpp
@@ -158,8 +158,7 @@ inline auto run(const typename detector_t::geometry_context gctx,
     auto sort_path = [&](const record_t &a, const record_t &b) -> bool {
         return (a.intersection < b.intersection);
     };
-    std::stable_sort(intersection_record.begin(), intersection_record.end(),
-                     sort_path);
+    std::ranges::stable_sort(intersection_record, sort_path);
 
     // Make sure the intersection record terminates at world portals
     auto is_world_exit = [](const record_t &r) {
@@ -168,8 +167,7 @@ inline auto run(const typename detector_t::geometry_context gctx,
                    r.intersection.volume_link)>();
     };
 
-    if (auto it = std::find_if(intersection_record.begin(),
-                               intersection_record.end(), is_world_exit);
+    if (auto it = std::ranges::find_if(intersection_record, is_world_exit);
         it != intersection_record.end()) {
         auto n{static_cast<std::size_t>(it - intersection_record.begin())};
         intersection_record.resize(n + 1u);

--- a/tests/include/detray/test/utils/detectors/build_telescope_detector.hpp
+++ b/tests/include/detray/test/utils/detectors/build_telescope_detector.hpp
@@ -99,9 +99,8 @@ struct tel_det_config {
     }
     constexpr tel_det_config &positions(const std::vector<scalar> &dists) {
         m_positions.clear();
-        std::copy_if(dists.begin(), dists.end(),
-                     std::back_inserter(m_positions),
-                     [](scalar d) { return (d >= 0.f); });
+        std::ranges::copy_if(dists, std::back_inserter(m_positions),
+                             [](scalar d) { return (d >= 0.f); });
         return *this;
     }
     constexpr tel_det_config &module_material(const material<scalar> &mat) {

--- a/tests/include/detray/test/utils/detectors/factories/barrel_generator.hpp
+++ b/tests/include/detray/test/utils/detectors/factories/barrel_generator.hpp
@@ -18,6 +18,7 @@
 #include "detray/materials/material.hpp"
 
 // System include(s)
+#include <algorithm>
 #include <cassert>
 #include <limits>
 
@@ -52,7 +53,7 @@ struct barrel_generator_config {
     }
     barrel_generator_config &module_bounds(const std::vector<scalar_t> &bnds) {
         m_mask_values.clear();
-        std::copy(bnds.begin(), bnds.end(), std::back_inserter(m_mask_values));
+        std::ranges::copy(bnds, std::back_inserter(m_mask_values));
         return *this;
     }
     constexpr barrel_generator_config &tilt_phi(const scalar_t tilt) {

--- a/tests/include/detray/test/utils/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/utils/navigation_validation_utils.hpp
@@ -197,9 +197,9 @@ auto compare_traces(truth_trace_t &truth_trace,
             if (is_swapped_portals(i)) {
                 // Have already checked the next record
                 ++i;
-            } else if (auto last_missed_tr = std::find_if(
-                           std::begin(truth_trace) + i, std::end(truth_trace),
-                           is_matched_truth);
+            } else if (auto last_missed_tr = std::ranges::find_if(
+                           std::ranges::begin(truth_trace) + i,
+                           std::ranges::end(truth_trace), is_matched_truth);
                        last_missed_tr != std::end(truth_trace)) {
 
                 // The navigator missed a(multiple) surface(s)
@@ -235,9 +235,9 @@ auto compare_traces(truth_trace_t &truth_trace,
                 // Continue checking where trace might match again
                 i += (n - 1);
 
-            } else if (auto last_missed_nav = std::find_if(
-                           std::begin(recorded_trace) + i,
-                           std::end(recorded_trace), is_matched_nav);
+            } else if (auto last_missed_nav = std::ranges::find_if(
+                           std::ranges::begin(recorded_trace) + i,
+                           std::ranges::end(recorded_trace), is_matched_nav);
                        last_missed_nav != std::end(recorded_trace)) {
                 // The detector scanner missed a(multiple) surface(s)
                 auto first_missed = std::begin(recorded_trace) + i;

--- a/tests/include/detray/test/utils/statistics.hpp
+++ b/tests/include/detray/test/utils/statistics.hpp
@@ -43,8 +43,8 @@ inline auto rms(
     using value_t = detray::ranges::range_value_t<range_t>;
 
     std::vector<value_t> diff(r.size());
-    std::transform(r.begin(), r.end(), diff.begin(),
-                   [mean](value_t x) { return x - mean; });
+    std::ranges::transform(r, diff.begin(),
+                           [mean](value_t x) { return x - mean; });
     value_t sq_sum =
         std::inner_product(diff.begin(), diff.end(), diff.begin(), value_t{});
     value_t variance = sq_sum * (1.0f / static_cast<value_t>(r.size()));
@@ -67,8 +67,8 @@ inline auto variance(const range_t& r) noexcept(false)
     value_t mean = statistics::mean(r);
 
     std::vector<value_t> diff(r.size());
-    std::transform(r.begin(), r.end(), diff.begin(),
-                   [mean](value_t x) { return x - mean; });
+    std::ranges::transform(r, diff.begin(),
+                           [mean](value_t x) { return x - mean; });
     value_t sq_sum =
         std::inner_product(diff.begin(), diff.end(), diff.begin(), value_t{});
 

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -31,6 +31,7 @@
 #include "detray/options/boost_program_options.hpp"
 
 // System include(s).
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -210,9 +211,7 @@ struct ridders_derivative {
         }
     }
 
-    bool is_complete() {
-        return (std::count(complete.begin(), complete.end(), false) == 0u);
-    }
+    bool is_complete() { return (std::ranges::count(complete, false) == 0u); }
 };
 
 void wrap_angles(const bound_param_vector_type& ref_vector,
@@ -744,8 +743,7 @@ void evaluate_jacobian_difference(
             constraint_step, hs, num_iterations, convergence);
     }
 
-    bool total_convergence =
-        (std::count(convergence.begin(), convergence.end(), false) == 0);
+    bool total_convergence = (std::ranges::count(convergence, false) == 0);
 
     // Ridders number of iterations
     for (unsigned int i = 0; i < 5u; i++) {
@@ -1144,8 +1142,7 @@ void evaluate_jacobian_difference_helix(
         }
     }
 
-    bool total_convergence =
-        (std::count(convergence.begin(), convergence.end(), false) == 0);
+    bool total_convergence = (std::ranges::count(convergence, false) == 0);
 
     file << trk_count << ",";
 

--- a/tests/unit_tests/cpu/geometry/tracking_volume.cpp
+++ b/tests/unit_tests/cpu/geometry/tracking_volume.cpp
@@ -16,6 +16,9 @@
 // GTest include(s)
 #include <gtest/gtest.h>
 
+// System include(s)
+#include <algorithm>
+
 // TODO: Move these into the test defs
 namespace {
 
@@ -104,7 +107,7 @@ GTEST_TEST(detray_geometry, tracking_volume) {
         sf_indices.push_back(sf.index());
     }
     auto seq = detray::views::iota(372u, 600u);
-    EXPECT_TRUE(std::equal(sf_indices.begin(), sf_indices.end(), seq.begin()));
+    EXPECT_TRUE(std::ranges::equal(sf_indices, seq));
 
     // Access to portals
     sf_indices.clear();
@@ -112,7 +115,7 @@ GTEST_TEST(detray_geometry, tracking_volume) {
         sf_indices.push_back(pt.index());
     }
     seq = detray::views::iota(596u, 600u);
-    EXPECT_TRUE(std::equal(sf_indices.begin(), sf_indices.end(), seq.begin()));
+    EXPECT_TRUE(std::ranges::equal(sf_indices, seq));
 
     // Access to sensitive surfaces
     sf_indices.clear();
@@ -120,7 +123,7 @@ GTEST_TEST(detray_geometry, tracking_volume) {
         sf_indices.push_back(sens.index());
     }
     seq = detray::views::iota(372u, 596u);
-    EXPECT_TRUE(std::equal(sf_indices.begin(), sf_indices.end(), seq.begin()));
+    EXPECT_TRUE(std::ranges::equal(sf_indices, seq));
     //
     // Volume 5 is negative endcap layer with sensitive surfaces
     //
@@ -141,7 +144,7 @@ GTEST_TEST(detray_geometry, tracking_volume) {
         sf_indices.push_back(sf.index());
     }
     seq = detray::views::iota(256u, 368u);
-    EXPECT_TRUE(std::equal(sf_indices.begin(), sf_indices.end(), seq.begin()));
+    EXPECT_TRUE(std::ranges::equal(sf_indices, seq));
 
     // Access to portals
     sf_indices.clear();
@@ -149,7 +152,7 @@ GTEST_TEST(detray_geometry, tracking_volume) {
         sf_indices.push_back(pt.index());
     }
     seq = detray::views::iota(364u, 368u);
-    EXPECT_TRUE(std::equal(sf_indices.begin(), sf_indices.end(), seq.begin()));
+    EXPECT_TRUE(std::ranges::equal(sf_indices, seq));
 
     // Access to sensitive surfaces
     sf_indices.clear();
@@ -157,7 +160,7 @@ GTEST_TEST(detray_geometry, tracking_volume) {
         sf_indices.push_back(sens.index());
     }
     seq = detray::views::iota(256u, 364u);
-    EXPECT_TRUE(std::equal(sf_indices.begin(), sf_indices.end(), seq.begin()));
+    EXPECT_TRUE(std::ranges::equal(sf_indices, seq));
 
     //
     // Volume 17 is the positive connector gap
@@ -179,14 +182,14 @@ GTEST_TEST(detray_geometry, tracking_volume) {
         sf_indices.push_back(sf.index());
     }
     seq = detray::views::iota(3012u, 3024u);
-    EXPECT_TRUE(std::equal(sf_indices.begin(), sf_indices.end(), seq.begin()));
+    EXPECT_TRUE(std::ranges::equal(sf_indices, seq));
 
     // Access to portals
     sf_indices.clear();
     for (const auto& pt : vol17.portals()) {
         sf_indices.push_back(pt.index());
     }
-    EXPECT_TRUE(std::equal(sf_indices.begin(), sf_indices.end(), seq.begin()));
+    EXPECT_TRUE(std::ranges::equal(sf_indices, seq));
 
     // Access to sensitive surfaces: None in gap volume
     sf_indices.clear();

--- a/tests/unit_tests/cpu/navigation/intersection/intersection2D.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection2D.cpp
@@ -63,7 +63,7 @@ GTEST_TEST(detray_intersection, intersection2D) {
     ASSERT_FALSE(invalid.status);
 
     dvector<intersection_t> intersections = {invalid, i0, i1};
-    std::sort(intersections.begin(), intersections.end());
+    std::ranges::sort(intersections);
 
     ASSERT_NEAR(intersections[0].path, 1.7f, tol);
     ASSERT_NEAR(intersections[1].path, 2.f, tol);

--- a/tests/unit_tests/cpu/simulation/landau_sampling.cpp
+++ b/tests/unit_tests/cpu/simulation/landau_sampling.cpp
@@ -80,8 +80,8 @@ TYPED_TEST(detray_simulation_LandauSamplingValidation, landau_sampling) {
 
     const std::size_t mpv_index = this->get_index(this->mpv);
 
-    const std::size_t max_index = static_cast<std::size_t>(std::distance(
-        counter.begin(), std::max_element(counter.begin(), counter.end())));
+    const std::size_t max_index = static_cast<std::size_t>(
+        std::distance(counter.begin(), std::ranges::max_element(counter)));
 
     // Bin range for i index: [ -2 + 0.05 * i, -2 + 0.05 * (i+1) ]
     // Bin range for i = 35 : [ -0.25, -0.2] which includes mpv (-0.22278)

--- a/tests/unit_tests/cpu/utils/grids/grid.cpp
+++ b/tests/unit_tests/cpu/utils/grids/grid.cpp
@@ -26,6 +26,7 @@
 // System include(s)
 #include <algorithm>
 #include <limits>
+#include <random>
 
 using namespace detray;
 using namespace detray::axis;
@@ -97,8 +98,9 @@ GTEST_TEST(detray_grid, single_grid) {
     // bin test entries
     grid_owning_t::bin_container_type bin_data{};
     bin_data.resize(40'000u);
-    std::generate_n(bin_data.begin(), 40'000u,
-                    bin_content_sequence<replace<>, bins::single<scalar>>());
+    std::ranges::generate_n(
+        bin_data.begin(), 40'000u,
+        bin_content_sequence<replace<>, bins::single<scalar>>());
 
     // Copy data that will be moved into the data owning types
     dvector<scalar> bin_edges_cp(bin_edges);
@@ -310,8 +312,9 @@ GTEST_TEST(detray_grid, bin_view) {
     // bin test entries
     grid_t::bin_container_type bin_data{};
     bin_data.resize(40'000u);
-    std::generate_n(bin_data.begin(), 40'000u,
-                    bin_content_sequence<replace<>, bins::single<scalar>>());
+    std::ranges::generate_n(
+        bin_data.begin(), 40'000u,
+        bin_content_sequence<replace<>, bins::single<scalar>>());
 
     // Copy data that will be moved into the data owning types
     dvector<scalar> bin_edges_cp(bin_edges);
@@ -344,16 +347,16 @@ GTEST_TEST(detray_grid, bin_view) {
 
     for (auto bin : bview1) {
         for (auto entry : bin) {
-            EXPECT_EQ(entry, *(grid_3D.bin(0))) << "bin entry: " << entry;
+            EXPECT_EQ(entry, grid_3D.bin(0).value()) << "bin entry: " << entry;
         }
     }
 
     for (scalar entry : joined_view1) {
-        EXPECT_EQ(entry, *(grid_3D.bin(0))) << "bin entry: " << entry;
+        EXPECT_EQ(entry, grid_3D.bin(0).value()) << "bin entry: " << entry;
     }
 
     for (scalar entry : grid_search1) {
-        EXPECT_EQ(entry, *(grid_3D.bin(0))) << "bin entry: " << entry;
+        EXPECT_EQ(entry, grid_3D.bin(0).value()) << "bin entry: " << entry;
     }
 
     //

--- a/tests/unit_tests/cpu/utils/grids/grid_collection.cpp
+++ b/tests/unit_tests/cpu/utils/grids/grid_collection.cpp
@@ -60,7 +60,7 @@ GTEST_TEST(detray_grid, grid_collection) {
     // Build test data
     grid_t::bin_container_type bin_data{};
     bin_data.resize(197u);
-    std::generate_n(
+    std::ranges::generate_n(
         bin_data.begin(), 197u,
         bin_content_sequence<attach<>, typename grid_t::bin_type>());
     dvector<dindex> grid_offsets = {0u, 48u, 72u};

--- a/tests/unit_tests/cpu/utils/grids/populators.cpp
+++ b/tests/unit_tests/cpu/utils/grids/populators.cpp
@@ -57,22 +57,22 @@ GTEST_TEST(detray_grid, replace_populator) {
     // Create some bin data
     dvector<bins::single<dindex>> bin_data{};
     bin_data.reserve(50);
-    std::generate_n(bin_data.begin(), 50,
-                    bin_content_sequence<bins::single<dindex>>());
+    std::ranges::generate_n(bin_data.begin(), 50,
+                            bin_content_sequence<bins::single<dindex>>());
 
     // Check test setup
-    EXPECT_EQ(*bin_data[0], 1u);
-    EXPECT_EQ(*bin_data[1], 2u);
-    EXPECT_EQ(*bin_data[2], 3u);
-    EXPECT_EQ(*bin_data[3], 4u);
-    EXPECT_EQ(*bin_data[19], 20u);
-    EXPECT_EQ(*bin_data[20], 21u);
-    EXPECT_EQ(*bin_data[21], 22u);
-    EXPECT_EQ(*bin_data[41], 42u);
-    EXPECT_EQ(*bin_data[42], 43u);
-    EXPECT_EQ(*bin_data[43], 44u);
-    EXPECT_EQ(*bin_data[48], 49u);
-    EXPECT_EQ(*bin_data[49], 50u);
+    EXPECT_EQ(bin_data[0].value(), 1u);
+    EXPECT_EQ(bin_data[1].value(), 2u);
+    EXPECT_EQ(bin_data[2].value(), 3u);
+    EXPECT_EQ(bin_data[3].value(), 4u);
+    EXPECT_EQ(bin_data[19].value(), 20u);
+    EXPECT_EQ(bin_data[20].value(), 21u);
+    EXPECT_EQ(bin_data[21].value(), 22u);
+    EXPECT_EQ(bin_data[41].value(), 42u);
+    EXPECT_EQ(bin_data[42].value(), 43u);
+    EXPECT_EQ(bin_data[43].value(), 44u);
+    EXPECT_EQ(bin_data[48].value(), 49u);
+    EXPECT_EQ(bin_data[49].value(), 50u);
 
     // Replace some bin entries
     replacer(bin_data[0], 500u);
@@ -81,18 +81,18 @@ GTEST_TEST(detray_grid, replace_populator) {
     replacer(bin_data[42], 55u);
     replacer(bin_data[49], 6u);
 
-    EXPECT_EQ(*bin_data[0], 500u);
-    EXPECT_EQ(*bin_data[1], 2u);
-    EXPECT_EQ(*bin_data[2], 5u);
-    EXPECT_EQ(*bin_data[3], 4u);
-    EXPECT_EQ(*bin_data[19], 20u);
-    EXPECT_EQ(*bin_data[20], 50u);
-    EXPECT_EQ(*bin_data[21], 22u);
-    EXPECT_EQ(*bin_data[41], 42u);
-    EXPECT_EQ(*bin_data[42], 55u);
-    EXPECT_EQ(*bin_data[43], 44u);
-    EXPECT_EQ(*bin_data[48], 49u);
-    EXPECT_EQ(*bin_data[49], 6u);
+    EXPECT_EQ(bin_data[0].value(), 500u);
+    EXPECT_EQ(bin_data[1].value(), 2u);
+    EXPECT_EQ(bin_data[2].value(), 5u);
+    EXPECT_EQ(bin_data[3].value(), 4u);
+    EXPECT_EQ(bin_data[19].value(), 20u);
+    EXPECT_EQ(bin_data[20].value(), 50u);
+    EXPECT_EQ(bin_data[21].value(), 22u);
+    EXPECT_EQ(bin_data[41].value(), 42u);
+    EXPECT_EQ(bin_data[42].value(), 55u);
+    EXPECT_EQ(bin_data[43].value(), 44u);
+    EXPECT_EQ(bin_data[48].value(), 49u);
+    EXPECT_EQ(bin_data[49].value(), 6u);
 }
 
 /// Complete populator
@@ -103,8 +103,9 @@ GTEST_TEST(detray_grid, complete_populator) {
     // Create some bin data
     dvector<bins::static_array<dindex, 4>> bin_data{};
     bin_data.reserve(50);
-    std::generate_n(bin_data.begin(), 50,
-                    bin_content_sequence<bins::static_array<dindex, 4>>());
+    std::ranges::generate_n(
+        bin_data.begin(), 50,
+        bin_content_sequence<bins::static_array<dindex, 4>>());
 
     // Check test setup
     std::array<dindex, 4> stored = {1u, inf, inf, inf};
@@ -173,8 +174,9 @@ GTEST_TEST(detray_grid, regular_attach_populator) {
     // Create some bin data
     dvector<bins::static_array<dindex, 4>> bin_data{};
     bin_data.reserve(50);
-    std::generate_n(bin_data.begin(), 50,
-                    bin_content_sequence<bins::static_array<dindex, 4>>());
+    std::ranges::generate_n(
+        bin_data.begin(), 50,
+        bin_content_sequence<bins::static_array<dindex, 4>>());
 
     // Check test setup
     std::array<dindex, 4> stored = {1u, inf, inf, inf};

--- a/tests/unit_tests/device/cuda/container_cuda.cpp
+++ b/tests/unit_tests/device/cuda/container_cuda.cpp
@@ -125,12 +125,9 @@ TEST(container_cuda, tuple_container) {
 
     vecmem::vector<double> new_data{10.5, 7.6, 14.5};
     auto& data_coll = detail::get<1>(mng_tcont);
-    std::copy(new_data.begin(), new_data.end(), std::back_inserter(data_coll));
-
-    std::copy(mng_tcont.get<0>().begin(), mng_tcont.get<0>().end(),
-              std::back_inserter(tcont.get<0>()));
-    std::copy(mng_tcont.get<1>().begin(), mng_tcont.get<1>().end(),
-              std::back_inserter(tcont.get<1>()));
+    std::ranges::copy(new_data, std::back_inserter(data_coll));
+    std::ranges::copy(mng_tcont.get<0>(), std::back_inserter(tcont.get<0>()));
+    std::ranges::copy(mng_tcont.get<1>(), std::back_inserter(tcont.get<1>()));
 
     EXPECT_EQ(mng_tcont.get<0>().size(), 1u);
     EXPECT_EQ(mng_tcont.get<1>().size(), 5u);
@@ -272,8 +269,7 @@ TEST(container_cuda, multi_store) {
     mng_store.get<1>().first = vecmem::vector<int>{2, 3};
     mng_store.get<1>().second = vecmem::vector<double>{18., 42.6};
 
-    std::copy(mng_store.get<0>().begin(), mng_store.get<0>().end(),
-              std::back_inserter(store.get<0>()));
+    std::ranges::copy(mng_store.get<0>(), std::back_inserter(store.get<0>()));
     store.get<1>() = mng_store.get<1>();
 
     EXPECT_EQ(mng_store.size<0>(), 2u);

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
@@ -85,7 +85,7 @@ TEST(grids_cuda, grid3_replace_populator) {
             for (unsigned int i_z = 0u; i_z < axis_z.nbins(); i_z++) {
                 const auto& bin = g3.bin({i_x, i_y, i_z});
                 auto invalid_bin = bin_t{};
-                test_content(*bin, *invalid_bin);
+                test_content(bin.value(), invalid_bin.value());
             }
         }
     }
@@ -105,7 +105,7 @@ TEST(grids_cuda, grid3_replace_populator) {
                                 axis_y.min() + gbin_f * axis_y.bin_width(),
                                 axis_z.min() + gbin_f * axis_z.bin_width()};
 
-                test_content(*bin, tp);
+                test_content(bin.value(), tp);
             }
         }
     }
@@ -149,7 +149,7 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
             const auto& bin = g2.bin({i_r, i_phi});
             auto invalid_bin = bin_t{};
 
-            test_content(*bin, *invalid_bin);
+            test_content(bin.value(), invalid_bin.value());
         }
     }
 
@@ -167,7 +167,7 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
                             axis_phi.min() + gbin_f * axis_phi.bin_width(),
                             0.5f};
 
-            test_content(*bin, tp);
+            test_content(bin.value(), tp);
         }
     }
 


### PR DESCRIPTION
Use range algorithms instead of the std equivalent. This helps readability and will make the code more robust, since ranges applies more compile-time checks. In a few places, the detray code had to be modified to fulfill the concepts that the ranges algorithms require.