### PR TITLE
ref: Reactivate clang-format artifacts in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,3 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check
         run: .github/check_format.sh .
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: changed
+          path: changed


### PR DESCRIPTION
This might still be useful for people who do not want to setup a local clang-format version matching the CI