### PR TITLE
use fabs instead of abs in set_phi to be nice with sycl/clang20

### DIFF
--- a/core/include/detray/tracks/bound_track_parameters.hpp
+++ b/core/include/detray/tracks/bound_track_parameters.hpp
@@ -124,7 +124,7 @@ struct bound_parameters_vector {
     /// Set the global phi angle
     DETRAY_HOST_DEVICE
     void set_phi(const scalar_type phi) {
-        assert(math::abs(phi) <= constant<scalar_type>::pi);
+        assert(math::fabs(phi) <= constant<scalar_type>::pi);
         matrix_operator().element(m_vector, e_bound_phi, 0u) = phi;
     }
 


### PR DESCRIPTION
This correction was suggested by @niermann999 as a fix for a compile error with a recent SYCL compiler. And worked. This is mostly to remind detray and ACTS experts that this is something to look into. Maybe this needs to be applied elsewhere.

For info the compiler is:
```
$ clang++ -v
clang version 20.0.0git (https://github.com/intel/llvm e95b34bb2bcef2641d88ca2e09d628039ef269d7)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2025.0/bin
Build config: +assertions
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/11
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/13
Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/13
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Candidate multilib: x32;@mx32
Selected multilib: .;@m64
Found HIP installation: /opt/rocm, version 6.2.41134
```
from 24/11/2024 daily release of Intel's LLVM:
https://github.com/intel/llvm/releases/download/nightly-2024-11-24/sycl_linux.tar.gz