### PR TITLE
ref: More realistic toy detector benchmarks

### DIFF
--- a/tests/benchmarks/cpu/benchmark_propagator.cpp
+++ b/tests/benchmarks/cpu/benchmark_propagator.cpp
@@ -76,19 +76,49 @@ auto toy_cfg =
     toy_det_config{}.n_brl_layers(4u).n_edc_layers(7u).do_check(false);
 
 void fill_tracks(vecmem::vector<free_track_parameters<algebra_t>> &tracks,
-                 const std::size_t theta_steps, const std::size_t phi_steps) {
-    // Set momentum of tracks
-    const scalar mom_mag{10.f * unit<scalar>::GeV};
+                 const std::size_t n_tracks, bool do_sort = true) {
+    using scalar_t = dscalar<algebra_t>;
+    using uniform_gen_t =
+        detail::random_numbers<scalar_t,
+                               std::uniform_real_distribution<scalar_t>>;
+    using trk_generator_t =
+        random_track_generator<free_track_parameters<algebra_t>, uniform_gen_t>;
+
+    trk_generator_t::configuration trk_gen_cfg{};
+    trk_gen_cfg.seed(42u);
+    trk_gen_cfg.n_tracks(n_tracks);
+    trk_gen_cfg.randomize_charge(true);
+    trk_gen_cfg.phi_range(-constant<scalar_t>::pi, constant<scalar_t>::pi);
+    trk_gen_cfg.eta_range(-3.f, 3.f);
+    trk_gen_cfg.mom_range(1.f * unit<scalar_t>::GeV,
+                          100.f * unit<scalar_t>::GeV);
+    trk_gen_cfg.origin({0.f, 0.f, 0.f});
+    trk_gen_cfg.origin_stddev({0.f * unit<scalar_t>::mm,
+                               0.f * unit<scalar_t>::mm,
+                               0.f * unit<scalar_t>::mm});
 
     // Iterate through uniformly distributed momentum directions
-    for (auto traj : uniform_track_generator<free_track_parameters<algebra_t>>(
-             phi_steps, theta_steps, mom_mag)) {
+    for (auto traj : trk_generator_t{trk_gen_cfg}) {
         tracks.push_back(traj);
+    }
+
+    if (do_sort) {
+        // Sort by theta angle
+        const auto traj_comp = [](const auto &lhs, const auto &rhs) {
+            constexpr auto pi_2{constant<scalar_t>::pi_2};
+            return math::fabs(pi_2 - getter::theta(lhs.dir())) <
+                   math::fabs(pi_2 - getter::theta(rhs.dir()));
+        };
+
+        std::ranges::sort(tracks, traj_comp);
     }
 }
 
 template <propagate_option opt>
 static void BM_PROPAGATOR_CPU(benchmark::State &state) {
+
+    std::size_t n_tracks{static_cast<std::size_t>(state.range(0)) *
+                         static_cast<std::size_t>(state.range(0))};
 
     // Create the toy geometry and bfield
     auto [det, names] = build_toy_detector(host_mr, toy_cfg);
@@ -109,8 +139,7 @@ static void BM_PROPAGATOR_CPU(benchmark::State &state) {
 
         // Get tracks
         vecmem::vector<free_track_parameters<algebra_t>> tracks(&host_mr);
-        fill_tracks(tracks, static_cast<std::size_t>(state.range(0)),
-                    static_cast<std::size_t>(state.range(0)));
+        fill_tracks(tracks, n_tracks);
 
         total_tracks += tracks.size();
 


### PR DESCRIPTION
Use random, but sorted tracks for benchmarks and copy the detector to device. I also changed the eta range to [-4, 4] and the momentum range to 1Gev - 100GeV