### PR TITLE
Remove unneeded state from Runge-Kutta stepper

### DIFF
--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -456,17 +456,6 @@ struct print_inspector {
         debug_stream << "Step size scale factor"
                      << "\t\t" << step_scalor << std::endl;
 
-        debug_stream << "Bfield points:" << std::endl;
-        const auto &f = state.step_data().b_first;
-        debug_stream << "\tfirst:" << tabs << f[0] << ", " << f[1] << ", "
-                     << f[2] << std::endl;
-        const auto &m = state.step_data().b_middle;
-        debug_stream << "\tmiddle:" << tabs << m[0] << ", " << m[1] << ", "
-                     << m[2] << std::endl;
-        const auto &l = state.step_data().b_last;
-        debug_stream << "\tlast:" << tabs << l[0] << ", " << l[1] << ", "
-                     << l[2] << std::endl;
-
         debug_stream << std::endl;
     }
 


### PR DESCRIPTION
Currently, the Runge-Kutta stepper holds a lot of state which is used only internally. The size of this state is 164 bytes, of which only 140 bytes are needed after the step. Keeping the remaining state between steps is therefore taking up a lot of memory.

In this PR, I remove this internal state from the externally facing stepper state and turn it into an intermediate struct which is not stored persistently, saving 140 bytes on the size of the stepper state (and, with it, the propagator state).