### PR TITLE
GCC 13.1 Fix, main branch (2024.11.08.)

### DIFF
--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -559,7 +559,7 @@ class navigator {
         }
 
         /// Our cache of candidates (intersections with any kind of surface)
-        candidate_cache_t m_candidates{};
+        candidate_cache_t m_candidates;
 
         /// Detector pointer
         const detector_type *m_detector{nullptr};


### PR DESCRIPTION
This is to try to address the compiler crash that we've seen with @nribaric earlier this week, and which @flg saw this morning himself.

GCC 13.1 crashes while compiling [traccc's host CKF code](https://github.com/acts-project/traccc/blob/main/core/src/finding/find_tracks.hpp) when `detray::navigator<...>::state::m_candidates` is initialized explicitly with curly braces. 😕

I'm worried about this update though. 🤔 By removing the curly braces, do I eliminate some explicit initialization to the elements of the array? [std::array](https://en.cppreference.com/w/cpp/container/array) has no constructor. So this change should not change anything... right? The code is initializing the array elements to something somewhere else, right? (If the logic requires some initialization that is. If not, then fine.)