### PR TITLE
Project Export Fix, main branch (2024.10.24.)

### DIFF
--- a/cmake/detray-config.cmake.in
+++ b/cmake/detray-config.cmake.in
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -14,7 +14,6 @@ set( DETRAY_SMATRIX_PLUGIN @DETRAY_SMATRIX_PLUGIN@ )
 set( DETRAY_VC_AOS_PLUGIN @DETRAY_VC_AOS_PLUGIN@ )
 set( DETRAY_VC_SOA_PLUGIN @DETRAY_VC_SOA_PLUGIN@ )
 set( DETRAY_DISPLAY @DETRAY_DISPLAY@ )
-set( DETRAY_BUILD_CUDA @DETRAY_BUILD_CUDA@ )
 
 # Set up some simple variables for using the package.
 set( detray_VERSION "@PROJECT_VERSION@" )
@@ -25,6 +24,7 @@ set_and_check( detray_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@" )
 # Find all packages that Detray needs to function.
 include( CMakeFindDependencyMacro )
 find_dependency( algebra-plugins )
+find_dependency( covfie )
 find_dependency( vecmem )
 find_dependency( dfelibs )
 find_dependency( nlohmann_json )


### PR DESCRIPTION
Made the installed project look for [covfie](https://github.com/acts-project/covfie). Similar to https://github.com/acts-project/acts/pull/3779, I bumped into this issue as well while helping Neza with using [traccc](https://github.com/acts-project/traccc) in [Athena](https://gitlab.cern.ch/atlas/athena/-/tree/main/Projects/Athena).

At the same time removed the `DETRAY_BUILD_CUDA` flag, as it's not relevant for an installed version of the project. 🤔