### PR TITLE
Ref: decouple stepper and navigator

### DIFF
--- a/core/include/detray/navigation/detail/ray.hpp
+++ b/core/include/detray/navigation/detail/ray.hpp
@@ -30,6 +30,13 @@ class ray {
 
     ray() = default;
 
+    /// Parametrized constructor from a position and direction
+    ///
+    /// @param pos the track position
+    /// @param dir the track momentum direction
+    DETRAY_HOST_DEVICE ray(point3_type &&pos, vector3_type &&dir)
+        : _pos{std::move(pos)}, _dir{std::move(dir)} {}
+
     /// Parametrized constructor that complies with track interface
     ///
     /// @param pos the track position
@@ -42,7 +49,7 @@ class ray {
     ///
     /// @param track the track state that should be approximated
     DETRAY_HOST_DEVICE explicit ray(const free_track_parameters_type &track)
-        : ray(track.pos(), 0.f, track.dir(), 0.f) {}
+        : ray(track.pos(), track.dir()) {}
 
     /// @returns position on the ray (compatible with tracks/intersectors)
     DETRAY_HOST_DEVICE point3_type pos() const { return _pos; }

--- a/core/include/detray/navigation/policies.hpp
+++ b/core/include/detray/navigation/policies.hpp
@@ -73,7 +73,8 @@ struct stepper_default_policy : actor {
         auto &navigation = propagation._navigation;
 
         // Not a severe change to track state expected
-        if (math::fabs(stepping.step_size()) <
+        // Policy is called after stepsize update -> use prev. step size
+        if (math::fabs(stepping._prev_step_size) <
             math::fabs(
                 stepping.constraints().template size<>(stepping.direction())) -
                 pol_state.tol) {
@@ -110,7 +111,8 @@ struct stepper_rk_policy : actor {
         const auto &stepping = propagation._stepping;
         auto &navigation = propagation._navigation;
 
-        const scalar rel_correction{(stepping.step_size() - navigation()) /
+        // Policy is called after stepsize update -> use prev. step size
+        const scalar rel_correction{(stepping._prev_step_size - navigation()) /
                                     navigation()};
 
         // Large correction to the stepsize - re-initialize the volume

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -87,7 +87,7 @@ struct target_aborter : actor {
 
         // In case the propagation starts on a module, make sure to not abort
         // directly
-        if (navigation.is_on_surface() && !navigation.is_on_portal() &&
+        if (navigation.is_on_surface() &&
             (navigation.barcode() == abrt_state._target_surface) &&
             (stepping.path_length() > 0.f)) {
             prop_state._heartbeat &= navigation.abort();

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -87,7 +87,7 @@ struct target_aborter : actor {
 
         // In case the propagation starts on a module, make sure to not abort
         // directly
-        if (navigation.is_on_module() &&
+        if (navigation.is_on_surface() && !navigation.is_on_portal() &&
             (navigation.barcode() == abrt_state._target_surface) &&
             (stepping.path_length() > 0.f)) {
             prop_state._heartbeat &= navigation.abort();

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -13,6 +13,7 @@
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/barcode.hpp"
 #include "detray/geometry/tracking_surface.hpp"
+#include "detray/materials/material.hpp"
 #include "detray/propagator/actors/parameter_resetter.hpp"
 #include "detray/propagator/constrained_step.hpp"
 #include "detray/propagator/stepping_config.hpp"
@@ -160,6 +161,16 @@ class base_stepper {
 
         /// Previous barcode to calculate the bound_to_free_jacobian
         dindex _prev_sf_id = detail::invalid_value<dindex>();
+
+        /// Volume material that track is passing through
+        const detray::material<scalar_type> *_mat{nullptr};
+
+        /// Access the current volume material
+        DETRAY_HOST_DEVICE
+        const auto &volume_material() const {
+            assert(_mat != nullptr);
+            return *_mat;
+        }
 
         /// Set new step constraint
         template <step::constraint type = step::constraint::e_actor>

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -76,28 +76,25 @@ class line_stepper final
         }
 
         DETRAY_HOST_DEVICE
-        inline vector3_type dtds() const { return {0.f, 0.f, 0.f}; }
+        constexpr vector3_type dtds() const { return {0.f, 0.f, 0.f}; }
 
         DETRAY_HOST_DEVICE
-        inline scalar_type dqopds() const { return 0.f; }
+        constexpr scalar_type dqopds() const { return 0.f; }
     };
 
     /// Take a step, regulared by a constrained step
     ///
+    /// @param dist_to_next The straight line distance to the next surface
     /// @param stepping The state object of a stepper
-    /// @param navigation The state object of a navigator
-    /// @param max_step_size Maximal distance for this step
+    /// @param cfg The stepping configuration
     ///
-    /// @return returning the heartbeat, indicating if the stepping is alive
-    template <typename propagation_state_t>
-    DETRAY_HOST_DEVICE bool step(propagation_state_t& propagation,
-                                 const stepping::config& cfg = {}) const {
-        // Get stepper and navigator states
-        state& stepping = propagation._stepping;
-        auto& navigation = propagation._navigation;
+    /// @returns returning the heartbeat, indicating if the stepping is alive
+    DETRAY_HOST_DEVICE bool step(const scalar_type dist_to_next,
+                                 state& stepping, const stepping::config& cfg,
+                                 const bool = true) const {
 
         // Straight line stepping: The distance given by the navigator is exact
-        stepping._step_size = navigation();
+        stepping._step_size = dist_to_next;
 
         // Update navigation direction
         const step::direction step_dir = stepping._step_size >= 0.f
@@ -106,14 +103,14 @@ class line_stepper final
         stepping.set_direction(step_dir);
 
         // Check constraints
-        if (math::fabs(stepping.step_size()) >
-            math::fabs(
-                stepping.constraints().template size<>(stepping.direction()))) {
+        if (const scalar_type max_step =
+                stepping.constraints().template size<>(stepping.direction());
+            math::fabs(stepping._step_size) > math::fabs(max_step)) {
+
             // Run inspection before step size is cut
             stepping.run_inspector(cfg, "Before constraint: ");
 
-            stepping.set_step_size(
-                stepping.constraints().template size<>(stepping.direction()));
+            stepping.set_step_size(max_step);
         }
 
         // Update track state
@@ -124,10 +121,6 @@ class line_stepper final
 
         // Count the number of steps
         stepping.count_trials();
-
-        // Call navigation update policy
-        typename line_stepper::policy_type{}(stepping.policy_state(),
-                                             propagation);
 
         // Run inspection if needed
         stepping.run_inspector(cfg, "Step complete: ");

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -96,13 +96,8 @@ class line_stepper final
         state& stepping = propagation._stepping;
         auto& navigation = propagation._navigation;
 
-        if (stepping._step_size == 0.f) {
-            stepping._step_size = navigation();
-        } else if (stepping._step_size > 0) {
-            stepping._step_size = math::min(stepping._step_size, navigation());
-        } else {
-            stepping._step_size = math::max(stepping._step_size, navigation());
-        }
+        // Straight line stepping: The distance given by the navigator is exact
+        stepping._step_size = navigation();
 
         // Update navigation direction
         const step::direction step_dir = stepping._step_size >= 0.f

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -133,16 +133,19 @@ struct propagator {
         state &propagation,
         typename actor_chain_t::state actor_state_refs) const {
 
+        auto &navigation = propagation._navigation;
+        const auto &track = propagation._stepping();
+
         // Initialize the navigation
         propagation._heartbeat =
-            m_navigator.init(propagation, m_cfg.navigation);
+            m_navigator.init(track, navigation, m_cfg.navigation);
 
         // Run all registered actors/aborters after init
         run_actors(actor_state_refs, propagation);
 
         // Find next candidate
         propagation._heartbeat &=
-            m_navigator.update(propagation, m_cfg.navigation);
+            m_navigator.update(track, navigation, m_cfg.navigation);
 
         // Run while there is a heartbeat
         while (propagation._heartbeat) {
@@ -153,14 +156,14 @@ struct propagator {
 
             // Find next candidate
             propagation._heartbeat &=
-                m_navigator.update(propagation, m_cfg.navigation);
+                m_navigator.update(track, navigation, m_cfg.navigation);
 
             // Run all registered actors/aborters after update
             run_actors(actor_state_refs, propagation);
 
             // And check the status
             propagation._heartbeat &=
-                m_navigator.update(propagation, m_cfg.navigation);
+                m_navigator.update(track, navigation, m_cfg.navigation);
 
 #if defined(__NO_DEVICE__)
             if (propagation.do_debug) {
@@ -197,16 +200,19 @@ struct propagator {
         state &propagation,
         typename actor_chain_t::state actor_state_refs) const {
 
+        auto &navigation = propagation._navigation;
+        const auto &track = propagation._stepping();
+
         // Initialize the navigation
         propagation._heartbeat =
-            m_navigator.init(propagation, m_cfg.navigation);
+            m_navigator.init(track, navigation, m_cfg.navigation);
 
         // Run all registered actors/aborters after init
         run_actors(actor_state_refs, propagation);
 
         // Find next candidate
         propagation._heartbeat &=
-            m_navigator.update(propagation, m_cfg.navigation);
+            m_navigator.update(track, navigation, m_cfg.navigation);
 
         while (propagation._heartbeat) {
 
@@ -220,7 +226,7 @@ struct propagator {
 
                 // Find next candidate
                 propagation._heartbeat &=
-                    m_navigator.update(propagation, m_cfg.navigation);
+                    m_navigator.update(track, navigation, m_cfg.navigation);
 
                 // If the track is on a sensitive surface, break the loop to
                 // synchornize the threads
@@ -232,7 +238,7 @@ struct propagator {
 
                     // And check the status
                     propagation._heartbeat &=
-                        m_navigator.update(propagation, m_cfg.navigation);
+                        m_navigator.update(track, navigation, m_cfg.navigation);
                 }
             }
 
@@ -243,7 +249,7 @@ struct propagator {
 
                 // And check the status
                 propagation._heartbeat &=
-                    m_navigator.update(propagation, m_cfg.navigation);
+                    m_navigator.update(track, navigation, m_cfg.navigation);
             }
 
 #if defined(__NO_DEVICE__)
@@ -296,7 +302,7 @@ struct propagator {
         }
 
         propagation.debug_stream << "surface: " << std::setw(14);
-        if (navigation.is_on_portal() || navigation.is_on_module()) {
+        if (navigation.is_on_surface()) {
             propagation.debug_stream << navigation.barcode();
         } else {
             propagation.debug_stream << "undefined";

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -11,7 +11,6 @@
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/materials/interaction.hpp"
-#include "detray/materials/material.hpp"
 #include "detray/materials/predefined_materials.hpp"
 #include "detray/navigation/policies.hpp"
 #include "detray/propagator/base_stepper.hpp"
@@ -87,16 +86,6 @@ class rk_stepper final
         /// Magnetic field view
         const magnetic_field_t _magnetic_field;
 
-        /// Material that track is passing through. Usually a volume material
-        const detray::material<scalar_type>* _mat{nullptr};
-
-        /// Access the current volume material
-        DETRAY_HOST_DEVICE
-        const auto& volume_material() const {
-            assert(_mat != nullptr);
-            return *_mat;
-        }
-
         /// Update the track state by Runge-Kutta-Nystrom integration.
         DETRAY_HOST_DEVICE
         void advance_track();
@@ -152,10 +141,15 @@ class rk_stepper final
 
     /// Take a step, using an adaptive Runge-Kutta algorithm.
     ///
+    /// @param dist_to_next The straight line distance to the next surface
+    /// @param stepping The state object of a stepper
+    /// @param cfg The stepping configuration
+    /// @param do_reset whether to reset the RKN step size to "dist to next"
+    ///
     /// @return returning the heartbeat, indicating if the stepping is alive
-    template <typename propagation_state_t>
-    DETRAY_HOST_DEVICE bool step(propagation_state_t& propagation,
-                                 const stepping::config& cfg) const;
+    DETRAY_HOST_DEVICE bool step(const scalar_type dist_to_next,
+                                 state& stepping, const stepping::config& cfg,
+                                 bool do_reset) const;
 };
 
 }  // namespace detray

--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -318,8 +318,7 @@ struct print_inspector {
         }
 
         debug_stream << "current object\t\t\t";
-        if (state.is_on_portal() || state.is_on_module() ||
-            state.status() == status::e_on_target) {
+        if (state.is_on_surface() || state.status() == status::e_on_target) {
             debug_stream << state.barcode() << std::endl;
         } else {
             debug_stream << "undefined" << std::endl;

--- a/tests/include/detray/test/utils/simulation/random_scatterer.hpp
+++ b/tests/include/detray/test/utils/simulation/random_scatterer.hpp
@@ -139,7 +139,7 @@ struct random_scatterer : actor {
 
         auto& navigation = prop_state._navigation;
 
-        if (!navigation.is_on_module()) {
+        if (!navigation.encountered_sf_material()) {
             return;
         }
 

--- a/tests/include/detray/test/validation/step_tracer.hpp
+++ b/tests/include/detray/test/validation/step_tracer.hpp
@@ -93,8 +93,7 @@ struct step_tracer : actor {
         const auto& stepping = prop_state._stepping;
 
         // Collect the data whenever requested
-        if (navigation.is_on_module() || navigation.is_on_portal() ||
-            tracer_state.m_collect_every_step) {
+        if (navigation.is_on_surface() || tracer_state.m_collect_every_step) {
 
             step_data_t sd{stepping.step_size(),         stepping.path_length(),
                            stepping.n_total_trials(),    navigation.direction(),

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -425,13 +425,13 @@ struct bound_getter : actor {
             propagation._heartbeat &= navigation.exit();
         }
 
-        if (navigation.is_on_module() && navigation.barcode().index() == 0u) {
+        if (navigation.is_on_surface() && navigation.barcode().index() == 0u) {
 
             actor_state.m_param_departure = stepping._bound_params;
         }
         // Get the bound track parameters and jacobian at the destination
         // surface
-        else if (navigation.is_on_module() &&
+        else if (navigation.is_on_surface() &&
                  navigation.barcode().index() == 1u) {
 
             actor_state.m_path_length = stepping._path_length;

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -425,13 +425,14 @@ struct bound_getter : actor {
             propagation._heartbeat &= navigation.exit();
         }
 
-        if (navigation.is_on_surface() && navigation.barcode().index() == 0u) {
+        if ((navigation.is_on_sensitive() || navigation.is_on_passive()) &&
+            navigation.barcode().index() == 0u) {
 
             actor_state.m_param_departure = stepping._bound_params;
         }
         // Get the bound track parameters and jacobian at the destination
         // surface
-        else if (navigation.is_on_surface() &&
+        else if ((navigation.is_on_sensitive() || navigation.is_on_passive()) &&
                  navigation.barcode().index() == 1u) {
 
             actor_state.m_path_length = stepping._path_length;

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -373,7 +373,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
 // No step size constraint
 INSTANTIATE_TEST_SUITE_P(
     detray_propagator_validation1, PropagatorWithRkStepper,
-    ::testing::Values(std::make_tuple(-100.f * unit<scalar_t>::mm,
+    ::testing::Values(std::make_tuple(-100.f * unit<scalar_t>::um,
                                       std::numeric_limits<scalar_t>::max(),
                                       vector3{0.f * unit<scalar_t>::T,
                                               0.f * unit<scalar_t>::T,

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -207,9 +207,19 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         EXPECT_TRUE(heartbeat_z2);
         EXPECT_TRUE(heartbeat_x);
 
-        heartbeat_z1 &= rk_stepper_z.step(propgation_z1, prop_cfg.stepping);
-        heartbeat_z2 &= rk_stepper_z.step(propgation_z2, prop_cfg.stepping);
-        heartbeat_x &= rk_stepper_x.step(propgation_x, prop_cfg.stepping);
+        const bool do_reset_z1{navigation_z1.is_on_surface() ||
+                               navigation_z1.is_init()};
+        const bool do_reset_z2{navigation_z2.is_on_surface() ||
+                               navigation_z2.is_init()};
+        const bool do_reset_x{navigation_x.is_on_surface() ||
+                              navigation_x.is_init()};
+
+        heartbeat_z1 &= rk_stepper_z.step(navigation_z1(), stepping_z1,
+                                          prop_cfg.stepping, do_reset_z1);
+        heartbeat_z2 &= rk_stepper_z.step(navigation_z2(), stepping_z2,
+                                          prop_cfg.stepping, do_reset_z2);
+        heartbeat_x &= rk_stepper_x.step(navigation_x(), stepping_x,
+                                         prop_cfg.stepping, do_reset_x);
 
         navigation_z1.set_high_trust();
         navigation_z2.set_high_trust();
@@ -278,8 +288,13 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         tel_navigator.init(tel_stepping(), tel_navigation, prop_cfg.navigation);
 
     while (heartbeat_tel) {
-        heartbeat_tel &= rk_stepper_z.step(tel_propagation, prop_cfg.stepping);
+        const bool do_reset_tel{navigation_z1.is_on_surface() ||
+                                navigation_z1.is_init()};
+        heartbeat_tel &= rk_stepper_z.step(tel_navigation(), tel_stepping,
+                                           prop_cfg.stepping, do_reset_tel);
+
         tel_navigation.set_high_trust();
+
         heartbeat_tel &= tel_navigator.update(tel_stepping(), tel_navigation,
                                               prop_cfg.navigation);
     }

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -193,9 +193,12 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     navigation_state_t &navigation_x = propgation_x._navigation;
 
     // propagate all telescopes
-    bool heartbeat_z1 = navigator_z1.init(propgation_z1, prop_cfg.navigation);
-    bool heartbeat_z2 = navigator_z2.init(propgation_z2, prop_cfg.navigation);
-    bool heartbeat_x = navigator_x.init(propgation_x, prop_cfg.navigation);
+    bool heartbeat_z1 =
+        navigator_z1.init(stepping_z1(), navigation_z1, prop_cfg.navigation);
+    bool heartbeat_z2 =
+        navigator_z2.init(stepping_z2(), navigation_z2, prop_cfg.navigation);
+    bool heartbeat_x =
+        navigator_x.init(stepping_x(), navigation_x, prop_cfg.navigation);
 
     while (heartbeat_z1 && heartbeat_z2 && heartbeat_x) {
 
@@ -212,9 +215,12 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         navigation_z2.set_high_trust();
         navigation_x.set_high_trust();
 
-        heartbeat_z1 &= navigator_z1.update(propgation_z1, prop_cfg.navigation);
-        heartbeat_z2 &= navigator_z2.update(propgation_z2, prop_cfg.navigation);
-        heartbeat_x &= navigator_x.update(propgation_x, prop_cfg.navigation);
+        heartbeat_z1 &= navigator_z1.update(stepping_z1(), navigation_z1,
+                                            prop_cfg.navigation);
+        heartbeat_z2 &= navigator_z2.update(stepping_z2(), navigation_z2,
+                                            prop_cfg.navigation);
+        heartbeat_x &=
+            navigator_x.update(stepping_x(), navigation_x, prop_cfg.navigation);
         // The track path lengths should match between all propagations
         EXPECT_NEAR(
             std::abs(stepping_z1._path_length - stepping_z2._path_length) /
@@ -265,16 +271,17 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     prop_state<stepping_state_t, navigation_state_t> tel_propagation(
         pilot_track, b_field_z, tel_detector);
     navigation_state_t &tel_navigation = tel_propagation._navigation;
+    stepping_state_t &tel_stepping = tel_propagation._stepping;
 
     // run propagation
     bool heartbeat_tel =
-        tel_navigator.init(tel_propagation, prop_cfg.navigation);
+        tel_navigator.init(tel_stepping(), tel_navigation, prop_cfg.navigation);
 
     while (heartbeat_tel) {
         heartbeat_tel &= rk_stepper_z.step(tel_propagation, prop_cfg.stepping);
         tel_navigation.set_high_trust();
-        heartbeat_tel &=
-            tel_navigator.update(tel_propagation, prop_cfg.navigation);
+        heartbeat_tel &= tel_navigator.update(tel_stepping(), tel_navigation,
+                                              prop_cfg.navigation);
     }
     // check that propagation was successful
     ASSERT_TRUE(tel_navigation.is_complete())

--- a/tests/unit_tests/cpu/navigation/navigator.cpp
+++ b/tests/unit_tests/cpu/navigation/navigator.cpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/line_stepper.hpp"
+#include "detray/propagator/propagation_config.hpp"
 #include "detray/tracks/tracks.hpp"
 
 // Detray test include(s)
@@ -92,18 +93,18 @@ inline void check_volume_switch(state_t &state, dindex vol_id) {
 template <typename navigator_t, typename stepper_t, typename prop_state_t>
 inline void step_and_check(navigator_t &nav, stepper_t &stepper,
                            prop_state_t &propagation,
-                           const navigation::config &cfg, dindex vol_id,
+                           const propagation::config &cfg, dindex vol_id,
                            std::size_t n_candidates, dindex current_id,
                            dindex next_id) {
     auto &navigation = propagation._navigation;
     auto &stepping = propagation._stepping;
 
     // Step onto the surface in volume
-    stepper.step(propagation);
+    stepper.step(navigation(), stepping, cfg.stepping);
     navigation.set_high_trust();
     // Stepper reduced trust level
     ASSERT_TRUE(navigation.trust_level() == navigation::trust_level::e_high);
-    ASSERT_TRUE(nav.update(stepping(), navigation, cfg));
+    ASSERT_TRUE(nav.update(stepping(), navigation, cfg.navigation));
     // Trust level is restored
     ASSERT_EQ(navigation.trust_level(), navigation::trust_level::e_full);
     // The status is on surface
@@ -144,8 +145,10 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
 
     stepper_t stepper;
     navigator_t nav;
-    navigation::config cfg{};
-    cfg.search_window = {3u, 3u};
+    propagation::config prop_cfg{};
+    stepping::config &stp_cfg = prop_cfg.stepping;
+    navigation::config &nav_cfg = prop_cfg.navigation;
+    nav_cfg.search_window = {3u, 3u};
 
     prop_state<stepper_t::state, navigator_t::state> propagation{
         stepper_t::state{traj}, navigator_t::state(toy_det)};
@@ -168,7 +171,7 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
 
     // Initialize navigation
     // Test that the navigator has a heartbeat
-    ASSERT_TRUE(nav.init(stepping(), navigation, cfg));
+    ASSERT_TRUE(nav.init(stepping(), navigation, nav_cfg));
     // The status is towards beampipe
     // Two candidates: beampipe and portal
     // First candidate is the beampipe
@@ -179,14 +182,14 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
     // Let's make half the step towards the beampipe
     stepping.template set_constraint<step::constraint::e_user>(navigation() *
                                                                0.5f);
-    stepper.step(propagation);
+    stepper.step(navigation(), stepping, stp_cfg);
     // Navigation policy might reduce trust level to fair trust
     navigation.set_fair_trust();
     // Release user constraint again
     stepping.template release_step<step::constraint::e_user>();
     ASSERT_TRUE(navigation.trust_level() == trust_level::e_fair);
     // Re-navigate
-    ASSERT_TRUE(nav.update(stepping(), navigation, cfg));
+    ASSERT_TRUE(nav.update(stepping(), navigation, nav_cfg));
     // Trust level is restored
     ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
     // The status remains: towards surface
@@ -195,20 +198,20 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
     ASSERT_NEAR(navigation(), 9.5f, tol);
 
     // Let's immediately update, nothing should change, as there is full trust
-    ASSERT_TRUE(nav.update(stepping(), navigation, cfg));
+    ASSERT_TRUE(nav.update(stepping(), navigation, nav_cfg));
     check_towards_surface<navigator_t>(navigation, 0u, 2u, 0u);
     ASSERT_NEAR(navigation(), 9.5f, tol);
 
     // Now step onto the beampipe (idx 0)
-    step_and_check(nav, stepper, propagation, cfg, 0u, 1u, 0u, 8u);
+    step_and_check(nav, stepper, propagation, prop_cfg, 0u, 1u, 0u, 8u);
     // New target: Distance to the beampipe volume cylinder portal
     ASSERT_NEAR(navigation(), 6.f, tol);
 
     // Step onto portal 7 in volume 0
-    stepper.step(propagation);
+    stepper.step(navigation(), stepping, stp_cfg);
     navigation.set_high_trust();
     ASSERT_TRUE(navigation.trust_level() == trust_level::e_high);
-    ASSERT_TRUE(nav.update(stepping(), navigation, cfg))
+    ASSERT_TRUE(nav.update(stepping(), navigation, nav_cfg))
         << navigation.inspector().to_string();
     ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
     ASSERT_EQ(navigation.volume(), 8u);
@@ -266,17 +269,17 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
         // Step through the module surfaces
         for (std::size_t sf = 1u; sf < sf_seq.size() - 1u; ++sf) {
             // Count only the currently reachable candidates
-            step_and_check(nav, stepper, propagation_cpy, cfg, vol_id,
+            step_and_check(nav, stepper, propagation_cpy, prop_cfg, vol_id,
                            n_candidates - sf, sf_seq[sf], sf_seq[sf + 1u]);
         }
 
         // Step onto the portal in volume
-        stepper.step(propagation_cpy);
+        stepper.step(navigation_cpy(), stepping_cpy, stp_cfg);
         navigation_cpy.set_high_trust();
 
         // Check agianst last volume
         if (vol_id == last_vol_id) {
-            ASSERT_FALSE(nav.update(stepping_cpy(), navigation_cpy, cfg));
+            ASSERT_FALSE(nav.update(stepping_cpy(), navigation_cpy, nav_cfg));
             // The status is: exited
             ASSERT_EQ(navigation_cpy.status(), status::e_on_target);
             // Switch to next volume leads out of the detector world -> exit
@@ -285,7 +288,7 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
             // We know we went out of the detector
             ASSERT_EQ(navigation_cpy.trust_level(), trust_level::e_full);
         } else {
-            ASSERT_TRUE(nav.update(stepping_cpy(), navigation_cpy, cfg));
+            ASSERT_TRUE(nav.update(stepping_cpy(), navigation_cpy, nav_cfg));
         }
 
         // Update the propagation state with current step (test assignment op)
@@ -328,10 +331,12 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
 
     stepper_t stepper;
     navigator_t nav;
-    navigation::config cfg{};
-    cfg.mask_tolerance_scalor = 1e-2f;
-    cfg.path_tolerance = 1.f * unit<float>::um;
-    cfg.search_window = {3u, 3u};
+    propagation::config prop_cfg{};
+    stepping::config &stp_cfg = prop_cfg.stepping;
+    navigation::config &nav_cfg = prop_cfg.navigation;
+    nav_cfg.mask_tolerance_scalor = 1e-2f;
+    nav_cfg.path_tolerance = 1.f * unit<float>::um;
+    nav_cfg.search_window = {3u, 3u};
 
     prop_state<stepper_t::state, navigator_t::state> propagation{
         stepper_t::state{traj}, navigator_t::state(wire_det)};
@@ -354,7 +359,7 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
 
     // Initialize navigation
     // Test that the navigator has a heartbeat
-    ASSERT_TRUE(nav.init(stepping(), navigation, cfg));
+    ASSERT_TRUE(nav.init(stepping(), navigation, nav_cfg));
     // The status is towards portal
     // One candidates: barrel cylinder portal
     check_towards_surface<navigator_t>(navigation, 0u, 1u, 0u);
@@ -364,14 +369,14 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
     // Let's make half the step towards the portal
     stepping.template set_constraint<step::constraint::e_user>(navigation() *
                                                                0.5f);
-    stepper.step(propagation);
+    stepper.step(navigation(), stepping, stp_cfg);
     // Navigation policy might reduce trust level to fair trust
     navigation.set_fair_trust();
     // Release user constraint again
     stepping.template release_step<step::constraint::e_user>();
     ASSERT_TRUE(navigation.trust_level() == trust_level::e_fair);
     // Re-navigate
-    ASSERT_TRUE(nav.update(stepping(), navigation, cfg));
+    ASSERT_TRUE(nav.update(stepping(), navigation, nav_cfg));
     // Trust level is restored
     ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
     // The status remains: towards surface
@@ -380,15 +385,15 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
     ASSERT_NEAR(navigation(), 250.f * unit<scalar>::mm, tol);
 
     // Let's immediately update, nothing should change, as there is full trust
-    ASSERT_TRUE(nav.update(stepping(), navigation, cfg));
+    ASSERT_TRUE(nav.update(stepping(), navigation, nav_cfg));
     check_towards_surface<navigator_t>(navigation, 0u, 1u, 0u);
     ASSERT_NEAR(navigation(), 250.f * unit<scalar>::mm, tol);
 
     // Step onto portal in volume 0
-    stepper.step(propagation);
+    stepper.step(navigation(), stepping, stp_cfg);
     navigation.set_high_trust();
     ASSERT_TRUE(navigation.trust_level() == trust_level::e_high);
-    ASSERT_TRUE(nav.update(stepping(), navigation, cfg))
+    ASSERT_TRUE(nav.update(stepping(), navigation, nav_cfg))
         << navigation.inspector().to_string();
     ASSERT_EQ(navigation.trust_level(), trust_level::e_full);
 
@@ -435,17 +440,17 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
         // Step through the module surfaces
         for (std::size_t sf = 1u; sf < sf_seq.size() - 1u; ++sf) {
             // Count only the currently reachable candidates
-            step_and_check(nav, stepper, propagation_cpy, cfg, vol_id,
+            step_and_check(nav, stepper, propagation_cpy, prop_cfg, vol_id,
                            n_candidates - sf, sf_seq[sf], sf_seq[sf + 1u]);
         }
 
         // Step onto the portal in volume
-        stepper.step(propagation_cpy);
+        stepper.step(navigation_cpy(), stepping_cpy, stp_cfg);
         navigation_cpy.set_high_trust();
 
         // Check agianst last volume
         if (vol_id == last_vol_id) {
-            ASSERT_FALSE(nav.update(stepping_cpy(), navigation_cpy, cfg));
+            ASSERT_FALSE(nav.update(stepping_cpy(), navigation_cpy, nav_cfg));
             // The status is: exited
             ASSERT_EQ(navigation_cpy.status(), status::e_on_target);
             // Switch to next volume leads out of the detector world -> exit
@@ -454,7 +459,7 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
             // We know we went out of the detector
             ASSERT_EQ(navigation_cpy.trust_level(), trust_level::e_full);
         } else {
-            ASSERT_TRUE(nav.update(stepping_cpy(), navigation_cpy, cfg))
+            ASSERT_TRUE(nav.update(stepping_cpy(), navigation_cpy, nav_cfg))
                 << navigation_cpy.inspector().to_string();
         }
 

--- a/tests/unit_tests/cpu/propagator/rk_stepper.cpp
+++ b/tests/unit_tests/cpu/propagator/rk_stepper.cpp
@@ -73,7 +73,8 @@ struct nav_state {
 
     scalar operator()() const { return m_step_size; }
     inline auto current_object() const -> dindex { return dindex_invalid; }
-    inline auto tolerance() const -> scalar { return tol; }
+    inline auto is_on_surface() const -> bool { return true; }
+    inline auto is_init() const -> bool { return true; }
     inline auto detector() const -> const detray::detector<> & {
         return *(m_det.get());
     }

--- a/tests/unit_tests/device/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda.cpp
@@ -71,14 +71,14 @@ TEST(navigator_cuda, navigator) {
         const stepper_t::state& stepping = propagation._stepping;
 
         // Start propagation and record volume IDs
-        bool heartbeat = nav.init(propagation, cfg);
+        bool heartbeat = nav.init(stepping(), navigation, cfg);
         while (heartbeat) {
 
             heartbeat &= stepper.step(propagation);
 
             navigation.set_high_trust();
 
-            heartbeat &= nav.update(propagation, cfg);
+            heartbeat &= nav.update(stepping(), navigation, cfg);
 
             // Record volume
             volume_records_host[i].push_back(navigation.volume());

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.cu
@@ -45,14 +45,14 @@ __global__ void navigator_test_kernel(
     navigation.set_volume(0u);
 
     // Start propagation and record volume IDs
-    bool heartbeat = nav.init(propagation, cfg);
+    bool heartbeat = nav.init(stepping(), navigation, cfg);
     while (heartbeat) {
 
         heartbeat &= stepper.step(propagation);
 
         navigation.set_high_trust();
 
-        heartbeat = nav.update(propagation, cfg);
+        heartbeat = nav.update(stepping(), navigation, cfg);
 
         // Record volume
         volume_records[gid].push_back(navigation.volume());

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.cu
@@ -13,7 +13,7 @@
 namespace detray {
 
 __global__ void navigator_test_kernel(
-    typename detector_host_t::view_type det_data, navigation::config cfg,
+    typename detector_host_t::view_type det_data, propagation::config cfg,
     vecmem::data::vector_view<free_track_parameters<algebra_t>> tracks_data,
     vecmem::data::jagged_vector_view<dindex> volume_records_data,
     vecmem::data::jagged_vector_view<point3> position_records_data) {
@@ -45,14 +45,16 @@ __global__ void navigator_test_kernel(
     navigation.set_volume(0u);
 
     // Start propagation and record volume IDs
-    bool heartbeat = nav.init(stepping(), navigation, cfg);
+    bool heartbeat = nav.init(stepping(), navigation, cfg.navigation);
     while (heartbeat) {
 
-        heartbeat &= stepper.step(propagation);
+        const bool do_reset{navigation.is_on_surface() || navigation.is_init()};
+        heartbeat &=
+            stepper.step(navigation(), stepping, cfg.stepping, do_reset);
 
         navigation.set_high_trust();
 
-        heartbeat = nav.update(stepping(), navigation, cfg);
+        heartbeat = nav.update(stepping(), navigation, cfg.navigation);
 
         // Record volume
         volume_records[gid].push_back(navigation.volume());
@@ -61,7 +63,7 @@ __global__ void navigator_test_kernel(
 }
 
 void navigator_test(
-    typename detector_host_t::view_type det_data, navigation::config& cfg,
+    typename detector_host_t::view_type det_data, propagation::config& cfg,
     vecmem::data::vector_view<free_track_parameters<algebra_t>>& tracks_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,
     vecmem::data::jagged_vector_view<point3>& position_records_data) {

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
@@ -13,6 +13,7 @@
 #include "detray/detectors/toy_metadata.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/line_stepper.hpp"
+#include "detray/propagator/propagation_config.hpp"
 
 // Detray test include(s)
 #include "detray/test/utils/simulation/event_generator/track_generators.hpp"
@@ -55,7 +56,7 @@ namespace detray {
 
 /// test function for navigator with single state
 void navigator_test(
-    typename detector_host_t::view_type det_data, navigation::config& cfg,
+    typename detector_host_t::view_type det_data, propagation::config& cfg,
     vecmem::data::vector_view<free_track_parameters<algebra_t>>& tracks_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,
     vecmem::data::jagged_vector_view<point3>& position_records_data);


### PR DESCRIPTION
Decouple the stepper and navigator so that they take only the bare minimum of information needed to fullfill their respective tasks and manipulating each others state becomes impossible. Like this, the interaction between the navigation and the track parameter transport is now visible directly in the propagator instead of being partially hidden in the implementation of the navigator and/or stepper.

Note: The random scatterer observes all material now and the step size scaling is always done with a the minimal and maximal cutoff