### PR TITLE
ref: Update the propagation config structs and improve navigation recovery due to extreme portal overstepping

### DIFF
--- a/core/include/detray/navigation/navigation_config.hpp
+++ b/core/include/detray/navigation/navigation_config.hpp
@@ -32,14 +32,14 @@ struct config {
     /// Minimal tolerance: ~ position uncertainty on surface
     float min_mask_tolerance{1e-5f * unit<float>::mm};
     /// Maximal tolerance: loose tolerance when still far away from surface
-    float max_mask_tolerance{1.f * unit<float>::mm};
+    float max_mask_tolerance{3.f * unit<float>::mm};
     /// Scale factor on the path used for the mask tolerance calculation
     float mask_tolerance_scalor{5e-2f};
     /// @}
     /// Maximal absolute path distance for a track to be considered 'on surface'
     float path_tolerance{1.f * unit<float>::um};
     /// How far behind the track position to look for candidates
-    float overstep_tolerance{-100.f * unit<float>::um};
+    float overstep_tolerance{-300.f * unit<float>::um};
     /// Search window size for grid based acceleration structures
     /// (0, 0): only look at current bin
     std::array<dindex, 2> search_window = {0u, 0u};

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -116,7 +116,9 @@ class line_stepper final
         stepping.advance_track();
 
         // Advance jacobian transport
-        stepping.advance_jacobian();
+        if (cfg.do_covariance_transport) {
+            stepping.advance_jacobian();
+        }
 
         // Count the number of steps
         stepping.count_trials();

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -52,7 +52,7 @@ struct propagator {
 
     /// Construct from a propagator configuration
     DETRAY_HOST_DEVICE
-    explicit constexpr propagator(const propagation::config &cfg = {})
+    explicit constexpr propagator(const propagation::config &cfg)
         : m_cfg{cfg} {}
 
     /// Propagation that state aggregates a stepping and a navigation state. It

--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -264,6 +264,8 @@ struct print_inspector {
         debug_stream << msg << std::endl;
 
         debug_stream << "Volume" << tabs << state.volume() << std::endl;
+        debug_stream << "Overstep tol:\t\t\t" << cfg.overstep_tolerance
+                     << std::endl;
         debug_stream << "Track pos: [r:" << getter::perp(track_pos)
                      << ", z:" << track_pos[2] << "], dir: [" << track_dir[0]
                      << ", " << track_dir[1] << ", " << track_dir[2] << "]"

--- a/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.name("telescope_detector_helix_navigation");
     cfg_hel_nav.whiteboard(white_board);
     cfg_hel_nav.propagation().navigation.overstep_tolerance =
-        -300.f * unit<float>::um;
+        -100.f * unit<float>::um;
 
     detail::register_checks<test::helix_navigation>(tel_det, tel_names,
                                                     cfg_hel_nav);

--- a/tests/integration_tests/cpu/material/material_interaction.cpp
+++ b/tests/integration_tests/cpu/material/material_interaction.cpp
@@ -79,7 +79,9 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     // Propagator is built from the stepper and navigator
-    propagator_t p{};
+    propagation::config prop_cfg{};
+    prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
+    propagator_t p{prop_cfg};
 
     constexpr scalar q{-1.f};
     constexpr scalar iniP{10.f * unit<scalar>::GeV};
@@ -193,7 +195,7 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
             interactor_state, parameter_resetter_state);
 
         // Propagator and its state
-        alt_propagator_t alt_p{};
+        alt_propagator_t alt_p{prop_cfg};
         alt_propagator_t::state alt_state(alt_bound_param, det);
 
         // Propagate
@@ -250,7 +252,9 @@ GTEST_TEST(detray_material, telescope_geometry_scattering_angle) {
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     // Propagator is built from the stepper and navigator
-    propagator_t p{};
+    propagation::config prop_cfg{};
+    prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
+    propagator_t p{prop_cfg};
 
     constexpr scalar q{-1.f};
     constexpr scalar iniP{10.f * unit<scalar>::GeV};
@@ -380,7 +384,9 @@ GTEST_TEST(detray_material, telescope_geometry_volume_material) {
         using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
         // Propagator is built from the stepper and navigator
-        propagator_t p{};
+        propagation::config prop_cfg{};
+        prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
+        propagator_t p{prop_cfg};
 
         propagator_t::state state(bound_param, const_bfield, det);
 

--- a/tests/integration_tests/cpu/propagator/guided_navigator.cpp
+++ b/tests/integration_tests/cpu/propagator/guided_navigator.cpp
@@ -81,7 +81,8 @@ GTEST_TEST(detray_navigation, guided_navigator) {
     pathlimit_aborter::state pathlimit{200.f * unit<scalar_t>::cm};
 
     // Propagator
-    propagator_t p{};
+    propagation::config prop_cfg{};
+    propagator_t p{prop_cfg};
     propagator_t::state guided_state(track, b_field, telescope_det);
 
     // Propagate

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -137,7 +137,8 @@ GTEST_TEST(detray_propagator, propagator_line_stepper) {
     const vector3 mom{1.f, 1.f, 0.f};
     free_track_parameters<algebra_t> track(pos, 0.f, mom, -1.f);
 
-    propagator_t p{};
+    propagation::config prop_cfg{};
+    propagator_t p{prop_cfg};
 
     propagator_t::state state(track, d);
 
@@ -387,7 +388,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     detray_propagator_validation2, PropagatorWithRkStepper,
     ::testing::Values(std::make_tuple(-400.f * unit<scalar_t>::um,
-                                      40.f * unit<scalar_t>::mm,
+                                      std::numeric_limits<scalar_t>::max(),
                                       vector3{0.f * unit<scalar_t>::T,
                                               1.f * unit<scalar_t>::T,
                                               1.f * unit<scalar_t>::T})));
@@ -395,7 +396,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     detray_propagator_validation3, PropagatorWithRkStepper,
     ::testing::Values(std::make_tuple(-400.f * unit<scalar_t>::um,
-                                      40.f * unit<scalar_t>::mm,
+                                      std::numeric_limits<scalar_t>::max(),
                                       vector3{1.f * unit<scalar_t>::T,
                                               0.f * unit<scalar_t>::T,
                                               1.f * unit<scalar_t>::T})));
@@ -403,7 +404,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     detray_propagator_validation4, PropagatorWithRkStepper,
     ::testing::Values(std::make_tuple(-600.f * unit<scalar_t>::um,
-                                      35.f * unit<scalar_t>::mm,
+                                      std::numeric_limits<scalar_t>::max(),
                                       vector3{1.f * unit<scalar_t>::T,
                                               1.f * unit<scalar_t>::T,
                                               1.f * unit<scalar_t>::T})));

--- a/tests/integration_tests/device/cuda/propagator_cuda.cpp
+++ b/tests/integration_tests/device/cuda/propagator_cuda.cpp
@@ -97,26 +97,29 @@ INSTANTIATE_TEST_SUITE_P(
                                                 0.f * unit<scalar_t>::T,
                                                 2.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation2, CudaPropConstBFieldMng,
-                         ::testing::Values(std::make_tuple(
-                             -400.f * unit<float>::um, 40.f * unit<float>::mm,
-                             vector3_t{0.f * unit<scalar_t>::T,
-                                       1.f * unit<scalar_t>::T,
-                                       1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(
+    CudaPropagatorValidation2, CudaPropConstBFieldMng,
+    ::testing::Values(std::make_tuple(-400.f * unit<float>::um,
+                                      std::numeric_limits<float>::max(),
+                                      vector3_t{0.f * unit<scalar_t>::T,
+                                                1.f * unit<scalar_t>::T,
+                                                1.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation3, CudaPropConstBFieldMng,
-                         ::testing::Values(std::make_tuple(
-                             -400.f * unit<float>::um, 40.f * unit<float>::mm,
-                             vector3_t{1.f * unit<scalar_t>::T,
-                                       0.f * unit<scalar_t>::T,
-                                       1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(
+    CudaPropagatorValidation3, CudaPropConstBFieldMng,
+    ::testing::Values(std::make_tuple(-400.f * unit<float>::um,
+                                      std::numeric_limits<float>::max(),
+                                      vector3_t{1.f * unit<scalar_t>::T,
+                                                0.f * unit<scalar_t>::T,
+                                                1.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation4, CudaPropConstBFieldMng,
-                         ::testing::Values(std::make_tuple(
-                             -600.f * unit<float>::um, 35.f * unit<float>::mm,
-                             vector3_t{1.f * unit<scalar_t>::T,
-                                       1.f * unit<scalar_t>::T,
-                                       1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(
+    CudaPropagatorValidation4, CudaPropConstBFieldMng,
+    ::testing::Values(std::make_tuple(-600.f * unit<float>::um,
+                                      std::numeric_limits<float>::max(),
+                                      vector3_t{1.f * unit<scalar_t>::T,
+                                                1.f * unit<scalar_t>::T,
+                                                1.f * unit<scalar_t>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation5, CudaPropConstBFieldCpy,
@@ -126,26 +129,29 @@ INSTANTIATE_TEST_SUITE_P(
                                                 0.f * unit<scalar_t>::T,
                                                 2.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation6, CudaPropConstBFieldCpy,
-                         ::testing::Values(std::make_tuple(
-                             -400.f * unit<float>::um, 40.f * unit<float>::mm,
-                             vector3_t{0.f * unit<scalar_t>::T,
-                                       1.f * unit<scalar_t>::T,
-                                       1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(
+    CudaPropagatorValidation6, CudaPropConstBFieldCpy,
+    ::testing::Values(std::make_tuple(-400.f * unit<float>::um,
+                                      std::numeric_limits<float>::max(),
+                                      vector3_t{0.f * unit<scalar_t>::T,
+                                                1.f * unit<scalar_t>::T,
+                                                1.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation7, CudaPropConstBFieldCpy,
-                         ::testing::Values(std::make_tuple(
-                             -400.f * unit<float>::um, 40.f * unit<float>::mm,
-                             vector3_t{1.f * unit<scalar_t>::T,
-                                       0.f * unit<scalar_t>::T,
-                                       1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(
+    CudaPropagatorValidation7, CudaPropConstBFieldCpy,
+    ::testing::Values(std::make_tuple(-400.f * unit<float>::um,
+                                      std::numeric_limits<float>::max(),
+                                      vector3_t{1.f * unit<scalar_t>::T,
+                                                0.f * unit<scalar_t>::T,
+                                                1.f * unit<scalar_t>::T})));
 
-INSTANTIATE_TEST_SUITE_P(CudaPropagatorValidation8, CudaPropConstBFieldCpy,
-                         ::testing::Values(std::make_tuple(
-                             -600.f * unit<float>::um, 35.f * unit<float>::mm,
-                             vector3_t{1.f * unit<scalar_t>::T,
-                                       1.f * unit<scalar_t>::T,
-                                       1.f * unit<scalar_t>::T})));
+INSTANTIATE_TEST_SUITE_P(
+    CudaPropagatorValidation8, CudaPropConstBFieldCpy,
+    ::testing::Values(std::make_tuple(-600.f * unit<float>::um,
+                                      std::numeric_limits<float>::max(),
+                                      vector3_t{1.f * unit<scalar_t>::T,
+                                                1.f * unit<scalar_t>::T,
+                                                1.f * unit<scalar_t>::T})));
 
 /// This tests the device propagation in an inhomogenepus magnetic field
 TEST(CudaPropagatorValidation9, inhomogeneous_bfield_cpy) {

--- a/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.name("telescope_detector_helix_navigation_cuda");
     cfg_hel_nav.whiteboard(white_board);
     cfg_hel_nav.propagation().navigation.overstep_tolerance =
-        -300.f * unit<float>::um;
+        -100.f * unit<float>::um;
 
     detail::register_checks<detray::cuda::helix_navigation>(tel_det, tel_names,
                                                             cfg_hel_nav);

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -95,7 +95,9 @@ GTEST_TEST(detray_propagator, covariance_transport) {
     parameter_transporter<algebra_t>::state bound_updater{};
     parameter_resetter<algebra_t>::state rst{};
 
-    propagator_t p{};
+    propagation::config prop_cfg{};
+    prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
+    propagator_t p{prop_cfg};
     propagator_t::state propagation(bound_param0, det);
 
     // Run propagator

--- a/tests/unit_tests/cpu/propagator/line_stepper.cpp
+++ b/tests/unit_tests/cpu/propagator/line_stepper.cpp
@@ -29,7 +29,7 @@ namespace {
 
 constexpr scalar tol{1e-3f};
 constexpr scalar step_size{1.f * unit<scalar>::mm};
-constexpr stepping::config stp_cfg{};
+constexpr stepping::config step_cfg{};
 
 }  // namespace
 
@@ -77,10 +77,10 @@ GTEST_TEST(detray_propagator, line_stepper) {
                 0.5f * unit<scalar>::mm, tol);
 
     // Run a few steps
-    ASSERT_TRUE(l_stepper.step(step_size, l_state, stp_cfg));
+    ASSERT_TRUE(l_stepper.step(step_size, l_state, step_cfg));
     // Step constraint to half step size
-    ASSERT_TRUE(cl_stepper.step(step_size, cl_state, stp_cfg));
-    ASSERT_TRUE(cl_stepper.step(step_size, cl_state, stp_cfg));
+    ASSERT_TRUE(cl_stepper.step(step_size, cl_state, step_cfg));
+    ASSERT_TRUE(cl_stepper.step(step_size, cl_state, step_cfg));
 
     track = l_state();
     ASSERT_NEAR(track.pos()[0], constant<scalar>::inv_sqrt2, tol);
@@ -92,7 +92,7 @@ GTEST_TEST(detray_propagator, line_stepper) {
     ASSERT_NEAR(c_track.pos()[1], constant<scalar>::inv_sqrt2, tol);
     ASSERT_NEAR(c_track.pos()[2], 0.f, tol);
 
-    ASSERT_TRUE(l_stepper.step(step_size, l_state, stp_cfg));
+    ASSERT_TRUE(l_stepper.step(step_size, l_state, step_cfg));
 
     track = l_state();
     ASSERT_NEAR(track.pos()[0], constant<scalar>::sqrt2, tol);

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
@@ -53,7 +53,8 @@ struct prop_state {
 
 /// test function for navigator with single state
 void navigator_test(
-    typename detector_host_t::view_type det_data, propagation::config& cfg,
+    typename detector_host_t::view_type det_data, navigation::config& nav_cfg,
+    stepping::config& step_cfg,
     vecmem::data::vector_view<free_track_parameters<algebra_t>>& tracks_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,
     vecmem::data::jagged_vector_view<point3>& position_records_data);

--- a/tutorials/src/cpu/propagation/navigation_inspection.cpp
+++ b/tutorials/src/cpu/propagation/navigation_inspection.cpp
@@ -70,7 +70,8 @@ int main() {
     typename toy_detector_t::geometry_context gctx{};
 
     // Build the propagator
-    propagator_t prop{};
+    detray::propagation::config prop_cfg{};
+    propagator_t prop{prop_cfg};
 
     // Track generation config
     // Trivial example: Single track escapes through beampipe


### PR DESCRIPTION
This PR updates the navigation config to the ODD/ITk defaults. This should help to use a more optimal configuration for the ODD and ITk without passing a specific configuration to detray. Not sure, if there is one configuration that will be optimal for all detectors, though, so the telescope detector needs to be configured explicitly now.

The configurations to the propagation also now have to be passed explicitly, which helps not passing the default configuration by mistake.

Edit: while debugging a navigation failure in the telescope with the new default configuration, I added "a last chance" navigation init with loose surface finding constraints that seems to also recover the odd B-field cases.