### PR TITLE
Add more `detray::tuple` features

### DIFF
--- a/core/include/detray/utils/tuple.hpp
+++ b/core/include/detray/utils/tuple.hpp
@@ -24,12 +24,26 @@ struct tuple<T, Ts...> {
 
     DETRAY_HOST_DEVICE constexpr tuple(){};
 
+    constexpr tuple(const tuple &o) requires(
+        std::is_copy_constructible_v<T> &&
+        (std::is_copy_constructible_v<Ts> && ...)) = default;
+
     template <typename U, typename... Us>
     requires std::is_constructible_v<T, U &&>
         &&std::is_constructible_v<tuple<Ts...>, Us &&...>
             DETRAY_HOST_DEVICE explicit constexpr tuple(
                 const tuple<U, Us...> &o)
         : v(o.v), r(o.r) {}
+
+    constexpr tuple(tuple &&o) noexcept
+        requires(std::is_move_constructible_v<T> &&
+                 (std::is_move_constructible_v<Ts> && ...)) = default;
+
+    template <typename U, typename... Us>
+    requires std::is_constructible_v<T, U &&>
+        &&std::is_constructible_v<tuple<Ts...>, Us &&...>
+            DETRAY_HOST_DEVICE explicit constexpr tuple(tuple<U, Us...> &&o)
+        : v(std::move(o.v)), r(std::move(o.r)) {}
 
     template <typename U, typename... Us>
         requires std::is_constructible_v<T, U &&>
@@ -40,9 +54,42 @@ struct tuple<T, Ts...> {
         : v(std::forward<U>(_v)),
     r(std::forward<Us>(_r)...) {}
 
+    constexpr ~tuple() noexcept = default;
+
+    constexpr tuple &operator=(const tuple &other) requires(
+        std::is_copy_assignable_v<T> &&
+        (std::is_copy_assignable_v<Ts> && ...)) = default;
+
+    template <typename U, typename... Us>
+    DETRAY_HOST_DEVICE constexpr tuple &
+    operator=(const tuple<U, Us...> &other) requires(
+        std::is_assignable_v<T &, const U &> &&
+        (std::is_assignable_v<Ts &, const Us &> && ...)) {
+        v = other.v;
+        r = other.r;
+        return *this;
+    }
+
+    constexpr tuple &operator=(tuple &&other) noexcept
+        requires(std::is_move_assignable_v<T> &&
+                 (std::is_move_assignable_v<Ts> && ...)) = default;
+
+    template <typename U, typename... Us>
+    DETRAY_HOST_DEVICE constexpr tuple &operator=(
+        tuple<U, Us...> &&other) requires(std::is_assignable_v<T &, U> &&
+                                          (std::is_assignable_v<Ts &, Us> &&
+                                           ...)) {
+        v = std::move(other.v);
+        r = std::move(other.r);
+        return *this;
+    }
+
     T v;
     tuple<Ts...> r;
 };
+
+template <typename T1, typename T2>
+using pair = tuple<T1, T2>;
 
 template <std::size_t I, typename... Ts>
 DETRAY_HOST_DEVICE const auto &get(const detray::tuple<Ts...> &t) noexcept {
@@ -95,5 +142,18 @@ DETRAY_HOST_DEVICE auto &get(detray::tuple<T, Ts...> &t) noexcept {
 template <typename... Ts>
 DETRAY_HOST_DEVICE constexpr detray::tuple<Ts &...> tie(Ts &... args) {
     return detray::tuple<Ts &...>(args...);
+}
+
+template <typename... Ts>
+DETRAY_HOST_DEVICE constexpr detray::tuple<std::decay_t<Ts>...> make_tuple(
+    Ts &&... vs) {
+    return detray::tuple<std::decay_t<Ts>...>(std::forward<Ts>(vs)...);
+}
+
+template <typename T1, typename T2>
+DETRAY_HOST_DEVICE constexpr detray::pair<std::decay_t<T1>, std::decay_t<T2>>
+make_pair(T1 &&v1, T2 &&v2) {
+    return detray::pair<std::decay_t<T1>, std::decay_t<T2>>(
+        std::forward<T1>(v1), std::forward<T2>(v2));
 }
 }  // namespace detray


### PR DESCRIPTION
The current tuple definition is a bit barebones and does not allow assignment on `detray::tie` objects. This commit adds additional functionality to the detray tuple, including assingment.