### PR TITLE
oneAPI 2025 Updates, main branch (2024.11.29.)

### DIFF
--- a/core/include/detray/definitions/detail/math.hpp
+++ b/core/include/detray/definitions/detail/math.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,7 +9,7 @@
 
 // SYCL include(s).
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 // System include(s).
@@ -19,7 +19,7 @@ namespace detray {
 
 /// Namespace to pick up math functions from
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
-namespace math = cl::sycl;
+namespace math = ::sycl;
 #elif IS_SOA
 
 namespace math {

--- a/core/include/detray/propagator/detail/jacobian_cartesian.hpp
+++ b/core/include/detray/propagator/detail/jacobian_cartesian.hpp
@@ -80,9 +80,9 @@ struct jacobian<cartesian2D<algebra_t>> {
         const matrix_type<3, 2> bound_pos_to_free_pos_derivative =
             matrix_operator().template block<3, 2>(frame, 0u, 0u);
 
-        matrix_operator().template set_block(bound_to_free_jacobian,
-                                             bound_pos_to_free_pos_derivative,
-                                             e_free_pos0, e_bound_loc0);
+        matrix_operator().set_block(bound_to_free_jacobian,
+                                    bound_pos_to_free_pos_derivative,
+                                    e_free_pos0, e_bound_loc0);
     }
 
     DETRAY_HOST_DEVICE
@@ -98,9 +98,9 @@ struct jacobian<cartesian2D<algebra_t>> {
         const matrix_type<2, 3> free_pos_to_bound_pos_derivative =
             matrix_operator().template block<2, 3>(frameT, 0, 0);
 
-        matrix_operator().template set_block(free_to_bound_jacobian,
-                                             free_pos_to_bound_pos_derivative,
-                                             e_bound_loc0, e_free_pos0);
+        matrix_operator().set_block(free_to_bound_jacobian,
+                                    free_pos_to_bound_pos_derivative,
+                                    e_bound_loc0, e_free_pos0);
     }
 
     DETRAY_HOST_DEVICE

--- a/core/include/detray/propagator/detail/jacobian_cylindrical.hpp
+++ b/core/include/detray/propagator/detail/jacobian_cylindrical.hpp
@@ -102,9 +102,9 @@ struct jacobian<cylindrical2D<algebra_t>> {
         const auto bound_pos_to_free_pos_derivative =
             matrix_operator().template block<3, 2>(frame, 0u, 0u);
 
-        matrix_operator().template set_block(bound_to_free_jacobian,
-                                             bound_pos_to_free_pos_derivative,
-                                             e_free_pos0, e_bound_loc0);
+        matrix_operator().set_block(bound_to_free_jacobian,
+                                    bound_pos_to_free_pos_derivative,
+                                    e_free_pos0, e_bound_loc0);
     }
 
     DETRAY_HOST_DEVICE
@@ -120,9 +120,9 @@ struct jacobian<cylindrical2D<algebra_t>> {
         const auto free_pos_to_bound_pos_derivative =
             matrix_operator().template block<2, 3>(frameT, 0u, 0u);
 
-        matrix_operator().template set_block(free_to_bound_jacobian,
-                                             free_pos_to_bound_pos_derivative,
-                                             e_bound_loc0, e_free_pos0);
+        matrix_operator().set_block(free_to_bound_jacobian,
+                                    free_pos_to_bound_pos_derivative,
+                                    e_bound_loc0, e_free_pos0);
     }
 
     DETRAY_HOST_DEVICE

--- a/core/include/detray/propagator/detail/jacobian_line.hpp
+++ b/core/include/detray/propagator/detail/jacobian_line.hpp
@@ -120,9 +120,9 @@ struct jacobian<line2D<algebra_t>> {
         const auto bound_pos_to_free_pos_derivative =
             matrix_operator().template block<3, 2>(frame, 0u, 0u);
 
-        matrix_operator().template set_block(bound_to_free_jacobian,
-                                             bound_pos_to_free_pos_derivative,
-                                             e_free_pos0, e_bound_loc0);
+        matrix_operator().set_block(bound_to_free_jacobian,
+                                    bound_pos_to_free_pos_derivative,
+                                    e_free_pos0, e_bound_loc0);
     }
 
     DETRAY_HOST_DEVICE
@@ -138,9 +138,9 @@ struct jacobian<line2D<algebra_t>> {
         const auto free_pos_to_bound_pos_derivative =
             matrix_operator().template block<2, 3>(frameT, 0u, 0u);
 
-        matrix_operator().template set_block(free_to_bound_jacobian,
-                                             free_pos_to_bound_pos_derivative,
-                                             e_bound_loc0, e_free_pos0);
+        matrix_operator().set_block(free_to_bound_jacobian,
+                                    free_pos_to_bound_pos_derivative,
+                                    e_bound_loc0, e_free_pos0);
     }
 
     DETRAY_HOST_DEVICE

--- a/core/include/detray/propagator/detail/jacobian_polar.hpp
+++ b/core/include/detray/propagator/detail/jacobian_polar.hpp
@@ -106,9 +106,9 @@ struct jacobian<polar2D<algebra_t>> {
         matrix_operator().template set_block<3, 1>(
             bound_pos_to_free_pos_derivative, col1, e_free_pos0, e_bound_loc1);
 
-        matrix_operator().template set_block(bound_to_free_jacobian,
-                                             bound_pos_to_free_pos_derivative,
-                                             e_free_pos0, e_bound_loc0);
+        matrix_operator().set_block(bound_to_free_jacobian,
+                                    bound_pos_to_free_pos_derivative,
+                                    e_free_pos0, e_bound_loc0);
     }
 
     DETRAY_HOST_DEVICE
@@ -149,9 +149,9 @@ struct jacobian<polar2D<algebra_t>> {
         matrix_operator().template set_block<1, 3>(
             free_pos_to_bound_pos_derivative, row1, e_bound_loc1, e_free_pos0);
 
-        matrix_operator().template set_block(free_to_bound_jacobian,
-                                             free_pos_to_bound_pos_derivative,
-                                             e_bound_loc0, e_free_pos0);
+        matrix_operator().set_block(free_to_bound_jacobian,
+                                    free_pos_to_bound_pos_derivative,
+                                    e_bound_loc0, e_free_pos0);
     }
 
     DETRAY_HOST_DEVICE

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -117,7 +117,7 @@ class geometry_reader {
         }
 
         // @TODO: Implement voume finder IO
-        det_builder.template set_volume_finder();
+        det_builder.set_volume_finder();
     }
 
     /// @returns a surface transform from its io payload @param trf_data


### PR DESCRIPTION
This is made on top of #890, to allow building the code with oneAPI 2025.0.0.

It's mostly trivial fixes necessitated by the new LLVM/Clang version. With one `<CL/sycl.hpp>` -> `<sycl/sycl.hpp>` change in addition.