### PR TITLE
fix: Navigation assertions in validation tools

### DIFF
--- a/io/include/detray/io/csv/track_parameters.hpp
+++ b/io/include/detray/io/csv/track_parameters.hpp
@@ -134,7 +134,9 @@ inline void write_free_track_params(
         for (const auto &[charge, track_param] : track_params) {
 
             const auto &glob_pos = track_param.pos();
-            const auto &p = track_param.mom(charge);
+            // Momentum may not be retrievable for straight-line tracks
+            const auto &p{charge != 0.f ? track_param.mom(charge)
+                                        : track_param.dir()};
 
             io::csv::free_track_parameters track_param_data{};
             track_param_data.track_id = track_idx;

--- a/tests/include/detray/test/validation/step_tracer.hpp
+++ b/tests/include/detray/test/validation/step_tracer.hpp
@@ -95,9 +95,16 @@ struct step_tracer : actor {
         // Collect the data whenever requested
         if (navigation.is_on_surface() || tracer_state.m_collect_every_step) {
 
-            step_data_t sd{stepping.step_size(),         stepping.path_length(),
-                           stepping.n_total_trials(),    navigation.direction(),
-                           navigation.barcode(),         stepping(),
+            const geometry::barcode bcd{navigation.is_on_surface()
+                                            ? navigation.barcode()
+                                            : geometry::barcode{}};
+
+            step_data_t sd{stepping.step_size(),
+                           stepping.path_length(),
+                           stepping.n_total_trials(),
+                           navigation.direction(),
+                           bcd,
+                           stepping(),
                            stepping.transport_jacobian()};
 
             tracer_state.m_steps.push_back(std::move(sd));


### PR DESCRIPTION
Fixes two assertions that were triggered by navigation validation tools:
- if the step stracer is set to record every step, make sure the barcode is only accessed when actually on surface
- since rays return zero for 'qop', make sure the free track parameter momentum is only written to file if it can be retrieved. Otherwise write the (normalized) direction to file