### PR TITLE
ref: Make surface implementation more concise

### DIFF
--- a/core/include/detray/builders/detail/bin_association.hpp
+++ b/core/include/detray/builders/detail/bin_association.hpp
@@ -15,7 +15,7 @@
 #include "detray/geometry/coordinates/concentric_cylindrical2D.hpp"
 #include "detray/geometry/coordinates/cylindrical2D.hpp"
 #include "detray/geometry/coordinates/polar2D.hpp"
-#include "detray/geometry/detail/vertexing.hpp"
+#include "detray/geometry/detail/vertexer.hpp"
 #include "detray/navigation/accelerators/concepts.hpp"
 #include "detray/utils/grid/populators.hpp"
 #include "detray/utils/ranges.hpp"

--- a/core/include/detray/builders/detail/portal_accessor.hpp
+++ b/core/include/detray/builders/detail/portal_accessor.hpp
@@ -12,7 +12,7 @@
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/geometry/shapes/cylinder2D.hpp"
 #include "detray/geometry/shapes/ring2D.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/geometry/tracking_volume.hpp"
 
 // System include(s).
@@ -37,7 +37,7 @@ auto get_cylinder_portals(const tracking_volume<detector_t> &vol) {
 
     // Loop over all portals
     for (const auto &pt_desc : vol.portals()) {
-        auto pt = tracking_surface{vol.detector(), pt_desc};
+        auto pt = geometry::surface{vol.detector(), pt_desc};
         const std::string name = pt.shape_name();
 
         if (name == "cylinder2D" || name == "concentric_cylinder2D") {

--- a/core/include/detray/builders/grid_builder.hpp
+++ b/core/include/detray/builders/grid_builder.hpp
@@ -13,7 +13,6 @@
 #include "detray/builders/surface_factory_interface.hpp"
 #include "detray/builders/volume_builder.hpp"
 #include "detray/builders/volume_builder_interface.hpp"
-#include "detray/geometry/tracking_surface.hpp"
 #include "detray/geometry/tracking_volume.hpp"
 #include "detray/utils/grid/detail/concepts.hpp"
 

--- a/core/include/detray/builders/material_map_builder.hpp
+++ b/core/include/detray/builders/material_map_builder.hpp
@@ -13,7 +13,7 @@
 #include "detray/builders/material_map_generator.hpp"
 #include "detray/builders/surface_factory_interface.hpp"
 #include "detray/builders/volume_builder_interface.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/materials/material_map.hpp"
 
 // System include(s)
@@ -124,7 +124,7 @@ class material_map_builder final : public volume_decorator<detector_t> {
             }
 
             // Construct and append the material map for a given surface shape
-            auto sf = tracking_surface{det, sf_desc};
+            auto sf = geometry::surface{det, sf_desc};
             [[maybe_unused]] auto [mat_id, mat_idx] = sf.template visit_mask<
                 detail::add_sf_material_map<materials_t>>(
                 m_factory, m_bin_data.at(sf_idx), m_n_bins.at(sf_idx),

--- a/core/include/detray/builders/volume_builder.hpp
+++ b/core/include/detray/builders/volume_builder.hpp
@@ -11,7 +11,7 @@
 #include "detray/builders/surface_factory_interface.hpp"
 #include "detray/builders/volume_builder_interface.hpp"
 #include "detray/definitions/geometry.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/utils/concepts.hpp"
 #include "detray/utils/grid/detail/concepts.hpp"
 
@@ -211,7 +211,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
         std::size_t n_portals{0u};
         for (auto& sf_desc : m_surfaces) {
 
-            const auto sf = tracking_surface{det, sf_desc};
+            const auto sf = geometry::surface{det, sf_desc};
 
             sf.template visit_mask<detail::mask_index_update>(sf_desc);
             sf_desc.set_volume(m_volume.index());

--- a/core/include/detray/geometry/detail/tracking_surface_kernels.hpp
+++ b/core/include/detray/geometry/detail/tracking_surface_kernels.hpp
@@ -1,0 +1,114 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/geometry/detail/surface_kernels.hpp"
+#include "detray/propagator/detail/jacobian_engine.hpp"
+#include "detray/tracks/detail/transform_track_parameters.hpp"
+#include "detray/tracks/tracks.hpp"
+
+// System include(s)
+#include <ostream>
+
+namespace detray::detail {
+
+/// Functors to be used in the @c tracking_surface class
+template <typename algebra_t>
+struct tracking_surface_kernels : public surface_kernels<algebra_t> {
+
+    using vector3_type = dvector3D<algebra_t>;
+    using transform3_type = dtransform3D<algebra_t>;
+    using bound_param_vector_type = bound_parameters_vector<algebra_t>;
+    using free_param_vector_type = free_parameters_vector<algebra_t>;
+    using free_matrix_type = free_matrix<algebra_t>;
+
+    /// A functor to get from a free to a bound vector
+    struct free_to_bound_vector {
+
+        // Visitor to the detector mask store that is called on the mask
+        // collection that contains the mask (shape) type of the surface
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline bound_param_vector_type operator()(
+            const mask_group_t& /*mask_group*/, const index_t& /*index*/,
+            const transform3_type& trf3,
+            const free_param_vector_type& free_vec) const {
+
+            using frame_t = typename mask_group_t::value_type::local_frame;
+
+            return detail::free_to_bound_vector<frame_t>(trf3, free_vec);
+        }
+    };
+
+    /// A functor to get from a bound to a free vector
+    struct bound_to_free_vector {
+
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline free_param_vector_type operator()(
+            const mask_group_t& mask_group, const index_t& index,
+            const transform3_type& trf3,
+            const bound_param_vector_type& bound_vec) const {
+
+            return detail::bound_to_free_vector(trf3, mask_group[index],
+                                                bound_vec);
+        }
+    };
+
+    /// A functor to get the free-to-bound Jacobian
+    struct free_to_bound_jacobian {
+
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline auto operator()(
+            const mask_group_t& /*mask_group*/, const index_t& /*index*/,
+            const transform3_type& trf3,
+            const free_param_vector_type& free_vec) const {
+
+            using frame_t = typename mask_group_t::value_type::local_frame;
+
+            return detail::jacobian_engine<frame_t>::free_to_bound_jacobian(
+                trf3, free_vec);
+        }
+    };
+
+    /// A functor to get the bound-to-free Jacobian
+    struct bound_to_free_jacobian {
+
+        template <typename mask_group_t, typename index_t>
+        DETRAY_HOST_DEVICE inline auto operator()(
+            const mask_group_t& mask_group, const index_t& index,
+            const transform3_type& trf3,
+            const bound_param_vector_type& bound_vec) const {
+
+            using frame_t = typename mask_group_t::value_type::local_frame;
+
+            return detail::jacobian_engine<frame_t>::bound_to_free_jacobian(
+                trf3, mask_group[index], bound_vec);
+        }
+    };
+
+    /// A functor to get the path correction
+    struct path_correction {
+
+        template <typename mask_group_t, typename index_t,
+                  concepts::scalar scalar_t>
+        DETRAY_HOST_DEVICE inline free_matrix_type operator()(
+            const mask_group_t& /*mask_group*/, const index_t& /*index*/,
+            const transform3_type& trf3, const vector3_type& pos,
+            const vector3_type& dir, const vector3_type& dtds,
+            const scalar_t dqopds) const {
+
+            using frame_t = typename mask_group_t::value_type::local_frame;
+
+            return detail::jacobian_engine<frame_t>::path_correction(
+                pos, dir, dtds, dqopds, trf3);
+        }
+    };
+};
+
+}  // namespace detray::detail

--- a/core/include/detray/geometry/detail/vertexer.hpp
+++ b/core/include/detray/geometry/detail/vertexer.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,9 +11,39 @@
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/math.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/utils/ranges.hpp"
 
 namespace detray::detail {
+
+template <concepts::point2D point2_t, concepts::point3D point3_t>
+struct vertexer;
+
+/// Compute vertices in global frame along the boundary of a surface
+///
+/// @param ctx geometry context
+/// @param sf the surface
+/// @param n_seg the number of segments used along arcs
+///
+/// @returns a vector of vetices (3D points)
+template <typename detector_t>
+DETRAY_HOST constexpr auto get_global_vertices(
+    const typename detector_t::geometry_context &ctx,
+    geometry::surface<detector_t> sf, const dindex n_seg) {
+    using algebra_t = typename detector_t::algebra_type;
+    using point2_t = dpoint2D<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
+
+    auto vertices = sf.template visit_mask<vertexer<point2_t, point3_t>>(n_seg);
+    const auto &trf = sf.transform(ctx);
+
+    const std::size_t n_vertices{vertices.size()};
+    for (std::size_t i = 0u; i < n_vertices; ++i) {
+        vertices[i] = trf.point_to_global(vertices[i]);
+    }
+
+    return vertices;
+}
 
 /// Generate phi values along an arc
 ///

--- a/core/include/detray/geometry/shapes/annulus2D.hpp
+++ b/core/include/detray/geometry/shapes/annulus2D.hpp
@@ -16,7 +16,7 @@
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/polar2D.hpp"
 #include "detray/geometry/detail/shape_utils.hpp"
-#include "detray/geometry/detail/vertexing.hpp"
+#include "detray/geometry/detail/vertexer.hpp"
 
 // System include(s)
 #include <limits>

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -1,0 +1,357 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/geometry.hpp"
+#include "detray/definitions/indexing.hpp"
+#include "detray/definitions/math.hpp"
+#include "detray/geometry/barcode.hpp"
+#include "detray/geometry/detail/surface_kernels.hpp"
+#include "detray/materials/material.hpp"
+
+// System include(s)
+#include <ostream>
+#include <type_traits>
+
+namespace detray::geometry {
+
+/// @brief Facade for a detray detector surface.
+///
+/// Provides an interface to geometry specific functionality like
+/// local-to-global coordinate transforms or mask and material visitors. It
+/// wraps a detector instance that contains the data and a surface descriptor
+/// that contains the indices into the detector data containers for the
+/// specific surface instance.
+template <typename detector_t>  // @TODO: This needs a concept
+class surface {
+
+    /// Surface descriptor type
+    using descr_t = typename detector_t::surface_type;
+    /// Implementation
+    using kernels = detail::surface_kernels<typename detector_t::algebra_type>;
+
+    public:
+    using algebra_type = typename detector_t::algebra_type;
+    using scalar_type = dscalar<algebra_type>;
+    using point2_type = dpoint2D<algebra_type>;
+    using point3_type = dpoint3D<algebra_type>;
+    using vector3_type = dvector3D<algebra_type>;
+    using transform3_type = dtransform3D<algebra_type>;
+    using context = typename detector_t::geometry_context;
+
+    /// Not allowed: always needs a detector and a descriptor.
+    surface() = delete;
+
+    /// Constructor from detector @param det and surface descriptor
+    /// @param desc from that detector.
+    DETRAY_HOST_DEVICE
+    constexpr surface(const detector_t &det, const descr_t &desc)
+        : m_detector{det}, m_desc{desc} {}
+
+    /// Constructor from detector @param det and barcode @param bcd in
+    /// that detector.
+    DETRAY_HOST_DEVICE
+    constexpr surface(const detector_t &det, const geometry::barcode bcd)
+        : surface(det, det.surface(bcd)) {}
+
+    /// Constructor from detector @param det and surface index @param sf_idx
+    DETRAY_HOST_DEVICE
+    constexpr surface(const detector_t &det, const dindex sf_idx)
+        : surface(det, det.surface(sf_idx)) {}
+
+    /// Conversion to surface interface around constant detector type
+    template <typename detector_type = detector_t>
+    requires(!std::is_const_v<detector_type>) DETRAY_HOST_DEVICE constexpr
+    operator surface<const detector_type>() const {
+        return surface<const detector_type>{this->m_detector, this->m_desc};
+    }
+
+    /// Equality operator
+    ///
+    /// @param rhs is the right hand side to be compared to
+    DETRAY_HOST_DEVICE
+    constexpr auto operator==(const surface &rhs) const -> bool {
+        return (&m_detector == &(rhs.m_detector) && m_desc == rhs.m_desc);
+    }
+
+    /// @returns the surface barcode
+    DETRAY_HOST_DEVICE
+    constexpr auto barcode() const -> geometry::barcode {
+        return m_desc.barcode();
+    }
+
+    /// @returns the index of the mother volume
+    DETRAY_HOST_DEVICE
+    constexpr auto volume() const -> dindex { return barcode().volume(); }
+
+    /// @returns the index of the surface in the detector surface lookup
+    DETRAY_HOST_DEVICE
+    constexpr auto index() const -> dindex { return barcode().index(); }
+
+    /// @returns the surface id (sensitive, passive or portal)
+    DETRAY_HOST_DEVICE
+    constexpr auto id() const -> surface_id { return barcode().id(); }
+
+    /// @returns the extra bits in the barcode
+    DETRAY_HOST_DEVICE
+    constexpr auto extra() const -> dindex { return barcode().extra(); }
+
+    /// @returns an id for the surface type (e.g. 'rectangle')
+    DETRAY_HOST_DEVICE
+    constexpr auto shape_id() const { return m_desc.mask().id(); }
+
+    /// @returns the surface source link
+    DETRAY_HOST_DEVICE
+    constexpr auto source() const {
+        return m_detector.surface(m_desc.barcode()).source;
+    }
+
+    /// @returns true if the surface is a senstive detector module.
+    DETRAY_HOST_DEVICE
+    constexpr auto is_sensitive() const -> bool {
+        return barcode().id() == surface_id::e_sensitive;
+    }
+
+    /// @returns true if the surface is a portal.
+    DETRAY_HOST_DEVICE
+    constexpr auto is_portal() const -> bool {
+        return barcode().id() == surface_id::e_portal;
+    }
+
+    /// @returns true if the surface is a passive detector element.
+    DETRAY_HOST_DEVICE
+    constexpr auto is_passive() const -> bool {
+        return barcode().id() == surface_id::e_passive;
+    }
+
+    /// @returns true if the surface carries material.
+    DETRAY_HOST_DEVICE
+    constexpr auto has_material() const -> bool {
+        return m_desc.material().id() !=
+                   static_cast<typename descr_t::material_link::id_type>(
+                       detector_t::materials::id::e_none) &&
+               !m_desc.material().is_invalid();
+    }
+
+    /// @returns the mask volume link
+    DETRAY_HOST_DEVICE
+    constexpr auto volume_link() const {
+        return visit_mask<typename kernels::get_volume_link>();
+    }
+
+    /// @returns the mask shape name
+    DETRAY_HOST
+    std::string shape_name() const {
+        return visit_mask<typename kernels::get_shape_name>();
+    }
+
+    /// @returns the coordinate transform matrix of the surface
+    DETRAY_HOST_DEVICE
+    constexpr auto transform(const context &ctx) const
+        -> const transform3_type & {
+        return m_detector.transform_store().at(m_desc.transform(), ctx);
+    }
+
+    /// @returns the mask volume link
+    template <concepts::point point_t = point2_type>
+    DETRAY_HOST_DEVICE constexpr bool is_inside(const point_t &loc_p,
+                                                const scalar_type tol) const {
+        return visit_mask<typename kernels::is_inside>(loc_p, tol);
+    }
+
+    /// @returns a boundary value of the surface, according to @param index
+    DETRAY_HOST_DEVICE
+    constexpr scalar_type boundary(std::size_t index) const {
+        return visit_mask<typename kernels::get_mask_value>(index);
+    }
+
+    /// @returns the centroid of the surface mask in local cartesian coordinates
+    DETRAY_HOST_DEVICE
+    constexpr auto centroid() const -> point3_type {
+        return visit_mask<typename kernels::centroid>();
+    }
+
+    /// @returns the center position of the surface in global coordinates
+    /// @note for shapes like the annulus this is not synonymous to the centroid
+    /// but instead the focal point of the strip system
+    DETRAY_HOST_DEVICE
+    constexpr auto center(const context &ctx) const -> point3_type {
+        return transform(ctx).translation();
+    }
+
+    /// @returns the surface normal in global coordinates at a given bound/local
+    /// position @param p
+    template <concepts::point point_t = point2_type>
+    DETRAY_HOST_DEVICE constexpr auto normal(const context &ctx,
+                                             const point_t &p) const
+        -> vector3_type {
+        return visit_mask<typename kernels::normal>(transform(ctx), p);
+    }
+
+    /// @returns a pointer to the material parameters at the local position
+    /// @param loc_p
+    DETRAY_HOST_DEVICE constexpr const material<scalar_type>
+        *material_parameters(const point2_type &loc_p) const {
+        return visit_material<typename kernels::get_material_params>(loc_p);
+    }
+
+    /// @returns the local position to the global point @param global for
+    /// a given geometry context @param ctx and track direction @param dir
+    DETRAY_HOST_DEVICE
+    constexpr point3_type global_to_local(const context &ctx,
+                                          const point3_type &global,
+                                          const vector3_type &dir) const {
+        return visit_mask<typename kernels::global_to_local>(transform(ctx),
+                                                             global, dir);
+    }
+
+    /// @returns the bound (2D) position to the global point @param global for
+    /// a given geometry context @param ctx and track direction @param dir
+    DETRAY_HOST_DEVICE
+    constexpr point2_type global_to_bound(const context &ctx,
+                                          const point3_type &global,
+                                          const vector3_type &dir) const {
+        const point3_type local{global_to_local(ctx, global, dir)};
+
+        return {local[0], local[1]};
+    }
+
+    /// @returns the global position to the given local position @param local
+    /// for a given geometry context @param ctx
+    template <concepts::point point_t = point2_type>
+    DETRAY_HOST_DEVICE constexpr point3_type local_to_global(
+        const context &ctx, const point_t &local,
+        const vector3_type &dir) const {
+        return visit_mask<typename kernels::local_to_global>(transform(ctx),
+                                                             local, dir);
+    }
+
+    /// Call a functor on the surfaces mask with additional arguments.
+    ///
+    /// @tparam functor_t the prescription to be applied to the mask
+    /// @tparam Args      types of additional arguments to the functor
+    template <typename functor_t, typename... Args>
+    DETRAY_HOST_DEVICE constexpr auto visit_mask(Args &&... args) const {
+        const auto &masks = m_detector.mask_store();
+
+        return masks.template visit<functor_t>(m_desc.mask(),
+                                               std::forward<Args>(args)...);
+    }
+
+    /// Call a functor on the surfaces material with additional arguments.
+    ///
+    /// @tparam functor_t the prescription to be applied to the material
+    /// @tparam Args      types of additional arguments to the functor
+    template <typename functor_t, typename... Args>
+    DETRAY_HOST_DEVICE constexpr auto visit_material(Args &&... args) const {
+        const auto &materials = m_detector.material_store();
+
+        return materials.template visit<functor_t>(m_desc.material(),
+                                                   std::forward<Args>(args)...);
+    }
+
+    /// Do a consistency check on the surface after building the detector.
+    ///
+    /// @param os output stream for error messages.
+    ///
+    /// @returns true if the surface is consistent
+    DETRAY_HOST bool self_check(std::ostream &os) const {
+        if (barcode().is_invalid()) {
+            os << "ERROR: Invalid barcode for surface:\n" << *this << std::endl;
+            return false;
+        }
+        if (index() >= m_detector.surfaces().size()) {
+            os << "ERROR: Surface index out of bounds for surface:\n"
+               << *this << std::endl;
+            return false;
+        }
+        if (volume() >= m_detector.volumes().size()) {
+            os << "ERROR: Surface volume index out of bounds for surface:\n"
+               << *this << std::endl;
+            return false;
+        }
+        if (detail::is_invalid_value(m_desc.transform())) {
+            os << "ERROR: Surface transform undefined for surface:\n"
+               << *this << std::endl;
+            return false;
+        }
+        if (m_desc.transform() >= m_detector.transform_store().size()) {
+            os << "ERROR: Surface transform index out of bounds for surface:\n"
+               << *this << std::endl;
+            return false;
+        }
+        if (detail::is_invalid_value(m_desc.mask())) {
+            os << "ERROR: Surface does not have a valid mask link:\n"
+               << *this << std::endl;
+            return false;
+        }
+        // Only check, if there is material in the detector
+        if (!m_detector.material_store().all_empty() && has_material() &&
+            m_desc.material().is_invalid_index()) {
+            os << "ERROR: Surface does not have valid material link:\n"
+               << *this << std::endl;
+            return false;
+        }
+        // Check the mask boundaries
+        if (!visit_mask<typename kernels::mask_self_check>(os)) {
+            os << "\nSurface: " << *this << std::endl;
+            return false;
+        }
+        // Check the mask volume link
+        const auto vol_link = visit_mask<typename kernels::get_volume_link>();
+        if (is_portal()) {
+            if (vol_link == volume()) {
+                os << "ERROR: Portal surface links to mother volume:\n"
+                   << *this << std::endl;
+                return false;
+            }
+        } else if (vol_link != volume()) {
+            os << "ERROR: Passive/sensitive surface does not link to mother "
+                  "volume:"
+               << "Mask volume link : " << vol_link << "\n"
+               << *this << std::endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    protected:
+    /// @returns a string stream that prints the surface details
+    DETRAY_HOST
+    friend std::ostream &operator<<(std::ostream &os, const surface &sf) {
+        os << sf.m_desc;
+        return os;
+    }
+
+    /// @returns access to the underlying detector object
+    DETRAY_HOST_DEVICE
+    const detector_t &detector() const { return m_detector; }
+
+    /// @returns access to the underlying surface descriptor object
+    DETRAY_HOST_DEVICE
+    descr_t descriptor() const { return m_desc; }
+
+    private:
+    /// Access to the detector stores
+    const detector_t &m_detector;
+    /// Access to the descriptor
+    const descr_t m_desc;
+};
+
+template <typename detector_t, typename descr_t>
+DETRAY_HOST_DEVICE surface(const detector_t &, const descr_t &)
+    ->surface<detector_t>;
+
+template <typename detector_t>
+DETRAY_HOST_DEVICE surface(const detector_t &, const geometry::barcode)
+    ->surface<detector_t>;
+
+}  // namespace detray::geometry

--- a/core/include/detray/geometry/tracking_surface.hpp
+++ b/core/include/detray/geometry/tracking_surface.hpp
@@ -1,7 +1,7 @@
 
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,67 +11,41 @@
 // Project include(s)
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
-#include "detray/definitions/geometry.hpp"
-#include "detray/definitions/indexing.hpp"
-#include "detray/definitions/math.hpp"
-#include "detray/geometry/barcode.hpp"
-#include "detray/geometry/detail/surface_kernels.hpp"
-#include "detray/materials/material.hpp"
-
-// System include(s)
-#include <ostream>
-#include <type_traits>
+#include "detray/geometry/detail/tracking_surface_kernels.hpp"
+#include "detray/geometry/surface.hpp"
 
 namespace detray {
 
-/// @brief Facade for a detray detector surface.
-///
-/// Provides an interface to geometry specific functionality like
-/// local-to-global coordinate transforms or mask and material visitors. It
-/// wraps a detector instance that contains the data and a surface descriptor
-/// that contains the indices into the detector data containers for the
-/// specific surface instance.
+/// @brief Facade for a detray detector surface with extra tracking capabilities
 template <typename detector_t>  // @TODO: This needs a concept
-class tracking_surface {
+class tracking_surface : public geometry::surface<detector_t> {
 
-    /// Surface descriptor type
-    using descr_t = typename detector_t::surface_type;
+    using base_surface_t = geometry::surface<detector_t>;
 
-    using kernels = detail::surface_kernels<typename detector_t::algebra_type>;
+    /// Implementation of tracking functionality
+    using kernels =
+        detail::tracking_surface_kernels<typename detector_t::algebra_type>;
     /// Vector type for track parameters in global coordinates
     using free_param_vector_type = typename kernels::free_param_vector_type;
     /// Vector type for track parameters in local (bound) coordinates
     using bound_param_vector_type = typename kernels::bound_param_vector_type;
 
     public:
-    using algebra_type = typename detector_t::algebra_type;
-    using scalar_type = dscalar<algebra_type>;
-    using point2_type = dpoint2D<algebra_type>;
-    using point3_type = dpoint3D<algebra_type>;
-    using vector3_type = dvector3D<algebra_type>;
-    using transform3_type = dtransform3D<algebra_type>;
-    using context = typename detector_t::geometry_context;
+    using algebra_type = typename base_surface_t::algebra_type;
+    using scalar_type = typename base_surface_t::scalar_type;
+    using point2_type = typename base_surface_t::point2_type;
+    using point3_type = typename base_surface_t::point3_type;
+    using vector3_type = typename base_surface_t::vector3_type;
+    using transform3_type = typename base_surface_t::transform3_type;
+    using context = typename base_surface_t::context;
 
-    /// Not allowed: always needs a detector and a descriptor.
-    tracking_surface() = delete;
+    /// Use base class constructors
+    using base_surface_t::base_surface_t;
 
-    /// Constructor from detector @param det and surface descriptor
-    /// @param desc from that detector.
+    /// Decorate a geometric surface with tracking functionality
     DETRAY_HOST_DEVICE
-    constexpr tracking_surface(const detector_t &det, const descr_t &desc)
-        : m_detector{det}, m_desc{desc} {}
-
-    /// Constructor from detector @param det and barcode @param bcd in
-    /// that detector.
-    DETRAY_HOST_DEVICE
-    constexpr tracking_surface(const detector_t &det,
-                               const geometry::barcode bcd)
-        : tracking_surface(det, det.surface(bcd)) {}
-
-    /// Constructor from detector @param det and surface index @param sf_idx
-    DETRAY_HOST_DEVICE
-    constexpr tracking_surface(const detector_t &det, const dindex sf_idx)
-        : tracking_surface(det, det.surface(sf_idx)) {}
+    explicit constexpr tracking_surface(const base_surface_t sf)
+        : base_surface_t(sf) {}
 
     /// Conversion to surface interface around constant detector type
     template <typename detector_type = detector_t>
@@ -81,198 +55,22 @@ class tracking_surface {
                                                      this->m_desc};
     }
 
-    /// Equality operator
-    ///
-    /// @param rhs is the right hand side to be compared to
-    DETRAY_HOST_DEVICE
-    constexpr auto operator==(const tracking_surface &rhs) const -> bool {
-        return (&m_detector == &(rhs.m_detector) && m_desc == rhs.m_desc);
-    }
-
-    /// @returns the surface barcode
-    DETRAY_HOST_DEVICE
-    constexpr auto barcode() const -> geometry::barcode {
-        return m_desc.barcode();
-    }
-
-    /// @returns the index of the mother volume
-    DETRAY_HOST_DEVICE
-    constexpr auto volume() const -> dindex { return barcode().volume(); }
-
-    /// @returns the index of the surface in the detector surface lookup
-    DETRAY_HOST_DEVICE
-    constexpr auto index() const -> dindex { return barcode().index(); }
-
-    /// @returns the surface id (sensitive, passive or portal)
-    DETRAY_HOST_DEVICE
-    constexpr auto id() const -> surface_id { return barcode().id(); }
-
-    /// @returns the extra bits in the barcode
-    DETRAY_HOST_DEVICE
-    constexpr auto extra() const -> dindex { return barcode().extra(); }
-
-    /// @returns an id for the surface type (e.g. 'rectangle')
-    DETRAY_HOST_DEVICE
-    constexpr auto shape_id() const { return m_desc.mask().id(); }
-
-    /// @returns the surface source link
-    DETRAY_HOST_DEVICE
-    constexpr auto source() const {
-        return m_detector.surface(m_desc.barcode()).source;
-    }
-
-    /// @returns true if the surface is a senstive detector module.
-    DETRAY_HOST_DEVICE
-    constexpr auto is_sensitive() const -> bool {
-        return barcode().id() == surface_id::e_sensitive;
-    }
-
-    /// @returns true if the surface is a portal.
-    DETRAY_HOST_DEVICE
-    constexpr auto is_portal() const -> bool {
-        return barcode().id() == surface_id::e_portal;
-    }
-
-    /// @returns true if the surface is a passive detector element.
-    DETRAY_HOST_DEVICE
-    constexpr auto is_passive() const -> bool {
-        return barcode().id() == surface_id::e_passive;
-    }
-
-    /// @returns true if the surface carries material.
-    DETRAY_HOST_DEVICE
-    constexpr auto has_material() const -> bool {
-        return m_desc.material().id() !=
-                   static_cast<typename descr_t::material_link::id_type>(
-                       detector_t::materials::id::e_none) &&
-               !m_desc.material().is_invalid();
-    }
-
-    /// @returns the mask volume link
-    DETRAY_HOST_DEVICE
-    constexpr auto volume_link() const {
-        return visit_mask<typename kernels::get_volume_link>();
-    }
-
-    /// @returns the mask shape name
-    DETRAY_HOST
-    std::string shape_name() const {
-        return visit_mask<typename kernels::get_shape_name>();
-    }
-
-    /// @returns the coordinate transform matrix of the surface
-    DETRAY_HOST_DEVICE
-    constexpr auto transform(const context &ctx) const
-        -> const transform3_type & {
-        return m_detector.transform_store().at(m_desc.transform(), ctx);
-    }
-
-    /// @returns the mask volume link
-    template <concepts::point point_t = point2_type>
-    DETRAY_HOST_DEVICE constexpr bool is_inside(const point_t &loc_p,
-                                                const scalar_type tol) const {
-        return visit_mask<typename kernels::is_inside>(loc_p, tol);
-    }
-
-    /// @returns a boundary value of the surface, according to @param index
-    DETRAY_HOST_DEVICE
-    constexpr scalar_type boundary(std::size_t index) const {
-        return visit_mask<typename kernels::get_mask_value>(index);
-    }
-
-    /// @returns the centroid of the surface mask in local cartesian coordinates
-    DETRAY_HOST_DEVICE
-    constexpr auto centroid() const -> point3_type {
-        return visit_mask<typename kernels::centroid>();
-    }
-
-    /// @returns the center position of the surface in global coordinates
-    /// @note for shapes like the annulus this is not synonymous to the controid
-    /// but the focal point of the strip system instead
-    DETRAY_HOST_DEVICE
-    constexpr auto center(const context &ctx) const -> point3_type {
-        return transform(ctx).translation();
-    }
-
-    /// @returns the surface normal in global coordinates at a given bound/local
-    /// position @param p
-    template <concepts::point point_t = point2_type>
-    DETRAY_HOST_DEVICE constexpr auto normal(const context &ctx,
-                                             const point_t &p) const
-        -> vector3_type {
-        return visit_mask<typename kernels::normal>(transform(ctx), p);
-    }
-
-    /// @returns the cosine of the incidence angle given a local/bound position
-    /// @param p and a global direction @param dir
-    /// @note The direction has to be normalized
-    template <concepts::point point_t = point2_type>
-    DETRAY_HOST_DEVICE constexpr auto cos_angle(const context &ctx,
-                                                const vector3_type &dir,
-                                                const point_t &p) const
-        -> scalar_type {
-        return math::fabs(vector::dot(dir, normal(ctx, p)));
-    }
-
-    /// @returns a pointer to the material parameters at the local position
-    /// @param loc_p
-    DETRAY_HOST_DEVICE constexpr const material<scalar_type>
-        *material_parameters(const point2_type &loc_p) const {
-        return visit_material<typename kernels::get_material_params>(loc_p);
-    }
-
-    /// @returns the bound (2D) position to the global point @param global for
-    /// a given geometry context @param ctx and track direction @param dir
-    DETRAY_HOST_DEVICE
-    constexpr point2_type global_to_bound(const context &ctx,
-                                          const point3_type &global,
-                                          const vector3_type &dir) const {
-        return visit_mask<typename kernels::global_to_bound>(transform(ctx),
-                                                             global, dir);
-    }
-
-    /// @returns the local position to the global point @param global for
-    /// a given geometry context @param ctx and track direction @param dir
-    DETRAY_HOST_DEVICE
-    constexpr point3_type global_to_local(const context &ctx,
-                                          const point3_type &global,
-                                          const vector3_type &dir) const {
-        return visit_mask<typename kernels::global_to_local>(transform(ctx),
-                                                             global, dir);
-    }
-
-    /// @returns the global position to the given local position @param local
-    /// for a given geometry context @param ctx
-    DETRAY_HOST_DEVICE constexpr point3_type local_to_global(
-        const context &ctx, const point3_type &local,
-        const vector3_type &dir) const {
-        return visit_mask<typename kernels::local_to_global>(transform(ctx),
-                                                             local, dir);
-    }
-
-    /// @returns the global position to the given bound position @param bound
-    /// for a given geometry context @param ctx
-    DETRAY_HOST_DEVICE constexpr point3_type bound_to_global(
-        const context &ctx, const point2_type &bound,
-        const vector3_type &dir) const {
-        return visit_mask<typename kernels::local_to_global>(transform(ctx),
-                                                             bound, dir);
-    }
-
     /// @returns the track parametrization projected onto the surface (bound)
     DETRAY_HOST_DEVICE
     constexpr auto free_to_bound_vector(
         const context &ctx, const free_param_vector_type &free_vec) const {
-        return visit_mask<typename kernels::free_to_bound_vector>(
-            transform(ctx), free_vec);
+        return this
+            ->template visit_mask<typename kernels::free_to_bound_vector>(
+                this->transform(ctx), free_vec);
     }
 
     /// @returns the global track parametrization from a bound representation
     DETRAY_HOST_DEVICE
     constexpr auto bound_to_free_vector(
         const context &ctx, const bound_param_vector_type &bound_vec) const {
-        return visit_mask<typename kernels::bound_to_free_vector>(
-            transform(ctx), bound_vec);
+        return this
+            ->template visit_mask<typename kernels::bound_to_free_vector>(
+                this->transform(ctx), bound_vec);
     }
 
     /// @returns the jacobian to go from a free to a bound track parametrization
@@ -281,7 +79,7 @@ class tracking_surface {
         const context &ctx, const free_param_vector_type &free_vec) const {
         return this
             ->template visit_mask<typename kernels::free_to_bound_jacobian>(
-                transform(ctx), free_vec);
+                this->transform(ctx), free_vec);
     }
 
     /// @returns the jacobian to go from a bound to a free track parametrization
@@ -290,7 +88,7 @@ class tracking_surface {
         const context &ctx, const bound_param_vector_type &bound_vec) const {
         return this
             ->template visit_mask<typename kernels::bound_to_free_jacobian>(
-                transform(ctx), bound_vec);
+                this->transform(ctx), bound_vec);
     }
 
     /// @returns the path correction term
@@ -299,151 +97,9 @@ class tracking_surface {
                                    const vector3_type &dir,
                                    const vector3_type &dtds,
                                    const scalar_type dqopds) const {
-        return visit_mask<typename kernels::path_correction>(
-            transform(ctx), pos, dir, dtds, dqopds);
+        return this->template visit_mask<typename kernels::path_correction>(
+            this->transform(ctx), pos, dir, dtds, dqopds);
     }
-
-    /// @returns the vertices in local frame with @param n_seg the number of
-    /// segments used along acrs
-    DETRAY_HOST
-    constexpr auto local_vertices(const dindex n_seg) const {
-        return visit_mask<typename kernels::vertices>(n_seg);
-    }
-
-    /// @returns the vertices in global frame with @param n_seg the number of
-    /// segments used along acrs
-    DETRAY_HOST
-    constexpr auto global_vertices(const context &ctx,
-                                   const dindex n_seg) const {
-        auto vertices = local_vertices(n_seg);
-        for (std::size_t i = 0u; i < vertices.size(); ++i) {
-            vertices[i] = transform(ctx).point_to_global(vertices[i]);
-        }
-        return vertices;
-    }
-
-    /// @returns the vertices in local frame with @param n_seg the number of
-    /// segments used along acrs
-    /// @note the point has to be inside the surface mask
-    template <concepts::point point_t>
-    DETRAY_HOST constexpr auto min_dist_to_boundary(
-        const point_t &loc_p) const {
-        return visit_mask<typename kernels::min_dist_to_boundary>(loc_p);
-    }
-
-    /// @brief Lower and upper point for minimal axis aligned bounding box.
-    ///
-    /// Computes the min and max vertices in a local cartesian frame.
-    DETRAY_HOST
-    constexpr auto local_min_bounds(
-        const scalar_type env =
-            std::numeric_limits<scalar_type>::epsilon()) const {
-        return visit_mask<typename kernels::local_min_bounds>(env);
-    }
-
-    /// Call a functor on the surfaces mask with additional arguments.
-    ///
-    /// @tparam functor_t the prescription to be applied to the mask
-    /// @tparam Args      types of additional arguments to the functor
-    template <typename functor_t, typename... Args>
-    DETRAY_HOST_DEVICE constexpr auto visit_mask(Args &&... args) const {
-        const auto &masks = m_detector.mask_store();
-
-        return masks.template visit<functor_t>(m_desc.mask(),
-                                               std::forward<Args>(args)...);
-    }
-
-    /// Call a functor on the surfaces material with additional arguments.
-    ///
-    /// @tparam functor_t the prescription to be applied to the material
-    /// @tparam Args      types of additional arguments to the functor
-    template <typename functor_t, typename... Args>
-    DETRAY_HOST_DEVICE constexpr auto visit_material(Args &&... args) const {
-        const auto &materials = m_detector.material_store();
-
-        return materials.template visit<functor_t>(m_desc.material(),
-                                                   std::forward<Args>(args)...);
-    }
-
-    /// Do a consistency check on the surface after building the detector.
-    ///
-    /// @param os output stream for error messages.
-    ///
-    /// @returns true if the surface is consistent
-    DETRAY_HOST bool self_check(std::ostream &os) const {
-        if (barcode().is_invalid()) {
-            os << "ERROR: Invalid barcode for surface:\n" << *this << std::endl;
-            return false;
-        }
-        if (index() >= m_detector.surfaces().size()) {
-            os << "ERROR: Surface index out of bounds for surface:\n"
-               << *this << std::endl;
-            return false;
-        }
-        if (volume() >= m_detector.volumes().size()) {
-            os << "ERROR: Surface volume index out of bounds for surface:\n"
-               << *this << std::endl;
-            return false;
-        }
-        if (detail::is_invalid_value(m_desc.transform())) {
-            os << "ERROR: Surface transform undefined for surface:\n"
-               << *this << std::endl;
-            return false;
-        }
-        if (m_desc.transform() >= m_detector.transform_store().size()) {
-            os << "ERROR: Surface transform index out of bounds for surface:\n"
-               << *this << std::endl;
-            return false;
-        }
-        if (detail::is_invalid_value(m_desc.mask())) {
-            os << "ERROR: Surface does not have a valid mask link:\n"
-               << *this << std::endl;
-            return false;
-        }
-        // Only check, if there is material in the detector
-        if (!m_detector.material_store().all_empty() && has_material() &&
-            m_desc.material().is_invalid_index()) {
-            os << "ERROR: Surface does not have valid material link:\n"
-               << *this << std::endl;
-            return false;
-        }
-        // Check the mask boundaries
-        if (!visit_mask<typename kernels::mask_self_check>(os)) {
-            os << "\nSurface: " << *this << std::endl;
-            return false;
-        }
-        // Check the mask volume link
-        const auto vol_link = visit_mask<typename kernels::get_volume_link>();
-        if (is_portal()) {
-            if (vol_link == volume()) {
-                os << "ERROR: Portal surface links to mother volume:\n"
-                   << *this << std::endl;
-                return false;
-            }
-        } else if (vol_link != volume()) {
-            os << "ERROR: Passive/sensitive surface does not link to mother "
-                  "volume:"
-               << "Mask volume link : " << vol_link << "\n"
-               << *this << std::endl;
-            return false;
-        }
-
-        return true;
-    }
-
-    /// @returns a string stream that prints the surface details
-    DETRAY_HOST
-    friend std::ostream &operator<<(std::ostream &os,
-                                    const tracking_surface &sf) {
-        os << sf.m_desc;
-        return os;
-    }
-
-    private:
-    /// Access to the detector stores
-    const detector_t &m_detector;
-    /// Access to the descriptor
-    const descr_t m_desc;
 };
 
 template <typename detector_t, typename descr_t>
@@ -452,6 +108,10 @@ DETRAY_HOST_DEVICE tracking_surface(const detector_t &, const descr_t &)
 
 template <typename detector_t>
 DETRAY_HOST_DEVICE tracking_surface(const detector_t &, const geometry::barcode)
+    ->tracking_surface<detector_t>;
+
+template <typename detector_t>
+DETRAY_HOST_DEVICE tracking_surface(const geometry::surface<detector_t>)
     ->tracking_surface<detector_t>;
 
 }  // namespace detray

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -15,6 +15,7 @@
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/barcode.hpp"
+#include "detray/geometry/tracking_surface.hpp"
 #include "detray/navigation/intersection/intersection.hpp"
 #include "detray/navigation/intersection/ray_intersector.hpp"
 #include "detray/navigation/intersection_kernel.hpp"
@@ -259,19 +260,17 @@ class navigator {
         }
 
         /// @returns the next surface the navigator intends to reach
-        DETRAY_HOST_DEVICE
-        inline auto next_surface() const {
-            return tracking_surface<detector_type>{*m_detector,
-                                                   target().sf_desc};
+        template <template <typename> class surface_t = tracking_surface>
+        DETRAY_HOST_DEVICE inline auto next_surface() const {
+            return surface_t{*m_detector, target().sf_desc};
         }
 
         /// @returns current detector surface the navigator is on
         /// (cannot be used when not on surface) - const
-        DETRAY_HOST_DEVICE
-        inline auto get_surface() const {
+        template <template <typename> class surface_t = tracking_surface>
+        DETRAY_HOST_DEVICE inline auto get_surface() const {
             assert(is_on_surface());
-            return tracking_surface<detector_type>{*m_detector,
-                                                   current().sf_desc};
+            return surface_t{*m_detector, current().sf_desc};
         }
 
         /// @returns current detector volume of the navigation stream
@@ -613,7 +612,7 @@ class navigator {
             const scalar_type mask_tol_scalor,
             const scalar_type overstep_tol) const {
 
-            const auto sf = tracking_surface{det, sf_descr};
+            const auto sf = geometry::surface{det, sf_descr};
 
             sf.template visit_mask<intersection_initialize<ray_intersector>>(
                 nav_state,
@@ -929,7 +928,7 @@ class navigator {
             return false;
         }
 
-        const auto sf = tracking_surface{det, candidate.sf_desc};
+        const auto sf = geometry::surface{det, candidate.sf_desc};
 
         // Check whether this candidate is reachable by the track
         return sf.template visit_mask<intersection_update<ray_intersector>>(

--- a/core/include/detray/propagator/actors/parameter_resetter.hpp
+++ b/core/include/detray/propagator/actors/parameter_resetter.hpp
@@ -11,7 +11,6 @@
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/track_parametrization.hpp"
-#include "detray/geometry/tracking_surface.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/propagator/detail/jacobian_engine.hpp"
 

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -11,14 +11,12 @@
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/track_parametrization.hpp"
-#include "detray/geometry/tracking_surface.hpp"
 #include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/detail/material_accessor.hpp"
 #include "detray/materials/interaction.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/tracks/bound_track_parameters.hpp"
-#include "detray/utils/ranges.hpp"
-#include "detray/utils/type_traits.hpp"
+#include "detray/utils/geometry_utils.hpp"
 
 namespace detray {
 
@@ -160,8 +158,8 @@ struct pointwise_material_interactor : actor {
         // Closest approach of the track to a line surface. Otherwise this is
         // ignored.
         const auto approach{bound_params[e_bound_loc0]};
-        const scalar_type cos_inc_angle{math::fabs(sf.cos_angle(
-            gctx, bound_params.dir(), bound_params.bound_local()))};
+        const scalar_type cos_inc_angle{cos_angle(gctx, sf, bound_params.dir(),
+                                                  bound_params.bound_local())};
 
         const bool succeed = sf.template visit_material<kernel>(
             interactor_state, ptc, bound_params, cos_inc_angle, approach);

--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Project include(s)
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/geometry/tracking_volume.hpp"
 #include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/predefined_materials.hpp"
@@ -56,7 +56,7 @@ struct surface_checker {
         const detector_t &det, const dindex vol_idx,
         const typename detector_t::name_map &names) const {
 
-        const auto sf = tracking_surface{det, sf_descr};
+        const auto sf = geometry::surface{det, sf_descr};
         const auto vol = tracking_volume{det, vol_idx};
         std::stringstream err_stream{};
         err_stream << "VOLUME \"" << print_volume_name(vol, names) << "\":\n";
@@ -93,7 +93,7 @@ struct surface_checker {
         // Check that the same surface is registered in the detector surface
         // lookup
         const auto sf_from_lkp =
-            tracking_surface{det, det.surface(sf.barcode())};
+            geometry::surface{det, det.surface(sf.barcode())};
         if (sf_from_lkp != sf) {
             err_stream << "ERROR: Surfaces in volume and detector lookups "
                        << "differ:\n In volume acceleration data structure: "
@@ -121,7 +121,7 @@ struct surface_checker {
         if (ref_descr.volume() != check_descr.volume()) {
             std::stringstream err_stream{};
             err_stream << "Incorrect volume index on surface: "
-                       << tracking_surface{det, check_descr};
+                       << geometry::surface{det, check_descr};
 
             throw std::invalid_argument(err_stream.str());
         }
@@ -323,7 +323,7 @@ inline bool check_consistency(const detector_t &det, const bool verbose = false,
     // Check the surfaces in the detector's surface lookup
     for (const auto &[idx, sf_desc] :
          detray::views::enumerate(det.surfaces())) {
-        const auto sf = tracking_surface{det, sf_desc};
+        const auto sf = geometry::surface{det, sf_desc};
         const auto vol = tracking_volume{det, sf.volume()};
         err_stream << "VOLUME \"" << print_volume_name(vol, names) << "\":\n";
 

--- a/core/include/detray/utils/geometry_utils.hpp
+++ b/core/include/detray/utils/geometry_utils.hpp
@@ -1,0 +1,34 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/algebra.hpp"
+#include "detray/definitions/math.hpp"
+#include "detray/geometry/surface.hpp"
+
+namespace detray {
+
+/// Helper to get the incidence angle of a direction vector on a surface
+///
+/// @param ctx the geometric context
+/// @param sf the geometric surface
+/// @param dir normalized direction vector (e.g. direction of a track)
+/// @param loc the local/bound position on the surface
+///
+/// @returns the cosine of the incidence angle given a local/bound position
+template <typename detector_t, concepts::point point_t>
+DETRAY_HOST_DEVICE constexpr dscalar<typename detector_t::algebra_type>
+cos_angle(const typename detector_t::geometry_context &ctx,
+          geometry::surface<detector_t> sf,
+          const dvector3D<typename detector_t::algebra_type> &dir,
+          const point_t &loc) {
+    return math::fabs(vector::dot(dir, sf.normal(ctx, loc)));
+}
+
+}  // namespace detray

--- a/io/include/detray/io/backend/geometry_writer.hpp
+++ b/io/include/detray/io/backend/geometry_writer.hpp
@@ -10,7 +10,7 @@
 // Project include(s)
 #include "detray/definitions/indexing.hpp"
 #include "detray/geometry/mask.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/io/backend/detail/basic_converter.hpp"
 #include "detray/io/backend/detail/type_info.hpp"
 #include "detray/io/frontend/payloads.hpp"
@@ -109,7 +109,7 @@ class geometry_writer {
 
     /// Convert a detector surface @param sf into its io payload
     template <typename detector_t>
-    static surface_payload to_payload(const tracking_surface<detector_t>& sf,
+    static surface_payload to_payload(const geometry::surface<detector_t>& sf,
                                       std::size_t sf_idx) {
         surface_payload sf_data;
 
@@ -143,7 +143,7 @@ class geometry_writer {
         for (const auto& sf_desc : det.surfaces()) {
             if (sf_desc.volume() == vol_desc.index()) {
                 vol_data.surfaces.push_back(
-                    to_payload(tracking_surface{det, sf_desc}, sf_idx++));
+                    to_payload(geometry::surface{det, sf_desc}, sf_idx++));
             }
         }
 

--- a/io/include/detray/io/backend/homogeneous_material_writer.hpp
+++ b/io/include/detray/io/backend/homogeneous_material_writer.hpp
@@ -10,7 +10,7 @@
 // Project include(s)
 #include "detray/core/concepts.hpp"
 #include "detray/definitions/algebra.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/geometry/tracking_volume.hpp"
 #include "detray/io/backend/detail/basic_converter.hpp"
 #include "detray/io/backend/detail/type_info.hpp"
@@ -112,7 +112,7 @@ class homogeneous_material_writer {
         for (const auto& sf_desc : vol.surfaces()) {
 
             // Convert material slabs and rods
-            const auto sf = tracking_surface{det, sf_desc};
+            const auto sf = geometry::surface{det, sf_desc};
 
             if (material_slab_payload mslp =
                     sf.template visit_material<get_material_payload>(sf_idx);

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/information_section.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/information_section.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Project include(s)
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/plugins/svgtools/meta/proto/information_section.hpp"
 
 // Actsvg include(s)
@@ -37,7 +37,7 @@ inline std::string point_to_string(point3_t point) {
 template <typename detector_t>
 inline auto information_section(
     const typename detector_t::geometry_context& context,
-    const detray::tracking_surface<detector_t>& d_surface) {
+    const detray::geometry::surface<detector_t>& d_surface) {
 
     using point3_t = typename detector_t::point3_type;
 

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/intersection.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/intersection.hpp
@@ -8,6 +8,9 @@
 #pragma once
 
 // Project include(s)
+#include "detray/geometry/surface.hpp"
+
+// Plugin include(s)
 #include "detray/plugins/svgtools/conversion/landmark.hpp"
 #include "detray/plugins/svgtools/meta/proto/intersection.hpp"
 
@@ -32,13 +35,13 @@ inline auto intersection(const detector_t& detector,
 
     for (const auto& intr : intersections) {
 
-        const detray::tracking_surface<detector_t> sf{detector, intr.sf_desc};
+        const detray::geometry::surface<detector_t> sf{detector, intr.sf_desc};
         if (sf.barcode().is_invalid()) {
             continue;
         }
 
         const point2_t bound{intr.local[0], intr.local[1]};
-        const auto position = sf.bound_to_global(gctx, bound, dir);
+        const auto position = sf.local_to_global(gctx, bound, dir);
         const auto p_lm = svgtools::conversion::landmark(position, style);
 
         p_ir._landmarks.push_back(p_lm);

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/link.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/link.hpp
@@ -8,7 +8,9 @@
 #pragma once
 
 // Project include(s)
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
+
+// Plugin include(s)
 #include "detray/plugins/svgtools/utils/link_utils.hpp"
 #include "detray/plugins/svgtools/utils/surface_kernels.hpp"
 
@@ -21,7 +23,7 @@ namespace detray::svgtools::conversion {
 template <typename detector_t>
 inline auto link(const typename detector_t::geometry_context& context,
                  const detector_t& detector,
-                 const detray::tracking_surface<detector_t>& d_portal) {
+                 const detray::geometry::surface<detector_t>& d_portal) {
 
     using point3_container_t = std::vector<typename detector_t::point3_type>;
     using p_link_t = typename actsvg::proto::portal<point3_container_t>::link;

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/portal.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/portal.hpp
@@ -8,7 +8,9 @@
 #pragma once
 
 // Project include(s)
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
+
+// Plugin include(s)
 #include "detray/plugins/svgtools/conversion/link.hpp"
 #include "detray/plugins/svgtools/conversion/surface.hpp"
 #include "detray/plugins/svgtools/styling/styling.hpp"
@@ -24,7 +26,7 @@ namespace detray::svgtools::conversion {
 template <typename detector_t, typename view_t>
 auto portal(const typename detector_t::geometry_context& context,
             const detector_t& detector,
-            const detray::tracking_surface<detector_t>& d_portal,
+            const detray::geometry::surface<detector_t>& d_portal,
             const view_t& view,
             const styling::portal_style& style =
                 styling::tableau_colorblind::portal_style,

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
@@ -11,7 +11,7 @@
 #include "detray/definitions/algebra.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 
 // Detray plugins include(s)
 #include "detray/plugins/svgtools/conversion/surface_material.hpp"
@@ -214,7 +214,7 @@ struct surface_converter {
 template <typename detector_t, typename view_t>
 auto surface(const typename detector_t::geometry_context& context,
              const detector_t& detector,
-             const detray::tracking_surface<detector_t>& d_surface,
+             const detray::geometry::surface<detector_t>& d_surface,
              const view_t& view,
              const styling::surface_style& style =
                  styling::tableau_colorblind::surface_style_sensitive,

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Project include(s)
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/utils/grid/detail/concepts.hpp"
 
 // Plugin include(s)
@@ -144,7 +144,7 @@ struct material_converter {
 /// @returns An actsvg proto surface material the material map.
 template <typename detector_t, typename view_t>
 auto surface_material(const detector_t& detector,
-                      const detray::tracking_surface<detector_t>& d_surface,
+                      const detray::geometry::surface<detector_t>& d_surface,
                       const view_t& view,
                       const styling::surface_material_style& style =
                           styling::tableau_colorblind::material_style) {

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/volume.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/volume.hpp
@@ -8,8 +8,10 @@
 #pragma once
 
 // Project include(s)
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/geometry/tracking_volume.hpp"
+
+// Plugin include(s)
 #include "detray/plugins/svgtools/conversion/portal.hpp"
 #include "detray/plugins/svgtools/conversion/surface.hpp"
 #include "detray/plugins/svgtools/conversion/surface_grid.hpp"
@@ -65,7 +67,7 @@ auto volume(const typename detector_t::geometry_context& context,
 
     for (const auto& desc : d_volume.surfaces()) {
 
-        const auto sf = detray::tracking_surface<detector_t>{detector, desc};
+        const auto sf = detray::geometry::surface<detector_t>{detector, desc};
 
         if (sf.is_portal()) {
             if (!hide_portals) {

--- a/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
@@ -9,7 +9,7 @@
 
 // Project include(s)
 #include "detray/definitions/algebra.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/plugins/svgtools/conversion/detector.hpp"
 #include "detray/plugins/svgtools/conversion/grid.hpp"
 #include "detray/plugins/svgtools/conversion/information_section.hpp"
@@ -108,7 +108,7 @@ class illustrator {
         const typename detector_t::geometry_context& gctx = {}) const {
 
         const auto surface =
-            detray::tracking_surface<detector_t>{_detector, index};
+            detray::geometry::surface<detector_t>{_detector, index};
 
         actsvg::svg::object ret;
         actsvg::svg::object material;
@@ -208,7 +208,7 @@ class illustrator {
                                       const view_t& view) const {
 
         const auto surface =
-            detray::tracking_surface<detector_t>{_detector, index};
+            detray::geometry::surface<detector_t>{_detector, index};
 
         if (_hide_material) {
             return actsvg::svg::object{};
@@ -526,7 +526,7 @@ class illustrator {
                 prefix + "_record", p_ir, view));
 
             // The intersection record is always sorted by path length
-            const auto sf{detray::tracking_surface{
+            const auto sf{detray::geometry::surface{
                 _detector, intersections.back().sf_desc}};
             const auto final_pos = sf.local_to_global(
                 gctx, intersections.back().local, trajectory.dir(0.f));

--- a/plugins/svgtools/include/detray/plugins/svgtools/utils/link_utils.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/utils/link_utils.hpp
@@ -8,9 +8,11 @@
 #pragma once
 
 // Project include(s)
-#include "detray/geometry/tracking_surface.hpp"
-#include "detray/plugins/svgtools/utils/surface_kernels.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/utils/invalid_values.hpp"
+
+// Plugin include(s)
+#include "detray/plugins/svgtools/utils/surface_kernels.hpp"
 
 // System include(s)
 #include <cassert>
@@ -21,7 +23,7 @@ namespace detray::svgtools::utils {
 /// @brief Checks if the detray surface has a volume link.
 template <typename detector_t>
 inline auto is_not_world_portal(
-    const detray::tracking_surface<detector_t>& d_portal) {
+    const detray::geometry::surface<detector_t>& d_portal) {
     const auto d_link_idx = d_portal.template visit_mask<link_getter>();
     return !detray::detail::is_invalid_value(d_link_idx);
 }
@@ -31,7 +33,7 @@ inline auto is_not_world_portal(
 template <typename detector_t>
 inline auto get_linked_volume(
     const detector_t& detector,
-    const detray::tracking_surface<detector_t>& d_portal) {
+    const detray::geometry::surface<detector_t>& d_portal) {
     assert(is_not_world_portal(d_portal));
     const auto d_link_idx = d_portal.template visit_mask<link_getter>();
     return tracking_volume{detector, d_link_idx};
@@ -43,7 +45,7 @@ inline auto get_linked_volume(
 template <typename detector_t>
 inline auto link_points(const typename detector_t::geometry_context& context,
                         const detector_t& detector,
-                        const detray::tracking_surface<detector_t>& d_portal,
+                        const detray::geometry::surface<detector_t>& d_portal,
                         typename detector_t::vector3_type dir,
                         const double link_length) {
     assert(is_not_world_portal(d_portal));

--- a/plugins/svgtools/include/detray/plugins/svgtools/utils/surface_kernels.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/utils/surface_kernels.hpp
@@ -12,7 +12,7 @@
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/geometry/tracking_volume.hpp"
 
 // System include(s)
@@ -246,7 +246,7 @@ struct link_end_getter {
             const vector3_t& surface_normal) const {
         for (const auto& desc : volume.portals()) {
 
-            const detray::tracking_surface surface{detector, desc};
+            const detray::geometry::surface surface{detector, desc};
 
             if (auto r = surface.template visit_mask<outer_radius_getter>()) {
                 if (*r > mask[shape_t::e_r]) {

--- a/tests/benchmarks/cpu/intersect_all.cpp
+++ b/tests/benchmarks/cpu/intersect_all.cpp
@@ -8,7 +8,7 @@
 // Project include(s)
 #include "detray/core/detector.hpp"
 #include "detray/definitions/units.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/navigation/intersection/ray_intersector.hpp"
 #include "detray/navigation/intersection_kernel.hpp"
 #include "detray/tracks/ray.hpp"
@@ -78,7 +78,7 @@ void BM_INTERSECT_ALL(benchmark::State &state) {
 
             // Loop over all surfaces in detector
             for (const sf_desc_t &sf_desc : d.surfaces()) {
-                const auto sf = tracking_surface{d, sf_desc};
+                const auto sf = geometry::surface{d, sf_desc};
                 sf.template visit_mask<
                     intersection_initialize<ray_intersector>>(
                     intersections, detail::ray(track), sf_desc, transforms,

--- a/tests/include/detray/test/cpu/detector_scan.hpp
+++ b/tests/include/detray/test/cpu/detector_scan.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 // Project include(s)
-#include "detray/geometry/tracking_surface.hpp"
 #include "detray/navigation/volume_graph.hpp"
 #include "detray/tracks/ray.hpp"
 

--- a/tests/include/detray/test/cpu/material_scan.hpp
+++ b/tests/include/detray/test/cpu/material_scan.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/geometry/surface.hpp"
 #include "detray/tracks/ray.hpp"
 
 // Detray IO include(s)
@@ -165,7 +166,7 @@ class material_scan : public test::fixture_base<> {
                 }
 
                 const auto sf =
-                    tracking_surface{m_det, record.intersection.sf_desc};
+                    geometry::surface{m_det, record.intersection.sf_desc};
 
                 if (!sf.has_material()) {
                     continue;
@@ -174,7 +175,7 @@ class material_scan : public test::fixture_base<> {
                 const auto &p = record.intersection.local;
                 const auto mat_params = sf.template visit_material<
                     material_validator::get_material_params>(
-                    point2_t{p[0], p[1]}, sf.cos_angle(m_gctx, ray.dir(), p));
+                    point2_t{p[0], p[1]}, cos_angle(m_gctx, sf, ray.dir(), p));
 
                 const scalar_t seg{mat_params.path};
                 const scalar_t t{mat_params.thickness};

--- a/tests/include/detray/test/utils/detectors/build_toy_detector.hpp
+++ b/tests/include/detray/test/utils/detectors/build_toy_detector.hpp
@@ -22,7 +22,6 @@
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/toy_metadata.hpp"
-#include "detray/geometry/tracking_surface.hpp"
 #include "detray/geometry/tracking_volume.hpp"
 #include "detray/materials/mixture.hpp"
 #include "detray/materials/predefined_materials.hpp"

--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -15,7 +15,7 @@
 // Project include(s)
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/math.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/navigation/navigation_config.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/base_actor.hpp"
@@ -288,7 +288,7 @@ struct print_inspector {
             if constexpr (state_type::value_type::is_debug()) {
                 const auto &local = sf_cand.local;
                 const auto pos =
-                    tracking_surface{state.detector(), sf_cand.sf_desc}
+                    geometry::surface{state.detector(), sf_cand.sf_desc}
                         .local_to_global(geo_ctx_t{}, local, track_dir);
                 debug_stream << ", glob: [r:" << vector::perp(pos)
                              << ", z:" << pos[2] << "]" << std::endl;

--- a/tests/include/detray/test/utils/simulation/random_scatterer.hpp
+++ b/tests/include/detray/test/utils/simulation/random_scatterer.hpp
@@ -13,13 +13,13 @@
 #include "detray/definitions/pdg_particle.hpp"
 #include "detray/definitions/track_parametrization.hpp"
 #include "detray/definitions/units.hpp"
-#include "detray/geometry/tracking_surface.hpp"
 #include "detray/materials/detail/concepts.hpp"
+#include "detray/materials/detail/material_accessor.hpp"
 #include "detray/materials/interaction.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/tracks/bound_track_parameters.hpp"
 #include "detray/utils/axis_rotation.hpp"
-#include "detray/utils/ranges.hpp"
+#include "detray/utils/geometry_utils.hpp"
 #include "detray/utils/unit_vectors.hpp"
 
 // Detray test include(s)
@@ -145,9 +145,9 @@ struct random_scatterer : actor {
         const auto& ptc = stepping.particle_hypothesis();
         auto& bound_params = stepping.bound_params();
         const auto sf = navigation.get_surface();
-        const scalar_type cos_inc_angle{
-            sf.cos_angle(geo_context_type{}, bound_params.dir(),
-                         bound_params.bound_local())};
+        const scalar_type cos_inc_angle{cos_angle(geo_context_type{}, sf,
+                                                  bound_params.dir(),
+                                                  bound_params.bound_local())};
 
         sf.template visit_material<kernel>(simulator_state, ptc, bound_params,
                                            cos_inc_angle,

--- a/tests/include/detray/test/validation/detector_scanner.hpp
+++ b/tests/include/detray/test/validation/detector_scanner.hpp
@@ -9,7 +9,7 @@
 
 // Project include(s)
 #include "detray/definitions/algebra.hpp"
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 #include "detray/navigation/intersection/intersection.hpp"
 #include "detray/navigation/intersection_kernel.hpp"
 #include "detray/navigation/intersector.hpp"
@@ -88,7 +88,7 @@ struct brute_force_scan {
         // Loop over all surfaces in the detector
         for (const sf_desc_t &sf_desc : detector.surfaces()) {
             // Retrieve candidate(s) from the surface
-            const auto sf = tracking_surface{detector, sf_desc};
+            const auto sf = geometry::surface{detector, sf_desc};
             sf.template visit_mask<intersection_kernel_t>(
                 intersections, traj, sf_desc, trf_store, ctx,
                 sf.is_portal() ? darray<scalar_t, 2>{0.f, 0.f}

--- a/tests/include/detray/test/validation/material_validation_utils.hpp
+++ b/tests/include/detray/test/validation/material_validation_utils.hpp
@@ -196,7 +196,7 @@ struct material_tracer : detray::actor {
 
         // Fetch the material parameters and pathlength through the material
         const auto mat_params = sf.template visit_material<get_material_params>(
-            loc_pos, sf.cos_angle(gctx, glob_dir, loc_pos));
+            loc_pos, cos_angle(gctx, sf, glob_dir, loc_pos));
 
         const scalar_t seg{mat_params.path};
         const scalar_t t{mat_params.thickness};

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -9,6 +9,7 @@
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/bfield.hpp"
+#include "detray/geometry/tracking_surface.hpp"
 #include "detray/navigation/intersection/helix_intersector.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/actors/parameter_resetter.hpp"

--- a/tests/unit_tests/cpu/CMakeLists.txt
+++ b/tests/unit_tests/cpu/CMakeLists.txt
@@ -51,7 +51,7 @@ macro(detray_add_cpu_test algebra)
        "geometry/masks/trapezoid2D.cpp"
        "geometry/masks/unbounded.cpp"
        "geometry/masks/unmasked.cpp"
-       "geometry/tracking_surface.cpp"
+       "geometry/surface.cpp"
        "geometry/tracking_volume.cpp"
        "grid2/axis.cpp"
        "grid2/grid2.cpp"

--- a/tests/unit_tests/cpu/geometry/surface.cpp
+++ b/tests/unit_tests/cpu/geometry/surface.cpp
@@ -6,9 +6,10 @@
  */
 
 // Project include(s)
-#include "detray/geometry/tracking_surface.hpp"
+#include "detray/geometry/surface.hpp"
 
 #include "detray/definitions/indexing.hpp"
+#include "detray/utils/geometry_utils.hpp"  //< cos incidence angle
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
@@ -95,10 +96,10 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
     using detector_t = detector<test::toy_metadata>;
 
     using test_algebra = detector_t::algebra_type;
-    using scalar = tracking_surface<detector_t>::scalar_type;
-    using point2 = tracking_surface<detector_t>::point2_type;
-    using point3 = tracking_surface<detector_t>::point3_type;
-    using vector3 = tracking_surface<detector_t>::vector3_type;
+    using scalar = geometry::surface<detector_t>::scalar_type;
+    using point2 = geometry::surface<detector_t>::point2_type;
+    using point3 = geometry::surface<detector_t>::point3_type;
+    using vector3 = geometry::surface<detector_t>::vector3_type;
 
     vecmem::host_memory_resource host_mr;
     toy_det_config<test::scalar> toy_cfg{};
@@ -112,7 +113,7 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
     // Disc
     //
     const auto disc_descr = toy_det.surfaces()[1u];
-    const auto disc = tracking_surface{toy_det, disc_descr};
+    const auto disc = geometry::surface{toy_det, disc_descr};
 
     // IDs
     ASSERT_EQ(disc.barcode(), disc_descr.barcode());
@@ -144,21 +145,22 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
 
     // Cos incidence angle
     vector3 dir = vector::normalize(vector3{1.f, 0.f, 1.f});
-    ASSERT_NEAR(disc.cos_angle(ctx, dir, point3{0.f, 0.f, 0.f}),
+    ASSERT_NEAR(cos_angle(ctx, disc, dir, point3{0.f, 0.f, 0.f}),
                 constant<scalar>::inv_sqrt2, tol);
-    ASSERT_NEAR(disc.cos_angle(ctx, dir, point2{0.f, 0.f}),
+    ASSERT_NEAR(cos_angle(ctx, disc, dir, point2{0.f, 0.f}),
                 constant<scalar>::inv_sqrt2, tol);
 
     dir = vector::normalize(vector3{1.f, 1.f, 0.f});
-    ASSERT_NEAR(disc.cos_angle(ctx, dir, point3{1.f, 0.5f, 0.f}), 0.f, tol);
-    ASSERT_NEAR(disc.cos_angle(ctx, dir, point2{1.f, 0.5f}), 0.f, tol);
+    ASSERT_NEAR(cos_angle(ctx, disc, dir, point3{1.f, 0.5f, 0.f}), 0.f, tol);
+    ASSERT_NEAR(cos_angle(ctx, disc, dir, point2{1.f, 0.5f}), 0.f, tol);
 
     dir = vector::normalize(vector3{1.f, 0.f, constant<scalar>::pi});
     scalar cos_inc_angle{constant<scalar>::pi /
                          std::sqrt(1.f + std::pow(constant<scalar>::pi, 2.f))};
-    ASSERT_NEAR(disc.cos_angle(ctx, dir, point3{2.f, 1.f, 0.f}), cos_inc_angle,
+    ASSERT_NEAR(cos_angle(ctx, disc, dir, point3{2.f, 1.f, 0.f}), cos_inc_angle,
                 tol);
-    ASSERT_NEAR(disc.cos_angle(ctx, dir, point2{2.f, 1.f}), cos_inc_angle, tol);
+    ASSERT_NEAR(cos_angle(ctx, disc, dir, point2{2.f, 1.f}), cos_inc_angle,
+                tol);
 
     // Coordinate transformations
     point3 glob_pos = {4.f, 7.f, 4.f};
@@ -172,7 +174,7 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
 
     // Roundtrip
     point3 global = disc.local_to_global(ctx, local, test_dir);
-    point3 global2 = disc.bound_to_global(ctx, bound, test_dir);
+    point3 global2 = disc.local_to_global(ctx, bound, test_dir);
 
     ASSERT_NEAR(glob_pos[0], global[0], tol);
     ASSERT_NEAR(glob_pos[1], global[1], tol);
@@ -193,7 +195,7 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
     // Rectangle
     //
     const auto rec_descr = toy_det.surfaces()[604u];
-    const auto rec = tracking_surface{toy_det, rec_descr};
+    const auto rec = geometry::surface{toy_det, rec_descr};
 
     // IDs
     ASSERT_EQ(rec.barcode(), rec_descr.barcode());
@@ -223,18 +225,18 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
 
     // Incidence angle
     dir = vector::normalize(global);
-    ASSERT_NEAR(rec.cos_angle(ctx, dir, point3{0.f, 0.f, 0.f}), 1.f, tol);
-    ASSERT_NEAR(rec.cos_angle(ctx, dir, point2{0.f, 0.f}), 1.f, tol);
+    ASSERT_NEAR(cos_angle(ctx, rec, dir, point3{0.f, 0.f, 0.f}), 1.f, tol);
+    ASSERT_NEAR(cos_angle(ctx, rec, dir, point2{0.f, 0.f}), 1.f, tol);
 
     dir = vector::normalize(vector3{0.f, -global[2], global[1]});
-    ASSERT_NEAR(rec.cos_angle(ctx, dir, point3{1.f, 0.5f, 0.f}), 0.f, tol);
-    ASSERT_NEAR(rec.cos_angle(ctx, dir, point2{1.f, 0.5f}), 0.f, tol);
+    ASSERT_NEAR(cos_angle(ctx, rec, dir, point3{1.f, 0.5f, 0.f}), 0.f, tol);
+    ASSERT_NEAR(cos_angle(ctx, rec, dir, point2{1.f, 0.5f}), 0.f, tol);
 
     dir = vector::normalize(vector3{1.f, 0.f, constant<scalar>::pi});
     cos_inc_angle = std::fabs(vector::dot(dir, global));
-    ASSERT_NEAR(rec.cos_angle(ctx, dir, point3{2.f, 1.f, 0.f}), cos_inc_angle,
+    ASSERT_NEAR(cos_angle(ctx, rec, dir, point3{2.f, 1.f, 0.f}), cos_inc_angle,
                 tol);
-    ASSERT_NEAR(rec.cos_angle(ctx, dir, point2{2.f, 1.f}), cos_inc_angle, tol);
+    ASSERT_NEAR(cos_angle(ctx, rec, dir, point2{2.f, 1.f}), cos_inc_angle, tol);
 
     // Coordinate transformation roundtrip
     glob_pos = {4.f, 7.f, 4.f};
@@ -254,7 +256,7 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
     ASSERT_NEAR(glob_pos[2], global[2], tol);
 
     bound = rec.global_to_bound(ctx, glob_pos, test_dir);
-    global = rec.bound_to_global(ctx, bound, test_dir);
+    global = rec.local_to_global(ctx, bound, test_dir);
     ASSERT_NEAR(global[0], glob_pos[0], tol);
     ASSERT_NEAR(global[1], glob_pos[1], tol);
     ASSERT_NEAR(global[2], glob_pos[2], tol);
@@ -268,7 +270,7 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
     // Concentric Cylinder
     //
     const auto cyl_descr = toy_det.surfaces()[8u];
-    const auto cyl = tracking_surface{toy_det, cyl_descr};
+    const auto cyl = geometry::surface{toy_det, cyl_descr};
 
     // IDs
     ASSERT_EQ(cyl.barcode(), cyl_descr.barcode());
@@ -319,23 +321,23 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
 
     // Incidence angle
     ASSERT_NEAR(
-        cyl.cos_angle(ctx, x_axis, point3{r * constant<scalar>::pi, 0.f, r}),
+        cos_angle(ctx, cyl, x_axis, point3{r * constant<scalar>::pi, 0.f, r}),
         1.f, tol);
     ASSERT_NEAR(
-        cyl.cos_angle(ctx, x_axis, point2{r * constant<scalar>::pi, 0.f}), 1.f,
+        cos_angle(ctx, cyl, x_axis, point2{r * constant<scalar>::pi, 0.f}), 1.f,
         tol);
 
     ASSERT_NEAR(
-        cyl.cos_angle(ctx, z_axis, point3{r * constant<scalar>::pi_2, 0.f, r}),
+        cos_angle(ctx, cyl, z_axis, point3{r * constant<scalar>::pi_2, 0.f, r}),
         0.f, tol);
     ASSERT_NEAR(
-        cyl.cos_angle(ctx, z_axis, point2{r * constant<scalar>::pi_2, 0.f}),
+        cos_angle(ctx, cyl, z_axis, point2{r * constant<scalar>::pi_2, 0.f}),
         0.f, tol);
 
     dir = vector::normalize(vector3{1.f, 1.f, 0.f});
-    ASSERT_NEAR(cyl.cos_angle(ctx, dir, point3{0.f, 1.f, r}),
+    ASSERT_NEAR(cos_angle(ctx, cyl, dir, point3{0.f, 1.f, r}),
                 constant<scalar>::inv_sqrt2, tol);
-    ASSERT_NEAR(cyl.cos_angle(ctx, dir, point2{0.f, 1.f}),
+    ASSERT_NEAR(cos_angle(ctx, cyl, dir, point2{0.f, 1.f}),
                 constant<scalar>::inv_sqrt2, tol);
 
     // Coordinate transformation roundtrip
@@ -357,7 +359,7 @@ GTEST_TEST(detray_geometry, surface_toy_detector) {
     ASSERT_NEAR(glob_pos[2], global[2], tol);
 
     bound = cyl.global_to_bound(ctx, glob_pos, test_dir);
-    global = cyl.bound_to_global(ctx, bound, test_dir);
+    global = cyl.local_to_global(ctx, bound, test_dir);
     ASSERT_NEAR(global[0], glob_pos[0], tol);
     ASSERT_NEAR(global[1], glob_pos[1], tol);
     ASSERT_NEAR(global[2], glob_pos[2], tol);
@@ -379,10 +381,10 @@ GTEST_TEST(detray_geometry, surface_wire_chamber) {
     using detector_t = detector<metadata_t>;
 
     using test_algebra = metadata_t::algebra_type;
-    using scalar = tracking_surface<detector_t>::scalar_type;
-    using point2 = tracking_surface<detector_t>::point2_type;
-    using point3 = tracking_surface<detector_t>::point3_type;
-    using vector3 = tracking_surface<detector_t>::vector3_type;
+    using scalar = geometry::surface<detector_t>::scalar_type;
+    using point2 = geometry::surface<detector_t>::point2_type;
+    using point3 = geometry::surface<detector_t>::point3_type;
+    using vector3 = geometry::surface<detector_t>::vector3_type;
 
     vecmem::host_memory_resource host_mr;
     wire_chamber_config<scalar> cfg{};
@@ -395,7 +397,7 @@ GTEST_TEST(detray_geometry, surface_wire_chamber) {
     // Line
     //
     const auto line_descr = wire_chmbr.surfaces()[23u];
-    const auto line = tracking_surface{wire_chmbr, line_descr};
+    const auto line = geometry::surface{wire_chmbr, line_descr};
 
     // IDs
     ASSERT_EQ(line.barcode(), line_descr.barcode());
@@ -428,17 +430,17 @@ GTEST_TEST(detray_geometry, surface_wire_chamber) {
 
     // Cos incidence angle
     vector3 dir = vector::normalize(global);
-    ASSERT_NEAR(line.cos_angle(ctx, dir, point3{1.f, 0.f, 0.f}), 1.f, tol);
-    ASSERT_NEAR(line.cos_angle(ctx, dir, point2{1.f, 0.f}), 1.f, tol);
+    ASSERT_NEAR(cos_angle(ctx, line, dir, point3{1.f, 0.f, 0.f}), 1.f, tol);
+    ASSERT_NEAR(cos_angle(ctx, line, dir, point2{1.f, 0.f}), 1.f, tol);
 
     dir = vector::normalize(vector3{0.f, -global[2], global[1]});
-    ASSERT_NEAR(line.cos_angle(ctx, dir, point3{1.f, 100.f, 0.f}), 0.f, tol);
-    ASSERT_NEAR(line.cos_angle(ctx, dir, point2{1.f, 100.f}), 0.f, tol);
+    ASSERT_NEAR(cos_angle(ctx, line, dir, point3{1.f, 100.f, 0.f}), 0.f, tol);
+    ASSERT_NEAR(cos_angle(ctx, line, dir, point2{1.f, 100.f}), 0.f, tol);
 
-    dir = {-0.685475f, -0.0404595f, 0.726971f};
-    ASSERT_NEAR(line.cos_angle(ctx, dir, point3{2.f, 1.f, 0.f}),
+    dir = vector3{-0.685475f, -0.0404595f, 0.726971f};
+    ASSERT_NEAR(cos_angle(ctx, line, dir, point3{2.f, 1.f, 0.f}),
                 constant<scalar>::inv_sqrt2, 0.0005);
-    ASSERT_NEAR(line.cos_angle(ctx, dir, point2{2.f, 1.f}),
+    ASSERT_NEAR(cos_angle(ctx, line, dir, point2{2.f, 1.f}),
                 constant<scalar>::inv_sqrt2, 0.0005);
 
     // Coordinate transformation roundtrip
@@ -463,7 +465,7 @@ GTEST_TEST(detray_geometry, surface_wire_chamber) {
     ASSERT_NEAR(glob_pos[2], global[2], red_tol);
 
     point2 bound = line.global_to_bound(ctx, glob_pos, test_dir);
-    global = line.bound_to_global(ctx, bound, test_dir);
+    global = line.local_to_global(ctx, bound, test_dir);
     ASSERT_NEAR(global[0], glob_pos[0], red_tol);
     ASSERT_NEAR(global[1], glob_pos[1], red_tol);
     ASSERT_NEAR(global[2], glob_pos[2], red_tol);

--- a/tests/unit_tests/cpu/propagator/rk_stepper.cpp
+++ b/tests/unit_tests/cpu/propagator/rk_stepper.cpp
@@ -12,7 +12,6 @@
 #include "detray/core/detector.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/bfield.hpp"
-#include "detray/geometry/tracking_surface.hpp"
 #include "detray/io/utils/file_handle.hpp"
 #include "detray/propagator/line_stepper.hpp"
 #include "detray/propagator/stepping_config.hpp"


### PR DESCRIPTION
Make the basic geometric surface interface type as concise as possible and instead only add additional functionality around it when actually needed. Also moves a few pieces of functionality to specialized free functions. The ```tracking_surface``` interface and functionality does not change and can continue to be used as is in tracking focused projects like traccc.

This is an attempt to reduce internal coupling, because most of the tracking surface functionality is only needed in very few places. It will also allow for non-tracking focused projects to not depend on tracking functionality in any way

Note: This PR also follows this recommendation https://sonarcloud.io/project/issues?open=AZPfWgeq_bLRcF2RbOJs&id=acts-project_detray&tab=why