### PR TITLE
ref: refactor type traits into concepts

### DIFF
--- a/core/include/detray/builders/bin_fillers.hpp
+++ b/core/include/detray/builders/bin_fillers.hpp
@@ -9,7 +9,9 @@
 
 // Project include(s).
 #include "detray/builders/detail/bin_association.hpp"
+#include "detray/navigation/accelerators/concepts.hpp"
 #include "detray/utils/grid/detail/axis.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 #include "detray/utils/grid/populators.hpp"
 
 // System include(s)
@@ -36,12 +38,13 @@ struct fill_by_bin {
         value_t single_element;
     };
 
-    template <typename grid_t>
+    template <concepts::grid grid_t>
     using bin_data_type = bin_data<grid_t::dim, typename grid_t::value_type>;
 
-    template <typename grid_t, typename volume_t, typename surface_container_t,
-              typename mask_container, typename transform_container,
-              typename context_t, typename... Args>
+    template <concepts::grid grid_t, typename volume_t,
+              typename surface_container_t, typename mask_container,
+              typename transform_container, typename context_t,
+              typename... Args>
     DETRAY_HOST auto operator()(grid_t &grid, const volume_t &,
                                 const surface_container_t &,
                                 const mask_container &, const context_t,
@@ -63,9 +66,10 @@ struct fill_by_bin {
 /// @param ctx the geometry context
 struct fill_by_pos {
 
-    template <typename grid_t, typename volume_t, typename surface_container_t,
-              typename mask_container, typename transform_container,
-              typename context_t, typename... Args>
+    template <concepts::surface_grid grid_t, typename volume_t,
+              typename surface_container_t, typename mask_container,
+              typename transform_container, typename context_t,
+              typename... Args>
     DETRAY_HOST auto operator()(grid_t &grid, const volume_t &vol,
                                 const surface_container_t &surfaces,
                                 const transform_container &transforms,
@@ -99,8 +103,8 @@ struct fill_by_pos {
 /// @param ctx the geometry context
 struct bin_associator {
 
-    template <typename detector_t, typename volume_type, typename grid_t,
-              typename... Args>
+    template <typename detector_t, typename volume_type,
+              concepts::surface_grid grid_t, typename... Args>
     DETRAY_HOST auto operator()(grid_t &grid, detector_t &det,
                                 const volume_type &vol,
                                 const typename detector_t::geometry_context ctx,
@@ -109,9 +113,10 @@ struct bin_associator {
                          det.transform_store(), ctx);
     }
 
-    template <typename grid_t, typename volume_t, typename surface_container_t,
-              typename mask_container, typename transform_container,
-              typename context_t, typename... Args>
+    template <concepts::surface_grid grid_t, typename volume_t,
+              typename surface_container_t, typename mask_container,
+              typename transform_container, typename context_t,
+              typename... Args>
     DETRAY_HOST auto operator()(grid_t &grid, const volume_t &,
                                 const surface_container_t &surfaces,
                                 const transform_container &transforms,

--- a/core/include/detray/builders/detail/bin_association.hpp
+++ b/core/include/detray/builders/detail/bin_association.hpp
@@ -15,6 +15,7 @@
 #include "detray/geometry/coordinates/cylindrical2D.hpp"
 #include "detray/geometry/coordinates/polar2D.hpp"
 #include "detray/geometry/detail/vertexing.hpp"
+#include "detray/navigation/accelerators/concepts.hpp"
 #include "detray/utils/grid/populators.hpp"
 #include "detray/utils/ranges.hpp"
 
@@ -36,13 +37,14 @@ namespace detray::detail {
 ///        taken absolute or relative
 template <typename context_t, typename surface_container_t,
           typename transform_container_t, typename mask_container_t,
-          typename grid_t>
-requires(grid_t::dim == 2) static inline void bin_association(
-    const context_t & /*context*/, const surface_container_t &surfaces,
-    const transform_container_t &transforms,
-    const mask_container_t &surface_masks, grid_t &grid,
-    const std::array<scalar, 2> &bin_tolerance,
-    bool absolute_tolerance = true) {
+          concepts::surface_grid grid_t>
+static inline void bin_association(const context_t & /*context*/,
+                                   const surface_container_t &surfaces,
+                                   const transform_container_t &transforms,
+                                   const mask_container_t &surface_masks,
+                                   grid_t &grid,
+                                   const std::array<scalar, 2> &bin_tolerance,
+                                   bool absolute_tolerance = true) {
 
     using algebra_t = typename grid_t::local_frame_type::algebra_type;
     using point2_t = dpoint2D<algebra_t>;

--- a/core/include/detray/builders/detector_builder.hpp
+++ b/core/include/detray/builders/detector_builder.hpp
@@ -14,6 +14,7 @@
 #include "detray/core/detector.hpp"
 #include "detray/core/detector_metadata.hpp"
 #include "detray/definitions/geometry.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 #include "detray/utils/type_traits.hpp"
 
 // Vecmem include(s)
@@ -117,7 +118,7 @@ class detector_builder {
         using vol_finder_t = typename detector_type::volume_finder;
 
         // Add dummy volume grid for now
-        if constexpr (detail::is_grid_v<vol_finder_t>) {
+        if constexpr (concepts::grid<vol_finder_t>) {
 
             // TODO: Construct it correctly with the grid builder
             mask<cylinder3D> vgrid_dims{0u,      0.f,   -constant<scalar>::pi,

--- a/core/include/detray/builders/grid_builder.hpp
+++ b/core/include/detray/builders/grid_builder.hpp
@@ -15,6 +15,7 @@
 #include "detray/builders/volume_builder_interface.hpp"
 #include "detray/geometry/tracking_surface.hpp"
 #include "detray/geometry/tracking_volume.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 
 // System include(s)
 #include <array>
@@ -28,7 +29,7 @@ namespace detray {
 ///
 /// Decorator class to a volume builder that adds a grid as the volumes
 /// geometry accelerator structure.
-template <typename detector_t, typename grid_t,
+template <typename detector_t, concepts::grid grid_t,
           typename bin_filler_t = fill_by_pos,
           typename grid_factory_t = grid_factory_type<grid_t>>
 class grid_builder : public volume_decorator<detector_t> {

--- a/core/include/detray/builders/grid_factory.hpp
+++ b/core/include/detray/builders/grid_factory.hpp
@@ -14,6 +14,7 @@
 #include "detray/geometry/shapes.hpp"
 #include "detray/utils/grid/detail/axis.hpp"
 #include "detray/utils/grid/detail/axis_helpers.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 #include "detray/utils/grid/grid.hpp"
 #include "detray/utils/grid/grid_collection.hpp"
 #include "detray/utils/grid/populators.hpp"
@@ -532,8 +533,8 @@ class grid_factory {
 
     /// Helper overload for grid builder: Build from mask and resolve bounds
     /// and binnings from concrete grid type
-    template <typename grid_t, typename grid_shape_t>
-    requires detail::is_grid_v<grid_t> auto new_grid(
+    template <concepts::grid grid_t, typename grid_shape_t>
+    auto new_grid(
         const mask<grid_shape_t> &m,
         const std::array<std::size_t, grid_t::dim> &n_bins,
         const std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
@@ -578,8 +579,8 @@ class grid_factory {
     /// @param ax_bin_edges the explicit bin edges for irregular axes
     ///                     (lower bin edges + the the upper edge of the
     ///                     last bin), otherwise ignored.
-    template <typename grid_t>
-    requires detail::is_grid_v<grid_t> auto new_grid(
+    template <concepts::grid grid_t>
+    auto new_grid(
         const std::vector<scalar_type> spans,
         const std::vector<std::size_t> n_bins,
         [[maybe_unused]] const std::vector<
@@ -684,7 +685,8 @@ class grid_factory {
 };
 
 // Infer a grid factory type from an already completely assembled grid type
-template <typename grid_t, typename algebra_t = ALGEBRA_PLUGIN<detray::scalar>>
+template <concepts::grid grid_t,
+          typename algebra_t = ALGEBRA_PLUGIN<detray::scalar>>
 using grid_factory_type =
     grid_factory<typename grid_t::bin_type,
                  simple_serializer /*grid_t::template serializer_type*/,

--- a/core/include/detray/builders/volume_builder.hpp
+++ b/core/include/detray/builders/volume_builder.hpp
@@ -12,6 +12,7 @@
 #include "detray/builders/volume_builder_interface.hpp"
 #include "detray/definitions/geometry.hpp"
 #include "detray/geometry/tracking_surface.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 
 // System include(s)
 #include <algorithm>
@@ -304,7 +305,7 @@ struct material_index_update {
         [[maybe_unused]] const group_t& group,
         [[maybe_unused]] const index_t& /*index*/,
         [[maybe_unused]] surface_t& sf) const {
-        if constexpr (!detail::is_grid_v<typename group_t::value_type>) {
+        if constexpr (!concepts::grid<typename group_t::value_type>) {
             sf.update_material(static_cast<dindex>(group.size()));
         }
     }

--- a/core/include/detray/core/detail/container_views.hpp
+++ b/core/include/detray/core/detail/container_views.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,7 +18,7 @@
 #include <vecmem/containers/jagged_device_vector.hpp>
 
 // System include(s)
-#include <type_traits>
+#include <concepts>
 
 namespace detray {
 
@@ -27,21 +27,139 @@ using device_container_types =
     container_types<vecmem::device_vector, detray::tuple, darray,
                     vecmem::jagged_device_vector>;
 
-namespace detail {
+/// Specialized view for @c vecmem::vector containers
+template <typename T>
+using dvector_view = vecmem::data::vector_view<T>;
 
+/// Specialized view for @c vecmem::jagged_vector containers
+template <typename T>
+using djagged_vector_view = vecmem::data::jagged_vector_view<T>;
+
+namespace detail {
 // Views for types that aggregate containers/other viewable types
 
 /// Empty view type for inheritance template resolution
 struct dbase_view {};
 
-/// Container view helper that aggregates multiple vecmem views and performs
-/// compile-time checks.
-template <bool /*check value*/, typename... view_ts>
-class dmulti_view_helper {};
+/// Helper trait to determine if a type can be interpreted as a (composite)
+/// vecemem view
+/// @{
+template <typename T>
+struct is_device_view : public std::false_type {};
 
-/// In case the checks fail
-template <typename... view_ts>
-class dmulti_view_helper<false, view_ts...> {};
+/// Specialization of 'is view' for @c vecmem::data::vector_view containers
+template <typename T>
+struct is_device_view<vecmem::data::vector_view<T>> : public std::true_type {};
+
+/// Specialization of 'is view' for constant @c vecmem::data::vector_view
+/// containers
+template <typename T>
+struct is_device_view<const vecmem::data::vector_view<T>>
+    : public std::true_type {};
+
+/// Specialization of 'is view' for @c vecmem::data::jagged_vector_view
+/// containers
+template <typename T>
+struct is_device_view<vecmem::data::jagged_vector_view<T>>
+    : public std::true_type {};
+
+/// Specialization of 'is view' for constant @c vecmem::data::jagged_vector_view
+/// containers
+template <typename T>
+struct is_device_view<const vecmem::data::jagged_vector_view<T>>
+    : public std::true_type {};
+
+template <typename T>
+inline constexpr bool is_device_view_v = is_device_view<T>::value;
+/// @}
+}  // namespace detail
+
+namespace concepts {
+
+template <typename T>
+concept device_view =
+    std::derived_from<std::remove_cvref_t<T>, detray::detail::dbase_view> ||
+    detail::is_device_view_v<T>;
+
+}  // namespace concepts
+
+namespace detail {
+/// Helper trait to check whether a type has a vecmem view defined
+/// @{
+template <class T>
+struct get_view : public std::false_type {
+    using type = void;
+};
+
+/// Get view of detray type
+template <class T>
+requires concepts::device_view<typename T::view_type> struct get_view<T>
+    : public std::true_type {
+    using type =
+        std::conditional_t<std::is_const_v<T>, typename T::const_view_type,
+                           typename T::view_type>;
+};
+
+/// Specialization of the view getter for @c vecmem::vector
+template <typename T>
+struct get_view<vecmem::vector<T>> : public std::true_type {
+    using type = dvector_view<T>;
+};
+
+/// Specialization of the view getter for @c vecmem::vector - const
+template <typename T>
+struct get_view<const vecmem::vector<T>> : public std::true_type {
+    using type = dvector_view<const T>;
+};
+
+/// Specialization of the view getter for @c vecmem::device_vector
+template <typename T>
+struct get_view<vecmem::device_vector<T>> : public std::true_type {
+    using type = dvector_view<T>;
+};
+
+/// Specialization of the view getter for @c vecmem::device_vector - const
+template <typename T>
+struct get_view<const vecmem::device_vector<T>> : public std::true_type {
+    using type = dvector_view<const T>;
+};
+
+/// Specialization of the view getter for @c vecmem::jagged_vector
+template <typename T>
+struct get_view<vecmem::jagged_vector<T>> : public std::true_type {
+    using type = djagged_vector_view<T>;
+};
+
+/// Specialization of the view getter for @c vecmem::jagged_vector - const
+template <typename T>
+struct get_view<const vecmem::jagged_vector<T>> : public std::true_type {
+    using type = djagged_vector_view<const T>;
+};
+
+/// Specialization of the view getter for @c vecmem::jagged_device_vector
+template <typename T>
+struct get_view<vecmem::jagged_device_vector<T>> : public std::true_type {
+    using type = djagged_vector_view<T>;
+};
+
+/// Specialization of the view getter for @c vecmem::jagged_device_vector
+/// - const
+template <typename T>
+struct get_view<const vecmem::jagged_device_vector<T>> : public std::true_type {
+    using type = djagged_vector_view<const T>;
+};
+
+template <class T>
+using get_view_t = typename get_view<T>::type;
+/// @}
+}  // namespace detail
+
+namespace concepts {
+
+template <class T>
+concept viewable = concepts::device_view<detail::get_view_t<T>>;
+
+}  // namespace concepts
 
 /// @brief General view type that aggregates vecmem based view implementations.
 ///
@@ -49,69 +167,20 @@ class dmulti_view_helper<false, view_ts...> {};
 /// view types of their own. The 'sub'-views are being aggregated in this helper
 /// and are extracted in the types contructor and then handed down to the
 /// member constructors.
-template <typename... view_ts>
-struct dmulti_view_helper<true, view_ts...> : public dbase_view {
+template <concepts::device_view... view_ts>
+struct dmulti_view : public detail::dbase_view {
     dtuple<view_ts...> m_view;
 
-    dmulti_view_helper() = default;
+    dmulti_view() = default;
 
     /// Tie multiple views together
     DETRAY_HOST_DEVICE
-    explicit dmulti_view_helper(view_ts&&... views)
-        : m_view(std::move(views)...) {}
+    explicit dmulti_view(view_ts&&... views) : m_view(std::move(views)...) {}
 
     /// Tie multiple views together
     DETRAY_HOST_DEVICE
-    explicit dmulti_view_helper(view_ts&... views) : m_view(views...) {}
+    explicit dmulti_view(view_ts&... views) : m_view(views...) {}
 };
-
-/// Helper trait to determine if a type can be interpreted as a (composite)
-/// vecemem view
-/// @{
-template <typename T, typename = void>
-struct is_device_view : public std::false_type {};
-
-template <typename T>
-struct is_device_view<
-    T, std::enable_if_t<
-           std::is_base_of_v<detray::detail::dbase_view,
-                             std::remove_reference_t<std::remove_cv_t<T>>>,
-           void>> : public std::true_type {};
-
-template <typename T>
-inline constexpr bool is_device_view_v = is_device_view<T>::value;
-/// @}
-
-/// Helper trait to check whether a type has a vecmem view defined
-/// @{
-template <class T, typename = void>
-struct has_view : public std::false_type {
-    using type = void;
-};
-
-template <class T>
-struct has_view<
-    T, std::enable_if_t<detray::detail::is_device_view_v<typename T::view_type>,
-                        void>> : public std::true_type {
-    using type =
-        std::conditional_t<std::is_const_v<T>, typename T::const_view_type,
-                           typename T::view_type>;
-};
-
-template <class T>
-inline constexpr bool has_view_v = has_view<T>::value;
-
-template <class T>
-using get_view_t = typename has_view<T>::type;
-/// @}
-
-}  // namespace detail
-
-/// The detray container view exists, if all contained view types also derive
-/// from @c dbase_view.
-template <typename... view_ts>
-using dmulti_view = detray::detail::dmulti_view_helper<
-    std::conjunction_v<detail::is_device_view<view_ts>...>, view_ts...>;
 
 /// @brief Detray version of 'get_data' - non-const
 ///
@@ -119,9 +188,7 @@ using dmulti_view = detray::detail::dmulti_view_helper<
 /// thus enabling 'duck typing'.
 ///
 /// @note This does not pick up the vecmem types.
-template <class T,
-          std::enable_if_t<detail::is_device_view_v<typename T::view_type>,
-                           bool> = true>
+template <concepts::viewable T>
 typename T::view_type get_data(T& viewable) {
     return viewable.get_data();
 }
@@ -132,19 +199,10 @@ typename T::view_type get_data(T& viewable) {
 /// thus enabling 'duck typing'.
 ///
 /// @note This does not pick up the vecmem types.
-template <class T,
-          std::enable_if_t<detail::is_device_view_v<typename T::view_type>,
-                           bool> = true>
+template <concepts::viewable T>
 typename T::const_view_type get_data(const T& viewable) {
     return viewable.get_data();
 }
-
-/// Type trait specializations for vecmem containers
-/// @{
-
-/// Specialized view for @c vecmem::vector containers
-template <typename T>
-using dvector_view = vecmem::data::vector_view<T>;
 
 /// Get the vecmem view type of a vector
 template <typename T, typename A>
@@ -157,92 +215,5 @@ template <typename T, typename A>
 dvector_view<const T> get_data(const std::vector<T, A>& vec) {
     return vecmem::get_data(vec);
 }
-
-/// Specialized view for @c vecmem::jagged_vector containers
-template <typename T>
-using djagged_vector_view = vecmem::data::jagged_vector_view<T>;
-
-/// Specialization of 'is view' for @c vecmem::data::vector_view containers
-template <typename T>
-struct detail::is_device_view<vecmem::data::vector_view<T>, void>
-    : public std::true_type {};
-
-/// Specialization of 'is view' for constant @c vecmem::data::vector_view
-/// containers
-template <typename T>
-struct detail::is_device_view<const vecmem::data::vector_view<T>, void>
-    : public std::true_type {};
-
-/// Specialization of the view getter for @c vecmem::vector
-template <typename T>
-struct detail::has_view<vecmem::vector<T>, void> : public std::true_type {
-    using type = dvector_view<T>;
-};
-
-/// Specialization of the view getter for @c vecmem::vector - const
-template <typename T>
-struct detail::has_view<const vecmem::vector<T>, void> : public std::true_type {
-    using type = dvector_view<const T>;
-};
-
-/// Specialization of the view getter for @c vecmem::device_vector
-template <typename T>
-struct detail::has_view<vecmem::device_vector<T>, void>
-    : public std::true_type {
-    using type = dvector_view<T>;
-};
-
-/// Specialization of the view getter for @c vecmem::device_vector - const
-template <typename T>
-struct detail::has_view<const vecmem::device_vector<T>, void>
-    : public std::true_type {
-    using type = dvector_view<const T>;
-};
-
-/// Specialized view for @c vecmem::jagged_vector containers
-template <typename T>
-using djagged_vector_view = vecmem::data::jagged_vector_view<T>;
-
-/// Specialization of 'is view' for @c vecmem::data::jagged_vector_view
-/// containers
-template <typename T>
-struct detail::is_device_view<vecmem::data::jagged_vector_view<T>, void>
-    : public std::true_type {};
-
-/// Specialization of 'is view' for constant @c vecmem::data::jagged_vector_view
-/// containers
-template <typename T>
-struct detail::is_device_view<const vecmem::data::jagged_vector_view<T>, void>
-    : public std::true_type {};
-
-/// Specialization of the view getter for @c vecmem::jagged_vector
-template <typename T>
-struct detail::has_view<vecmem::jagged_vector<T>, void>
-    : public std::true_type {
-    using type = djagged_vector_view<T>;
-};
-
-/// Specialization of the view getter for @c vecmem::jagged_vector - const
-template <typename T>
-struct detail::has_view<const vecmem::jagged_vector<T>, void>
-    : public std::true_type {
-    using type = djagged_vector_view<const T>;
-};
-
-/// Specialization of the view getter for @c vecmem::jagged_device_vector
-template <typename T>
-struct detail::has_view<vecmem::jagged_device_vector<T>, void>
-    : public std::true_type {
-    using type = djagged_vector_view<T>;
-};
-
-/// Specialization of the view getter for @c vecmem::jagged_device_vector
-/// - const
-template <typename T>
-struct detail::has_view<const vecmem::jagged_device_vector<T>, void>
-    : public std::true_type {
-    using type = djagged_vector_view<const T>;
-};
-/// @}
 
 }  // namespace detray

--- a/core/include/detray/core/detail/single_store.hpp
+++ b/core/include/detray/core/detail/single_store.hpp
@@ -63,22 +63,22 @@ class single_store {
     /// Construct with a specific memory resource @param resource
     /// (host-side only)
     template <typename allocator_t = vecmem::memory_resource>
-    requires(!detail::is_device_view_v<allocator_t>) DETRAY_HOST
-        explicit single_store(allocator_t &resource)
+    requires(std::derived_from<allocator_t, std::pmr::memory_resource>)
+        DETRAY_HOST explicit single_store(allocator_t &resource)
         : m_container(&resource) {}
 
     /// Copy Construct with a specific memory resource @param resource
     /// (host-side only)
     template <typename allocator_t = vecmem::memory_resource,
               typename C = container_t<T>>
-    requires std::is_same_v<C, std::vector<T>> DETRAY_HOST
-    single_store(allocator_t &resource, const T &arg)
+    requires(std::is_same_v<C, std::vector<T>>
+                 &&std::derived_from<allocator_t, std::pmr::memory_resource>)
+        DETRAY_HOST single_store(allocator_t &resource, const T &arg)
         : m_container(&resource, arg) {}
 
     /// Construct from the container @param view . Mainly used device-side.
-    template <typename container_view_t>
-    requires detail::is_device_view_v<container_view_t>
-        DETRAY_HOST_DEVICE explicit single_store(container_view_t &view)
+    template <concepts::device_view container_view_t>
+    DETRAY_HOST_DEVICE explicit single_store(container_view_t &view)
         : m_container(view) {}
 
     /// @returns a pointer to the underlying container - const

--- a/core/include/detray/core/detail/surface_lookup.hpp
+++ b/core/include/detray/core/detail/surface_lookup.hpp
@@ -90,7 +90,7 @@ class surface_lookup {
     /// Construct with a specific memory resource @param resource
     /// (host-side only)
     template <typename allocator_t = vecmem::memory_resource>
-    requires(!detail::is_device_view_v<allocator_t>) DETRAY_HOST
+    requires(!concepts::device_view<allocator_t>) DETRAY_HOST
         explicit surface_lookup(allocator_t &resource)
         : m_container(&resource) {}
 
@@ -104,9 +104,8 @@ class surface_lookup {
         : m_container(&resource, arg) {}
 
     /// Construct from the container @param view . Mainly used device-side.
-    template <typename container_view_t>
-    requires detail::is_device_view_v<container_view_t>
-        DETRAY_HOST_DEVICE explicit surface_lookup(container_view_t &view)
+    template <concepts::device_view container_view_t>
+    DETRAY_HOST_DEVICE explicit surface_lookup(container_view_t &view)
         : m_container(view) {}
 
     /// @returns the size of the underlying container

--- a/core/include/detray/core/detail/tuple_container.hpp
+++ b/core/include/detray/core/detail/tuple_container.hpp
@@ -55,7 +55,7 @@ class tuple_container {
     /// Construct with a specific vecmem memory resource @param resource
     /// (host-side only)
     template <typename allocator_t = vecmem::memory_resource>
-    requires(!is_device_view_v<allocator_t>) DETRAY_HOST
+    requires(!concepts::device_view<allocator_t>) DETRAY_HOST
         explicit tuple_container(allocator_t &resource)
         : _tuple(Ts(&resource)...) {}
 
@@ -68,9 +68,8 @@ class tuple_container {
         : _tuple(std::allocator_arg, resource, args...) {}
 
     /// Construct from the container @param view type. Mainly used device-side.
-    template <typename tuple_view_t>
-    requires is_device_view_v<tuple_view_t>
-        DETRAY_HOST_DEVICE explicit tuple_container(tuple_view_t &view)
+    template <concepts::device_view tuple_view_t>
+    DETRAY_HOST_DEVICE explicit tuple_container(tuple_view_t &view)
         : _tuple(
               unroll_views(view, std::make_index_sequence<sizeof...(Ts)>{})) {}
 
@@ -142,25 +141,23 @@ class tuple_container {
 
     private:
     /// @returns the view for all contained types.
-    template <bool all_viewable = std::conjunction_v<detail::has_view<Ts>...>,
-              std::size_t... I>
-    requires all_viewable DETRAY_HOST view_type
-    get_data(std::index_sequence<I...> /*seq*/) noexcept {
+    template <std::size_t... I>
+    requires(concepts::viewable<Ts> &&...) DETRAY_HOST view_type
+        get_data(std::index_sequence<I...> /*seq*/) noexcept {
         return view_type{detray::get_data(detail::get<I>(_tuple))...};
     }
 
     /// @returns the const view for all contained types.
-    template <bool all_viewable = std::conjunction_v<detail::has_view<Ts>...>,
-              std::size_t... I>
-    requires all_viewable DETRAY_HOST const_view_type
-    get_data(std::index_sequence<I...> /*seq*/) const noexcept {
+    template <std::size_t... I>
+    requires(concepts::viewable<Ts> &&...) DETRAY_HOST const_view_type
+        get_data(std::index_sequence<I...> /*seq*/) const noexcept {
         return const_view_type{detray::get_data(detail::get<I>(_tuple))...};
     }
 
     /// @returns a tuple constructed from the elements @param view s.
-    template <typename tuple_view_t, std::size_t... I>
-    requires is_device_view_v<tuple_view_t> DETRAY_HOST_DEVICE auto
-    unroll_views(tuple_view_t &view, std::index_sequence<I...> /*seq*/) {
+    template <concepts::device_view tuple_view_t, std::size_t... I>
+    DETRAY_HOST_DEVICE auto unroll_views(tuple_view_t &view,
+                                         std::index_sequence<I...> /*seq*/) {
         return detail::make_tuple<tuple_t>(Ts(detail::get<I>(view.m_view))...);
     }
 

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -129,7 +129,7 @@ class detector {
                                   typename accelerator_container::view_type,
                                   typename volume_finder::view_type>;
 
-    static_assert(detail::is_device_view_v<view_type>,
+    static_assert(concepts::device_view<view_type>,
                   "Detector view type ill-formed");
 
     using const_view_type =
@@ -141,7 +141,7 @@ class detector {
                     typename accelerator_container::const_view_type,
                     typename volume_finder::const_view_type>;
 
-    static_assert(detail::is_device_view_v<const_view_type>,
+    static_assert(concepts::device_view<const_view_type>,
                   "Detector const view type ill-formed");
 
     /// Detector buffer types
@@ -154,7 +154,7 @@ class detector {
                       typename accelerator_container::buffer_type,
                       typename volume_finder::buffer_type>;
 
-    static_assert(detail::is_buffer_v<buffer_type>,
+    static_assert(concepts::device_buffer<buffer_type>,
                   "Detector buffer type ill-formed");
 
     detector() = delete;
@@ -185,9 +185,8 @@ class detector {
           _resource(&resource) {}
 
     /// Constructor from detector data view
-    template <typename detector_view_t>
-    requires detail::is_device_view_v<detector_view_t>
-        DETRAY_HOST_DEVICE explicit detector(detector_view_t &det_data)
+    template <concepts::device_view detector_view_t>
+    DETRAY_HOST_DEVICE explicit detector(detector_view_t &det_data)
         : _volumes(detray::detail::get<0>(det_data.m_view)),
           _surfaces(detray::detail::get<1>(det_data.m_view)),
           _transforms(detray::detail::get<2>(det_data.m_view)),

--- a/core/include/detray/definitions/detail/boolean.hpp
+++ b/core/include/detray/definitions/detail/boolean.hpp
@@ -22,13 +22,13 @@ namespace detail {
 template <typename A, typename = void>
 struct get_bool {};
 
-template <typename A>
-struct get_bool<A, std::enable_if_t<!detray::detail::is_soa_v<A>, void>> {
+template <concepts::aos_algebra A>
+struct get_bool<A> {
     using boolean = bool;
 };
 
-template <typename A>
-struct get_bool<A, std::enable_if_t<detray::detail::is_soa_v<A>, void>> {
+template <concepts::soa_algebra A>
+struct get_bool<A> {
     using boolean = typename A::boolean;
 };
 /// @}
@@ -54,21 +54,18 @@ constexpr bool none_of(bool b) {
 }
 
 #if (IS_SOA)
-template <typename T,
-          std::enable_if_t<Vc::Traits::is_simd_mask<T>::value, bool> = true>
-inline bool any_of(T &&mask) {
+template <typename T>
+requires Vc::Traits::is_simd_mask<T>::value inline bool any_of(T &&mask) {
     return Vc::any_of(std::forward<T>(mask));
 }
 
-template <typename T,
-          std::enable_if_t<Vc::Traits::is_simd_mask<T>::value, bool> = true>
-inline bool all_of(T &&mask) {
+template <typename T>
+requires Vc::Traits::is_simd_mask<T>::value inline bool all_of(T &&mask) {
     return Vc::all_of(std::forward<T>(mask));
 }
 
-template <typename T,
-          std::enable_if_t<Vc::Traits::is_simd_mask<T>::value, bool> = true>
-inline bool none_of(T &&mask) {
+template <typename T>
+requires Vc::Traits::is_simd_mask<T>::value inline bool none_of(T &&mask) {
     return Vc::none_of(std::forward<T>(mask));
 }
 #endif

--- a/core/include/detray/geometry/detail/surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/surface_kernels.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/detail/material_accessor.hpp"
 #include "detray/materials/material.hpp"
 #include "detray/propagator/detail/jacobian_engine.hpp"
@@ -114,7 +115,7 @@ struct surface_kernels {
 
             using material_t = typename mat_group_t::value_type;
 
-            if constexpr (detail::is_surface_material_v<material_t>) {
+            if constexpr (concepts::surface_material<material_t>) {
                 return &(detail::material_accessor::get(mat_group, idx, loc_p)
                              .get_material());
             } else {

--- a/core/include/detray/geometry/detail/volume_kernels.hpp
+++ b/core/include/detray/geometry/detail/volume_kernels.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/detail/material_accessor.hpp"
 #include "detray/materials/material.hpp"
 
@@ -23,9 +24,9 @@ struct get_material_params {
                                               const point_t &loc_p) const {
         using material_t = typename mat_group_t::value_type;
 
-        if constexpr (detail::is_volume_material_v<material_t>) {
+        if constexpr (concepts::volume_material<material_t>) {
 
-            if constexpr (detail::is_hom_material_v<material_t>) {
+            if constexpr (concepts::homogeneous_material<material_t>) {
                 // Homogeneous volume material
                 return &(detail::material_accessor::get(mat_group, idx, loc_p));
             } else {

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -11,8 +11,8 @@
 #include "detray/definitions/detail/algebra.hpp"
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/utils/concepts.hpp"
 #include "detray/utils/invalid_values.hpp"
-#include "detray/utils/type_traits.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/data/vector_view.hpp>
@@ -625,7 +625,7 @@ template <typename axis_t, typename scalar_t>
         : n_bins(_n_bins), min(_min), max(_max) {}
     /// Construct a const data object from a non-const one
     template <typename other_scalar_t>
-    requires detail::is_same_nc<scalar_t, other_scalar_t>::value
+    requires concepts::same_as_no_const<scalar_t, other_scalar_t>
         DETRAY_HOST_DEVICE explicit axis_data(
             const axis_data<axis_t, other_scalar_t, void> &parent)
         : n_bins(parent.n_bins), min(parent.min), max(parent.max) {}
@@ -648,7 +648,7 @@ requires(axis_t::axis_identifier == 2) struct axis_data<axis_t, scalar_t> {
         : n_bins(_n_bins), min(_min), max(_max), boundaries(_boundaries) {}
     /// Construct a const data object from a non-const one
     template <typename other_scalar_t>
-    requires detail::is_same_nc<scalar_t, other_scalar_t>::value
+    requires concepts::same_as_no_const<scalar_t, other_scalar_t>
         DETRAY_HOST_DEVICE explicit axis_data(
             const axis_data<axis_t, other_scalar_t, void> &parent)
         : n_bins(parent.n_bins),

--- a/core/include/detray/materials/detail/concepts.hpp
+++ b/core/include/detray/materials/detail/concepts.hpp
@@ -1,0 +1,139 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Detray include(s)
+#include "detray/materials/material.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
+
+namespace detray::concepts {
+
+/// Material parameters
+template <class M>
+concept material_params = requires(const M m) {
+
+    typename M::ratio;
+
+    { m.X0() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { m.L0() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { m.Ar() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { m.Z() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { m.mass_density() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { m.molar_density() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { m.state() }
+    ->std::same_as<detray::material_state>;
+
+    { m.molar_electron_density() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { m.density_effect_data() }
+    ->std::same_as<
+        const detray::detail::density_effect_data<typename M::scalar_type> &>;
+
+    { m.mean_excitation_energy() }
+    ->std::same_as<typename M::scalar_type>;
+};
+
+/// Material parameters with a thickness
+template <class M>
+concept material_slab = requires(const M slab) {
+
+    typename M::material_type;
+
+    requires concepts::material_params<typename M::material_type>;
+
+    { slab.thickness() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { slab.thickness_in_X0() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { slab.thickness_in_L0() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { slab.path_segment(typename M::scalar_type(), typename M::scalar_type()) }
+    ->std::same_as<typename M::scalar_type>;
+
+    {
+        slab.path_segment_in_X0(typename M::scalar_type(),
+                                typename M::scalar_type())
+    }
+    ->std::same_as<typename M::scalar_type>;
+
+    {
+        slab.path_segment_in_L0(typename M::scalar_type(),
+                                typename M::scalar_type())
+    }
+    ->std::same_as<typename M::scalar_type>;
+};
+
+/// Material parameters with a radius
+template <class M>
+concept material_rod = requires(const M rod) {
+
+    typename M::material_type;
+
+    requires concepts::material_params<typename M::material_type>;
+
+    { rod.thickness() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { rod.radius() }
+    ->std::same_as<typename M::scalar_type>;
+
+    { rod.path_segment(typename M::scalar_type(), typename M::scalar_type()) }
+    ->std::same_as<typename M::scalar_type>;
+
+    {
+        rod.path_segment_in_X0(typename M::scalar_type(),
+                               typename M::scalar_type())
+    }
+    ->std::same_as<typename M::scalar_type>;
+
+    {
+        rod.path_segment_in_L0(typename M::scalar_type(),
+                               typename M::scalar_type())
+    }
+    ->std::same_as<typename M::scalar_type>;
+};
+
+/// Homogeneous material
+template <class M>
+concept homogeneous_material =
+    concepts::material_slab<M> || concepts::material_rod<M> ||
+    concepts::material_params<M>;
+
+/// Material map concept: Material grid
+template <class M>
+concept material_map =
+    concepts::grid<M> &&concepts::material_slab<typename M::value_type>;
+
+/// Material that can used for surfaces
+template <class M>
+concept surface_material =
+    (concepts::material_map<M> && (M::dim == 2)) ||
+    concepts::material_slab<M> || concepts::material_rod<M>;
+
+/// Material that can be used for volumes
+template <class M>
+concept volume_material = (concepts::material_map<M> && (M::dim == 3)) ||
+                          concepts::material_params<M>;
+
+}  // namespace detray::concepts

--- a/core/include/detray/materials/detail/material_accessor.hpp
+++ b/core/include/detray/materials/detail/material_accessor.hpp
@@ -9,6 +9,9 @@
 
 // Project include(s)
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/materials/detail/concepts.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
+#include "detray/utils/ranges/ranges.hpp"
 #include "detray/utils/type_traits.hpp"
 
 /// @brief Access a single unit of material in different types of material
@@ -18,8 +21,8 @@ namespace detray::detail::material_accessor {
 /// Access to material slabs or rods in a homogeneous material
 /// description and to raw material in a homogeneous volume material
 /// description
-template <class material_coll_t, typename point_t = void>
-requires detail::is_hom_material_v<typename material_coll_t::value_type>
+template <detray::ranges::range material_coll_t, typename point_t = void>
+requires concepts::homogeneous_material<typename material_coll_t::value_type>
     DETRAY_HOST_DEVICE constexpr decltype(auto) get(
         const material_coll_t &material_coll, const dindex idx,
         const point_t &) noexcept {
@@ -28,8 +31,8 @@ requires detail::is_hom_material_v<typename material_coll_t::value_type>
 }
 
 /// Access to material slabs in a material map or volume material
-template <class material_coll_t>
-requires detail::is_grid_v<typename material_coll_t::value_type>
+template <typename material_coll_t>
+requires concepts::material_map<typename material_coll_t::value_type>
     DETRAY_HOST_DEVICE constexpr decltype(auto) get(
         const material_coll_t &material_coll, const dindex idx,
         const typename material_coll_t::value_type::point_type

--- a/core/include/detray/materials/material.hpp
+++ b/core/include/detray/materials/material.hpp
@@ -245,18 +245,6 @@ struct material {
     bool m_has_density_effect_data = false;
 };
 
-namespace detail {
-
-// Pick the raw material type up for homogeneous volume material
-template <typename scalar_t>
-struct is_hom_material<material<scalar_t>, void> : public std::true_type {};
-
-// Pick the raw material type up for homogeneous volume material
-template <typename scalar_t>
-struct is_volume_material<material<scalar_t>, void> : public std::true_type {};
-
-}  // namespace detail
-
 // Macro for declaring the predefined materials (w/o Density effect data)
 #define DETRAY_DECLARE_MATERIAL(MATERIAL_NAME, X0, L0, Ar, Z, Rho, State)   \
     template <typename scalar_t, typename R = std::ratio<1, 1>>             \

--- a/core/include/detray/materials/material_map.hpp
+++ b/core/include/detray/materials/material_map.hpp
@@ -12,6 +12,7 @@
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/materials/material_slab.hpp"
 #include "detray/utils/grid/detail/axis_helpers.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 #include "detray/utils/grid/detail/grid_bins.hpp"
 #include "detray/utils/grid/grid.hpp"
 #include "detray/utils/grid/serializers.hpp"
@@ -32,35 +33,5 @@ using material_map = grid<axes<shape>, bins::single<material_slab<scalar_t>>,
 template <typename scalar_t = detray::scalar>
 using material_grid_factory =
     grid_factory<bins::single<material_slab<scalar_t>>, simple_serializer>;
-
-namespace detail {
-
-// TODO: Define concepts
-
-template <class material_t>
-struct is_material_map<
-    material_t,
-    std::enable_if_t<
-        is_grid_v<material_t> &&
-            std::is_same_v<
-                typename material_t::value_type,
-                material_slab<typename material_t::value_type::scalar_type>>,
-        void>> : public std::true_type {};
-
-// Pick the 2D material map types up for surface material maps
-template <typename material_t>
-struct is_surface_material<
-    material_t,
-    std::enable_if_t<is_material_map_v<material_t> && (material_t::dim == 2),
-                     void>> : public std::true_type {};
-
-// Pick the 3D material map types up for volume material maps
-template <typename material_t>
-struct is_volume_material<
-    material_t,
-    std::enable_if_t<is_material_map_v<material_t> && (material_t::dim == 3),
-                     void>> : public std::true_type {};
-
-}  // namespace detail
 
 }  // namespace detray

--- a/core/include/detray/materials/material_rod.hpp
+++ b/core/include/detray/materials/material_rod.hpp
@@ -116,17 +116,4 @@ struct material_rod {
     scalar_type m_radius_in_L0 = std::numeric_limits<scalar_type>::epsilon();
 };
 
-namespace detail {
-
-// Used directly for homogeneous line-surface material
-template <typename scalar_t>
-struct is_hom_material<material_rod<scalar_t>, void> : public std::true_type {};
-
-// Pick the material rod type up for homogeneous surface material
-template <typename scalar_t>
-struct is_surface_material<material_rod<scalar_t>, void>
-    : public std::true_type {};
-
-}  // namespace detail
-
 }  // namespace detray

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -113,18 +113,4 @@ struct material_slab {
     scalar_type m_thickness_in_L0 = std::numeric_limits<scalar>::epsilon();
 };
 
-namespace detail {
-
-// Used directly for homogeneous surface material
-template <class scalar_t>
-struct is_hom_material<material_slab<scalar_t>, void> : public std::true_type {
-};
-
-// Pick the material slab type up for homogeneous surface material
-template <typename scalar_t>
-struct is_surface_material<material_slab<scalar_t>, void>
-    : public std::true_type {};
-
-}  // namespace detail
-
 }  // namespace detray

--- a/core/include/detray/navigation/accelerators/brute_force_finder.hpp
+++ b/core/include/detray/navigation/accelerators/brute_force_finder.hpp
@@ -78,13 +78,6 @@ class brute_force_collection {
 
         /// @returns an iterator over all surfaces in the data structure
         DETRAY_HOST_DEVICE auto all() { return *this; }
-
-        /// @return the maximum number of surface candidates during a
-        /// neighborhood lookup
-        DETRAY_HOST_DEVICE constexpr auto n_max_candidates() const
-            -> unsigned int {
-            return static_cast<unsigned int>(this->size());
-        }
     };
 
     using value_type = brute_forcer;
@@ -116,9 +109,8 @@ class brute_force_collection {
         : brute_force_collection(&resource) {}
 
     /// Device-side construction from a vecmem based view type
-    template <typename coll_view_t>
-    requires detail::is_device_view_v<coll_view_t>
-        DETRAY_HOST_DEVICE explicit brute_force_collection(coll_view_t& view)
+    template <concepts::device_view coll_view_t>
+    DETRAY_HOST_DEVICE explicit brute_force_collection(coll_view_t& view)
         : m_offsets(detail::get<0>(view.m_view)),
           m_surfaces(detail::get<1>(view.m_view)) {}
 

--- a/core/include/detray/navigation/accelerators/concepts.hpp
+++ b/core/include/detray/navigation/accelerators/concepts.hpp
@@ -1,0 +1,27 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/geometry/detail/surface_descriptor.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
+
+// System include(s)
+#include <concepts>
+
+namespace detray::concepts {
+
+template <class accelerator_t>
+concept surface_grid = concepts::grid<accelerator_t>&& std::same_as<
+    typename accelerator_t::value_type,
+    surface_descriptor<typename accelerator_t::value_type::mask_link,
+                       typename accelerator_t::value_type::material_link,
+                       typename accelerator_t::value_type::transform_link,
+                       typename accelerator_t::value_type::navigation_link>>;
+
+}  // namespace detray::concepts

--- a/core/include/detray/navigation/accelerators/surface_grid.hpp
+++ b/core/include/detray/navigation/accelerators/surface_grid.hpp
@@ -13,24 +13,3 @@
 #include "detray/utils/grid/detail/grid_bins.hpp"
 #include "detray/utils/grid/grid.hpp"
 #include "detray/utils/grid/grid_collection.hpp"
-#include "detray/utils/type_traits.hpp"
-
-namespace detray::detail {
-
-// TODO: Define concepts
-
-template <class accelerator_t>
-struct is_surface_grid<
-    accelerator_t,
-    std::enable_if_t<
-        is_grid_v<accelerator_t> &&
-            std::is_same_v<
-                typename accelerator_t::value_type,
-                surface_descriptor<
-                    typename accelerator_t::value_type::mask_link,
-                    typename accelerator_t::value_type::material_link,
-                    typename accelerator_t::value_type::transform_link,
-                    typename accelerator_t::value_type::navigation_link>>,
-        void>> : public std::true_type {};
-
-}  // namespace detray::detail

--- a/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
@@ -33,9 +33,9 @@ struct helix_intersector_impl;
 /// The algorithm uses the Newton-Raphson method to find an intersection on
 /// the unbounded surface and then applies the mask.
 /// @note Don't use for low p_t tracks!
-template <typename algebra_t>
+template <concepts::aos_algebra algebra_t>
 struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
-    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, false> {
+    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
 
     using scalar_type = dscalar<algebra_t>;
     using point3_type = dpoint3D<algebra_t>;

--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -28,7 +28,7 @@ struct helix_intersector_impl;
 ///
 /// The algorithm uses the Newton-Raphson method to find an intersection on
 /// the unbounded surface and then applies the mask.
-template <typename algebra_t>
+template <concepts::aos_algebra algebra_t>
 struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
 
     using scalar_type = dscalar<algebra_t>;

--- a/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
@@ -29,7 +29,7 @@ struct helix_intersector_impl;
 ///
 /// The algorithm uses the Newton-Raphson method to find an intersection on
 /// the unbounded surface and then applies the mask.
-template <typename algebra_t>
+template <concepts::aos_algebra algebra_t>
 struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
 
     using scalar_type = dscalar<algebra_t>;
@@ -191,7 +191,7 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
     bool run_rtsafe{true};
 };
 
-template <typename algebra_t>
+template <concepts::aos_algebra algebra_t>
 struct helix_intersector_impl<polar2D<algebra_t>, algebra_t>
     : public helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {};
 

--- a/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
@@ -24,7 +24,7 @@ namespace detray {
 
 /// A functor to find intersections between trajectory and concentric cylinder
 /// mask
-template <typename algebra_t>
+template <concepts::aos_algebra algebra_t>
 struct ray_concentric_cylinder_intersector {
 
     /// linear algebra types

--- a/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
@@ -22,12 +22,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t, bool is_soa>
+template <typename frame_t, typename algebra_t>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between a ray and a 2D cylinder mask
-template <typename algebra_t>
-struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, false> {
+template <concepts::aos_algebra algebra_t>
+struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
 
     /// Linear algebra types
     /// @{

--- a/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
@@ -23,7 +23,7 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t, bool is_soa>
+template <typename frame_t, typename algebra_t>
 struct ray_intersector_impl;
 
 /// @brief A functor to find intersections between a straight line and a
@@ -31,10 +31,9 @@ struct ray_intersector_impl;
 ///
 /// With the way the navigation works, only the closest one of the two possible
 /// intersection points is needed in the case of a cylinderical portal surface.
-template <typename algebra_t>
-struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
-                            false>
-    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, false> {
+template <concepts::aos_algebra algebra_t>
+struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t>
+    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
 
     /// linear algebra types
     /// @{

--- a/core/include/detray/navigation/intersection/ray_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_intersector.hpp
@@ -24,12 +24,12 @@ namespace detray {
 ///
 /// @note specialized into the concrete intersectors for the different local
 /// geometries in the respective header files
-template <typename frame_t, typename algebra_t, bool is_soa = false>
+template <typename frame_t, typename algebra_t>
 struct ray_intersector_impl {};
 
 template <typename shape_t, typename algebra_t>
 using ray_intersector =
     ray_intersector_impl<typename shape_t::template local_frame_type<algebra_t>,
-                         algebra_t, detail::is_soa_v<algebra_t>>;
+                         algebra_t>;
 
 }  // namespace detray

--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -20,12 +20,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t, bool is_soa>
+template <typename frame_t, typename algebra_t>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between trajectory and line mask
-template <typename algebra_t>
-struct ray_intersector_impl<line2D<algebra_t>, algebra_t, false> {
+template <concepts::aos_algebra algebra_t>
+struct ray_intersector_impl<line2D<algebra_t>, algebra_t> {
 
     using scalar_type = dscalar<algebra_t>;
     using point3_type = dpoint3D<algebra_t>;

--- a/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
@@ -21,12 +21,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t, bool is_soa>
+template <typename frame_t, typename algebra_t>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between straight line and planar surface
-template <typename algebra_t>
-struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {
+template <concepts::aos_algebra algebra_t>
+struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
 
     /// linear algebra types
     /// @{
@@ -133,8 +133,8 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {
     }
 };
 
-template <typename algebra_t>
-struct ray_intersector_impl<polar2D<algebra_t>, algebra_t, false>
-    : public ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, false> {};
+template <concepts::aos_algebra algebra_t>
+struct ray_intersector_impl<polar2D<algebra_t>, algebra_t>
+    : public ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {};
 
 }  // namespace detray

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_intersector.hpp
@@ -21,12 +21,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t, bool is_soa>
+template <typename frame_t, typename algebra_t>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between straight line and planar surface
-template <typename algebra_t>
-struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, true> {
+template <concepts::soa_algebra algebra_t>
+struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
 
     /// Linear algebra types
     /// @{

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
@@ -26,10 +26,9 @@ namespace detray {
 ///
 /// With the way the navigation works, only the closest one of the two possible
 /// intersection points is needed in the case of a cylinderical portal surface.
-template <typename algebra_t>
-struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
-                            true>
-    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, true> {
+template <concepts::soa_algebra algebra_t>
+struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t>
+    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
 
     /// Linear algebra types
     /// @{

--- a/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
@@ -20,12 +20,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t, bool is_soa>
+template <typename frame_t, typename algebra_t>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between straight line and planar surface
-template <typename algebra_t>
-struct ray_intersector_impl<line2D<algebra_t>, algebra_t, true> {
+template <concepts::soa_algebra algebra_t>
+struct ray_intersector_impl<line2D<algebra_t>, algebra_t> {
 
     /// Linear algebra types
     /// @{

--- a/core/include/detray/navigation/intersection/soa/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_plane_intersector.hpp
@@ -21,12 +21,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t, bool is_soa>
+template <typename frame_t, typename algebra_t>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between straight line and planar surface
-template <typename algebra_t>
-struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, true> {
+template <concepts::soa_algebra algebra_t>
+struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
 
     /// Linear algebra types
     /// @{
@@ -131,8 +131,8 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, true> {
     }
 };
 
-template <typename algebra_t>
-struct ray_intersector_impl<polar2D<algebra_t>, algebra_t, true>
-    : public ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, true> {};
+template <concepts::soa_algebra algebra_t>
+struct ray_intersector_impl<polar2D<algebra_t>, algebra_t>
+    : public ray_intersector_impl<cartesian2D<algebra_t>, algebra_t> {};
 
 }  // namespace detray

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -166,9 +166,8 @@ class navigator {
         explicit state(const detector_type &det) : m_detector(&det) {}
 
         /// Constructor from detector @param det and inspector view @param view
-        template <typename view_t>
-        requires detail::is_device_view_v<view_t> DETRAY_HOST_DEVICE
-        state(const detector_type &det, view_t view)
+        template <concepts::device_view view_t>
+        DETRAY_HOST_DEVICE state(const detector_type &det, view_t view)
             : m_detector(&det), m_inspector(view) {}
 
         /// @return start position of the valid candidate range - const

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/track_parametrization.hpp"
 #include "detray/geometry/tracking_surface.hpp"
+#include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/detail/material_accessor.hpp"
 #include "detray/materials/interaction.hpp"
 #include "detray/propagator/base_actor.hpp"
@@ -73,7 +74,7 @@ struct pointwise_material_interactor : actor {
             using material_t = typename mat_group_t::value_type;
 
             // Filter material types for which to do "pointwise" interactions
-            if constexpr (detail::is_surface_material_v<material_t>) {
+            if constexpr (concepts::surface_material<material_t>) {
 
                 const auto mat = detail::material_accessor::get(
                     material_group, mat_index, bound_params.bound_local());

--- a/core/include/detray/utils/concepts.hpp
+++ b/core/include/detray/utils/concepts.hpp
@@ -1,0 +1,56 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/indexing.hpp"
+#include "detray/utils/type_traits.hpp"
+
+// System include(s)
+#include <concepts>
+#include <ranges>
+#include <type_traits>
+
+namespace detray::concepts {
+
+/// Arithmetic types
+template <typename T>
+concept arithmetic = std::is_arithmetic_v<T>;
+
+template <typename T>
+concept arithmetic_cvref = concepts::arithmetic<std::remove_cvref_t<T>>;
+
+/// Same, except for cv qualifiers and reference
+template <typename T, typename U>
+concept same_as_cvref =
+    std::same_as<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
+
+/// Concept for detecting when a type is a non-const version of another
+template <typename T, typename U>
+concept same_as_no_const = std::same_as<std::remove_cv_t<T>, U>;
+
+/// Concept that checks if a type models an interval of some value that can
+/// be obtained with 'get'.
+template <typename I>
+concept interval = requires(I i) {
+
+    requires(!concepts::arithmetic_cvref<I>);
+
+    { detray::detail::get<0>(i) }
+    ->concepts::arithmetic_cvref;
+
+    { detray::detail::get<1>(i) }
+    ->concepts::arithmetic_cvref;
+};
+
+/// Range of a given type
+template <typename R, typename T>
+concept range_of =
+    std::ranges::range<R>&& std::same_as<std::ranges::range_value_t<R>, T>;
+
+}  // namespace detray::concepts

--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -10,6 +10,7 @@
 // Project include(s)
 #include "detray/geometry/tracking_surface.hpp"
 #include "detray/geometry/tracking_volume.hpp"
+#include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/predefined_materials.hpp"
 #include "detray/utils/ranges.hpp"
 
@@ -152,7 +153,7 @@ struct material_checker {
     /// @param idx the specific grid to be checked
     /// @param id type id of the material grid collection
     template <typename material_coll_t, typename index_t, typename id_t>
-    requires detail::is_material_map_v<typename material_coll_t::value_type>
+    requires concepts::material_map<typename material_coll_t::value_type>
         DETRAY_HOST_DEVICE void operator()(const material_coll_t &material_coll,
                                            const index_t idx,
                                            const id_t id) const {
@@ -184,7 +185,8 @@ struct material_checker {
     /// @param material_coll collection of material slabs/rods/raw mat
     /// @param idx the specific instance to be checked
     template <typename material_coll_t, typename index_t, typename id_t>
-    requires detail::is_hom_material_v<typename material_coll_t::value_type>
+    requires concepts::homogeneous_material<
+        typename material_coll_t::value_type>
         DETRAY_HOST_DEVICE void operator()(const material_coll_t &material_coll,
                                            const index_t idx,
                                            const id_t) const {
@@ -195,7 +197,7 @@ struct material_checker {
         const material_t &mat = material_coll.at(idx);
 
         // Homogeneous volume material
-        if constexpr (std::is_same_v<material_t, material<scalar_t>>) {
+        if constexpr (concepts::material_params<material_t>) {
 
             if (mat == detray::vacuum<scalar_t>{}) {
                 throw_material_error("homogeneous volume material", idx, mat);

--- a/core/include/detray/utils/grid/detail/axis.hpp
+++ b/core/include/detray/utils/grid/detail/axis.hpp
@@ -15,6 +15,7 @@
 #include "detray/definitions/grid_axis.hpp"
 #include "detray/utils/grid/detail/axis_binning.hpp"
 #include "detray/utils/grid/detail/axis_bounds.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 #include "detray/utils/ranges.hpp"
 #include "detray/utils/type_list.hpp"
 #include "detray/utils/type_registry.hpp"
@@ -69,7 +70,7 @@ struct single_axis {
 
     /// Defines the geometrical bounds of the axis as a service:
     /// open, closed or circular
-    bounds_type m_bounds{};
+    [[no_unique_address]] bounds_type m_bounds{};
     /// Defines the binning on the axis as a service: regular vs irregular
     binning_type m_binning{};
 
@@ -178,7 +179,7 @@ struct single_axis {
 ///
 /// @note can be owning the data (as member of a standalone grid) or can be
 /// non-owning if the grid is part of a larger collection.
-template <bool ownership, typename local_frame_t, typename... axis_ts>
+template <bool ownership, typename local_frame_t, concepts::axis... axis_ts>
 class multi_axis {
 
     /// Match an axis to its label at compile time
@@ -273,9 +274,8 @@ class multi_axis {
     /// Construct containers from vecmem based view type
     ///
     /// @param view vecmem view on the axes data
-    template <typename view_t>
-    requires detray::detail::is_device_view_v<view_t>
-        DETRAY_HOST_DEVICE explicit multi_axis(const view_t &view)
+    template <concepts::device_view view_t>
+    DETRAY_HOST_DEVICE explicit multi_axis(const view_t &view)
         : m_edge_offsets(detray::detail::get<0>(view.m_view)),
           m_edges(detray::detail::get<1>(view.m_view)) {}
 

--- a/core/include/detray/utils/grid/detail/bin_storage.hpp
+++ b/core/include/detray/utils/grid/detail/bin_storage.hpp
@@ -84,9 +84,8 @@ class bin_storage : public detray::ranges::view_interface<
         : m_bin_data(bin_data, dindex_range{offset, offset + size}) {}
 
     /// Construct bin storage from its vecmem view
-    template <typename view_t>
-    requires detail::is_device_view_v<view_t>
-        DETRAY_HOST_DEVICE explicit bin_storage(const view_t& view)
+    template <concepts::device_view view_t>
+    DETRAY_HOST_DEVICE explicit bin_storage(const view_t& view)
         : m_bin_data(view) {}
 
     /// begin and end of the bin range
@@ -156,9 +155,8 @@ struct dynamic_bin_container {
         default;
 
     /// Device-side construction from a vecmem based view type
-    template <typename view_t>
-    requires detail::is_device_view_v<view_t>
-        DETRAY_HOST_DEVICE explicit dynamic_bin_container(view_t& view)
+    template <concepts::device_view view_t>
+    DETRAY_HOST_DEVICE explicit dynamic_bin_container(view_t& view)
         : bins(detail::get<0>(view.m_view)),
           entries(detail::get<1>(view.m_view)) {}
 
@@ -404,9 +402,8 @@ class bin_storage<is_owning, detray::bins::dynamic_array<entry_t>, containers>
               dindex_range{0u, static_cast<dindex>(bin_data.entries.size())}) {}
 
     /// Construct bin storage from its vecmem view
-    template <typename view_t>
-    requires detail::is_device_view_v<view_t>
-        DETRAY_HOST_DEVICE explicit bin_storage(const view_t& view)
+    template <concepts::device_view view_t>
+    DETRAY_HOST_DEVICE explicit bin_storage(const view_t& view)
         : m_bin_data(detray::detail::get<0>(view.m_view)),
           m_entry_data(detray::detail::get<1>(view.m_view)) {}
 

--- a/core/include/detray/utils/grid/detail/bin_view.hpp
+++ b/core/include/detray/utils/grid/detail/bin_view.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/utils/grid/detail/axis_bounds.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 #include "detray/utils/ranges.hpp"
 
 // System include(s)
@@ -18,7 +19,7 @@
 
 namespace detray::axis::detail {
 
-template <typename G, typename I>
+template <concepts::grid G, std::input_iterator I>
 struct bin_iterator;
 
 /// @returns the local bin indexer for the given @param search_window.
@@ -33,7 +34,7 @@ DETRAY_HOST_DEVICE inline auto get_bin_indexer(
 }
 
 /// @brief Range adaptor that fetches grid bins according to a search window.
-template <typename grid_t>
+template <concepts::grid grid_t>
 struct bin_view : public detray::ranges::view_interface<bin_view<grid_t>> {
 
     /// Cartesian product view over the local bin index sequences
@@ -99,7 +100,7 @@ struct bin_view : public detray::ranges::view_interface<bin_view<grid_t>> {
 };
 
 /// @brief Iterate through the bin search area.
-template <typename grid_t, typename bin_indexer_t>
+template <concepts::grid grid_t, std::input_iterator bin_indexer_t>
 struct bin_iterator {
 
     using difference_type = std::ptrdiff_t;

--- a/core/include/detray/utils/grid/detail/concepts.hpp
+++ b/core/include/detray/utils/grid/detail/concepts.hpp
@@ -1,0 +1,120 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/core/detail/container_buffers.hpp"
+#include "detray/core/detail/container_views.hpp"
+#include "detray/definitions/detail/indexing.hpp"
+#include "detray/definitions/grid_axis.hpp"
+#include "detray/utils/concepts.hpp"
+
+// System include(s)
+#include <array>
+#include <concepts>
+#include <utility>
+
+namespace detray::concepts {
+
+template <typename A>
+concept axis = requires(const A ax) {
+
+    typename A::bounds_type;
+    typename A::binning_type;
+    typename A::scalar_type;
+
+    { ax.label() }
+    ->std::same_as<axis::label>;
+
+    { ax.bounds() }
+    ->std::same_as<axis::bounds>;
+
+    { ax.binning() }
+    ->std::same_as<axis::binning>;
+
+    { ax.nbins() }
+    ->std::same_as<dindex>;
+
+    { ax.bin(typename A::scalar_type()) }
+    ->std::same_as<dindex>;
+
+    { ax.range(typename A::scalar_type(), std::array<dindex, 2>()) }
+    ->std::same_as<std::array<int, 2>>;
+
+    {
+        ax.range(typename A::scalar_type(),
+                 std::array<typename A::scalar_type, 2>())
+    }
+    ->std::same_as<std::array<int, 2>>;
+
+    { ax.bin_edges(dindex()) }
+    ->std::same_as<std::array<typename A::scalar_type, 2>>;
+
+    { ax.bin_edges() }
+    ->concepts::range_of<typename A::scalar_type>;
+
+    { ax.span() }
+    ->std::same_as<std::array<typename A::scalar_type, 2>>;
+
+    { ax.min() }
+    ->std::same_as<typename A::scalar_type>;
+
+    { ax.max() }
+    ->std::same_as<typename A::scalar_type>;
+};
+
+template <typename G>
+concept grid = viewable<G>&& bufferable<G>&& requires(const G g) {
+
+    G::dim;
+
+    typename G::bin_type;
+    typename G::value_type;
+    typename G::glob_bin_index;
+    typename G::loc_bin_index;
+    typename G::local_frame_type;
+    typename G::point_type;
+
+    G::is_owning;
+
+    // TODO: Implement cooridnate frame concept
+    { g.get_local_frame() }
+    ->std::same_as<typename G::local_frame_type>;
+
+    { g.template get_axis<0>() }
+    ->concepts::axis;
+
+    { g.nbins() }
+    ->std::same_as<dindex>;
+
+    { g.size() }
+    ->std::same_as<dindex>;
+
+    { g.deserialize(typename G::glob_bin_index()) }
+    ->std::same_as<typename G::loc_bin_index>;
+
+    { g.serialize(typename G::loc_bin_index()) }
+    ->std::same_as<typename G::glob_bin_index>;
+
+    { g.bins() }
+    ->concepts::range_of<typename G::bin_type>;
+
+    { g.bin(typename G::glob_bin_index()) }
+    ->concepts::same_as_cvref<typename G::bin_type>;
+
+    { g.bin(typename G::loc_bin_index()) }
+    ->concepts::same_as_cvref<typename G::bin_type>;
+
+    { g.at(typename G::loc_bin_index(), dindex()) }
+    ->concepts::same_as_cvref<typename G::value_type>;
+
+    { g.at(typename G::glob_bin_index(), dindex()) }
+    ->concepts::same_as_cvref<typename G::value_type>;
+};
+
+}  // namespace detray::concepts

--- a/core/include/detray/utils/grid/grid.hpp
+++ b/core/include/detray/utils/grid/grid.hpp
@@ -127,9 +127,8 @@ class grid_impl {
           m_axes(std::move(axes)) {}
 
     /// Device-side construction from a vecmem based view type
-    template <typename grid_view_t>
-    requires detail::is_device_view_v<grid_view_t>
-        DETRAY_HOST_DEVICE explicit grid_impl(grid_view_t &view)
+    template <concepts::device_view grid_view_t>
+    DETRAY_HOST_DEVICE explicit grid_impl(grid_view_t &view)
         : m_bins(detray::detail::get<0>(view.m_view)),
           m_axes(detray::detail::get<1>(view.m_view)) {}
 
@@ -344,13 +343,6 @@ class grid_impl {
     }
     /// @}
 
-    /// @return the maximum number of surface candidates during a
-    /// neighborhood lookup
-    DETRAY_HOST_DEVICE constexpr auto n_max_candidates() const -> unsigned int {
-        // @todo: Hotfix for the toy geometry
-        return 20u;
-    }
-
     /// @returns view of a grid, including the grids multi_axis. Also valid if
     /// the value type of the grid is cv qualified (then value_t propagates
     /// quialifiers) - non-const
@@ -383,14 +375,5 @@ template <typename axes_t, typename bin_t,
 using grid =
     grid_impl<coordinate_axes<axes_t, ownership, containers, algebra_t>, bin_t,
               simple_serializer>;
-
-namespace detail {
-
-template <typename multi_axis_t, typename bin_t,
-          template <std::size_t> class serializer_t>
-struct is_grid<grid_impl<multi_axis_t, bin_t, serializer_t>>
-    : public std::true_type {};
-
-}  // namespace detail
 
 }  // namespace detray

--- a/core/include/detray/utils/grid/grid_collection.hpp
+++ b/core/include/detray/utils/grid/grid_collection.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 #include "detray/utils/grid/grid.hpp"
 
 // VecMem include(s).
@@ -24,7 +25,7 @@ namespace detray {
 ///
 /// @tparam grid_t The type of grid in this collection. Must be non-owning, so
 ///                that the grid collection can manage the underlying memory.
-template <typename grid_t, typename = void>
+template <concepts::grid grid_t, typename = void>
 class grid_collection {};
 
 /// Specialization for @c detray::grid
@@ -153,9 +154,8 @@ requires(!detray::grid_impl<axes_t, bin_t, serializer_t>::
           m_bin_edges(std::move(edges)) {}
 
     /// Device-side construction from a vecmem based view type
-    template <typename coll_view_t>
-    requires detail::is_device_view_v<coll_view_t>
-        DETRAY_HOST_DEVICE explicit grid_collection(coll_view_t &view)
+    template <concepts::device_view coll_view_t>
+    DETRAY_HOST_DEVICE explicit grid_collection(coll_view_t &view)
         : m_bin_offsets(detail::get<0>(view.m_view)),
           m_bins(detail::get<1>(view.m_view)),
           m_bin_edge_offsets(detail::get<2>(view.m_view)),
@@ -188,11 +188,11 @@ requires(!detray::grid_impl<axes_t, bin_t, serializer_t>::
 
     /// @returns an iterator that points to the first grid
     DETRAY_HOST_DEVICE
-    constexpr auto begin() const noexcept { return iterator{*this, 0u}; }
+    constexpr auto begin() const { return iterator{*this, 0u}; }
 
     /// @returns an iterator that points to the coll. end
     DETRAY_HOST_DEVICE
-    constexpr auto end() const noexcept { return iterator{*this, size()}; }
+    constexpr auto end() const { return iterator{*this, size()}; }
 
     /// @returns the number of grids in the collection - const
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/ranges/iota.hpp
+++ b/core/include/detray/utils/ranges/iota.hpp
@@ -10,8 +10,8 @@
 // Project include(s)
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/utils/concepts.hpp"
 #include "detray/utils/ranges/ranges.hpp"
-#include "detray/utils/type_traits.hpp"
 
 // System include(s)
 #include <iterator>
@@ -102,9 +102,8 @@ class iota_view : public detray::ranges::view_interface<iota_view<incr_t>> {
     constexpr iota_view() requires std::default_initializable<incr_t> = default;
 
     /// Construct from an @param interval that defines start and end values.
-    template <typename interval_t>
-    requires detray::detail::is_interval_v<interval_t>
-        DETRAY_HOST_DEVICE constexpr explicit iota_view(interval_t &&interval)
+    template <concepts::interval interval_t>
+    DETRAY_HOST_DEVICE constexpr explicit iota_view(interval_t &&interval)
         : m_start{detray::detail::get<0>(std::forward<interval_t>(interval))},
           m_end{detray::detail::get<1>(std::forward<interval_t>(interval))} {}
 
@@ -140,9 +139,8 @@ struct iota : public detray::ranges::iota_view<incr_t> {
 
     constexpr iota() requires std::default_initializable<incr_t> = default;
 
-    template <typename interval_t>
-    requires detray::detail::is_interval_v<interval_t>
-        DETRAY_HOST_DEVICE constexpr explicit iota(interval_t &&interval)
+    template <concepts::interval interval_t>
+    DETRAY_HOST_DEVICE constexpr explicit iota(interval_t &&interval)
         : base_type(std::forward<interval_t>(interval)) {}
 
     DETRAY_HOST_DEVICE constexpr iota(incr_t start, incr_t end)
@@ -156,8 +154,8 @@ struct iota : public detray::ranges::iota_view<incr_t> {
 
 template <typename interval_t>
 DETRAY_HOST_DEVICE iota(interval_t &&interval)
-    ->iota<detray::detail::remove_cvref_t<
-        decltype(std::get<0>(std::declval<interval_t>()))>>;
+    ->iota<
+        std::remove_cvref_t<decltype(std::get<0>(std::declval<interval_t>()))>>;
 
 template <typename I = dindex>
 DETRAY_HOST_DEVICE iota(I start, I end)->iota<I>;

--- a/core/include/detray/utils/ranges/ranges.hpp
+++ b/core/include/detray/utils/ranges/ranges.hpp
@@ -73,17 +73,16 @@ template <class R>
 using range_size_t = decltype(detray::ranges::size(std::declval<R&>()));
 
 template <class R>
-using range_difference_t =
-    typename std::iterator_traits<detray::ranges::iterator_t<
-        detray::detail::remove_cvref_t<R>>>::difference_type;
+using range_difference_t = typename std::iterator_traits<
+    detray::ranges::iterator_t<std::remove_cvref_t<R>>>::difference_type;
 
 template <class R>
 using range_value_t = typename std::iterator_traits<
-    detray::ranges::iterator_t<detray::detail::remove_cvref_t<R>>>::value_type;
+    detray::ranges::iterator_t<std::remove_cvref_t<R>>>::value_type;
 
 template <class R>
 using range_reference_t = typename std::iterator_traits<
-    detray::ranges::iterator_t<detray::detail::remove_cvref_t<R>>>::reference;
+    detray::ranges::iterator_t<std::remove_cvref_t<R>>>::reference;
 
 template <class R>
 using range_const_reference_t = const range_reference_t<R>;
@@ -130,7 +129,7 @@ inline constexpr bool disable_sized_range = false;
 /// @brief A function 'size' is implemented for the range @tparam R
 template <class R>
 inline constexpr bool sized_range =
-    !ranges::disable_sized_range<detray::detail::remove_cvref_t<R>> &&
+    !ranges::disable_sized_range<std::remove_cvref_t<R>> &&
     (detray::ranges::range<R> &&
      std::is_integral_v<detray::ranges::range_size_t<R>>);
 
@@ -142,7 +141,7 @@ template <class R>
 inline constexpr bool borrowed_range =
     detray::ranges::range<R> &&
     (std::is_lvalue_reference_v<R> ||
-     ranges::enable_borrowed_range<detray::detail::remove_cvref_t<R>>);
+     ranges::enable_borrowed_range<std::remove_cvref_t<R>>);
 
 /// @brief models a dangling iterator
 /// @see https://en.cppreference.com/w/cpp/ranges/dangling
@@ -288,9 +287,9 @@ inline constexpr bool view = detray::ranges::range<R>&& std::is_object_v<R>&&
     std::is_move_constructible_v<R>&& enable_view<R>;
 
 template <class R>
-inline constexpr bool viewable_range =
-    detray::ranges::range<R> &&
-    (borrowed_range<R> || view<detray::detail::remove_cvref_t<R>>);
+inline constexpr bool viewable_range = detray::ranges::range<R> &&
+                                       (borrowed_range<R> ||
+                                        view<std::remove_cvref_t<R>>);
 /// @}
 
 }  // namespace detray::ranges

--- a/core/include/detray/utils/ranges/subrange.hpp
+++ b/core/include/detray/utils/ranges/subrange.hpp
@@ -10,8 +10,8 @@
 // Project include(s)
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/utils/concepts.hpp"
 #include "detray/utils/ranges/ranges.hpp"
-#include "detray/utils/type_traits.hpp"
 
 // System include(s)
 #include <type_traits>
@@ -58,16 +58,18 @@ class subrange : public detray::ranges::view_interface<subrange<range_t>> {
           m_end{detray::ranges::next(m_begin)} {}
 
     /// Construct from a @param range and an index range @param pos.
-    template <detray::ranges::range deduced_range_t, typename index_range_t>
-    requires detray::detail::is_interval_v<index_range_t>
-        DETRAY_HOST_DEVICE constexpr subrange(deduced_range_t &&range,
-                                              index_range_t &&pos)
+    template <detray::ranges::range deduced_range_t,
+              concepts::interval index_range_t>
+    DETRAY_HOST_DEVICE constexpr subrange(deduced_range_t &&range,
+                                          index_range_t &&pos)
         : m_begin{detray::ranges::next(
               detray::ranges::begin(std::forward<deduced_range_t>(range)),
-              static_cast<difference_t>(detray::detail::get<0>(pos)))},
+              static_cast<difference_t>(
+                  detray::detail::get<0>(std::forward<index_range_t>(pos))))},
           m_end{detray::ranges::next(
               detray::ranges::begin(std::forward<deduced_range_t>(range)),
-              static_cast<difference_t>(detray::detail::get<1>(pos)))} {}
+              static_cast<difference_t>(
+                  detray::detail::get<1>(std::forward<index_range_t>(pos))))} {}
 
     /// @return start position of range.
     DETRAY_HOST_DEVICE
@@ -100,9 +102,9 @@ requires std::convertible_to<
     DETRAY_HOST_DEVICE subrange(deduced_range_t &&range, index_t pos)
         ->subrange<deduced_range_t>;
 
-template <detray::ranges::range deduced_range_t, typename index_range_t>
-requires detray::detail::is_interval_v<index_range_t> DETRAY_HOST_DEVICE
-subrange(deduced_range_t &&range, index_range_t &&pos)
+template <detray::ranges::range deduced_range_t,
+          concepts::interval index_range_t>
+DETRAY_HOST_DEVICE subrange(deduced_range_t &&range, index_range_t &&pos)
     ->subrange<deduced_range_t>;
 
 /// @see https://en.cppreference.com/w/cpp/ranges/borrowed_iterator_t

--- a/core/include/detray/utils/type_list.hpp
+++ b/core/include/detray/utils/type_list.hpp
@@ -75,7 +75,7 @@ struct get_at {};
 
 template <std::size_t N, typename T, typename... Ts>
 struct get_at<N, list<T, Ts...>> {
-    using type = detail::remove_cvref_t<decltype(
+    using type = std::remove_cvref_t<decltype(
         detray::get<N>(detray::tuple<T, Ts...>{}))>;
 };
 template <typename L, std::size_t N>

--- a/core/include/detray/utils/type_traits.hpp
+++ b/core/include/detray/utils/type_traits.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,72 +15,26 @@
 
 namespace detray::detail {
 
-/// Helper trait that should emulate std::remove_cvref_t in c++20
-template <typename T>
-using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
-
-/// Helper trait for detecting when a type is a non-const version of another
-///
-/// This comes into play multiple times to enable certain constructors
-/// conditionally through SFINAE.
-///
-/// @{
-template <typename CTYPE, typename NCTYPE>
-struct is_same_nc {
-    static constexpr bool value = false;
-};
-
-template <typename TYPE>
-struct is_same_nc<const TYPE, TYPE> {
-    static constexpr bool value = true;
-};
-/// @}
-
 /// Extract the value type of e.g. a container.
 /// @{
-template <typename T, typename = void>
+template <typename T>
 struct get_value_type {
     using type = T;
 };
 
 template <typename T>
-struct get_value_type<T*, void> {
+struct get_value_type<T*> {
     using type = T;
 };
 
 template <typename container_t>
-struct get_value_type<
-    container_t,
-    std::enable_if_t<
-        !std::is_same_v<typename remove_cvref_t<container_t>::value_type, void>,
-        void>> {
-    using type = typename remove_cvref_t<container_t>::value_type;
+requires(!std::same_as<typename std::remove_cvref_t<container_t>::value_type,
+                       void>) struct get_value_type<container_t> {
+    using type = typename std::remove_cvref_t<container_t>::value_type;
 };
 
 template <typename T>
 using get_value_t = typename get_value_type<T>::type;
-/// @}
-
-/// Helper trait that checks if a type models an interval of some value that can
-/// be obtained with 'get'.
-/// @{
-template <typename TYPE, typename = void, typename = void>
-struct is_interval : public std::false_type {};
-
-template <typename TYPE>
-struct is_interval<
-    TYPE,
-    std::enable_if_t<!std::is_arithmetic_v<std::remove_reference_t<TYPE>> &&
-                         std::is_arithmetic_v<std::remove_reference_t<decltype(
-                             detray::detail::get<0>(std::declval<TYPE>()))>>,
-                     void>,
-    std::enable_if_t<!std::is_arithmetic_v<std::remove_reference_t<TYPE>> &&
-                         std::is_arithmetic_v<std::remove_reference_t<decltype(
-                             detray::detail::get<1>(std::declval<TYPE>()))>>,
-                     void>> : public std::true_type {};
-
-template <typename TYPE>
-inline constexpr bool is_interval_v = is_interval<TYPE>::value;
 /// @}
 
 /// Extract the first type from a parameter pack.
@@ -128,41 +82,5 @@ struct get_type_pos {
 template <typename T, typename... Ts>
 inline constexpr std::size_t get_type_pos_v = get_type_pos<T, Ts...>::value;
 /// @}
-
-template <class grid_t>
-struct is_grid : public std::false_type {};
-
-template <typename T>
-inline constexpr bool is_grid_v = is_grid<T>::value;
-
-template <class accelerator_t, typename = void>
-struct is_surface_grid : public std::false_type {};
-
-template <typename T>
-inline constexpr bool is_surface_grid_v = is_surface_grid<T>::value;
-
-template <class material_t, typename = void>
-struct is_hom_material : public std::false_type {};
-
-template <typename T>
-inline constexpr bool is_hom_material_v = is_hom_material<T>::value;
-
-template <class material_t, typename = void>
-struct is_material_map : public std::false_type {};
-
-template <typename T>
-inline constexpr bool is_material_map_v = is_material_map<T>::value;
-
-template <class material_t, typename = void>
-struct is_volume_material : public std::false_type {};
-
-template <typename T>
-inline constexpr bool is_volume_material_v = is_volume_material<T>::value;
-
-template <class material_t, typename = void>
-struct is_surface_material : public std::false_type {};
-
-template <typename T>
-inline constexpr bool is_surface_material_v = is_surface_material<T>::value;
 
 }  // namespace detray::detail

--- a/io/include/detray/io/common/detail/grid_writer.hpp
+++ b/io/include/detray/io/common/detail/grid_writer.hpp
@@ -12,6 +12,7 @@
 #include "detray/io/common/detail/basic_converter.hpp"
 #include "detray/io/common/detail/type_info.hpp"
 #include "detray/io/frontend/payloads.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 #include "detray/utils/grid/grid.hpp"
 #include "detray/utils/type_list.hpp"
 
@@ -179,7 +180,7 @@ class grid_writer {
 
             using coll_value_t = typename grid_group_t::value_type;
 
-            if constexpr (detray::detail::is_grid_v<coll_value_t>) {
+            if constexpr (concepts::grid<coll_value_t>) {
 
                 using value_t = typename coll_value_t::value_type;
 
@@ -205,7 +206,7 @@ class grid_writer {
         constexpr auto coll_id{store_t::value_types::to_id(I)};
         using value_type = typename store_t::template get_type<coll_id>;
 
-        if constexpr (detray::detail::is_grid_v<value_type>) {
+        if constexpr (concepts::grid<value_type>) {
             n += store.template size<coll_id>();
         }
 

--- a/io/include/detray/io/common/geometry_writer.hpp
+++ b/io/include/detray/io/common/geometry_writer.hpp
@@ -14,6 +14,7 @@
 #include "detray/io/common/detail/basic_converter.hpp"
 #include "detray/io/common/detail/type_info.hpp"
 #include "detray/io/frontend/payloads.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 
 // System include(s)
 #include <algorithm>
@@ -194,7 +195,7 @@ class geometry_writer {
             auto id{acc_links_payload::type_id::unknown};
 
             // Only convert grids
-            if constexpr (detray::detail::is_grid_v<accel_t>) {
+            if constexpr (concepts::grid<accel_t>) {
                 id = io::detail::get_id<accel_t>();
             }
 

--- a/io/include/detray/io/common/homogeneous_material_reader.hpp
+++ b/io/include/detray/io/common/homogeneous_material_reader.hpp
@@ -81,7 +81,7 @@ class homogeneous_material_reader {
                 mat_factory->add_material(
                     mat_id::e_slab, convert<scalar_t>(slab_data), sf_link);
             }
-            if constexpr (detray::detail::has_material_rods_v<detector_t>) {
+            if constexpr (concepts::has_material_rods<detector_t>) {
                 if (mv_data.mat_rods.has_value()) {
                     for (const auto& rod_data : *(mv_data.mat_rods)) {
                         assert(rod_data.type == io::material_id::rod);

--- a/io/include/detray/io/common/homogeneous_material_writer.hpp
+++ b/io/include/detray/io/common/homogeneous_material_writer.hpp
@@ -43,12 +43,12 @@ class homogeneous_material_writer {
 
         header_data.sub_header.emplace();
         auto& mat_sub_header = header_data.sub_header.value();
-        if constexpr (detray::detail::has_material_slabs_v<detector_t>) {
+        if constexpr (concepts::has_material_slabs<detector_t>) {
             mat_sub_header.n_slabs =
                 materials.template size<detector_t::materials::id::e_slab>();
         }
         mat_sub_header.n_rods = 0u;
-        if constexpr (detray::detail::has_material_rods_v<detector_t>) {
+        if constexpr (concepts::has_material_rods<detector_t>) {
             mat_sub_header.n_rods =
                 materials.template size<detector_t::materials::id::e_rod>();
         }
@@ -89,7 +89,7 @@ class homogeneous_material_writer {
         // If this reader is called, the detector has at least material slabs
         if (det.material_store().template empty<mat_id::e_slab>()) {
             // Check for material rods that are present in e.g. wire chambers
-            if constexpr (detray::detail::has_material_rods_v<detector_t>) {
+            if constexpr (concepts::has_material_rods<detector_t>) {
                 if (det.material_store().template empty<mat_id::e_rod>()) {
                     return mv_data;
                 }

--- a/io/include/detray/io/frontend/detail/type_traits.hpp
+++ b/io/include/detray/io/frontend/detail/type_traits.hpp
@@ -8,96 +8,148 @@
 #pragma once
 
 // Project include(s)
+#include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/material_rod.hpp"
 #include "detray/materials/material_slab.hpp"
+#include "detray/navigation/accelerators/concepts.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
+#include "detray/utils/type_registry.hpp"
 #include "detray/utils/type_traits.hpp"
 
 // System include(s)
 #include <type_traits>
 
-namespace detray::detail {
+namespace detray {
+
+namespace detail {
 
 /// Check for grid types in a data store
 /// @{
 template <typename>
 struct contains_grids;
 
-template <template <typename, typename...> class R, class ID, typename... Ts>
-struct contains_grids<R<ID, Ts...>> {
-    static constexpr bool value{std::disjunction_v<detail::is_grid<Ts>...>};
+template <class ID, typename... Ts>
+struct contains_grids<type_registry<ID, Ts...>> {
+    static constexpr bool value{(concepts::grid<Ts> || ...)};
 };
 
 template <typename T>
 inline constexpr bool contains_grids_v = contains_grids<T>::value;
 /// @}
 
-/// Check for the various types of material
+/// Check for surface grid types in a data store
 /// @{
-template <class detector_t, typename = void>
-struct has_surface_grids : public std::false_type {};
+template <typename>
+struct contains_surface_grids;
 
-template <class detector_t>
-struct has_surface_grids<
-    detector_t,
-    std::enable_if_t<contains_grids_v<typename detector_t::accel>, void>>
-    : public std::true_type {};
+template <class ID, typename... Ts>
+struct contains_surface_grids<type_registry<ID, Ts...>> {
+    static constexpr bool value{(concepts::surface_grid<Ts> || ...)};
+};
 
 template <typename T>
-inline constexpr bool has_surface_grids_v = has_surface_grids<T>::value;
+inline constexpr bool contains_surface_grids_v =
+    contains_surface_grids<T>::value;
 /// @}
 
 /// Check for the various types of material
 /// @{
-template <class detector_t, typename = void>
-struct has_material_slabs : public std::false_type {};
 
-template <class detector_t>
-struct has_material_slabs<
-    detector_t,
-    std::enable_if_t<detector_t::materials::template is_defined<
-                         material_slab<typename detector_t::scalar_type>>(),
-                     void>> : public std::true_type {};
+/// Contains slabs
+/// @{
+template <typename>
+struct contains_material_slabs {};
 
-template <typename T>
-inline constexpr bool has_material_slabs_v = has_material_slabs<T>::value;
-
-template <class detector_t, typename = void>
-struct has_material_rods : public std::false_type {};
-
-template <class detector_t>
-struct has_material_rods<
-    detector_t,
-    std::enable_if_t<detector_t::materials::template is_defined<
-                         material_rod<typename detector_t::scalar_type>>(),
-                     void>> : public std::true_type {};
+template <class ID, typename... Ts>
+struct contains_material_slabs<type_registry<ID, Ts...>> {
+    static constexpr bool value{(concepts::material_slab<Ts> || ...)};
+};
 
 template <typename T>
-inline constexpr bool has_material_rods_v = has_material_rods<T>::value;
-
-template <class detector_t, typename = void>
-struct has_homogeneous_material : public std::false_type {};
-
-template <class detector_t>
-struct has_homogeneous_material<
-    detector_t, std::enable_if_t<has_material_slabs_v<detector_t> ||
-                                     has_material_rods_v<detector_t>,
-                                 void>> : public std::true_type {};
-
-template <typename T>
-inline constexpr bool has_homogeneous_material_v =
-    has_homogeneous_material<T>::value;
-
-template <class detector_t, typename = void>
-struct has_material_grids : public std::false_type {};
-
-template <class detector_t>
-struct has_material_grids<
-    detector_t,
-    std::enable_if_t<contains_grids_v<typename detector_t::materials>, void>>
-    : public std::true_type {};
-
-template <typename T>
-inline constexpr bool has_material_grids_v = has_material_grids<T>::value;
+inline constexpr bool contains_material_slabs_v =
+    contains_material_slabs<T>::value;
 /// @}
 
-}  // namespace detray::detail
+/// Contains rods
+/// @{
+template <typename>
+struct contains_material_rods {};
+
+template <class ID, typename... Ts>
+struct contains_material_rods<type_registry<ID, Ts...>> {
+    static constexpr bool value{(concepts::material_rod<Ts> || ...)};
+};
+
+template <typename T>
+inline constexpr bool contains_material_rods_v =
+    contains_material_rods<T>::value;
+/// @}
+
+/// Contains homogeneous material
+/// @{
+template <typename>
+struct contains_homogeneous_material {};
+
+template <class ID, typename... Ts>
+struct contains_homogeneous_material<type_registry<ID, Ts...>> {
+    static constexpr bool value{(concepts::homogeneous_material<Ts> || ...)};
+};
+
+template <typename T>
+inline constexpr bool contains_homogeneous_material_v =
+    contains_homogeneous_material<T>::value;
+/// @}
+
+/// Contains material maps
+/// @{
+template <typename>
+struct contains_material_maps {};
+
+template <class ID, typename... Ts>
+struct contains_material_maps<type_registry<ID, Ts...>> {
+    static constexpr bool value{(concepts::material_map<Ts> || ...)};
+};
+
+template <typename T>
+inline constexpr bool contains_material_maps_v =
+    contains_material_maps<T>::value;
+/// @}
+
+}  // namespace detail
+
+namespace concepts {
+
+/// Check for the the presence of any type of grids in a detector definition
+template <class detector_t>
+concept has_grids = detail::contains_grids_v<typename detector_t::accel> ||
+                    detail::contains_grids_v<typename detector_t::materials>;
+
+/// Check for the the presence of surface grids in a detector definition
+template <class detector_t>
+concept has_surface_grids =
+    detail::contains_surface_grids_v<typename detector_t::accel>;
+
+/// Check for the the presence of material slabs in a detector definition
+template <class detector_t>
+concept has_material_slabs =
+    detail::contains_material_slabs_v<typename detector_t::materials>;
+
+/// Check for the the presence of material rods in a detector definition
+template <class detector_t>
+concept has_material_rods =
+    detail::contains_material_rods_v<typename detector_t::materials>;
+
+/// Check for the the presence of homogeneous material types in a detector
+/// definition
+template <class detector_t>
+concept has_homogeneous_material =
+    detail::contains_homogeneous_material_v<typename detector_t::materials>;
+
+/// Check for the the presence of material maps in a detector definition
+template <class detector_t>
+concept has_material_maps =
+    detail::contains_material_maps_v<typename detector_t::materials>;
+
+}  // namespace concepts
+
+}  // namespace detray

--- a/io/include/detray/io/frontend/implementation/json_readers.hpp
+++ b/io/include/detray/io/frontend/implementation/json_readers.hpp
@@ -90,8 +90,7 @@ inline void add_json_readers(
             reader.template add<json_geometry_reader>(file_name);
 
         } else if (header.tag == "homogeneous_material") {
-            if constexpr (detray::detail::has_homogeneous_material_v<
-                              detector_t>) {
+            if constexpr (concepts::has_homogeneous_material<detector_t>) {
                 using json_hom_material_reader =
                     json_reader<detector_t, homogeneous_material_reader>;
 
@@ -100,7 +99,7 @@ inline void add_json_readers(
                 print_type_warning<detector_t>(header.tag);
             }
         } else if (header.tag == "material_maps") {
-            if constexpr (detray::detail::has_material_grids_v<detector_t>) {
+            if constexpr (concepts::has_material_maps<detector_t>) {
                 using json_material_map_reader =
                     json_reader<detector_t,
                                 material_map_reader<
@@ -111,7 +110,7 @@ inline void add_json_readers(
                 print_type_warning<detector_t>(header.tag);
             }
         } else if (header.tag == "surface_grids") {
-            if constexpr (detray::detail::has_surface_grids_v<detector_t>) {
+            if constexpr (concepts::has_surface_grids<detector_t>) {
                 using json_surface_grid_reader =
                     json_reader<detector_t,
                                 surface_grid_reader<

--- a/io/include/detray/io/frontend/implementation/json_writers.hpp
+++ b/io/include/detray/io/frontend/implementation/json_writers.hpp
@@ -36,14 +36,14 @@ void add_json_writers(detector_components_writer<detector_t>& writers,
     // Find other writers, depending on the detector type
     if (cfg.write_material()) {
         // Simple material
-        if constexpr (detray::detail::has_homogeneous_material_v<detector_t>) {
+        if constexpr (concepts::has_homogeneous_material<detector_t>) {
             using json_homogeneous_material_writer =
                 json_writer<detector_t, homogeneous_material_writer>;
 
             writers.template add<json_homogeneous_material_writer>();
         }
         // Material maps
-        if constexpr (detray::detail::has_material_grids_v<detector_t>) {
+        if constexpr (concepts::has_material_maps<detector_t>) {
             using json_material_map_writer =
                 json_writer<detector_t, material_map_writer>;
 
@@ -51,7 +51,7 @@ void add_json_writers(detector_components_writer<detector_t>& writers,
         }
     }
     // Navigation acceleration structures
-    if constexpr (detray::detail::has_surface_grids_v<detector_t>) {
+    if constexpr (concepts::has_surface_grids<detector_t>) {
         using json_surface_grid_writer =
             json_writer<detector_t, surface_grid_writer>;
 

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
@@ -11,6 +11,9 @@
 #include "detray/core/detector.hpp"
 #include "detray/definitions/grid_axis.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
+
+// Plugin include(s)
 #include "detray/plugins/svgtools/styling/styling.hpp"
 #include "detray/plugins/svgtools/utils/surface_kernels.hpp"
 
@@ -31,7 +34,7 @@ namespace detail {
 enum grid_type : std::uint8_t { e_barrel = 0, e_endcap = 1, e_unknown = 2 };
 
 /// @returns the actsvg grid type and edge values for a detray 2D cylinder grid.
-template <typename grid_t, typename view_t>
+template <concepts::grid grid_t, typename view_t>
     requires std::is_same_v<
         typename grid_t::local_frame_type,
         detray::concentric_cylindrical2D<
@@ -69,7 +72,7 @@ template <typename grid_t, typename view_t>
 }
 
 /// @returns the actsvg grid type and edge values for a detray disc grid.
-template <typename grid_t, typename view_t>
+template <concepts::grid grid_t, typename view_t>
 requires std::is_same_v<
     typename grid_t::local_frame_type,
     detray::polar2D<
@@ -92,7 +95,7 @@ grid_type_and_edges(const grid_t& grid, const view_t&) {
 }
 
 /// @returns the actsvg grid type and edge values for a detray rectangular grid.
-template <typename grid_t, typename view_t>
+template <concepts::grid grid_t, typename view_t>
 requires std::is_same_v<
     typename grid_t::local_frame_type,
     detray::cartesian2D<
@@ -126,7 +129,7 @@ struct type_and_edge_getter {
 
         using value_t = typename group_t::value_type;
 
-        if constexpr (detray::detail::is_grid_v<value_t>) {
+        if constexpr (concepts::grid<value_t>) {
             // Only two dimensional grids for actsvg
             if constexpr (value_t::dim == 2) {
                 return grid_type_and_edges(group[index], view);

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
@@ -11,6 +11,9 @@
 #include "detray/core/detector.hpp"
 #include "detray/definitions/grid_axis.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
+
+// PLugin include(s)
 #include "detray/plugins/svgtools/conversion/grid.hpp"
 #include "detray/plugins/svgtools/styling/styling.hpp"
 
@@ -40,7 +43,7 @@ struct bin_association_getter {
 
         using accel_t = typename group_t::value_type;
 
-        if constexpr (detray::detail::is_grid_v<accel_t>) {
+        if constexpr (concepts::grid<accel_t>) {
 
             using transform3_t =
                 typename accel_t::local_frame_type::transform3_type;

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
@@ -9,6 +9,9 @@
 
 // Project include(s)
 #include "detray/geometry/tracking_surface.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
+
+// Plugin include(s)
 #include "detray/plugins/svgtools/conversion/grid.hpp"
 #include "detray/plugins/svgtools/styling/styling.hpp"
 
@@ -69,7 +72,7 @@ struct material_converter {
 
         std::vector<std::vector<actsvg::proto::material_slab>> m_matrix;
 
-        if constexpr (detray::detail::is_grid_v<material_t>) {
+        if constexpr (concepts::grid<material_t>) {
 
             using loc_bin_idx_t = typename material_t::loc_bin_index;
             using algebra_t =

--- a/tests/benchmarks/cpu/grid.cpp
+++ b/tests/benchmarks/cpu/grid.cpp
@@ -12,6 +12,7 @@
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/geometry/shapes/rectangle2D.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 
 // Detray test include(s).
 #include "detray/test/utils/types.hpp"
@@ -98,7 +99,7 @@ auto make_irregular_grid(vecmem::memory_resource &mr) {
 }
 
 /// Fill a grid with some values.
-template <typename populator_t, typename grid_t>
+template <typename populator_t, concepts::grid grid_t>
 void populate_grid(grid_t &grid) {
 
     for (dindex gbin = 0u; gbin < grid.nbins(); ++gbin) {

--- a/tests/include/detray/test/utils/detectors/create_wire_chamber.hpp
+++ b/tests/include/detray/test/utils/detectors/create_wire_chamber.hpp
@@ -437,7 +437,7 @@ inline auto create_wire_chamber(vecmem::memory_resource &resource,
             det.mask_store().template get<cyl_id>().at(portal_mask_idx);
 
         // Correct cylinder radius so that the grid lies in the middle
-        using cyl_mask_t = detail::remove_cvref_t<decltype(outer_cyl_mask)>;
+        using cyl_mask_t = std::remove_cvref_t<decltype(outer_cyl_mask)>;
         typename cyl_mask_t::mask_values mask_values{outer_cyl_mask.values()};
         mask_values[cylinder2D::e_r] =
             0.5f * (inner_cyl_mask.values()[cylinder2D::e_r] +

--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -48,9 +48,8 @@ struct aggregate_inspector {
     aggregate_inspector() = default;
 
     /// Construct from the inspector @param view type. Mainly used device-side.
-    template <typename view_t>
-    requires detail::is_device_view_v<view_t>
-        DETRAY_HOST_DEVICE explicit aggregate_inspector(view_t &view)
+    template <concepts::device_view view_t>
+    DETRAY_HOST_DEVICE explicit aggregate_inspector(view_t &view)
         : _inspectors(unroll_views(
               view, std::make_index_sequence<sizeof...(Inspectors)>{})) {}
 
@@ -97,9 +96,9 @@ struct aggregate_inspector {
     }
 
     /// @returns a tuple constructed from the inspector @param view s.
-    template <typename view_t, std::size_t... I>
-    requires detail::is_device_view_v<view_t> DETRAY_HOST_DEVICE constexpr auto
-    unroll_views(view_t &view, std::index_sequence<I...> /*seq*/) {
+    template <concepts::device_view view_t, std::size_t... I>
+    DETRAY_HOST_DEVICE constexpr auto unroll_views(
+        view_t &view, std::index_sequence<I...> /*seq*/) {
         return detail::make_tuple<std::tuple>(
             Inspectors(detail::get<I>(view.m_view))...);
     }

--- a/tests/include/detray/test/utils/material_validation_utils.hpp
+++ b/tests/include/detray/test/utils/material_validation_utils.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/detail/material_accessor.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/actor_chain.hpp"
@@ -77,7 +78,7 @@ struct get_material_params {
         constexpr auto inv{detail::invalid_value<scalar_t>()};
 
         // Access homogeneous surface material or material maps
-        if constexpr (detail::is_surface_material_v<material_t>) {
+        if constexpr (concepts::surface_material<material_t>) {
 
             // Slab or rod
             const auto mat =

--- a/tests/include/detray/test/utils/simulation/random_scatterer.hpp
+++ b/tests/include/detray/test/utils/simulation/random_scatterer.hpp
@@ -13,6 +13,7 @@
 #include "detray/definitions/track_parametrization.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/tracking_surface.hpp"
+#include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/interaction.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/tracks/bound_track_parameters.hpp"
@@ -81,7 +82,7 @@ struct random_scatterer : actor {
 
             using material_t = typename mat_group_t::value_type;
 
-            if constexpr (detail::is_surface_material_v<material_t>) {
+            if constexpr (concepts::surface_material<material_t>) {
 
                 const scalar qop = bound_params.qop();
 

--- a/tests/unit_tests/cpu/material/material_maps.cpp
+++ b/tests/unit_tests/cpu/material/material_maps.cpp
@@ -9,6 +9,7 @@
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes.hpp"
+#include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/material_map.hpp"
 
 // GTest include(s)
@@ -36,6 +37,11 @@ GTEST_TEST(detray_material, annulus_map) {
     mask<annulus2D> ann2{0u, minR, maxR, minPhi, maxPhi, 0.f, -2.f, 2.f};
 
     auto annulus_map = mat_map_factory.new_grid(ann2, {10u, 20u});
+
+    static_assert(concepts::material_map<decltype(annulus_map)>);
+    static_assert(!concepts::homogeneous_material<decltype(annulus_map)>);
+    static_assert(concepts::surface_material<decltype(annulus_map)>);
+    static_assert(!concepts::volume_material<decltype(annulus_map)>);
 
     EXPECT_EQ(annulus_map.dim, 2u);
     EXPECT_EQ(annulus_map.nbins(), 200u);
@@ -80,6 +86,11 @@ GTEST_TEST(detray_material, cylinder_map) {
 
     auto cylinder_map = mat_map_factory.new_grid(cyl, {10u, 20u});
 
+    static_assert(concepts::material_map<decltype(cylinder_map)>);
+    static_assert(!concepts::homogeneous_material<decltype(cylinder_map)>);
+    static_assert(concepts::surface_material<decltype(cylinder_map)>);
+    static_assert(!concepts::volume_material<decltype(cylinder_map)>);
+
     EXPECT_EQ(cylinder_map.dim, 2u);
     EXPECT_EQ(cylinder_map.nbins(), 200u);
 
@@ -122,6 +133,11 @@ GTEST_TEST(detray_material, rectangle_map) {
 
     auto rectangle_map = mat_map_factory.new_grid(r2, {10u, 20u});
 
+    static_assert(concepts::material_map<decltype(rectangle_map)>);
+    static_assert(!concepts::homogeneous_material<decltype(rectangle_map)>);
+    static_assert(concepts::surface_material<decltype(rectangle_map)>);
+    static_assert(!concepts::volume_material<decltype(rectangle_map)>);
+
     EXPECT_EQ(rectangle_map.dim, 2u);
     EXPECT_EQ(rectangle_map.nbins(), 200u);
 
@@ -163,6 +179,11 @@ GTEST_TEST(detray_material, disc_map) {
     mask<ring2D> r2{0u, inner_r, outer_r};
 
     auto disc_map = mat_map_factory.new_grid(r2, {10u, 20u});
+
+    static_assert(concepts::material_map<decltype(disc_map)>);
+    static_assert(!concepts::homogeneous_material<decltype(disc_map)>);
+    static_assert(concepts::surface_material<decltype(disc_map)>);
+    static_assert(!concepts::volume_material<decltype(disc_map)>);
 
     EXPECT_EQ(disc_map.dim, 2u);
     EXPECT_EQ(disc_map.nbins(), 200u);
@@ -207,6 +228,11 @@ GTEST_TEST(detray_material, trapezoid_map) {
     mask<trapezoid2D> t2{0u, hx_miny, hx_maxy, hy, divisor};
 
     auto trapezoid_map = mat_map_factory.new_grid(t2, {10u, 20u});
+
+    static_assert(concepts::material_map<decltype(trapezoid_map)>);
+    static_assert(!concepts::homogeneous_material<decltype(trapezoid_map)>);
+    static_assert(concepts::surface_material<decltype(trapezoid_map)>);
+    static_assert(!concepts::volume_material<decltype(trapezoid_map)>);
 
     EXPECT_EQ(trapezoid_map.dim, 2u);
     EXPECT_EQ(trapezoid_map.nbins(), 200u);

--- a/tests/unit_tests/cpu/material/materials.cpp
+++ b/tests/unit_tests/cpu/material/materials.cpp
@@ -10,6 +10,7 @@
 #include "detray/geometry/detail/surface_descriptor.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes/line.hpp"
+#include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/material.hpp"
 #include "detray/materials/material_rod.hpp"
 #include "detray/materials/material_slab.hpp"
@@ -46,6 +47,13 @@ constexpr auto max_val{std::numeric_limits<scalar>::max()};
 GTEST_TEST(detray_material, materials) {
     // vacuum
     constexpr vacuum<scalar_t> vac;
+
+    static_assert(concepts::material_params<decltype(vac)>);
+    static_assert(concepts::homogeneous_material<decltype(vac)>);
+    static_assert(!concepts::surface_material<decltype(vac)>);
+    static_assert(concepts::volume_material<decltype(vac)>);
+    static_assert(!concepts::material_map<decltype(vac)>);
+
     EXPECT_EQ(vac.X0(), max_val);
     EXPECT_EQ(vac.L0(), max_val);
     EXPECT_EQ(vac.Ar(), scalar_t{0});
@@ -55,6 +63,13 @@ GTEST_TEST(detray_material, materials) {
 
     // beryllium
     constexpr beryllium_tml<scalar_t> beryll;
+
+    static_assert(concepts::material_params<decltype(beryll)>);
+    static_assert(concepts::homogeneous_material<decltype(beryll)>);
+    static_assert(!concepts::surface_material<decltype(beryll)>);
+    static_assert(concepts::volume_material<decltype(beryll)>);
+    static_assert(!concepts::material_map<decltype(beryll)>);
+
     EXPECT_NEAR(beryll.X0(), static_cast<scalar_t>(352.8 * unit<double>::mm),
                 1e-4);
     EXPECT_NEAR(beryll.L0(), static_cast<scalar_t>(407.0 * unit<double>::mm),
@@ -71,6 +86,13 @@ GTEST_TEST(detray_material, materials) {
 
     // silicon
     constexpr silicon_tml<scalar_t> silicon;
+
+    static_assert(concepts::material_params<decltype(silicon)>);
+    static_assert(concepts::homogeneous_material<decltype(silicon)>);
+    static_assert(!concepts::surface_material<decltype(silicon)>);
+    static_assert(concepts::volume_material<decltype(silicon)>);
+    static_assert(!concepts::material_map<decltype(silicon)>);
+
     EXPECT_NEAR(silicon.X0(), static_cast<scalar_t>(95.7 * unit<double>::mm),
                 1e-5);
     EXPECT_NEAR(silicon.L0(), static_cast<scalar_t>(465.2 * unit<double>::mm),
@@ -92,6 +114,12 @@ GTEST_TEST(detray_material, mixture) {
                       aluminium<scalar_t, std::ratio<0, 1>>>
         oxygen_mix;
 
+    static_assert(concepts::material_params<decltype(oxygen_mix)>);
+    static_assert(concepts::homogeneous_material<decltype(oxygen_mix)>);
+    static_assert(!concepts::surface_material<decltype(oxygen_mix)>);
+    static_assert(concepts::volume_material<decltype(oxygen_mix)>);
+    static_assert(!concepts::material_map<decltype(oxygen_mix)>);
+
     EXPECT_NEAR(pure_oxygen.X0(), oxygen_mix.X0(), 0.02f);
     EXPECT_NEAR(pure_oxygen.L0(), oxygen_mix.L0(), tol);
     EXPECT_NEAR(pure_oxygen.Ar(), oxygen_mix.Ar(), tol);
@@ -106,6 +134,12 @@ GTEST_TEST(detray_material, mixture) {
                       argon_gas<scalar_t, std::ratio<1, 100>>>
         air_mix;
     constexpr air<scalar_t> pure_air;
+
+    static_assert(concepts::material_params<decltype(pure_air)>);
+    static_assert(concepts::homogeneous_material<decltype(pure_air)>);
+    static_assert(!concepts::surface_material<decltype(pure_air)>);
+    static_assert(concepts::volume_material<decltype(pure_air)>);
+    static_assert(!concepts::material_map<decltype(pure_air)>);
 
     EXPECT_TRUE(std::abs(air_mix.X0() - pure_air.X0()) / pure_air.X0() < 0.01f);
     EXPECT_TRUE(std::abs(air_mix.L0() - pure_air.L0()) / pure_air.L0() < 0.01f);
@@ -140,6 +174,12 @@ GTEST_TEST(detray_material, mixture2) {
                       cesium_iodide_with_ded<scalar_t, std::ratio<2, 3>>>
         mix;
 
+    static_assert(concepts::material_params<decltype(mix)>);
+    static_assert(concepts::homogeneous_material<decltype(mix)>);
+    static_assert(!concepts::surface_material<decltype(mix)>);
+    static_assert(concepts::volume_material<decltype(mix)>);
+    static_assert(!concepts::material_map<decltype(mix)>);
+
     // For the moment, the mixture is not supposed to have density effect data
     // in any case
     EXPECT_EQ(mix.has_density_effect_data(), false);
@@ -154,6 +194,12 @@ GTEST_TEST(detray_material, material_slab) {
 
     constexpr material_slab<scalar_t> slab(oxygen_gas<scalar_t>(),
                                            2.f * unit<scalar_t>::mm);
+
+    static_assert(concepts::material_slab<decltype(slab)>);
+    static_assert(concepts::homogeneous_material<decltype(slab)>);
+    static_assert(concepts::surface_material<decltype(slab)>);
+    static_assert(!concepts::volume_material<decltype(slab)>);
+    static_assert(!concepts::material_map<decltype(slab)>);
 
     const scalar_t cos_inc_ang{0.3f};
 
@@ -171,6 +217,12 @@ GTEST_TEST(detray_material, material_rod) {
     // Rod with 1 mm radius
     constexpr material_rod<scalar_t> rod(oxygen_gas<scalar_t>(),
                                          1.f * unit<scalar_t>::mm);
+
+    static_assert(concepts::material_rod<decltype(rod)>);
+    static_assert(concepts::homogeneous_material<decltype(rod)>);
+    static_assert(concepts::surface_material<decltype(rod)>);
+    static_assert(!concepts::volume_material<decltype(rod)>);
+    static_assert(!concepts::material_map<decltype(rod)>);
 
     // tf3 with Identity rotation and no translation
     const vector3 x{1.f, 0.f, 0.f};

--- a/tests/unit_tests/cpu/utils/grids/axis.cpp
+++ b/tests/unit_tests/cpu/utils/grids/axis.cpp
@@ -13,6 +13,7 @@
 #include "detray/geometry/coordinates/coordinates.hpp"
 #include "detray/utils/grid/detail/axis_binning.hpp"
 #include "detray/utils/grid/detail/axis_bounds.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 
 // Detray test include(s)
 #include "detray/test/utils/types.hpp"
@@ -56,7 +57,10 @@ GTEST_TEST(detray_grid, open_regular_axis) {
     const dindex_range edge_range = {2u, 10u};
 
     // An open regular x-axis
-    single_axis<open<label::e_x>, regular<>> or_axis{edge_range, &bin_edges};
+    using x_axis_t = single_axis<open<label::e_x>, regular<>>;
+    x_axis_t or_axis{edge_range, &bin_edges};
+
+    static_assert(concepts::axis<x_axis_t>);
 
     // Test axis bounds
     EXPECT_EQ(or_axis.label(), axis::label::e_x);
@@ -129,7 +133,10 @@ GTEST_TEST(detray_grid, closed_regular_axis) {
     const dindex_range edge_range = {2u, 10u};
 
     // A closed regular r-axis
-    single_axis<closed<label::e_r>, regular<>> cr_axis{edge_range, &bin_edges};
+    using r_axis_t = single_axis<closed<label::e_r>, regular<>>;
+    r_axis_t cr_axis{edge_range, &bin_edges};
+
+    static_assert(concepts::axis<r_axis_t>);
 
     // Test axis bounds
     EXPECT_EQ(cr_axis.label(), axis::label::e_r);
@@ -204,7 +211,10 @@ GTEST_TEST(detray_grid, circular_regular_axis) {
     const dindex_range edge_range = {1u, 36u};
 
     // A closed regular x-axis
-    single_axis<circular<>, regular<>> cr_axis(edge_range, &bin_edges);
+    using axis_t = single_axis<circular<>, regular<>>;
+    axis_t cr_axis(edge_range, &bin_edges);
+
+    static_assert(concepts::axis<axis_t>);
 
     // Test axis bounds
     EXPECT_EQ(cr_axis.label(), axis::label::e_phi);

--- a/tests/unit_tests/cpu/utils/grids/grid.cpp
+++ b/tests/unit_tests/cpu/utils/grids/grid.cpp
@@ -11,6 +11,7 @@
 #include "detray/builders/grid_builder.hpp"
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/geometry/shapes/cuboid3D.hpp"
+#include "detray/utils/grid/detail/concepts.hpp"
 
 // Detray test include(s)
 #include "detray/test/utils/types.hpp"
@@ -71,7 +72,7 @@ struct bin_content_sequence {
 };
 
 /// Test bin content element by element
-template <typename grid_t, typename content_t>
+template <concepts::grid grid_t, typename content_t>
 void test_content(const grid_t& g, const point3& p, const content_t& expected) {
     dindex i = 0u;
     for (const auto& entry : g.search(p)) {
@@ -93,6 +94,10 @@ GTEST_TEST(detray_grid, single_grid) {
 
     using grid_device_t = grid<axes<cuboid3D>, bins::single<scalar>,
                                simple_serializer, device_container_types>;
+
+    static_assert(concepts::grid<grid_owning_t>);
+    static_assert(concepts::grid<grid_n_owning_t>);
+    static_assert(concepts::grid<grid_device_t>);
 
     // Fill the bin data for every test
     // bin test entries
@@ -196,6 +201,10 @@ GTEST_TEST(detray_grid, dynamic_array) {
 
     using grid_device_t = grid<axes<cuboid3D>, bins::dynamic_array<scalar>,
                                simple_serializer, device_container_types>;
+
+    static_assert(concepts::grid<grid_owning_t>);
+    static_assert(concepts::grid<grid_n_owning_t>);
+    static_assert(concepts::grid<grid_device_t>);
 
     // Fill the bin data for every test
     // bin test entries
@@ -307,6 +316,8 @@ GTEST_TEST(detray_grid, bin_view) {
 
     // Non-owning, 3D cartesian, replacing grid
     using grid_t = grid<axes<cuboid3D>, bins::single<scalar>>;
+
+    static_assert(concepts::grid<grid_t>);
 
     // Fill the bin data for every test
     // bin test entries
@@ -441,6 +452,9 @@ GTEST_TEST(detray_grid, replace_population) {
     // Non-owning, 3D cartesian  grid
     using grid_t = grid<decltype(ax_n_own), bins::single<scalar>,
                         simple_serializer, host_container_types, false>;
+
+    static_assert(concepts::grid<grid_t>);
+
     // init
     using bin_t = grid_t::bin_type;
     grid_t::bin_container_type bin_data{};
@@ -494,6 +508,8 @@ GTEST_TEST(detray_grid, complete_population) {
                         simple_serializer, host_container_types, false>;
     using bin_t = grid_t::bin_type;
     using bin_content_t = std::array<scalar, 4>;
+
+    static_assert(concepts::grid<grid_t>);
 
     // init
     grid_t::bin_container_type bin_data{};
@@ -578,6 +594,8 @@ GTEST_TEST(detray_grid, regular_attach_population) {
                         simple_serializer, host_container_types, false>;
     using bin_t = grid_t::bin_type;
     using bin_content_t = std::array<scalar, 4>;
+
+    static_assert(concepts::grid<grid_t>);
 
     // init
     grid_t::bin_container_type bin_data{};

--- a/tests/unit_tests/device/cuda/container_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/container_cuda_kernel.hpp
@@ -59,8 +59,8 @@ struct test {
     DETRAY_HOST explicit test(vecmem::memory_resource* mr)
         : first(mr), second(mr) {}
 
-    template <typename view_t>
-    requires detail::is_device_view_v<view_t> DETRAY_HOST_DEVICE test(view_t v)
+    template <concepts::device_view view_t>
+    DETRAY_HOST_DEVICE explicit test(view_t v)
         : first(detail::get<0>(v.m_view)), second(detail::get<1>(v.m_view)) {}
 
     DETRAY_HOST view_type get_data() {


### PR DESCRIPTION
The existing detray type traits are refactored into concepts and applied to template parameters where possible. To constrain types even further, additional concepts should be written in the future, based on and extending the ones introduced in this PR.