### PR TITLE
Benchmarking On Main Repo Only, main branch (2024.10.24.)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,3 +1,9 @@
+# Detray library, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
 name: Benchmarks
 
 on:
@@ -6,6 +12,7 @@ on:
       - main
 jobs:
   detray_benchmark_job:
+    if: github.repository == 'acts-project/detray'
     runs-on: ubuntu-latest
     steps:
       - run: >


### PR DESCRIPTION
Only run benchmarking on the main repository. So that it wouldn't start every time I update the `main` branch of my fork. 🤔

![image](https://github.com/user-attachments/assets/646ce915-f6b3-449d-a07b-a07b93032e4a)

The formalism is the same that I used for achieving the same with the Doxygen documentation generation in [vecmem](https://github.com/acts-project/vecmem):

https://github.com/acts-project/vecmem/blob/main/.github/workflows/pages.yml#L32