### PR TITLE
ref: Remove code duplication from helix intersectors

### DIFF
--- a/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,10 +19,7 @@
 #include "detray/navigation/intersection/ray_cylinder_intersector.hpp"
 #include "detray/tracks/helix.hpp"
 #include "detray/utils/invalid_values.hpp"
-
-// System include(s)
-#include <limits>
-#include <type_traits>
+#include "detray/utils/root_finding.hpp"
 
 namespace detray {
 
@@ -39,12 +36,11 @@ template <algebra::concepts::aos algebra_t>
 struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
     : public ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t,
                                   intersection::contains_pos> {
+    private:
+    using scalar_t = dscalar<algebra_t>;
 
+    public:
     using algebra_type = algebra_t;
-    using scalar_type = dscalar<algebra_t>;
-    using point3_type = dpoint3D<algebra_t>;
-    using vector3_type = dvector3D<algebra_t>;
-    using transform3_type = dtransform3D<algebra_t>;
 
     template <typename surface_descr_t>
     using intersection_type =
@@ -58,204 +54,117 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
 
     using result_type = darray<intersection_point_err<algebra_t>, n_solutions>;
 
-    /// Operator function to find intersections between ray and planar mask
+    /// Operator function to find intersections between a helix and a cylinder
+    /// surface
     ///
-    /// @param ray is the input ray trajectory
-    /// @param sf the surface handle the mask is associated with
-    /// @param mask is the input mask that defines the surface extent
+    /// @param h is the input helix trajectory
     /// @param trf is the surface placement transform
-    /// @param mask_tolerance is the tolerance for mask edges
-    /// @param overstep_tol negative cutoff for the path
+    /// @param mask is the input mask that defines the surface extent
     ///
     /// @return the intersection
     template <typename mask_t>
     DETRAY_HOST_DEVICE constexpr result_type point_of_intersection(
-        const trajectory_type<algebra_t> &h, const transform3_type &trf,
-        const mask_t &mask, const scalar_type = 0.f) const {
+        const trajectory_type<algebra_t> &h, const dtransform3D<algebra_t> &trf,
+        const mask_t &mask, const scalar_t = 0.f) const {
+
+        using point3_t = dpoint3D<algebra_t>;
+        using vector3_t = dvector3D<algebra_t>;
 
         result_type ret{};
 
-        if (!run_rtsafe) {
-            // Get the surface placement
-            const auto &sm = trf.matrix();
-            // Cylinder z axis
-            const vector3_type sz = getter::vector<3>(sm, 0u, 2u);
-            // Cylinder centre
-            const point3_type sc = getter::vector<3>(sm, 0u, 3u);
+        // Cylinder z axis
+        const vector3_t sz = trf.z();
+        // Cylinder centre
+        const point3_t sc = trf.translation();
 
-            // Starting point on the helix for the Newton iteration
-            // The mask is a cylinder -> it provides its radius as the first
-            // value
-            const scalar_type r{mask[cylinder2D::e_r]};
+        // Starting point on the helix for the Newton iteration
+        // The mask is a cylinder -> it provides its radius as the first
+        // value
+        const scalar_t r{mask[cylinder2D::e_r]};
 
-            // Try to guess the best starting positions for the iteration
+        // Try to guess the best starting positions for the iteration
 
-            // Direction of the track at the helix origin
-            const auto h_dir = h.dir(0.f);
-            // Default starting path length for the Newton iteration (assumes
-            // concentric cylinder)
-            const scalar_type default_s{r * vector::perp(h_dir)};
+        // Direction of the track at the helix origin
+        const auto h_dir = h.dir(0.5f * r);
+        // Default starting path length for the Newton iteration (assumes
+        // concentric cylinder)
+        const scalar_t default_s{r * vector::perp(h_dir)};
 
-            // Initial helix path length parameter
-            darray<scalar_type, 2> paths{default_s, default_s};
+        // Initial helix path length parameter
+        darray<scalar_t, 2> paths{default_s, default_s};
 
-            // try to guess good starting path by calculating the intersection
-            // path of the helix tangential with the cylinder. This only has a
-            // chance of working for tracks with reasonably high p_T !
-            detail::ray<algebra_t> t{h.pos(), h.time(), h_dir, h.qop()};
-            const auto qe = this->solve_intersection(t, mask, trf);
+        // try to guess good starting path by calculating the intersection
+        // path of the helix tangential with the cylinder. This only has a
+        // chance of working for tracks with reasonably high p_T !
+        detail::ray<algebra_t> t{h.pos(), h.time(), h_dir, h.qop()};
+        const auto qe = this->solve_intersection(t, mask, trf);
 
-            // Obtain both possible solutions by looping over the (different)
-            // starting positions
-            auto n_runs{static_cast<unsigned int>(qe.solutions())};
+        // Obtain both possible solutions by looping over the (different)
+        // starting positions
+        auto n_runs{static_cast<unsigned int>(qe.solutions())};
 
-            // Note: the default path length might be smaller than either
-            // solution
-            switch (qe.solutions()) {
-                case 2:
-                    paths[1] = qe.larger();
-                    // If there are two solutions, reuse the case for a single
-                    // solution to setup the intersection with the smaller path
-                    // in ret[0]
-                    [[fallthrough]];
-                case 1: {
-                    paths[0] = qe.smaller();
-                    break;
-                }
-                    // Even if the ray is parallel to the cylinder, the helix
-                    // might still hit it
-                default: {
-                    n_runs = 2u;
-                    paths[0] = r;
-                    paths[1] = -r;
-                }
+        // Note: the default path length might be smaller than either
+        // solution
+        switch (qe.solutions()) {
+            case 2:
+                paths[1] = qe.larger();
+                // If there are two solutions, reuse the case for a single
+                // solution to setup the intersection with the smaller path
+                // in ret[0]
+                [[fallthrough]];
+            case 1: {
+                paths[0] = qe.smaller();
+                break;
             }
-
-            for (unsigned int i = 0u; i < n_runs; ++i) {
-
-                scalar_type &s = paths[i];
-
-                // Path length in the previous iteration step
-                scalar_type s_prev{0.f};
-
-                // f(s) = ((h.pos(s) - sc) x sz)^2 - r^2 == 0
-                // Run the iteration on s
-                std::size_t n_tries{0u};
-                while (math::fabs(s - s_prev) > convergence_tolerance &&
-                       n_tries < max_n_tries) {
-
-                    // f'(s) = 2 * ( (h.pos(s) - sc) x sz) * (h.dir(s) x sz) )
-                    const vector3_type crp = vector::cross(h.pos(s) - sc, sz);
-                    const scalar_type denom{
-                        2.f * vector::dot(crp, vector::cross(h.dir(s), sz))};
-
-                    // No intersection can be found if dividing by zero
-                    if (denom == 0.f) {
-                        return {};
-                    }
-
-                    // x_n+1 = x_n - f(s) / f'(s)
-                    s_prev = s;
-                    s -= (vector::dot(crp, crp) - r * r) / denom;
-
-                    ++n_tries;
-                }
-                // No intersection found within max number of trials
-                if (n_tries == max_n_tries) {
-                    return {};
-                }
-
-                ret[i] = {s, h.pos(s), s - s_prev};
+            default: {
+                n_runs = 2u;
+                paths[0] = r;
+                paths[1] = -r;
             }
-
-            return ret;
-        } else {
-            // Cylinder z axis
-            const vector3_type sz = trf.z();
-            // Cylinder centre
-            const point3_type sc = trf.translation();
-
-            // Starting point on the helix for the Newton iteration
-            // The mask is a cylinder -> it provides its radius as the first
-            // value
-            const scalar_type r{mask[cylinder2D::e_r]};
-
-            // Try to guess the best starting positions for the iteration
-
-            // Direction of the track at the helix origin
-            const auto h_dir = h.dir(0.5f * r);
-            // Default starting path length for the Newton iteration (assumes
-            // concentric cylinder)
-            const scalar_type default_s{r * vector::perp(h_dir)};
-
-            // Initial helix path length parameter
-            darray<scalar_type, 2> paths{default_s, default_s};
-
-            // try to guess good starting path by calculating the intersection
-            // path of the helix tangential with the cylinder. This only has a
-            // chance of working for tracks with reasonably high p_T !
-            detail::ray<algebra_t> t{h.pos(), h.time(), h_dir, h.qop()};
-            const auto qe = this->solve_intersection(t, mask, trf);
-
-            // Obtain both possible solutions by looping over the (different)
-            // starting positions
-            auto n_runs{static_cast<unsigned int>(qe.solutions())};
-
-            // Note: the default path length might be smaller than either
-            // solution
-            switch (qe.solutions()) {
-                case 2:
-                    paths[1] = qe.larger();
-                    // If there are two solutions, reuse the case for a single
-                    // solution to setup the intersection with the smaller path
-                    // in ret[0]
-                    [[fallthrough]];
-                case 1: {
-                    paths[0] = qe.smaller();
-                    break;
-                }
-                default: {
-                    n_runs = 2u;
-                    paths[0] = r;
-                    paths[1] = -r;
-                }
-            }
-
-            /// Evaluate the function and its derivative at the point @param x
-            auto cyl_inters_func = [&h, &r, &sz, &sc](const scalar_type x) {
-                const vector3_type crp = vector::cross(h.pos(x) - sc, sz);
-
-                // f(s) = ((h.pos(s) - sc) x sz)^2 - r^2 == 0
-                const scalar_type f_s{(vector::dot(crp, crp) - r * r)};
-                // f'(s) = 2 * ( (h.pos(s) - sc) x sz) * (h.dir(s) x sz) )
-                const scalar_type df_s{
-                    2.f * vector::dot(crp, vector::cross(h.dir(x), sz))};
-
-                return std::make_tuple(f_s, df_s);
-            };
-
-            for (unsigned int i = 0u; i < n_runs; ++i) {
-
-                const scalar_type &s_ini = paths[i];
-
-                // Run the root finding algorithm
-                const auto [s, ds] = newton_raphson_safe(cyl_inters_func, s_ini,
-                                                         convergence_tolerance,
-                                                         max_n_tries, max_path);
-
-                ret[i] = {s, h.pos(s), ds};
-            }
-
-            return ret;
         }
+
+        /// Evaluate the function and its derivative at the point @param x
+        auto cyl_inters_func = [&h, &r, &sz, &sc](const scalar_t x) {
+            const vector3_t crp = vector::cross(h.pos(x) - sc, sz);
+
+            // f(s) = ((h.pos(s) - sc) x sz)^2 - r^2 == 0
+            const scalar_t f_s{(vector::dot(crp, crp) - r * r)};
+            // f'(s) = 2 * ( (h.pos(s) - sc) x sz) * (h.dir(s) x sz) )
+            const scalar_t df_s{2.f *
+                                vector::dot(crp, vector::cross(h.dir(x), sz))};
+
+            return std::make_tuple(f_s, df_s);
+        };
+
+        for (unsigned int i = 0u; i < n_runs; ++i) {
+
+            const scalar_t &s_ini = paths[i];
+
+            // Run the root finding algorithm
+            scalar_t s;
+            scalar_t ds;
+            if (run_rtsafe) {
+                std::tie(s, ds) = newton_raphson_safe(cyl_inters_func, s_ini,
+                                                      convergence_tolerance,
+                                                      max_n_tries, max_path);
+            } else {
+                std::tie(s, ds) = newton_raphson(cyl_inters_func, s_ini,
+                                                 convergence_tolerance,
+                                                 max_n_tries, max_path);
+            }
+
+            ret[i] = {s, h.pos(s), ds};
+        }
+
+        return ret;
     }
 
     /// Tolerance for convergence
-    scalar_type convergence_tolerance{1.f * unit<scalar_type>::um};
+    scalar_t convergence_tolerance{1.f * unit<scalar_t>::um};
     // Guard against inifinite loops
     std::size_t max_n_tries{1000u};
     // Early exit, if the intersection is too far away
-    scalar_type max_path{5.f * unit<scalar_type>::m};
+    scalar_t max_path{5.f * unit<scalar_t>::m};
     // Complement the Newton algorithm with Bisection steps
     bool run_rtsafe{true};
 };
@@ -264,14 +173,7 @@ template <concepts::algebra algebra_t>
 struct helix_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t>
     : public helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t> {
 
-    using base_type =
-        helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>;
-
     using algebra_type = algebra_t;
-    using scalar_type = dscalar<algebra_t>;
-    using point3_type = dpoint3D<algebra_t>;
-    using vector3_type = dvector3D<algebra_t>;
-    using transform3_type = dtransform3D<algebra_t>;
 
     template <typename surface_descr_t>
     using intersection_type =
@@ -285,24 +187,25 @@ struct helix_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t>
 
     using result_type = intersection_point_err<algebra_t>;
 
-    /// Operator function to find intersections between ray and planar mask
+    /// Operator function to find intersections between helix and a
+    /// concentric cylinder surface
     ///
-    /// @param ray is the input ray trajectory
-    /// @param sf the surface handle the mask is associated with
-    /// @param mask is the input mask that defines the surface extent
+    /// @param h is the input helix trajectory
     /// @param trf is the surface placement transform
-    /// @param mask_tolerance is the tolerance for mask edges
-    /// @param overstep_tol negative cutoff for the path
+    /// @param mask is the input mask that defines the surface extent
     ///
     /// @return the intersection
     template <typename mask_t>
     DETRAY_HOST_DEVICE constexpr result_type point_of_intersection(
-        const trajectory_type<algebra_t> &h, const transform3_type &trf,
-        const mask_t &mask, const scalar_type = 0.f) const {
+        const trajectory_type<algebra_t> &h, const dtransform3D<algebra_t> &trf,
+        const mask_t &mask, const dscalar<algebra_t> = 0.f) const {
+
+        using base_t =
+            helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>;
 
         // Array of two solutions
-        typename base_type::result_type results =
-            base_type::point_of_intersection(h, trf, mask, 0.f);
+        typename base_t::result_type results =
+            base_t::point_of_intersection(h, trf, mask, 0.f);
 
         // For portals, only take the solution along the helix direction,
         // not the one in the opposite direction

--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,10 +16,7 @@
 #include "detray/navigation/intersection/intersection.hpp"
 #include "detray/tracks/helix.hpp"
 #include "detray/utils/log.hpp"
-
-// System include(s)
-#include <iostream>
-#include <type_traits>
+#include "detray/utils/root_finding.hpp"
 
 namespace detray {
 
@@ -34,11 +31,11 @@ struct helix_intersector_impl;
 template <algebra::concepts::aos algebra_t>
 struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
 
+    private:
+    using scalar_t = dscalar<algebra_t>;
+
+    public:
     using algebra_type = algebra_t;
-    using scalar_type = dscalar<algebra_t>;
-    using point3_type = dpoint3D<algebra_t>;
-    using vector3_type = dvector3D<algebra_t>;
-    using transform3_type = dtransform3D<algebra_t>;
 
     template <typename surface_descr_t>
     using intersection_type =
@@ -52,191 +49,111 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
 
     using result_type = intersection_point_err<algebra_t>;
 
-    /// Operator function to find intersections between ray and planar mask
+    /// Operator function to find intersections between a helix and a line
+    /// surface
     ///
     /// @param h is the input helix trajectory
-    /// @param sf the surface handle the mask is associated with
     /// @param trf is the surface placement transform
-    /// @param mask_tolerance is the tolerance for mask edges
-    /// @param overstep_tol negative cutoff for the path
     ///
     /// @return the intersection
     DETRAY_HOST_DEVICE constexpr result_type point_of_intersection(
-        const trajectory_type<algebra_t> &h, const transform3_type &trf,
-        const scalar_type = 0.f) const {
+        const trajectory_type<algebra_t> &h, const dtransform3D<algebra_t> &trf,
+        const scalar_t = 0.f) const {
 
-        if (!run_rtsafe) {
-            // line axis direction
-            const vector3_type l = getter::vector<3>(trf.matrix(), 0u, 2u);
+        using point3_t = dpoint3D<algebra_t>;
+        using vector3_t = dvector3D<algebra_t>;
 
-            // line center
-            const point3_type c = trf.translation();
+        // line axis direction
+        const vector3_t l = getter::vector<3>(trf.matrix(), 0u, 2u);
 
-            // initial track direction
-            const vector3_type t0 = h.dir(0.f);
+        // line center
+        const point3_t c = trf.translation();
 
-            // initial track position
-            const point3_type r0 = h.pos(0.f);
+        // initial track direction
+        const vector3_t t0 = h.dir(0.f);
 
-            // Projection of line to track direction
-            const scalar_type lt0{vector::dot(l, t0)};
+        // initial track position
+        const point3_t r0 = h.pos(0.f);
 
-            const scalar_type denom{1.f - (lt0 * lt0)};
+        // Projection of line to track direction
+        const scalar_t lt0{vector::dot(l, t0)};
 
-            // Case for wire is parallel to track
-            // @NOTE We might not have to call this which is meant to be for ray
-            // intersection...
-            if (denom < 1e-5f) {
-                return {};
-            }
+        const scalar_t denom{1.f - (lt0 * lt0)};
 
-            // vector from track position to line center
-            const vector3_type D = c - r0;
-
-            // D projection on line direction
-            const scalar_type P{vector::dot(D, l)};
-
-            // D projection on track direction
-            const scalar_type Q{vector::dot(D, t0)};
-
-            // Path length to the point of closest approach on the track
-            // @NOTE Ray intersection algorithm is used for the initial guess on
-            // the path length
-            scalar_type s{1.f / denom * (Q - P * lt0)};
-            scalar_type s_prev{0.f};
-
-            // Run the iteration on s
-            std::size_t n_tries{0u};
-            while (math::fabs(s - s_prev) > convergence_tolerance &&
-                   n_tries < max_n_tries) {
-
-                // track direction
-                const vector3_type t = h.dir(s);
-
-                // track position
-                const point3_type r = h.pos(s);
-
-                // Projection of (track position - center) to the line
-                const scalar_type A = vector::dot(r - c, l);
-
-                // Vector orthogonal to the line and passing the track position
-                // w = r - (c + ((r - c) * l)l)
-                const vector3_type w = r - (c + A * l);
-
-                // f(s) = t * w = 0
-                const scalar_type f = vector::dot(t, w);
-
-                // dtds = d^2r/ds^2 = qop * (t X b_field)
-                const vector3_type dtds =
-                    h.qop() * vector::cross(t, h.b_field());
-                // dwds = t - (t * l)l
-                const vector3_type dwds = t - vector::dot(t, l) * l;
-
-                // f'(s) = dtds * w + t * dwds
-                const scalar_type dfds =
-                    vector::dot(dtds, w) + vector::dot(t, dwds);
-
-                // x_n+1 = x_n - f(s) / f'(s)
-                s_prev = s;
-                s -= f / dfds;
-
-                ++n_tries;
-            }
-
-            // No intersection found within max number of trials
-            if (n_tries == max_n_tries) {
-                return {};
-            }
-
-            return {s, h.pos(s), s - s_prev};
-        } else {
-            // line axis direction
-            const vector3_type l = getter::vector<3>(trf.matrix(), 0u, 2u);
-
-            // line center
-            const point3_type c = trf.translation();
-
-            // initial track direction
-            const vector3_type t0 = h.dir(0.f);
-
-            // initial track position
-            const point3_type r0 = h.pos(0.f);
-
-            // Projection of line to track direction
-            const scalar_type lt0{vector::dot(l, t0)};
-
-            const scalar_type denom{1.f - (lt0 * lt0)};
-
-            // Case for wire is parallel to track
-            // @NOTE We might not have to call this which is meant to be for ray
-            // intersection...
-            if (denom < 1e-5f) {
-                DETRAY_ERROR_HOST(
-                    "Helix line intersector encountered "
-                    "invalid value!");
-                return {};
-            }
-
-            // vector from track position to line center
-            const vector3_type D = c - r0;
-
-            // D projection on line direction
-            const scalar_type P{vector::dot(D, l)};
-
-            // D projection on track direction
-            const scalar_type Q{vector::dot(D, t0)};
-
-            // Path length to the point of closest approach on the track
-            // @NOTE Ray intersection algorithm is used for the initial guess on
-            // the path length
-            scalar_type s_ini{1.f / denom * (Q - P * lt0)};
-
-            /// Evaluate the function and its derivative at the point @param x
-            auto line_inters_func = [&h, &c, &l](const scalar_type x) {
-                // track direction
-                const vector3_type t = h.dir(x);
-
-                // track position
-                const point3_type r = h.pos(x);
-
-                // Projection of (track position - center) to the line
-                const scalar_type A = vector::dot(r - c, l);
-
-                // Vector orthogonal to the line and passing the track position
-                // w = r - (c + ((r - c) * l)l)
-                const vector3_type w = r - (c + A * l);
-
-                // f(s) = t * w = 0
-                const scalar_type f = vector::dot(t, w);
-
-                // dtds = d^2r/ds^2 = qop * (t X b_field)
-                const vector3_type dtds =
-                    h.qop() * vector::cross(t, h.b_field());
-                // dwds = t - (t * l)l
-                const vector3_type dwds = t - vector::dot(t, l) * l;
-
-                // f'(s) = dtds * w + t * dwds
-                const scalar_type dfds =
-                    vector::dot(dtds, w) + vector::dot(t, dwds);
-
-                return std::make_tuple(f, dfds);
-            };
-
-            // Run the root finding algorithm
-            const auto [s, ds] = newton_raphson_safe(line_inters_func, s_ini,
-                                                     convergence_tolerance,
-                                                     max_n_tries, max_path);
-
-            return {s, h.pos(s), ds};
+        // Case for wire is parallel to track
+        // @NOTE We might not have to call this which is meant to be for ray
+        // intersection...
+        if (denom < 1e-5f) {
+            DETRAY_ERROR_HOST(
+                "Helix line intersector encountered invalid value!");
+            return {};
         }
+
+        // vector from track position to line center
+        const vector3_t D = c - r0;
+
+        // D projection on line direction
+        const scalar_t P{vector::dot(D, l)};
+
+        // D projection on track direction
+        const scalar_t Q{vector::dot(D, t0)};
+
+        // Path length to the point of closest approach on the track
+        // @NOTE Ray intersection algorithm is used for the initial guess on
+        // the path length
+        scalar_t s_ini{1.f / denom * (Q - P * lt0)};
+
+        /// Evaluate the function and its derivative at the point @param x
+        auto line_inters_func = [&h, &c, &l](const scalar_t x) {
+            // track direction
+            const vector3_t t = h.dir(x);
+
+            // track position
+            const point3_t r = h.pos(x);
+
+            // Projection of (track position - center) to the line
+            const scalar_t A = vector::dot(r - c, l);
+
+            // Vector orthogonal to the line and passing the track position
+            // w = r - (c + ((r - c) * l)l)
+            const vector3_t w = r - (c + A * l);
+
+            // f(s) = t * w = 0
+            const scalar_t f = vector::dot(t, w);
+
+            // dtds = d^2r/ds^2 = qop * (t X b_field)
+            const vector3_t dtds = h.qop() * vector::cross(t, h.b_field());
+            // dwds = t - (t * l)l
+            const vector3_t dwds = t - vector::dot(t, l) * l;
+
+            // f'(s) = dtds * w + t * dwds
+            const scalar_t dfds = vector::dot(dtds, w) + vector::dot(t, dwds);
+
+            return std::make_tuple(f, dfds);
+        };
+
+        // Run the root finding algorithm
+        scalar_t s;
+        scalar_t ds;
+        if (run_rtsafe) {
+            std::tie(s, ds) = newton_raphson_safe(line_inters_func, s_ini,
+                                                  convergence_tolerance,
+                                                  max_n_tries, max_path);
+        } else {
+            std::tie(s, ds) =
+                newton_raphson(line_inters_func, s_ini, convergence_tolerance,
+                               max_n_tries, max_path);
+        }
+
+        return {s, h.pos(s), ds};
     }
 
     /// Tolerance for convergence
-    scalar_type convergence_tolerance{1.f * unit<scalar_type>::um};
+    scalar_t convergence_tolerance{1.f * unit<scalar_t>::um};
     // Guard against inifinite loops
     std::size_t max_n_tries{1000u};
     // Early exit, if the intersection is too far away
-    scalar_type max_path{5.f * unit<scalar_type>::m};
+    scalar_t max_path{5.f * unit<scalar_t>::m};
     // Complement the Newton algorithm with Bisection steps
     bool run_rtsafe{true};
 };

--- a/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,11 +34,11 @@ struct helix_intersector_impl;
 template <algebra::concepts::aos algebra_t>
 struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
 
+    private:
+    using scalar_t = dscalar<algebra_t>;
+
+    public:
     using algebra_type = algebra_t;
-    using scalar_type = dscalar<algebra_t>;
-    using point3_type = dpoint3D<algebra_t>;
-    using vector3_type = dvector3D<algebra_t>;
-    using transform3_type = dtransform3D<algebra_t>;
 
     template <typename surface_descr_t>
     using intersection_type =
@@ -52,104 +52,67 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
 
     using result_type = intersection_point_err<algebra_t>;
 
-    /// Operator function to find intersections between ray and planar mask
+    /// Operator function to find intersections between a helix and a planar
+    /// surface
     ///
-    /// @param ray is the input ray trajectory
-    /// @param sf the surface handle the mask is associated with
-    /// @param mask is the input mask that defines the surface extent
+    /// @param h is the input helix trajectory
     /// @param trf is the surface placement transform
-    /// @param mask_tolerance is the tolerance for mask edges
-    /// @param overstep_tol negative cutoff for the path
     ///
     /// @return the intersection
     DETRAY_HOST_DEVICE constexpr result_type point_of_intersection(
-        const trajectory_type<algebra_t> &h, const transform3_type &trf,
-        const scalar_type = 0.f) const {
+        const trajectory_type<algebra_t> &h, const dtransform3D<algebra_t> &trf,
+        const scalar_t = 0.f) const {
 
-        if (!run_rtsafe) {
-            // Get the surface info
-            const auto &sm = trf.matrix();
-            // Surface normal
-            const vector3_type sn = getter::vector<3>(sm, 0u, 2u);
-            // Surface translation
-            const point3_type st = getter::vector<3>(sm, 0u, 3u);
+        using point3_t = dpoint3D<algebra_t>;
+        using vector3_t = dvector3D<algebra_t>;
 
-            // Starting point on the helix for the Newton iteration
-            const vector3_type dist{st - h.pos(0.f)};
-            scalar_type denom{vector::dot(sn, h.dir(0.f))};
+        // Surface normal
+        const vector3_t sn = trf.z();
+        // Surface translation
+        const point3_t st = trf.translation();
 
-            scalar_type s;
-            if (denom == 0.f) {
-                s = vector::norm(dist);
-            }
-            s = math::fabs(vector::dot(sn, dist) / denom);
-
-            scalar_type s_prev{0.f};
-
-            // f(s) = sn * (h.pos(s) - st) == 0
-            // Run the iteration on s
-            std::size_t n_tries{0u};
-            while (math::fabs(s - s_prev) > convergence_tolerance &&
-                   n_tries < max_n_tries) {
-                // f'(s) = sn * h.dir(s)
-                denom = vector::dot(sn, h.dir(s));
-                // No intersection can be found if dividing by zero
-                if (denom == 0.f) {
-                    return {};
-                }
-                // x_n+1 = x_n - f(s) / f'(s)
-                s_prev = s;
-                s -= vector::dot(sn, h.pos(s) - st) / denom;
-                ++n_tries;
-            }
-            // No intersection found within max number of trials
-            if (n_tries == max_n_tries) {
-                return {};
-            }
-
-            return {s, h.pos(s), s - s_prev};
+        // Starting point on the helix for the Newton iteration
+        const vector3_t dist{st - h.pos(0.f)};
+        scalar_t denom{vector::dot(sn, h.dir(0.5f * vector::norm(dist)))};
+        scalar_t s_ini;
+        if (denom == 0.f) {
+            s_ini = vector::norm(dist);
         } else {
-            // Surface normal
-            const vector3_type sn = trf.z();
-            // Surface translation
-            const point3_type st = trf.translation();
-
-            // Starting point on the helix for the Newton iteration
-            const vector3_type dist{st - h.pos(0.f)};
-            scalar_type denom{
-                vector::dot(sn, h.dir(0.5f * vector::norm(dist)))};
-            scalar_type s_ini;
-            if (denom == 0.f) {
-                s_ini = vector::norm(dist);
-            } else {
-                s_ini = vector::dot(sn, dist) / denom;
-            }
-
-            /// Evaluate the function and its derivative at the point @param x
-            auto plane_inters_func = [&h, &st, &sn](const scalar_type x) {
-                // f(s) = sn * (h.pos(s) - st) == 0
-                const scalar_type f_s{vector::dot(sn, (h.pos(x) - st))};
-                // f'(s) = sn * h.dir(s)
-                const scalar_type df_s{vector::dot(sn, h.dir(x))};
-
-                return std::make_tuple(f_s, df_s);
-            };
-
-            // Run the root finding algorithm
-            const auto [s, ds] = newton_raphson_safe(plane_inters_func, s_ini,
-                                                     convergence_tolerance,
-                                                     max_n_tries, max_path);
-
-            return {s, h.pos(s), ds};
+            s_ini = vector::dot(sn, dist) / denom;
         }
+
+        /// Evaluate the function and its derivative at the point @param x
+        auto plane_inters_func = [&h, &st, &sn](const scalar_t x) {
+            // f(s) = sn * (h.pos(s) - st) == 0
+            const scalar_t f_s{vector::dot(sn, (h.pos(x) - st))};
+            // f'(s) = sn * h.dir(s)
+            const scalar_t df_s{vector::dot(sn, h.dir(x))};
+
+            return std::make_tuple(f_s, df_s);
+        };
+
+        // Run the root finding algorithm
+        scalar_t s;
+        scalar_t ds;
+        if (run_rtsafe) {
+            std::tie(s, ds) = newton_raphson_safe(plane_inters_func, s_ini,
+                                                  convergence_tolerance,
+                                                  max_n_tries, max_path);
+        } else {
+            std::tie(s, ds) =
+                newton_raphson(plane_inters_func, s_ini, convergence_tolerance,
+                               max_n_tries, max_path);
+        }
+
+        return {s, h.pos(s), ds};
     }
 
     /// Tolerance for convergence
-    scalar_type convergence_tolerance{1.f * unit<scalar_type>::um};
+    scalar_t convergence_tolerance{1.f * unit<scalar_t>::um};
     // Guard against inifinite loops
     std::size_t max_n_tries{1000u};
     // Early exit, if the intersection is too far away
-    scalar_type max_path{5.f * unit<scalar_type>::m};
+    scalar_t max_path{5.f * unit<scalar_t>::m};
     // Complement the Newton algorithm with Bisection steps
     bool run_rtsafe{true};
 };

--- a/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -36,15 +36,7 @@ template <algebra::concepts::aos algebra_t, bool resolve_pos>
 struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
                             resolve_pos> {
 
-    /// linear algebra types
-    /// @{
     using algebra_type = algebra_t;
-    using scalar_type = dscalar<algebra_t>;
-    using point2_type = dpoint2D<algebra_t>;
-    using point3_type = dpoint3D<algebra_t>;
-    using vector3_type = dvector3D<algebra_t>;
-    using transform3_type = dtransform3D<algebra_t>;
-    /// @}
 
     template <typename surface_descr_t>
     using intersection_type =
@@ -56,8 +48,8 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
     // Maximum number of solutions this intersector can produce
     static constexpr std::uint8_t n_solutions{1u};
 
-    using result_type =
-        intersection_point<algebra_t, point2_type, intersection::contains_pos>;
+    using result_type = intersection_point<algebra_t, dpoint2D<algebra_t>,
+                                           intersection::contains_pos>;
 
     /// Operator function to find intersections between ray and cylinder mask
     ///
@@ -75,47 +67,51 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
     /// @return the closest intersection
     template <typename mask_t>
     DETRAY_HOST_DEVICE constexpr result_type point_of_intersection(
-        const trajectory_type<algebra_t> &ray, const transform3_type & /*trf*/,
-        const mask_t &mask, const scalar_type overstep_tol = 0.f) const {
+        const trajectory_type<algebra_t> &ray,
+        const dtransform3D<algebra_t> & /*trf*/, const mask_t &mask,
+        const dscalar<algebra_t> overstep_tol = 0.f) const {
 
-        const scalar_type r{mask[mask_t::shape::e_r]};
-        constexpr scalar_type inv{detail::invalid_value<dvalue<algebra_t>>()};
+        using scalar_t = dscalar<algebra_t>;
+        using point2_t = dpoint2D<algebra_t>;
+        using point3_t = dpoint3D<algebra_t>;
+        using vector3_t = dvector3D<algebra_t>;
 
-        const point3_type &ro = ray.pos();
-        const vector3_type &rd = ray.dir();
-        scalar_type path{inv};
+        const scalar_t r{mask[mask_t::shape::e_r]};
+        constexpr scalar_t inv{detail::invalid_value<dvalue<algebra_t>>()};
 
-        const scalar_type rd_perp_2{rd[0] * rd[0] + rd[1] * rd[1]};
+        const point3_t &ro = ray.pos();
+        const vector3_t &rd = ray.dir();
+        scalar_t path{inv};
+
+        const scalar_t rd_perp_2{rd[0] * rd[0] + rd[1] * rd[1]};
 
         // The ray is parallel to the cylinder axis (z-axis)...
-        if (rd_perp_2 < std::numeric_limits<scalar_type>::epsilon())
-            [[unlikely]] {
+        if (rd_perp_2 < std::numeric_limits<scalar_t>::epsilon()) [[unlikely]] {
             return {};
         }
 
         // ...otherwise, two solutions should exist, if the descriminator is
         // greater than zero
-        const scalar_type ro_perp_2{ro[0] * ro[0] + ro[1] * ro[1]};
+        const scalar_t ro_perp_2{ro[0] * ro[0] + ro[1] * ro[1]};
         // This leads to numerical instabilites in single precision on the GPU
         const double rad_diff{r * r - ro_perp_2};
 
         // Only calculate the path, when not already on surface
-        if (math::fabs(rad_diff) > 1.f * unit<scalar_type>::um) {
+        if (math::fabs(rad_diff) > 1.f * unit<scalar_t>::um) {
 
-            const scalar_type rd_perp_inv_2{1.f / rd_perp_2};
-            const scalar_type k{-rd_perp_inv_2 *
-                                (ro[0] * rd[0] + ro[1] * rd[1])};
+            const scalar_t rd_perp_inv_2{1.f / rd_perp_2};
+            const scalar_t k{-rd_perp_inv_2 * (ro[0] * rd[0] + ro[1] * rd[1])};
             const auto discr{
-                static_cast<scalar_type>(rd_perp_inv_2 * rad_diff + k * k)};
+                static_cast<scalar_t>(rd_perp_inv_2 * rad_diff + k * k)};
 
             // No intersection found
             if (discr < 0.f) [[unlikely]] {
                 return {};
             }
 
-            const scalar_type sqrt_discr{math::sqrt(discr)};
-            const scalar_type s1{k + sqrt_discr};
-            const scalar_type s2{k - sqrt_discr};
+            const scalar_t sqrt_discr{math::sqrt(discr)};
+            const scalar_t s1{k + sqrt_discr};
+            const scalar_t s2{k - sqrt_discr};
 
             // Take the nearest solution
             path = (math::fabs(s1) < math::fabs(s2)) ? s1 : s2;
@@ -126,7 +122,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
                 path = (math::fabs(s1) >= math::fabs(s2)) ? s1 : s2;
             }
         } else {
-            path = static_cast<scalar_type>(rad_diff);
+            path = static_cast<scalar_t>(rad_diff);
         }
 
         if (path < overstep_tol) {
@@ -134,7 +130,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
         }
 
         // Only need the global z-component for the mask check
-        return {path, point2_type{inv, ro[2] + path * rd[2]}};
+        return {path, point2_t{inv, ro[2] + path * rd[2]}};
     }
 };
 

--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -29,10 +29,6 @@ template <algebra::concepts::aos algebra_t, bool resolve_pos>
 struct ray_intersector_impl<line2D<algebra_t>, algebra_t, resolve_pos> {
 
     using algebra_type = algebra_t;
-    using scalar_type = dscalar<algebra_t>;
-    using point3_type = dpoint3D<algebra_t>;
-    using vector3_type = dvector3D<algebra_t>;
-    using transform3_type = dtransform3D<algebra_t>;
 
     template <typename surface_descr_t>
     using intersection_type =
@@ -44,8 +40,8 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, resolve_pos> {
     // Maximum number of solutions this intersector can produce
     static constexpr std::uint8_t n_solutions{1u};
 
-    using result_type =
-        intersection_point<algebra_t, point3_type, intersection::contains_pos>;
+    using result_type = intersection_point<algebra_t, dpoint3D<algebra_t>,
+                                           intersection::contains_pos>;
 
     /// Operator function to find intersections between ray and line mask
     ///
@@ -58,21 +54,26 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, resolve_pos> {
     //
     /// @return the intersection
     DETRAY_HOST_DEVICE constexpr result_type point_of_intersection(
-        const trajectory_type<algebra_t> &ray, const transform3_type &trf,
-        const scalar_type /*overstep_tol*/ = 0.f) const {
+        const trajectory_type<algebra_t> &ray,
+        const dtransform3D<algebra_t> &trf,
+        const dscalar<algebra_t> /*overstep_tol*/ = 0.f) const {
 
-        const vector3_type &rd = ray.dir();
-        const point3_type &ro = ray.pos();
+        using scalar_t = dscalar<algebra_t>;
+        using point3_t = dpoint3D<algebra_t>;
+        using vector3_t = dvector3D<algebra_t>;
+
+        const vector3_t &rd = ray.dir();
+        const point3_t &ro = ray.pos();
 
         // line direction
-        const vector3_type &_z = trf.z();
+        const vector3_t &_z = trf.z();
         // line center
-        const point3_type &_t = trf.translation();
+        const point3_t &_t = trf.translation();
 
         // Projection of line to track direction
-        const scalar_type zd{vector::dot(_z, rd)};
+        const scalar_t zd{vector::dot(_z, rd)};
 
-        const scalar_type denom{1.f - (zd * zd)};
+        const scalar_t denom{1.f - (zd * zd)};
 
         // Case for wire is parallel to track
         if (denom < 1e-5f) {
@@ -80,17 +81,17 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, resolve_pos> {
         }
 
         // vector from track position to line center
-        const point3_type t2l = _t - ro;
+        const point3_t t2l = _t - ro;
 
         // t2l projection on line direction
-        const scalar_type t2l_on_line{vector::dot(t2l, _z)};
+        const scalar_t t2l_on_line{vector::dot(t2l, _z)};
 
         // t2l projection on track direction
-        const scalar_type t2l_on_track{vector::dot(t2l, rd)};
+        const scalar_t t2l_on_track{vector::dot(t2l, rd)};
 
         // path length to the point of closest approach on the track
-        const scalar_type s{1.f / denom * (t2l_on_track - t2l_on_line * zd)};
-        const point3_type glob_pos = ro + s * rd;
+        const scalar_t s{1.f / denom * (t2l_on_track - t2l_on_line * zd)};
+        const point3_t glob_pos = ro + s * rd;
 
         return {s, glob_pos};
     }

--- a/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
@@ -29,14 +29,7 @@ struct ray_intersector_impl;
 template <algebra::concepts::aos algebra_t, bool resolve_pos>
 struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, resolve_pos> {
 
-    /// linear algebra types
-    /// @{
     using algebra_type = algebra_t;
-    using scalar_type = dscalar<algebra_t>;
-    using point3_type = dpoint3D<algebra_t>;
-    using vector3_type = dvector3D<algebra_t>;
-    using transform3_type = dtransform3D<algebra_t>;
-    /// @}
 
     template <typename surface_descr_t>
     using intersection_type =
@@ -49,8 +42,8 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, resolve_pos> {
     static constexpr std::uint8_t n_solutions{1u};
 
     /// Always includes the intersection position, in order to resolve the mask
-    using result_type =
-        intersection_point<algebra_t, point3_type, intersection::contains_pos>;
+    using result_type = intersection_point<algebra_t, dpoint3D<algebra_t>,
+                                           intersection::contains_pos>;
 
     /// Operator function to find intersections between ray and planar mask
     ///
@@ -63,25 +56,30 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, resolve_pos> {
     ///
     /// @return the intersection
     DETRAY_HOST_DEVICE constexpr result_type point_of_intersection(
-        const trajectory_type<algebra_t> &ray, const transform3_type &trf,
-        const scalar_type /*overstep_tol*/ = 0.f) const {
+        const trajectory_type<algebra_t> &ray,
+        const dtransform3D<algebra_t> &trf,
+        const dscalar<algebra_t> /*overstep_tol*/ = 0.f) const {
+
+        using scalar_t = dscalar<algebra_t>;
+        using point3_t = dpoint3D<algebra_t>;
+        using vector3_t = dvector3D<algebra_t>;
 
         // Retrieve the surface normal & translation (context resolved)
-        const vector3_type &sn = trf.z();
-        const vector3_type &st = trf.translation();
+        const vector3_t &sn = trf.z();
+        const vector3_t &st = trf.translation();
 
         // Intersection code
-        const point3_type &ro = ray.pos();
-        const vector3_type &rd = ray.dir();
-        const scalar_type denom = vector::dot(rd, sn);
+        const point3_t &ro = ray.pos();
+        const vector3_t &rd = ray.dir();
+        const scalar_t denom = vector::dot(rd, sn);
 
         // this is dangerous
         if (denom == 0.f) {
             return {};
         }
 
-        scalar_type s{vector::dot(sn, st - ro) / denom};
-        point3_type glob_pos = ro + s * rd;
+        scalar_t s{vector::dot(sn, st - ro) / denom};
+        point3_t glob_pos = ro + s * rd;
 
         return {s, glob_pos};
     }

--- a/core/include/detray/utils/root_finding.hpp
+++ b/core/include/detray/utils/root_finding.hpp
@@ -59,13 +59,30 @@ DETRAY_HOST_DEVICE inline bool expand_bracket(const scalar_t a,
     scalar_t f_u{f(upper)};
     std::size_t n_tries{0u};
 
+    /// Check if the bracket has become invalid
+    const auto check_bracket = [a, b, &bracket](std::size_t n, scalar_t fl,
+                                                scalar_t fu, scalar_t l,
+                                                scalar_t u) {
+        if ((n == 1000u) || !std::isfinite(fl) || !std::isfinite(fu) ||
+            !std::isfinite(l) || !std::isfinite(u)) {
+
+            DETRAY_VERBOSE_HOST("Could not bracket a root (a="
+                                << l << ", b=" << u << ", f(a)=" << fl
+                                << ", f(b)=" << fu
+                                << ", root might not exist). Running "
+                                   "Newton-Raphson without bisection.");
+            // Reset value
+            bracket = {a, b};
+            return false;
+        }
+        return true;
+    };
+
     // If there is no sign change in interval, we don't know if there is a root
     while (!math::signbit(f_l * f_u)) {
         // No interval could be found to bracket the root
         // Might be correct, if there is not root
-        if ((n_tries == 1000u) || !std::isfinite(f_l) || !std::isfinite(f_u)) {
-            DETRAY_VERBOSE_HOST("Could not bracket a root");
-            bracket = {a, b};
+        if (!check_bracket(n_tries, f_l, f_u, lower, upper)) {
             return false;
         }
         scalar_t d{k * (upper - lower)};
@@ -80,16 +97,92 @@ DETRAY_HOST_DEVICE inline bool expand_bracket(const scalar_t a,
         ++n_tries;
     }
 
-    bracket = {lower, upper};
-    return true;
+    if (!check_bracket(n_tries, f_l, f_u, lower, upper)) {
+        return false;
+    } else {
+        bracket = {lower, upper};
+        return true;
+    }
+}
+
+/// @brief Find a root using the Newton-Raphson algorithm
+///
+/// @param evaluate_func evaluate the function and its derivative
+/// @param s initial guess for the root
+/// @param convergence_tolerance max distance between from root before finished
+/// @param max_n_tries max number of Newton-Bisection step to try
+/// @param max_path don't consider root if it is too far away
+///
+/// @see Numerical Recepies pp. 445
+///
+/// @return pathlength to root and the last step size
+template <typename scalar_t, typename function_t>
+DETRAY_HOST_DEVICE inline std::pair<scalar_t, scalar_t> newton_raphson(
+    function_t &evaluate_func, scalar_t s,
+    const scalar_t convergence_tolerance = 1.f * unit<scalar_t>::um,
+    const std::size_t max_n_tries = 1000u,
+    const scalar_t max_path = 5.f * unit<scalar_t>::m) {
+
+    constexpr scalar_t inv{detail::invalid_value<scalar_t>()};
+    constexpr scalar_t epsilon{std::numeric_limits<scalar_t>::epsilon()};
+
+    if (math::fabs(s) >= max_path) {
+        DETRAY_VERBOSE_HOST(
+            "Initial path estimate outside search area: s=" << s);
+    }
+    if (math::fabs(s) >= inv) {
+        const std::string err_msg{"Initial path estimate invalid"};
+        DETRAY_FATAL_HOST(err_msg);
+        throw std::invalid_argument(err_msg);
+    }
+
+    // Run the iteration on s
+    scalar_t s_prev{0.f};
+    std::size_t n_tries{0u};
+    auto [f_s, df_s] = evaluate_func(s);
+
+    while (math::fabs(s - s_prev) > convergence_tolerance) {
+
+        // Root already found?
+        if (math::fabs(f_s) < convergence_tolerance) {
+            return std::make_pair(s, epsilon);
+        }
+
+        // No intersection can be found if dividing by zero
+        if (math::fabs(df_s) == 0.f) {
+            DETRAY_VERBOSE_HOST(
+                "Newton step encountered invalid derivative "
+                "- skipping");
+            return std::make_pair(inv, inv);
+        }
+
+        // Newton step
+        s_prev = s;
+        s -= f_s / df_s;
+
+        // Update function evaluation
+        std::tie(f_s, df_s) = evaluate_func(s);
+
+        ++n_tries;
+
+        // No intersection found within max number of trials
+        if (n_tries >= max_n_tries) {
+            DETRAY_VERBOSE_HOST("Helix intersector did not converge after "
+                                << n_tries << " steps - skipping");
+            return std::make_pair(inv, inv);
+        }
+    }
+    // Final pathlengt to root and latest step size
+    return std::make_pair(s, math::fabs(s - s_prev));
 }
 
 /// @brief Find a root using the Newton-Raphson and Bisection algorithms
 ///
-/// @param s initial guess for the root
 /// @param evaluate_func evaluate the function and its derivative
+/// @param s initial guess for the root
+/// @param convergence_tolerance max distance between from root before finished
+/// @param max_n_tries max number of Newton-Bisection step to try
 /// @param max_path don't consider root if it is too far away
-/// @param run_rtsafe whether to run pure Newton
 ///
 /// @see Numerical Recepies pp. 445
 ///
@@ -104,35 +197,61 @@ DETRAY_HOST_DEVICE inline std::pair<scalar_t, scalar_t> newton_raphson_safe(
     constexpr scalar_t inv{detail::invalid_value<scalar_t>()};
     constexpr scalar_t epsilon{std::numeric_limits<scalar_t>::epsilon()};
 
-    // First, try to bracket a root
+    // Evaluate the test function at point 'x'
     auto f = [&evaluate_func](const scalar_t x) {
         auto [f_x, df_x] = evaluate_func(x);
 
         return f_x;
     };
 
-    // Initial bracket
-    scalar_t a{math::fabs(s) == 0.f ? -0.1f : 0.9f * s};
-    scalar_t b{math::fabs(s) == 0.f ? 0.1f : 1.1f * s};
+    if (math::fabs(s) >= max_path) {
+        DETRAY_VERBOSE_HOST(
+            "Initial path estimate outside search area: s=" << s);
+    }
+    if (math::fabs(s) >= inv) {
+        const std::string err_msg{"Initial path estimate invalid"};
+        DETRAY_ERROR_HOST(err_msg);
+        throw std::invalid_argument(err_msg);
+    }
+
+    // Initial bracket (test a certain range around 's')
+    scalar_t a{math::fabs(s) == 0.f ? -0.2f : 0.8f * s};
+    scalar_t b{math::fabs(s) == 0.f ? 0.2f : 1.2f * s};
     darray<scalar_t, 2> br{};
     bool is_bracketed = expand_bracket(a, b, f, br);
 
     // Update initial guess on the root after bracketing
     s = is_bracketed ? 0.5f * (br[1] + br[0]) : s;
 
-    if (is_bracketed) {
+    if (!is_bracketed) {
+        DETRAY_VERBOSE_HOST(
+            "Bracketing failed for initial path estimate: s=" << s);
+    } else {
         // Check bracket
         [[maybe_unused]] auto [f_a, df_a] = evaluate_func(br[0]);
         [[maybe_unused]] auto [f_b, df_b] = evaluate_func(br[1]);
 
-        assert(math::signbit(f_a * f_b) && "Incorrect bracket around root");
+        // Bracket is not guaranteed to contain a root
+        if (!math::signbit(f_a * f_b)) {
+            throw std::runtime_error(
+                "Incorrect bracket around root: No sign change!");
+        }
+
+        // No bisection algorithm possible if one bracket boundary is inf
+        // (is already checked in bracketing alg)
+        if ((math::fabs(br[0]) >= inv) || (math::fabs(br[1]) >= inv)) {
+            throw std::runtime_error(
+                "Incorrect bracket around root: Boundary reached inf!");
+        }
 
         // Root is not within the maximal pathlength
-        bool bracket_outside_tol{s > max_path &&
-                                 ((br[0] < -max_path && br[1] < -max_path) ||
-                                  (br[0] > max_path && br[1] > max_path))};
+        bool bracket_outside_tol{math::fabs(s) > max_path &&
+                                 math::fabs(br[0]) >= max_path &&
+                                 math::fabs(br[1]) >= max_path};
         if (bracket_outside_tol) {
-            DETRAY_VERBOSE_HOST("Root outside maximum search area - skipping");
+            DETRAY_VERBOSE_HOST("Root outside maximum search area (s = "
+                                << s << ", a: " << br[0] << ", b: " << br[1]
+                                << ") - skipping");
             return std::make_pair(inv, inv);
         }
 
@@ -200,7 +319,8 @@ DETRAY_HOST_DEVICE inline std::pair<scalar_t, scalar_t> newton_raphson_safe(
             // No intersection can be found if dividing by zero
             if (!is_bracketed && math::fabs(df_s) == 0.f) {
                 DETRAY_VERBOSE_HOST(
-                    "Encountered invalid derivative - skipping");
+                    "Newton step encountered invalid derivative at s="
+                    << s << " after " << n_tries << " steps - skipping");
 
                 return std::make_pair(inv, inv);
             }
@@ -216,18 +336,21 @@ DETRAY_HOST_DEVICE inline std::pair<scalar_t, scalar_t> newton_raphson_safe(
             b = s;
         }
 
-        // Converges to a point outside the search space
+        // Converges to a point outside the search space - early stop
         if (math::fabs(s) > max_path && math::fabs(s_prev) > max_path &&
             ((a < -max_path && b < -max_path) ||
              (a > max_path && b > max_path))) {
 
             DETRAY_VERBOSE_HOST(
-                "Root finding left the search space - skipping");
+                "WARNING: Root finding left the search space at (s = "
+                << s << ", a: " << a << ", b: " << b << ") after " << n_tries
+                << " steps - skipping");
 
             return std::make_pair(inv, inv);
         }
 
         ++n_tries;
+
         // No intersection found within max number of trials
         if (n_tries >= max_n_tries) {
 
@@ -240,15 +363,14 @@ DETRAY_HOST_DEVICE inline std::pair<scalar_t, scalar_t> newton_raphson_safe(
                 DETRAY_FATAL_HOST(err_str.str());
                 throw std::runtime_error(err_str.str());
             } else {
-                DETRAY_VERBOSE_HOST(
-                    "Helix intersector did not "
-                    "converge after "
-                    << n_tries << " steps unbracketed search - skipping");
+                DETRAY_VERBOSE_HOST("Helix intersector did not converge after "
+                                    << n_tries
+                                    << " steps unbracketed search - skipping");
             }
             return std::make_pair(inv, inv);
         }
     }
-    //  Final pathlengt to root and latest step size
+    // Final pathlengt to root and latest step size
     return std::make_pair(s, math::fabs(s - s_prev));
 }
 


### PR DESCRIPTION
Moves the old Newton-Raphson algorithm into an abstraction (it is at this point only used in the jacobian and covaraince transport integration tests) and reuses the setup of the rt_safe algorithm