### PR TITLE
Ref: stepper state encapsulation

### DIFF
--- a/core/include/detray/navigation/policies.hpp
+++ b/core/include/detray/navigation/policies.hpp
@@ -74,7 +74,7 @@ struct stepper_default_policy : actor {
 
         // Not a severe change to track state expected
         // Policy is called after stepsize update -> use prev. step size
-        if (math::fabs(stepping._prev_step_size) <
+        if (math::fabs(stepping.prev_step_size()) <
             math::fabs(
                 stepping.constraints().template size<>(stepping.direction())) -
                 pol_state.tol) {
@@ -112,7 +112,7 @@ struct stepper_rk_policy : actor {
         auto &navigation = propagation._navigation;
 
         // Policy is called after stepsize update -> use prev. step size
-        const scalar rel_correction{(stepping._prev_step_size - navigation()) /
+        const scalar rel_correction{(stepping.prev_step_size() - navigation()) /
                                     navigation()};
 
         // Large correction to the stepsize - re-initialize the volume

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -51,7 +51,7 @@ struct pathlimit_aborter : actor {
 
         const scalar step_limit =
             abrt_state.path_limit() -
-            math::fabs(prop_state._stepping._abs_path_length);
+            math::fabs(prop_state._stepping.abs_path_length());
 
         // Check the path limit
         if (step_limit <= 0.f) {
@@ -112,7 +112,7 @@ struct next_surface_aborter : actor {
 
         // Abort at the next sensitive surface
         if (navigation.is_on_sensitive() &&
-            stepping._s > abrt_state.min_step_length) {
+            stepping.path_from_surface() > abrt_state.min_step_length) {
             prop_state._heartbeat &= navigation.abort();
             abrt_state.success = true;
         }

--- a/core/include/detray/propagator/actors/parameter_resetter.hpp
+++ b/core/include/detray/propagator/actors/parameter_resetter.hpp
@@ -42,16 +42,16 @@ struct parameter_resetter : actor {
 
             // Reset the free vector
             stepping() = detail::bound_to_free_vector(trf3, mask,
-                                                      stepping._bound_params);
+                                                      stepping.bound_params());
 
             // Reset the path length
-            stepping._s = 0;
+            stepping.reset_path_from_surface();
 
             // Reset jacobian transport to identity matrix
-            matrix_operator().set_identity(stepping._jac_transport);
+            stepping.reset_transport_jacobian();
 
             // Reset the surface index
-            stepping._prev_sf_id = sf_idx;
+            stepping.set_prev_sf_index(sf_idx);
         }
     };
 

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -143,8 +143,8 @@ struct pointwise_material_interactor : actor {
 
             auto &stepping = prop_state._stepping;
 
-            this->update(geo_context_type{}, stepping._ptc,
-                         stepping._bound_params, interactor_state,
+            this->update(geo_context_type{}, stepping.particle_hypothesis(),
+                         stepping.bound_params(), interactor_state,
                          static_cast<int>(navigation.direction()),
                          navigation.get_surface());
         }

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -43,20 +43,15 @@ template <typename algebra_t, typename constraint_t, typename policy_t,
 class base_stepper {
 
     public:
-    using inspector_type = inspector_t;
-    using policy_type = policy_t;
-
     using scalar_type = dscalar<algebra_t>;
-    using transform3_type = dtransform3D<algebra_t>;
-
     using matrix_operator = dmatrix_operator<algebra_t>;
-
     using free_track_parameters_type = free_track_parameters<algebra_t>;
     using bound_track_parameters_type = bound_track_parameters<algebra_t>;
-
     using free_matrix_type = free_matrix<algebra_t>;
     using bound_matrix_type = bound_matrix<algebra_t>;
-    using bound_to_free_matrix_type = bound_to_free_matrix<algebra_t>;
+
+    using inspector_type = inspector_t;
+    using policy_type = policy_t;
 
     /// @brief State struct holding the track
     ///
@@ -66,26 +61,23 @@ class base_stepper {
         /// Sets track parameters.
         DETRAY_HOST_DEVICE
         explicit state(const free_track_parameters_type &free_params)
-            : _track(free_params) {
+            : m_track(free_params) {
 
             curvilinear_frame<algebra_t> cf(free_params);
 
             // Set bound track parameters
-            _bound_params.set_parameter_vector(cf.m_bound_vec);
+            m_bound_params.set_parameter_vector(cf.m_bound_vec);
 
             // A dummy covariance - should not be used
-            _bound_params.set_covariance(
+            m_bound_params.set_covariance(
                 matrix_operator()
                     .template identity<e_bound_size, e_bound_size>());
 
             // A dummy barcode - should not be used
-            _bound_params.set_surface_link(geometry::barcode{});
-
-            // Reset the path length
-            _s = 0.f;
+            m_bound_params.set_surface_link(geometry::barcode{});
 
             // Reset jacobian transport to identity matrix
-            matrix_operator().set_identity(_jac_transport);
+            matrix_operator().set_identity(m_jac_transport);
         }
 
         /// Sets track parameters from bound track parameter.
@@ -93,7 +85,7 @@ class base_stepper {
         DETRAY_HOST_DEVICE state(
             const bound_track_parameters_type &bound_params,
             const detector_t &det)
-            : _bound_params(bound_params) {
+            : m_bound_params(bound_params) {
 
             // Surface
             const auto sf = tracking_surface{det, bound_params.surface_link()};
@@ -104,135 +96,172 @@ class base_stepper {
                 sf.transform(ctx), sf.index(), *this);
         }
 
-        /// free track parameter
-        free_track_parameters_type _track;
-
-        /// Full jacobian
-        bound_matrix_type _full_jacobian =
-            matrix_operator().template identity<e_bound_size, e_bound_size>();
-
-        /// jacobian transport matrix
-        free_matrix_type _jac_transport =
-            matrix_operator().template identity<e_free_size, e_free_size>();
-
-        /// bound covariance
-        bound_track_parameters_type _bound_params;
-
-        /// @returns track parameters - const access
+        /// @returns free track parameters - non-const access
         DETRAY_HOST_DEVICE
-        free_track_parameters_type &operator()() { return _track; }
+        free_track_parameters_type &operator()() { return m_track; }
 
-        /// @returns track parameters.
+        /// @returns free track parameters - const access
         DETRAY_HOST_DEVICE
-        const free_track_parameters_type &operator()() const { return _track; }
+        const free_track_parameters_type &operator()() const { return m_track; }
 
-        step::direction _direction{step::direction::e_forward};
-
-        // Stepping constraints
-        constraint_t _constraint = {};
-
-        // Navigation policy state
-        typename policy_t::state _policy_state = {};
-
-        /// The inspector type of the stepping
-        inspector_type _inspector;
-
-        /// Total number of step trials
-        std::size_t _n_total_trials{0u};
-
-        /// Track path length
-        scalar_type _path_length{0.f};
-
-        /// Absolute path length
-        scalar_type _abs_path_length{0.f};
-
-        /// Track path length from the last surface. It will be reset to 0 when
-        /// the track reaches a new surface
-        scalar_type _s{0.f};
-
-        /// Current step size
-        scalar_type _step_size{0.f};
-
-        /// Previous step size (DEBUG purpose only)
-        scalar_type _prev_step_size{0.f};
-
-        /// The default particle hypothesis is muon
-        pdg_particle<scalar_type> _ptc = muon<scalar_type>();
-
-        /// Previous barcode to calculate the bound_to_free_jacobian
-        dindex _prev_sf_id = detail::invalid_value<dindex>();
-
-        /// Volume material that track is passing through
-        const detray::material<scalar_type> *_mat{nullptr};
-
-        /// Access the current volume material
+        /// @returns bound track parameters - const access
         DETRAY_HOST_DEVICE
-        const auto &volume_material() const {
-            assert(_mat != nullptr);
-            return *_mat;
+        bound_track_parameters_type &bound_params() { return m_bound_params; }
+
+        /// @returns bound track parameters.
+        DETRAY_HOST_DEVICE
+        const bound_track_parameters_type &bound_params() const {
+            return m_bound_params;
         }
 
-        /// Set new step constraint
-        template <step::constraint type = step::constraint::e_actor>
-        DETRAY_HOST_DEVICE inline void set_constraint(scalar_type step_size) {
-            _constraint.template set<type>(step_size);
-        }
+        /// Get stepping direction
+        DETRAY_HOST_DEVICE
+        inline step::direction direction() const { return m_direction; }
 
-        /// Set new navigation direction
+        /// Set stepping direction
         DETRAY_HOST_DEVICE inline void set_direction(step::direction dir) {
-            _direction = dir;
-        }
-
-        /// @returns access to this states step constraints
-        DETRAY_HOST_DEVICE
-        inline const constraint_t &constraints() const { return _constraint; }
-
-        /// @returns access to this states step constraints
-        DETRAY_HOST_DEVICE
-        inline typename policy_t::state &policy_state() {
-            return _policy_state;
+            m_direction = dir;
         }
 
         /// @returns the total number of step trials. For steppers that don't
         /// use adaptive step size scaling, this is the number of steps
         DETRAY_HOST_DEVICE inline std::size_t n_total_trials() const {
-            return _n_total_trials;
-        }
-
-        /// Updates the total number of step trials
-        DETRAY_HOST_DEVICE inline void count_trials() { ++_n_total_trials; }
-
-        /// @returns the navigation direction
-        DETRAY_HOST_DEVICE
-        inline step::direction direction() const { return _direction; }
-
-        /// Remove [all] constraints
-        template <step::constraint type = step::constraint::e_actor>
-        DETRAY_HOST_DEVICE inline void release_step() {
-            _constraint.template release<type>();
+            return m_n_total_trials;
         }
 
         /// Set next step size
         DETRAY_HOST_DEVICE
-        inline void set_step_size(const scalar_type step) { _step_size = step; }
+        inline void set_step_size(const scalar_type step) {
+            m_step_size = step;
+        }
 
         /// @returns the current step size of this state.
         DETRAY_HOST_DEVICE
-        inline scalar_type step_size() const { return _step_size; }
+        inline scalar_type step_size() const { return m_step_size; }
 
-        /// @returns this states remaining path length.
+        /// Set previous step size
         DETRAY_HOST_DEVICE
-        inline scalar_type path_length() const { return _path_length; }
+        inline void set_prev_step_size(const scalar_type step) {
+            m_prev_step_size = step;
+        }
+
+        /// @returns the previous step size of this state.
+        DETRAY_HOST_DEVICE
+        inline scalar_type prev_step_size() const { return m_prev_step_size; }
+
+        /// @returns this states path length.
+        DETRAY_HOST_DEVICE
+        inline scalar_type path_length() const { return m_path_length; }
+
+        /// @returns this states total integration path length.
+        DETRAY_HOST_DEVICE
+        inline scalar_type abs_path_length() const { return m_abs_path_length; }
+
+        /// @returns path length since last surface was encountered
+        DETRAY_HOST_DEVICE
+        inline scalar_type path_from_surface() const { return m_path_from_sf; }
+
+        /// Reset the path length since last surface
+        DETRAY_HOST_DEVICE inline void reset_path_from_surface() {
+            m_path_from_sf = 0.f;
+        }
+
+        /// Add a new segment to all path lengths (forward or backward)
+        DETRAY_HOST_DEVICE inline void update_path_lengths(scalar_type seg) {
+            m_path_length += seg;
+            m_path_from_sf += seg;
+            m_abs_path_length += math::fabs(seg);
+        }
+
+        /// Updates the total number of step trials
+        DETRAY_HOST_DEVICE inline void count_trials() { ++m_n_total_trials; }
+
+        /// Set new step constraint
+        template <step::constraint type = step::constraint::e_actor>
+        DETRAY_HOST_DEVICE inline void set_constraint(scalar_type step_size) {
+            m_constraint.template set<type>(step_size);
+        }
+
+        /// @returns access to this states step constraints
+        DETRAY_HOST_DEVICE
+        inline const constraint_t &constraints() const { return m_constraint; }
+
+        /// Remove [all] constraints
+        template <step::constraint type = step::constraint::e_actor>
+        DETRAY_HOST_DEVICE inline void release_step() {
+            m_constraint.template release<type>();
+        }
+
+        /// @returns the index of the previous surface for cov. transport
+        DETRAY_HOST_DEVICE dindex prev_sf_index() const { return m_prev_sf_id; }
+
+        /// Set the index of the previous surface for cov. transport
+        DETRAY_HOST_DEVICE
+        void set_prev_sf_index(dindex prev_idx) {
+            assert(!detail::is_invalid_value(prev_idx));
+            m_prev_sf_id = prev_idx;
+        }
+
+        /// @returns true if the current volume contains volume material
+        DETRAY_HOST_DEVICE
+        bool volume_has_material() const { return (m_vol_mat != nullptr); }
+
+        /// Access the current volume material
+        DETRAY_HOST_DEVICE
+        const auto &volume_material() const {
+            assert(m_vol_mat != nullptr);
+            return *m_vol_mat;
+        }
+
+        /// Set new volume material access
+        DETRAY_HOST_DEVICE
+        inline void set_volume_material(const material<scalar_type> *mat_ptr) {
+            m_vol_mat = mat_ptr;
+        }
+
+        /// Access the current particle hypothesis
+        DETRAY_HOST_DEVICE
+        const auto &particle_hypothesis() const { return m_ptc; }
+
+        /// Set new particle hypothesis
+        DETRAY_HOST_DEVICE
+        inline void set_particle(const pdg_particle<scalar_type> &ptc) {
+            m_ptc = ptc;
+        }
 
         /// @returns the current transport Jacbian.
         DETRAY_HOST_DEVICE
         inline const free_matrix_type &transport_jacobian() const {
-            return _jac_transport;
+            return m_jac_transport;
+        }
+
+        /// @returns the current full Jacbian.
+        DETRAY_HOST_DEVICE
+        inline const bound_matrix_type &full_jacobian() const {
+            return m_full_jacobian;
+        }
+
+        /// Set new full Jacbian.
+        DETRAY_HOST_DEVICE
+        inline void set_full_jacobian(const bound_matrix_type &jac) {
+            m_full_jacobian = jac;
+        }
+
+        /// Reset transport Jacbian.
+        DETRAY_HOST_DEVICE
+        inline void reset_transport_jacobian() {
+            matrix_operator().set_identity(m_jac_transport);
+        }
+
+        /// @returns access to this states step constraints
+        DETRAY_HOST_DEVICE
+        inline typename policy_t::state &policy_state() {
+            return m_policy_state;
         }
 
         /// @returns the stepping inspector
         DETRAY_HOST
-        constexpr auto &inspector() { return _inspector; }
+        constexpr auto &inspector() { return m_inspector; }
 
         /// Call the stepping inspector
         DETRAY_HOST_DEVICE
@@ -240,9 +269,71 @@ class base_stepper {
                                   [[maybe_unused]] const char *message) {
             if constexpr (!std::is_same_v<inspector_t,
                                           stepping::void_inspector>) {
-                _inspector(*this, cfg, message);
+                m_inspector(*this, cfg, message);
             }
         }
+
+        protected:
+        /// Set new transport Jacbian.
+        DETRAY_HOST_DEVICE
+        inline void set_transport_jacobian(const free_matrix_type &jac) {
+            m_jac_transport = jac;
+        }
+
+        private:
+        /// Stepping direction
+        step::direction m_direction{step::direction::e_forward};
+
+        /// Total number of step trials
+        std::size_t m_n_total_trials{0u};
+
+        /// Current step size
+        scalar_type m_step_size{0.f};
+
+        /// Previous step size
+        scalar_type m_prev_step_size{0.f};
+
+        /// Track path length
+        scalar_type m_path_length{0.f};
+
+        /// Absolute path length
+        scalar_type m_abs_path_length{0.f};
+
+        /// Track path length from the last surface. It will be reset to 0 when
+        /// the track reaches a new surface
+        scalar_type m_path_from_sf{0.f};
+
+        /// The default particle hypothesis is muon
+        pdg_particle<scalar_type> m_ptc = muon<scalar_type>();
+
+        /// Volume material that track is passing through
+        const material<scalar_type> *m_vol_mat{nullptr};
+
+        /// Previous surface index to calculate the bound_to_free_jacobian
+        dindex m_prev_sf_id = detail::invalid_value<dindex>();
+
+        /// free track parameter
+        free_track_parameters_type m_track;
+
+        /// Full jacobian
+        bound_matrix_type m_full_jacobian =
+            matrix_operator().template identity<e_bound_size, e_bound_size>();
+
+        /// jacobian transport matrix
+        free_matrix_type m_jac_transport =
+            matrix_operator().template identity<e_free_size, e_free_size>();
+
+        /// bound covariance
+        bound_track_parameters_type m_bound_params;
+
+        /// Step size constraints
+        constraint_t m_constraint = {};
+
+        /// Navigation policy state
+        typename policy_t::state m_policy_state = {};
+
+        /// The inspector type of the stepping
+        inspector_type m_inspector;
     };
 };
 

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -107,7 +107,7 @@ struct propagator {
         /// Set the particle hypothesis
         DETRAY_HOST_DEVICE
         void set_particle(const pdg_particle<scalar_type> &ptc) {
-            _stepping._ptc = ptc;
+            _stepping.set_particle(ptc);
         }
 
         // Is the propagation still alive?
@@ -170,8 +170,9 @@ struct propagator {
 
         // Set access to the volume material for the stepper
         auto vol = navigation.get_volume();
-        stepping._mat =
-            vol.has_material() ? vol.material_parameters(track.pos()) : nullptr;
+        stepping.set_volume_material(vol.has_material()
+                                         ? vol.material_parameters(track.pos())
+                                         : nullptr);
 
         // Break automatic step size scaling by the stepper when a surface
         // was reached and whenever the navigation is (re-)initialized
@@ -274,9 +275,9 @@ struct propagator {
 
                 // Set access to the volume material for the stepper
                 auto vol = navigation.get_volume();
-                stepping._mat = vol.has_material()
-                                    ? vol.material_parameters(track.pos())
-                                    : nullptr;
+                stepping.set_volume_material(
+                    vol.has_material() ? vol.material_parameters(track.pos())
+                                       : nullptr);
 
                 // Break automatic step size scaling by the stepper
                 const bool reset_stepsize{navigation.is_on_surface() ||
@@ -374,7 +375,7 @@ struct propagator {
         }
 
         propagation.debug_stream << "step_size: " << std::setw(10)
-                                 << stepping._prev_step_size << std::endl;
+                                 << stepping.prev_step_size() << std::endl;
 
         propagation.debug_stream << std::setw(10)
                                  << detail::ray<algebra_type>(stepping())

--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -445,13 +445,13 @@ struct print_inspector {
                      << "\t\t" << step_scalor << std::endl;
 
         debug_stream << "Bfield points:" << std::endl;
-        const auto &f = state._step_data.b_first;
+        const auto &f = state.step_data().b_first;
         debug_stream << "\tfirst:" << tabs << f[0] << ", " << f[1] << ", "
                      << f[2] << std::endl;
-        const auto &m = state._step_data.b_middle;
+        const auto &m = state.step_data().b_middle;
         debug_stream << "\tmiddle:" << tabs << m[0] << ", " << m[1] << ", "
                      << m[2] << std::endl;
-        const auto &l = state._step_data.b_last;
+        const auto &l = state.step_data().b_last;
         debug_stream << "\tlast:" << tabs << l[0] << ", " << l[1] << ", "
                      << l[2] << std::endl;
 

--- a/tests/include/detray/test/utils/simulation/random_scatterer.hpp
+++ b/tests/include/detray/test/utils/simulation/random_scatterer.hpp
@@ -144,8 +144,8 @@ struct random_scatterer : actor {
         }
 
         auto& stepping = prop_state._stepping;
-        const auto& ptc = stepping._ptc;
-        auto& bound_params = stepping._bound_params;
+        const auto& ptc = stepping.particle_hypothesis();
+        auto& bound_params = stepping.bound_params();
         const auto sf = navigation.get_surface();
         const scalar_type cos_inc_angle{
             sf.cos_angle(geo_context_type{}, bound_params.dir(),
@@ -170,8 +170,8 @@ struct random_scatterer : actor {
                                      simulator_state.generator);
 
         // Update Phi and Theta
-        stepping._bound_params.set_phi(getter::phi(new_dir));
-        stepping._bound_params.set_theta(getter::theta(new_dir));
+        stepping.bound_params().set_phi(getter::phi(new_dir));
+        stepping.bound_params().set_theta(getter::theta(new_dir));
 
         // Flag renavigation of the current candidate
         prop_state._navigation.set_high_trust();

--- a/tests/include/detray/test/validation/material_validation_utils.hpp
+++ b/tests/include/detray/test/validation/material_validation_utils.hpp
@@ -191,7 +191,7 @@ struct material_tracer : detray::actor {
                           typename parameter_transporter<algebra_t>::state &,
                           typename propagator_state_t::actor_chain_type::
                               state>) {
-            const auto &track_param = prop_state._stepping._bound_params;
+            const auto &track_param = prop_state._stepping.bound_params();
             loc_pos = track_param.bound_local();
         } else {
             const auto &track_param = prop_state._stepping();

--- a/tests/integration_tests/cpu/material/material_interaction.cpp
+++ b/tests/integration_tests/cpu/material/material_interaction.cpp
@@ -113,7 +113,7 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
         << state.debug_stream.str() << std::endl;
 
     // new momentum
-    const scalar newP{state._stepping._bound_params.p(ptc.charge())};
+    const scalar newP{state._stepping.bound_params().p(ptc.charge())};
 
     // mass
     const auto mass = ptc.mass();
@@ -126,7 +126,7 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
 
     // New qop variance
     const scalar new_var_qop{
-        matrix_operator().element(state._stepping._bound_params.covariance(),
+        matrix_operator().element(state._stepping.bound_params().covariance(),
                                   e_bound_qoverp, e_bound_qoverp)};
 
     // Interaction object
@@ -199,13 +199,13 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
         // Propagate
         alt_p.propagate(alt_state, alt_actor_states);
 
-        alt_bound_param = alt_state._stepping._bound_params;
+        alt_bound_param = alt_state._stepping.bound_params();
 
         // Terminate the propagation if the next sensitive surface was not found
         if (!next_surface_aborter_state.success) {
             // if (alt_state._navigation.is_complete()){
             const scalar altP =
-                alt_state._stepping._bound_params.p(ptc.charge());
+                alt_state._stepping.bound_params().p(ptc.charge());
             altE = std::hypot(altP, mass);
             break;
         }
@@ -293,7 +293,7 @@ GTEST_TEST(detray_material, telescope_geometry_scattering_angle) {
         ASSERT_TRUE(p.propagate(state, actor_states))
             << state.debug_stream.str() << std::endl;
 
-        const auto& final_param = state._stepping._bound_params;
+        const auto& final_param = state._stepping.bound_params();
 
         // Updated phi and theta variance
         if (i == 0u) {
@@ -395,7 +395,7 @@ GTEST_TEST(detray_material, telescope_geometry_volume_material) {
 
         const auto eloss_approx =
             interaction<scalar>().compute_energy_loss_bethe_bloch(
-                state._stepping._path_length, mat, ptc,
+                state._stepping.path_length(), mat, ptc,
                 {ptc, bound_param.qop()});
 
         const auto iniE = std::sqrt(iniP * iniP + mass * mass);

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -407,7 +407,7 @@ struct bound_getter : actor {
         const scalar N = static_cast<scalar>(actor_state.step_count);
 
         actor_state.m_avg_step_size = ((N - 1.f) * actor_state.m_avg_step_size +
-                                       stepping._prev_step_size) /
+                                       stepping.prev_step_size()) /
                                       N;
 
         // Warning for too many step counts
@@ -428,23 +428,23 @@ struct bound_getter : actor {
         if ((navigation.is_on_sensitive() || navigation.is_on_passive()) &&
             navigation.barcode().index() == 0u) {
 
-            actor_state.m_param_departure = stepping._bound_params;
+            actor_state.m_param_departure = stepping.bound_params();
         }
         // Get the bound track parameters and jacobian at the destination
         // surface
         else if ((navigation.is_on_sensitive() || navigation.is_on_passive()) &&
                  navigation.barcode().index() == 1u) {
 
-            actor_state.m_path_length = stepping._path_length;
-            actor_state.m_abs_path_length = stepping._abs_path_length;
-            actor_state.m_param_destination = stepping._bound_params;
-            actor_state.m_jacobi = stepping._full_jacobian;
+            actor_state.m_path_length = stepping.path_length();
+            actor_state.m_abs_path_length = stepping.abs_path_length();
+            actor_state.m_param_destination = stepping.bound_params();
+            actor_state.m_jacobi = stepping.full_jacobian();
 
             // Stop navigation if the destination surface found
             propagation._heartbeat &= navigation.exit();
         }
 
-        if (stepping._path_length > actor_state.m_min_path_length) {
+        if (stepping.path_length() > actor_state.m_min_path_length) {
             propagation._navigation.set_no_trust();
         }
 

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -233,12 +233,12 @@ GTEST_TEST(detray_detectors, telescope_detector) {
             navigator_x.update(stepping_x(), navigation_x, prop_cfg.navigation);
         // The track path lengths should match between all propagations
         EXPECT_NEAR(
-            std::abs(stepping_z1._path_length - stepping_z2._path_length) /
-                stepping_z1._path_length,
+            std::abs(stepping_z1.path_length() - stepping_z2.path_length()) /
+                stepping_z1.path_length(),
             0.f, tol);
         EXPECT_NEAR(
-            std::abs(stepping_z1._path_length - stepping_x._path_length) /
-                stepping_x._path_length,
+            std::abs(stepping_z1.path_length() - stepping_x.path_length()) /
+                stepping_x.path_length(),
             0.f, tol);
         // The track positions in z should match exactly
         EXPECT_NEAR(getter::norm(stepping_z1().pos() - stepping_z2().pos()) /

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -102,7 +102,7 @@ GTEST_TEST(detray_propagator, covariance_transport) {
     p.propagate(propagation, detray::tie(bound_updater, rst));
 
     // Bound state after one turn propagation
-    const auto& bound_param1 = propagation._stepping._bound_params;
+    const auto& bound_param1 = propagation._stepping.bound_params();
 
     // const auto bound_vec0 = bound_param0;
     // const auto bound_vec1 = bound_param1;

--- a/tests/unit_tests/cpu/propagator/rk_stepper.cpp
+++ b/tests/unit_tests/cpu/propagator/rk_stepper.cpp
@@ -248,7 +248,7 @@ TEST(detray_propagator, qop_derivative) {
         // RK Stepping into forward direction
         rk_stepper_t<bfield_t>::state rk_state{track, hom_bfield};
 
-        rk_state._mat = &vol_mat;
+        rk_state.set_volume_material(&vol_mat);
 
         for (unsigned int i_s = 0u; i_s < rk_steps; i_s++) {
 


### PR DESCRIPTION
Apply better encapsulation to stepper states. This allows a centralized control over how the data in the state can be changed and allows to insert assertions more easily.