### PR TITLE
ref: Reduce size of navigation state

### DIFF
--- a/core/include/detray/core/detector_metadata.hpp
+++ b/core/include/detray/core/detector_metadata.hpp
@@ -151,7 +151,7 @@ struct default_metadata {
 
     /// Give your mask types a name (needs to be consecutive and has to match
     /// the types position in the mask store!)
-    enum class mask_ids : std::uint8_t {
+    enum class mask_ids : std::uint_least8_t {
         e_rectangle2 = 0,
         e_portal_rectangle2 = 0,
         e_trapezoid2 = 1,
@@ -188,7 +188,7 @@ unbounded_cell, unmasked_plane*/>;
 
     /// Give your material types a name (needs to be consecutive and has to
     /// match the types position in the mask store!)
-    enum class material_ids : std::uint8_t {
+    enum class material_ids : std::uint_least8_t {
         // Material texture (grid) shapes
         e_disc2_map = 0u,
         e_concentric_cylinder2_map = 1u,
@@ -234,7 +234,7 @@ unbounded_cell, unmasked_plane*/>;
     /// How to index the constituent objects (surfaces) in a volume
     /// If they share the same index value here, they will be added into the
     /// same acceleration data structure (brute force is always at 0)
-    enum geo_objects : std::uint8_t {
+    enum geo_objects : std::uint_least8_t {
         e_portal = 0,     // Brute force search
         e_sensitive = 1,  // Grid accelerated search (can be different types)
         e_passive = 0,    // Brute force search
@@ -243,7 +243,7 @@ unbounded_cell, unmasked_plane*/>;
     };
 
     /// Acceleration data structures
-    enum class accel_ids : std::uint8_t {
+    enum class accel_ids : std::uint_least8_t {
         e_brute_force = 0,     // test all surfaces in a volume (brute force)
         e_disc_grid = 1,       // e.g. endcap layers
         e_cylinder2_grid = 2,  // e.g. barrel layers

--- a/core/include/detray/geometry/detail/surface_descriptor.hpp
+++ b/core/include/detray/geometry/detail/surface_descriptor.hpp
@@ -30,7 +30,7 @@ namespace detray {
 template <typename mask_link_t = dtyped_index<dindex, dindex>,
           typename material_link_t = dtyped_index<dindex, dindex>,
           typename transform_link_t = dindex,
-          typename navigation_link_t = dindex>
+          typename navigation_link_t = std::uint_least16_t>
 class surface_descriptor {
 
     public:

--- a/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
@@ -35,7 +35,7 @@ struct helix_intersector_impl;
 /// @note Don't use for low p_t tracks!
 template <concepts::aos_algebra algebra_t>
 struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
-    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
+    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, true> {
 
     using scalar_type = dscalar<algebra_t>;
     using point3_type = dpoint3D<algebra_t>;
@@ -43,7 +43,7 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
     using transform3_type = dtransform3D<algebra_t>;
 
     template <typename surface_descr_t>
-    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+    using intersection_type = intersection2D<surface_descr_t, algebra_t, true>;
     using helix_type = detail::helix<algebra_t>;
 
     /// Operator function to find intersections between helix and cylinder mask

--- a/core/include/detray/navigation/intersection/helix_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_intersector.hpp
@@ -25,7 +25,7 @@ namespace detray {
 template <typename frame_t, typename algebra_t>
 struct helix_intersector_impl {};
 
-template <typename shape_t, typename algebra_t>
+template <typename shape_t, typename algebra_t, bool = true>
 using helix_intersector = helix_intersector_impl<
     typename shape_t::template local_frame_type<algebra_t>, algebra_t>;
 

--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -37,7 +37,7 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
     using transform3_type = dtransform3D<algebra_t>;
 
     template <typename surface_descr_t>
-    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+    using intersection_type = intersection2D<surface_descr_t, algebra_t, true>;
     using helix_type = detail::helix<algebra_t>;
 
     /// Operator function to find intersections between helix and line mask

--- a/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
@@ -38,7 +38,7 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
     using transform3_type = dtransform3D<algebra_t>;
 
     template <typename surface_descr_t>
-    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+    using intersection_type = intersection2D<surface_descr_t, algebra_t, true>;
     using helix_type = detail::helix<algebra_t>;
 
     /// Operator function to find intersections between helix and planar mask

--- a/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
@@ -22,12 +22,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t>
+template <typename frame_t, typename algebra_t, bool do_debug>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between a ray and a 2D cylinder mask
-template <concepts::aos_algebra algebra_t>
-struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
+template <concepts::aos_algebra algebra_t, bool do_debug>
+struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
 
     /// Linear algebra types
     /// @{
@@ -38,7 +38,8 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
     /// @}
 
     template <typename surface_descr_t>
-    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+    using intersection_type =
+        intersection2D<surface_descr_t, algebra_t, do_debug>;
     using ray_type = detail::ray<algebra_t>;
 
     /// Operator function to find intersections between a ray and a 2D cylinder
@@ -189,10 +190,13 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
             is.path = path;
             const point3_type p3 = ro + is.path * rd;
 
-            is.local = mask_t::to_local_frame(trf, p3);
+            const auto loc{mask_t::to_local_frame(trf, p3)};
+            if constexpr (intersection_type<surface_descr_t>::is_debug()) {
+                is.local = loc;
+            }
             // Tolerance: per mille of the distance
             is.status = mask.is_inside(
-                is.local,
+                loc,
                 math::max(mask_tolerance[0],
                           math::min(mask_tolerance[1],
                                     mask_tol_scalor * math::fabs(is.path))));

--- a/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
@@ -23,7 +23,7 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t>
+template <typename frame_t, typename algebra_t, bool do_debug>
 struct ray_intersector_impl;
 
 /// @brief A functor to find intersections between a straight line and a
@@ -31,9 +31,11 @@ struct ray_intersector_impl;
 ///
 /// With the way the navigation works, only the closest one of the two possible
 /// intersection points is needed in the case of a cylinderical portal surface.
-template <concepts::aos_algebra algebra_t>
-struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t>
-    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
+template <concepts::aos_algebra algebra_t, bool do_debug>
+struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
+                            do_debug>
+    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t,
+                                  do_debug> {
 
     /// linear algebra types
     /// @{
@@ -44,7 +46,8 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t>
     /// @}
 
     template <typename surface_descr_t>
-    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+    using intersection_type =
+        intersection2D<surface_descr_t, algebra_t, do_debug>;
     using ray_type = detail::ray<algebra_t>;
 
     /// Operator function to find intersections between ray and cylinder mask

--- a/core/include/detray/navigation/intersection/ray_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_intersector.hpp
@@ -24,12 +24,12 @@ namespace detray {
 ///
 /// @note specialized into the concrete intersectors for the different local
 /// geometries in the respective header files
-template <typename frame_t, typename algebra_t>
+template <typename frame_t, typename algebra_t, bool do_debug>
 struct ray_intersector_impl {};
 
-template <typename shape_t, typename algebra_t>
+template <typename shape_t, typename algebra_t, bool do_debug = false>
 using ray_intersector =
     ray_intersector_impl<typename shape_t::template local_frame_type<algebra_t>,
-                         algebra_t>;
+                         algebra_t, do_debug>;
 
 }  // namespace detray

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_intersector.hpp
@@ -21,12 +21,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t>
+template <typename frame_t, typename algebra_t, bool do_debug>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between straight line and planar surface
-template <concepts::soa_algebra algebra_t>
-struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
+template <concepts::soa_algebra algebra_t, bool do_debug>
+struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
 
     /// Linear algebra types
     /// @{
@@ -37,7 +37,8 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
     /// @}
 
     template <typename surface_descr_t>
-    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+    using intersection_type =
+        intersection2D<surface_descr_t, algebra_t, do_debug>;
 
     /// Operator function to find intersections between a ray and a 2D cylinder
     ///
@@ -171,12 +172,14 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
         is.path = path;
         const point3_type p3 = ro + is.path * rd;
 
-        is.local = mask_t::to_local_frame(trf, p3);
+        const auto loc = mask_t::to_local_frame(trf, p3);
+        if constexpr (intersection_type<surface_descr_t>::is_debug()) {
+            is.local = loc;
+        }
         is.status = mask.is_inside(
-            is.local,
-            math::max(mask_tolerance[0],
-                      math::min(mask_tolerance[1],
-                                mask_tol_scalor * math::fabs(is.path))));
+            loc, math::max(mask_tolerance[0],
+                           math::min(mask_tolerance[1],
+                                     mask_tol_scalor * math::fabs(is.path))));
 
         is.direction = !math::signbit(is.path);
         is.volume_link = mask.volume_link();

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
@@ -26,9 +26,11 @@ namespace detray {
 ///
 /// With the way the navigation works, only the closest one of the two possible
 /// intersection points is needed in the case of a cylinderical portal surface.
-template <concepts::soa_algebra algebra_t>
-struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t>
-    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
+template <concepts::soa_algebra algebra_t, bool do_debug>
+struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
+                            do_debug>
+    : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t,
+                                  do_debug> {
 
     /// Linear algebra types
     /// @{
@@ -39,7 +41,8 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t>
     /// @}
 
     template <typename surface_descr_t>
-    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+    using intersection_type =
+        intersection2D<surface_descr_t, algebra_t, do_debug>;
 
     /// Operator function to find intersections between ray and cylinder mask
     ///

--- a/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
@@ -20,12 +20,12 @@
 
 namespace detray {
 
-template <typename frame_t, typename algebra_t>
+template <typename frame_t, typename algebra_t, bool do_debug>
 struct ray_intersector_impl;
 
 /// A functor to find intersections between straight line and planar surface
-template <concepts::soa_algebra algebra_t>
-struct ray_intersector_impl<line2D<algebra_t>, algebra_t> {
+template <concepts::soa_algebra algebra_t, bool do_debug>
+struct ray_intersector_impl<line2D<algebra_t>, algebra_t, do_debug> {
 
     /// Linear algebra types
     /// @{
@@ -36,7 +36,8 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t> {
     /// @}
 
     template <typename surface_descr_t>
-    using intersection_type = intersection2D<surface_descr_t, algebra_t>;
+    using intersection_type =
+        intersection2D<surface_descr_t, algebra_t, do_debug>;
 
     /// Operator function to find intersections between ray and line mask
     ///
@@ -98,12 +99,14 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t> {
 
         // point of closest approach on the track
         const point3_type m = ro + rd * is.path;
-        is.local = mask_t::to_local_frame(trf, m, rd);
+        const auto loc = mask_t::to_local_frame(trf, m, rd);
+        if constexpr (intersection_type<surface_descr_t>::is_debug()) {
+            is.local = loc;
+        }
         is.status = mask.is_inside(
-            is.local,
-            math::max(mask_tolerance[0],
-                      math::min(mask_tolerance[1],
-                                mask_tol_scalor * math::fabs(is.path))));
+            loc, math::max(mask_tolerance[0],
+                           math::min(mask_tolerance[1],
+                                     mask_tol_scalor * math::fabs(is.path))));
 
         // Early return, in case all intersections are invalid
         if (detray::detail::none_of(is.status)) {

--- a/core/include/detray/navigation/intersection_kernel.hpp
+++ b/core/include/detray/navigation/intersection_kernel.hpp
@@ -17,7 +17,7 @@
 namespace detray {
 
 /// A functor to add all valid intersections between the trajectory and surface
-template <template <typename, typename> class intersector_t>
+template <template <typename, typename, bool> class intersector_t>
 struct intersection_initialize {
 
     /// Operator function to initalize intersections
@@ -53,6 +53,7 @@ struct intersection_initialize {
 
         using mask_t = typename mask_group_t::value_type;
         using algebra_t = typename mask_t::algebra_type;
+        using intersection_t = typename is_container_t::value_type;
 
         const auto &ctf = contextual_transforms.at(surface.transform());
 
@@ -61,7 +62,8 @@ struct intersection_initialize {
              detray::ranges::subrange(mask_group, mask_range)) {
 
             if (place_in_collection(
-                    intersector_t<typename mask_t::shape, algebra_t>{}(
+                    intersector_t<typename mask_t::shape, algebra_t,
+                                  intersection_t::is_debug()>{}(
                         traj, surface, mask, ctf, mask_tolerance,
                         mask_tol_scalor, overstep_tol),
                     is_container)) {
@@ -107,7 +109,7 @@ struct intersection_initialize {
 
 /// A functor to update the closest intersection between the trajectory and
 /// surface
-template <template <typename, typename> class intersector_t>
+template <template <typename, typename, bool> class intersector_t>
 struct intersection_update {
 
     /// Operator function to update the intersection
@@ -149,9 +151,10 @@ struct intersection_update {
         for (const auto &mask :
              detray::ranges::subrange(mask_group, mask_range)) {
 
-            intersector_t<typename mask_t::shape, algebra_t>{}.update(
-                traj, sfi, mask, ctf, mask_tolerance, mask_tol_scalor,
-                overstep_tol);
+            intersector_t<typename mask_t::shape, algebra_t,
+                          intersection_t::is_debug()>{}
+                .update(traj, sfi, mask, ctf, mask_tolerance, mask_tol_scalor,
+                        overstep_tol);
 
             if (sfi.status) {
                 return true;

--- a/core/include/detray/navigation/intersector.hpp
+++ b/core/include/detray/navigation/intersector.hpp
@@ -16,7 +16,7 @@ namespace detray {
 /// @brief Intersection interface for detector surfaces.
 ///
 /// Composes the different intersector options into a unifyed interface
-template <typename shape_t, typename algebra_t>
+template <typename shape_t, typename algebra_t, bool do_debug = false>
 struct intersector {
 
     using algebra_type = algebra_t;
@@ -24,10 +24,17 @@ struct intersector {
     using transform3_type = dtransform3D<algebra_t>;
 
     /// How to intersect surfaces with rays
-    using ray_intersector_type = ray_intersector<shape_t, algebra_t>;
+    using ray_intersector_type = ray_intersector<shape_t, algebra_t, do_debug>;
 
     /// How to intersect surfaces with helices
-    using helix_intersector_type = helix_intersector<shape_t, algebra_t>;
+    using helix_intersector_type =
+        helix_intersector<shape_t, algebra_t, do_debug>;
+
+    // Test with int as dummy surface descriptor type
+    static_assert(
+        std::same_as<
+            typename ray_intersector_type::template intersection_type<int>,
+            typename helix_intersector_type::template intersection_type<int>>);
 
     /// @returns the intersection(s) between a surface and the ray @param ray
     template <typename surface_descr_t, typename mask_t>

--- a/core/include/detray/navigation/navigation_config.hpp
+++ b/core/include/detray/navigation/navigation_config.hpp
@@ -18,11 +18,11 @@
 namespace detray::navigation {
 
 /// Navigation trust levels determine how the candidates chache is updated
-enum class trust_level {
-    e_no_trust = 0,  ///< re-initialize the volume (i.e. run local navigation)
-    e_fair = 1,      ///< update the distance & order of the candidates
-    e_high = 3,  ///< update the distance to the next candidate (current target)
-    e_full = 4   ///< don't update anything
+enum class trust_level : std::uint_least8_t {
+    e_no_trust = 0u,  ///< re-initialize the volume (i.e. run local navigation)
+    e_fair = 1u,      ///< update the distance & order of the candidates
+    e_high = 3u,  ///< update the dist. to the next candidate (current target)
+    e_full = 4u   ///< don't update anything
 };
 
 /// Navigation configuration

--- a/detectors/include/detray/detectors/itk_metadata.hpp
+++ b/detectors/include/detray/detectors/itk_metadata.hpp
@@ -84,7 +84,7 @@ struct itk_metadata {
     /// good idea to have the most common types in the first tuple entries, in
     /// order to minimize the depth of the 'unrolling' before a mask is found
     /// in the tuple
-    enum class mask_ids : std::uint8_t {
+    enum class mask_ids : std::uint_least8_t {
         e_rectangle2 = 0u,
         e_annulus2 = 1u,
         e_portal_cylinder2 = 2u,
@@ -101,7 +101,7 @@ struct itk_metadata {
                             rectangle, annulus, cylinder_portal, disc_portal>;
 
     /// Similar to the mask store, there is a material store, which
-    enum class material_ids : std::uint8_t {
+    enum class material_ids : std::uint_least8_t {
         e_disc2_map = 0u,
         e_annulus2_map = 0u,
         e_concentric_cylinder2_map = 1u,
@@ -134,7 +134,7 @@ struct itk_metadata {
     /// How to index the constituent objects in a volume
     /// If they share the same index value here, they will be added into the
     /// same acceleration data structure in every respective volume
-    enum geo_objects : std::uint8_t {
+    enum geo_objects : std::uint_least8_t {
         e_surface = 0u,  //< This detector keeps all surfaces in the same
         e_portal = 0u,   //  acceleration data structure (id 0)
         e_passive = 0u,
@@ -143,7 +143,7 @@ struct itk_metadata {
 
     /// The acceleration data structures live in another tuple that needs to be
     /// indexed correctly:
-    enum class accel_ids : std::uint8_t {
+    enum class accel_ids : std::uint_least8_t {
         e_brute_force = 0u,  //< test all surfaces in a volume (brute force)
         e_default = e_brute_force,
     };

--- a/detectors/include/detray/detectors/telescope_metadata.hpp
+++ b/detectors/include/detray/detectors/telescope_metadata.hpp
@@ -49,7 +49,7 @@ struct telescope_metadata {
 
     /// Rectangles are always needed as portals (but the yhave the same type as
     /// module rectangles). Only one additional mask shape is allowed
-    enum class mask_ids : std::uint8_t {
+    enum class mask_ids : std::uint_least8_t {
         e_rectangle2 = 0,
         e_portal_rectangle2 = 0,
         e_annulus2 = 1,
@@ -82,7 +82,7 @@ struct telescope_metadata {
                             rectangle, mask<mask_shape_t, nav_link>>>;
 
     /// Material type ids
-    enum class material_ids : std::uint8_t {
+    enum class material_ids : std::uint_least8_t {
         e_slab = 0u,
         e_raw_material = 1u,  //< used for homogeneous volume material
         e_rod = 2u,
@@ -111,7 +111,7 @@ struct telescope_metadata {
         surface_descriptor<mask_link, material_link, transform_link, nav_link>;
 
     /// No grids/other acceleration data structure, everything is brute forced
-    enum geo_objects : std::uint8_t {
+    enum geo_objects : std::uint_least8_t {
         e_portal = 0,
         e_sensitive = 1,
         e_size = 2,

--- a/detectors/include/detray/detectors/toy_metadata.hpp
+++ b/detectors/include/detray/detectors/toy_metadata.hpp
@@ -82,7 +82,7 @@ struct toy_metadata {
         single_store<dtransform3D<algebra_type>, vector_t, geometry_context>;
 
     /// Mask type ids
-    enum class mask_ids : std::uint8_t {
+    enum class mask_ids : std::uint_least8_t {
         e_rectangle2 = 0,
         e_trapezoid2 = 1,
         e_portal_cylinder2 = 2,
@@ -98,7 +98,7 @@ struct toy_metadata {
                             rectangle, trapezoid, cylinder_portal, disc_portal>;
 
     /// Material type ids
-    enum class material_ids : std::uint8_t {
+    enum class material_ids : std::uint_least8_t {
         e_disc2_map = 0u,
         e_concentric_cylinder2_map = 1u,
         e_rectangle2_map = 2u,
@@ -125,7 +125,7 @@ struct toy_metadata {
         surface_descriptor<mask_link, material_link, transform_link, nav_link>;
 
     /// Portals and passives in the brute froce search, sensitives in the grids
-    enum geo_objects : std::uint8_t {
+    enum geo_objects : std::uint_least8_t {
         e_portal = 0,
         e_passive = 0,
         e_sensitive = 1,
@@ -134,7 +134,7 @@ struct toy_metadata {
     };
 
     /// Acceleration data structures
-    enum class accel_ids : std::uint8_t {
+    enum class accel_ids : std::uint_least8_t {
         e_brute_force = 0,     // test all surfaces in a volume (brute force)
         e_disc_grid = 1,       // endcap
         e_cylinder2_grid = 2,  // barrel

--- a/io/include/detray/io/csv/intersection2D.hpp
+++ b/io/include/detray/io/csv/intersection2D.hpp
@@ -59,7 +59,7 @@ inline auto read_intersection2D(const std::string &file_name) {
     using mask_id_t = typename detector_t::masks::id;
     using material_id_t = typename detector_t::materials::id;
 
-    using intersection_t = detray::intersection2D<surface_t, algebra_t>;
+    using intersection_t = detray::intersection2D<surface_t, algebra_t, true>;
 
     dfe::NamedTupleCsvReader<io::csv::intersection2D> inters_reader(file_name);
 

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/grid.hpp
@@ -31,7 +31,7 @@ namespace detray::svgtools::conversion {
 
 namespace detail {
 
-enum class grid_type : std::uint8_t {
+enum class grid_type : std::uint_least8_t {
     e_barrel = 0,
     e_endcap = 1,
     e_unknown = 2

--- a/tests/include/detray/test/device/cuda/navigation_validation.cu
+++ b/tests/include/detray/test/device/cuda/navigation_validation.cu
@@ -56,7 +56,7 @@ __global__ void navigation_validation_kernel(
     // Navigation with inspection
     using navigator_t =
         navigator<detector_device_t, navigation::default_cache_size,
-                  object_tracer_t>;
+                  object_tracer_t, intersection_t>;
 
     // Propagator with pathlimit aborter
     using material_tracer_t =

--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -277,14 +277,18 @@ struct print_inspector {
 
         using geo_ctx_t = typename state_type::detector_type::geometry_context;
         for (const auto &sf_cand : state) {
-            const auto &local = sf_cand.local;
-            const auto pos =
-                tracking_surface{state.detector(), sf_cand.sf_desc}
-                    .local_to_global(geo_ctx_t{}, local, track_dir);
 
             debug_stream << sf_cand;
-            debug_stream << ", glob: [r:" << getter::perp(pos)
-                         << ", z:" << pos[2] << "]" << std::endl;
+
+            // Use additional debug information that was gathered on the cand.
+            if constexpr (state_type::value_type::is_debug()) {
+                const auto &local = sf_cand.local;
+                const auto pos =
+                    tracking_surface{state.detector(), sf_cand.sf_desc}
+                        .local_to_global(geo_ctx_t{}, local, track_dir);
+                debug_stream << ", glob: [r:" << getter::perp(pos)
+                             << ", z:" << pos[2] << "]" << std::endl;
+            }
         }
         if (!state.candidates().empty()) {
             debug_stream << "=> next: ";

--- a/tests/include/detray/test/validation/detector_scanner.hpp
+++ b/tests/include/detray/test/validation/detector_scanner.hpp
@@ -32,7 +32,7 @@ struct intersection_record {
     using scalar_t = dscalar<algebra_t>;
     using track_parameter_type = free_track_parameters<algebra_t>;
     using intersection_type =
-        intersection2D<typename detector_t::surface_type, algebra_t>;
+        intersection2D<typename detector_t::surface_type, algebra_t, true>;
 
     /// The charge associated with the track parameters
     scalar_t charge;
@@ -70,7 +70,7 @@ struct brute_force_scan {
         using nav_link_t = typename detector_t::surface_type::navigation_link;
 
         using intersection_t =
-            intersection2D<sf_desc_t, typename detector_t::algebra_type>;
+            intersection2D<sf_desc_t, typename detector_t::algebra_type, true>;
 
         using intersection_kernel_t = intersection_initialize<intersector>;
 

--- a/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -49,7 +49,7 @@ inline auto record_propagation(
 
     /// Type that holds the intersection information
     using intersection_t =
-        intersection2D<typename detector_t::surface_type, algebra_t>;
+        intersection2D<typename detector_t::surface_type, algebra_t, true>;
 
     /// Inspector that records all encountered surfaces
     using object_tracer_t =
@@ -64,8 +64,8 @@ inline auto record_propagation(
         aggregate_inspector<object_tracer_t, nav_print_inspector_t>;
 
     // Navigation with inspection
-    using navigator_t =
-        navigator<detector_t, navigation::default_cache_size, inspector_t>;
+    using navigator_t = navigator<detector_t, navigation::default_cache_size,
+                                  inspector_t, intersection_t>;
 
     // Propagator with pathlimit aborter and validation actors
     using step_tracer_t = step_tracer<algebra_t, dvector>;

--- a/tests/integration_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/integration_tests/cpu/propagator/covariance_transport.cpp
@@ -30,7 +30,8 @@ using scalar_type = test::scalar;
 using matrix_operator = test::matrix_operator;
 using transform3 = test::transform3;
 using vector3 = test::vector3;
-using intersection_t = intersection2D<surface_descriptor<>, test::algebra>;
+using intersection_t =
+    intersection2D<surface_descriptor<>, test::algebra, true>;
 
 // Mask types to be tested
 // @TODO: Remove unbounded tag

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -193,12 +193,17 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     navigation_state_t &navigation_x = propgation_x._navigation;
 
     // propagate all telescopes
-    bool heartbeat_z1 =
-        navigator_z1.init(stepping_z1(), navigation_z1, prop_cfg.navigation);
-    bool heartbeat_z2 =
-        navigator_z2.init(stepping_z2(), navigation_z2, prop_cfg.navigation);
-    bool heartbeat_x =
-        navigator_x.init(stepping_x(), navigation_x, prop_cfg.navigation);
+    navigator_z1.init(stepping_z1(), navigation_z1, prop_cfg.navigation);
+    navigator_z2.init(stepping_z2(), navigation_z2, prop_cfg.navigation);
+    navigator_x.init(stepping_x(), navigation_x, prop_cfg.navigation);
+
+    bool heartbeat_z1 = navigation_z1.is_alive();
+    bool heartbeat_z2 = navigation_z2.is_alive();
+    bool heartbeat_x = navigation_x.is_alive();
+
+    bool do_reset_z1{true};
+    bool do_reset_z2{true};
+    bool do_reset_x{true};
 
     while (heartbeat_z1 && heartbeat_z2 && heartbeat_x) {
 
@@ -206,13 +211,6 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         EXPECT_TRUE(heartbeat_z1);
         EXPECT_TRUE(heartbeat_z2);
         EXPECT_TRUE(heartbeat_x);
-
-        const bool do_reset_z1{navigation_z1.is_on_surface() ||
-                               navigation_z1.is_init()};
-        const bool do_reset_z2{navigation_z2.is_on_surface() ||
-                               navigation_z2.is_init()};
-        const bool do_reset_x{navigation_x.is_on_surface() ||
-                              navigation_x.is_init()};
 
         heartbeat_z1 &= rk_stepper_z.step(navigation_z1(), stepping_z1,
                                           prop_cfg.stepping, do_reset_z1);
@@ -225,12 +223,22 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         navigation_z2.set_high_trust();
         navigation_x.set_high_trust();
 
-        heartbeat_z1 &= navigator_z1.update(stepping_z1(), navigation_z1,
-                                            prop_cfg.navigation);
-        heartbeat_z2 &= navigator_z2.update(stepping_z2(), navigation_z2,
-                                            prop_cfg.navigation);
-        heartbeat_x &=
+        do_reset_z1 = navigator_z1.update(stepping_z1(), navigation_z1,
+                                          prop_cfg.navigation);
+        do_reset_z2 = navigator_z2.update(stepping_z2(), navigation_z2,
+                                          prop_cfg.navigation);
+        do_reset_x =
             navigator_x.update(stepping_x(), navigation_x, prop_cfg.navigation);
+
+        // Also reset when reached a surface
+        do_reset_z1 |= navigation_z1.is_on_surface();
+        do_reset_z2 |= navigation_z2.is_on_surface();
+        do_reset_x |= navigation_x.is_on_surface();
+
+        heartbeat_z1 &= navigation_z1.is_alive();
+        heartbeat_z2 &= navigation_z2.is_alive();
+        heartbeat_x &= navigation_x.is_alive();
+
         // The track path lengths should match between all propagations
         EXPECT_NEAR(
             std::abs(stepping_z1.path_length() - stepping_z2.path_length()) /
@@ -284,19 +292,22 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     stepping_state_t &tel_stepping = tel_propagation._stepping;
 
     // run propagation
-    bool heartbeat_tel =
-        tel_navigator.init(tel_stepping(), tel_navigation, prop_cfg.navigation);
+    tel_navigator.init(tel_stepping(), tel_navigation, prop_cfg.navigation);
+    bool heartbeat_tel = tel_navigation.is_alive();
+
+    bool do_reset_tel{true};
 
     while (heartbeat_tel) {
-        const bool do_reset_tel{navigation_z1.is_on_surface() ||
-                                navigation_z1.is_init()};
         heartbeat_tel &= rk_stepper_z.step(tel_navigation(), tel_stepping,
                                            prop_cfg.stepping, do_reset_tel);
 
         tel_navigation.set_high_trust();
 
-        heartbeat_tel &= tel_navigator.update(tel_stepping(), tel_navigation,
-                                              prop_cfg.navigation);
+        do_reset_tel = tel_navigator.update(tel_stepping(), tel_navigation,
+                                            prop_cfg.navigation);
+
+        do_reset_tel |= navigation_z1.is_on_surface();
+        heartbeat_tel &= tel_navigation.is_alive();
     }
     // check that propagation was successful
     ASSERT_TRUE(tel_navigation.is_complete())

--- a/tests/unit_tests/cpu/geometry/tracking_surface.cpp
+++ b/tests/unit_tests/cpu/geometry/tracking_surface.cpp
@@ -51,6 +51,8 @@ GTEST_TEST(detray_geometry, surface_descriptor) {
     surface_descriptor<mask_link_t, material_link_t> desc(
         1u, mask_id, material_id, 2u, surface_id::e_sensitive);
 
+    static_assert(sizeof(decltype(desc)) == 16);
+
     // Test access
     ASSERT_EQ(desc.transform(), 1u);
     ASSERT_EQ(desc.volume(), 2u);

--- a/tests/unit_tests/cpu/material/materials.cpp
+++ b/tests/unit_tests/cpu/material/materials.cpp
@@ -239,7 +239,7 @@ GTEST_TEST(detray_material, material_rod) {
     const mask<line_circular> ln{0u, 1.f * unit<scalar_t>::mm,
                                  std::numeric_limits<scalar_t>::infinity()};
 
-    auto is = ray_intersector<line_circular, algebra_t>{}(
+    auto is = ray_intersector<line_circular, algebra_t, true>{}(
         detail::ray<algebra_t>(trk), surface_descriptor<>{}, ln, tf);
 
     const scalar_t cos_inc_ang{std::abs(vector::dot(

--- a/tests/unit_tests/cpu/navigation/intersection/cylinder_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/cylinder_intersector.cpp
@@ -47,7 +47,7 @@ const scalar hz{10.f};
 GTEST_TEST(detray_intersection, translated_cylinder) {
     // Create a translated cylinder and test untersection
     const transform3_t shifted(vector3{3.f, 2.f, 10.f});
-    ray_intersector<cylinder2D, algebra_t> ci;
+    ray_intersector<cylinder2D, algebra_t, true> ci;
 
     // Test ray
     const point3 ori = {3.f, 2.f, 5.f};
@@ -101,8 +101,8 @@ GTEST_TEST(detray_intersection, cylinder_portal) {
     const transform3_t identity{};
     mask<cylinder2D, std::uint_least16_t, algebra_t> cylinder{0u, r, -hz, hz};
 
-    ray_intersector<cylinder2D, algebra_t> ci;
-    ray_intersector<concentric_cylinder2D, algebra_t> cpi;
+    ray_intersector<cylinder2D, algebra_t, true> ci;
+    ray_intersector<concentric_cylinder2D, algebra_t, true> cpi;
 
     // Intersect
     const auto hits_cylinrical =
@@ -145,8 +145,8 @@ GTEST_TEST(detray_intersection, concentric_cylinders) {
     const transform3_t identity{};
     mask<cylinder2D, std::uint_least16_t, algebra_t> cylinder{0u, r, -hz, hz};
 
-    ray_intersector<cylinder2D, algebra_t> ci;
-    ray_concentric_cylinder_intersector<algebra_t> cci;
+    ray_intersector<cylinder2D, algebra_t, true> ci;
+    ray_concentric_cylinder_intersector<algebra_t, true> cci;
 
     // Intersect
     const auto hits_cylinrical =

--- a/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
@@ -38,7 +38,7 @@ using transform3_t = test::transform3;
 using vector3 = test::vector3;
 using point3 = test::point3;
 using helix_t = detray::detail::helix<algebra_t>;
-using intersection_t = intersection2D<surface_descriptor<>, algebra_t>;
+using intersection_t = intersection2D<surface_descriptor<>, algebra_t, true>;
 
 constexpr auto not_defined{detail::invalid_value<scalar>()};
 constexpr scalar tol{1e-4f};

--- a/tests/unit_tests/cpu/navigation/intersection/intersection2D.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection2D.cpp
@@ -39,6 +39,7 @@ constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
 }  // namespace
 
 using algebra_t = test::algebra;
+using scalar_t = dscalar<algebra_t>;
 using point2 = test::point2;
 using vector3 = test::vector3;
 using point3 = test::point3;
@@ -50,14 +51,29 @@ using surface_t = surface_descriptor<mask_link_t, material_link_t, algebra_t>;
 // This tests the construction of a intresection
 GTEST_TEST(detray_intersection, intersection2D) {
 
-    using intersection_t = intersection2D<surface_t, algebra_t>;
+    using intersection_t = intersection2D<surface_t, algebra_t, true>;
+    using nominal_inters_t = intersection2D<surface_t, algebra_t, false>;
 
-    intersection_t i0 = {surface_t{}, point3{0.2f, 0.4f, 0.f}, 2.f, 1u, false,
-                         true};
+    // Check memory layout of intersection struct
+    static_assert(offsetof(nominal_inters_t, sf_desc) == 0);
+    static_assert(offsetof(nominal_inters_t, path) == 16);
+    // Depends on floating point precision of 'path' member variable
+    static_assert((offsetof(nominal_inters_t, volume_link) == 20) ||
+                  (offsetof(nominal_inters_t, volume_link) == 24));
+    static_assert((offsetof(nominal_inters_t, status) == 22) ||
+                  (offsetof(nominal_inters_t, status) == 26));
+    static_assert((offsetof(nominal_inters_t, direction) == 23) ||
+                  (offsetof(nominal_inters_t, direction) == 27));
 
-    intersection_t i1 = {
-        surface_t{}, point3{0.2f, 0.4f, 0.f}, 1.7f, 0u, true, false,
-    };
+    // 24 bytes for single precision, 32 bytes for double
+    static_assert((sizeof(nominal_inters_t) == 24) ||
+                  (sizeof(nominal_inters_t) == 32));
+
+    const surface_t sf{};
+    const point3 test_pt{0.2f, 0.4f, 0.f};
+
+    intersection_t i0{{sf, 2.f, 1u, false, true}, test_pt};
+    intersection_t i1{{sf, 1.7f, 0u, true, false}, test_pt};
 
     intersection_t invalid{};
     ASSERT_FALSE(invalid.status);

--- a/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
@@ -155,7 +155,7 @@ GTEST_TEST(detray_intersection, intersection_kernel_ray) {
         expected_cylinder1, expected_cylinder2, expected_cylinder_pt};
 
     // Initialize kernel
-    std::vector<intersection2D<surface_t, algebra_t>> sfi_init;
+    std::vector<intersection2D<surface_t, algebra_t, true>> sfi_init;
     sfi_init.reserve(expected_points.size());
 
     for (const auto &surface : surfaces) {
@@ -285,7 +285,7 @@ GTEST_TEST(detray_intersection, intersection_kernel_helix) {
     const point3 expected_annulus{0.03f, 0.03f, 30.f};
     const std::vector<point3> expected_points = {
         expected_rectangle, expected_trapezoid, expected_annulus};
-    std::vector<intersection2D<surface_t, algebra_t>> sfi_helix{};
+    std::vector<intersection2D<surface_t, algebra_t, true>> sfi_helix{};
     sfi_helix.reserve(expected_points.size());
 
     // Try the intersections - with automated dispatching via the kernel

--- a/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
@@ -33,8 +33,8 @@ using cartesian = cartesian2D<transform3>;
 using vector3 = test::vector3;
 using point3 = test::point3;
 using point2 = test::point2;
-using intersection_t = intersection2D<surface_descriptor<>, algebra_t>;
-using line_intersector_type = ray_intersector<line_circular, algebra_t>;
+using intersection_t = intersection2D<surface_descriptor<>, algebra_t, true>;
+using line_intersector_type = ray_intersector<line_circular, algebra_t, true>;
 
 constexpr scalar tol{1e-5f};
 

--- a/tests/unit_tests/cpu/navigation/intersection/plane_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/plane_intersector.cpp
@@ -44,7 +44,7 @@ GTEST_TEST(detray_intersection, translated_plane_ray) {
     const detail::ray<algebra_t> r(pos, 0.f, mom, 0.f);
 
     // The same test but bound to local frame
-    ray_intersector<unmasked<2>, algebra_t> pi;
+    ray_intersector<unmasked<2>, algebra_t, true> pi;
     mask<unmasked<2>> unmasked_bound{};
     const auto hit_bound =
         pi(r, surface_descriptor<>{}, unmasked_bound, shifted);

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -38,7 +38,6 @@ using algebra_t = test::algebra;
 using point2 = test::point2;
 using vector3 = test::vector3;
 using matrix_operator = test::matrix_operator;
-using intersection_t = intersection2D<surface_descriptor<>, algebra_t>;
 
 // Mask types to be tested
 // @TODO: Remove unbounded tag

--- a/tests/unit_tests/device/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda.cpp
@@ -75,17 +75,20 @@ TEST(navigator_cuda, navigator) {
         stepper_t::state& stepping = propagation._stepping;
 
         // Start propagation and record volume IDs
-        bool heartbeat = nav.init(stepping(), navigation, nav_cfg);
+        nav.init(stepping(), navigation, nav_cfg);
+        bool heartbeat = navigation.is_alive();
+        bool do_reset{true};
+
         while (heartbeat) {
 
-            const bool do_reset{navigation.is_on_surface() ||
-                                navigation.is_init()};
             heartbeat &=
                 stepper.step(navigation(), stepping, step_cfg, do_reset);
 
             navigation.set_high_trust();
 
-            heartbeat &= nav.update(stepping(), navigation, nav_cfg);
+            do_reset = nav.update(stepping(), navigation, nav_cfg);
+            do_reset |= navigation.is_on_surface();
+            heartbeat &= navigation.is_alive();
 
             // Record volume
             volume_records_host[i].push_back(navigation.volume());

--- a/tutorials/include/detray/tutorial/detector_metadata.hpp
+++ b/tutorials/include/detray/tutorial/detector_metadata.hpp
@@ -71,7 +71,7 @@ struct my_metadata {
     /// How to index the constituent objects in a volume
     /// If they share the same index value here, they will be added into the
     /// same acceleration data structure in every respective volume
-    enum geo_objects : std::uint8_t {
+    enum geo_objects : std::uint_least8_t {
         e_surface = 0u,  //< This detector keeps all surfaces in the same
                          //  acceleration data structure (id 0)
         e_size = 1u
@@ -91,7 +91,7 @@ struct my_metadata {
     /// good idea to have the most common types in the first tuple entries, in
     /// order to minimize the depth of the 'unrolling' before a mask is found
     /// in the tuple
-    enum class mask_ids : std::uint8_t {
+    enum class mask_ids : std::uint_least8_t {
         e_square2 = 0,
         e_trapezoid2 = 1,
         e_portal_rectangle2 = 2
@@ -107,7 +107,7 @@ struct my_metadata {
                             trapezoid, rectangle>;
 
     /// Similar to the mask store, there is a material store, which
-    enum class material_ids : std::uint8_t {
+    enum class material_ids : std::uint_least8_t {
         e_slab = 0,
         e_none = 1,
     };
@@ -131,7 +131,7 @@ struct my_metadata {
 
     /// The acceleration data structures live in another tuple that needs to
     /// indexed correctly
-    enum class accel_ids : std::uint8_t {
+    enum class accel_ids : std::uint_least8_t {
         e_brute_force = 0,  //< test all surfaces in a volume (brute force)
         e_default = e_brute_force,
     };

--- a/tutorials/src/cpu/propagation/navigation_inspection.cpp
+++ b/tutorials/src/cpu/propagation/navigation_inspection.cpp
@@ -36,7 +36,7 @@ int main() {
     /// Type that holds the intersection information
     using intersection_t =
         detray::intersection2D<typename toy_detector_t::surface_type,
-                               detray::tutorial::algebra_t>;
+                               detray::tutorial::algebra_t, true>;
 
     /// Inspector that records all encountered surfaces
     using object_tracer_t = detray::navigation::object_tracer<
@@ -55,8 +55,8 @@ int main() {
     constexpr std::size_t cache_size{detray::navigation::default_cache_size};
 
     // Navigation with inspection
-    using navigator_t =
-        detray::navigator<toy_detector_t, cache_size, inspector_t>;
+    using navigator_t = detray::navigator<toy_detector_t, cache_size,
+                                          inspector_t, intersection_t>;
     // Line stepper
     using stepper_t = detray::line_stepper<detray::tutorial::algebra_t>;
     // Propagator with empty actor chain


### PR DESCRIPTION
Reduce the size of the navigation state to 256 bytes (single precision) by reducing the sizes of the involved data types and conditionally removing the local position from the intersection struct. The local position is currently only used in validation code and removing it brings a measurable performance benefit. This PR also removes the ```is_init``` flag from the navigator state and returns it from the update call instead. The navigation/propagation heartbeat can be obtained from the states instead.