### PR TITLE
VecMem Update, main branch (2024.11.29.)

### DIFF
--- a/core/include/detray/core/detail/container_buffers.hpp
+++ b/core/include/detray/core/detail/container_buffers.hpp
@@ -157,11 +157,10 @@ struct dmulti_buffer : public detail::dbase_buffer {
 
 /// @brief Get the buffer representation of a vecmem vector - non-const
 template <class T>
-auto get_buffer(
-    const dvector_view<T>& vec_view, vecmem::memory_resource& mr,
-    vecmem::copy& cpy, detray::copy cpy_type = detray::copy::sync,
-    vecmem::data::buffer_type buff_type = vecmem::data::buffer_type::fixed_size
-    /*, stream*/) {
+auto get_buffer(const dvector_view<T>& vec_view, vecmem::memory_resource& mr,
+                vecmem::copy& cpy, detray::copy cpy_type = detray::copy::sync,
+                vecmem::data::buffer_type buff_type =
+                    vecmem::data::buffer_type::fixed_size) {
 
     // In case the view references a const object, return a non-const buffer
     using ret_buffer_t = dvector_buffer<std::remove_cv_t<T>>;
@@ -171,7 +170,7 @@ auto get_buffer(
     // TODO: Move this to detray copy util, which bundles vecmem copy object and
     // stream handle and gets this switch case right automatically
     if (cpy_type == detray::copy::async) {
-        cpy(vec_view, buff /*, stream*/);
+        cpy(vec_view, buff)->ignore();
     } else {
         cpy(vec_view, buff)->wait();
     }

--- a/extern/vecmem/CMakeLists.txt
+++ b/extern/vecmem/CMakeLists.txt
@@ -18,7 +18,7 @@ message(STATUS "Building VecMem as part of the Detray project")
 
 # Declare where to get VecMem from.
 set(DETRAY_VECMEM_SOURCE
-    "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.8.0.tar.gz;URL_MD5;afddf52d9568964f25062e1c887246b7"
+    "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.13.0.tar.gz;URL_MD5;02fe327552c21779f501c224b8c95e87"
     CACHE STRING
     "Source for VecMem, when built as part of this project"
 )

--- a/tests/include/detray/test/device/cuda/material_validation.hpp
+++ b/tests/include/detray/test/device/cuda/material_validation.hpp
@@ -81,13 +81,13 @@ struct run_material_validation {
         vecmem::data::vector_buffer<material_record_t> mat_records_buffer(
             static_cast<unsigned int>(tracks.size()), *dev_mr,
             vecmem::data::buffer_type::fixed_size);
-        cuda_cpy.setup(mat_records_buffer);
+        cuda_cpy.setup(mat_records_buffer)->wait();
         auto mat_records_view = vecmem::get_data(mat_records_buffer);
 
         // Buffer for the material parameters at every surface per track
         vecmem::data::jagged_vector_buffer<material_params_t> mat_steps_buffer(
             capacities, *dev_mr, host_mr, vecmem::data::buffer_type::resizable);
-        cuda_cpy.setup(mat_steps_buffer);
+        cuda_cpy.setup(mat_steps_buffer)->wait();
         auto mat_steps_view = vecmem::get_data(mat_steps_buffer);
 
         // Run the material tracing on device
@@ -96,10 +96,10 @@ struct run_material_validation {
 
         // Get the results back to the host and pass them on to be checked
         vecmem::vector<material_record_t> mat_records(host_mr);
-        cuda_cpy(mat_records_buffer, mat_records);
+        cuda_cpy(mat_records_buffer, mat_records)->wait();
 
         vecmem::jagged_vector<material_params_t> mat_steps(host_mr);
-        cuda_cpy(mat_steps_buffer, mat_steps);
+        cuda_cpy(mat_steps_buffer, mat_steps)->wait();
 
         return std::make_tuple(mat_records, mat_steps);
     }

--- a/tests/include/detray/test/device/cuda/navigation_validation.hpp
+++ b/tests/include/detray/test/device/cuda/navigation_validation.hpp
@@ -103,20 +103,20 @@ inline auto run_navigation_validation(
         navigation::detail::candidate_record<intersection_t>>
         recorded_intersections_buffer(capacities, *dev_mr, host_mr,
                                       vecmem::data::buffer_type::resizable);
-    cuda_cpy.setup(recorded_intersections_buffer);
+    cuda_cpy.setup(recorded_intersections_buffer)->wait();
     auto recorded_intersections_view =
         vecmem::get_data(recorded_intersections_buffer);
 
     vecmem::data::vector_buffer<material_record_t> mat_records_buffer(
         static_cast<unsigned int>(truth_intersection_traces_view.size()),
         *dev_mr, vecmem::data::buffer_type::fixed_size);
-    cuda_cpy.setup(mat_records_buffer);
+    cuda_cpy.setup(mat_records_buffer)->wait();
     auto mat_records_view = vecmem::get_data(mat_records_buffer);
 
     // Buffer for the material parameters at every step per track
     vecmem::data::jagged_vector_buffer<material_params_t> mat_steps_buffer(
         capacities, *dev_mr, host_mr, vecmem::data::buffer_type::resizable);
-    cuda_cpy.setup(mat_steps_buffer);
+    cuda_cpy.setup(mat_steps_buffer)->wait();
     auto mat_steps_view = vecmem::get_data(mat_steps_buffer);
 
     // Run the navigation validation test on device
@@ -127,13 +127,13 @@ inline auto run_navigation_validation(
     // Get the results back to the host and pass them on to the checking
     vecmem::jagged_vector<navigation::detail::candidate_record<intersection_t>>
         recorded_intersections(host_mr);
-    cuda_cpy(recorded_intersections_buffer, recorded_intersections);
+    cuda_cpy(recorded_intersections_buffer, recorded_intersections)->wait();
 
     vecmem::vector<material_record_t> mat_records(host_mr);
-    cuda_cpy(mat_records_buffer, mat_records);
+    cuda_cpy(mat_records_buffer, mat_records)->wait();
 
     vecmem::jagged_vector<material_params_t> mat_steps(host_mr);
-    cuda_cpy(mat_steps_buffer, mat_steps);
+    cuda_cpy(mat_steps_buffer, mat_steps)->wait();
 
     return std::make_tuple(std::move(recorded_intersections),
                            std::move(mat_records), std::move(mat_steps));

--- a/tests/integration_tests/device/cuda/propagator_cuda_kernel.hpp
+++ b/tests/integration_tests/device/cuda/propagator_cuda_kernel.hpp
@@ -68,7 +68,7 @@ inline auto run_propagation_device(
         steps_buffer(capacities, *mr, nullptr,
                      vecmem::data::buffer_type::resizable);
 
-    copy.setup(steps_buffer);
+    copy.setup(steps_buffer)->wait();
 
     // Run the propagator test for GPU device
     propagator_test<bfield_bknd_t, detector_t>(det_view, cfg, field_data,
@@ -76,7 +76,7 @@ inline auto run_propagation_device(
 
     vecmem::jagged_vector<detail::step_data<algebra_t>> steps(mr);
 
-    copy(steps_buffer, steps);
+    copy(steps_buffer, steps)->wait();
 
     return steps;
 }

--- a/tests/integration_tests/device/sycl/propagator_sycl_kernel.hpp
+++ b/tests/integration_tests/device/sycl/propagator_sycl_kernel.hpp
@@ -55,7 +55,7 @@ inline auto run_propagation_device(
         steps_buffer(capacities, *mr, nullptr,
                      vecmem::data::buffer_type::resizable);
 
-    copy.setup(steps_buffer);
+    copy.setup(steps_buffer)->wait();
 
     // Run the propagator test for GPU device
     propagator_test<bfield_bknd_t, detector_t>(
@@ -63,7 +63,7 @@ inline auto run_propagation_device(
 
     vecmem::jagged_vector<detail::step_data<algebra_t>> steps(mr);
 
-    copy(steps_buffer, steps);
+    copy(steps_buffer, steps)->wait();
 
     return steps;
 }

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
@@ -227,7 +227,7 @@ TEST(grids_cuda, grid2_buffer_attach_populator) {
     grid2_buffer<host_grid2_attach> g2_buffer(
         xaxis, yaxis, {100, 200, 300, 400}, mng_mr, nullptr,
         vecmem::data::buffer_type::resizable);
-    copy.setup(g2_buffer._buffer);
+    copy.setup(g2_buffer._buffer)->wait();
 
     // Check if the initialization work well
     // Non-zero starting size not working yet so initial argument for sizes is
@@ -246,7 +246,7 @@ TEST(grids_cuda, grid2_buffer_attach_populator) {
     grid_attach_fill_test(g2_buffer);
 
     host_grid2_attach g2(xaxis, yaxis, mng_mr, test::point3{0.f, 0.f, 0.f});
-    copy(g2_buffer._buffer, g2.data());
+    copy(g2_buffer._buffer, g2.data())->wait();
 
     // Check if each bin has 100 points
     EXPECT_EQ(g2.data()[0].size(), 100u);
@@ -272,7 +272,7 @@ TEST(grids_cuda, grid2_buffer_attach_populator2) {
 
     grid2_buffer<host_grid2_attach> g2_buffer(xaxis, yaxis, {1, 2, 3, 4},
                                               mng_mr);
-    copy.setup(g2_buffer._buffer);
+    copy.setup(g2_buffer._buffer)->wait();
 
     // Check if the initialization works well
     const auto& ptr = g2_buffer._buffer.host_ptr();
@@ -289,7 +289,7 @@ TEST(grids_cuda, grid2_buffer_attach_populator2) {
     grid_attach_assign_test(g2_buffer);
 
     host_grid2_attach g2(xaxis, yaxis, mng_mr, test::point3{0.f, 0.f, 0.f});
-    copy(g2_buffer._buffer, g2.data());
+    copy(g2_buffer._buffer, g2.data())->wait();
 
     // Check the outputs
     auto bin0 = g2.bin(0u);

--- a/tests/unit_tests/device/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda.cpp
@@ -92,7 +92,7 @@ TEST(mask_store_cuda, mask_store) {
         {n_points, n_points, n_points, n_points, n_points}, mng_mr, nullptr,
         vecmem::data::buffer_type::resizable);
 
-    copy.setup(output_buffer);
+    copy.setup(output_buffer)->wait();
 
     auto input_point3_data = vecmem::get_data(input_point3);
     auto store_data = get_data(store);
@@ -101,7 +101,7 @@ TEST(mask_store_cuda, mask_store) {
     mask_test(store_data, input_point3_data, output_buffer);
 
     vecmem::jagged_vector<int> output_device(&mng_mr);
-    copy(output_buffer, output_device);
+    copy(output_buffer, output_device)->wait();
 
     // Compare the values
     for (unsigned int i = 0u; i < n_points; i++) {

--- a/tests/unit_tests/device/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -110,11 +110,11 @@ TEST(navigator_cuda, navigator) {
 
     vecmem::data::jagged_vector_buffer<dindex> volume_records_buffer(
         capacities, dev_mr, &mng_mr, vecmem::data::buffer_type::resizable);
-    copy.setup(volume_records_buffer);
+    copy.setup(volume_records_buffer)->wait();
 
     vecmem::data::jagged_vector_buffer<point3> position_records_buffer(
         capacities, dev_mr, &mng_mr, vecmem::data::buffer_type::resizable);
-    copy.setup(position_records_buffer);
+    copy.setup(position_records_buffer)->wait();
 
     // Get detector data
     auto det_data = detray::get_data(det);
@@ -127,8 +127,8 @@ TEST(navigator_cuda, navigator) {
                    volume_records_buffer, position_records_buffer);
 
     // Copy volume record buffer into volume & position records device
-    copy(volume_records_buffer, volume_records_device);
-    copy(position_records_buffer, position_records_device);
+    copy(volume_records_buffer, volume_records_device)->wait();
+    copy(position_records_buffer, position_records_device)->wait();
 
     for (unsigned int i = 0u; i < volume_records_host.size(); i++) {
 

--- a/tests/unit_tests/device/cuda/utils_ranges_cuda.cpp
+++ b/tests/unit_tests/device/cuda/utils_ranges_cuda.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -63,14 +63,14 @@ TEST(utils_ranges_cuda, iota) {
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(range[1] -
                                                                     range[0]),
         managed_resource, vecmem::data::buffer_type::resizable);
-    copy.setup(check_buffer);
+    copy.setup(check_buffer)->wait();
 
     // Run test function
     test_iota(range, check_buffer);
 
     // Copy vector buffer to output vector
     vecmem::vector<dindex> check{&managed_resource};
-    copy(check_buffer, check);
+    copy(check_buffer, check)->wait();
 
     // Check the result
     ASSERT_EQ(check, reference);
@@ -112,14 +112,14 @@ TEST(utils_ranges_cuda, cartesian_product) {
     buffer_t check_buffer(static_cast<buffer_t::size_type>(size),
                           managed_resource,
                           vecmem::data::buffer_type::resizable);
-    copy.setup(check_buffer);
+    copy.setup(check_buffer)->wait();
 
     // Run test function
     test_cartesian_product(range1, range2, range3, check_buffer);
 
     // Copy vector buffer to output vector
     vecmem::vector<std::tuple<dindex, dindex, dindex>> check{&managed_resource};
-    copy(check_buffer, check);
+    copy(check_buffer, check)->wait();
 
     // Check the result
     ASSERT_EQ(result.size(), check.size());
@@ -154,22 +154,22 @@ TEST(utils_ranges_cuda, enumerate) {
     vecmem::data::vector_buffer<dindex> idx_buffer(
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(seq.size()),
         managed_resource, vecmem::data::buffer_type::resizable);
-    copy.setup(idx_buffer);
+    copy.setup(idx_buffer)->wait();
 
     vecmem::data::vector_buffer<dindex> value_buffer(
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(seq.size()),
         managed_resource, vecmem::data::buffer_type::resizable);
-    copy.setup(value_buffer);
+    copy.setup(value_buffer)->wait();
 
     // Run test function
     test_enumerate(seq_data, idx_buffer, value_buffer);
 
     // Copy vector buffer to output vector
     vecmem::vector<dindex> idx_vec{&managed_resource};
-    copy(idx_buffer, idx_vec);
+    copy(idx_buffer, idx_vec)->wait();
 
     vecmem::vector<dindex> value_vec{&managed_resource};
-    copy(value_buffer, value_vec);
+    copy(value_buffer, value_vec)->wait();
 
     // Check the result
     for (std::size_t i = 0u; i < idx_vec.size(); i++) {
@@ -200,22 +200,22 @@ TEST(utils_ranges_cuda, pick) {
     vecmem::data::vector_buffer<dindex> idx_buffer(
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(seq.size()),
         managed_resource, vecmem::data::buffer_type::resizable);
-    copy.setup(idx_buffer);
+    copy.setup(idx_buffer)->wait();
 
     vecmem::data::vector_buffer<dindex> value_buffer(
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(seq.size()),
         managed_resource, vecmem::data::buffer_type::resizable);
-    copy.setup(value_buffer);
+    copy.setup(value_buffer)->wait();
 
     // Run test function
     test_pick(seq_data, idx_data, idx_buffer, value_buffer);
 
     // Copy vector buffer to output vector
     vecmem::vector<dindex> idx_vec{&managed_resource};
-    copy(idx_buffer, idx_vec);
+    copy(idx_buffer, idx_vec)->wait();
 
     vecmem::vector<dindex> value_vec{&managed_resource};
-    copy(value_buffer, value_vec);
+    copy(value_buffer, value_vec)->wait();
 
     // Check the result
     for (std::size_t i = 0u; i < idx_vec.size(); i++) {
@@ -247,14 +247,14 @@ TEST(utils_ranges_cuda, join) {
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(
             seq_1.size() + seq_2.size()),
         managed_resource, vecmem::data::buffer_type::resizable);
-    copy.setup(value_buffer);
+    copy.setup(value_buffer)->wait();
 
     // Run test function
     test_join(seq_data_1, seq_data_2, value_buffer);
 
     // Copy vector buffer to output vector
     vecmem::vector<dindex> value_vec{&managed_resource};
-    copy(value_buffer, value_vec);
+    copy(value_buffer, value_vec)->wait();
 
     // First sequence
     for (std::size_t i = 0u; i < seq_1.size(); i++) {
@@ -289,14 +289,14 @@ TEST(utils_ranges_cuda, static_join) {
         static_cast<vecmem::data::vector_buffer<dindex>::size_type>(
             seq_1.size() + seq_2.size()),
         managed_resource, vecmem::data::buffer_type::resizable);
-    copy.setup(value_buffer);
+    copy.setup(value_buffer)->wait();
 
     // Run test function
     test_static_join(seq_data_1, seq_data_2, value_buffer);
 
     // Copy vector buffer to output vector
     vecmem::vector<dindex> value_vec{&managed_resource};
-    copy(value_buffer, value_vec);
+    copy(value_buffer, value_vec)->wait();
 
     // First sequence
     for (std::size_t i = 0u; i < seq_1.size(); i++) {
@@ -330,14 +330,14 @@ TEST(utils_ranges_cuda, subrange) {
     vecmem::data::vector_buffer<int> check_buffer(
         static_cast<vecmem::data::vector_buffer<int>::size_type>(end - begin),
         managed_resource, vecmem::data::buffer_type::resizable);
-    copy.setup(check_buffer);
+    copy.setup(check_buffer)->wait();
 
     // Run test function
     test_subrange(seq_data, check_buffer, begin, end);
 
     // Copy vector buffer to output vector
     vecmem::vector<int> check{&managed_resource};
-    copy(check_buffer, check);
+    copy(check_buffer, check)->wait();
 
     // Check the result
     ASSERT_EQ(check[0], 1);


### PR DESCRIPTION
Update the project to [vecmem 1.13.0](https://github.com/acts-project/vecmem/releases/tag/v1.13.0). This is needed for the oneAPI 2025.0.0 compatibility updates to be added shortly.