### PR TITLE
Add additional assertions for tracking volumes

### DIFF
--- a/core/include/detray/geometry/tracking_surface.hpp
+++ b/core/include/detray/geometry/tracking_surface.hpp
@@ -58,7 +58,8 @@ class tracking_surface {
     /// @param desc from that detector.
     DETRAY_HOST_DEVICE
     constexpr tracking_surface(const detector_t &det, const descr_t &desc)
-        : m_detector{det}, m_desc{desc} {}
+        : m_detector{det},
+          m_desc{(assert(desc.volume() < m_detector.volumes().size()), desc)} {}
 
     /// Constructor from detector @param det and barcode @param bcd in
     /// that detector.

--- a/core/include/detray/geometry/tracking_volume.hpp
+++ b/core/include/detray/geometry/tracking_volume.hpp
@@ -55,12 +55,14 @@ class tracking_volume {
     /// Constructor from detector @param det and volume descriptor
     /// @param vol_idx from that detector.
     constexpr tracking_volume(const detector_t &det, const descr_t &desc)
-        : m_detector{det}, m_desc{desc} {}
+        : m_detector{det},
+          m_desc{(assert(desc.index() < m_detector.volumes().size()), desc)} {}
 
     /// Constructor from detector @param det and volume index @param vol_idx in
     /// that detector.
     constexpr tracking_volume(const detector_t &det, const dindex vol_idx)
-        : tracking_volume(det, det.volume(vol_idx)) {}
+        : tracking_volume(det, (assert(vol_idx < det.volumes().size()),
+                                det.volume(vol_idx))) {}
 
     /// @returns access to the underlying detector
     DETRAY_HOST_DEVICE


### PR DESCRIPTION
This commit adds some assertions to catch situations where a tracking volume is created with an invalid index.