### PR TITLE
ref: re-template algebra

### DIFF
--- a/core/include/detray/builders/bin_fillers.hpp
+++ b/core/include/detray/builders/bin_fillers.hpp
@@ -122,10 +122,13 @@ struct bin_associator {
                                 const transform_container &transforms,
                                 const mask_container &masks,
                                 const context_t ctx, Args &&...) const -> void {
+
+        using scalar_t = dscalar<typename grid_t::algebra_type>;
+
         // Fill the surfaces into the grid by matching their contour onto the
         // grid bins
-        bin_association(ctx, surfaces, transforms, masks, grid, {0.1f, 0.1f},
-                        false);
+        bin_association(ctx, surfaces, transforms, masks, grid,
+                        std::array<scalar_t, 2>{0.1f, 0.1f}, false);
     }
 };
 

--- a/core/include/detray/builders/cuboid_portal_generator.hpp
+++ b/core/include/detray/builders/cuboid_portal_generator.hpp
@@ -30,13 +30,14 @@ template <typename detector_t>
 class cuboid_portal_generator final
     : public surface_factory_interface<detector_t> {
 
-    using scalar_type = typename detector_t::scalar_type;
-    using transform3_type = typename detector_t::transform3_type;
+    using algebra_type = typename detector_t::algebra_type;
+    using scalar_type = dscalar<algebra_type>;
+    using transform3_type = dtransform3D<algebra_type>;
 
     /// A functor to construct global bounding boxes around masks
     struct bounding_box_creator {
 
-        using aabb_t = axis_aligned_bounding_volume<cuboid3D>;
+        using aabb_t = axis_aligned_bounding_volume<cuboid3D, algebra_type>;
 
         template <typename mask_group_t, typename index_t>
         DETRAY_HOST_DEVICE inline void operator()(
@@ -86,15 +87,15 @@ class cuboid_portal_generator final
                     typename detector_t::geometry_context ctx = {})
         -> dindex_range override {
 
-        using point3_t = typename detector_t::point3_type;
-        using vector3_t = typename detector_t::vector3_type;
+        using point3_t = dpoint3D<algebra_type>;
+        using vector3_t = dvector3D<algebra_type>;
 
         using surface_t = typename detector_t::surface_type;
         using nav_link_t = typename surface_t::navigation_link;
         using mask_link_t = typename surface_t::mask_link;
         using material_link_t = typename surface_t::material_link;
 
-        using aabb_t = axis_aligned_bounding_volume<cuboid3D>;
+        using aabb_t = axis_aligned_bounding_volume<cuboid3D, algebra_type>;
 
         constexpr auto invalid_src_link{detail::invalid_value<std::uint64_t>()};
 

--- a/core/include/detray/builders/cylinder_portal_generator.hpp
+++ b/core/include/detray/builders/cylinder_portal_generator.hpp
@@ -110,15 +110,16 @@ template <typename detector_t>
 class cylinder_portal_generator final
     : public surface_factory_interface<detector_t> {
 
-    using scalar_t = typename detector_t::scalar_type;
-    using point3_t = typename detector_t::point3_type;
-    using vector3_t = typename detector_t::vector3_type;
-    using transform3_t = typename detector_t::transform3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using scalar_t = dscalar<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
+    using vector3_t = dvector3D<algebra_t>;
+    using transform3_t = dtransform3D<algebra_t>;
 
     /// A functor to construct global bounding boxes around masks
     struct bounding_box_creator {
 
-        using aabb_t = axis_aligned_bounding_volume<cuboid3D>;
+        using aabb_t = axis_aligned_bounding_volume<cuboid3D, algebra_t>;
 
         template <typename mask_group_t, typename index_t>
         DETRAY_HOST_DEVICE inline void operator()(
@@ -182,7 +183,7 @@ class cylinder_portal_generator final
                     typename detector_t::geometry_context ctx = {})
         -> dindex_range override {
 
-        using aabb_t = axis_aligned_bounding_volume<cuboid3D>;
+        using aabb_t = axis_aligned_bounding_volume<cuboid3D, algebra_t>;
 
         // Only build portals for cylinder volumes
         assert(volume.id() == volume_id::e_cylinder);
@@ -227,9 +228,9 @@ class cylinder_portal_generator final
 
             // Get the half lengths for the cylinder height and disc translation
             const point3_t h_lengths = 0.5f * (box_max - box_min);
-            const scalar h_x{math::fabs(h_lengths[0])};
-            const scalar h_y{math::fabs(h_lengths[1])};
-            const scalar h_z{math::fabs(h_lengths[2])};
+            const scalar_t h_x{math::fabs(h_lengths[0])};
+            const scalar_t h_y{math::fabs(h_lengths[1])};
+            const scalar_t h_z{math::fabs(h_lengths[2])};
 
             const scalar_t outer_r_min{math::max(h_x, h_y)};
             const scalar_t mean_radius{get_mean_radius(surfaces, transforms)};

--- a/core/include/detray/builders/detail/associator.hpp
+++ b/core/include/detray/builders/detail/associator.hpp
@@ -18,31 +18,34 @@
 
 namespace detray::detail {
 
-/** Struct that assigns the center of gravity to a rectangular bin */
+/// Struct that assigns the center of gravity to a rectangular bin
+template <typename algebra_t>
 struct center_of_gravity_rectangle {
-    /** Call operator to the struct, allows to chain several chain operators
-     * together
-     *
-     * @param bin_contour The contour description of the bin -> target
-     * @param surface_contour The contour description of the surface -> test
-     *
-     * @note the bin_contour is asummed to be a rectangle
-     *
-     * @return whether this should be associated
-     */
-    template <typename point2_t>
-    bool operator()(const std::vector<point2_t> &bin_contour,
-                    const std::vector<point2_t> &surface_contour) {
+    /// Call operator to the struct, allows to chain several chain operators
+    /// together
+    ///
+    /// @param bin_contour The contour description of the bin -> target
+    /// @param surface_contour The contour description of the surface -> test
+    ///
+    /// @note the bin_contour is asummed to be a rectangle
+    ///
+    /// @return whether this should be associated
+    bool operator()(const std::vector<dpoint2D<algebra_t>> &bin_contour,
+                    const std::vector<dpoint2D<algebra_t>> &surface_contour) {
+
+        using scalar_t = dscalar<algebra_t>;
+        using point2_t = dpoint2D<algebra_t>;
+
         // Check if centre of gravity is inside bin
         point2_t cgs = {0.f, 0.f};
         for (const auto &svtx : surface_contour) {
             cgs = cgs + svtx;
         }
-        cgs = 1.f / static_cast<scalar>(surface_contour.size()) * cgs;
-        scalar min_l0 = std::numeric_limits<scalar>::max();
-        scalar max_l0 = -std::numeric_limits<scalar>::max();
-        scalar min_l1 = std::numeric_limits<scalar>::max();
-        scalar max_l1 = -std::numeric_limits<scalar>::max();
+        cgs = 1.f / static_cast<scalar_t>(surface_contour.size()) * cgs;
+        scalar_t min_l0 = std::numeric_limits<scalar_t>::max();
+        scalar_t max_l0 = -std::numeric_limits<scalar_t>::max();
+        scalar_t min_l1 = std::numeric_limits<scalar_t>::max();
+        scalar_t max_l1 = -std::numeric_limits<scalar_t>::max();
         for (const auto &b : bin_contour) {
             min_l0 = math::min(b[0], min_l0);
             max_l0 = math::max(b[0], max_l0);
@@ -59,25 +62,28 @@ struct center_of_gravity_rectangle {
     }
 };
 
-/** Check if center of mass is inside a generic polygon bin */
+/// Check if center of mass is inside a generic polygon bin
+template <typename algebra_t>
 struct center_of_gravity_generic {
-    /** Call operator to the struct, allows to chain several chain operators
-     * together
-     *
-     * @param bin_contour The contour description of the bin -> target
-     * @param surface_contour The contour description of the surface -> test
-     *
-     * @return whether this should be associated
-     */
-    template <typename point2_t>
-    bool operator()(const std::vector<point2_t> &bin_contour,
-                    const std::vector<point2_t> &surface_contour) {
+    /// Call operator to the struct, allows to chain several chain operators
+    /// together
+    ///
+    /// @param bin_contour The contour description of the bin -> target
+    /// @param surface_contour The contour description of the surface -> test
+    ///
+    /// @return whether this should be associated
+    bool operator()(const std::vector<dpoint2D<algebra_t>> &bin_contour,
+                    const std::vector<dpoint2D<algebra_t>> &surface_contour) {
+
+        using scalar_t = dscalar<algebra_t>;
+        using point2_t = dpoint2D<algebra_t>;
+
         // Check if centre of gravity is inside bin
         point2_t cgs = {0.f, 0.f};
         for (const auto &svtx : surface_contour) {
             cgs = cgs + svtx;
         }
-        cgs = 1.f / static_cast<scalar>(surface_contour.size()) * cgs;
+        cgs = 1.f / static_cast<scalar_t>(surface_contour.size()) * cgs;
 
         std::size_t i = 0u;
         std::size_t j = 0u;
@@ -97,25 +103,27 @@ struct center_of_gravity_generic {
     }
 };
 
-/** Check if the egdes of the bin and surface contour overlap */
+/// Check if the egdes of the bin and surface contour overlap
+template <typename algebra_t>
 struct edges_intersect_generic {
 
-    /** Call operator to the struct, allows to chain several chain operators
-     * together
-     *
-     * @param bin_contour The contour description of the bin -> target
-     * @param surface_contour The contour description of the surface -> test
-     *
-     * @return whether this should be associated
-     */
-    template <typename point2_t>
-    bool operator()(const std::vector<point2_t> &bin_contour,
-                    const std::vector<point2_t> &surface_contour) {
+    /// Call operator to the struct, allows to chain several chain operators
+    /// together
+    ///
+    /// @param bin_contour The contour description of the bin -> target
+    /// @param surface_contour The contour description of the surface -> test
+    ///
+    /// @return whether this should be associated
+    bool operator()(const std::vector<dpoint2D<algebra_t>> &bin_contour,
+                    const std::vector<dpoint2D<algebra_t>> &surface_contour) {
+
+        using scalar_t = dscalar<algebra_t>;
+        using point2_t = dpoint2D<algebra_t>;
 
         auto intersect = [](const point2_t &pi, const point2_t &pj,
                             const point2_t &pk, const point2_t &pl) {
-            scalar d = (pj[0] - pi[0]) * (pl[1] - pk[1]) -
-                       (pj[1] - pi[1]) * (pl[0] - pk[0]);
+            scalar_t d = (pj[0] - pi[0]) * (pl[1] - pk[1]) -
+                         (pj[1] - pi[1]) * (pl[0] - pk[0]);
 
             if (d != 0.f) {
                 double r = ((pi[1] - pk[1]) * (pl[0] - pk[0]) -

--- a/core/include/detray/builders/detail/portal_accessor.hpp
+++ b/core/include/detray/builders/detail/portal_accessor.hpp
@@ -27,7 +27,7 @@ namespace detray::detail {
 template <typename detector_t>
 auto get_cylinder_portals(const tracking_volume<detector_t> &vol) {
 
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
 
     std::vector<const typename detector_t::volume_type &> inner_pt{},
         outer_pt{}, lower_pt{}, upper_pr{};

--- a/core/include/detray/builders/detail/volume_connector.hpp
+++ b/core/include/detray/builders/detail/volume_connector.hpp
@@ -30,7 +30,7 @@ template <typename detector_t,
 void connect_cylindrical_volumes(
     detector_t &d, const typename detector_t::volume_finder &volume_grid) {
 
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
     typename detector_t::context default_context = {};
 
     // The grid is populated, now create portal surfaces

--- a/core/include/detray/builders/grid_builder.hpp
+++ b/core/include/detray/builders/grid_builder.hpp
@@ -37,9 +37,10 @@ class grid_builder : public volume_decorator<detector_t> {
     using link_id_t = typename detector_t::volume_type::object_id;
 
     public:
-    using scalar_type = typename detector_t::scalar_type;
     using detector_type = detector_t;
+    using algebra_type = typename detector_t::algebra_type;
     using value_type = typename detector_type::surface_type;
+    using scalar_type = dscalar<algebra_type>;
 
     /// Decorate a volume with a grid
     DETRAY_HOST
@@ -78,7 +79,7 @@ class grid_builder : public volume_decorator<detector_t> {
     /// Delegate init call depending on @param span type
     template <typename grid_shape_t>
     DETRAY_HOST void init_grid(
-        const mask<grid_shape_t> &m,
+        const mask<grid_shape_t, algebra_type> &m,
         const std::array<std::size_t, grid_t::dim> &n_bins,
         const std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
             &bin_capacities = {},
@@ -210,12 +211,12 @@ template <typename detector_t,
           typename grid_shape_t, typename bin_t,
           template <std::size_t> class serializer_t,
           axis::bounds e_bounds = axis::bounds::e_closed,
-          typename algebra_t = typename detector_t::transform3,
           template <typename, typename> class... binning_ts>
 using grid_builder_type = grid_builder<
     detector_t,
-    typename grid_factory_t<bin_t, serializer_t, algebra_t>::template grid_type<
-        axes<grid_shape_t, e_bounds, binning_ts...>>,
-    grid_factory_t<bin_t, serializer_t, algebra_t>>;
+    typename grid_factory_t<bin_t, serializer_t,
+                            typename detector_t::algebra_type>::
+        template grid_type<axes<grid_shape_t, e_bounds, binning_ts...>>,
+    grid_factory_t<bin_t, serializer_t, typename detector_t::algebra_type>>;
 
 }  // namespace detray

--- a/core/include/detray/builders/grid_factory.hpp
+++ b/core/include/detray/builders/grid_factory.hpp
@@ -43,7 +43,7 @@ namespace detray {
 /// @note that if non-zero axis_spans are provided the values of the
 /// mask is overwritten
 template <typename bin_t, template <std::size_t> class serializer_t,
-          typename algebra_t = ALGEBRA_PLUGIN<detray::scalar>>
+          typename algebra_t>
 class grid_factory {
 
     public:
@@ -52,7 +52,8 @@ class grid_factory {
 
     using bin_type = bin_t;
     template <typename grid_shape_t>
-    using grid_type = grid<axes<grid_shape_t>, bin_type, serializer_t>;
+    using grid_type =
+        grid<algebra_t, axes<grid_shape_t>, bin_type, serializer_t>;
     template <typename grid_shape_t>
     using loc_bin_index = typename grid_type<grid_shape_t>::loc_bin_index;
 
@@ -73,10 +74,10 @@ class grid_factory {
     template <
         typename r_bounds = axis::closed<axis::label::e_r>,
         typename phi_bounds = axis::circular<>,
-        typename r_binning = axis::regular<host_container_types, scalar_type>,
-        typename phi_binning = axis::regular<host_container_types, scalar_type>>
+        typename r_binning = axis::regular<scalar_type, host_container_types>,
+        typename phi_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(r_bounds::label)> auto new_grid(
-        const mask<annulus2D> &grid_bounds,
+        const mask<annulus2D, algebra_type> &grid_bounds,
         const std::array<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<annulus2D>, dindex>>
             &bin_capacities = {},
@@ -130,11 +131,11 @@ class grid_factory {
         typename x_bounds = axis::closed<axis::label::e_x>,
         typename y_bounds = axis::closed<axis::label::e_y>,
         typename z_bounds = axis::closed<axis::label::e_z>,
-        typename x_binning = axis::regular<host_container_types, scalar_type>,
-        typename y_binning = axis::regular<host_container_types, scalar_type>,
-        typename z_binning = axis::regular<host_container_types, scalar_type>>
+        typename x_binning = axis::regular<scalar_type, host_container_types>,
+        typename y_binning = axis::regular<scalar_type, host_container_types>,
+        typename z_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(x_bounds::label)> auto new_grid(
-        const mask<cuboid3D> &grid_bounds,
+        const mask<cuboid3D, algebra_type> &grid_bounds,
         const std::array<std::size_t, 3UL> n_bins,
         const std::vector<std::pair<loc_bin_index<cuboid3D>, dindex>>
             &bin_capacities = {},
@@ -187,10 +188,10 @@ class grid_factory {
         typename rphi_bounds = axis::circular<axis::label::e_rphi>,
         typename z_bounds = axis::closed<axis::label::e_cyl_z>,
         typename rphi_binning =
-            axis::regular<host_container_types, scalar_type>,
-        typename z_binning = axis::regular<host_container_types, scalar_type>>
+            axis::regular<scalar_type, host_container_types>,
+        typename z_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(rphi_bounds::label)> auto new_grid(
-        const mask<cylinder2D> &grid_bounds,
+        const mask<cylinder2D, algebra_type> &grid_bounds,
         const std::array<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<cylinder2D>, dindex>>
             &bin_capacities = {},
@@ -233,10 +234,10 @@ class grid_factory {
         typename rphi_bounds = axis::circular<axis::label::e_rphi>,
         typename z_bounds = axis::closed<axis::label::e_cyl_z>,
         typename rphi_binning =
-            axis::regular<host_container_types, scalar_type>,
-        typename z_binning = axis::regular<host_container_types, scalar_type>>
+            axis::regular<scalar_type, host_container_types>,
+        typename z_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(rphi_bounds::label)> auto new_grid(
-        const mask<concentric_cylinder2D> &grid_bounds,
+        const mask<concentric_cylinder2D, algebra_type> &grid_bounds,
         const std::array<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<concentric_cylinder2D>,
                                     dindex>> &bin_capacities = {},
@@ -280,11 +281,11 @@ class grid_factory {
         typename r_bounds = axis::closed<axis::label::e_r>,
         typename phi_bounds = axis::circular<>,
         typename z_bounds = axis::closed<axis::label::e_z>,
-        typename r_binning = axis::regular<host_container_types, scalar_type>,
-        typename phi_binning = axis::regular<host_container_types, scalar_type>,
-        typename z_binning = axis::regular<host_container_types, scalar_type>>
+        typename r_binning = axis::regular<scalar_type, host_container_types>,
+        typename phi_binning = axis::regular<scalar_type, host_container_types>,
+        typename z_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(r_bounds::label)> auto new_grid(
-        const mask<cylinder3D> &grid_bounds,
+        const mask<cylinder3D, algebra_type> &grid_bounds,
         const std::array<std::size_t, 3UL> n_bins,
         const std::vector<std::pair<loc_bin_index<cylinder3D>, dindex>>
             &bin_capacities = {},
@@ -344,10 +345,10 @@ class grid_factory {
     template <
         typename r_bounds = axis::closed<axis::label::e_r>,
         typename phi_bounds = axis::circular<>,
-        typename r_binning = axis::regular<host_container_types, scalar_type>,
-        typename phi_binning = axis::regular<host_container_types, scalar_type>>
+        typename r_binning = axis::regular<scalar_type, host_container_types>,
+        typename phi_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(r_bounds::label)> auto new_grid(
-        const mask<ring2D> &grid_bounds,
+        const mask<ring2D, algebra_type> &grid_bounds,
         const std::array<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<ring2D>, dindex>>
             &bin_capacities = {},
@@ -390,10 +391,10 @@ class grid_factory {
     template <
         typename x_bounds = axis::closed<axis::label::e_x>,
         typename y_bounds = axis::closed<axis::label::e_y>,
-        typename x_binning = axis::regular<host_container_types, scalar_type>,
-        typename y_binning = axis::regular<host_container_types, scalar_type>>
+        typename x_binning = axis::regular<scalar_type, host_container_types>,
+        typename y_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(x_bounds::label)> auto new_grid(
-        const mask<rectangle2D> &grid_bounds,
+        const mask<rectangle2D, algebra_type> &grid_bounds,
         const std::array<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<rectangle2D>, dindex>>
             &bin_capacities = {},
@@ -435,10 +436,10 @@ class grid_factory {
     template <
         typename x_bounds = axis::closed<axis::label::e_x>,
         typename y_bounds = axis::closed<axis::label::e_y>,
-        typename x_binning = axis::regular<host_container_types, scalar_type>,
-        typename y_binning = axis::regular<host_container_types, scalar_type>>
+        typename x_binning = axis::regular<scalar_type, host_container_types>,
+        typename y_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(x_bounds::label)> auto new_grid(
-        const mask<trapezoid2D> &grid_bounds,
+        const mask<trapezoid2D, algebra_type> &grid_bounds,
         const std::array<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<trapezoid2D>, dindex>>
             &bin_capacities = {},
@@ -509,7 +510,7 @@ class grid_factory {
         using axes_t =
             axis::multi_axis<is_owning, grid_frame_t,
                              axis::single_axis<bound_ts, binning_ts>...>;
-        using grid_t = grid<axes_t, bin_t, serializer_t>;
+        using grid_t = grid<algebra_t, axes_t, bin_t, serializer_t>;
 
         return new_grid<grid_t>(spans, n_bins, bin_capacities, ax_bin_edges);
     }
@@ -535,7 +536,7 @@ class grid_factory {
     /// and binnings from concrete grid type
     template <concepts::grid grid_t, typename grid_shape_t>
     auto new_grid(
-        const mask<grid_shape_t> &m,
+        const mask<grid_shape_t, algebra_type> &m,
         const std::array<std::size_t, grid_t::dim> &n_bins,
         const std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
             &bin_capacities = {},
@@ -555,7 +556,7 @@ class grid_factory {
         typename grid_shape_t, typename... bound_ts, typename... binning_ts,
         std::enable_if_t<std::is_enum_v<typename grid_shape_t::boundaries>,
                          bool> = true>
-    auto new_grid(const mask<grid_shape_t> &m,
+    auto new_grid(const mask<grid_shape_t, algebra_type> &m,
                   const std::array<std::size_t, grid_shape_t::dim> &n_bins,
                   const std::vector<
                       std::pair<axis::multi_bin<sizeof...(bound_ts)>, dindex>>
@@ -652,7 +653,7 @@ class grid_factory {
                    vector_type<scalar_type> &bin_edges) const {
         if constexpr (std::is_same_v<
                           types::at<binnings, I>,
-                          axis::regular<host_container_types, scalar_type>>) {
+                          axis::regular<scalar_type, host_container_types>>) {
             axes_data.push_back({static_cast<dindex>(bin_edges.size()),
                                  static_cast<dindex>(n_bins.at(I))});
             bin_edges.push_back(spans.at(I * 2u));
@@ -685,11 +686,10 @@ class grid_factory {
 };
 
 // Infer a grid factory type from an already completely assembled grid type
-template <concepts::grid grid_t,
-          typename algebra_t = ALGEBRA_PLUGIN<detray::scalar>>
+template <concepts::grid grid_t>
 using grid_factory_type =
     grid_factory<typename grid_t::bin_type,
                  simple_serializer /*grid_t::template serializer_type*/,
-                 algebra_t>;
+                 typename grid_t::algebra_type>;
 
 }  // namespace detray

--- a/core/include/detray/builders/homogeneous_material_builder.hpp
+++ b/core/include/detray/builders/homogeneous_material_builder.hpp
@@ -29,7 +29,7 @@ class homogeneous_material_builder final : public volume_decorator<detector_t> {
 
     public:
     using material_id = typename detector_t::materials::id;
-    using scalar_type = typename detector_t::scalar_type;
+    using scalar_type = dscalar<typename detector_t::algebra_type>;
 
     /// @param vol_builder volume builder that should be decorated with material
     DETRAY_HOST

--- a/core/include/detray/builders/homogeneous_material_factory.hpp
+++ b/core/include/detray/builders/homogeneous_material_factory.hpp
@@ -150,7 +150,7 @@ class homogeneous_material_factory final
     using placeholder_factory_t = surface_factory<detector_t, unmasked<>>;
 
     public:
-    using scalar_type = typename detector_t::scalar_type;
+    using scalar_type = dscalar<typename detector_t::algebra_type>;
 
     using base_factory::operator();
 

--- a/core/include/detray/builders/homogeneous_material_generator.hpp
+++ b/core/include/detray/builders/homogeneous_material_generator.hpp
@@ -79,7 +79,7 @@ template <typename detector_t>
 class homogeneous_material_generator final
     : public factory_decorator<detector_t> {
 
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
 
     public:
     /// Construct from configuration @param cfg

--- a/core/include/detray/builders/homogeneous_volume_material_builder.hpp
+++ b/core/include/detray/builders/homogeneous_volume_material_builder.hpp
@@ -30,7 +30,7 @@ class homogeneous_volume_material_builder final
     : public volume_decorator<detector_t> {
 
     public:
-    using scalar_type = typename detector_t::scalar_type;
+    using scalar_type = dscalar<typename detector_t::algebra_type>;
 
     /// @param vol_builder volume builder that should be decorated with volume
     /// material

--- a/core/include/detray/builders/material_map_builder.hpp
+++ b/core/include/detray/builders/material_map_builder.hpp
@@ -41,12 +41,12 @@ struct add_sf_material_map;
 /// surfaces or volumes
 template <typename detector_t, std::size_t DIM = 2u,
           typename mat_map_factory_t =
-              material_grid_factory<typename detector_t::scalar_type>>
+              material_grid_factory<typename detector_t::algebra_type>>
 class material_map_builder final : public volume_decorator<detector_t> {
     using materials_t = typename detector_t::materials;
 
     public:
-    using scalar_type = typename detector_t::scalar_type;
+    using scalar_type = dscalar<typename detector_t::algebra_type>;
     using detector_type = detector_t;
     using value_type = material_slab<scalar_type>;
     using bin_data_type =

--- a/core/include/detray/builders/material_map_factory.hpp
+++ b/core/include/detray/builders/material_map_factory.hpp
@@ -44,7 +44,7 @@ class material_map_factory final : public factory_decorator<detector_t> {
     using placeholder_factory_t = surface_factory<detector_t, unmasked<>>;
 
     public:
-    using scalar_type = typename detector_t::scalar_type;
+    using scalar_type = dscalar<typename detector_t::algebra_type>;
     using data_type = material_data<scalar_type>;
 
     using base_factory::operator();

--- a/core/include/detray/builders/material_map_generator.hpp
+++ b/core/include/detray/builders/material_map_generator.hpp
@@ -148,7 +148,7 @@ struct material_map_config {
 template <typename detector_t>
 class material_map_generator final : public factory_decorator<detector_t> {
 
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
 
     public:
     /// Construct from configuration @param cfg

--- a/core/include/detray/builders/surface_factory.hpp
+++ b/core/include/detray/builders/surface_factory.hpp
@@ -37,8 +37,10 @@ namespace detray {
 template <typename detector_t, typename mask_shape_t>
 class surface_factory : public surface_factory_interface<detector_t> {
 
-    using scalar_t = typename detector_t::scalar_type;
+    using algebra_t = typename detector_t::algebra_type;
     using volume_link_t = typename detector_t::surface_type::navigation_link;
+    using scalar_t = dscalar<algebra_t>;
+
     // Set individual volume link for portals, but only the mothervolume index
     // for other surfaces.
     using volume_link_collection = std::vector<volume_link_t>;
@@ -149,6 +151,7 @@ class surface_factory : public surface_factory_interface<detector_t> {
                     [[maybe_unused]]
                     typename detector_t::geometry_context ctx = {})
         -> dindex_range override {
+
         // In case the surfaces container is prefilled with other surfaces
         const auto surfaces_offset{static_cast<dindex>(surfaces.size())};
 
@@ -157,10 +160,10 @@ class surface_factory : public surface_factory_interface<detector_t> {
             return {surfaces_offset, surfaces_offset};
         }
 
-        constexpr auto mask_id{detector_t::masks::template get_id<
-            mask<mask_shape_t, volume_link_t>>()};
-
-        if constexpr (static_cast<std::size_t>(mask_id) >=
+        if constexpr (constexpr auto mask_id =
+                          detector_t::masks::template get_id<
+                              mask<mask_shape_t, algebra_t, volume_link_t>>();
+                      static_cast<std::size_t>(mask_id) >=
                       detector_t::masks::n_types) {
 
             throw std::invalid_argument(

--- a/core/include/detray/builders/volume_builder.hpp
+++ b/core/include/detray/builders/volume_builder.hpp
@@ -33,7 +33,7 @@ template <typename detector_t>
 class volume_builder : public volume_builder_interface<detector_t> {
 
     public:
-    using scalar_type = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
     using volume_type = typename detector_t::volume_type;
     using geo_obj_ids = typename detector_t::geo_obj_ids;
 

--- a/core/include/detray/builders/volume_builder_interface.hpp
+++ b/core/include/detray/builders/volume_builder_interface.hpp
@@ -29,7 +29,8 @@ class volume_builder_interface {
     friend class volume_decorator<detector_t>;
 
     public:
-    using scalar_type = typename detector_t::scalar_type;
+    using algebra_type = typename detector_t::algebra_type;
+    using scalar_type = dscalar<algebra_type>;
     template <typename T, std::size_t N>
     using array_type = typename detector_t::template array_type<T, N>;
 
@@ -64,21 +65,19 @@ class volume_builder_interface {
     /// @brief Add the transform for the volume placement - copy
     DETRAY_HOST
     virtual void add_volume_placement(
-        const typename detector_t::transform3_type &trf = {}) = 0;
+        const dtransform3D<algebra_type> &trf = {}) = 0;
 
     /// @brief Add the transform for the volume placement from the translation
     /// @param t. The rotation will be the identity matrix.
     DETRAY_HOST
-    virtual void add_volume_placement(
-        const typename detector_t::point3_type &t) = 0;
+    virtual void add_volume_placement(const dpoint3D<algebra_type> &t) = 0;
 
     /// @brief Add the transform for the volume placement from the translation
     /// @param t , the new x- and z-axis (@param x, @param z).
     DETRAY_HOST
-    virtual void add_volume_placement(
-        const typename detector_t::point3_type &t,
-        const typename detector_t::vector3_type &x,
-        const typename detector_t::vector3_type &z) = 0;
+    virtual void add_volume_placement(const dpoint3D<algebra_type> &t,
+                                      const dvector3D<algebra_type> &x,
+                                      const dvector3D<algebra_type> &z) = 0;
 
     /// @brief Add surfaces to the volume
     /// @returns the index range of the sensitives in the temporary surface
@@ -105,7 +104,7 @@ template <typename detector_t>
 class volume_decorator : public volume_builder_interface<detector_t> {
 
     public:
-    using scalar_type = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
     template <typename T, std::size_t N>
     using array_type = typename detector_t::template array_type<T, N>;
 

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -16,7 +16,6 @@
 #include "detray/core/detail/container_buffers.hpp"
 #include "detray/core/detail/container_views.hpp"
 #include "detray/core/detail/surface_lookup.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/definitions/detail/algebra.hpp"
 #include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
@@ -53,8 +52,7 @@ void set_transform(detector_t &det, const transform3_t &trf, unsigned int i) {
 ///
 /// @tparam metadata helper that defines collection and link types centrally
 /// @tparam container_t type collection of the underlying containers
-template <typename metadata_t = default_metadata,
-          typename container_t = host_container_types>
+template <typename metadata_t, typename container_t = host_container_types>
 class detector {
 
     // Allow the building of the detector containers

--- a/core/include/detray/geometry/detail/volume_descriptor.hpp
+++ b/core/include/detray/geometry/detail/volume_descriptor.hpp
@@ -23,7 +23,7 @@ namespace detray {
 /// that is stored in the detector data stores.
 ///
 /// @tparam ID enum of object types contained in the volume
-///         (@see @c detector_metadata ).
+///         (@see @c default_metadata ).
 /// @tparam link_t the type of link to the volumes surfaces finder(s)
 ///         (accelerator structure, e.g. a grid). The surface finder types
 ///         cannot be given directly, since the containers differ between host

--- a/core/include/detray/geometry/mask.hpp
+++ b/core/include/detray/geometry/mask.hpp
@@ -36,8 +36,8 @@ namespace detray {
 /// @tparam shape_t underlying geometrical shape of the mask, rectangle etc
 /// @tparam links_t the type of link into the volume container
 ///                 (e.g. single index vs range)
-template <typename shape_t, typename links_t = std::uint_least16_t,
-          typename algebra_t = ALGEBRA_PLUGIN<detray::scalar>>
+template <typename shape_t, typename algebra_t,
+          typename links_t = std::uint_least16_t>
 class mask {
     public:
     // Linear algebra types
@@ -85,7 +85,7 @@ class mask {
     /// @param rhs is the right hand side object
     DETRAY_HOST
     auto operator=(const mask_values& rhs)
-        -> mask<shape_t, links_t, algebra_t>& {
+        -> mask<shape_t, algebra_t, links_t>& {
         _values = rhs;
         return (*this);
     }
@@ -217,7 +217,7 @@ class mask {
     DETRAY_HOST_DEVICE
     auto local_min_bounds(const scalar_type env =
                               std::numeric_limits<scalar_type>::epsilon()) const
-        -> mask<cuboid3D, unsigned int> {
+        -> mask<cuboid3D, algebra_t, unsigned int> {
         const auto bounds =
             get_shape().template local_min_bounds<algebra_t>(_values, env);
         static_assert(bounds.size() == cuboid3D::e_size,

--- a/core/include/detray/geometry/shapes/cylinder3D.hpp
+++ b/core/include/detray/geometry/shapes/cylinder3D.hpp
@@ -128,7 +128,7 @@ class cylinder3D {
     template <typename scalar_t>
     DETRAY_HOST_DEVICE constexpr scalar_t volume(
         const bounds_type<scalar_t> &bounds) const {
-        return constant<scalar>::pi * (bounds[e_max_z] - bounds[e_min_z]) *
+        return constant<scalar_t>::pi * (bounds[e_max_z] - bounds[e_min_z]) *
                (bounds[e_max_r] * bounds[e_max_r] -
                 bounds[e_min_r] * bounds[e_min_r]);
     }

--- a/core/include/detray/geometry/shapes/line.hpp
+++ b/core/include/detray/geometry/shapes/line.hpp
@@ -146,7 +146,7 @@ class line {
             return 8.f * bounds[e_half_z] * bounds[e_cross_section] *
                    bounds[e_cross_section];
         } else {
-            return constant<scalar>::pi * 2.f * bounds[e_half_z] *
+            return constant<scalar_t>::pi * 2.f * bounds[e_half_z] *
                    bounds[e_cross_section] * bounds[e_cross_section];
         }
     }

--- a/core/include/detray/geometry/shapes/ring2D.hpp
+++ b/core/include/detray/geometry/shapes/ring2D.hpp
@@ -106,7 +106,7 @@ class ring2D {
         const bounds_type<scalar_t> &bounds) const {
         return (bounds[e_outer_r] * bounds[e_outer_r] -
                 bounds[e_inner_r] * bounds[e_inner_r]) *
-               constant<scalar>::pi;
+               constant<scalar_t>::pi;
     }
 
     /// @brief Lower and upper point for minimal axis aligned bounding box.

--- a/core/include/detray/geometry/tracking_volume.hpp
+++ b/core/include/detray/geometry/tracking_volume.hpp
@@ -38,9 +38,10 @@ namespace detray {
 template <typename detector_t>  // @TODO: This needs a concept
 class tracking_volume {
 
-    /// Scalar type
-    using scalar_type = typename detector_t::scalar_type;
-    using point3_type = typename detector_t::point3_type;
+    /// Linear algebra types
+    using algebra_type = typename detector_t::algebra_type;
+    using scalar_type = dscalar<algebra_type>;
+    using point3_type = dpoint3D<algebra_type>;
 
     /// Volume descriptor type
     using descr_t = typename detector_t::volume_type;

--- a/core/include/detray/grids/axis.hpp
+++ b/core/include/detray/grids/axis.hpp
@@ -26,6 +26,8 @@
 
 namespace detray {
 
+using scalar = DETRAY_CUSTOM_SCALARTYPE;
+
 namespace axis2 {
 /** A regular closed axis.
  *

--- a/core/include/detray/grids/grid2.hpp
+++ b/core/include/detray/grids/grid2.hpp
@@ -21,6 +21,8 @@
 
 namespace detray {
 
+using scalar = DETRAY_CUSTOM_SCALARTYPE;
+
 /** A two-dimensional grid for object storage
  *
  * @tparam populator_t  is a prescription what to do when a bin gets

--- a/core/include/detray/materials/material_map.hpp
+++ b/core/include/detray/materials/material_map.hpp
@@ -23,15 +23,17 @@
 namespace detray {
 
 /// Definition of binned material
-template <typename shape, typename scalar_t,
+template <typename algebra_t, typename shape,
           typename container_t = host_container_types, bool owning = false>
-using material_map = grid<axes<shape>, bins::single<material_slab<scalar_t>>,
+using material_map = grid<algebra_t, axes<shape>,
+                          bins::single<material_slab<dscalar<algebra_t>>>,
                           simple_serializer, container_t, owning>;
 
 /// How to build material maps of various shapes
 // TODO: Move to material_map_builder once available
-template <typename scalar_t = detray::scalar>
+template <typename algebra_t>
 using material_grid_factory =
-    grid_factory<bins::single<material_slab<scalar_t>>, simple_serializer>;
+    grid_factory<bins::single<material_slab<dscalar<algebra_t>>>,
+                 simple_serializer, algebra_t>;
 
 }  // namespace detray

--- a/core/include/detray/materials/material_slab.hpp
+++ b/core/include/detray/materials/material_slab.hpp
@@ -108,9 +108,9 @@ struct material_slab {
 
     private:
     material_type m_material = {};
-    scalar_type m_thickness = std::numeric_limits<scalar>::epsilon();
-    scalar_type m_thickness_in_X0 = std::numeric_limits<scalar>::epsilon();
-    scalar_type m_thickness_in_L0 = std::numeric_limits<scalar>::epsilon();
+    scalar_type m_thickness = std::numeric_limits<scalar_type>::epsilon();
+    scalar_type m_thickness_in_X0 = std::numeric_limits<scalar_type>::epsilon();
+    scalar_type m_thickness_in_L0 = std::numeric_limits<scalar_type>::epsilon();
 };
 
 }  // namespace detray

--- a/core/include/detray/materials/predefined_materials.hpp
+++ b/core/include/detray/materials/predefined_materials.hpp
@@ -27,144 +27,146 @@ namespace detray {
  * charge number (Z) are doubled
  */
 // Vacuum
-DETRAY_DECLARE_MATERIAL(vacuum, std::numeric_limits<scalar>::max(),
-                        std::numeric_limits<scalar>::max(), 0.f, 0.f, 0.f,
+DETRAY_DECLARE_MATERIAL(vacuum, std::numeric_limits<scalar_t>::max(),
+                        std::numeric_limits<scalar_t>::max(), 0.f, 0.f, 0.f,
                         material_state::e_unknown);
 
 // H₂ (1): Hydrogen Gas
-DETRAY_DECLARE_MATERIAL(hydrogen_gas, 7.526E3f * unit<scalar>::m,
-                        6.209E3f * unit<scalar>::m, 2.f * 1.008f, 2.f * 1.f,
-                        static_cast<scalar>(8.376E-5 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(hydrogen_gas, 7.526E3f * unit<scalar_t>::m,
+                        6.209E3f * unit<scalar_t>::m, 2.f * 1.008f, 2.f * 1.f,
+                        static_cast<scalar_t>(8.376E-5 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_gas);
 
 // H₂ (1): Hydrogen Liquid
-DETRAY_DECLARE_MATERIAL(hydrogen_liquid, 8.904f * unit<scalar>::m,
-                        7.346f * unit<scalar>::m, 2.f * 1.008f, 2.f * 1.f,
-                        static_cast<scalar>(0.07080f * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(hydrogen_liquid, 8.904f * unit<scalar_t>::m,
+                        7.346f * unit<scalar_t>::m, 2.f * 1.008f, 2.f * 1.f,
+                        static_cast<scalar_t>(0.07080f * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_liquid);
 
 // He (2): Helium Gas
-DETRAY_DECLARE_MATERIAL(helium_gas, 5.671E3f * unit<scalar>::m,
-                        4.269E3f * unit<scalar>::m, 4.003f, 2.f,
-                        static_cast<scalar>(1.663E-4 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(helium_gas, 5.671E3f * unit<scalar_t>::m,
+                        4.269E3f * unit<scalar_t>::m, 4.003f, 2.f,
+                        static_cast<scalar_t>(1.663E-4 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_gas);
 
 // Be (4)
-DETRAY_DECLARE_MATERIAL(beryllium, 352.8f * unit<scalar>::mm,
-                        421.0f * unit<scalar>::mm, 9.012f, 4.f,
-                        static_cast<scalar>(1.848 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(beryllium, 352.8f * unit<scalar_t>::mm,
+                        421.0f * unit<scalar_t>::mm, 9.012f, 4.f,
+                        static_cast<scalar_t>(1.848 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_solid);
 
 // C (6): Carbon (amorphous)
-DETRAY_DECLARE_MATERIAL(carbon_gas, 213.5f * unit<scalar>::mm,
-                        429.0f * unit<scalar>::mm, 12.01f, 6.f,
-                        static_cast<scalar>(2.0 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(carbon_gas, 213.5f * unit<scalar_t>::mm,
+                        429.0f * unit<scalar_t>::mm, 12.01f, 6.f,
+                        static_cast<scalar_t>(2.0 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_gas);
 
 // N₂ (7): Nitrogen Gas
-DETRAY_DECLARE_MATERIAL(nitrogen_gas, 3.260E+02f * unit<scalar>::m,
-                        7.696E+02f * unit<scalar>::m, 2.f * 14.007f, 2.f * 7.f,
-                        static_cast<scalar>(1.165E-03 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(nitrogen_gas, 3.260E+02f * unit<scalar_t>::m,
+                        7.696E+02f * unit<scalar_t>::m, 2.f * 14.007f,
+                        2.f * 7.f,
+                        static_cast<scalar_t>(1.165E-03 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_gas);
 
 // O₂ (8): Oxygen Gas
-DETRAY_DECLARE_MATERIAL(oxygen_gas, 2.571E+02f * unit<scalar>::m,
-                        6.772E+02f * unit<scalar>::m, 2.f * 15.999f, 2.f * 8.f,
-                        static_cast<scalar>(1.332E-3 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(oxygen_gas, 2.571E+02f * unit<scalar_t>::m,
+                        6.772E+02f * unit<scalar_t>::m, 2.f * 15.999f,
+                        2.f * 8.f,
+                        static_cast<scalar_t>(1.332E-3 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_gas);
 
 // O₂ (8): Oxygen liquid
-DETRAY_DECLARE_MATERIAL(oxygen_liquid, 300.1f * unit<scalar>::mm,
-                        790.3f * unit<scalar>::mm, 2.f * 15.999f, 2.f * 8.f,
-                        static_cast<scalar>(1.141 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(oxygen_liquid, 300.1f * unit<scalar_t>::mm,
+                        790.3f * unit<scalar_t>::mm, 2.f * 15.999f, 2.f * 8.f,
+                        static_cast<scalar_t>(1.141 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_liquid);
 
 // Al (13)
-DETRAY_DECLARE_MATERIAL(aluminium, 88.97f * unit<scalar>::mm,
-                        397.0f * unit<scalar>::mm, 26.98f, 13.f,
-                        static_cast<scalar>(2.699 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(aluminium, 88.97f * unit<scalar_t>::mm,
+                        397.0f * unit<scalar_t>::mm, 26.98f, 13.f,
+                        static_cast<scalar_t>(2.699 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_solid);
 
 // Si (14)
-DETRAY_DECLARE_MATERIAL(silicon, 93.7f * unit<scalar>::mm,
-                        465.2f * unit<scalar>::mm, 28.0855f, 14.f,
-                        static_cast<scalar>(2.329 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(silicon, 93.7f * unit<scalar_t>::mm,
+                        465.2f * unit<scalar_t>::mm, 28.0855f, 14.f,
+                        static_cast<scalar_t>(2.329 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_solid);
 
 // Si (14) with density effect data
-DETRAY_DECLARE_MATERIAL_WITH_DED(silicon_with_ded, 93.7f * unit<scalar>::mm,
-                                 465.2f * unit<scalar>::mm, 28.0855f, 14.f,
-                                 static_cast<scalar>(2.329 * unit<double>::g /
-                                                     unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL_WITH_DED(silicon_with_ded, 93.7f * unit<scalar_t>::mm,
+                                 465.2f * unit<scalar_t>::mm, 28.0855f, 14.f,
+                                 static_cast<scalar_t>(2.329 * unit<double>::g /
+                                                       unit<double>::cm3),
                                  material_state::e_solid, 0.1492f, 3.2546f,
                                  0.2015f, 2.8716f, 173.0f, 4.4355f, 0.14f);
 
 // Ar (18): Argon gas
-DETRAY_DECLARE_MATERIAL(argon_gas, 1.176E+02f * unit<scalar>::m,
-                        7.204E+02f * unit<scalar>::m, 39.948f, 18.f,
-                        static_cast<scalar>(1.662E-03 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(argon_gas, 1.176E+02f * unit<scalar_t>::m,
+                        7.204E+02f * unit<scalar_t>::m, 39.948f, 18.f,
+                        static_cast<scalar_t>(1.662E-03 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_gas);
 
 // Ar (18): Argon liquid
-DETRAY_DECLARE_MATERIAL(argon_liquid, 14.f * unit<scalar>::cm,
-                        85.77f * unit<scalar>::cm, 39.948f, 18.f,
-                        static_cast<scalar>(1.396 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(argon_liquid, 14.f * unit<scalar_t>::cm,
+                        85.77f * unit<scalar_t>::cm, 39.948f, 18.f,
+                        static_cast<scalar_t>(1.396 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_liquid);
 
 // Fe (26)
-DETRAY_DECLARE_MATERIAL(iron, 1.757f * unit<scalar>::cm,
-                        16.77f * unit<scalar>::cm, 55.845f, 26.f,
-                        static_cast<scalar>(7.874 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(iron, 1.757f * unit<scalar_t>::cm,
+                        16.77f * unit<scalar_t>::cm, 55.845f, 26.f,
+                        static_cast<scalar_t>(7.874 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_solid);
 
 // Fe (26) with density effect data
-DETRAY_DECLARE_MATERIAL_WITH_DED(iron_with_ded, 1.757f * unit<scalar>::cm,
-                                 16.77f * unit<scalar>::cm, 55.845f, 26.f,
-                                 static_cast<scalar>(7.874 * unit<double>::g /
-                                                     unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL_WITH_DED(iron_with_ded, 1.757f * unit<scalar_t>::cm,
+                                 16.77f * unit<scalar_t>::cm, 55.845f, 26.f,
+                                 static_cast<scalar_t>(7.874 * unit<double>::g /
+                                                       unit<double>::cm3),
                                  material_state::e_solid, 0.14680f, 2.9632f,
                                  -0.0012f, 3.1531f, 286.0f, 4.2911f, 0.12f);
 
 // Copper (29)
-DETRAY_DECLARE_MATERIAL(copper, 1.436f * unit<scalar>::cm,
-                        15.32f * unit<scalar>::cm, 63.546f, 29.f,
-                        static_cast<scalar>(8.960 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(copper, 1.436f * unit<scalar_t>::cm,
+                        15.32f * unit<scalar_t>::cm, 63.546f, 29.f,
+                        static_cast<scalar_t>(8.960 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_solid);
 
 // Copper (29) with density effect data
-DETRAY_DECLARE_MATERIAL_WITH_DED(copper_with_ded, 1.436f * unit<scalar>::cm,
-                                 15.32f * unit<scalar>::cm, 63.546f, 29.f,
-                                 static_cast<scalar>(8.960 * unit<double>::g /
-                                                     unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL_WITH_DED(copper_with_ded, 1.436f * unit<scalar_t>::cm,
+                                 15.32f * unit<scalar_t>::cm, 63.546f, 29.f,
+                                 static_cast<scalar_t>(8.960 * unit<double>::g /
+                                                       unit<double>::cm3),
                                  material_state::e_solid, 0.14339f, 2.9044f,
                                  -0.0254f, 3.2792f, 322.0f, 4.4190f, 0.08f);
 
 // W (74)
-DETRAY_DECLARE_MATERIAL(tungsten, 3.504f * unit<scalar>::mm,
-                        99.46f * unit<scalar>::mm, 183.84f, 74.f,
-                        static_cast<scalar>(19.3 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(tungsten, 3.504f * unit<scalar_t>::mm,
+                        99.46f * unit<scalar_t>::mm, 183.84f, 74.f,
+                        static_cast<scalar_t>(19.3 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_solid);
 
 // Au (79)
-DETRAY_DECLARE_MATERIAL(gold, 3.344f * unit<scalar>::mm,
-                        101.6f * unit<scalar>::mm, 196.97f, 79.f,
-                        static_cast<scalar>(19.32 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(gold, 3.344f * unit<scalar_t>::mm,
+                        101.6f * unit<scalar_t>::mm, 196.97f, 79.f,
+                        static_cast<scalar_t>(19.32 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_solid);
 
 /**
@@ -173,17 +175,17 @@ DETRAY_DECLARE_MATERIAL(gold, 3.344f * unit<scalar>::mm,
  */
 
 // Be (4)
-DETRAY_DECLARE_MATERIAL(beryllium_tml, 352.8f * unit<scalar>::mm,
-                        407.f * unit<scalar>::mm, 9.012f, 4.f,
-                        static_cast<scalar>(1.848 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(beryllium_tml, 352.8f * unit<scalar_t>::mm,
+                        407.f * unit<scalar_t>::mm, 9.012f, 4.f,
+                        static_cast<scalar_t>(1.848 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_solid);
 
 // Si (14)
-DETRAY_DECLARE_MATERIAL(silicon_tml, 95.7f * unit<scalar>::mm,
-                        465.2f * unit<scalar>::mm, 28.03f, 14.f,
-                        static_cast<scalar>(2.32 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(silicon_tml, 95.7f * unit<scalar_t>::mm,
+                        465.2f * unit<scalar_t>::mm, 28.03f, 14.f,
+                        static_cast<scalar_t>(2.32 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_solid);
 
 /**
@@ -194,10 +196,10 @@ DETRAY_DECLARE_MATERIAL(silicon_tml, 95.7f * unit<scalar>::mm,
 // @note:
 // https://pdg.lbl.gov/2020/AtomicNuclearProperties/HTML/air_dry_1_atm.html
 // @note: Ar from Wikipedia (https://en.wikipedia.org/wiki/Molar_mass)
-DETRAY_DECLARE_MATERIAL(air, 3.039E+02f * unit<scalar>::m,
-                        7.477E+02f * unit<scalar>::m, 28.97f, 14.46f,
-                        static_cast<scalar>(1.205E-03 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(air, 3.039E+02f * unit<scalar_t>::m,
+                        7.477E+02f * unit<scalar_t>::m, 28.97f, 14.46f,
+                        static_cast<scalar_t>(1.205E-03 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_gas);
 
 // (CH3)2CHCH3 Gas
@@ -206,36 +208,35 @@ DETRAY_DECLARE_MATERIAL(air, 3.039E+02f * unit<scalar>::m,
 // @note: Z was caculated by simply summing the number of atoms. Surprisingly
 // it seems the right value because Z/A is 0.58496, which is the same with <Z/A>
 // in the pdg refernce
-DETRAY_DECLARE_MATERIAL(isobutane, 1693E+02f * unit<scalar>::mm,
-                        288.3f * unit<scalar>::mm, 58.124f, 34.f,
-                        static_cast<scalar>(2.67 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(isobutane, 1693E+02f * unit<scalar_t>::mm,
+                        288.3f * unit<scalar_t>::mm, 58.124f, 34.f,
+                        static_cast<scalar_t>(2.67 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_gas);
 
 // C3H8 Gas
 // @note: (X0, L0, mass_rho) from
 // https://pdg.lbl.gov/2020/AtomicNuclearProperties/HTML/propane.html
 // @note: Ar from Wikipedia (https://en.wikipedia.org/wiki/Propane)
-DETRAY_DECLARE_MATERIAL(propane, 2.429E+02f * unit<scalar>::m,
-                        4.106E+02f * unit<scalar>::m, 44.097f, 26.f,
-                        static_cast<scalar>(1.868E-03 * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(propane, 2.429E+02f * unit<scalar_t>::m,
+                        4.106E+02f * unit<scalar_t>::m, 44.097f, 26.f,
+                        static_cast<scalar_t>(1.868E-03 * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_gas);
 
 // Cesium Iodide (CsI)
 // https://pdg.lbl.gov/2023/AtomicNuclearProperties/HTML/cesium_iodide_CsI.html
-DETRAY_DECLARE_MATERIAL(cesium_iodide, 1.86f * unit<scalar>::cm,
-                        38.04f * unit<scalar>::cm, 259.81f, 108.f,
-                        static_cast<scalar>(4.510f * unit<double>::g /
-                                            unit<double>::cm3),
+DETRAY_DECLARE_MATERIAL(cesium_iodide, 1.86f * unit<scalar_t>::cm,
+                        38.04f * unit<scalar_t>::cm, 259.81f, 108.f,
+                        static_cast<scalar_t>(4.510f * unit<double>::g /
+                                              unit<double>::cm3),
                         material_state::e_solid);
 
-DETRAY_DECLARE_MATERIAL_WITH_DED(cesium_iodide_with_ded,
-                                 1.86f * unit<scalar>::cm,
-                                 38.04f * unit<scalar>::cm, 259.81f, 108.f,
-                                 static_cast<scalar>(4.510f * unit<double>::g /
-                                                     unit<double>::cm3),
-                                 material_state::e_solid, 0.25381f, 2.6657f,
-                                 0.0395f, 3.3353f, 553.1f, 6.2807f, 0.00f);
+DETRAY_DECLARE_MATERIAL_WITH_DED(
+    cesium_iodide_with_ded, 1.86f * unit<scalar_t>::cm,
+    38.04f * unit<scalar_t>::cm, 259.81f, 108.f,
+    static_cast<scalar_t>(4.510f * unit<double>::g / unit<double>::cm3),
+    material_state::e_solid, 0.25381f, 2.6657f, 0.0395f, 3.3353f, 553.1f,
+    6.2807f, 0.00f);
 
 }  // namespace detray

--- a/core/include/detray/navigation/detail/helix.hpp
+++ b/core/include/detray/navigation/detail/helix.hpp
@@ -70,7 +70,7 @@ class helix {
 
         // Momentum
         const vector3_type mom =
-            1.f / static_cast<scalar_type>(math::fabs(qop)) * _t0;
+            (1.f / static_cast<scalar_type>(math::fabs(qop))) * _t0;
 
         // Normalized _h0 X _t0
         _n0 = vector::normalize(vector::cross(_h0, _t0));
@@ -194,8 +194,8 @@ class helix {
         // Get drdt
         auto drdt = Z33;
 
-        const scalar sin_ks = math::sin(_K * s);
-        const scalar cos_ks = math::cos(_K * s);
+        const scalar_type sin_ks = math::sin(_K * s);
+        const scalar_type cos_ks = math::cos(_K * s);
         drdt = drdt + sin_ks / _K * I33;
 
         matrix_type<3, 1> H0 = matrix::zero<matrix_type<3, 1>>();
@@ -265,7 +265,7 @@ class helix {
     vector3_type const *_mag_field;
 
     /// B field strength
-    scalar _B;
+    scalar_type _B;
 
     /// Normalized b field
     vector3_type _h0;

--- a/core/include/detray/navigation/intersection/intersection.hpp
+++ b/core/include/detray/navigation/intersection/intersection.hpp
@@ -30,8 +30,8 @@ struct intersection2D {};
 template <typename surface_descr_t, typename algebra_t>
 struct intersection2D<surface_descr_t, algebra_t, false> {
 
-    using T = typename algebra_t::value_type;
     using algebra_type = algebra_t;
+    using T = dvalue<algebra_t>;
     using bool_t = dbool<algebra_t>;
     using scalar_type = dscalar<algebra_t>;
     using point2_type = dpoint2D<algebra_t>;

--- a/core/include/detray/navigation/policies.hpp
+++ b/core/include/detray/navigation/policies.hpp
@@ -56,10 +56,11 @@ struct guided_navigation : actor {
 /// hit, lower the trustlevel to 'fair trust', otherwise stay in 'high trust'.
 /// The reasoning is, that the track state might have changed much when a
 /// constraint was triggered.
+template <typename scalar_t>
 struct stepper_default_policy : actor {
 
     struct state {
-        scalar tol{std::numeric_limits<scalar>::epsilon()};
+        scalar_t tol{std::numeric_limits<scalar_t>::epsilon()};
     };
 
     /// Sets the navigation trust level depending on the step size limit
@@ -93,11 +94,12 @@ struct stepper_default_policy : actor {
 /// Specific navigation policy for the Runge-Kutta stepper: Use the relative
 /// amount of step size correction as a measure for the change in direction of
 /// the track state.
+template <typename scalar_t>
 struct stepper_rk_policy : actor {
 
     struct state {
-        scalar m_threshold_fair_trust{0.05f};
-        scalar m_threshold_no_trust{0.1f};
+        scalar_t m_threshold_fair_trust{0.05f};
+        scalar_t m_threshold_no_trust{0.1f};
     };
 
     /// Sets the navigation trust level depending on the step size correction
@@ -112,8 +114,8 @@ struct stepper_rk_policy : actor {
         auto &navigation = propagation._navigation;
 
         // How strongly did the RKN algorithm reduce the step size?
-        const scalar rel_correction{(stepping.step_size() - navigation()) /
-                                    navigation()};
+        const scalar_t rel_correction{(stepping.step_size() - navigation()) /
+                                      navigation()};
 
         // Large correction to the stepsize - re-initialize the volume
         if (rel_correction > pol_state.m_threshold_no_trust) {

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -18,20 +18,21 @@
 namespace detray {
 
 /// Aborter that checks whether the track has exceeded its pathlimit
+template <typename scalar_t>
 struct pathlimit_aborter : actor {
 
     /// Pathlimit for a single propagation workflow
     struct state {
         /// Absolute path limit
-        scalar _path_limit = std::numeric_limits<scalar>::max();
+        scalar_t _path_limit = std::numeric_limits<scalar_t>::max();
 
         /// Set the path limit to a scalar @param pl
         DETRAY_HOST_DEVICE
-        inline void set_path_limit(const scalar pl) { _path_limit = pl; }
+        inline void set_path_limit(const scalar_t pl) { _path_limit = pl; }
 
         /// @returns this states remaining path length.
         DETRAY_HOST_DEVICE
-        inline scalar path_limit() const { return _path_limit; }
+        inline scalar_t path_limit() const { return _path_limit; }
     };
 
     /// Enforces the path limit on a stepper state
@@ -49,7 +50,7 @@ struct pathlimit_aborter : actor {
             return;
         }
 
-        const scalar step_limit =
+        const scalar_t step_limit =
             abrt_state.path_limit() -
             math::fabs(prop_state._stepping.abs_path_length());
 

--- a/core/include/detray/propagator/detail/jacobian_engine.hpp
+++ b/core/include/detray/propagator/detail/jacobian_engine.hpp
@@ -142,7 +142,7 @@ requires std::is_object_v<typename frame_t::loc_point> struct jacobian_engine {
 
     DETRAY_HOST_DEVICE static inline free_matrix<algebra_type> path_correction(
         const vector3_type& pos, const vector3_type& dir,
-        const vector3_type& dtds, const scalar dqopds,
+        const vector3_type& dtds, const scalar_type dqopds,
         const transform3_type& trf3) {
 
         free_to_path_matrix_type path_derivative =

--- a/core/include/detray/propagator/detail/jacobian_line.hpp
+++ b/core/include/detray/propagator/detail/jacobian_line.hpp
@@ -87,7 +87,7 @@ struct jacobian<line2D<algebra_t>> {
         // Cosine of angle between momentum direction and local frame z axis
         const scalar_type dz = vector::dot(local_zaxis, dir);
 
-        // local x axis component of pc:
+        // Local x axis component of pc:
         const vector3_type pc_x = pc - pz * local_zaxis;
 
         const scalar_type norm =

--- a/core/include/detray/propagator/detail/jacobian_polar.hpp
+++ b/core/include/detray/propagator/detail/jacobian_polar.hpp
@@ -78,6 +78,7 @@ struct jacobian<polar2D<algebra_t>> {
 
         const point2_type local =
             coordinate_frame::global_to_local(trf3, pos, dir);
+
         const scalar_type lrad{local[0]};
         const scalar_type lphi{local[1]};
 
@@ -88,13 +89,12 @@ struct jacobian<polar2D<algebra_t>> {
         const rotation_matrix frame = reference_frame(trf3, pos, dir);
 
         // dxdu = d(x,y,z)/du
-        const matrix_type<3, 1> dxdL = getter::block<3, 1>(frame, 0u, 0u);
+        const vector3_type dxdL = getter::vector<3>(frame, 0u, 0u);
         // dxdv = d(x,y,z)/dv
-        const matrix_type<3, 1> dydL = getter::block<3, 1>(frame, 0u, 1u);
+        const vector3_type dydL = getter::vector<3>(frame, 0u, 1u);
 
-        const matrix_type<3, 1> col0 = dxdL * lcos_phi + dydL * lsin_phi;
-        const matrix_type<3, 1> col1 =
-            (dydL * lcos_phi - dxdL * lsin_phi) * lrad;
+        const vector3_type col0 = dxdL * lcos_phi + dydL * lsin_phi;
+        const vector3_type col1 = (dydL * lcos_phi - dxdL * lsin_phi) * lrad;
 
         getter::set_block(bound_pos_to_free_pos_derivative, col0, e_free_pos0,
                           e_bound_loc0);
@@ -135,7 +135,7 @@ struct jacobian<polar2D<algebra_t>> {
 
         const matrix_type<1, 3> row0 = dudG * lcos_phi + dvdG * lsin_phi;
         const matrix_type<1, 3> row1 =
-            1.f / lrad * (lcos_phi * dvdG - lsin_phi * dudG);
+            (1.f / lrad) * (lcos_phi * dvdG - lsin_phi * dudG);
 
         getter::set_block(free_pos_to_bound_pos_derivative, row0, e_bound_loc0,
                           e_free_pos0);

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -16,8 +16,9 @@
 namespace detray {
 
 /// Straight line stepper implementation
-template <typename algebra_t, typename constraint_t = unconstrained_step,
-          typename policy_t = stepper_default_policy,
+template <typename algebra_t,
+          typename constraint_t = unconstrained_step<dscalar<algebra_t>>,
+          typename policy_t = stepper_default_policy<dscalar<algebra_t>>,
           typename inspector_t = stepping::void_inspector>
 class line_stepper final
     : public base_stepper<algebra_t, constraint_t, policy_t, inspector_t> {

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -22,8 +22,8 @@ namespace detray {
 /// @tparam track_t the type of track that is being advanced by the stepper
 /// @tparam constraint_ the type of constraints on the stepper
 template <typename magnetic_field_t, typename algebra_t,
-          typename constraint_t = unconstrained_step,
-          typename policy_t = stepper_rk_policy,
+          typename constraint_t = unconstrained_step<dscalar<algebra_t>>,
+          typename policy_t = stepper_rk_policy<dscalar<algebra_t>>,
           typename inspector_t = stepping::void_inspector>
 class rk_stepper final
     : public base_stepper<algebra_t, constraint_t, policy_t, inspector_t> {

--- a/core/include/detray/tracks/detail/transform_track_parameters.hpp
+++ b/core/include/detray/tracks/detail/transform_track_parameters.hpp
@@ -26,7 +26,6 @@ DETRAY_HOST_DEVICE inline auto free_to_bound_vector(
     const free_parameters_vector<typename local_frame_t::algebra_type>&
         free_vec) {
 
-    // Matrix operator
     using algebra_t = typename local_frame_t::algebra_type;
 
     const auto pos = free_vec.pos();
@@ -51,12 +50,10 @@ DETRAY_HOST_DEVICE inline auto bound_to_free_vector(
     const dtransform3D<typename mask_t::algebra_type>& trf3, const mask_t& mask,
     const bound_parameters_vector<typename mask_t::algebra_type>& bound_vec) {
 
-    // Matrix operator
     using algebra_t = typename mask_t::algebra_type;
     using local_frame_t = typename mask_t::local_frame;
 
     const auto bound_local = bound_vec.bound_local();
-
     const auto dir = bound_vec.dir();
 
     const auto pos =

--- a/core/include/detray/utils/bounding_volume.hpp
+++ b/core/include/detray/utils/bounding_volume.hpp
@@ -26,15 +26,16 @@
 namespace detray {
 
 /// An axis aligned bounding box of a given @tparam shape_t
-template <typename shape_t, typename scalar_t = scalar>
+template <typename shape_t, typename algebra_t>
 class axis_aligned_bounding_volume {
     public:
     /// Define geometric properties
     /// @{
+    using scalar_t = dscalar<algebra_t>;
     using shape = shape_t;
     using boundaries = typename shape_t::boundaries;
-    template <typename algebra_t>
-    using local_frame = typename shape_t::template local_frame_type<algebra_t>;
+    template <typename A>
+    using local_frame = typename shape_t::template local_frame_type<A>;
 
     static constexpr std::size_t dim{shape_t::dim};
     /// @}
@@ -104,9 +105,9 @@ class axis_aligned_bounding_volume {
                 max_z = max_point[2] > max_z ? max_point[2] : max_z;
             }
         }
-        m_mask = mask<shape, std::size_t>{box_id,      min_x - env, min_y - env,
-                                          min_z - env, max_x + env, max_y + env,
-                                          max_z + env};
+        m_mask = mask<shape, algebra_t, std::size_t>{
+            box_id,      min_x - env, min_y - env, min_z - env,
+            max_x + env, max_y + env, max_z + env};
     }
 
     /// Subscript operator @returns a single box boundary.
@@ -121,7 +122,8 @@ class axis_aligned_bounding_volume {
 
     /// @returns the bounds of the box, depending on its shape
     DETRAY_HOST_DEVICE
-    constexpr auto bounds() const -> const mask<shape, std::size_t>& {
+    constexpr auto bounds() const
+        -> const mask<shape, algebra_t, std::size_t>& {
         return m_mask;
     }
 
@@ -307,7 +309,6 @@ class axis_aligned_bounding_volume {
 
     /// Intersect the box with a ray
     DETRAY_HOST_DEVICE
-    template <typename algebra_t>
     constexpr bool intersect(
         const detail::ray<algebra_t>& ray,
         const scalar_t t = std::numeric_limits<scalar_t>::epsilon()) const {
@@ -323,7 +324,7 @@ class axis_aligned_bounding_volume {
         return os << aabb.bounds().to_string();
     }
     /// Keeps the box boundary values and id
-    mask<shape, std::size_t> m_mask;
+    mask<shape, algebra_t, std::size_t> m_mask;
 };
 
 }  // namespace detray

--- a/core/include/detray/utils/curvilinear_frame.hpp
+++ b/core/include/detray/utils/curvilinear_frame.hpp
@@ -44,7 +44,7 @@ struct curvilinear_frame {
     DETRAY_HOST_DEVICE
     bound_to_free_matrix_type bound_to_free_jacobian() const {
         return jacobian_engine_type().bound_to_free_jacobian(
-            m_trf, mask<rectangle2D>{}, m_bound_vec);
+            m_trf, mask<rectangle2D, algebra_t>{}, m_bound_vec);
     }
 
     transform3_type m_trf{};

--- a/core/include/detray/utils/grid/detail/axis.hpp
+++ b/core/include/detray/utils/grid/detail/axis.hpp
@@ -208,6 +208,7 @@ class multi_axis {
 
     /// Projection onto local coordinate system that is spanned by the axes
     using local_frame_type = local_frame_t;
+    using algebra_type = typename local_frame_type::algebra_type;
     using point_type = typename local_frame_type::loc_point;
 
     using scalar_type =

--- a/core/include/detray/utils/grid/detail/axis_binning.hpp
+++ b/core/include/detray/utils/grid/detail/axis_binning.hpp
@@ -28,8 +28,7 @@ using bin_range = std::array<int, 2>;
 ///
 /// The binning on the input parameter space is regular and therefore only needs
 /// the span and the number of bins to match a value to a bin.
-template <typename dcontainers = host_container_types,
-          typename scalar_t = scalar>
+template <typename scalar_t, typename dcontainers = host_container_types>
 struct regular {
 
     // Extract container types
@@ -189,8 +188,7 @@ struct regular {
 ///
 /// @note The bin search makes this type comparatively expensive. Only use when
 /// absolutely needed.
-template <typename dcontainers = host_container_types,
-          typename scalar_t = scalar>
+template <typename scalar_t, typename dcontainers = host_container_types>
 struct irregular {
 
     // Extract container types

--- a/core/include/detray/utils/grid/detail/axis_helpers.hpp
+++ b/core/include/detray/utils/grid/detail/axis_helpers.hpp
@@ -49,9 +49,8 @@ struct axes {
 };
 
 /// Helper trait to resolve the type of a @c multi_axis from a shape
-template <typename axes_t, bool is_owning = true,
-          typename containers = host_container_types,
-          typename algebra_t = ALGEBRA_PLUGIN<detray::scalar>>
+template <typename axes_t, typename algebra_t, bool is_owning = true,
+          typename containers = host_container_types>
 using coordinate_axes = typename axis::detail::get_coordinate_axes_type<
     axes_t, is_owning, containers, algebra_t>::type;
 
@@ -86,8 +85,8 @@ struct get_axes_types<cartesian2D<A>, e_bounds, binning0_t, binning1_t,
 
     using bounds = detray::types::list<bounds_t<e_bounds, label0>,
                                        bounds_t<e_bounds, label1>>;
-    template <typename C, typename S>
-    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>>;
+    template <typename S, typename C>
+    using binning = detray::types::list<binning0_t<S, C>, binning1_t<S, C>>;
 };
 
 /// Behaviour of the three local axes (linear in x, y, z)
@@ -107,9 +106,9 @@ struct get_axes_types<cartesian3D<A>, e_bounds, binning0_t, binning1_t,
     using bounds = detray::types::list<bounds_t<e_bounds, label0>,
                                        bounds_t<e_bounds, label1>,
                                        bounds_t<e_bounds, label2>>;
-    template <typename C, typename S>
-    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>,
-                                        binning2_t<C, S>>;
+    template <typename S, typename C>
+    using binning = detray::types::list<binning0_t<S, C>, binning1_t<S, C>,
+                                        binning2_t<S, C>>;
 };
 
 /// Behaviour of the two local axes (linear in r, circular in phi)
@@ -127,8 +126,8 @@ struct get_axes_types<polar2D<A>, e_bounds, binning0_t, binning1_t,
 
     using bounds =
         detray::types::list<bounds_t<e_bounds, label0>, axis::circular<label1>>;
-    template <typename C, typename S>
-    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>>;
+    template <typename S, typename C>
+    using binning = detray::types::list<binning0_t<S, C>, binning1_t<S, C>>;
 };
 
 /// Behaviour of the two local axes (circular in r-phi, linear in z)
@@ -146,8 +145,8 @@ struct get_axes_types<cylindrical2D<A>, e_bounds, binning0_t, binning1_t,
 
     using bounds =
         detray::types::list<axis::circular<label0>, bounds_t<e_bounds, label1>>;
-    template <typename C, typename S>
-    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>>;
+    template <typename S, typename C>
+    using binning = detray::types::list<binning0_t<S, C>, binning1_t<S, C>>;
 };
 
 /// Behaviour of the two local axes (circular in r-phi, linear in z)
@@ -165,8 +164,8 @@ struct get_axes_types<concentric_cylindrical2D<A>, e_bounds, binning0_t,
 
     using bounds =
         detray::types::list<axis::circular<label0>, bounds_t<e_bounds, label1>>;
-    template <typename C, typename S>
-    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>>;
+    template <typename S, typename C>
+    using binning = detray::types::list<binning0_t<S, C>, binning1_t<S, C>>;
 };
 
 /// Behaviour of the two local axes (linear in r, circular in phi, linear in z)
@@ -186,9 +185,9 @@ struct get_axes_types<cylindrical3D<A>, e_bounds, binning0_t, binning1_t,
     using bounds =
         detray::types::list<bounds_t<e_bounds, label0>, axis::circular<label1>,
                             bounds_t<e_bounds, label2>>;
-    template <typename C, typename S>
-    using binning = detray::types::list<binning0_t<C, S>, binning1_t<C, S>,
-                                        binning2_t<C, S>>;
+    template <typename S, typename C>
+    using binning = detray::types::list<binning0_t<S, C>, binning1_t<S, C>,
+                                        binning2_t<S, C>>;
 };
 
 /// Construct a @c multi_axis type from a given axes-shape
@@ -203,7 +202,7 @@ requires std::is_same_v<typename axes_t::bounds,
         typename axes_t::template type<algebra_t>::template frame<algebra_t>,
         typename axes_t::template type<algebra_t>::bounds,
         typename axes_t::template type<algebra_t>::template binning<
-            containers, dscalar<algebra_t>>>::type;
+            dscalar<algebra_t>, containers>>::type;
 };
 
 /// Don't do anything if the type is already a @c multi_axis

--- a/core/include/detray/utils/grid/detail/concepts.hpp
+++ b/core/include/detray/utils/grid/detail/concepts.hpp
@@ -78,6 +78,7 @@ concept grid = viewable<G>&& bufferable<G>&& requires(const G g) {
     typename G::glob_bin_index;
     typename G::loc_bin_index;
     typename G::local_frame_type;
+    typename G::algebra_type;
     typename G::point_type;
 
     G::is_owning;

--- a/core/include/detray/utils/grid/grid.hpp
+++ b/core/include/detray/utils/grid/grid.hpp
@@ -55,8 +55,9 @@ class grid_impl {
     using glob_bin_index = dindex;
     using loc_bin_index = typename axes_type::loc_bin_index;
     using local_frame_type = typename axes_type::local_frame_type;
+    using algebra_type = typename axes_type::algebra_type;
+    using scalar_type = dscalar<algebra_type>;
     using point_type = typename axes_type::point_type;
-    using scalar_type = typename axes_type::scalar_type;
 
     static constexpr bool is_owning{axes_type::is_owning};
 
@@ -392,12 +393,11 @@ class grid_impl {
 };
 
 /// Type alias for easier construction
-template <typename axes_t, typename bin_t,
+template <typename algebra_t, typename axes_t, typename bin_t,
           template <std::size_t> class serializer_t = simple_serializer,
-          typename containers = host_container_types, bool ownership = true,
-          typename algebra_t = ALGEBRA_PLUGIN<detray::scalar>>
+          typename containers = host_container_types, bool ownership = true>
 using grid =
-    grid_impl<coordinate_axes<axes_t, ownership, containers, algebra_t>, bin_t,
+    grid_impl<coordinate_axes<axes_t, algebra_t, ownership, containers>, bin_t,
               simple_serializer>;
 
 }  // namespace detray

--- a/detectors/include/detray/detectors/bfield.hpp
+++ b/detectors/include/detray/detectors/bfield.hpp
@@ -23,36 +23,41 @@
 namespace detray::bfield {
 
 /// Constant bfield (host and device)
-using const_bknd_t =
-    covfie::backend::constant<covfie::vector::vector_d<detray::scalar, 3>,
-                              covfie::vector::vector_d<detray::scalar, 3>>;
+template <typename T>
+using const_bknd_t = covfie::backend::constant<covfie::vector::vector_d<T, 3>,
+                                               covfie::vector::vector_d<T, 3>>;
 
-using const_field_t = covfie::field<const_bknd_t>;
+template <typename T>
+using const_field_t = covfie::field<const_bknd_t<T>>;
 
 /// Inhomogeneous field (host)
+template <typename T>
 using inhom_bknd_t =
     covfie::backend::affine<covfie::backend::linear<covfie::backend::strided<
         covfie::vector::vector_d<std::size_t, 3>,
-        covfie::backend::array<covfie::vector::vector_d<detray::scalar, 3>>>>>;
+        covfie::backend::array<covfie::vector::vector_d<T, 3>>>>>;
 
 /// Inhomogeneous field with nearest neighbor (host)
+template <typename T>
 using inhom_bknd_nn_t = covfie::backend::affine<
     covfie::backend::nearest_neighbour<covfie::backend::strided<
         covfie::vector::ulong3,
-        covfie::backend::array<covfie::vector::vector_d<detray::scalar, 3>>>>>;
+        covfie::backend::array<covfie::vector::vector_d<T, 3>>>>>;
 
-using inhom_field_t = covfie::field<inhom_bknd_t>;
+template <typename T>
+using inhom_field_t = covfie::field<inhom_bknd_t<T>>;
 
 /// @returns a constant covfie field constructed from the field vector @param B
-template <typename vector3_t>
-inline const_field_t create_const_field(const vector3_t &B) {
-    return const_field_t{covfie::make_parameter_pack(
-        const_bknd_t::configuration_t{B[0], B[1], B[2]})};
+template <typename T, typename vector3_t>
+inline const_field_t<T> create_const_field(const vector3_t &B) {
+    return const_field_t<T>{covfie::make_parameter_pack(
+        typename const_bknd_t<T>::configuration_t{B[0], B[1], B[2]})};
 }
 
 /// @returns a constant covfie field constructed from the field vector @param B
-inline inhom_field_t create_inhom_field() {
-    return io::read_bfield<inhom_field_t>(
+template <typename T>
+inline inhom_field_t<T> create_inhom_field() {
+    return io::read_bfield<inhom_field_t<T>>(
         !std::getenv("DETRAY_BFIELD_FILE") ? ""
                                            : std::getenv("DETRAY_BFIELD_FILE"));
 }

--- a/detectors/include/detray/detectors/default_metadata.hpp
+++ b/detectors/include/detray/detectors/default_metadata.hpp
@@ -27,72 +27,78 @@
 namespace detray {
 
 /// Assembles the detector type. This metatdata contains all available types
+template <typename algebra_t>
 struct default_metadata {
 
     /// Define the algebra type for the geometry and navigation
-    using algebra_type = ALGEBRA_PLUGIN<detray::scalar>;
+    using algebra_type = algebra_t;
+    using scalar_t = dscalar<algebra_type>;
 
     /// Mask-to-(next)-volume link (potentially switchable for SoA)
     using nav_link = std::uint_least16_t;
 
     /// Mask types
     /// @TODO: Need to duplicate for pixel/strip measurement dimensions?
-    using rectangle = mask<rectangle2D, nav_link>;
-    using trapezoid = mask<trapezoid2D, nav_link>;
-    using annulus = mask<annulus2D, nav_link>;
-    using cylinder = mask<cylinder2D, nav_link>;
-    using cylinder_portal = mask<concentric_cylinder2D, nav_link>;
-    using disc = mask<ring2D, nav_link>;
-    using straw_tube = mask<line_circular, nav_link>;
-    using drift_cell = mask<line_square, nav_link>;
-    using single_1 = mask<single3D<1>, nav_link>;
-    using single_2 = mask<single3D<2>, nav_link>;
+    using rectangle = mask<rectangle2D, algebra_type, nav_link>;
+    using trapezoid = mask<trapezoid2D, algebra_type, nav_link>;
+    using annulus = mask<annulus2D, algebra_type, nav_link>;
+    using cylinder = mask<cylinder2D, algebra_type, nav_link>;
+    using cylinder_portal = mask<concentric_cylinder2D, algebra_type, nav_link>;
+    using disc = mask<ring2D, algebra_type, nav_link>;
+    using straw_tube = mask<line_circular, algebra_type, nav_link>;
+    using drift_cell = mask<line_square, algebra_type, nav_link>;
+    using single_1 = mask<single3D<1>, algebra_type, nav_link>;
+    using single_2 = mask<single3D<2>, algebra_type, nav_link>;
     // TODO: Can single3 be used instead of cylinder portal type or remove it?
-    using single_3 = mask<single3D<3>, nav_link>;
+    using single_3 = mask<single3D<3>, algebra_type, nav_link>;
     // Debug types, e.g. telescope detector
-    using unbounded_rectangle = mask<unbounded<rectangle2D>, nav_link>;
-    using unbounded_trapezoid = mask<unbounded<trapezoid2D>, nav_link>;
-    using unbounded_annulus = mask<unbounded<annulus2D>, nav_link>;
-    using unbounded_cylinder = mask<unbounded<cylinder2D>, nav_link>;
-    using unbounded_disc = mask<unbounded<ring2D>, nav_link>;
-    using unbounded_straw_tube = mask<unbounded<line_circular>, nav_link>;
-    using unbounded_drift_cell = mask<unbounded<line_square>, nav_link>;
-    using unmasked_plane = mask<unmasked<>, nav_link>;
+    using unbounded_rectangle =
+        mask<unbounded<rectangle2D>, algebra_type, nav_link>;
+    using unbounded_trapezoid =
+        mask<unbounded<trapezoid2D>, algebra_type, nav_link>;
+    using unbounded_annulus =
+        mask<unbounded<annulus2D>, algebra_type, nav_link>;
+    using unbounded_cylinder =
+        mask<unbounded<cylinder2D>, algebra_type, nav_link>;
+    using unbounded_disc = mask<unbounded<ring2D>, algebra_type, nav_link>;
+    using unbounded_straw_tube =
+        mask<unbounded<line_circular>, algebra_type, nav_link>;
+    using unbounded_drift_cell =
+        mask<unbounded<line_square>, algebra_type, nav_link>;
+    using unmasked_plane = mask<unmasked<>, algebra_type, nav_link>;
 
     /// Material types
-    using slab = material_slab<detray::scalar>;
-    using rod = material_rod<detray::scalar>;
+    using slab = material_slab<scalar_t>;
+    using rod = material_rod<scalar_t>;
 
     /// Material grid types (default: closed bounds, regular binning)
     /// @{
 
     // Disc material grid
     template <typename container_t>
-    using disc_map_t = material_map<ring2D, detray::scalar, container_t>;
+    using disc_map_t = material_map<algebra_type, ring2D, container_t>;
 
     // Cylindrical material grid
     template <typename container_t>
-    using cylinder2_map_t =
-        material_map<cylinder2D, detray::scalar, container_t>;
+    using cylinder2_map_t = material_map<algebra_type, cylinder2D, container_t>;
 
     // Concentric cylindrical material grid
     template <typename container_t>
     using concentric_cylinder2_map_t =
-        material_map<concentric_cylinder2D, detray::scalar, container_t>;
+        material_map<algebra_type, concentric_cylinder2D, container_t>;
 
     // Rectangular material grid
     template <typename container_t>
     using rectangular_map_t =
-        material_map<rectangle2D, detray::scalar, container_t>;
+        material_map<algebra_type, rectangle2D, container_t>;
 
     // Cuboid volume material grid
     template <typename container_t>
-    using cuboid_map_t = material_map<cuboid3D, detray::scalar, container_t>;
+    using cuboid_map_t = material_map<algebra_type, cuboid3D, container_t>;
 
     // Cylindrical volume material grid
     template <typename container_t>
-    using cylinder3_map_t =
-        material_map<cylinder3D, detray::scalar, container_t>;
+    using cylinder3_map_t = material_map<algebra_type, cylinder3D, container_t>;
 
     /// @}
 
@@ -103,8 +109,9 @@ struct default_metadata {
 
     // surface grid definition: bin-content: std::array<surface_type, 9>
     template <typename axes_t, typename bin_entry_t, typename container_t>
-    using surface_grid_t = grid<axes_t, bins::dynamic_array<bin_entry_t>,
-                                simple_serializer, container_t, false>;
+    using surface_grid_t =
+        grid<algebra_type, axes_t, bins::dynamic_array<bin_entry_t>,
+             simple_serializer, container_t, false>;
 
     // 2D cylindrical grid for the barrel layers
     template <typename bin_entry_t, typename container_t>
@@ -219,7 +226,7 @@ unbounded_cell, unmasked_plane*/>;
         grid_collection<rectangular_map_t<container_t>>,
         typename container_t::template vector_type<slab>,
         typename container_t::template vector_type<rod>,
-        typename container_t::template vector_type<material<detray::scalar>>,
+        typename container_t::template vector_type<material<scalar_t>>,
         grid_collection<cuboid_map_t<container_t>>,
         grid_collection<cylinder3_map_t<container_t>>>;
 
@@ -281,7 +288,8 @@ container_t>>*/>;
     /// Volume search grid
     template <typename container_t = host_container_types>
     using volume_finder =
-        grid<axes<cylinder3D, axis::bounds::e_open, axis::irregular,
+        grid<algebra_type,
+             axes<cylinder3D, axis::bounds::e_open, axis::irregular,
                   axis::regular, axis::irregular>,
              bins::single<dindex>, simple_serializer, container_t>;
 };

--- a/detectors/include/detray/detectors/itk_metadata.hpp
+++ b/detectors/include/detray/detectors/itk_metadata.hpp
@@ -34,10 +34,12 @@ namespace detray {
 
 /// Defines a detector that contains squares, trapezoids and a bounding portal
 /// box.
+template <typename algebra_t>
 struct itk_metadata {
 
     /// Define the algebra type for the geometry and navigation
-    using algebra_type = ALGEBRA_PLUGIN<detray::scalar>;
+    using algebra_type = algebra_t;
+    using scalar_t = dscalar<algebra_type>;
 
     /// Portal link type between volumes
     using nav_link = std::uint_least16_t;
@@ -47,11 +49,11 @@ struct itk_metadata {
     //
 
     /// The mask types for the detector sensitive surfaces
-    using annulus = mask<annulus2D, nav_link>;
-    using rectangle = mask<rectangle2D, nav_link>;
+    using annulus = mask<annulus2D, algebra_type, nav_link>;
+    using rectangle = mask<rectangle2D, algebra_type, nav_link>;
     // Types for portals
-    using cylinder_portal = mask<concentric_cylinder2D, nav_link>;
-    using disc_portal = mask<ring2D, nav_link>;
+    using cylinder_portal = mask<concentric_cylinder2D, algebra_type, nav_link>;
+    using disc_portal = mask<ring2D, algebra_type, nav_link>;
 
     //
     // Material Description
@@ -59,20 +61,21 @@ struct itk_metadata {
 
     /// The material types to be mapped onto the surfaces: Here homogeneous
     /// material
-    using slab = material_slab<detray::scalar>;
+    using slab = material_slab<scalar_t>;
 
     // Cylindrical material map
     template <typename container_t>
     using cylinder_map_t =
-        material_map<concentric_cylinder2D, scalar, container_t>;
+        material_map<algebra_type, concentric_cylinder2D, container_t>;
 
     // Disc material map
     template <typename container_t>
-    using disc_map_t = material_map<ring2D, scalar, container_t>;
+    using disc_map_t = material_map<algebra_type, ring2D, container_t>;
 
     // Rectangular material map
     template <typename container_t>
-    using rectangular_map_t = material_map<rectangle2D, scalar, container_t>;
+    using rectangular_map_t =
+        material_map<algebra_type, rectangle2D, container_t>;
 
     /// How to store and link transforms. The geometry context allows to resolve
     /// the conditions data for e.g. module alignment
@@ -167,7 +170,8 @@ struct itk_metadata {
     /// given position. Here: Uniform grid with a 3D cylindrical shape
     template <typename container_t = host_container_types>
     using volume_finder =
-        grid<axes<cylinder3D, axis::bounds::e_open, axis::irregular,
+        grid<algebra_type,
+             axes<cylinder3D, axis::bounds::e_open, axis::irregular,
                   axis::regular, axis::irregular>,
              bins::single<dindex>, simple_serializer, container_t>;
 };

--- a/detectors/include/detray/detectors/toy_metadata.hpp
+++ b/detectors/include/detray/detectors/toy_metadata.hpp
@@ -26,44 +26,48 @@
 namespace detray {
 
 /// Defines the data types needed for the toy detector
+template <typename algebra_t>
 struct toy_metadata {
 
     /// Define the algebra type for the geometry and navigation
-    using algebra_type = ALGEBRA_PLUGIN<detray::scalar>;
+    using algebra_type = algebra_t;
+    using scalar_t = dscalar<algebra_type>;
 
     /// Mask to (next) volume link: next volume(s)
     using nav_link = std::uint_least16_t;
 
     /// Mask types
-    using rectangle = mask<rectangle2D, nav_link>;
-    using trapezoid = mask<trapezoid2D, nav_link>;
-    // using cylinder = mask<cylinder2D, nav_link>;  // beampipe
-    using cylinder_portal = mask<concentric_cylinder2D, nav_link>;
-    using disc_portal = mask<ring2D, nav_link>;
+    using rectangle = mask<rectangle2D, algebra_type, nav_link>;
+    using trapezoid = mask<trapezoid2D, algebra_type, nav_link>;
+    // using cylinder = mask<cylinder2D, algebra_type, nav_link>;  // beampipe
+    using cylinder_portal = mask<concentric_cylinder2D, algebra_type, nav_link>;
+    using disc_portal = mask<ring2D, algebra_type, nav_link>;
 
     /// Material types
-    using slab = material_slab<detray::scalar>;
+    using slab = material_slab<scalar_t>;
 
     // Cylindrical material grid
     template <typename container_t>
     using cylinder_map_t =
-        material_map<concentric_cylinder2D, scalar, container_t>;
+        material_map<algebra_type, concentric_cylinder2D, container_t>;
 
     // Disc material grid
     template <typename container_t>
-    using disc_map_t = material_map<ring2D, scalar, container_t>;
+    using disc_map_t = material_map<algebra_type, ring2D, container_t>;
 
     // Rectangular material grid
     template <typename container_t>
-    using rectangular_map_t = material_map<rectangle2D, scalar, container_t>;
+    using rectangular_map_t =
+        material_map<algebra_type, rectangle2D, container_t>;
 
     /// Surface grid types (regular, open binning)
     /// @{
 
     // Surface grid definition: bin-content: std::array<sf_descriptor, 1>
     template <typename axes_t, typename bin_entry_t, typename container_t>
-    using surface_grid_t = grid<axes_t, bins::static_array<bin_entry_t, 1>,
-                                simple_serializer, container_t, false>;
+    using surface_grid_t =
+        grid<algebra_type, axes_t, bins::static_array<bin_entry_t, 1>,
+             simple_serializer, container_t, false>;
 
     // cylindrical grid for the barrel layers
     template <typename bin_entry_t, typename container_t>
@@ -157,7 +161,8 @@ struct toy_metadata {
     /// Volume search grid
     template <typename container_t = host_container_types>
     using volume_finder =
-        grid<axes<cylinder3D, axis::bounds::e_open, axis::irregular,
+        grid<algebra_type,
+             axes<cylinder3D, axis::bounds::e_open, axis::irregular,
                   axis::regular, axis::irregular>,
              bins::single<dindex>, simple_serializer, container_t>;
 };

--- a/io/include/detray/io/common/detail/grid_reader.hpp
+++ b/io/include/detray/io/common/detail/grid_reader.hpp
@@ -156,9 +156,9 @@ class grid_reader {
 
         using namespace axis;
 
-        using scalar_t = typename detector_t::scalar_type;
-        using regular_binning_t = regular<host_container_types, scalar_t>;
-        using irregular_binning_t = irregular<host_container_types, scalar_t>;
+        using scalar_t = dscalar<typename detector_t::algebra_type>;
+        using regular_binning_t = regular<scalar_t, host_container_types>;
+        using irregular_binning_t = irregular<scalar_t, host_container_types>;
 
         // Base case: If the binning types are filled, continue with the frame
         if constexpr (types::size<binning_ts> == dim) {
@@ -290,7 +290,8 @@ class grid_reader {
                 &det_builder,
             types::list<bounds_ts...>, types::list<binning_ts...>) {
 
-        using scalar_t = typename detector_t::scalar_type;
+        using algebra_t = typename detector_t::algebra_type;
+        using scalar_t = dscalar<algebra_t>;
 
         // Assemble the grid type
         using axes_t =
@@ -299,7 +300,7 @@ class grid_reader {
         using bin_t =
             std::conditional_t<bin_capacity == 0, bins::dynamic_array<value_t>,
                                bins::static_array<value_t, bin_capacity>>;
-        using grid_t = grid<axes_t, bin_t, serializer_t>;
+        using grid_t = grid<algebra_t, axes_t, bin_t, serializer_t>;
 
         static_assert(grid_t::dim == dim,
                       "Grid dimension does not meet dimension of grid reader");

--- a/io/include/detray/io/common/detail/type_info.hpp
+++ b/io/include/detray/io/common/detail/type_info.hpp
@@ -125,7 +125,7 @@ struct mask_info {
 /// Check for a stereo annulus shape
 template <typename detector_t>
 requires(detector_t::masks::template is_defined<
-         mask<annulus2D,
+         mask<annulus2D, typename detector_t::algebra_type,
               std::uint_least16_t>>()) struct mask_info<io::shape_id::annulus2,
                                                         detector_t> {
     using type = annulus2D;
@@ -136,7 +136,7 @@ requires(detector_t::masks::template is_defined<
 /// Check for a 2D cylinder shape
 template <typename detector_t>
 requires(detector_t::masks::template is_defined<
-         mask<cylinder2D,
+         mask<cylinder2D, typename detector_t::algebra_type,
               std::uint_least16_t>>()) struct mask_info<io::shape_id::cylinder2,
                                                         detector_t> {
     using type = cylinder2D;
@@ -147,7 +147,7 @@ requires(detector_t::masks::template is_defined<
 /// Check for a 2D cylinder portal shape
 template <typename detector_t>
 requires(detector_t::masks::template is_defined<
-         mask<concentric_cylinder2D,
+         mask<concentric_cylinder2D, typename detector_t::algebra_type,
               std::uint_least16_t>>()) struct mask_info<io::shape_id::
                                                             portal_cylinder2,
                                                         detector_t> {
@@ -160,7 +160,7 @@ requires(detector_t::masks::template is_defined<
 template <typename detector_t>
 requires(
     detector_t::masks::template is_defined<
-        mask<line_square,
+        mask<line_square, typename detector_t::algebra_type,
              std::uint_least16_t>>()) struct mask_info<io::shape_id::drift_cell,
                                                        detector_t> {
     using type = line_square;
@@ -172,7 +172,7 @@ requires(
 template <typename detector_t>
 requires(
     detector_t::masks::template is_defined<
-        mask<line_circular,
+        mask<line_circular, typename detector_t::algebra_type,
              std::uint_least16_t>>()) struct mask_info<io::shape_id::straw_tube,
                                                        detector_t> {
     using type = line_circular;
@@ -184,7 +184,7 @@ requires(
 template <typename detector_t>
 requires(
     detector_t::masks::template is_defined<
-        mask<rectangle2D,
+        mask<rectangle2D, typename detector_t::algebra_type,
              std::uint_least16_t>>()) struct mask_info<io::shape_id::rectangle2,
                                                        detector_t> {
     using type = rectangle2D;
@@ -194,10 +194,10 @@ requires(
 
 /// Check for a ring/disc shape
 template <typename detector_t>
-requires(
-    detector_t::masks::template is_defined<mask<
-        ring2D, std::uint_least16_t>>()) struct mask_info<io::shape_id::ring2,
-                                                          detector_t> {
+requires(detector_t::masks::template is_defined<
+         mask<ring2D, typename detector_t::algebra_type,
+              std::uint_least16_t>>()) struct mask_info<io::shape_id::ring2,
+                                                        detector_t> {
     using type = ring2D;
     static constexpr typename detector_t::masks::id value{
         detector_t::masks::id::e_portal_ring2};
@@ -206,7 +206,7 @@ requires(
 /// Check for a single masked value (1st value is checked)
 template <typename detector_t>
 requires(detector_t::masks::template is_defined<
-         mask<single3D<0>,
+         mask<single3D<0>, typename detector_t::algebra_type,
               std::uint_least16_t>>()) struct mask_info<io::shape_id::single1,
                                                         detector_t> {
     using type = single3D<0>;
@@ -217,7 +217,7 @@ requires(detector_t::masks::template is_defined<
 /// Check for a single masked value (2nd value is checked)
 template <typename detector_t>
 requires(detector_t::masks::template is_defined<
-         mask<single3D<1>,
+         mask<single3D<1>, typename detector_t::algebra_type,
               std::uint_least16_t>>()) struct mask_info<io::shape_id::single2,
                                                         detector_t> {
     using type = single3D<1>;
@@ -228,7 +228,7 @@ requires(detector_t::masks::template is_defined<
 /// Check for a single masked value (3rd value is checked)
 template <typename detector_t>
 requires(detector_t::masks::template is_defined<
-         mask<single3D<2>,
+         mask<single3D<2>, typename detector_t::algebra_type,
               std::uint_least16_t>>()) struct mask_info<io::shape_id::single3,
                                                         detector_t> {
     using type = single3D<2>;
@@ -240,7 +240,7 @@ requires(detector_t::masks::template is_defined<
 template <typename detector_t>
 requires(
     detector_t::masks::template is_defined<
-        mask<trapezoid2D,
+        mask<trapezoid2D, typename detector_t::algebra_type,
              std::uint_least16_t>>()) struct mask_info<io::shape_id::trapezoid2,
                                                        detector_t> {
     using type = trapezoid2D;
@@ -264,51 +264,45 @@ struct mat_map_info {
 /// Check for a 2D disc material map
 template <typename detector_t>
 requires(
-    detector_t::materials::template is_defined<material_map<
-        ring2D,
-        typename detector_t::
-            scalar_type>>()) struct mat_map_info<io::material_id::ring2_map,
-                                                 detector_t> {
-    using type = material_map<ring2D, typename detector_t::scalar_type>;
+    detector_t::materials::template is_defined<
+        material_map<typename detector_t::algebra_type,
+                     ring2D>>()) struct mat_map_info<io::material_id::ring2_map,
+                                                     detector_t> {
+    using type = material_map<typename detector_t::algebra_type, ring2D>;
     static constexpr typename detector_t::materials::id value{
         detector_t::materials::id::e_disc2_map};
 };
 
 /// Check for a 2D cartesian material map
 template <typename detector_t>
-requires(detector_t::materials::template is_defined<material_map<
-             rectangle2D,
-             typename detector_t::
-                 scalar_type>>()) struct mat_map_info<io::material_id::
-                                                          rectangle2_map,
-                                                      detector_t> {
-    using type = material_map<rectangle2D, typename detector_t::scalar_type>;
+requires(
+    detector_t::materials::template is_defined<material_map<
+        typename detector_t::algebra_type,
+        rectangle2D>>()) struct mat_map_info<io::material_id::rectangle2_map,
+                                             detector_t> {
+    using type = material_map<typename detector_t::algebra_type, rectangle2D>;
     static constexpr typename detector_t::materials::id value{
         detector_t::materials::id::e_rectangle2_map};
 };
 
 /// Check for a 3D cuboid volume material map
 template <typename detector_t>
-requires(
-    detector_t::materials::template is_defined<material_map<
-        cuboid3D,
-        typename detector_t::
-            scalar_type>>()) struct mat_map_info<io::material_id::cuboid3_map,
-                                                 detector_t> {
-    using type = material_map<cuboid3D, typename detector_t::scalar_type>;
+requires(detector_t::materials::template is_defined<material_map<
+             typename detector_t::algebra_type,
+             cuboid3D>>()) struct mat_map_info<io::material_id::cuboid3_map,
+                                               detector_t> {
+    using type = material_map<typename detector_t::algebra_type, cuboid3D>;
     static constexpr typename detector_t::materials::id value{
         detector_t::materials::id::e_cuboid3_map};
 };
 
 /// Check for a 2D cylindrical material map
 template <typename detector_t>
-requires(
-    detector_t::materials::template is_defined<material_map<
-        cylinder2D,
-        typename detector_t::
-            scalar_type>>()) struct mat_map_info<io::material_id::cylinder2_map,
+requires(detector_t::materials::template is_defined<material_map<
+             typename detector_t::algebra_type,
+             cylinder2D>>()) struct mat_map_info<io::material_id::cylinder2_map,
                                                  detector_t> {
-    using type = material_map<cylinder2D, typename detector_t::scalar_type>;
+    using type = material_map<typename detector_t::algebra_type, cylinder2D>;
     static constexpr typename detector_t::materials::id value{
         detector_t::materials::id::e_cylinder2_map};
 };
@@ -317,26 +311,21 @@ requires(
 template <typename detector_t>
 requires(
     detector_t::materials::template is_defined<material_map<
-        concentric_cylinder2D,
-        typename detector_t::
-            scalar_type>>()) struct mat_map_info<io::material_id::
-                                                     concentric_cylinder2_map,
-                                                 detector_t> {
+        typename detector_t::algebra_type, concentric_cylinder2D>>()) struct
+    mat_map_info<io::material_id::concentric_cylinder2_map, detector_t> {
     using type =
-        material_map<concentric_cylinder2D, typename detector_t::scalar_type>;
+        material_map<typename detector_t::algebra_type, concentric_cylinder2D>;
     static constexpr typename detector_t::materials::id value{
         detector_t::materials::id::e_concentric_cylinder2_map};
 };
 
 /// Check for a 3D cylindrical volume material map
 template <typename detector_t>
-requires(
-    detector_t::materials::template is_defined<material_map<
-        cylinder3D,
-        typename detector_t::
-            scalar_type>>()) struct mat_map_info<io::material_id::cylinder3_map,
+requires(detector_t::materials::template is_defined<material_map<
+             typename detector_t::algebra_type,
+             cylinder3D>>()) struct mat_map_info<io::material_id::cylinder3_map,
                                                  detector_t> {
-    using type = material_map<cylinder3D, typename detector_t::scalar_type>;
+    using type = material_map<typename detector_t::algebra_type, cylinder3D>;
     static constexpr typename detector_t::materials::id value{
         detector_t::materials::id::e_cylinder3_map};
 };

--- a/io/include/detray/io/common/geometry_reader.hpp
+++ b/io/include/detray/io/common/geometry_reader.hpp
@@ -124,8 +124,9 @@ class geometry_reader {
     template <class detector_t>
     static typename detector_t::transform3_type convert(
         const transform_payload& trf_data) {
-        using scalar_t = typename detector_t::scalar_type;
-        using vector3_t = typename detector_t::vector3_type;
+        using algebra_t = typename detector_t::algebra_type;
+        using scalar_t = dscalar<algebra_t>;
+        using vector3_t = dvector3D<algebra_t>;
 
         vector3_t t{static_cast<scalar_t>(trf_data.tr[0]),
                     static_cast<scalar_t>(trf_data.tr[1]),
@@ -140,7 +141,7 @@ class geometry_reader {
                     static_cast<scalar_t>(trf_data.rot[7]),
                     static_cast<scalar_t>(trf_data.rot[8])};
 
-        return typename detector_t::transform3_type{t, x, y, z};
+        return dtransform3D<algebra_t>{t, x, y, z};
     }
 
     /// @returns surface data for a surface factory from a surface io payload
@@ -149,7 +150,7 @@ class geometry_reader {
     static surface_data<detector_t> convert(const surface_payload& sf_data) {
 
         using nav_link_t = typename detector_t::surface_type::navigation_link;
-        using scalar_t = typename detector_t::scalar_type;
+        using scalar_t = dscalar<typename detector_t::algebra_type>;
 
         // Transcribe mask boundaries onto correct vector type
         std::vector<scalar_t> mask_boundaries;

--- a/io/include/detray/io/common/homogeneous_material_reader.hpp
+++ b/io/include/detray/io/common/homogeneous_material_reader.hpp
@@ -45,7 +45,7 @@ class homogeneous_material_reader {
         typename detector_t::name_map& /*name_map*/,
         const detector_homogeneous_material_payload& det_mat_data) {
 
-        using scalar_t = typename detector_t::scalar_type;
+        using scalar_t = dscalar<typename detector_t::algebra_type>;
         using mat_id = typename detector_t::materials::id;
 
         // Convert the material volume by volume

--- a/io/include/detray/io/common/material_map_reader.hpp
+++ b/io/include/detray/io/common/material_map_reader.hpp
@@ -48,7 +48,7 @@ class material_map_reader {
                         detector_grids_payload<material_slab_payload,
                                                io::material_id> &&grids_data) {
 
-        using scalar_t = typename detector_t::scalar_type;
+        using scalar_t = dscalar<typename detector_t::algebra_type>;
         using mat_factory_t = material_map_factory<detector_t, bin_index_type>;
         using mat_data_t = typename mat_factory_t::data_type;
         using mat_id = typename detector_t::materials::id;

--- a/io/include/detray/io/csv/intersection2D.hpp
+++ b/io/include/detray/io/csv/intersection2D.hpp
@@ -51,7 +51,7 @@ template <typename detector_t>
 inline auto read_intersection2D(const std::string &file_name) {
 
     using algebra_t = typename detector_t::algebra_type;
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<algebra_t>;
     using surface_t = typename detector_t::surface_type;
     using nav_link_t = typename surface_t::navigation_link;
     using mask_link_t = typename surface_t::mask_link;

--- a/io/include/detray/io/csv/track_parameters.hpp
+++ b/io/include/detray/io/csv/track_parameters.hpp
@@ -58,11 +58,11 @@ struct bound_track_parameters {
 template <typename detector_t>
 inline auto read_free_track_params(const std::string &file_name) {
 
-    using scalar_t = typename detector_t::scalar_type;
-    using point3_t = typename detector_t::point3_type;
-    using vector3_t = typename detector_t::vector3_type;
-    using track_t =
-        detray::free_track_parameters<typename detector_t::algebra_type>;
+    using algebra_t = typename detector_t::algebra_type;
+    using scalar_t = dscalar<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
+    using vector3_t = dvector3D<algebra_t>;
+    using track_t = detray::free_track_parameters<algebra_t>;
 
     dfe::NamedTupleCsvReader<io::csv::free_track_parameters> track_param_reader(
         file_name);

--- a/plugins/algebra/CMakeLists.txt
+++ b/plugins/algebra/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # Mozilla Public License Version 2.0
 
-# Temporary setting for the detray::scalar type, until it can be removed.
+# Temporary setting for the scalar type, until it can be removed.
 set(DETRAY_CUSTOM_SCALARTYPE
     "double"
     CACHE STRING

--- a/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
+++ b/plugins/algebra/array/include/detray/plugins/algebra/array_definitions.hpp
@@ -10,15 +10,10 @@
 // Algebra-Plugins include
 #include "algebra/array_cmath.hpp"
 
-#define ALGEBRA_PLUGIN detray::array
-
 namespace detray {
 
-// Define scalar type
-using scalar = DETRAY_CUSTOM_SCALARTYPE;
-
 /// The plugin definition
-template <typename scalar_t = DETRAY_CUSTOM_SCALARTYPE>
+template <typename scalar_t>
 using array = algebra::plugin::array<scalar_t>;
 
 using algebra::cmath::operator*;

--- a/plugins/algebra/eigen/include/detray/plugins/algebra/eigen_definitions.hpp
+++ b/plugins/algebra/eigen/include/detray/plugins/algebra/eigen_definitions.hpp
@@ -10,15 +10,10 @@
 // Algebra-Plugins include
 #include "algebra/eigen_eigen.hpp"
 
-#define ALGEBRA_PLUGIN detray::eigen
-
 namespace detray {
 
-// Define scalar type
-using scalar = DETRAY_CUSTOM_SCALARTYPE;
-
 /// The plugin definition
-template <typename scalar_t = DETRAY_CUSTOM_SCALARTYPE>
+template <typename scalar_t>
 using eigen = algebra::plugin::eigen<scalar_t>;
 
 namespace getter {

--- a/plugins/algebra/smatrix/include/detray/plugins/algebra/smatrix_definitions.hpp
+++ b/plugins/algebra/smatrix/include/detray/plugins/algebra/smatrix_definitions.hpp
@@ -15,15 +15,10 @@
 // Algebra-Plugins include
 #include "algebra/smatrix_smatrix.hpp"
 
-#define ALGEBRA_PLUGIN detray::smatrix
-
 namespace detray {
 
-// Define scalar type
-using scalar = DETRAY_CUSTOM_SCALARTYPE;
-
 /// The plugin definition
-template <typename scalar_t = DETRAY_CUSTOM_SCALARTYPE>
+template <typename scalar_t>
 using smatrix = algebra::plugin::smatrix<scalar_t>;
 
 namespace getter {

--- a/plugins/algebra/vc_aos/include/detray/plugins/algebra/vc_aos_definitions.hpp
+++ b/plugins/algebra/vc_aos/include/detray/plugins/algebra/vc_aos_definitions.hpp
@@ -10,15 +10,10 @@
 // Algebra-Plugins include
 #include "algebra/vc_aos.hpp"
 
-#define ALGEBRA_PLUGIN detray::vc_aos
-
 namespace detray {
 
-// Define scalar type
-using scalar = DETRAY_CUSTOM_SCALARTYPE;
-
 /// The plugin definition
-template <typename scalar_t = DETRAY_CUSTOM_SCALARTYPE>
+template <typename scalar_t>
 using vc_aos = algebra::plugin::vc_aos<scalar_t>;
 
 namespace getter {

--- a/plugins/algebra/vc_soa/include/detray/plugins/algebra/vc_soa_definitions.hpp
+++ b/plugins/algebra/vc_soa/include/detray/plugins/algebra/vc_soa_definitions.hpp
@@ -12,11 +12,8 @@
 
 namespace detray {
 
-// Define scalar type
-using scalar = DETRAY_CUSTOM_SCALARTYPE;
-
 /// The plugin definition
-template <typename scalar_t = DETRAY_CUSTOM_SCALARTYPE>
+template <typename scalar_t>
 using vc_soa = algebra::plugin::vc_soa<scalar_t>;
 
 // Pull in additional arithmetic operators for the algebra types

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
@@ -69,12 +69,12 @@ auto inline surface(const transform_t& transform, const mask_t& m) {
 }
 
 /// @brief Returns the proto surface for 2D cylinders.
-template <typename transform_t, typename shape_t>
+template <typename transform_t, typename shape_t, typename algebra_t>
     requires std::is_same_v<shape_t, cylinder2D> ||
     std::is_same_v<shape_t, concentric_cylinder2D> auto inline surface(
-        const transform_t& transform, const mask<shape_t>& m) {
+        const transform_t& transform, const mask<shape_t, algebra_t>& m) {
 
-    using point3_t = typename mask<shape_t>::point3_type;
+    using point3_t = typename mask<shape_t, algebra_t>::point3_type;
     using p_surface_t = actsvg::proto::surface<std::vector<point3_t>>;
 
     p_surface_t p_surface;
@@ -106,11 +106,11 @@ template <typename transform_t, typename shape_t>
 }
 
 /// @brief Returns the proto surface for 2D rings.
-template <typename transform_t>
-auto surface(const transform_t& transform, const mask<ring2D>& m) {
+template <typename transform_t, typename algebra_t>
+auto surface(const transform_t& transform, const mask<ring2D, algebra_t>& m) {
 
     using shape_t = ring2D;
-    using point3_t = typename mask<ring2D>::point3_type;
+    using point3_t = typename mask<ring2D, algebra_t>::point3_type;
     using p_surface_t = actsvg::proto::surface<std::vector<point3_t>>;
 
     p_surface_t p_surface;
@@ -131,10 +131,11 @@ auto surface(const transform_t& transform, const mask<ring2D>& m) {
 }
 
 /// @brief Returns the proto surface for 2D annuli.
-template <typename transform_t>
-auto inline surface(const transform_t& transform, const mask<annulus2D>& m) {
+template <typename transform_t, typename algebra_t>
+auto inline surface(const transform_t& transform,
+                    const mask<annulus2D, algebra_t>& m) {
 
-    using point3_t = typename mask<annulus2D>::point3_type;
+    using point3_t = typename mask<annulus2D, algebra_t>::point3_type;
     using p_surface_t = actsvg::proto::surface<std::vector<point3_t>>;
 
     p_surface_t p_surface;
@@ -147,12 +148,12 @@ auto inline surface(const transform_t& transform, const mask<annulus2D>& m) {
 }
 
 /// @brief Returns the proto surface for 2D rings.
-template <typename transform_t, bool kSquareCrossSect>
+template <typename transform_t, bool kSquareCrossSect, typename algebra_t>
 auto surface(const transform_t& transform,
-             const mask<line<kSquareCrossSect>>& m) {
+             const mask<line<kSquareCrossSect>, algebra_t>& m) {
 
     using shape_t = line<kSquareCrossSect>;
-    using point3_t = typename mask<shape_t>::point3_type;
+    using point3_t = typename mask<shape_t, algebra_t>::point3_type;
     using p_surface_t = actsvg::proto::surface<std::vector<point3_t>>;
 
     p_surface_t p_surface;

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
@@ -136,7 +136,7 @@ auto surface_grid(const detector_t& detector, const dindex index,
                   const styling::grid_style& style =
                       styling::tableau_colorblind::grid_style) {
 
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
     using geo_object_ids = typename detector_t::geo_obj_ids;
 
     const auto vol_desc = detector.volume(index);

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
@@ -39,7 +39,7 @@ auto material_grid(const detector_t& detector, const dindex index,
                    const styling::grid_style& style =
                        styling::tableau_colorblind::grid_style) {
 
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
 
     const auto& sf_desc = detector.surface(index);
     const auto& link = sf_desc.material();

--- a/plugins/svgtools/include/detray/plugins/svgtools/utils/link_utils.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/utils/link_utils.hpp
@@ -23,7 +23,7 @@ template <typename detector_t>
 inline auto is_not_world_portal(
     const detray::tracking_surface<detector_t>& d_portal) {
     const auto d_link_idx = d_portal.template visit_mask<link_getter>();
-    return !detail::is_invalid_value(d_link_idx);
+    return !detray::detail::is_invalid_value(d_link_idx);
 }
 
 /// @note expects that the detray surface has a volume link.

--- a/plugins/svgtools/include/detray/plugins/svgtools/utils/surface_kernels.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/utils/surface_kernels.hpp
@@ -26,46 +26,53 @@ struct outer_radius_getter {
 
     public:
     template <typename mask_group_t, typename index_t>
-    DETRAY_HOST inline std::optional<detray::scalar> operator()(
-        const mask_group_t& mask_group, const index_t& index) const {
+    DETRAY_HOST inline auto operator()(const mask_group_t& mask_group,
+                                       const index_t& index) const {
         return outer_radius(mask_group[index]);
     }
 
     private:
-    // The remaining shapes do not have an outer radius.
+    // Struct to access the radius of a surface
     template <typename mask_t>
-    std::optional<detray::scalar> inline outer_radius(
+    DETRAY_HOST std::optional<typename mask_t::scalar_type> inline outer_radius(
         const mask_t& /*mask*/) const {
         return std::nullopt;
     }
 
     // Calculates the outer radius for rings.
-    auto inline outer_radius(const detray::mask<detray::ring2D>& mask) const {
-        return std::optional<detray::scalar>(mask[ring2D::e_outer_r]);
+    template <typename algebra_t>
+    DETRAY_HOST inline auto outer_radius(
+        const detray::mask<detray::ring2D, algebra_t>& mask) const {
+        return std::optional(mask[ring2D::e_outer_r]);
     }
 
     // Calculates the outer radius for annuluses.
-    auto inline outer_radius(
-        const detray::mask<detray::annulus2D>& mask) const {
-        return std::optional<detray::scalar>(mask[annulus2D::e_max_r]);
+    template <typename algebra_t>
+    DETRAY_HOST inline auto outer_radius(
+        const detray::mask<detray::annulus2D, algebra_t>& mask) const {
+        return std::optional(mask[annulus2D::e_max_r]);
     }
 
     // Calculates the outer radius for cylinders (2D).
-    auto inline outer_radius(
-        const detray::mask<detray::cylinder2D>& mask) const {
-        return std::optional<detray::scalar>(mask[cylinder2D::e_r]);
+    template <typename algebra_t>
+    DETRAY_HOST inline auto outer_radius(
+        const detray::mask<detray::cylinder2D, algebra_t>& mask) const {
+        return std::optional(mask[cylinder2D::e_r]);
     }
 
     // Calculates the outer radius for concentric cylinders (2D).
-    auto inline outer_radius(
-        const detray::mask<detray::concentric_cylinder2D>& mask) const {
-        return std::optional<detray::scalar>(mask[concentric_cylinder2D::e_r]);
+    template <typename algebra_t>
+    DETRAY_HOST inline auto outer_radius(
+        const detray::mask<detray::concentric_cylinder2D, algebra_t>& mask)
+        const {
+        return std::optional(mask[concentric_cylinder2D::e_r]);
     }
 
     // Calculates the outer radius for cylinders (3D).
-    auto inline outer_radius(
-        const detray::mask<detray::cylinder3D>& mask) const {
-        return std::optional<detray::scalar>(mask[cylinder3D::e_max_r]);
+    template <typename algebra_t>
+    DETRAY_HOST inline auto outer_radius(
+        const detray::mask<detray::cylinder3D, algebra_t>& mask) const {
+        return std::optional(mask[cylinder3D::e_max_r]);
     }
 };
 
@@ -99,12 +106,12 @@ struct link_start_getter {
     }
 
     // Calculates the (optimal) link starting point for rings.
-    template <typename transform_t>
-    auto inline link_start(const detray::mask<detray::ring2D>& mask,
+    template <typename transform_t, typename algebra_t>
+    auto inline link_start(const detray::mask<detray::ring2D, algebra_t>& mask,
                            const transform_t& transform) const {
 
         using shape_t = detray::ring2D;
-        using mask_t = detray::mask<shape_t>;
+        using mask_t = detray::mask<shape_t, algebra_t>;
         using point3_t = typename mask_t::point3_type;
         using scalar_t = typename mask_t::scalar_type;
 
@@ -116,12 +123,13 @@ struct link_start_getter {
     }
 
     // Calculates the (optimal) link starting point for annuluses.
-    template <typename transform_t>
-    auto inline link_start(const detray::mask<detray::annulus2D>& mask,
-                           const transform_t& transform) const {
+    template <typename transform_t, typename algebra_t>
+    auto inline link_start(
+        const detray::mask<detray::annulus2D, algebra_t>& mask,
+        const transform_t& transform) const {
 
         using shape_t = detray::annulus2D;
-        using mask_t = detray::mask<shape_t>;
+        using mask_t = detray::mask<shape_t, algebra_t>;
         using point3_t = typename mask_t::point3_type;
         using scalar_t = typename mask_t::scalar_type;
 
@@ -133,10 +141,11 @@ struct link_start_getter {
     }
 
     // Calculates the (optimal) link starting point for concentric cylinders
-    template <typename transform_t>
-    auto inline link_start(const detray::mask<concentric_cylinder2D>& mask,
-                           const transform_t& transform) const {
-        using mask_t = detray::mask<concentric_cylinder2D>;
+    template <typename transform_t, typename algebra_t>
+    auto inline link_start(
+        const detray::mask<concentric_cylinder2D, algebra_t>& mask,
+        const transform_t& transform) const {
+        using mask_t = detray::mask<concentric_cylinder2D, algebra_t>;
         using point3_t = typename mask_t::point3_type;
         using scalar_t = typename mask_t::scalar_type;
 
@@ -149,10 +158,10 @@ struct link_start_getter {
     }
 
     // Calculates the (optimal) link starting point for cylinders (2D).
-    template <typename transform_t>
-    auto inline link_start(const detray::mask<cylinder2D>& mask,
+    template <typename transform_t, typename algebra_t>
+    auto inline link_start(const detray::mask<cylinder2D, algebra_t>& mask,
                            const transform_t& transform) const {
-        using mask_t = detray::mask<cylinder2D>;
+        using mask_t = detray::mask<cylinder2D, algebra_t>;
         using point3_t = typename mask_t::point3_type;
         using scalar_t = typename mask_t::scalar_type;
 
@@ -165,12 +174,13 @@ struct link_start_getter {
     }
 
     // Calculates the (optimal) link starting point for cylinders (3D).
-    template <typename transform_t>
-    auto inline link_start(const detray::mask<detray::cylinder3D>& mask,
-                           const transform_t& transform) const {
+    template <typename transform_t, typename algebra_t>
+    auto inline link_start(
+        const detray::mask<detray::cylinder3D, algebra_t>& mask,
+        const transform_t& transform) const {
 
         using shape_t = detray::cylinder3D;
-        using mask_t = detray::mask<shape_t>;
+        using mask_t = detray::mask<shape_t, algebra_t>;
         using point3_t = typename mask_t::point3_type;
         using scalar_t = typename mask_t::scalar_type;
 
@@ -225,7 +235,9 @@ struct link_end_getter {
               typename shape_t>
         requires std::is_same_v<shape_t, cylinder2D> ||
         std::is_same_v<shape_t, concentric_cylinder2D> inline auto link_dir(
-            const detray::mask<shape_t>& mask, const detector_t& detector,
+            const detray::mask<shape_t, typename detector_t::algebra_type>&
+                mask,
+            const detector_t& detector,
             const detray::tracking_volume<detector_t>& volume,
             const point3_t& /*surface_point*/,
             const vector3_t& surface_normal) const {

--- a/tests/benchmarks/cpu/CMakeLists.txt
+++ b/tests/benchmarks/cpu/CMakeLists.txt
@@ -83,6 +83,11 @@ if(DETRAY_VC_SOA_PLUGIN)
            detray::test_utils
         )
 
+        target_compile_options(
+            detray_benchmark_cpu_vc_soa_vs_${algebra}
+            PRIVATE "-march=native"
+        )
+
         # Add Vc specific flags
         target_compile_options(
             detray_benchmark_cpu_vc_soa_vs_${algebra}
@@ -106,4 +111,6 @@ if(DETRAY_VC_SOA_PLUGIN)
     endmacro()
 
     detray_add_soa_benchmark( array )
+    # detray_add_soa_benchmark( eigen )
+    # detray_add_soa_benchmark( vc_aos )
 endif()

--- a/tests/benchmarks/cpu/find_volume.cpp
+++ b/tests/benchmarks/cpu/find_volume.cpp
@@ -21,6 +21,9 @@
 // Use the detray:: namespace implicitly.
 using namespace detray;
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+
 // Benchmarks the cost of searching a volume by position
 void BM_FIND_VOLUMES(benchmark::State &state) {
 
@@ -30,9 +33,9 @@ void BM_FIND_VOLUMES(benchmark::State &state) {
 
     // Detector configuration
     vecmem::host_memory_resource host_mr;
-    toy_det_config toy_cfg{};
+    toy_det_config<scalar> toy_cfg{};
     toy_cfg.n_edc_layers(7u);
-    auto [d, names] = build_toy_detector(host_mr, toy_cfg);
+    auto [d, names] = build_toy_detector<test_algebra>(host_mr, toy_cfg);
 
     static const unsigned int itest = 10000u;
 

--- a/tests/benchmarks/cpu/grid.cpp
+++ b/tests/benchmarks/cpu/grid.cpp
@@ -32,6 +32,9 @@
 // Use the detray:: namespace implicitly.
 using namespace detray;
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+
 namespace {
 
 #ifdef DETRAY_BENCHMARK_PRINTOUTS
@@ -60,7 +63,7 @@ template <typename bin_t>
 auto make_regular_grid(vecmem::memory_resource &mr) {
 
     // Data-owning grids with bin capacity 1
-    auto gr_factory = grid_factory<bin_t, simple_serializer>{mr};
+    auto gr_factory = grid_factory<bin_t, simple_serializer, test_algebra>{mr};
 
     // Spans of the axes
     std::vector<scalar> spans = {0.f, 25.f, 0.f, 60.f};
@@ -72,7 +75,7 @@ auto make_regular_grid(vecmem::memory_resource &mr) {
         spans, nbins, {}, {},
         types::list<axis::closed<axis::label::e_x>,
                     axis::closed<axis::label::e_y>>{},
-        types::list<axis::regular<>, axis::regular<>>{});
+        types::list<axis::regular<scalar>, axis::regular<scalar>>{});
 }
 
 /// Make an irregular grid for the tests.
@@ -91,14 +94,14 @@ auto make_irregular_grid(vecmem::memory_resource &mr) {
     }
 
     // Data-owning grids with bin capacity 1
-    auto gr_factory = grid_factory<bin_t, simple_serializer>{mr};
+    auto gr_factory = grid_factory<bin_t, simple_serializer, test_algebra>{mr};
 
     // Rectangular grid with closed bin bounds and irregular binning on all axes
     return gr_factory.template new_grid<rectangle2D>(
         {}, {}, {}, boundaries,
         types::list<axis::closed<axis::label::e_x>,
                     axis::closed<axis::label::e_y>>{},
-        types::list<axis::irregular<>, axis::irregular<>>{});
+        types::list<axis::irregular<scalar>, axis::irregular<scalar>>{});
 }
 
 /// Fill a grid with some values.

--- a/tests/benchmarks/cpu/intersect_all.cpp
+++ b/tests/benchmarks/cpu/intersect_all.cpp
@@ -34,8 +34,10 @@
 // Use the detray:: namespace implicitly.
 using namespace detray;
 
+using test_algebra = test::algebra;
+
 using trk_generator_t =
-    uniform_track_generator<free_track_parameters<test::algebra>>;
+    uniform_track_generator<free_track_parameters<test_algebra>>;
 
 constexpr unsigned int theta_steps{100u};
 constexpr unsigned int phi_steps{100u};
@@ -45,12 +47,12 @@ void BM_INTERSECT_ALL(benchmark::State &state) {
 
     // Detector configuration
     vecmem::host_memory_resource host_mr;
-    toy_det_config toy_cfg{};
+    toy_det_config<test::scalar> toy_cfg{};
     toy_cfg.n_edc_layers(7u);
-    auto [d, names] = build_toy_detector(host_mr, toy_cfg);
+    auto [d, names] = build_toy_detector<test_algebra>(host_mr, toy_cfg);
 
     using detector_t = decltype(d);
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<test_algebra>;
     using sf_desc_t = typename detector_t::surface_type;
 
     detector_t::geometry_context geo_context;
@@ -61,8 +63,7 @@ void BM_INTERSECT_ALL(benchmark::State &state) {
     std::size_t missed{0u};
     std::size_t n_surfaces{0u};
     test::point3 origin{0.f, 0.f, 0.f};
-    std::vector<intersection2D<sf_desc_t, typename detector_t::algebra_type>>
-        intersections{};
+    std::vector<intersection2D<sf_desc_t, test_algebra>> intersections{};
 
     // Iterate through uniformly distributed momentum directions
     auto trk_generator = trk_generator_t{};

--- a/tests/benchmarks/cpu/intersect_surfaces.cpp
+++ b/tests/benchmarks/cpu/intersect_surfaces.cpp
@@ -25,7 +25,9 @@
 // Use the detray:: namespace implicitly.
 using namespace detray;
 
-using ray_generator_t = uniform_track_generator<detail::ray<test::algebra>>;
+using test_algebra = test::algebra;
+
+using ray_generator_t = uniform_track_generator<detail::ray<test_algebra>>;
 
 static const unsigned int theta_steps = 100u;
 static const unsigned int phi_steps = 100u;
@@ -41,7 +43,7 @@ void BM_INTERSECT_PLANES(benchmark::State &state) {
 
     auto [plane_descs, transforms] = test::planes_along_direction(
         dists, vector::normalize(test::vector3{1.f, 1.f, 1.f}));
-    constexpr mask<rectangle2D> rect{0u, 10.f, 20.f};
+    constexpr mask<rectangle2D, test_algebra> rect{0u, 10.f, 20.f};
 
     // Iterate through uniformly distributed momentum directions
     auto ray_generator = ray_generator_t{};
@@ -55,7 +57,7 @@ void BM_INTERSECT_PLANES(benchmark::State &state) {
         for (const auto ray : ray_generator) {
 
             for (const auto &desc : plane_descs) {
-                auto pi = ray_intersector<rectangle2D, test::algebra>{};
+                auto pi = ray_intersector<rectangle2D, test_algebra>{};
                 auto is = pi(ray, desc, rect, transforms[desc.transform()]);
 
                 benchmark::DoNotOptimize(sfhit);
@@ -95,12 +97,12 @@ using mask_link_t = dtyped_index<mask_ids, dindex>;
 using material_link_t = dtyped_index<material_ids, dindex>;
 
 using surface_desc_t = surface_descriptor<mask_link_t, material_link_t>;
-using intersection_t = intersection2D<surface_desc_t, test::algebra>;
+using intersection_t = intersection2D<surface_desc_t, test_algebra>;
 
 /// This benchmark runs intersection with the cylinder intersector
 void BM_INTERSECT_CYLINDERS(benchmark::State &state) {
 
-    using cylinder_mask = mask<cylinder2D>;
+    using cylinder_mask = mask<cylinder2D, test_algebra>;
 
     unsigned int sfhit = 0u;
     unsigned int sfmiss = 0u;
@@ -129,7 +131,7 @@ void BM_INTERSECT_CYLINDERS(benchmark::State &state) {
         for (const auto ray : ray_generator) {
 
             for (const auto &cylinder : cylinders) {
-                auto ci = ray_intersector<cylinder2D, test::algebra>{};
+                auto ci = ray_intersector<cylinder2D, test_algebra>{};
                 auto inters = ci(ray, sf_desc, cylinder, trf);
 
                 benchmark::DoNotOptimize(sfhit);
@@ -157,7 +159,7 @@ BENCHMARK(BM_INTERSECT_CYLINDERS)
 /// intersector
 void BM_INTERSECT_PORTAL_CYLINDERS(benchmark::State &state) {
 
-    using cylinder_mask = mask<concentric_cylinder2D>;
+    using cylinder_mask = mask<concentric_cylinder2D, test_algebra>;
 
     unsigned int sfhit = 0u;
     unsigned int sfmiss = 0u;
@@ -187,7 +189,7 @@ void BM_INTERSECT_PORTAL_CYLINDERS(benchmark::State &state) {
 
             for (const auto &cylinder : cylinders) {
                 auto cpi =
-                    ray_intersector<concentric_cylinder2D, test::algebra>{};
+                    ray_intersector<concentric_cylinder2D, test_algebra>{};
                 auto is = cpi(ray, sf_desc, cylinder, trf);
 
                 benchmark::DoNotOptimize(sfhit);
@@ -214,7 +216,7 @@ void BM_INTERSECT_CONCETRIC_CYLINDERS(benchmark::State &state) {
     unsigned int sfhit = 0u;
     unsigned int sfmiss = 0u;
 
-    using cylinder_mask = mask<concentric_cylinder2D>;
+    using cylinder_mask = mask<concentric_cylinder2D, test_algebra>;
 
     dvector<cylinder_mask> cylinders;
     for (test::scalar r : dists) {
@@ -238,7 +240,7 @@ void BM_INTERSECT_CONCETRIC_CYLINDERS(benchmark::State &state) {
         for (const auto ray : ray_generator) {
 
             for (const auto &cylinder : cylinders) {
-                auto cci = ray_concentric_cylinder_intersector<test::algebra>{};
+                auto cci = ray_concentric_cylinder_intersector<test_algebra>{};
                 auto is = cci(ray, sf_desc, cylinder, trf);
 
                 benchmark::DoNotOptimize(sfhit);

--- a/tests/benchmarks/cpu/intersectors.cpp
+++ b/tests/benchmarks/cpu/intersectors.cpp
@@ -6,7 +6,9 @@
  */
 
 // Algebra include(s).
-#include "detray/plugins/algebra/vc_aos_definitions.hpp"
+#include "detray/plugins/algebra/array_definitions.hpp"
+//#include "detray/plugins/algebra/eigen_definitions.hpp"
+//#include "detray/plugins/algebra/vc_aos_definitions.hpp"
 #include "detray/plugins/algebra/vc_soa_definitions.hpp"
 
 // Detray core include(s).
@@ -39,8 +41,11 @@ static constexpr unsigned int n_surfaces{16u};
 using algebra_v = detray::vc_soa<test::scalar>;
 
 /// Linear algebra implementation using AoS memory layout
-using algebra_s = detray::vc_aos<test::scalar>;
-// using algebra_s = detray::array<test::scalar>;
+using algebra_array = detray::array<test::scalar>;
+// using algebra_vc_aos = detray::vc_aos<test::scalar>;
+// using algebra_eigen = detray::eigen<test::scalar>;
+
+using algebra_s = algebra_array;
 
 // Size of an SoA batch
 constexpr std::size_t simd_size{dscalar<algebra_v>::size()};
@@ -118,7 +123,7 @@ dvector<dscalar<algebra_v>> get_dists<algebra_v>(std::size_t n) {
 /// This benchmark runs intersection with the planar intersector
 void BM_INTERSECT_PLANES_AOS(benchmark::State& state) {
 
-    using mask_t = mask<rectangle2D, std::uint_least16_t, algebra_s>;
+    using mask_t = mask<rectangle2D, algebra_s, std::uint_least16_t>;
 
     auto dists = get_dists<algebra_s>(n_surfaces);
     auto [plane_descs, tranforms] = test::planes_along_direction<algebra_s>(
@@ -175,7 +180,7 @@ BENCHMARK(BM_INTERSECT_PLANES_AOS)
 /// This benchmark runs intersection with the planar intersector
 void BM_INTERSECT_PLANES_SOA(benchmark::State& state) {
 
-    using mask_t = mask<rectangle2D, std::uint_least16_t, algebra_v>;
+    using mask_t = mask<rectangle2D, algebra_v, std::uint_least16_t>;
     using vector3_t = dvector3D<algebra_v>;
 
     auto dists = get_dists<algebra_v>(n_surfaces);
@@ -237,7 +242,7 @@ void BM_INTERSECT_CYLINDERS_AOS(benchmark::State& state) {
     using transform3_t = dtransform3D<algebra_s>;
     using scalar_t = dscalar<algebra_s>;
 
-    using mask_t = mask<cylinder2D, std::uint_least16_t, algebra_s>;
+    using mask_t = mask<cylinder2D, algebra_s, std::uint_least16_t>;
 
     std::vector<mask_t> masks;
     for (const scalar_t r : get_dists<algebra_s>(n_surfaces)) {
@@ -303,7 +308,7 @@ void BM_INTERSECT_CYLINDERS_SOA(benchmark::State& state) {
     using transform3_t = dtransform3D<algebra_v>;
     using scalar_t = dscalar<algebra_v>;
 
-    using mask_t = mask<cylinder2D, std::uint_least16_t, algebra_v>;
+    using mask_t = mask<cylinder2D, algebra_v, std::uint_least16_t>;
 
     std::vector<mask_t> masks;
     for (const scalar_t r : get_dists<algebra_v>(n_surfaces)) {
@@ -366,7 +371,7 @@ void BM_INTERSECT_CONCETRIC_CYLINDERS_AOS(benchmark::State& state) {
     using transform3_t = dtransform3D<algebra_s>;
     using scalar_t = dscalar<algebra_s>;
 
-    using mask_t = mask<concentric_cylinder2D, std::uint_least16_t, algebra_s>;
+    using mask_t = mask<concentric_cylinder2D, algebra_s, std::uint_least16_t>;
 
     std::vector<mask_t> masks;
     for (const scalar_t r : get_dists<algebra_s>(n_surfaces)) {
@@ -428,7 +433,7 @@ void BM_INTERSECT_CONCETRIC_CYLINDERS_SOA(benchmark::State& state) {
     using transform3_t = dtransform3D<algebra_v>;
     using scalar_t = dscalar<algebra_v>;
 
-    using mask_t = mask<concentric_cylinder2D, std::uint_least16_t, algebra_v>;
+    using mask_t = mask<concentric_cylinder2D, algebra_v, std::uint_least16_t>;
 
     std::vector<mask_t> masks;
     for (const scalar_t r : get_dists<algebra_v>(n_surfaces)) {

--- a/tests/benchmarks/cpu/masks.cpp
+++ b/tests/benchmarks/cpu/masks.cpp
@@ -27,7 +27,10 @@
 
 // Use the detray:: namespace implicitly.
 using namespace detray;
+
+using test_algebra = test::algebra;
 using point3 = test::point3;
+using scalar = test::scalar;
 
 static constexpr unsigned int steps_x3{1000u};
 static constexpr unsigned int steps_y3{1000u};
@@ -41,7 +44,7 @@ static constexpr scalar tol{0.f};
 // This runs a benchmark on a rectangle2D mask
 void BM_MASK_CUBOID_3D(benchmark::State &state) {
 
-    using mask_type = mask<cuboid3D>;
+    using mask_type = mask<cuboid3D, test_algebra>;
     constexpr mask_type cb(0u, 0.f, 0.f, 0.f, 3.f, 4.f, 1.f);
 
     constexpr scalar world{10.f};
@@ -93,7 +96,7 @@ BENCHMARK(BM_MASK_CUBOID_3D)
 // This runs a benchmark on a rectangle2D mask
 void BM_MASK_RECTANGLE_2D(benchmark::State &state) {
 
-    using mask_type = mask<rectangle2D>;
+    using mask_type = mask<rectangle2D, test_algebra>;
     constexpr mask_type r(0u, 3.f, 4.f);
 
     constexpr scalar world{10.f};
@@ -145,7 +148,7 @@ BENCHMARK(BM_MASK_RECTANGLE_2D)
 // This runs a benchmark on a trapezoid2D mask
 void BM_MASK_TRAPEZOID_2D(benchmark::State &state) {
 
-    using mask_type = mask<trapezoid2D>;
+    using mask_type = mask<trapezoid2D, test_algebra>;
     constexpr mask_type t{0u, 2.f, 3.f, 4.f, 1.f / (2.f * 4.f)};
 
     constexpr scalar world{10.f};
@@ -197,7 +200,7 @@ BENCHMARK(BM_MASK_TRAPEZOID_2D)
 // This runs a benchmark on a ring2D mask (as disc)
 void BM_MASK_DISC_2D(benchmark::State &state) {
 
-    using mask_type = mask<ring2D>;
+    using mask_type = mask<ring2D, test_algebra>;
     constexpr mask_type r{0u, 0.f, 5.f};
 
     constexpr scalar world{10.f};
@@ -249,7 +252,7 @@ BENCHMARK(BM_MASK_DISC_2D)
 // This runs a benchmark on a ring2D mask
 void BM_MASK_RING_2D(benchmark::State &state) {
 
-    using mask_type = mask<ring2D>;
+    using mask_type = mask<ring2D, test_algebra>;
     constexpr mask_type r{0u, 2.f, 5.f};
 
     constexpr scalar world{10.f};
@@ -301,7 +304,7 @@ BENCHMARK(BM_MASK_RING_2D)
 // This runs a benchmark on a cylinder2D mask
 void BM_MASK_CYLINDER_3D(benchmark::State &state) {
 
-    using mask_type = mask<cylinder3D>;
+    using mask_type = mask<cylinder3D, test_algebra>;
     constexpr mask_type c{
         0u, 1.f, -constant<scalar>::pi, 0.f, 3.f, constant<scalar>::pi, 5.f};
 
@@ -355,7 +358,7 @@ BENCHMARK(BM_MASK_CYLINDER_3D)
 // This runs a benchmark on a cylinder2D mask
 void BM_MASK_CYLINDER_2D(benchmark::State &state) {
 
-    using mask_type = mask<cylinder2D>;
+    using mask_type = mask<cylinder2D, test_algebra>;
     constexpr mask_type c{0u, 3.f, 0.f, 5.f};
 
     constexpr scalar world{10.f};
@@ -405,7 +408,7 @@ BENCHMARK(BM_MASK_CYLINDER_2D)
 // This runs a benchmark on a cylinder2D mask
 void BM_MASK_CONCENTRIC_CYLINDER_2D(benchmark::State &state) {
 
-    using mask_type = mask<concentric_cylinder2D>;
+    using mask_type = mask<concentric_cylinder2D, test_algebra>;
     constexpr mask_type c{0u, 3.f, 0.f, 5.f};
 
     constexpr scalar world{10.f};
@@ -455,7 +458,7 @@ BENCHMARK(BM_MASK_CONCENTRIC_CYLINDER_2D)
 // This runs a benchmark on an annulus2D mask
 void BM_MASK_ANNULUS_2D(benchmark::State &state) {
 
-    using mask_type = mask<annulus2D>;
+    using mask_type = mask<annulus2D, test_algebra>;
     constexpr mask_type ann{0u, 2.5f, 5.f, -0.64299f, 4.13173f, 1.f, 0.5f, 0.f};
 
     constexpr scalar world{10.f};
@@ -505,7 +508,7 @@ BENCHMARK(BM_MASK_ANNULUS_2D)
 // This runs a benchmark on a straw tube mask
 void BM_MASK_LINE_CIRCULAR(benchmark::State &state) {
 
-    using mask_type = mask<line_circular>;
+    using mask_type = mask<line_circular, test_algebra>;
     constexpr mask_type st{0u, 3.f, 5.f};
 
     constexpr scalar world{10.f};
@@ -557,7 +560,7 @@ BENCHMARK(BM_MASK_LINE_CIRCULAR)
 // This runs a benchmark on a wire cell mask
 void BM_MASK_LINE_SQUARE(benchmark::State &state) {
 
-    using mask_type = mask<line_square>;
+    using mask_type = mask<line_square, test_algebra>;
     constexpr mask_type dcl{0u, 3.f, 5.f};
 
     constexpr scalar world{10.f};

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda.cpp
@@ -32,16 +32,17 @@ vecmem::binary_page_memory_resource bp_mng_mr(mng_mr);
 
 // detector configuration
 auto toy_cfg =
-    toy_det_config{}.n_brl_layers(4u).n_edc_layers(7u).do_check(false);
+    toy_det_config<scalar>{}.n_brl_layers(4u).n_edc_layers(7u).do_check(false);
 
-void fill_tracks(vecmem::vector<free_track_parameters<algebra_t>> &tracks,
+void fill_tracks(vecmem::vector<free_track_parameters<test_algebra>> &tracks,
                  const std::size_t n_tracks, bool do_sort = true) {
-    using scalar_t = dscalar<algebra_t>;
+    using scalar_t = dscalar<test_algebra>;
     using uniform_gen_t =
         detail::random_numbers<scalar_t,
                                std::uniform_real_distribution<scalar_t>>;
     using trk_generator_t =
-        random_track_generator<free_track_parameters<algebra_t>, uniform_gen_t>;
+        random_track_generator<free_track_parameters<test_algebra>,
+                               uniform_gen_t>;
 
     trk_generator_t::configuration trk_gen_cfg{};
     trk_gen_cfg.seed(42u);
@@ -80,9 +81,9 @@ static void BM_PROPAGATOR_CUDA(benchmark::State &state) {
                          static_cast<std::size_t>(state.range(0))};
 
     // Create the toy geometry
-    auto [det, names] = build_toy_detector(host_mr, toy_cfg);
+    auto [det, names] = build_toy_detector<test_algebra>(host_mr, toy_cfg);
     test::vector3 B{0.f, 0.f, 2.f * unit<scalar>::T};
-    auto bfield = bfield::create_const_field(B);
+    auto bfield = bfield::create_const_field<scalar>(B);
 
     // vecmem copy helper object
     vecmem::cuda::copy cuda_cpy;
@@ -98,7 +99,7 @@ static void BM_PROPAGATOR_CUDA(benchmark::State &state) {
         state.PauseTiming();
 
         // Get tracks
-        vecmem::vector<free_track_parameters<algebra_t>> tracks(&bp_mng_mr);
+        vecmem::vector<free_track_parameters<test_algebra>> tracks(&bp_mng_mr);
         fill_tracks(tracks, n_tracks);
 
         total_tracks += tracks.size();

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.cu
@@ -12,14 +12,15 @@ namespace detray {
 
 __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
     typename detector_host_type::view_type det_data,
-    covfie::field_view<bfield::const_bknd_t> field_data,
-    vecmem::data::vector_view<free_track_parameters<algebra_t>> tracks_data,
+    covfie::field_view<bfield::const_bknd_t<scalar>> field_data,
+    vecmem::data::vector_view<free_track_parameters<test_algebra>> tracks_data,
     const propagate_option opt) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
 
     detector_device_type det(det_data);
-    vecmem::device_vector<free_track_parameters<algebra_t>> tracks(tracks_data);
+    vecmem::device_vector<free_track_parameters<test_algebra>> tracks(
+        tracks_data);
 
     if (gid >= tracks.size()) {
         return;
@@ -30,9 +31,9 @@ __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
     cfg.navigation.search_window = {3u, 3u};
     propagator_device_type p{cfg};
 
-    parameter_transporter<algebra_t>::state transporter_state{};
-    pointwise_material_interactor<algebra_t>::state interactor_state{};
-    parameter_resetter<algebra_t>::state resetter_state{};
+    parameter_transporter<test_algebra>::state transporter_state{};
+    pointwise_material_interactor<test_algebra>::state interactor_state{};
+    parameter_resetter<test_algebra>::state resetter_state{};
 
     // Create the actor states
     auto actor_states =
@@ -50,8 +51,8 @@ __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
 
 void propagator_benchmark(
     typename detector_host_type::view_type det_data,
-    covfie::field_view<bfield::const_bknd_t> field_data,
-    vecmem::data::vector_view<free_track_parameters<algebra_t>>& tracks_data,
+    covfie::field_view<bfield::const_bknd_t<scalar>> field_data,
+    vecmem::data::vector_view<free_track_parameters<test_algebra>>& tracks_data,
     const propagate_option opt) {
 
     constexpr int thread_dim = 256;

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
@@ -11,7 +11,6 @@
 #include "detray/definitions/detail/algebra.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/bfield.hpp"
-#include "detray/detectors/toy_metadata.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/actors/aborters.hpp"
@@ -23,21 +22,29 @@
 #include "detray/propagator/rk_stepper.hpp"
 #include "detray/tracks/tracks.hpp"
 
-using algebra_t = ALGEBRA_PLUGIN<detray::scalar>;
+// Detray test include(s).
+#include "detray/test/utils/types.hpp"
+
+namespace detray {
+
+using matadata_t = test::toy_metadata;
+using test_algebra = matadata_t::algebra_type;
+using scalar = detray::dscalar<test_algebra>;
 
 using detector_host_type =
-    detray::detector<detray::toy_metadata, detray::host_container_types>;
+    detray::detector<matadata_t, detray::host_container_types>;
 using detector_device_type =
-    detray::detector<detray::toy_metadata, detray::device_container_types>;
+    detray::detector<matadata_t, detray::device_container_types>;
 
 using navigator_host_type = detray::navigator<detector_host_type>;
 using navigator_device_type = detray::navigator<detector_device_type>;
-using field_type = detray::bfield::const_field_t;
-using rk_stepper_type = detray::rk_stepper<field_type::view_t, algebra_t>;
+using field_type = detray::bfield::const_field_t<scalar>;
+using rk_stepper_type = detray::rk_stepper<field_type::view_t, test_algebra>;
 using actor_chain_t =
-    detray::actor_chain<detray::tuple, detray::parameter_transporter<algebra_t>,
-                        detray::pointwise_material_interactor<algebra_t>,
-                        detray::parameter_resetter<algebra_t>>;
+    detray::actor_chain<detray::tuple,
+                        detray::parameter_transporter<test_algebra>,
+                        detray::pointwise_material_interactor<test_algebra>,
+                        detray::parameter_resetter<test_algebra>>;
 using propagator_host_type =
     detray::propagator<rk_stepper_type, navigator_host_type, actor_chain_t>;
 using propagator_device_type =
@@ -48,13 +55,11 @@ enum class propagate_option {
     e_sync = 1,
 };
 
-namespace detray {
-
 /// test function for propagator with single state
 void propagator_benchmark(
     typename detector_host_type::view_type det_data,
     typename field_type::view_t field_data,
-    vecmem::data::vector_view<free_track_parameters<algebra_t>>& tracks_data,
+    vecmem::data::vector_view<free_track_parameters<test_algebra>>& tracks_data,
     const propagate_option opt);
 
 }  // namespace detray

--- a/tests/include/detray/test/common/detector_scan_config.hpp
+++ b/tests/include/detray/test/common/detector_scan_config.hpp
@@ -39,8 +39,8 @@ struct detector_scan_config : public test::fixture_base<>::configuration {
     std::string m_track_param_file{"truth_trk_parameters"};
     /// Mask tolerance for the intersectors
     std::array<scalar_type, 2> m_mask_tol{
-        std::numeric_limits<float>::epsilon(),
-        std::numeric_limits<float>::epsilon()};
+        std::numeric_limits<scalar_type>::epsilon(),
+        std::numeric_limits<scalar_type>::epsilon()};
     /// B-field vector for helix
     vector3_type m_B{0.f * unit<scalar_type>::T, 0.f * unit<scalar_type>::T,
                      2.f * unit<scalar_type>::T};

--- a/tests/include/detray/test/common/fixture_base.hpp
+++ b/tests/include/detray/test/common/fixture_base.hpp
@@ -31,8 +31,8 @@ class fixture_base : public scope {
     public:
     /// Linear algebra typedefs
     /// @{
-    using algebra_t = ALGEBRA_PLUGIN<test::scalar>;
-    using scalar = detray::scalar;
+    using algebra_t = test::algebra;
+    using scalar = test::scalar;
     using point2 = test::point2;
     using point3 = test::point3;
     using vector3 = test::vector3;
@@ -44,11 +44,11 @@ class fixture_base : public scope {
         /// General testing
         /// @{
         /// Tolerance to compare two floating point values
-        float m_tolerance{std::numeric_limits<float>::epsilon()};
+        scalar m_tolerance{std::numeric_limits<scalar>::epsilon()};
         /// Shorthand for infinity
-        float inf{std::numeric_limits<float>::infinity()};
+        scalar inf{std::numeric_limits<scalar>::infinity()};
         /// Shorthand for the floating point epsilon
-        float epsilon{std::numeric_limits<float>::epsilon()};
+        scalar epsilon{std::numeric_limits<scalar>::epsilon()};
         /// @}
 
         /// Propagation
@@ -58,7 +58,7 @@ class fixture_base : public scope {
 
         /// Setters
         /// @{
-        configuration& tol(float t) {
+        configuration& tol(scalar t) {
             m_tolerance = t;
             return *this;
         }
@@ -66,7 +66,7 @@ class fixture_base : public scope {
 
         /// Getters
         /// @{
-        float tol() const { return m_tolerance; }
+        scalar tol() const { return m_tolerance; }
         propagation::config& propagation() { return m_prop_cfg; }
         const propagation::config& propagation() const { return m_prop_cfg; }
         /// @}
@@ -109,12 +109,12 @@ class fixture_base : public scope {
     }
 
     private:
-    float tolerance{};
-    float inf{};
-    float epsilon{};
-    float path_limit{};
-    float overstep_tolerance{};
-    float step_constraint{};
+    scalar tolerance{};
+    scalar inf{};
+    scalar epsilon{};
+    scalar path_limit{};
+    scalar overstep_tolerance{};
+    scalar step_constraint{};
 };
 
 }  // namespace detray::test

--- a/tests/include/detray/test/cpu/material_scan.hpp
+++ b/tests/include/detray/test/cpu/material_scan.hpp
@@ -35,8 +35,8 @@ template <typename detector_t>
 class material_scan : public test::fixture_base<> {
 
     using algebra_t = typename detector_t::algebra_type;
-    using point2_t = typename detector_t::point2_type;
-    using scalar_t = typename detector_t::scalar_type;
+    using point2_t = dpoint2D<algebra_t>;
+    using scalar_t = dscalar<algebra_t>;
     using ray_t = detail::ray<algebra_t>;
     using track_generator_t = uniform_track_generator<ray_t>;
 

--- a/tests/include/detray/test/cpu/material_validation.hpp
+++ b/tests/include/detray/test/cpu/material_validation.hpp
@@ -42,7 +42,7 @@ struct run_material_validation {
             &tracks,
         const std::vector<std::size_t> & = {}) {
 
-        using scalar_t = typename detector_t::scalar_type;
+        using scalar_t = dscalar<typename detector_t::algebra_type>;
 
         typename detector_t::geometry_context gctx{};
 
@@ -80,8 +80,8 @@ struct run_material_validation {
 template <typename detector_t, typename material_validator_t>
 class material_validation_impl : public test::fixture_base<> {
 
-    using scalar_t = typename detector_t::scalar_type;
     using algebra_t = typename detector_t::algebra_type;
+    using scalar_t = dscalar<algebra_t>;
     using free_track_parameters_t = free_track_parameters<algebra_t>;
     using material_record_t = material_validator::material_record<scalar_t>;
 

--- a/tests/include/detray/test/cpu/toy_detector_test.hpp
+++ b/tests/include/detray/test/cpu/toy_detector_test.hpp
@@ -78,7 +78,7 @@ test_mat_map(const mat_map_t& mat_map, const bool is_cyl) {
 
         for (const auto& mat_slab : mat_map.all()) {
             EXPECT_TRUE(mat_slab.get_material() ==
-                            toy_det_config{}.mapped_material() ||
+                            toy_det_config<scalar_t>{}.mapped_material() ||
                         mat_slab.get_material() == beryllium_tml<scalar_t>{});
         }
     } else {
@@ -96,18 +96,19 @@ test_mat_map(const mat_map_t& mat_map, const bool is_cyl) {
 
         for (const auto& mat_slab : mat_map.all()) {
             EXPECT_TRUE(mat_slab.get_material() ==
-                        toy_det_config{}.mapped_material());
+                        toy_det_config<scalar_t>{}.mapped_material());
         }
     }
 }
 
-template <typename bfield_t>
+template <typename algebra_t, typename bfield_t>
 inline bool toy_detector_test(
-    const detector<toy_metadata, bfield_t>& toy_det,
-    const typename detector<toy_metadata, bfield_t>::name_map& names) {
+    const detector<toy_metadata<algebra_t>, bfield_t>& toy_det,
+    const typename detector<toy_metadata<algebra_t>, bfield_t>::name_map&
+        names) {
 
-    using detector_t = detector<toy_metadata, bfield_t>;
-    using scalar_t = typename detector_t::scalar_type;
+    using detector_t = detector<toy_metadata<algebra_t>, bfield_t>;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
     using geo_obj_ids = typename detector_t::geo_obj_ids;
     using volume_t = typename detector_t::volume_type;
     using nav_link_t = typename detector_t::surface_type::navigation_link;
@@ -133,8 +134,9 @@ inline bool toy_detector_test(
     auto& materials = toy_det.material_store();
 
     // Materials
-    auto portal_mat = material_slab<scalar_t>(
-        toy_det_config{}.mapped_material(), 1.5f * unit<scalar_t>::mm);
+    auto portal_mat =
+        material_slab<scalar_t>(toy_det_config<scalar_t>{}.mapped_material(),
+                                1.5f * unit<scalar_t>::mm);
     auto beampipe_mat = material_slab<scalar_t>(beryllium_tml<scalar_t>(),
                                                 0.8f * unit<scalar_t>::mm);
     auto pixel_mat = material_slab<scalar_t>(silicon_tml<scalar_t>(),

--- a/tests/include/detray/test/device/cuda/material_validation.cu
+++ b/tests/include/detray/test/device/cuda/material_validation.cu
@@ -6,8 +6,6 @@
  */
 
 #include "detray/definitions/detail/cuda_definitions.hpp"
-#include "detray/detectors/telescope_metadata.hpp"
-#include "detray/detectors/toy_metadata.hpp"
 #include "detray/propagator/actors/aborters.hpp"
 #include "detray/propagator/actors/parameter_resetter.hpp"
 #include "detray/propagator/actors/parameter_transporter.hpp"
@@ -41,11 +39,11 @@ __global__ void material_validation_kernel(
     // material tracer
     using material_tracer_t =
         material_validator::material_tracer<scalar_t, vecmem::device_vector>;
-    using actor_chain_t =
-        actor_chain<tuple, pathlimit_aborter, parameter_transporter<algebra_t>,
-                    parameter_resetter<algebra_t>,
-                    pointwise_material_interactor<algebra_t>,
-                    material_tracer_t>;
+    using pathlimit_aborter_t = pathlimit_aborter<scalar_t>;
+    using actor_chain_t = actor_chain<
+        tuple, pathlimit_aborter_t, parameter_transporter<algebra_t>,
+        parameter_resetter<algebra_t>, pointwise_material_interactor<algebra_t>,
+        material_tracer_t>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     detector_device_t det(det_data);
@@ -65,7 +63,7 @@ __global__ void material_validation_kernel(
     propagator_t p{cfg};
 
     // Create the actor states
-    pathlimit_aborter::state aborter_state{cfg.stepping.path_limit};
+    typename pathlimit_aborter_t::state aborter_state{cfg.stepping.path_limit};
     typename parameter_transporter<algebra_t>::state transporter_state{};
     typename parameter_resetter<algebra_t>::state resetter_state{};
     typename pointwise_material_interactor<algebra_t>::state interactor_state{};
@@ -124,8 +122,8 @@ void material_validation_device(
         vecmem::data::jagged_vector_view<material_validator::material_params< \
             typename detector<METADATA>::scalar_type>> &);
 
-DECLARE_MATERIAL_VALIDATION(default_metadata)
-DECLARE_MATERIAL_VALIDATION(toy_metadata)
-DECLARE_MATERIAL_VALIDATION(telescope_metadata<rectangle2D>)
+DECLARE_MATERIAL_VALIDATION(test::default_metadata)
+DECLARE_MATERIAL_VALIDATION(test::toy_metadata)
+DECLARE_MATERIAL_VALIDATION(test::default_telescope_metadata)
 
 }  // namespace detray::cuda

--- a/tests/include/detray/test/device/cuda/material_validation.hpp
+++ b/tests/include/detray/test/device/cuda/material_validation.hpp
@@ -59,9 +59,9 @@ struct run_material_validation {
             free_track_parameters<typename detector_t::algebra_type>> &tracks,
         const std::vector<std::size_t> &capacities) {
 
-        using scalar_t = typename detector_t::scalar_type;
-        using track_t =
-            free_track_parameters<typename detector_t::algebra_type>;
+        using algebra_t = typename detector_t::algebra_type;
+        using scalar_t = dscalar<algebra_t>;
+        using track_t = free_track_parameters<algebra_t>;
         using material_record_t = material_validator::material_record<scalar_t>;
         using material_params_t = material_validator::material_params<scalar_t>;
 

--- a/tests/include/detray/test/device/cuda/navigation_validation.hpp
+++ b/tests/include/detray/test/device/cuda/navigation_validation.hpp
@@ -69,8 +69,8 @@ inline auto run_navigation_validation(
     const std::vector<std::vector<intersection_record_t>>
         &truth_intersection_traces) {
 
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
     using intersection_t = typename intersection_record_t::intersection_type;
-    using scalar_t = typename detector_t::scalar_type;
     using material_record_t = material_validator::material_record<scalar_t>;
     using material_params_t = material_validator::material_params<scalar_t>;
 
@@ -146,9 +146,9 @@ inline auto run_navigation_validation(
 template <typename detector_t, template <typename> class scan_type>
 class navigation_validation : public test::fixture_base<> {
 
-    using scalar_t = typename detector_t::scalar_type;
     using algebra_t = typename detector_t::algebra_type;
-    using vector3_t = typename detector_t::vector3_type;
+    using scalar_t = dscalar<algebra_t>;
+    using vector3_t = dvector3D<algebra_t>;
     using free_track_parameters_t = free_track_parameters<algebra_t>;
     using trajectory_type = typename scan_type<algebra_t>::trajectory_type;
     using intersection_trace_t = typename scan_type<
@@ -220,10 +220,10 @@ class navigation_validation : public test::fixture_base<> {
         using namespace navigation;
 
         // Runge-Kutta stepper
-        using hom_bfield_t = bfield::const_field_t;
+        using hom_bfield_t = bfield::const_field_t<scalar_t>;
         using bfield_view_t =
             std::conditional_t<k_use_rays, navigation_validator::empty_bfield,
-                               hom_bfield_t::view_t>;
+                               typename hom_bfield_t::view_t>;
         using bfield_t =
             std::conditional_t<k_use_rays, navigation_validator::empty_bfield,
                                hom_bfield_t>;
@@ -232,7 +232,7 @@ class navigation_validation : public test::fixture_base<> {
 
         bfield_t b_field{};
         if constexpr (!k_use_rays) {
-            b_field = bfield::create_const_field(m_cfg.B_vector());
+            b_field = bfield::create_const_field<scalar_t>(m_cfg.B_vector());
         }
 
         // Fetch the truth data

--- a/tests/include/detray/test/utils/detectors/build_toy_detector.hpp
+++ b/tests/include/detray/test/utils/detectors/build_toy_detector.hpp
@@ -45,64 +45,69 @@
 namespace detray {
 
 /// Configure the toy detector
+template <typename scalar_t>
 struct toy_det_config {
 
     /// Default toy detector configuration
     toy_det_config() {
         // Barrel module creator
-        m_barrel_factory_cfg.half_length(500.f * unit<scalar>::mm)
-            .module_bounds({8.4f * unit<scalar>::mm, 36.f * unit<scalar>::mm})
+        m_barrel_factory_cfg.half_length(500.f * unit<scalar_t>::mm)
+            .module_bounds(
+                {8.4f * unit<scalar_t>::mm, 36.f * unit<scalar_t>::mm})
             .tilt_phi(0.14f /*0.145*/)
-            .radial_stagger(0.5f * unit<scalar>::mm /*2.f*/)
-            .z_overlap(2.f * unit<scalar>::mm /*5.f*/);
+            .radial_stagger(0.5f * unit<scalar_t>::mm /*2.f*/)
+            .z_overlap(2.f * unit<scalar_t>::mm /*5.f*/);
 
         // Endcap module creator
         m_endcap_factory_cfg.inner_radius(m_beampipe_volume_radius)
             .outer_radius(m_outer_radius)
-            .module_bounds({{3.f * unit<scalar>::mm, 9.5f * unit<scalar>::mm,
-                             39.f * unit<scalar>::mm},
-                            {6.f * unit<scalar>::mm, 10.f * unit<scalar>::mm,
-                             39.f * unit<scalar>::mm}})
-            .ring_stagger(2.f * unit<scalar>::mm)
-            .phi_stagger({4.f * unit<scalar>::mm, 4.f * unit<scalar>::mm})
-            .phi_sub_stagger({0.5f * unit<scalar>::mm, 0.5f * unit<scalar>::mm})
+            .module_bounds(
+                {{3.f * unit<scalar_t>::mm, 9.5f * unit<scalar_t>::mm,
+                  39.f * unit<scalar_t>::mm},
+                 {6.f * unit<scalar_t>::mm, 10.f * unit<scalar_t>::mm,
+                  39.f * unit<scalar_t>::mm}})
+            .ring_stagger(2.f * unit<scalar_t>::mm)
+            .phi_stagger({4.f * unit<scalar_t>::mm, 4.f * unit<scalar_t>::mm})
+            .phi_sub_stagger(
+                {0.5f * unit<scalar_t>::mm, 0.5f * unit<scalar_t>::mm})
             .module_tilt({0.f, 0.f})
             .binning({40u, 68u});
 
         // Configure the material generation
-        m_material_config.sensitive_material(silicon_tml<scalar>())
-            .passive_material(beryllium_tml<scalar>())  // < beampipe
-            .portal_material(vacuum<scalar>())
-            .thickness(1.5f * unit<scalar>::mm);
+        m_material_config.sensitive_material(silicon_tml<scalar_t>())
+            .passive_material(beryllium_tml<scalar_t>())  // < beampipe
+            .portal_material(vacuum<scalar_t>())
+            .thickness(1.5f * unit<scalar_t>::mm);
 
         // Configure the material map generation
         m_beampipe_map_cfg.n_bins = {20u, 20u};
         m_beampipe_map_cfg.axis_index = 1u;
-        m_beampipe_map_cfg.mapped_material = beryllium_tml<scalar>();
-        m_beampipe_map_cfg.thickness = 0.8f * unit<scalar>::mm;
+        m_beampipe_map_cfg.mapped_material = beryllium_tml<scalar_t>();
+        m_beampipe_map_cfg.thickness = 0.8f * unit<scalar_t>::mm;
         // Don't scale the generation of the material thickness
         m_beampipe_map_cfg.scalor = 0.f;
         m_beampipe_map_cfg.mat_generator =
-            detray::detail::generate_cyl_mat<scalar>;
+            detray::detail::generate_cyl_mat<scalar_t>;
 
         m_disc_map_cfg.n_bins = {3u, 20u};
         m_disc_map_cfg.axis_index = 0u;
         m_disc_map_cfg.mapped_material =
-            mixture<scalar, silicon_tml<scalar, std::ratio<9, 10>>,
-                    aluminium<scalar, std::ratio<1, 10>>>{};
-        m_disc_map_cfg.thickness = 1.f * unit<scalar>::mm;
+            mixture<scalar_t, silicon_tml<scalar_t, std::ratio<9, 10>>,
+                    aluminium<scalar_t, std::ratio<1, 10>>>{};
+        m_disc_map_cfg.thickness = 1.f * unit<scalar_t>::mm;
         m_disc_map_cfg.scalor = 1e-6f;
         m_disc_map_cfg.mat_generator =
-            detray::detail::generate_disc_mat<scalar>;
+            detray::detail::generate_disc_mat<scalar_t>;
 
         m_cyl_map_cfg.n_bins = {20u, 20u};
         m_cyl_map_cfg.axis_index = 1u;
         m_cyl_map_cfg.mapped_material =
-            mixture<scalar, silicon_tml<scalar, std::ratio<9, 10>>,
-                    aluminium<scalar, std::ratio<1, 10>>>{};
-        m_cyl_map_cfg.thickness = 5.f * unit<scalar>::mm;
+            mixture<scalar_t, silicon_tml<scalar_t, std::ratio<9, 10>>,
+                    aluminium<scalar_t, std::ratio<1, 10>>>{};
+        m_cyl_map_cfg.thickness = 5.f * unit<scalar_t>::mm;
         m_cyl_map_cfg.scalor = 1e-8f;
-        m_cyl_map_cfg.mat_generator = detray::detail::generate_cyl_mat<scalar>;
+        m_cyl_map_cfg.mat_generator =
+            detray::detail::generate_cyl_mat<scalar_t>;
     }
 
     /// No. of barrel layers the detector should be built with
@@ -110,43 +115,43 @@ struct toy_det_config {
     /// No. of endcap layers (on either side) the detector should be built with
     unsigned int m_n_edc_layers{3u};
     /// Total outer radius of the pixel subdetector
-    scalar m_outer_radius{180.f * unit<scalar>::mm};
+    scalar_t m_outer_radius{180.f * unit<scalar_t>::mm};
     // Radius of the innermost volume that contains the beampipe
-    scalar m_beampipe_volume_radius{25.f * unit<scalar>::mm};
+    scalar_t m_beampipe_volume_radius{25.f * unit<scalar_t>::mm};
     // Envelope around the modules used by the cylinder portal generator
-    scalar m_portal_envelope{0.5f * unit<scalar>::mm};
+    scalar_t m_portal_envelope{0.5f * unit<scalar_t>::mm};
     /// Configuration for the homogeneous material generator
-    hom_material_config<scalar> m_material_config{};
+    hom_material_config<scalar_t> m_material_config{};
     /// Put material maps on portals or use homogenous material on modules
     bool m_use_material_maps{false};
     /// Configuration for the material map generator (beampipe)
-    typename material_map_config<scalar>::map_config m_beampipe_map_cfg{};
+    typename material_map_config<scalar_t>::map_config m_beampipe_map_cfg{};
     /// Configuration for the material map generator (disc)
-    typename material_map_config<scalar>::map_config m_disc_map_cfg{};
+    typename material_map_config<scalar_t>::map_config m_disc_map_cfg{};
     /// Configuration for the material map generator (cylinder)
-    typename material_map_config<scalar>::map_config m_cyl_map_cfg{};
+    typename material_map_config<scalar_t>::map_config m_cyl_map_cfg{};
     /// Thickness of the beampipe material
-    scalar m_beampipe_mat_thickness{0.8f * unit<scalar>::mm};
+    scalar_t m_beampipe_mat_thickness{0.8f * unit<scalar_t>::mm};
     /// Thickness of the material slabs in the homogeneous material description
-    scalar m_module_mat_thickness{1.5f * unit<scalar>::mm};
+    scalar_t m_module_mat_thickness{1.5f * unit<scalar_t>::mm};
     /// Radii at which to place the barrel module layers (including beampipe)
-    std::vector<scalar> m_barrel_layer_radii = {
-        19.f * unit<scalar>::mm, 32.f * unit<scalar>::mm,
-        72.f * unit<scalar>::mm, 116.f * unit<scalar>::mm,
-        172.f * unit<scalar>::mm};
+    std::vector<scalar_t> m_barrel_layer_radii = {
+        19.f * unit<scalar_t>::mm, 32.f * unit<scalar_t>::mm,
+        72.f * unit<scalar_t>::mm, 116.f * unit<scalar_t>::mm,
+        172.f * unit<scalar_t>::mm};
     /// Number of modules in phi and z for the barrel
     std::vector<std::pair<unsigned int, unsigned int>> m_barrel_binning = {
         {0u, 0u}, {16u, 14u}, {32u, 14u}, {52u, 14u}, {78u, 14u}};
     /// Positions at which to place the endcap module layers on either side
-    std::vector<scalar> m_endcap_layer_positions = {
-        600.f * unit<scalar>::mm,  700.f * unit<scalar>::mm,
-        820.f * unit<scalar>::mm,  960.f * unit<scalar>::mm,
-        1100.f * unit<scalar>::mm, 1300.f * unit<scalar>::mm,
-        1500.f * unit<scalar>::mm};
+    std::vector<scalar_t> m_endcap_layer_positions = {
+        600.f * unit<scalar_t>::mm,  700.f * unit<scalar_t>::mm,
+        820.f * unit<scalar_t>::mm,  960.f * unit<scalar_t>::mm,
+        1100.f * unit<scalar_t>::mm, 1300.f * unit<scalar_t>::mm,
+        1500.f * unit<scalar_t>::mm};
     /// Config for the module generation (barrel)
-    barrel_generator_config<scalar> m_barrel_factory_cfg{};
+    barrel_generator_config<scalar_t> m_barrel_factory_cfg{};
     /// Config for the module generation (endcaps)
-    endcap_generator_config<scalar> m_endcap_factory_cfg{};
+    endcap_generator_config<scalar_t> m_endcap_factory_cfg{};
     /// Run detector consistency check after reading
     bool m_do_check{true};
 
@@ -160,7 +165,7 @@ struct toy_det_config {
         m_n_edc_layers = n;
         return *this;
     }
-    constexpr toy_det_config &envelope(const scalar env) {
+    constexpr toy_det_config &envelope(const scalar_t env) {
         m_portal_envelope = env;
         return *this;
     }
@@ -178,23 +183,23 @@ struct toy_det_config {
         m_disc_map_cfg.n_bins = {n_r, n_phi};
         return *this;
     }
-    constexpr toy_det_config &material_map_min_thickness(const scalar t) {
+    constexpr toy_det_config &material_map_min_thickness(const scalar_t t) {
         assert(t > 0.f);
         m_cyl_map_cfg.thickness = t;
         m_disc_map_cfg.thickness = t;
         return *this;
     }
-    constexpr toy_det_config &beampipe_mat_thickness(const scalar t) {
+    constexpr toy_det_config &beampipe_mat_thickness(const scalar_t t) {
         assert(t > 0.f);
         m_beampipe_mat_thickness = t;
         return *this;
     }
-    constexpr toy_det_config &module_mat_thickness(const scalar t) {
+    constexpr toy_det_config &module_mat_thickness(const scalar_t t) {
         assert(t > 0.f);
         m_module_mat_thickness = t;
         return *this;
     }
-    constexpr toy_det_config &mapped_material(const material<scalar> &mat) {
+    constexpr toy_det_config &mapped_material(const material<scalar_t> &mat) {
         m_cyl_map_cfg.mapped_material = mat;
         m_disc_map_cfg.mapped_material = mat;
         return *this;
@@ -210,8 +215,8 @@ struct toy_det_config {
     constexpr unsigned int n_brl_layers() const { return m_n_brl_layers; }
     constexpr unsigned int n_edc_layers() const { return m_n_edc_layers; }
     constexpr const auto &outer_radius() const { return m_outer_radius; }
-    constexpr scalar envelope() const { return m_portal_envelope; }
-    constexpr scalar beampipe_vol_radius() const {
+    constexpr scalar_t envelope() const { return m_portal_envelope; }
+    constexpr scalar_t beampipe_vol_radius() const {
         return m_beampipe_volume_radius;
     }
     constexpr auto &material_config() { return m_material_config; }
@@ -231,19 +236,19 @@ struct toy_det_config {
     constexpr const std::array<std::size_t, 2> &disc_map_bins() const {
         return m_disc_map_cfg.n_bins;
     }
-    constexpr scalar material_map_min_thickness() const {
+    constexpr scalar_t material_map_min_thickness() const {
         assert(m_cyl_map_cfg.thickness == m_disc_map_cfg.thickness);
         return m_cyl_map_cfg.thickness;
     }
-    constexpr scalar beampipe_mat_thickness() const {
+    constexpr scalar_t beampipe_mat_thickness() const {
         return m_beampipe_mat_thickness;
     }
-    constexpr scalar module_mat_thickness() const {
+    constexpr scalar_t module_mat_thickness() const {
         return m_module_mat_thickness;
     }
     auto barrel_mat_generator() const { return m_cyl_map_cfg.mat_generator; }
     auto edc_mat_generator() const { return m_disc_map_cfg.mat_generator; }
-    constexpr material<scalar> mapped_material() const {
+    constexpr material<scalar_t> mapped_material() const {
         assert(m_cyl_map_cfg.mapped_material == m_disc_map_cfg.mapped_material);
         return m_cyl_map_cfg.mapped_material;
     }
@@ -256,10 +261,10 @@ struct toy_det_config {
     constexpr const auto &barrel_layer_binning() const {
         return m_barrel_binning;
     }
-    constexpr barrel_generator_config<scalar> &barrel_config() {
+    constexpr barrel_generator_config<scalar_t> &barrel_config() {
         return m_barrel_factory_cfg;
     }
-    constexpr endcap_generator_config<scalar> &endcap_config() {
+    constexpr endcap_generator_config<scalar_t> &endcap_config() {
         return m_endcap_factory_cfg;
     }
     constexpr bool do_check() const { return m_do_check; }
@@ -284,19 +289,20 @@ struct toy_det_config {
                 << "    -> disc map bins    : (r: " << disc_map_bins[0]
                 << ", phi: " << disc_map_bins[1] << ")\n"
                 << "    -> cyl. min. thickness: "
-                << cfg.cyl_material_map().thickness / detray::unit<float>::mm
+                << cfg.cyl_material_map().thickness / detray::unit<scalar_t>::mm
                 << " [mm]\n"
                 << "    -> disc min. thickness: "
-                << cfg.disc_material_map().thickness / detray::unit<float>::mm
+                << cfg.disc_material_map().thickness /
+                       detray::unit<scalar_t>::mm
                 << " [mm]\n"
                 << "    -> Material         : " << cfg.mapped_material()
                 << "\n";
         } else {
             out << "  Homogeneous material \n"
                 << "    -> Thickness        : "
-                << cfg.module_mat_thickness() / detray::unit<float>::mm
+                << cfg.module_mat_thickness() / detray::unit<scalar_t>::mm
                 << " [mm]\n"
-                << "    -> Material         : " << silicon_tml<scalar>()
+                << "    -> Material         : " << silicon_tml<scalar_t>()
                 << "\n";
         }
 
@@ -363,11 +369,11 @@ volume_builder_interface<detector_t> *decorate_material(
 /// @returns the decorated volume builder and surface factory
 template <typename detector_t>
 std::shared_ptr<surface_factory_interface<detector_t>> decorate_material(
-    toy_det_config &cfg,
+    toy_det_config<typename detector_t::scalar_type> &cfg,
     std::unique_ptr<surface_factory_interface<detector_t>> sf_factory,
     bool is_module_factory = false) {
 
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
     using mask_id = typename detector_t::masks::id;
     using material_id = typename detector_t::materials::id;
 
@@ -433,7 +439,7 @@ std::shared_ptr<surface_factory_interface<detector_t>> decorate_material(
 template <typename detector_t>
 void add_cylinder_portals(volume_builder_interface<detector_t> *v_builder,
                           typename detector_t::name_map &names,
-                          toy_det_config &cfg,
+                          toy_det_config<typename detector_t::scalar_type> &cfg,
                           const typename detector_t::scalar_type lower_z,
                           const typename detector_t::scalar_type upper_z,
                           const typename detector_t::scalar_type inner_r,
@@ -441,9 +447,10 @@ void add_cylinder_portals(volume_builder_interface<detector_t> *v_builder,
                           const dindex link_north, const dindex link_south,
                           const dindex link_east, const dindex link_west) {
 
-    using transform3_t = typename detector_t::transform3_type;
-    using scalar_t = typename detector_t::scalar_type;
-    using point3_t = typename detector_t::point3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using transform3_t = dtransform3D<algebra_t>;
+    using scalar_t = dscalar<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
     using nav_link_t = typename detector_t::surface_type::navigation_link;
 
     const transform3_t identity{};
@@ -503,11 +510,14 @@ void add_cylinder_portals(volume_builder_interface<detector_t> *v_builder,
 /// @param cfg config for the toy detector
 /// @param vol_index index of the volume to which the grid should be added
 template <typename detector_builder_t>
-inline void add_cylinder_grid(detector_builder_t &det_builder,
-                              toy_det_config &cfg, const dindex vol_index) {
+inline void add_cylinder_grid(
+    detector_builder_t &det_builder,
+    toy_det_config<typename detector_builder_t::detector_type::scalar_type>
+        &cfg,
+    const dindex vol_index) {
 
     using detector_t = typename detector_builder_t::detector_type;
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
 
     constexpr auto grid_id = detector_t::accel::id::e_cylinder2_grid;
 
@@ -537,11 +547,14 @@ inline void add_cylinder_grid(detector_builder_t &det_builder,
 /// @param cfg config for the toy detector
 /// @param vol_index index of the volume to which the grid should be added
 template <typename detector_builder_t>
-inline void add_disc_grid(detector_builder_t &det_builder, toy_det_config &cfg,
-                          const dindex vol_index) {
+inline void add_disc_grid(
+    detector_builder_t &det_builder,
+    toy_det_config<typename detector_builder_t::detector_type::scalar_type>
+        &cfg,
+    const dindex vol_index) {
 
     using detector_t = typename detector_builder_t::detector_type;
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
 
     constexpr auto grid_id = detector_t::accel::id::e_disc_grid;
 
@@ -574,7 +587,7 @@ inline void add_disc_grid(detector_builder_t &det_builder, toy_det_config &cfg,
 /// @param[out] vol_bounds boundary struct
 template <typename detector_t>
 inline void get_volume_extent(
-    toy_det_config &cfg,
+    toy_det_config<typename detector_t::scalar_type> &cfg,
     std::shared_ptr<surface_factory_interface<detector_t>> sf_factory,
     typename cylinder_portal_generator<detector_t>::boundaries &vol_bounds) {
 
@@ -615,13 +628,15 @@ template <typename detector_builder_t>
 inline auto add_barrel_detector(
     detector_builder_t &det_builder,
     typename detector_builder_t::detector_type::geometry_context &gctx,
-    toy_det_config &cfg,
+    toy_det_config<typename detector_builder_t::detector_type::scalar_type>
+        &cfg,
     typename detector_builder_t::detector_type::name_map &names,
     dindex beampipe_idx) {
 
     using detector_t = typename detector_builder_t::detector_type;
-    using scalar_t = typename detector_t::scalar_type;
-    using transform3_t = typename detector_t::transform3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using scalar_t = dscalar<algebra_t>;
+    using transform3_t = dtransform3D<algebra_t>;
     using nav_link_t = typename detector_t::surface_type::navigation_link;
 
     // Register the sizes in z per volume index
@@ -770,13 +785,15 @@ template <typename detector_builder_t>
 inline auto add_endcap_detector(
     detector_builder_t &det_builder,
     typename detector_builder_t::detector_type::geometry_context &gctx,
-    toy_det_config &cfg,
+    toy_det_config<typename detector_builder_t::detector_type::scalar_type>
+        &cfg,
     typename detector_builder_t::detector_type::name_map &names,
     dindex beampipe_idx) {
 
     using detector_t = typename detector_builder_t::detector_type;
-    using scalar_t = typename detector_t::scalar_type;
-    using point3_t = typename detector_t::point3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using scalar_t = dscalar<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
     using nav_link_t = typename detector_t::surface_type::navigation_link;
 
     std::vector<std::pair<dindex, extent2D<scalar_t>>> volume_sizes{};
@@ -951,16 +968,18 @@ inline auto add_endcap_detector(
 /// @param neg_edc_lay_sizes indices and z-extent of the endcap volumes of one
 ///                          detector side (positive or negative)
 template <typename detector_builder_t, typename vol_extent_data_t>
-inline void add_connector_portals(detector_builder_t &det_builder,
-                                  toy_det_config &cfg,
-                                  const dindex beampipe_idx,
-                                  const vol_extent_data_t edc_vol_extents,
-                                  const vol_extent_data_t &brl_vol_extents) {
+inline void add_connector_portals(
+    detector_builder_t &det_builder,
+    toy_det_config<typename detector_builder_t::detector_type::scalar_type>
+        &cfg,
+    const dindex beampipe_idx, const vol_extent_data_t edc_vol_extents,
+    const vol_extent_data_t &brl_vol_extents) {
 
     using detector_t = typename detector_builder_t::detector_type;
-    using transform3_t = typename detector_t::transform3_type;
-    using scalar_t = typename detector_t::scalar_type;
-    using point3_t = typename detector_t::point3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using transform3_t = dtransform3D<algebra_t>;
+    using scalar_t = dscalar<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
     using nav_link_t = typename detector_t::surface_type::navigation_link;
 
     using factory_interface_t = surface_factory_interface<detector_t>;
@@ -1051,11 +1070,12 @@ inline void add_connector_portals(detector_builder_t &det_builder,
 template <typename detector_t>
 inline void add_beampipe_portals(
     volume_builder_interface<detector_t> *beampipe_builder,
-    toy_det_config &cfg) {
+    toy_det_config<typename detector_t::scalar_type> &cfg) {
 
-    using scalar_t = typename detector_t::scalar_type;
-    using transform3_t = typename detector_t::transform3_type;
-    using point3_t = typename detector_t::point3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using transform3_t = dtransform3D<algebra_t>;
+    using scalar_t = dscalar<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
     using nav_link_t = typename detector_t::surface_type::navigation_link;
 
     using factory_interface_t = surface_factory_interface<detector_t>;
@@ -1125,12 +1145,14 @@ inline void add_beampipe_portals(
 ///                          detector side (positive or negative)
 template <typename detector_t, typename layer_size_cont_t>
 inline void add_beampipe_portals(
-    volume_builder_interface<detector_t> *beampipe_builder, toy_det_config &cfg,
+    volume_builder_interface<detector_t> *beampipe_builder,
+    toy_det_config<typename detector_t::scalar_type> &cfg,
     const layer_size_cont_t &edc_lay_sizes) {
 
-    using scalar_t = typename detector_t::scalar_type;
-    using transform3_t = typename detector_t::transform3_type;
-    using point3_t = typename detector_t::point3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using transform3_t = dtransform3D<algebra_t>;
+    using scalar_t = dscalar<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
     using nav_link_t = typename detector_t::surface_type::navigation_link;
 
     using factory_interface_t = surface_factory_interface<detector_t>;
@@ -1198,13 +1220,15 @@ inline void add_beampipe_portals(
 /// @param cfg toy detector configuration
 ///
 /// @returns a complete detector object
+template <typename algebra_t>
 inline auto build_toy_detector(vecmem::memory_resource &resource,
-                               toy_det_config cfg = {}) {
+                               toy_det_config<dscalar<algebra_t>> cfg = {}) {
 
-    using builder_t = detector_builder<toy_metadata, volume_builder>;
+    using scalar_t = dscalar<algebra_t>;
+    using transform3_t = dtransform3D<algebra_t>;
+
+    using builder_t = detector_builder<toy_metadata<algebra_t>, volume_builder>;
     using detector_t = typename builder_t::detector_type;
-    using scalar_t = typename detector_t::scalar_type;
-    using transform3_t = typename detector_t::transform3_type;
     using nav_link_t = typename detector_t::surface_type::navigation_link;
     using cyl_factory_t = surface_factory<detector_t, concentric_cylinder2D>;
     using vol_extent_container_t =

--- a/tests/include/detray/test/utils/detectors/build_wire_chamber.hpp
+++ b/tests/include/detray/test/utils/detectors/build_wire_chamber.hpp
@@ -14,9 +14,9 @@
 #include "detray/builders/homogeneous_material_builder.hpp"
 #include "detray/builders/homogeneous_material_generator.hpp"
 #include "detray/core/detector.hpp"
-#include "detray/core/detector_metadata.hpp"
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/detectors/default_metadata.hpp"
 #include "detray/geometry/shapes/line.hpp"
 #include "detray/materials/predefined_materials.hpp"
 #include "detray/utils/consistency_checker.hpp"
@@ -30,23 +30,23 @@
 namespace detray {
 
 /// Configuration for building a wire chamber detector
-template <typename wire_shape_t = line_square>
+template <typename scalar_t, typename wire_shape_t = line_square>
 struct wire_chamber_config {
 
     /// Number of layers
     unsigned int m_n_layers{10u};
     /// The inner radius of the first layer
-    scalar m_first_layer_inner_rad{500.f * unit<scalar>::mm};
+    scalar_t m_first_layer_inner_rad{500.f * unit<scalar_t>::mm};
     /// Half z of cylinder chamber
-    scalar m_half_z{1000.f * unit<scalar>::mm};
+    scalar_t m_half_z{1000.f * unit<scalar_t>::mm};
     /// Radius of the material rods
-    scalar m_mat_radius{15.f * unit<scalar>::um};
+    scalar_t m_mat_radius{15.f * unit<scalar_t>::um};
     /// Type of material for the material rods
-    material<scalar> m_wire_mat{tungsten<scalar>()};
+    material<scalar_t> m_wire_mat{tungsten<scalar_t>()};
     /// Config for the wire generation (barrel)
-    wire_layer_generator_config<scalar> m_wire_factory_cfg{};
+    wire_layer_generator_config<scalar_t> m_wire_factory_cfg{};
     /// Configuration for the homogeneous material generator
-    hom_material_config<scalar> m_material_config{};
+    hom_material_config<scalar_t> m_material_config{};
     /// Do a full detector consistency check after building
     bool m_do_check{true};
 
@@ -56,27 +56,27 @@ struct wire_chamber_config {
         m_n_layers = n;
         return *this;
     }
-    constexpr wire_chamber_config &first_layer_inner_radius(const scalar r) {
+    constexpr wire_chamber_config &first_layer_inner_radius(const scalar_t r) {
         m_first_layer_inner_rad = r;
         return *this;
     }
-    constexpr wire_chamber_config &half_z(const scalar hz) {
+    constexpr wire_chamber_config &half_z(const scalar_t hz) {
         m_half_z = hz;
         return *this;
     }
-    constexpr wire_chamber_config &cell_size(const scalar c) {
+    constexpr wire_chamber_config &cell_size(const scalar_t c) {
         m_wire_factory_cfg.cell_size(c);
         return *this;
     }
-    constexpr wire_chamber_config &stereo_angle(const scalar s) {
+    constexpr wire_chamber_config &stereo_angle(const scalar_t s) {
         m_wire_factory_cfg.stereo_angle(s);
         return *this;
     }
-    constexpr wire_chamber_config &mat_radius(const scalar r) {
+    constexpr wire_chamber_config &mat_radius(const scalar_t r) {
         m_mat_radius = r;
         return *this;
     }
-    constexpr wire_chamber_config &wire_material(const material<scalar> &m) {
+    constexpr wire_chamber_config &wire_material(const material<scalar_t> &m) {
         m_wire_mat = m;
         return *this;
     }
@@ -89,24 +89,25 @@ struct wire_chamber_config {
     /// Getters
     /// @{
     constexpr unsigned int n_layers() const { return m_n_layers; }
-    constexpr scalar first_layer_inner_radius() const {
+    constexpr scalar_t first_layer_inner_radius() const {
         return m_first_layer_inner_rad;
     }
-    constexpr scalar half_z() const { return m_half_z; }
-    constexpr scalar cell_size() const {
+    constexpr scalar_t half_z() const { return m_half_z; }
+    constexpr scalar_t cell_size() const {
         return m_wire_factory_cfg.cell_size();
     }
-    constexpr scalar stereo_angle() const {
+    constexpr scalar_t stereo_angle() const {
         return m_wire_factory_cfg.stereo_angle();
     }
-    constexpr scalar mat_radius() const { return m_mat_radius; }
-    constexpr const material<scalar> &wire_material() const {
+    constexpr scalar_t mat_radius() const { return m_mat_radius; }
+    constexpr const material<scalar_t> &wire_material() const {
         return m_wire_mat;
     }
-    constexpr wire_layer_generator_config<scalar> &layer_config() {
+    constexpr wire_layer_generator_config<scalar_t> &layer_config() {
         return m_wire_factory_cfg;
     }
-    constexpr const wire_layer_generator_config<scalar> &layer_config() const {
+    constexpr const wire_layer_generator_config<scalar_t> &layer_config()
+        const {
         return m_wire_factory_cfg;
     }
     constexpr auto &material_config() { return m_material_config; }
@@ -141,13 +142,15 @@ struct wire_chamber_config {
 
 };  // wire chamber config
 
-template <typename wire_shape_t>
-inline auto build_wire_chamber(vecmem::memory_resource &resource,
-                               wire_chamber_config<wire_shape_t> &cfg) {
+template <typename algebra_t, typename wire_shape_t>
+inline auto build_wire_chamber(
+    vecmem::memory_resource &resource,
+    wire_chamber_config<dscalar<algebra_t>, wire_shape_t> &cfg) {
 
-    using builder_t = detector_builder<default_metadata, volume_builder>;
+    using builder_t =
+        detector_builder<default_metadata<algebra_t>, volume_builder>;
     using detector_t = typename builder_t::detector_type;
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
 
     // Wire chamber detector builder
     builder_t det_builder;

--- a/tests/include/detray/test/utils/detectors/factories/barrel_generator.hpp
+++ b/tests/include/detray/test/utils/detectors/factories/barrel_generator.hpp
@@ -101,10 +101,11 @@ struct barrel_generator_config {
 template <typename detector_t, typename mask_shape_t = rectangle2D>
 class barrel_generator final : public surface_factory_interface<detector_t> {
 
-    using scalar_t = typename detector_t::scalar_type;
-    using transform3_t = typename detector_t::transform3_type;
-    using point3_t = typename detector_t::point3_type;
-    using vector3_t = typename detector_t::vector3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using scalar_t = dscalar<algebra_t>;
+    using transform3_t = dtransform3D<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
+    using vector3_t = dvector3D<algebra_t>;
 
     public:
     /// Build a barrel layer according to the parameters given in @param cfg
@@ -157,7 +158,7 @@ class barrel_generator final : public surface_factory_interface<detector_t> {
 
         // The type id of the surface mask shape
         constexpr auto mask_id{detector_t::mask_container::template get_id<
-            mask<mask_shape_t>>::value};
+            mask<mask_shape_t, algebra_t>>::value};
 
         // The material will be added in a later step
         constexpr auto no_material{surface_t::material_id::e_none};

--- a/tests/include/detray/test/utils/detectors/factories/endcap_generator.hpp
+++ b/tests/include/detray/test/utils/detectors/factories/endcap_generator.hpp
@@ -46,13 +46,13 @@ struct endcap_generator_config {
     /// Stagger between the two rings
     scalar_t m_ring_stagger{2.f * unit<scalar_t>::mm};
     /// Stagger in phi (per ring)
-    std::vector<scalar> m_phi_stagger = {4.f * unit<scalar_t>::mm,
-                                         4.f * unit<scalar_t>::mm};
+    std::vector<scalar_t> m_phi_stagger = {4.f * unit<scalar_t>::mm,
+                                           4.f * unit<scalar_t>::mm};
     /// Substagger in phi (per ring)
-    std::vector<scalar> m_phi_sub_stagger = {0.5f * unit<scalar_t>::mm,
-                                             0.5f * unit<scalar_t>::mm};
+    std::vector<scalar_t> m_phi_sub_stagger = {0.5f * unit<scalar_t>::mm,
+                                               0.5f * unit<scalar_t>::mm};
     /// Module tilt (per ring)
-    std::vector<scalar> m_tilt = {0.f, 0.f};
+    std::vector<scalar_t> m_tilt = {0.f, 0.f};
     /// Number of modules in phi (per ring)
     std::vector<unsigned int> m_binning = {40u, 68u};
 
@@ -128,10 +128,11 @@ struct endcap_generator_config {
 template <typename detector_t, typename mask_shape_t = trapezoid2D>
 class endcap_generator final : public surface_factory_interface<detector_t> {
 
-    using scalar_t = typename detector_t::scalar_type;
-    using transform3_t = typename detector_t::transform3_type;
-    using point3_t = typename detector_t::point3_type;
-    using vector3_t = typename detector_t::vector3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using scalar_t = dscalar<algebra_t>;
+    using transform3_t = dtransform3D<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
+    using vector3_t = dvector3D<algebra_t>;
 
     public:
     /// Build an endcap layer according to the parameters given in @param cfg
@@ -188,7 +189,7 @@ class endcap_generator final : public surface_factory_interface<detector_t> {
 
         // The type id of the surface mask shape
         constexpr auto mask_id{detector_t::mask_container::template get_id<
-            mask<mask_shape_t>>::value};
+            mask<mask_shape_t, algebra_t>>::value};
         // The material will be added in a later step
         constexpr auto no_material{surface_t::material_id::e_none};
         // Modules link back to mother volume in navigation

--- a/tests/include/detray/test/utils/detectors/factories/telescope_generator.hpp
+++ b/tests/include/detray/test/utils/detectors/factories/telescope_generator.hpp
@@ -33,10 +33,11 @@ template <typename detector_t, typename mask_shape_t = rectangle2D,
               detail::ray<typename detector_t::algebra_type>>
 class telescope_generator final : public surface_factory_interface<detector_t> {
 
-    using scalar_t = typename detector_t::scalar_type;
     using algebra_t = typename detector_t::algebra_type;
-    using point3_t = typename detector_t::point3_type;
-    using vector3_t = typename detector_t::vector3_type;
+    using scalar_t = dscalar<algebra_t>;
+    using transform3_t = dtransform3D<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
+    using vector3_t = dvector3D<algebra_t>;
 
     public:
     /// Build a surface at with extent given in @param boundaries at every
@@ -118,7 +119,7 @@ class telescope_generator final : public surface_factory_interface<detector_t> {
 
         // The type id of the surface mask shape
         constexpr auto mask_id{detector_t::mask_container::template get_id<
-            mask<mask_shape_t>>::value};
+            mask<mask_shape_t, algebra_t>>::value};
 
         // The material will be added in a later step
         constexpr auto no_material{surface_t::material_id::e_none};

--- a/tests/include/detray/test/utils/detectors/factories/wire_layer_generator.hpp
+++ b/tests/include/detray/test/utils/detectors/factories/wire_layer_generator.hpp
@@ -28,7 +28,7 @@ namespace detray {
 template <typename scalar_t>
 struct wire_layer_generator_config {
     /// Half length of the layer (z)
-    scalar_t m_half_z{1000.f * unit<scalar>::mm};
+    scalar_t m_half_z{1000.f * unit<scalar_t>::mm};
     /// Cell size/radius
     scalar_t m_cell_size{10.f * unit<scalar_t>::mm};
     /// Stereo angle between wires
@@ -74,10 +74,11 @@ template <typename detector_t, typename mask_shape_t = line_square>
 class wire_layer_generator final
     : public surface_factory_interface<detector_t> {
 
-    using scalar_t = typename detector_t::scalar_type;
-    using transform3_t = typename detector_t::transform3_type;
-    using point3_t = typename detector_t::point3_type;
-    using vector3_t = typename detector_t::vector3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using scalar_t = dscalar<algebra_t>;
+    using transform3_t = dtransform3D<algebra_t>;
+    using point3_t = dpoint3D<algebra_t>;
+    using vector3_t = dvector3D<algebra_t>;
 
     public:
     /// Build a wire chamber/straw tube layer according to the parameters given
@@ -125,7 +126,6 @@ class wire_layer_generator final
                     typename detector_t::geometry_context ctx = {})
         -> dindex_range override {
 
-        using algebra_t = typename detector_t::algebra_type;
         using surface_t = typename detector_t::surface_type;
         using nav_link_t = typename surface_t::navigation_link;
         using mask_link_t = typename surface_t::mask_link;
@@ -139,7 +139,7 @@ class wire_layer_generator final
 
         // The type id of the surface mask shape (drift cell or straw tube)
         constexpr auto mask_id{detector_t::mask_container::template get_id<
-            mask<mask_shape_t>>::value};
+            mask<mask_shape_t, algebra_t>>::value};
         // Modules link back to mother volume in navigation
         const auto mask_volume_link{static_cast<nav_link_t>(volume_idx)};
 

--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -13,6 +13,7 @@
 #endif
 
 // Project include(s)
+#include "detray/definitions/detail/math.hpp"
 #include "detray/geometry/tracking_surface.hpp"
 #include "detray/navigation/detail/ray.hpp"
 #include "detray/navigation/navigation_config.hpp"
@@ -333,7 +334,8 @@ struct print_inspector {
         }
 
         debug_stream << "distance to next\t\t";
-        if (math::fabs(state()) < static_cast<scalar>(cfg.path_tolerance)) {
+        if (math::fabs(state()) <
+            static_cast<decltype(math::fabs(state()))>(cfg.path_tolerance)) {
             debug_stream << "on obj (within tol)" << std::endl;
         } else {
             debug_stream << state() << std::endl;
@@ -433,17 +435,15 @@ struct print_inspector {
 
         debug_stream << "Pos:\t[r = " << math::hypot(pos[0], pos[1])
                      << ", z = " << pos[2] << "]" << std::endl;
-        debug_stream << "Tangent:\t"
-                     << detail::ray<ALGEBRA_PLUGIN<detray::scalar>>(state())
-                     << std::endl;
+        debug_stream << "Tangent:\t" << detail::ray(state()) << std::endl;
         debug_stream << std::endl;
     }
 
     /// Inspector interface. Gathers detailed information during stepping
-    template <typename state_type>
+    template <typename state_type, typename scalar_t>
     void operator()(const state_type &state, const stepping::config &,
                     const char *message, const std::size_t n_trials,
-                    const scalar step_scalor) {
+                    const scalar_t step_scalor) {
         std::string msg(message);
         std::string tabs = "\t\t\t\t";
 

--- a/tests/include/detray/test/utils/simulation/event_generator/random_numbers.hpp
+++ b/tests/include/detray/test/utils/simulation/event_generator/random_numbers.hpp
@@ -19,7 +19,7 @@
 namespace detray::detail {
 
 /// Wrapper for CPU random number generatrion for the @c random_track_generator
-template <typename scalar_t = scalar,
+template <typename scalar_t,
           typename distribution_t = std::uniform_real_distribution<scalar_t>,
           typename engine_t = std::mt19937_64>
 struct random_numbers {

--- a/tests/include/detray/test/utils/simulation/event_generator/random_track_generator_config.hpp
+++ b/tests/include/detray/test/utils/simulation/event_generator/random_track_generator_config.hpp
@@ -26,6 +26,7 @@
 namespace detray {
 
 /// Configuration for the random track generator
+template <typename scalar_t>
 struct random_track_generator_config {
 
     using seed_t = std::uint64_t;
@@ -34,32 +35,32 @@ struct random_track_generator_config {
     bool m_do_vtx_smearing = false;
 
     /// Monte-Carlo seed
-    seed_t m_seed{detail::random_numbers<>::default_seed()};
+    seed_t m_seed{detail::random_numbers<scalar_t>::default_seed()};
 
     /// How many tracks will be generated
     std::size_t m_n_tracks{10u};
 
     /// Range for phi [-pi, pi) and theta [0, pi)
-    std::array<scalar, 2> m_phi_range{-constant<scalar>::pi,
-                                      constant<scalar>::pi};
-    std::array<scalar, 2> m_theta_range{0.f, constant<scalar>::pi};
+    std::array<scalar_t, 2> m_phi_range{-constant<scalar_t>::pi,
+                                        constant<scalar_t>::pi};
+    std::array<scalar_t, 2> m_theta_range{0.f, constant<scalar_t>::pi};
 
     /// Momentum range
-    std::array<scalar, 2> m_mom_range{1.f * unit<scalar>::GeV,
-                                      1.f * unit<scalar>::GeV};
+    std::array<scalar_t, 2> m_mom_range{1.f * unit<scalar_t>::GeV,
+                                        1.f * unit<scalar_t>::GeV};
     /// Whether to interpret the momentum @c m_mom_range as p_T
     bool m_is_pT{false};
 
     /// Track origin
-    std::array<scalar, 3> m_origin{0.f, 0.f, 0.f};
-    std::array<scalar, 3> m_origin_stddev{0.f, 0.f, 0.f};
+    std::array<scalar_t, 3> m_origin{0.f, 0.f, 0.f};
+    std::array<scalar_t, 3> m_origin_stddev{0.f, 0.f, 0.f};
 
     /// Randomly flip the charge sign?
     bool m_randomize_charge{false};
 
     /// Time parameter and charge of the track
-    scalar m_time{0.f * unit<scalar>::us};
-    scalar m_charge{-1.f * unit<scalar>::e};
+    scalar_t m_time{0.f * unit<scalar_t>::us};
+    scalar_t m_charge{-1.f * unit<scalar_t>::e};
 
     /// Setters
     /// @{
@@ -78,103 +79,104 @@ struct random_track_generator_config {
         return *this;
     }
     DETRAY_HOST_DEVICE random_track_generator_config& phi_range(
-        const scalar low, const scalar high) {
+        const scalar_t low, const scalar_t high) {
         auto min_phi{
-            std::clamp(low, -constant<scalar>::pi, constant<scalar>::pi)};
+            std::clamp(low, -constant<scalar_t>::pi, constant<scalar_t>::pi)};
         auto max_phi{
-            std::clamp(high, -constant<scalar>::pi, constant<scalar>::pi)};
+            std::clamp(high, -constant<scalar_t>::pi, constant<scalar_t>::pi)};
 
         assert(min_phi <= max_phi);
 
         m_phi_range = {min_phi, max_phi};
         return *this;
     }
-    template <typename scalar_t>
+    template <typename o_scalar_t>
     DETRAY_HOST_DEVICE random_track_generator_config& phi_range(
-        std::array<scalar_t, 2> r) {
-        phi_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        std::array<o_scalar_t, 2> r) {
+        phi_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
-    DETRAY_HOST_DEVICE random_track_generator_config& theta_range(scalar low,
-                                                                  scalar high) {
-        auto min_theta{std::clamp(low, scalar{0.f}, constant<scalar>::pi)};
-        auto max_theta{std::clamp(high, scalar{0.f}, constant<scalar>::pi)};
+    DETRAY_HOST_DEVICE random_track_generator_config& theta_range(
+        scalar_t low, scalar_t high) {
+        auto min_theta{std::clamp(low, scalar_t{0.f}, constant<scalar_t>::pi)};
+        auto max_theta{std::clamp(high, scalar_t{0.f}, constant<scalar_t>::pi)};
 
         assert(min_theta <= max_theta);
 
         m_theta_range = {min_theta, max_theta};
         return *this;
     }
-    template <typename scalar_t>
+    template <typename o_scalar_t>
     DETRAY_HOST_DEVICE random_track_generator_config& theta_range(
-        std::array<scalar_t, 2> r) {
-        theta_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        std::array<o_scalar_t, 2> r) {
+        theta_range(static_cast<o_scalar_t>(r[0]),
+                    static_cast<o_scalar_t>(r[1]));
         return *this;
     }
-    DETRAY_HOST_DEVICE random_track_generator_config& eta_range(scalar low,
-                                                                scalar high) {
+    DETRAY_HOST_DEVICE random_track_generator_config& eta_range(scalar_t low,
+                                                                scalar_t high) {
         // This value is more or less random
-        constexpr auto num_max{0.001f * std::numeric_limits<scalar>::max()};
+        constexpr auto num_max{0.001f * std::numeric_limits<scalar_t>::max()};
         auto min_eta{low > -num_max ? low : -num_max};
         auto max_eta{high < num_max ? high : num_max};
 
         assert(min_eta <= max_eta);
 
-        auto get_theta = [](const scalar eta) {
+        auto get_theta = [](const scalar_t eta) {
             return 2.f * math::atan(math::exp(-eta));
         };
 
         theta_range(get_theta(max_eta), get_theta(min_eta));
         return *this;
     }
-    template <typename scalar_t>
+    template <typename o_scalar_t>
     DETRAY_HOST_DEVICE random_track_generator_config& eta_range(
-        std::array<scalar_t, 2> r) {
-        eta_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        std::array<o_scalar_t, 2> r) {
+        eta_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
-    DETRAY_HOST_DEVICE random_track_generator_config& mom_range(scalar low,
-                                                                scalar high) {
+    DETRAY_HOST_DEVICE random_track_generator_config& mom_range(scalar_t low,
+                                                                scalar_t high) {
         m_is_pT = false;
         assert(low >= 0.f);
         assert(low <= high);
         m_mom_range = {low, high};
         return *this;
     }
-    template <typename scalar_t>
+    template <typename o_scalar_t>
     DETRAY_HOST_DEVICE random_track_generator_config& mom_range(
-        std::array<scalar_t, 2> r) {
-        mom_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        std::array<o_scalar_t, 2> r) {
+        mom_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
-    DETRAY_HOST_DEVICE random_track_generator_config& pT_range(scalar low,
-                                                               scalar high) {
+    DETRAY_HOST_DEVICE random_track_generator_config& pT_range(scalar_t low,
+                                                               scalar_t high) {
         m_is_pT = true;
         assert(low >= 0.f);
         assert(low <= high);
         m_mom_range = {low, high};
         return *this;
     }
-    template <typename scalar_t>
+    template <typename o_scalar_t>
     DETRAY_HOST_DEVICE random_track_generator_config& pT_range(
-        std::array<scalar_t, 2> r) {
-        pT_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        std::array<o_scalar_t, 2> r) {
+        pT_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
-    DETRAY_HOST_DEVICE random_track_generator_config& p_tot(scalar p) {
+    DETRAY_HOST_DEVICE random_track_generator_config& p_tot(scalar_t p) {
         mom_range(p, p);
         return *this;
     }
-    DETRAY_HOST_DEVICE random_track_generator_config& p_T(scalar p) {
+    DETRAY_HOST_DEVICE random_track_generator_config& p_T(scalar_t p) {
         pT_range(p, p);
         return *this;
     }
-    template <typename point3_t = std::array<scalar, 3>>
+    template <typename point3_t = std::array<scalar_t, 3>>
     DETRAY_HOST_DEVICE random_track_generator_config& origin(point3_t ori) {
         m_origin = {ori[0], ori[1], ori[2]};
         return *this;
     }
-    template <typename point3_t = std::array<scalar, 3>>
+    template <typename point3_t = std::array<scalar_t, 3>>
     DETRAY_HOST_DEVICE random_track_generator_config& origin_stddev(
         point3_t stddev) {
         m_do_vtx_smearing = true;
@@ -186,12 +188,12 @@ struct random_track_generator_config {
         m_randomize_charge = rc;
         return *this;
     }
-    DETRAY_HOST_DEVICE random_track_generator_config& time(scalar t) {
+    DETRAY_HOST_DEVICE random_track_generator_config& time(scalar_t t) {
         assert(t >= 0.f);
         m_time = t;
         return *this;
     }
-    DETRAY_HOST_DEVICE random_track_generator_config& charge(scalar q) {
+    DETRAY_HOST_DEVICE random_track_generator_config& charge(scalar_t q) {
         m_charge = q;
         return *this;
     }
@@ -206,15 +208,15 @@ struct random_track_generator_config {
     DETRAY_HOST_DEVICE constexpr std::size_t n_tracks() const {
         return m_n_tracks;
     }
-    DETRAY_HOST_DEVICE constexpr const std::array<scalar, 2>& phi_range()
+    DETRAY_HOST_DEVICE constexpr const std::array<scalar_t, 2>& phi_range()
         const {
         return m_phi_range;
     }
-    DETRAY_HOST_DEVICE constexpr const std::array<scalar, 2>& theta_range()
+    DETRAY_HOST_DEVICE constexpr const std::array<scalar_t, 2>& theta_range()
         const {
         return m_theta_range;
     }
-    DETRAY_HOST_DEVICE constexpr const std::array<scalar, 2>& mom_range()
+    DETRAY_HOST_DEVICE constexpr const std::array<scalar_t, 2>& mom_range()
         const {
         return m_mom_range;
     }
@@ -226,8 +228,8 @@ struct random_track_generator_config {
     DETRAY_HOST_DEVICE constexpr bool randomize_charge() const {
         return m_randomize_charge;
     }
-    DETRAY_HOST_DEVICE constexpr scalar time() const { return m_time; }
-    DETRAY_HOST_DEVICE constexpr scalar charge() const { return m_charge; }
+    DETRAY_HOST_DEVICE constexpr scalar_t time() const { return m_time; }
+    DETRAY_HOST_DEVICE constexpr scalar_t charge() const { return m_charge; }
     /// @}
 
     /// Print the random track generator configuration
@@ -244,7 +246,7 @@ struct random_track_generator_config {
             << "----------------------------\n"
             << "  No. tracks            : " << cfg.n_tracks() << "\n"
             << "  Charge                : "
-            << cfg.charge() / detray::unit<scalar>::e << " [e]\n"
+            << cfg.charge() / detray::unit<scalar_t>::e << " [e]\n"
             << "  Rand. charge          : " << std::boolalpha
             << cfg.randomize_charge() << std::noboolalpha << "\n";
 
@@ -254,18 +256,18 @@ struct random_track_generator_config {
         } else {
             out << "  Momentum              : [";
         }
-        out << mom_range[0] / detray::unit<scalar>::GeV << ", "
-            << mom_range[1] / detray::unit<scalar>::GeV << ") [GeV]\n"
+        out << mom_range[0] / detray::unit<scalar_t>::GeV << ", "
+            << mom_range[1] / detray::unit<scalar_t>::GeV << ") [GeV]\n"
             << "  Phi range             : ["
-            << phi_range[0] / detray::unit<scalar>::rad << ", "
-            << phi_range[1] / detray::unit<scalar>::rad << ") [rad]\n"
+            << phi_range[0] / detray::unit<scalar_t>::rad << ", "
+            << phi_range[1] / detray::unit<scalar_t>::rad << ") [rad]\n"
             << "  Theta range           : ["
-            << theta_range[0] / detray::unit<scalar>::rad << ", "
-            << theta_range[1] / detray::unit<scalar>::rad << ") [rad]\n"
+            << theta_range[0] / detray::unit<scalar_t>::rad << ", "
+            << theta_range[1] / detray::unit<scalar_t>::rad << ") [rad]\n"
             << "  Origin                : ["
-            << ori[0] / detray::unit<scalar>::mm << ", "
-            << ori[1] / detray::unit<scalar>::mm << ", "
-            << ori[2] / detray::unit<scalar>::mm << "] [mm]\n"
+            << ori[0] / detray::unit<scalar_t>::mm << ", "
+            << ori[1] / detray::unit<scalar_t>::mm << ", "
+            << ori[2] / detray::unit<scalar_t>::mm << "] [mm]\n"
             << "  Do vertex smearing    : " << std::boolalpha
             << cfg.do_vertex_smearing() << "\n"
             << std::noboolalpha;
@@ -273,9 +275,9 @@ struct random_track_generator_config {
         if (cfg.do_vertex_smearing()) {
             const auto& ori_stddev = cfg.origin_stddev();
             out << "  Origin stddev         : ["
-                << ori_stddev[0] / detray::unit<scalar>::mm << ", "
-                << ori_stddev[1] / detray::unit<scalar>::mm << ", "
-                << ori_stddev[2] / detray::unit<scalar>::mm << "] [mm]\n";
+                << ori_stddev[0] / detray::unit<scalar_t>::mm << ", "
+                << ori_stddev[1] / detray::unit<scalar_t>::mm << ", "
+                << ori_stddev[2] / detray::unit<scalar_t>::mm << "] [mm]\n";
         }
 
         return out;

--- a/tests/include/detray/test/utils/simulation/event_generator/uniform_track_generator_config.hpp
+++ b/tests/include/detray/test/utils/simulation/event_generator/uniform_track_generator_config.hpp
@@ -24,21 +24,22 @@
 namespace detray {
 
 /// Configuration for the uniform track generator
+template <typename scalar_t>
 struct uniform_track_generator_config {
 
     using seed_t = std::uint64_t;
 
     /// Monte-Carlo seed
-    seed_t m_seed{detail::random_numbers<>::default_seed()};
+    seed_t m_seed{detail::random_numbers<scalar_t>::default_seed()};
 
     /// Ensure same angle space as random track generator
-    static constexpr scalar k_max_pi{constant<scalar>::pi -
-                                     std::numeric_limits<scalar>::epsilon()};
+    static constexpr scalar_t k_max_pi{
+        constant<scalar_t>::pi - std::numeric_limits<scalar_t>::epsilon()};
 
     /// Range for phi [-pi, pi) and theta [0, pi)
-    std::array<scalar, 2> m_phi_range{-constant<scalar>::pi, k_max_pi};
-    std::array<scalar, 2> m_theta_range{0.f, k_max_pi};
-    std::array<scalar, 2> m_eta_range{-5.f, 5.f};
+    std::array<scalar_t, 2> m_phi_range{-constant<scalar_t>::pi, k_max_pi};
+    std::array<scalar_t, 2> m_theta_range{0.f, k_max_pi};
+    std::array<scalar_t, 2> m_eta_range{-5.f, 5.f};
 
     /// Angular step size
     std::size_t m_phi_steps{50u};
@@ -49,11 +50,11 @@ struct uniform_track_generator_config {
     bool m_uniform_eta{false};
 
     /// Track origin
-    std::array<scalar, 3> m_origin{0.f, 0.f, 0.f};
+    std::array<scalar_t, 3> m_origin{0.f, 0.f, 0.f};
 
     /// Magnitude of momentum: Default is one to keep directions normalized
     /// if no momentum information is needed (e.g. for a ray)
-    scalar m_p_mag{1.f * unit<scalar>::GeV};
+    scalar_t m_p_mag{1.f * unit<scalar_t>::GeV};
     /// Whether to interpret the momentum @c m_p_mag as p_T
     bool m_is_pT{false};
 
@@ -61,8 +62,8 @@ struct uniform_track_generator_config {
     bool m_randomize_charge{false};
 
     /// Time parameter and charge of the track
-    scalar m_time{0.f * unit<scalar>::us};
-    scalar m_charge{-1.f * unit<scalar>::e};
+    scalar_t m_time{0.f * unit<scalar_t>::us};
+    scalar_t m_charge{-1.f * unit<scalar_t>::e};
 
     /// Setters
     /// @{
@@ -70,26 +71,26 @@ struct uniform_track_generator_config {
         m_seed = s;
         return *this;
     }
-    DETRAY_HOST_DEVICE uniform_track_generator_config& phi_range(scalar low,
-                                                                 scalar high) {
-        auto min_phi{std::clamp(low, -constant<scalar>::pi, k_max_pi)};
-        auto max_phi{std::clamp(high, -constant<scalar>::pi, k_max_pi)};
+    DETRAY_HOST_DEVICE uniform_track_generator_config& phi_range(
+        scalar_t low, scalar_t high) {
+        auto min_phi{std::clamp(low, -constant<scalar_t>::pi, k_max_pi)};
+        auto max_phi{std::clamp(high, -constant<scalar_t>::pi, k_max_pi)};
 
         assert(min_phi <= max_phi);
 
         m_phi_range = {min_phi, max_phi};
         return *this;
     }
-    template <typename scalar_t>
+    template <typename o_scalar_t>
     DETRAY_HOST_DEVICE uniform_track_generator_config& phi_range(
-        std::array<scalar_t, 2> r) {
-        phi_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        std::array<o_scalar_t, 2> r) {
+        phi_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
     DETRAY_HOST_DEVICE uniform_track_generator_config& theta_range(
-        scalar low, scalar high) {
-        auto min_theta{std::clamp(low, scalar{0.f}, k_max_pi)};
-        auto max_theta{std::clamp(high, scalar{0.f}, k_max_pi)};
+        scalar_t low, scalar_t high) {
+        auto min_theta{std::clamp(low, scalar_t{0.f}, k_max_pi)};
+        auto max_theta{std::clamp(high, scalar_t{0.f}, k_max_pi)};
 
         assert(min_theta <= max_theta);
 
@@ -97,16 +98,17 @@ struct uniform_track_generator_config {
         m_uniform_eta = false;
         return *this;
     }
-    template <typename scalar_t>
+    template <typename o_scalar_t>
     DETRAY_HOST_DEVICE uniform_track_generator_config& theta_range(
-        std::array<scalar_t, 2> r) {
-        theta_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        std::array<o_scalar_t, 2> r) {
+        theta_range(static_cast<o_scalar_t>(r[0]),
+                    static_cast<o_scalar_t>(r[1]));
         return *this;
     }
-    DETRAY_HOST_DEVICE uniform_track_generator_config& eta_range(scalar low,
-                                                                 scalar high) {
+    DETRAY_HOST_DEVICE uniform_track_generator_config& eta_range(
+        scalar_t low, scalar_t high) {
         // This value is more or less random
-        constexpr auto num_max{0.001f * std::numeric_limits<scalar>::max()};
+        constexpr auto num_max{0.001f * std::numeric_limits<scalar_t>::max()};
         auto min_eta{low > -num_max ? low : -num_max};
         auto max_eta{high < num_max ? high : num_max};
 
@@ -116,10 +118,10 @@ struct uniform_track_generator_config {
         m_uniform_eta = true;
         return *this;
     }
-    template <typename scalar_t>
+    template <typename o_scalar_t>
     DETRAY_HOST_DEVICE uniform_track_generator_config& eta_range(
-        std::array<scalar_t, 2> r) {
-        eta_range(static_cast<scalar>(r[0]), static_cast<scalar>(r[1]));
+        std::array<o_scalar_t, 2> r) {
+        eta_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
     DETRAY_HOST_DEVICE uniform_track_generator_config& phi_steps(
@@ -146,18 +148,18 @@ struct uniform_track_generator_config {
         m_uniform_eta = b;
         return *this;
     }
-    template <typename point3_t = std::array<scalar, 3>>
+    template <typename point3_t = std::array<scalar_t, 3>>
     DETRAY_HOST_DEVICE uniform_track_generator_config& origin(point3_t ori) {
         m_origin = {ori[0], ori[1], ori[2]};
         return *this;
     }
-    DETRAY_HOST_DEVICE uniform_track_generator_config& p_tot(scalar p) {
+    DETRAY_HOST_DEVICE uniform_track_generator_config& p_tot(scalar_t p) {
         assert(p > 0.f);
         m_is_pT = false;
         m_p_mag = p;
         return *this;
     }
-    DETRAY_HOST_DEVICE uniform_track_generator_config& p_T(scalar p) {
+    DETRAY_HOST_DEVICE uniform_track_generator_config& p_T(scalar_t p) {
         assert(p > 0.f);
         m_is_pT = true;
         m_p_mag = p;
@@ -168,11 +170,11 @@ struct uniform_track_generator_config {
         m_randomize_charge = rc;
         return *this;
     }
-    DETRAY_HOST_DEVICE uniform_track_generator_config& time(scalar t) {
+    DETRAY_HOST_DEVICE uniform_track_generator_config& time(scalar_t t) {
         m_time = t;
         return *this;
     }
-    DETRAY_HOST_DEVICE uniform_track_generator_config& charge(scalar q) {
+    DETRAY_HOST_DEVICE uniform_track_generator_config& charge(scalar_t q) {
         m_charge = q;
         return *this;
     }
@@ -184,13 +186,13 @@ struct uniform_track_generator_config {
     DETRAY_HOST_DEVICE constexpr std::size_t n_tracks() const {
         return phi_steps() * theta_steps();
     }
-    DETRAY_HOST_DEVICE constexpr std::array<scalar, 2> phi_range() const {
+    DETRAY_HOST_DEVICE constexpr std::array<scalar_t, 2> phi_range() const {
         return m_phi_range;
     }
-    DETRAY_HOST_DEVICE constexpr std::array<scalar, 2> theta_range() const {
+    DETRAY_HOST_DEVICE constexpr std::array<scalar_t, 2> theta_range() const {
         return m_theta_range;
     }
-    DETRAY_HOST_DEVICE constexpr std::array<scalar, 2> eta_range() const {
+    DETRAY_HOST_DEVICE constexpr std::array<scalar_t, 2> eta_range() const {
         return m_eta_range;
     }
     DETRAY_HOST_DEVICE constexpr std::size_t phi_steps() const {
@@ -210,8 +212,8 @@ struct uniform_track_generator_config {
     DETRAY_HOST_DEVICE constexpr bool randomize_charge() const {
         return m_randomize_charge;
     }
-    DETRAY_HOST_DEVICE constexpr scalar time() const { return m_time; }
-    DETRAY_HOST_DEVICE constexpr scalar charge() const { return m_charge; }
+    DETRAY_HOST_DEVICE constexpr scalar_t time() const { return m_time; }
+    DETRAY_HOST_DEVICE constexpr scalar_t charge() const { return m_charge; }
     /// @}
 
     /// Print the unifrom track generator configuration
@@ -228,23 +230,23 @@ struct uniform_track_generator_config {
             << "    -> phi steps        : " << cfg.phi_steps() << "\n"
             << "    -> theta/eta steps  : " << cfg.theta_steps() << "\n"
             << "  Charge                : "
-            << cfg.charge() / detray::unit<scalar>::e << " [e]\n"
+            << cfg.charge() / detray::unit<scalar_t>::e << " [e]\n"
             << "  Rand. charge          : " << std::boolalpha
             << cfg.randomize_charge() << std::noboolalpha << "\n";
 
         // Momentum
         if (cfg.is_pT()) {
             out << "  Transverse mom.       : "
-                << cfg.m_p_mag / detray::unit<scalar>::GeV << " [GeV]\n";
+                << cfg.m_p_mag / detray::unit<scalar_t>::GeV << " [GeV]\n";
         } else {
             out << "  Momentum              : "
-                << cfg.m_p_mag / detray::unit<scalar>::GeV << " [GeV]\n";
+                << cfg.m_p_mag / detray::unit<scalar_t>::GeV << " [GeV]\n";
         }
 
         // Direction
         out << "  Phi range             : ["
-            << phi_range[0] / detray::unit<scalar>::rad << ", "
-            << phi_range[1] / detray::unit<scalar>::rad << ") [rad]\n";
+            << phi_range[0] / detray::unit<scalar_t>::rad << ", "
+            << phi_range[1] / detray::unit<scalar_t>::rad << ") [rad]\n";
         if (cfg.uniform_eta()) {
             const auto& eta_range = cfg.eta_range();
             out << "  Eta range             : [" << eta_range[0] << ", "
@@ -252,15 +254,15 @@ struct uniform_track_generator_config {
         } else {
             const auto& theta_range = cfg.theta_range();
             out << "  Theta range           : ["
-                << theta_range[0] / detray::unit<scalar>::rad << ", "
-                << theta_range[1] / detray::unit<scalar>::rad << ") [rad]\n";
+                << theta_range[0] / detray::unit<scalar_t>::rad << ", "
+                << theta_range[1] / detray::unit<scalar_t>::rad << ") [rad]\n";
         }
 
         // Origin
         out << "  Origin                : ["
-            << ori[0] / detray::unit<scalar>::mm << ", "
-            << ori[1] / detray::unit<scalar>::mm << ", "
-            << ori[2] / detray::unit<scalar>::mm << "] [mm]\n";
+            << ori[0] / detray::unit<scalar_t>::mm << ", "
+            << ori[1] / detray::unit<scalar_t>::mm << ", "
+            << ori[2] / detray::unit<scalar_t>::mm << "] [mm]\n";
 
         return out;
     }

--- a/tests/include/detray/test/utils/simulation/random_scatterer.hpp
+++ b/tests/include/detray/test/utils/simulation/random_scatterer.hpp
@@ -83,7 +83,7 @@ struct random_scatterer : actor {
 
             if constexpr (concepts::surface_material<material_t>) {
 
-                const scalar qop = bound_params.qop();
+                const scalar_type qop = bound_params.qop();
 
                 const auto mat = detail::material_accessor::get(
                     material_group, mat_index, bound_params.bound_local());

--- a/tests/include/detray/test/utils/types.hpp
+++ b/tests/include/detray/test/utils/types.hpp
@@ -10,10 +10,32 @@
 // Detray core include(s).
 #include "detray/definitions/detail/algebra.hpp"
 
+// Detray detector include(s)
+#include "detray/detectors/default_metadata.hpp"
+#include "detray/detectors/telescope_metadata.hpp"
+#include "detray/detectors/toy_metadata.hpp"
+
 namespace detray::test {
 
-using algebra = ALGEBRA_PLUGIN<detray::scalar>;
+// Select algebra-plugin to compile the test with
+#if DETRAY_ALGEBRA_ARRAY
+using algebra = detray::array<DETRAY_CUSTOM_SCALARTYPE>;
+static constexpr char filenames[] = "array-";
 
+#elif DETRAY_ALGEBRA_EIGEN
+using algebra = detray::eigen<DETRAY_CUSTOM_SCALARTYPE>;
+static constexpr char filenames[] = "eigen-";
+
+#elif DETRAY_ALGEBRA_SMATRIX
+using algebra = detray::smatrix<DETRAY_CUSTOM_SCALARTYPE>;
+static constexpr char filenames[] = "smatrix-";
+
+#elif DETRAY_ALGEBRA_VC_AOS
+using algebra = detray::vc_aos<DETRAY_CUSTOM_SCALARTYPE>;
+static constexpr char filenames[] = "vc_aos-";
+#endif
+
+// Test algebra types
 using scalar = dscalar<algebra>;
 using point2 = dpoint2D<algebra>;
 using point3 = dpoint3D<algebra>;
@@ -22,14 +44,10 @@ using transform3 = dtransform3D<algebra>;
 template <std::size_t ROWS, std::size_t COLS>
 using matrix = dmatrix<algebra, ROWS, COLS>;
 
-#if DETRAY_ALGEBRA_ARRAY
-static constexpr char filenames[] = "array-";
-#elif DETRAY_ALGEBRA_EIGEN
-static constexpr char filenames[] = "eigen-";
-#elif DETRAY_ALGEBRA_SMATRIX
-static constexpr char filenames[] = "smatrix-";
-#elif DETRAY_ALGEBRA_VC_AOS
-static constexpr char filenames[] = "vc_aos-";
-#endif
+// Test detector types
+using default_metadata = detray::default_metadata<algebra>;
+using toy_metadata = detray::toy_metadata<algebra>;
+using default_telescope_metadata =
+    detray::telescope_metadata<algebra, rectangle2D>;
 
 }  // namespace detray::test

--- a/tests/include/detray/test/validation/detector_scanner.hpp
+++ b/tests/include/detray/test/validation/detector_scanner.hpp
@@ -209,7 +209,7 @@ inline auto write_tracks(
     const std::vector<std::vector<intersection_record<detector_t>>>
         &intersection_traces) {
 
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
     using record_t = intersection_record<detector_t>;
     using track_param_t = typename record_t::track_parameter_type;
 

--- a/tests/include/detray/test/validation/material_validation_utils.hpp
+++ b/tests/include/detray/test/validation/material_validation_utils.hpp
@@ -241,18 +241,19 @@ inline auto record_material(
     // Propagator with pathlimit aborter
     using material_tracer_t =
         material_validator::material_tracer<scalar_t, vecmem::vector>;
-    using actor_chain_t =
-        actor_chain<dtuple, pathlimit_aborter, parameter_transporter<algebra_t>,
-                    parameter_resetter<algebra_t>,
-                    pointwise_material_interactor<algebra_t>,
-                    material_tracer_t>;
+    using pathlimit_aborter_t = pathlimit_aborter<scalar_t>;
+    using actor_chain_t = actor_chain<
+        dtuple, pathlimit_aborter_t, parameter_transporter<algebra_t>,
+        parameter_resetter<algebra_t>, pointwise_material_interactor<algebra_t>,
+        material_tracer_t>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     // Propagator
     propagator_t prop{cfg};
 
     // Build actor and propagator states
-    pathlimit_aborter::state pathlimit_aborter_state{cfg.stepping.path_limit};
+    typename pathlimit_aborter_t::state pathlimit_aborter_state{
+        cfg.stepping.path_limit};
     typename parameter_transporter<algebra_t>::state transporter_state{};
     typename parameter_resetter<algebra_t>::state resetter_state{};
     typename pointwise_material_interactor<algebra_t>::state interactor_state{};

--- a/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -69,17 +69,19 @@ inline auto record_propagation(
 
     // Propagator with pathlimit aborter and validation actors
     using step_tracer_t = step_tracer<algebra_t, dvector>;
+    using pathlimit_aborter_t = pathlimit_aborter<scalar_t>;
     using material_tracer_t =
         material_validator::material_tracer<scalar_t, dvector>;
-    using actor_chain_t = actor_chain<dtuple, pathlimit_aborter, step_tracer_t,
-                                      material_tracer_t>;
+    using actor_chain_t = actor_chain<dtuple, pathlimit_aborter_t,
+                                      step_tracer_t, material_tracer_t>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     // Propagator
     propagator_t prop{cfg};
 
     // Build actor and propagator states
-    pathlimit_aborter::state pathlimit_aborter_state{cfg.stepping.path_limit};
+    typename pathlimit_aborter_t::state pathlimit_aborter_state{
+        cfg.stepping.path_limit};
     typename step_tracer_t::state step_tracer_state{*host_mr};
     typename material_tracer_t::state mat_tracer_state{*host_mr};
     auto actor_states = detray::tie(pathlimit_aborter_state, step_tracer_state,

--- a/tests/integration_tests/cpu/builders/grid_builder.cpp
+++ b/tests/integration_tests/cpu/builders/grid_builder.cpp
@@ -12,7 +12,6 @@
 #include "detray/builders/volume_builder.hpp"
 #include "detray/core/detector.hpp"
 #include "detray/definitions/detail/indexing.hpp"
-#include "detray/detectors/toy_metadata.hpp"
 #include "detray/geometry/mask.hpp"
 #include "detray/test/utils/types.hpp"
 
@@ -33,25 +32,27 @@ using namespace detray::axis;
 
 namespace {
 
+using scalar = test::scalar;
 using point3 = test::point3;
 using vector3 = test::vector3;
 
 test::transform3 Identity{};
 
-using detector_t = detector<toy_metadata>;
+using detector_t = detector<test::toy_metadata>;
 
 }  // anonymous namespace
 
 /// Integration test: grid builder as volume builder decorator
 GTEST_TEST(detray_builders, decorator_grid_builder) {
 
-    using transform3 = typename detector_t::transform3_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using transform3 = dtransform3D<algebra_t>;
     using geo_obj_id = typename detector_t::geo_obj_ids;
     using acc_ids = typename detector_t::accel::id;
     using mask_id = typename detector_t::masks::id;
 
     // cylinder grid type of the toy detector
-    using cyl_grid_t = grid<axes<concentric_cylinder2D>,
+    using cyl_grid_t = grid<algebra_t, axes<concentric_cylinder2D>,
                             bins::static_array<detector_t::surface_type, 1>,
                             simple_serializer, host_container_types, false>;
 
@@ -75,7 +76,8 @@ GTEST_TEST(detray_builders, decorator_grid_builder) {
     // gbuilder.set_add_surfaces();
 
     // The cylinder portals are at the end of the surface range by construction
-    const auto cyl_mask = mask<concentric_cylinder2D>{0u, 10.f, -500.f, 500.f};
+    const auto cyl_mask =
+        mask<concentric_cylinder2D, algebra_t>{0u, 10.f, -500.f, 500.f};
     std::size_t n_phi_bins{5u};
     std::size_t n_z_bins{4u};
 
@@ -148,7 +150,7 @@ GTEST_TEST(detray_builders, decorator_grid_builder) {
     EXPECT_EQ(vol.id(), volume_id::e_cylinder);
 
     // only the portals are referenced through the volume
-    typename toy_metadata::object_link_type sf_range{};
+    test::toy_metadata::object_link_type sf_range{};
     sf_range[0] = {acc_ids::e_default, 0u};
     sf_range[1] = {acc_ids::e_cylinder2_grid, 0u};
 

--- a/tests/integration_tests/cpu/builders/homogeneous_material_builder.cpp
+++ b/tests/integration_tests/cpu/builders/homogeneous_material_builder.cpp
@@ -34,9 +34,11 @@ using namespace detray;
 
 namespace {
 
+using scalar = test::scalar;
 using point3 = test::point3;
 
-using detector_t = detector<>;
+using metadata_t = test::default_metadata;
+using detector_t = detector<metadata_t>;
 
 constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
 
@@ -185,7 +187,7 @@ GTEST_TEST(detray_builders, detector_builder_with_material) {
     using trapezoid_factory = surface_factory<detector_t, trapezoid2D>;
 
     // detector builder
-    detector_builder<default_metadata> det_builder{};
+    detector_builder<typename detector_t::metadata> det_builder{};
     auto geo_ctx = typename detector_t::geometry_context{};
 
     // Vanilla volume builder
@@ -218,7 +220,7 @@ GTEST_TEST(detray_builders, detector_builder_with_material) {
                                  {1.f * unit<scalar>::mm, silicon<scalar>()});
 
     // Add a portal box around the cuboid volume with a min distance of 'env'
-    constexpr auto env{0.1f * unit<detray::scalar>::mm};
+    constexpr auto env{0.1f * unit<scalar>::mm};
     auto portal_generator =
         std::make_unique<cuboid_portal_generator<detector_t>>(env);
 

--- a/tests/integration_tests/cpu/builders/material_map_builder.cpp
+++ b/tests/integration_tests/cpu/builders/material_map_builder.cpp
@@ -37,7 +37,8 @@ namespace {
 
 using point3 = test::point3;
 
-using detector_t = detector<>;
+using metadata_t = test::default_metadata;
+using detector_t = detector<metadata_t>;
 using mat_id = typename detector_t::materials::id;
 using bin_index_t = axis::multi_bin<2u>;
 
@@ -69,8 +70,9 @@ auto add_material_data(const material_factory_t& mat_factory, mat_id id,
 /// Integration test: material builder as volume builder decorator
 GTEST_TEST(detray_builders, decorator_material_map_builder) {
 
-    using transform3 = typename detector_t::transform3_type;
-    using scalar_t = typename detector_t::scalar_type;
+    using test_algebra = typename detector_t::algebra_type;
+    using scalar = dscalar<test_algebra>;
+    using transform3 = dtransform3D<test_algebra>;
     using mask_id = typename detector_t::masks::id;
 
     using pt_cylinder_factory_t =
@@ -131,33 +133,33 @@ GTEST_TEST(detray_builders, decorator_material_map_builder) {
     // Now add the material for each surface
     auto mat_pt_cyl_factory =
         std::make_shared<mat_factory_t>(std::move(pt_cyl_factory));
-    scalar_t t{1.f * unit<scalar_t>::mm};
+    scalar t{1.f * unit<scalar>::mm};
     add_material_data(mat_pt_cyl_factory, mat_id::e_concentric_cylinder2_map,
-                      0u, t, silicon<scalar_t>());
+                      0u, t, silicon<scalar>());
     add_material_data(mat_pt_cyl_factory, mat_id::e_concentric_cylinder2_map,
-                      1u, t, silicon<scalar_t>());
+                      1u, t, silicon<scalar>());
 
     auto mat_rect_factory =
         std::make_shared<mat_factory_t>(std::move(rect_factory));
-    t = 1.f * unit<scalar_t>::mm;
+    t = 1.f * unit<scalar>::mm;
     add_material_data(mat_rect_factory, mat_id::e_rectangle2_map, 2u, t,
-                      tungsten<scalar_t>());
+                      tungsten<scalar>());
     // No material for surface with index 3
-    t = 3.f * unit<scalar_t>::mm;
+    t = 3.f * unit<scalar>::mm;
     add_material_data(mat_rect_factory, mat_id::e_rectangle2_map, 4u, t,
-                      tungsten<scalar_t>());
+                      tungsten<scalar>());
 
     auto mat_trpz_factory =
         std::make_shared<mat_factory_t>(std::move(trpz_factory));
-    t = 1.f * unit<scalar_t>::mm;
+    t = 1.f * unit<scalar>::mm;
     add_material_data(mat_trpz_factory, mat_id::e_trapezoid2_map, 5u, t,
-                      tungsten<scalar_t>());
+                      tungsten<scalar>());
 
     auto mat_cyl_factory =
         std::make_shared<mat_factory_t>(std::move(cyl_factory));
-    t = 1.5f * unit<scalar_t>::mm;
+    t = 1.5f * unit<scalar>::mm;
     add_material_data(mat_cyl_factory, mat_id::e_cylinder2_map, 6u, t,
-                      gold<scalar_t>());
+                      gold<scalar>());
 
     // Add surfaces and material to detector
     mat_builder.add_surfaces(mat_pt_cyl_factory, geo_ctx);

--- a/tests/integration_tests/cpu/builders/volume_builder.cpp
+++ b/tests/integration_tests/cpu/builders/volume_builder.cpp
@@ -27,6 +27,7 @@
 
 namespace {
 
+using scalar = detray::test::scalar;
 using point3 = detray::test::point3;
 
 /// Check volume links for a collection of masks in a given detector
@@ -48,7 +49,8 @@ GTEST_TEST(detray_builders, tracking_volume_construction) {
 
     using namespace detray;
 
-    using detector_t = detector<>;
+    using metadata_t = test::default_metadata;
+    using detector_t = detector<metadata_t>;
     using transform3 = typename detector_t::transform3_type;
     using geo_obj_id = typename detector_t::geo_obj_ids;
     using mask_id = typename detector_t::masks::id;
@@ -57,7 +59,7 @@ GTEST_TEST(detray_builders, tracking_volume_construction) {
     // Surface factories
     using portal_cylinder_factory =
         surface_factory<detector_t,
-                        typename default_metadata::cylinder_portal::shape>;
+                        typename detector_t::metadata::cylinder_portal::shape>;
     using annulus_factory = surface_factory<detector_t, annulus2D>;
     using cylinder_factory = surface_factory<detector_t, cylinder2D>;
     using rectangle_factory = surface_factory<detector_t, rectangle2D>;

--- a/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
@@ -34,19 +34,21 @@ int main(int argc, char **argv) {
     //
     // Telescope detector configuration
     //
-    using tel_detector_t = detector<telescope_metadata<rectangle2D>>;
-    using scalar_t = typename tel_detector_t::scalar_type;
+    using metadata_t = test::default_telescope_metadata;
+    using tel_detector_t = detector<metadata_t>;
+    using test_algebra = metadata_t::algebra_type;
+    using scalar = dscalar<test_algebra>;
 
-    tel_det_config<rectangle2D> tel_cfg{20.f * unit<scalar_t>::mm,
-                                        20.f * unit<scalar_t>::mm};
+    tel_det_config<test_algebra, rectangle2D> tel_cfg{20.f * unit<scalar>::mm,
+                                                      20.f * unit<scalar>::mm};
     tel_cfg.n_surfaces(10u)
-        .length(500.f * unit<scalar_t>::mm)
-        .envelope(500.f * unit<scalar_t>::um);
+        .length(500.f * unit<scalar>::mm)
+        .envelope(500.f * unit<scalar>::um);
 
     vecmem::host_memory_resource host_mr;
 
     const auto [tel_det, tel_names] =
-        build_telescope_detector(host_mr, tel_cfg);
+        build_telescope_detector<test_algebra>(host_mr, tel_cfg);
 
     auto white_board = std::make_shared<test::whiteboard>();
 
@@ -62,8 +64,8 @@ int main(int argc, char **argv) {
     cfg_ray_scan.track_generator().n_tracks(10000u);
     // The first surface is at z=0, so shift the track origin back
     cfg_ray_scan.track_generator().origin({0.f, 0.f, -0.05f});
-    cfg_ray_scan.track_generator().theta_range(
-        0.f, 0.25f * constant<scalar_t>::pi_4);
+    cfg_ray_scan.track_generator().theta_range(0.f,
+                                               0.25f * constant<scalar>::pi_4);
 
     detail::register_checks<test::ray_scan>(tel_det, tel_names, cfg_ray_scan);
 
@@ -85,13 +87,13 @@ int main(int argc, char **argv) {
     cfg_hel_scan.name("telescope_detector_helix_scan");
     cfg_hel_scan.whiteboard(white_board);
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
-                                 detray::detail::invalid_value<scalar_t>()});
+    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar>(),
+                                 detray::detail::invalid_value<scalar>()});
     cfg_hel_scan.track_generator().n_tracks(10000u);
-    cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar>::GeV);
     cfg_hel_scan.track_generator().origin({0.f, 0.f, -0.05f});
-    cfg_hel_scan.track_generator().theta_range(
-        0.f, 0.25f * constant<scalar_t>::pi_4);
+    cfg_hel_scan.track_generator().theta_range(0.f,
+                                               0.25f * constant<scalar>::pi_4);
 
     detail::register_checks<test::helix_scan>(tel_det, tel_names, cfg_hel_scan);
 

--- a/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
@@ -36,15 +36,18 @@ int main(int argc, char **argv) {
     //
     vecmem::host_memory_resource host_mr;
 
-    using wire_chamber_t = detector<>;
-    using scalar_t = typename wire_chamber_t::scalar_type;
+    using metadata_t = test::default_metadata;
+    using wire_chamber_t = detector<metadata_t>;
+    using test_algebra = metadata_t::algebra_type;
+    using scalar = dscalar<test_algebra>;
 
-    wire_chamber_config<> wire_chamber_cfg{};
+    wire_chamber_config<scalar> wire_chamber_cfg{};
     wire_chamber_cfg.half_z(500.f * unit<scalar>::mm);
 
     std::cout << wire_chamber_cfg << std::endl;
 
-    auto [det, names] = build_wire_chamber(host_mr, wire_chamber_cfg);
+    auto [det, names] =
+        build_wire_chamber<test_algebra>(host_mr, wire_chamber_cfg);
 
     auto white_board = std::make_shared<test::whiteboard>();
 
@@ -81,13 +84,13 @@ int main(int argc, char **argv) {
     cfg_hel_scan.name("wire_chamber_helix_scan");
     cfg_hel_scan.whiteboard(white_board);
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
-                                 detray::detail::invalid_value<scalar_t>()});
+    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar>(),
+                                 detray::detail::invalid_value<scalar>()});
     cfg_hel_scan.track_generator().n_tracks(10000u);
     cfg_hel_scan.track_generator().randomize_charge(true);
     cfg_hel_scan.track_generator().eta_range(-1.f, 1.f);
     // TODO: Fails for smaller momenta
-    cfg_hel_scan.track_generator().p_T(4.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_T(4.f * unit<scalar>::GeV);
 
     detail::register_checks<test::helix_scan>(det, names, cfg_hel_scan);
 
@@ -115,7 +118,7 @@ int main(int argc, char **argv) {
     mat_val_cfg.name("wire_chamber_material_validaiton");
     mat_val_cfg.whiteboard(white_board);
     // Reduce tolerance for single precision tests
-    if constexpr (std::is_same_v<scalar_t, float>) {
+    if constexpr (std::is_same_v<scalar, float>) {
         mat_val_cfg.relative_error(130.f);
     }
     mat_val_cfg.propagation() = cfg_str_nav.propagation();

--- a/tests/integration_tests/cpu/propagator/guided_navigator.cpp
+++ b/tests/integration_tests/cpu/propagator/guided_navigator.cpp
@@ -33,8 +33,8 @@ GTEST_TEST(detray_navigation, guided_navigator) {
     using namespace detray;
     using namespace navigation;
 
-    using algebra_t = test::algebra;
-    using scalar_t = test::scalar;
+    using test_algebra = test::algebra;
+    using scalar = test::scalar;
     using point3 = test::point3;
     using vector3 = test::vector3;
 
@@ -45,40 +45,41 @@ GTEST_TEST(detray_navigation, guided_navigator) {
                                            60.f, 70.f, 80.f, 90.f, 100.f};
 
     // Build telescope detector with unbounded rectangles
-    tel_det_config<unbounded<rectangle2D>> tel_cfg{20.f * unit<scalar_t>::mm,
-                                                   20.f * unit<scalar_t>::mm};
-    tel_cfg.positions(positions).envelope(0.2f * unit<scalar_t>::mm);
+    tel_det_config<test_algebra, unbounded<rectangle2D>> tel_cfg{
+        20.f * unit<scalar>::mm, 20.f * unit<scalar>::mm};
+    tel_cfg.positions(positions).envelope(0.2f * unit<scalar>::mm);
 
     const auto [telescope_det, names] =
-        build_telescope_detector(host_mr, tel_cfg);
+        build_telescope_detector<test_algebra>(host_mr, tel_cfg);
 
     // Inspectors are optional, of course
     using detector_t = decltype(telescope_det);
     using intersection_t =
-        intersection2D<typename detector_t::surface_type, algebra_t>;
+        intersection2D<typename detector_t::surface_type, test_algebra>;
     using object_tracer_t =
         object_tracer<intersection_t, dvector, status::e_on_portal,
                       status::e_on_module>;
     using inspector_t = aggregate_inspector<object_tracer_t, print_inspector>;
-    using b_field_t = bfield::const_field_t;
+    using b_field_t = bfield::const_field_t<scalar>;
     using runge_kutta_stepper =
-        rk_stepper<b_field_t::view_t, algebra_t, unconstrained_step,
+        rk_stepper<b_field_t::view_t, test_algebra, unconstrained_step<scalar>,
                    guided_navigation>;
     using guided_navigator =
         navigator<detector_t, navigation::default_cache_size, inspector_t>;
-    using actor_chain_t = actor_chain<dtuple, pathlimit_aborter>;
+    using pathlimit_aborter_t = pathlimit_aborter<scalar>;
+    using actor_chain_t = actor_chain<dtuple, pathlimit_aborter_t>;
     using propagator_t =
         propagator<runge_kutta_stepper, guided_navigator, actor_chain_t>;
 
     // track must point into the direction of the telescope
     const point3 pos{0.f, 0.f, 0.f};
     const vector3 mom{0.f, 0.f, 1.f};
-    free_track_parameters<algebra_t> track(pos, 0.f, mom, -1.f);
-    const vector3 B{0.f, 0.f, 1.f * unit<scalar_t>::T};
-    const b_field_t b_field = bfield::create_const_field(B);
+    free_track_parameters<test_algebra> track(pos, 0.f, mom, -1.f);
+    const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
+    const b_field_t b_field = bfield::create_const_field<scalar>(B);
 
     // Actors
-    pathlimit_aborter::state pathlimit{200.f * unit<scalar_t>::cm};
+    pathlimit_aborter_t::state pathlimit{200.f * unit<scalar>::cm};
 
     // Propagator
     propagation::config prop_cfg{};

--- a/tests/integration_tests/device/cuda/propagator_cuda.cpp
+++ b/tests/integration_tests/device/cuda/propagator_cuda.cpp
@@ -24,7 +24,7 @@
 using namespace detray;
 
 class CudaPropConstBFieldMng
-    : public ::testing::TestWithParam<std::tuple<float, float, vector3_t>> {};
+    : public ::testing::TestWithParam<std::tuple<float, float, vector3>> {};
 
 /// Propagation test using unified memory
 TEST_P(CudaPropConstBFieldMng, propagator) {
@@ -35,7 +35,7 @@ TEST_P(CudaPropConstBFieldMng, propagator) {
     // Test configuration
     propagator_test_config cfg{};
     cfg.track_generator.phi_steps(20).theta_steps(20);
-    cfg.track_generator.p_tot(10.f * unit<scalar_t>::GeV);
+    cfg.track_generator.p_tot(10.f * unit<scalar>::GeV);
     cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
     // Configuration for non-z-aligned B-fields
@@ -43,18 +43,18 @@ TEST_P(CudaPropConstBFieldMng, propagator) {
     cfg.propagation.stepping.step_constraint = std::get<1>(GetParam());
 
     // Get the magnetic field
-    const vector3_t B = std::get<2>(GetParam());
-    auto field = bfield::create_const_field(B);
+    const vector3 B = std::get<2>(GetParam());
+    auto field = bfield::create_const_field<scalar>(B);
 
     // Create the toy geometry
-    auto [det, names] = build_toy_detector(mng_mr);
+    auto [det, names] = build_toy_detector<test_algebra>(mng_mr);
 
-    run_propagation_test<bfield::const_bknd_t>(
+    run_propagation_test<bfield::const_bknd_t<scalar>>(
         &mng_mr, det, cfg, detray::get_data(det), std::move(field));
 }
 
 class CudaPropConstBFieldCpy
-    : public ::testing::TestWithParam<std::tuple<float, float, vector3_t>> {};
+    : public ::testing::TestWithParam<std::tuple<float, float, vector3>> {};
 
 /// Propagation test using vecmem copy
 TEST_P(CudaPropConstBFieldCpy, propagator) {
@@ -69,7 +69,7 @@ TEST_P(CudaPropConstBFieldCpy, propagator) {
     // Test configuration
     propagator_test_config cfg{};
     cfg.track_generator.phi_steps(20u).theta_steps(20u);
-    cfg.track_generator.p_tot(10.f * unit<scalar_t>::GeV);
+    cfg.track_generator.p_tot(10.f * unit<scalar>::GeV);
     cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
     // Configuration for non-z-aligned B-fields
@@ -77,15 +77,15 @@ TEST_P(CudaPropConstBFieldCpy, propagator) {
     cfg.propagation.stepping.step_constraint = std::get<1>(GetParam());
 
     // Get the magnetic field
-    const vector3_t B = std::get<2>(GetParam());
-    auto field = bfield::create_const_field(B);
+    const vector3 B = std::get<2>(GetParam());
+    auto field = bfield::create_const_field<scalar>(B);
 
     // Create the toy geometry
-    auto [det, names] = build_toy_detector(host_mr);
+    auto [det, names] = build_toy_detector<test_algebra>(host_mr);
 
     auto det_buff = detray::get_buffer(det, dev_mr, cuda_cpy);
 
-    run_propagation_test<bfield::const_bknd_t>(
+    run_propagation_test<bfield::const_bknd_t<scalar>>(
         &mng_mr, det, cfg, detray::get_data(det_buff), std::move(field));
 }
 
@@ -93,65 +93,65 @@ INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation1, CudaPropConstBFieldMng,
     ::testing::Values(std::make_tuple(-100.f * unit<float>::um,
                                       std::numeric_limits<float>::max(),
-                                      vector3_t{0.f * unit<scalar_t>::T,
-                                                0.f * unit<scalar_t>::T,
-                                                2.f * unit<scalar_t>::T})));
+                                      vector3{0.f * unit<scalar>::T,
+                                              0.f * unit<scalar>::T,
+                                              2.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation2, CudaPropConstBFieldMng,
     ::testing::Values(std::make_tuple(-400.f * unit<float>::um,
                                       std::numeric_limits<float>::max(),
-                                      vector3_t{0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+                                      vector3{0.f * unit<scalar>::T,
+                                              1.f * unit<scalar>::T,
+                                              1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation3, CudaPropConstBFieldMng,
     ::testing::Values(std::make_tuple(-400.f * unit<float>::um,
                                       std::numeric_limits<float>::max(),
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+                                      vector3{1.f * unit<scalar>::T,
+                                              0.f * unit<scalar>::T,
+                                              1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation4, CudaPropConstBFieldMng,
     ::testing::Values(std::make_tuple(-600.f * unit<float>::um,
                                       std::numeric_limits<float>::max(),
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+                                      vector3{1.f * unit<scalar>::T,
+                                              1.f * unit<scalar>::T,
+                                              1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation5, CudaPropConstBFieldCpy,
     ::testing::Values(std::make_tuple(-100.f * unit<float>::um,
                                       std::numeric_limits<float>::max(),
-                                      vector3_t{0.f * unit<scalar_t>::T,
-                                                0.f * unit<scalar_t>::T,
-                                                2.f * unit<scalar_t>::T})));
+                                      vector3{0.f * unit<scalar>::T,
+                                              0.f * unit<scalar>::T,
+                                              2.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation6, CudaPropConstBFieldCpy,
     ::testing::Values(std::make_tuple(-400.f * unit<float>::um,
                                       std::numeric_limits<float>::max(),
-                                      vector3_t{0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+                                      vector3{0.f * unit<scalar>::T,
+                                              1.f * unit<scalar>::T,
+                                              1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation7, CudaPropConstBFieldCpy,
     ::testing::Values(std::make_tuple(-400.f * unit<float>::um,
                                       std::numeric_limits<float>::max(),
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+                                      vector3{1.f * unit<scalar>::T,
+                                              0.f * unit<scalar>::T,
+                                              1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     CudaPropagatorValidation8, CudaPropConstBFieldCpy,
     ::testing::Values(std::make_tuple(-600.f * unit<float>::um,
                                       std::numeric_limits<float>::max(),
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+                                      vector3{1.f * unit<scalar>::T,
+                                              1.f * unit<scalar>::T,
+                                              1.f * unit<scalar>::T})));
 
 /// This tests the device propagation in an inhomogenepus magnetic field
 TEST(CudaPropagatorValidation9, inhomogeneous_bfield_cpy) {
@@ -166,15 +166,15 @@ TEST(CudaPropagatorValidation9, inhomogeneous_bfield_cpy) {
     // Test configuration
     propagator_test_config cfg{};
     cfg.track_generator.phi_steps(10u).theta_steps(10u);
-    cfg.track_generator.p_tot(10.f * unit<scalar_t>::GeV);
+    cfg.track_generator.p_tot(10.f * unit<scalar>::GeV);
     cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
 
     // Get the magnetic field
-    auto field = bfield::create_inhom_field();
+    auto field = bfield::create_inhom_field<scalar>();
 
     // Create the toy geometry with inhomogeneous bfield from file
-    auto [det, names] = build_toy_detector(host_mr);
+    auto [det, names] = build_toy_detector<test_algebra>(host_mr);
 
     auto det_buff = detray::get_buffer(det, dev_mr, cuda_cpy);
 

--- a/tests/integration_tests/device/cuda/propagator_cuda_kernel.cu
+++ b/tests/integration_tests/device/cuda/propagator_cuda_kernel.cu
@@ -17,8 +17,9 @@ template <typename bfield_bknd_t, typename detector_t>
 __global__ void propagator_test_kernel(
     typename detector_t::view_type det_data, const propagation::config cfg,
     covfie::field_view<bfield_bknd_t> field_data,
-    vecmem::data::vector_view<track_t> tracks_data,
-    vecmem::data::jagged_vector_view<detail::step_data<algebra_t>> steps_data) {
+    vecmem::data::vector_view<test_track> tracks_data,
+    vecmem::data::jagged_vector_view<detail::step_data<test_algebra>>
+        steps_data) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
     using detector_device_t =
@@ -29,8 +30,8 @@ __global__ void propagator_test_kernel(
                   "Host and device detector views do not match");
 
     detector_device_t det(det_data);
-    vecmem::device_vector<track_t> tracks(tracks_data);
-    vecmem::jagged_device_vector<detail::step_data<algebra_t>> steps(
+    vecmem::device_vector<test_track> tracks(tracks_data);
+    vecmem::jagged_device_vector<detail::step_data<test_algebra>> steps(
         steps_data);
 
     if (gid >= tracks.size()) {
@@ -49,10 +50,10 @@ __global__ void propagator_test_kernel(
     // Create actor states
     step_tracer_device_t::state tracer_state(steps.at(gid));
     tracer_state.collect_only_on_surface(true);
-    pathlimit_aborter::state aborter_state{cfg.stepping.path_limit};
-    parameter_transporter<algebra_t>::state transporter_state{};
-    pointwise_material_interactor<algebra_t>::state interactor_state{};
-    parameter_resetter<algebra_t>::state resetter_state{};
+    pathlimit_aborter_t::state aborter_state{cfg.stepping.path_limit};
+    parameter_transporter<test_algebra>::state transporter_state{};
+    pointwise_material_interactor<test_algebra>::state interactor_state{};
+    parameter_resetter<test_algebra>::state resetter_state{};
 
     // Create the actor states
     auto actor_states =
@@ -73,8 +74,9 @@ template <typename bfield_bknd_t, typename detector_t>
 void propagator_test(
     typename detector_t::view_type det_view, const propagation::config& cfg,
     covfie::field_view<bfield_bknd_t> field_data,
-    vecmem::data::vector_view<track_t>& tracks_data,
-    vecmem::data::jagged_vector_view<detail::step_data<algebra_t>>& step_data) {
+    vecmem::data::vector_view<test_track>& tracks_data,
+    vecmem::data::jagged_vector_view<detail::step_data<test_algebra>>&
+        step_data) {
 
     constexpr int thread_dim = 2 * WARP_SIZE;
     int block_dim = tracks_data.size() / thread_dim + 1;
@@ -90,19 +92,22 @@ void propagator_test(
 }
 
 /// Explicit instantiation for a constant magnetic field
-template void propagator_test<bfield::const_bknd_t,
-                              detector<toy_metadata, host_container_types>>(
-    detector<toy_metadata, host_container_types>::view_type,
-    const propagation::config&, covfie::field_view<bfield::const_bknd_t>,
-    vecmem::data::vector_view<track_t>&,
-    vecmem::data::jagged_vector_view<detail::step_data<algebra_t>>&);
+template void
+propagator_test<bfield::const_bknd_t<dscalar<test_algebra>>,
+                detector<toy_metadata<test_algebra>, host_container_types>>(
+    detector<toy_metadata<test_algebra>, host_container_types>::view_type,
+    const propagation::config&,
+    covfie::field_view<bfield::const_bknd_t<dscalar<test_algebra>>>,
+    vecmem::data::vector_view<test_track>&,
+    vecmem::data::jagged_vector_view<detail::step_data<test_algebra>>&);
 
 /// Explicit instantiation for an inhomogeneous magnetic field
-template void propagator_test<bfield::cuda::inhom_bknd_t,
-                              detector<toy_metadata, host_container_types>>(
-    detector<toy_metadata, host_container_types>::view_type,
+template void
+propagator_test<bfield::cuda::inhom_bknd_t,
+                detector<toy_metadata<test_algebra>, host_container_types>>(
+    detector<toy_metadata<test_algebra>, host_container_types>::view_type,
     const propagation::config&, covfie::field_view<bfield::cuda::inhom_bknd_t>,
-    vecmem::data::vector_view<track_t>&,
-    vecmem::data::jagged_vector_view<detail::step_data<algebra_t>>&);
+    vecmem::data::vector_view<test_track>&,
+    vecmem::data::jagged_vector_view<detail::step_data<test_algebra>>&);
 
 }  // namespace detray

--- a/tests/integration_tests/device/cuda/propagator_cuda_kernel.hpp
+++ b/tests/integration_tests/device/cuda/propagator_cuda_kernel.hpp
@@ -23,6 +23,8 @@
 
 namespace detray {
 
+using scalar = test::scalar;
+
 namespace bfield::cuda {
 
 // Inhomogeneous field (cuda)
@@ -37,17 +39,17 @@ using inhom_bknd_t = covfie::backend::affine<covfie::backend::linear<
 template <typename bfield_bknd_t, typename detector_t>
 void propagator_test(
     typename detector_t::view_type, const propagation::config &,
-    covfie::field_view<bfield_bknd_t>, vecmem::data::vector_view<track_t> &,
-    vecmem::data::jagged_vector_view<detail::step_data<algebra_t>> &);
+    covfie::field_view<bfield_bknd_t>, vecmem::data::vector_view<test_track> &,
+    vecmem::data::jagged_vector_view<detail::step_data<test_algebra>> &);
 
 /// Test function for propagator on the device
 template <typename bfield_bknd_t, typename detector_t>
 inline auto run_propagation_device(
     vecmem::memory_resource *mr, const propagation::config &cfg,
     typename detector_t::view_type det_view,
-    covfie::field_view<bfield_bknd_t> field_data, dvector<track_t> &tracks,
-    const vecmem::jagged_vector<detail::step_data<algebra_t>> &host_steps)
-    -> vecmem::jagged_vector<detail::step_data<algebra_t>> {
+    covfie::field_view<bfield_bknd_t> field_data, dvector<test_track> &tracks,
+    const vecmem::jagged_vector<detail::step_data<test_algebra>> &host_steps)
+    -> vecmem::jagged_vector<detail::step_data<test_algebra>> {
 
     // Helper object for performing memory copies.
     vecmem::copy copy;
@@ -64,7 +66,7 @@ inline auto run_propagation_device(
         capacities.push_back(st.size() + 10u);
     }
 
-    vecmem::data::jagged_vector_buffer<detail::step_data<algebra_t>>
+    vecmem::data::jagged_vector_buffer<detail::step_data<test_algebra>>
         steps_buffer(capacities, *mr, nullptr,
                      vecmem::data::buffer_type::resizable);
 
@@ -74,7 +76,7 @@ inline auto run_propagation_device(
     propagator_test<bfield_bknd_t, detector_t>(det_view, cfg, field_data,
                                                tracks_data, steps_buffer);
 
-    vecmem::jagged_vector<detail::step_data<algebra_t>> steps(mr);
+    vecmem::jagged_vector<detail::step_data<test_algebra>> steps(mr);
 
     copy(steps_buffer, steps)->wait();
 
@@ -91,7 +93,7 @@ inline auto run_propagation_test(vecmem::memory_resource *mr, detector_t &det,
 
     // Create the vector of initial track parameterizations
     auto tracks_host = generate_tracks<generator_t>(mr, cfg.track_generator);
-    vecmem::vector<track_t> tracks_device(tracks_host, mr);
+    vecmem::vector<test_track> tracks_device(tracks_host, mr);
 
     // Host propagation
     auto host_steps =

--- a/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
@@ -34,6 +34,8 @@ int main(int argc, char **argv) {
 
     using namespace detray;
 
+    using test_algebra = test::algebra;
+
     // Filter out the google test flags
     ::testing::InitGoogleTest(&argc, argv);
 
@@ -43,19 +45,19 @@ int main(int argc, char **argv) {
     //
     // Telescope detector configuration
     //
-    using tel_detector_t = detector<telescope_metadata<rectangle2D>>;
-    using scalar_t = typename tel_detector_t::scalar_type;
+    using tel_detector_t = detector<test::default_telescope_metadata>;
+    using scalar = typename tel_detector_t::scalar_type;
 
-    tel_det_config<rectangle2D> tel_cfg{20.f * unit<scalar_t>::mm,
-                                        20.f * unit<scalar_t>::mm};
+    tel_det_config<test_algebra, rectangle2D> tel_cfg{20.f * unit<scalar>::mm,
+                                                      20.f * unit<scalar>::mm};
     tel_cfg.n_surfaces(10u)
-        .length(500.f * unit<scalar_t>::mm)
-        .envelope(500.f * unit<scalar_t>::um);
+        .length(500.f * unit<scalar>::mm)
+        .envelope(500.f * unit<scalar>::um);
 
     vecmem::host_memory_resource host_mr;
 
     const auto [tel_det, tel_names] =
-        build_telescope_detector(host_mr, tel_cfg);
+        build_telescope_detector<test_algebra>(host_mr, tel_cfg);
 
     auto white_board = std::make_shared<test::whiteboard>();
 
@@ -66,8 +68,8 @@ int main(int argc, char **argv) {
     cfg_ray_scan.track_generator().n_tracks(1000u);
     // The first surface is at z=0, so shift the track origin back
     cfg_ray_scan.track_generator().origin({0.f, 0.f, -0.05f});
-    cfg_ray_scan.track_generator().theta_range(
-        0.f, 0.25f * constant<scalar_t>::pi_4);
+    cfg_ray_scan.track_generator().theta_range(0.f,
+                                               0.25f * constant<scalar>::pi_4);
 
     detail::register_checks<test::ray_scan>(tel_det, tel_names, cfg_ray_scan);
 
@@ -90,13 +92,13 @@ int main(int argc, char **argv) {
     cfg_hel_scan.name("telescope_detector_helix_scan_for_cuda");
     cfg_hel_scan.whiteboard(white_board);
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
-                                 detray::detail::invalid_value<scalar_t>()});
+    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar>(),
+                                 detray::detail::invalid_value<scalar>()});
     cfg_hel_scan.track_generator().n_tracks(1000u);
-    cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar>::GeV);
     cfg_hel_scan.track_generator().origin({0.f, 0.f, -0.05f});
-    cfg_hel_scan.track_generator().theta_range(
-        0.f, 0.25f * constant<scalar_t>::pi_4);
+    cfg_hel_scan.track_generator().theta_range(0.f,
+                                               0.25f * constant<scalar>::pi_4);
 
     detail::register_checks<test::helix_scan>(tel_det, tel_names, cfg_hel_scan);
 

--- a/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
@@ -16,6 +16,7 @@
 #include "detray/test/device/cuda/material_validation.hpp"
 #include "detray/test/device/cuda/navigation_validation.hpp"
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
@@ -37,8 +38,9 @@ int main(int argc, char **argv) {
     // Filter out the google test flags
     ::testing::InitGoogleTest(&argc, argv);
 
-    using toy_detector_t = detector<toy_metadata>;
-    using scalar_t = typename toy_detector_t::scalar_type;
+    using toy_detector_t = detector<test::toy_metadata>;
+    using test_algebra = typename toy_detector_t::algebra_type;
+    using scalar = dscalar<test_algebra>;
 
     /// Vecmem memory resource for the device allocations
     vecmem::cuda::device_memory_resource dev_mr{};
@@ -46,12 +48,13 @@ int main(int argc, char **argv) {
     //
     // Toy detector configuration
     //
-    toy_det_config toy_cfg{};
+    toy_det_config<scalar> toy_cfg{};
     toy_cfg.n_brl_layers(4u).n_edc_layers(7u);
 
     // Build the geometry
     vecmem::host_memory_resource host_mr;
-    auto [toy_det, toy_names] = build_toy_detector(host_mr, toy_cfg);
+    auto [toy_det, toy_names] =
+        build_toy_detector<test_algebra>(host_mr, toy_cfg);
 
     auto white_board = std::make_shared<test::whiteboard>();
 
@@ -83,11 +86,11 @@ int main(int argc, char **argv) {
     cfg_hel_scan.name("toy_detector_helix_scan_for_cuda");
     cfg_hel_scan.whiteboard(white_board);
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
-                                 detray::detail::invalid_value<scalar_t>()});
+    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar>(),
+                                 detray::detail::invalid_value<scalar>()});
     cfg_hel_scan.track_generator().n_tracks(1000u);
     cfg_hel_scan.track_generator().eta_range(-4.f, 4.f);
-    cfg_hel_scan.track_generator().p_T(1.f * unit<scalar_t>::GeV);
+    cfg_hel_scan.track_generator().p_T(1.f * unit<scalar>::GeV);
 
     detail::register_checks<test::helix_scan>(toy_det, toy_names, cfg_hel_scan);
 
@@ -126,7 +129,7 @@ int main(int argc, char **argv) {
     toy_cfg.use_material_maps(false);
 
     auto [toy_det_hom_mat, toy_names_hom_mat] =
-        build_toy_detector(host_mr, toy_cfg);
+        build_toy_detector<test_algebra>(host_mr, toy_cfg);
     toy_names_hom_mat.at(0) += "_hom_material";
 
     // Record the material using a ray scan

--- a/tests/integration_tests/device/sycl/propagator.sycl
+++ b/tests/integration_tests/device/sycl/propagator.sycl
@@ -32,7 +32,7 @@ auto handle_async_error = [](::sycl::exception_list elist) {
     }
 };
 class SyclPropConstBFieldMng : public ::testing::TestWithParam<
-                                   std::tuple<scalar_t, scalar_t, vector3_t>> {
+                                   std::tuple<scalar, scalar, vector3>> {
 };
 
 TEST_P(SyclPropConstBFieldMng, propagator) {
@@ -48,7 +48,7 @@ TEST_P(SyclPropConstBFieldMng, propagator) {
     // Test configuration
     propagator_test_config cfg{};
     cfg.track_generator.phi_steps(20u).theta_steps(20u);
-    cfg.track_generator.p_tot(10.f * unit<scalar_t>::GeV);
+    cfg.track_generator.p_tot(10.f * unit<scalar>::GeV);
     cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
     // Configuration for non-z-aligned B-fields
@@ -56,20 +56,20 @@ TEST_P(SyclPropConstBFieldMng, propagator) {
     cfg.propagation.stepping.step_constraint = std::get<1>(GetParam());
 
     // Set the magnetic field
-    const vector3_t B = std::get<2>(GetParam());
-    auto field = bfield::create_const_field(B);
+    const vector3 B = std::get<2>(GetParam());
+    auto field = bfield::create_const_field<scalar>(B);
 
     // Create the toy geometry
-    auto [det, names] = build_toy_detector(shared_mr);
+    auto [det, names] = build_toy_detector<test_algebra>(shared_mr);
 
     auto det_view = detray::get_data(det);
 
-    run_propagation_test<bfield::const_bknd_t>(&shared_mr, &q, det, cfg,
-                                               det_view, field);
+    run_propagation_test<bfield::const_bknd_t<scalar>>(&shared_mr, &q, det,
+                                                         cfg, det_view, field);
 }
 
 class SyclPropConstBFieldCpy : public ::testing::TestWithParam<
-                                   std::tuple<scalar_t, scalar_t, vector3_t>> {
+                                   std::tuple<scalar, scalar, vector3>> {
 };
 
 TEST_P(SyclPropConstBFieldCpy, propagator) {
@@ -90,7 +90,7 @@ TEST_P(SyclPropConstBFieldCpy, propagator) {
     // Test configuration
     propagator_test_config cfg{};
     cfg.track_generator.phi_steps(20u).theta_steps(20u);
-    cfg.track_generator.p_tot(10.f * unit<scalar_t>::GeV);
+    cfg.track_generator.p_tot(10.f * unit<scalar>::GeV);
     cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
     // Configuration for non-z-aligned B-fields
@@ -98,81 +98,81 @@ TEST_P(SyclPropConstBFieldCpy, propagator) {
     cfg.propagation.stepping.step_constraint = std::get<1>(GetParam());
 
     // Set the magnetic field
-    const vector3_t B = std::get<2>(GetParam());
-    auto field = bfield::create_const_field(B);
+    const vector3 B = std::get<2>(GetParam());
+    auto field = bfield::create_const_field<scalar>(B);
 
     // Create the toy geometry
-    auto [det, names] = build_toy_detector(host_mr);
+    auto [det, names] = build_toy_detector<test_algebra>(host_mr);
 
     auto det_buff = detray::get_buffer(det, dev_mr, sycl_cpy);
 
-    run_propagation_test<bfield::const_bknd_t>(
+    run_propagation_test<bfield::const_bknd_t<scalar>>(
         &shared_mr, &q, det, cfg, detray::get_data(det_buff), field);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     SyclPropagatorValidation1, SyclPropConstBFieldMng,
-    ::testing::Values(std::make_tuple(-100.f * unit<scalar_t>::um,
-                                      std::numeric_limits<scalar_t>::max(),
-                                      vector3_t{0.f * unit<scalar_t>::T,
-                                                0.f * unit<scalar_t>::T,
-                                                2.f * unit<scalar_t>::T})));
+    ::testing::Values(std::make_tuple(-100.f * unit<scalar>::um,
+                                      std::numeric_limits<scalar>::max(),
+                                      vector3{0.f * unit<scalar>::T,
+                                                0.f * unit<scalar>::T,
+                                                2.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     SyclPropagatorValidation2, SyclPropConstBFieldMng,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      5.f * unit<scalar_t>::mm,
-                                      vector3_t{0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+    ::testing::Values(std::make_tuple(-800.f * unit<scalar>::um,
+                                      5.f * unit<scalar>::mm,
+                                      vector3{0.f * unit<scalar>::T,
+                                                1.f * unit<scalar>::T,
+                                                1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     SyclPropagatorValidation3, SyclPropConstBFieldMng,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      5.f * unit<scalar_t>::mm,
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+    ::testing::Values(std::make_tuple(-800.f * unit<scalar>::um,
+                                      5.f * unit<scalar>::mm,
+                                      vector3{1.f * unit<scalar>::T,
+                                                0.f * unit<scalar>::T,
+                                                1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     SyclPropagatorValidation4, SyclPropConstBFieldMng,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      1.f * unit<scalar_t>::mm,
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+    ::testing::Values(std::make_tuple(-800.f * unit<scalar>::um,
+                                      1.f * unit<scalar>::mm,
+                                      vector3{1.f * unit<scalar>::T,
+                                                1.f * unit<scalar>::T,
+                                                1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     SyclPropagatorValidation5, SyclPropConstBFieldCpy,
-    ::testing::Values(std::make_tuple(-100.f * unit<scalar_t>::um,
-                                      std::numeric_limits<scalar_t>::max(),
-                                      vector3_t{0.f * unit<scalar_t>::T,
-                                                0.f * unit<scalar_t>::T,
-                                                2.f * unit<scalar_t>::T})));
+    ::testing::Values(std::make_tuple(-100.f * unit<scalar>::um,
+                                      std::numeric_limits<scalar>::max(),
+                                      vector3{0.f * unit<scalar>::T,
+                                                0.f * unit<scalar>::T,
+                                                2.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     SyclPropagatorValidation6, SyclPropConstBFieldCpy,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      5.f * unit<scalar_t>::mm,
-                                      vector3_t{0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+    ::testing::Values(std::make_tuple(-800.f * unit<scalar>::um,
+                                      5.f * unit<scalar>::mm,
+                                      vector3{0.f * unit<scalar>::T,
+                                                1.f * unit<scalar>::T,
+                                                1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     SyclPropagatorValidation7, SyclPropConstBFieldCpy,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      5.f * unit<scalar_t>::mm,
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                0.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+    ::testing::Values(std::make_tuple(-800.f * unit<scalar>::um,
+                                      5.f * unit<scalar>::mm,
+                                      vector3{1.f * unit<scalar>::T,
+                                                0.f * unit<scalar>::T,
+                                                1.f * unit<scalar>::T})));
 
 INSTANTIATE_TEST_SUITE_P(
     SyclPropagatorValidation8, SyclPropConstBFieldCpy,
-    ::testing::Values(std::make_tuple(-800.f * unit<scalar_t>::um,
-                                      1.f * unit<scalar_t>::mm,
-                                      vector3_t{1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T,
-                                                1.f * unit<scalar_t>::T})));
+    ::testing::Values(std::make_tuple(-800.f * unit<scalar>::um,
+                                      1.f * unit<scalar>::mm,
+                                      vector3{1.f * unit<scalar>::T,
+                                                1.f * unit<scalar>::T,
+                                                1.f * unit<scalar>::T})));
 
 /// This tests the device propagation in an inhomogenepus magnetic field
 /*
@@ -193,12 +193,12 @@ TEST(SyclPropagatorValidation10, inhomogeneous_bfield_cpy) {
     // Test configuration
     propagator_test_config cfg{};
     cfg.track_generator.phi_steps(10u).theta_steps(10u);
-    cfg.track_generator.p_tot(10.f * unit<scalar_t>::GeV);
+    cfg.track_generator.p_tot(10.f * unit<scalar>::GeV);
     cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
 
     // Create the toy geometry with inhomogeneous bfield from file
-    auto [det, names] = build_toy_detector<bfield::inhom_bknd_t>(
+    auto [det, names] = build_toy_detector<test_algebra, bfield::inhom_bknd_t>(
         shared_mr, toy_cfg);
 
     auto det_buff = detray::get_buffer<bfield::sycl::inhom_bknd_t>(det,

--- a/tests/integration_tests/device/sycl/propagator_kernel.sycl
+++ b/tests/integration_tests/device/sycl/propagator_kernel.sycl
@@ -16,8 +16,8 @@ template <typename bfield_bknd_t, typename detector_t>
 void propagator_test(
     typename detector_t::view_type det_data, const propagation::config& cfg,
     covfie::field_view<bfield_bknd_t> field_data,
-    vecmem::data::vector_view<track_t>& tracks_data,
-    vecmem::data::jagged_vector_view<detail::step_data<algebra_t>>& steps_data,
+    vecmem::data::vector_view<test_track>& tracks_data,
+    vecmem::data::jagged_vector_view<detail::step_data<test_algebra>>& steps_data,
     detray::sycl::queue_wrapper queue) {
 
     unsigned int localSize = 64;
@@ -42,8 +42,8 @@ void propagator_test(
 
                 detector_device_t dev_det(det_data);
 
-                vecmem::device_vector<track_t> tracks(tracks_data);
-                vecmem::jagged_device_vector<detail::step_data<algebra_t>>
+                vecmem::device_vector<test_track> tracks(tracks_data);
+                vecmem::jagged_device_vector<detail::step_data<test_algebra>>
                     steps(steps_data);
 
                 unsigned int gid = item.get_global_linear_id();
@@ -64,11 +64,12 @@ void propagator_test(
                 // Create actor states
                 step_tracer_device_t::state tracer_state(steps.at(gid));
                 tracer_state.collect_only_on_surface(true);
-                pathlimit_aborter::state aborter_state{cfg.stepping.path_limit};
-                parameter_transporter<algebra_t>::state transporter_state{};
-                pointwise_material_interactor<algebra_t>::state
+                pathlimit_aborter_t::state aborter_state{
+                    cfg.stepping.path_limit};
+                parameter_transporter<test_algebra>::state transporter_state{};
+                pointwise_material_interactor<test_algebra>::state
                     interactor_state{};
-                parameter_resetter<algebra_t>::state resetter_state{};
+                parameter_resetter<test_algebra>::state resetter_state{};
 
                 // Create the actor states
                 auto actor_states = ::detray::tie(
@@ -89,22 +90,23 @@ void propagator_test(
 }
 
 /// Explicit instantiation for a constant magnetic field
-template void propagator_test<bfield::const_bknd_t,
-                              detector<toy_metadata, host_container_types>>(
-    detector<toy_metadata, host_container_types>::view_type,
-    const propagation::config&, covfie::field_view<bfield::const_bknd_t>,
-    vecmem::data::vector_view<track_t>&,
-    vecmem::data::jagged_vector_view<detail::step_data<algebra_t>>&,
+template void
+propagator_test<bfield::const_bknd_t<dscalar<test_algebra>>,
+                detector<toy_metadata<test_algebra>, host_container_types>>(
+    detector<toy_metadata<test_algebra>, host_container_types>::view_type,
+    const propagation::config&,
+    covfie::field_view<bfield::const_bknd_t<dscalar<test_algebra>>>,
+    vecmem::data::vector_view<test_track>&,
+    vecmem::data::jagged_vector_view<detail::step_data<test_algebra>>&,
     detray::sycl::queue_wrapper);
 
 /// Explicit instantiation for an inhomogeneous magnetic field
 /*template void propagator_test<bfield::sycl::inhom_bknd_t,
-   detector<toy_metadata, host_container_types>>( detector<toy_metadata,
-   host_container_types>::view_type,
-    const propagation::config&,
-    covfie::field_view<bfield::sycl::inhom_bknd_t>,
-    vecmem::data::vector_view<track_t>&,
-    vecmem::data::jagged_vector_view<detail::step_data<algebra_t>>&,
+   detector<toy_metadata<test_algebra>, host_container_types>>(
+   detector<toy_metadata<test_algebra>, host_container_types>::view_type, const
+   propagation::config&, covfie::field_view<bfield::sycl::inhom_bknd_t>,
+    vecmem::data::vector_view<test_track>&,
+    vecmem::data::jagged_vector_view<detail::step_data<test_algebra>>&,
     detray::sycl::queue_wrapper);*/
 
 }  // namespace detray

--- a/tests/integration_tests/device/sycl/propagator_sycl_kernel.hpp
+++ b/tests/integration_tests/device/sycl/propagator_sycl_kernel.hpp
@@ -24,8 +24,8 @@ namespace detray {
 template <typename bfield_bknd_t, typename detector_t>
 void propagator_test(
     typename detector_t::view_type, const propagation::config &,
-    covfie::field_view<bfield_bknd_t>, vecmem::data::vector_view<track_t> &,
-    vecmem::data::jagged_vector_view<detail::step_data<algebra_t>> &,
+    covfie::field_view<bfield_bknd_t>, vecmem::data::vector_view<test_track> &,
+    vecmem::data::jagged_vector_view<detail::step_data<test_algebra>> &,
     sycl::queue_wrapper);
 
 /// test function for propagator on the device
@@ -34,9 +34,9 @@ inline auto run_propagation_device(
     vecmem::memory_resource *mr, const propagation::config &cfg,
     typename detector_t::view_type det_view,
     covfie::field_view<bfield_bknd_t> field_data, sycl::queue_wrapper queue,
-    dvector<track_t> &tracks,
-    const vecmem::jagged_vector<detail::step_data<algebra_t>> &host_steps)
-    -> vecmem::jagged_vector<detail::step_data<algebra_t>> {
+    dvector<test_track> &tracks,
+    const vecmem::jagged_vector<detail::step_data<test_algebra>> &host_steps)
+    -> vecmem::jagged_vector<detail::step_data<test_algebra>> {
 
     // Helper object for performing memory copies.
     vecmem::copy copy;
@@ -51,7 +51,7 @@ inline auto run_propagation_device(
         capacities.push_back(st.size());
     }
 
-    vecmem::data::jagged_vector_buffer<detail::step_data<algebra_t>>
+    vecmem::data::jagged_vector_buffer<detail::step_data<test_algebra>>
         steps_buffer(capacities, *mr, nullptr,
                      vecmem::data::buffer_type::resizable);
 
@@ -61,7 +61,7 @@ inline auto run_propagation_device(
     propagator_test<bfield_bknd_t, detector_t>(
         det_view, cfg, field_data, tracks_data, steps_buffer, queue);
 
-    vecmem::jagged_vector<detail::step_data<algebra_t>> steps(mr);
+    vecmem::jagged_vector<detail::step_data<test_algebra>> steps(mr);
 
     copy(steps_buffer, steps)->wait();
 
@@ -79,7 +79,7 @@ inline auto run_propagation_test(vecmem::memory_resource *mr, ::sycl::queue *q,
 
     // Create the vector of initial track parameterizations
     auto tracks_host = generate_tracks<generator_t>(mr, cfg.track_generator);
-    vecmem::vector<track_t> tracks_device(tracks_host, mr);
+    vecmem::vector<test_track> tracks_device(tracks_host, mr);
 
     // Host propagation
     auto host_steps =

--- a/tests/tools/include/detray/options/detector_io_options.hpp
+++ b/tests/tools/include/detray/options/detector_io_options.hpp
@@ -41,7 +41,7 @@ void add_options<detray::io::detector_reader_config>(
 /// Configure the detray detector reader
 template <>
 void configure_options<detray::io::detector_reader_config>(
-    boost::program_options::variables_map &vm,
+    const boost::program_options::variables_map &vm,
     detray::io::detector_reader_config &cfg) {
 
     // Input files
@@ -77,7 +77,7 @@ void add_options<detray::io::detector_writer_config>(
 /// Configure the detray detector writer
 template <>
 void configure_options<detray::io::detector_writer_config>(
-    boost::program_options::variables_map &vm,
+    const boost::program_options::variables_map &vm,
     detray::io::detector_writer_config &cfg) {
 
     if (!vm["outdir"].defaulted()) {

--- a/tests/tools/include/detray/options/options_handling.hpp
+++ b/tests/tools/include/detray/options/options_handling.hpp
@@ -23,7 +23,7 @@ void add_options(boost::program_options::options_description &,
 
 /// Fill the configuration type T from the boost variable map
 template <typename T>
-void configure_options(boost::program_options::variables_map &,
+void configure_options(const boost::program_options::variables_map &,
                        T &) { /* Do nothing */
 }
 

--- a/tests/tools/include/detray/options/parse_options.hpp
+++ b/tests/tools/include/detray/options/parse_options.hpp
@@ -23,7 +23,7 @@ template <typename T>
 void add_options(boost::program_options::options_description&, const T&);
 
 template <typename T>
-void configure_options(boost::program_options::variables_map&, T&);
+void configure_options(const boost::program_options::variables_map&, T&);
 
 /// Parse commandline options and add them to detray configuration types
 template <typename... CONFIGS>

--- a/tests/tools/include/detray/options/propagation_options.hpp
+++ b/tests/tools/include/detray/options/propagation_options.hpp
@@ -94,7 +94,7 @@ void add_options<detray::propagation::config>(
 /// Configure the navigator
 template <>
 void configure_options<detray::navigation::config>(
-    boost::program_options::variables_map &vm,
+    const boost::program_options::variables_map &vm,
     detray::navigation::config &cfg) {
 
     // Local navigation search window
@@ -144,7 +144,8 @@ void configure_options<detray::navigation::config>(
 /// Configure the stepper
 template <>
 void configure_options<detray::stepping::config>(
-    boost::program_options::variables_map &vm, detray::stepping::config &cfg) {
+    const boost::program_options::variables_map &vm,
+    detray::stepping::config &cfg) {
 
     // Overstepping tolerance
     if (!vm["minimum_stepsize"].defaulted()) {
@@ -188,7 +189,7 @@ void configure_options<detray::stepping::config>(
 /// Configure the propagation
 template <>
 void configure_options<detray::propagation::config>(
-    boost::program_options::variables_map &vm,
+    const boost::program_options::variables_map &vm,
     detray::propagation::config &cfg) {
 
     configure_options(vm, cfg.navigation);

--- a/tests/tools/include/detray/options/toy_detector_options.hpp
+++ b/tests/tools/include/detray/options/toy_detector_options.hpp
@@ -20,11 +20,12 @@
 
 namespace detray::options {
 
+namespace detail {
+
 /// Add options for the detray toy detector
-template <>
-void add_options<toy_det_config>(
-    boost::program_options::options_description &desc,
-    const toy_det_config &cfg) {
+template <typename scalar_t>
+void add_toy_det_options(boost::program_options::options_description &desc,
+                         const toy_det_config<scalar_t> &cfg) {
 
     desc.add_options()(
         "barrel_layers",
@@ -41,9 +42,9 @@ void add_options<toy_det_config>(
 }
 
 /// Configure the detray toy detector
-template <>
-void configure_options<toy_det_config>(
-    boost::program_options::variables_map &vm, toy_det_config &cfg) {
+template <typename scalar_t>
+void configure_toy_det_options(const boost::program_options::variables_map &vm,
+                               toy_det_config<scalar_t> &cfg) {
 
     cfg.n_brl_layers(vm["barrel_layers"].as<unsigned int>());
     cfg.n_edc_layers(vm["endcap_layers"].as<unsigned int>());
@@ -59,5 +60,41 @@ void configure_options<toy_det_config>(
         cfg.use_material_maps(true);
     }
 }
+
+}  // namespace detail
+
+/// Add options for the toy detector
+/// @{
+template <>
+void add_options<toy_det_config<float>>(
+    boost::program_options::options_description &desc,
+    const toy_det_config<float> &cfg) {
+    detail::add_toy_det_options(desc, cfg);
+}
+
+template <>
+void add_options<toy_det_config<double>>(
+    boost::program_options::options_description &desc,
+    const toy_det_config<double> &cfg) {
+    detail::add_toy_det_options(desc, cfg);
+}
+/// @}
+
+/// Configure the detray toy detector
+/// @{
+template <>
+void configure_options<toy_det_config<float>>(
+    const boost::program_options::variables_map &vm,
+    toy_det_config<float> &cfg) {
+    detail::configure_toy_det_options(vm, cfg);
+}
+
+template <>
+void configure_options<toy_det_config<double>>(
+    const boost::program_options::variables_map &vm,
+    toy_det_config<double> &cfg) {
+    detail::configure_toy_det_options(vm, cfg);
+}
+/// @}
 
 }  // namespace detray::options

--- a/tests/tools/include/detray/options/track_generator_options.hpp
+++ b/tests/tools/include/detray/options/track_generator_options.hpp
@@ -21,11 +21,13 @@
 
 namespace detray::options {
 
+namespace detail {
+
 /// Add options for detray event generation
-template <>
-void add_options<uniform_track_generator_config>(
+template <typename scalar_t>
+void add_uniform_track_gen_options(
     boost::program_options::options_description &desc,
-    const uniform_track_generator_config &cfg) {
+    const uniform_track_generator_config<scalar_t> &cfg) {
 
     desc.add_options()(
         "phi_steps",
@@ -37,34 +39,34 @@ void add_options<uniform_track_generator_config>(
             cfg.eta_steps()),
         "No. eta steps for particle gun")(
         "eta_range",
-        boost::program_options::value<std::vector<float>>()->multitoken(),
+        boost::program_options::value<std::vector<scalar_t>>()->multitoken(),
         "Min, Max range of eta values for particle gun")(
         "randomize_charge", "Randomly flip charge sign per track")(
         "origin",
-        boost::program_options::value<std::vector<float>>()->multitoken(),
+        boost::program_options::value<std::vector<scalar_t>>()->multitoken(),
         "Coordintates for particle gun origin position [mm]")(
         "p_tot",
-        boost::program_options::value<float>()->default_value(
-            static_cast<float>(cfg.m_p_mag) / unit<float>::GeV),
+        boost::program_options::value<scalar_t>()->default_value(
+            static_cast<scalar_t>(cfg.m_p_mag) / unit<scalar_t>::GeV),
         "Total momentum of the test particle [GeV]")(
         "p_T",
-        boost::program_options::value<float>()->default_value(
-            static_cast<float>(cfg.m_p_mag) / unit<float>::GeV),
+        boost::program_options::value<scalar_t>()->default_value(
+            static_cast<scalar_t>(cfg.m_p_mag) / unit<scalar_t>::GeV),
         "Transverse momentum of the test particle [GeV]");
 }
 
 /// Add options for detray event generation
-template <>
-void configure_options<uniform_track_generator_config>(
-    boost::program_options::variables_map &vm,
-    uniform_track_generator_config &cfg) {
+template <typename scalar_t>
+void configure_uniform_track_gen_options(
+    const boost::program_options::variables_map &vm,
+    uniform_track_generator_config<scalar_t> &cfg) {
 
     cfg.phi_steps(vm["phi_steps"].as<std::size_t>());
     cfg.eta_steps(vm["eta_steps"].as<std::size_t>());
     cfg.randomize_charge(vm.count("randomize_charge"));
 
     if (vm.count("eta_range")) {
-        const auto eta_range = vm["eta_range"].as<std::vector<float>>();
+        const auto eta_range = vm["eta_range"].as<std::vector<scalar_t>>();
         if (eta_range.size() == 2u) {
             cfg.eta_range(eta_range[0], eta_range[1]);
         } else {
@@ -72,11 +74,11 @@ void configure_options<uniform_track_generator_config>(
         }
     }
     if (vm.count("origin")) {
-        const auto origin = vm["origin"].as<std::vector<float>>();
+        const auto origin = vm["origin"].as<std::vector<scalar_t>>();
         if (origin.size() == 3u) {
-            cfg.origin({origin[0] * unit<float>::mm,
-                        origin[1] * unit<float>::mm,
-                        origin[2] * unit<float>::mm});
+            cfg.origin({origin[0] * unit<scalar_t>::mm,
+                        origin[1] * unit<scalar_t>::mm,
+                        origin[2] * unit<scalar_t>::mm});
         } else {
             throw std::invalid_argument(
                 "Particle gun origin needs three arguments");
@@ -88,17 +90,17 @@ void configure_options<uniform_track_generator_config>(
             "time");
     }
     if (!vm["p_T"].defaulted()) {
-        cfg.p_T(vm["p_T"].as<float>() * unit<float>::GeV);
+        cfg.p_T(vm["p_T"].as<scalar_t>() * unit<scalar_t>::GeV);
     } else {
-        cfg.p_tot(vm["p_tot"].as<float>() * unit<float>::GeV);
+        cfg.p_tot(vm["p_tot"].as<scalar_t>() * unit<scalar_t>::GeV);
     }
 }
 
 /// Add options for detray event generation
-template <>
-void add_options<random_track_generator_config>(
+template <typename scalar_t>
+void add_rnd_track_gen_options(
     boost::program_options::options_description &desc,
-    const random_track_generator_config &cfg) {
+    const random_track_generator_config<scalar_t> &cfg) {
 
     desc.add_options()(
         "n_tracks",
@@ -106,30 +108,30 @@ void add_options<random_track_generator_config>(
             cfg.n_tracks()),
         "No. of tracks for particle gun")(
         "theta_range",
-        boost::program_options::value<std::vector<float>>()->multitoken(),
+        boost::program_options::value<std::vector<scalar_t>>()->multitoken(),
         "Min, Max range of theta values for particle gun")(
         "eta_range",
-        boost::program_options::value<std::vector<float>>()->multitoken(),
+        boost::program_options::value<std::vector<scalar_t>>()->multitoken(),
         "Min, Max range of eta values for particle gun")(
         "randomize_charge", "Randomly flip charge sign per track")(
         "origin",
-        boost::program_options::value<std::vector<float>>()->multitoken(),
+        boost::program_options::value<std::vector<scalar_t>>()->multitoken(),
         "Coordintates for particle gun origin position")(
         "p_tot",
-        boost::program_options::value<float>()->default_value(
-            static_cast<float>(cfg.mom_range()[0]) / unit<float>::GeV),
+        boost::program_options::value<scalar_t>()->default_value(
+            static_cast<scalar_t>(cfg.mom_range()[0]) / unit<scalar_t>::GeV),
         "Total momentum of the test particle [GeV]")(
         "p_T",
-        boost::program_options::value<float>()->default_value(
-            static_cast<float>(cfg.mom_range()[0]) / unit<float>::GeV),
+        boost::program_options::value<scalar_t>()->default_value(
+            static_cast<scalar_t>(cfg.mom_range()[0]) / unit<scalar_t>::GeV),
         "Transverse momentum of the test particle [GeV]");
 }
 
 /// Add options for detray event generation
-template <>
-void configure_options<random_track_generator_config>(
-    boost::program_options::variables_map &vm,
-    random_track_generator_config &cfg) {
+template <typename scalar_t>
+void configure_rnd_track_gen_options(
+    const boost::program_options::variables_map &vm,
+    random_track_generator_config<scalar_t> &cfg) {
 
     cfg.n_tracks(vm["n_tracks"].as<std::size_t>());
     cfg.randomize_charge(vm.count("randomize_charge"));
@@ -138,14 +140,14 @@ void configure_options<random_track_generator_config>(
         throw std::invalid_argument(
             "Eta range and theta range cannot be specified at the same time");
     } else if (vm.count("eta_range")) {
-        const auto eta_range = vm["eta_range"].as<std::vector<float>>();
+        const auto eta_range = vm["eta_range"].as<std::vector<scalar_t>>();
         if (eta_range.size() == 2u) {
-            float min_theta{2.f * std::atan(std::exp(-eta_range[0]))};
-            float max_theta{2.f * std::atan(std::exp(-eta_range[1]))};
+            scalar_t min_theta{2.f * std::atan(std::exp(-eta_range[0]))};
+            scalar_t max_theta{2.f * std::atan(std::exp(-eta_range[1]))};
 
             // Wrap around
             if (min_theta > max_theta) {
-                float tmp{min_theta};
+                scalar_t tmp{min_theta};
                 min_theta = max_theta;
                 max_theta = tmp;
             }
@@ -155,7 +157,7 @@ void configure_options<random_track_generator_config>(
             throw std::invalid_argument("Eta range needs two arguments");
         }
     } else if (vm.count("theta_range")) {
-        const auto theta_range = vm["theta_range"].as<std::vector<float>>();
+        const auto theta_range = vm["theta_range"].as<std::vector<scalar_t>>();
         if (theta_range.size() == 2u) {
             cfg.theta_range(theta_range[0], theta_range[1]);
         } else {
@@ -163,7 +165,7 @@ void configure_options<random_track_generator_config>(
         }
     }
     if (vm.count("origin")) {
-        const auto origin = vm["origin"].as<std::vector<float>>();
+        const auto origin = vm["origin"].as<std::vector<scalar_t>>();
         if (origin.size() == 3u) {
             cfg.origin({origin[0], origin[1], origin[2]});
         } else {
@@ -177,10 +179,80 @@ void configure_options<random_track_generator_config>(
             "time");
     }
     if (!vm["p_T"].defaulted()) {
-        cfg.p_T(vm["p_T"].as<float>() * unit<float>::GeV);
+        cfg.p_T(vm["p_T"].as<scalar_t>() * unit<scalar_t>::GeV);
     } else {
-        cfg.p_tot(vm["p_tot"].as<float>() * unit<float>::GeV);
+        cfg.p_tot(vm["p_tot"].as<scalar_t>() * unit<scalar_t>::GeV);
     }
 }
+
+}  // namespace detail
+
+/// Add options for the uniform track generator
+/// @{
+template <>
+void add_options<uniform_track_generator_config<float>>(
+    boost::program_options::options_description &desc,
+    const uniform_track_generator_config<float> &cfg) {
+    detail::add_uniform_track_gen_options(desc, cfg);
+}
+
+template <>
+void add_options<uniform_track_generator_config<double>>(
+    boost::program_options::options_description &desc,
+    const uniform_track_generator_config<double> &cfg) {
+    detail::add_uniform_track_gen_options(desc, cfg);
+}
+/// @}
+
+/// Configure the detray uniform track generator
+/// @{
+template <>
+void configure_options<uniform_track_generator_config<float>>(
+    const boost::program_options::variables_map &vm,
+    uniform_track_generator_config<float> &cfg) {
+    detail::configure_uniform_track_gen_options(vm, cfg);
+}
+
+template <>
+void configure_options<uniform_track_generator_config<double>>(
+    const boost::program_options::variables_map &vm,
+    uniform_track_generator_config<double> &cfg) {
+    detail::configure_uniform_track_gen_options(vm, cfg);
+}
+/// @}
+
+/// Add options for the random track generator
+/// @{
+template <>
+void add_options<random_track_generator_config<float>>(
+    boost::program_options::options_description &desc,
+    const random_track_generator_config<float> &cfg) {
+    detail::add_rnd_track_gen_options(desc, cfg);
+}
+
+template <>
+void add_options<random_track_generator_config<double>>(
+    boost::program_options::options_description &desc,
+    const random_track_generator_config<double> &cfg) {
+    detail::add_rnd_track_gen_options(desc, cfg);
+}
+/// @}
+
+/// Configure the detray random track generator
+/// @{
+template <>
+void configure_options<random_track_generator_config<float>>(
+    const boost::program_options::variables_map &vm,
+    random_track_generator_config<float> &cfg) {
+    detail::configure_rnd_track_gen_options(vm, cfg);
+}
+
+template <>
+void configure_options<random_track_generator_config<double>>(
+    const boost::program_options::variables_map &vm,
+    random_track_generator_config<double> &cfg) {
+    detail::configure_rnd_track_gen_options(vm, cfg);
+}
+/// @}
 
 }  // namespace detray::options

--- a/tests/tools/include/detray/options/wire_chamber_options.hpp
+++ b/tests/tools/include/detray/options/wire_chamber_options.hpp
@@ -25,9 +25,10 @@ namespace detray::options {
 namespace detail {
 
 /// Add options that are independent of the wire surface shape
-template <typename wire_shape_t>
-void add_wire_chamber_options(boost::program_options::options_description &desc,
-                              const wire_chamber_config<wire_shape_t> &cfg) {
+template <typename scalar_t, typename wire_shape_t>
+void add_wire_chamber_options(
+    boost::program_options::options_description &desc,
+    const wire_chamber_config<scalar_t, wire_shape_t> &cfg) {
 
     desc.add_options()(
         "layers",
@@ -53,9 +54,10 @@ void add_wire_chamber_options(boost::program_options::options_description &desc,
 }
 
 /// Configure options that are independent of the wire surface shape
-template <typename wire_shape_t>
-void configure_wire_chamber_options(boost::program_options::variables_map &vm,
-                                    wire_chamber_config<wire_shape_t> &cfg) {
+template <typename scalar_t, typename wire_shape_t>
+void configure_wire_chamber_options(
+    const boost::program_options::variables_map &vm,
+    wire_chamber_config<scalar_t, wire_shape_t> &cfg) {
 
     cfg.n_layers(vm["layers"].as<unsigned int>());
     cfg.half_z(vm["half_z"].as<float>());
@@ -67,35 +69,67 @@ void configure_wire_chamber_options(boost::program_options::variables_map &vm,
 }  // namespace detail
 
 /// Add options for the wire chamber with wire cells
+/// @{
 template <>
-void add_options<wire_chamber_config<detray::line_square>>(
+void add_options<wire_chamber_config<float, detray::line_square>>(
     boost::program_options::options_description &desc,
-    const wire_chamber_config<detray::line_square> &cfg) {
+    const wire_chamber_config<float, detray::line_square> &cfg) {
     detail::add_wire_chamber_options(desc, cfg);
 }
+template <>
+void add_options<wire_chamber_config<double, detray::line_square>>(
+    boost::program_options::options_description &desc,
+    const wire_chamber_config<double, detray::line_square> &cfg) {
+    detail::add_wire_chamber_options(desc, cfg);
+}
+/// @}
 
 /// Add options for the wire chamber with straw tubes
+/// @{
 template <>
-void add_options<wire_chamber_config<detray::line_circular>>(
+void add_options<wire_chamber_config<float, detray::line_circular>>(
     boost::program_options::options_description &desc,
-    const wire_chamber_config<detray::line_circular> &cfg) {
+    const wire_chamber_config<float, detray::line_circular> &cfg) {
     detail::add_wire_chamber_options(desc, cfg);
 }
+template <>
+void add_options<wire_chamber_config<double, detray::line_circular>>(
+    boost::program_options::options_description &desc,
+    const wire_chamber_config<double, detray::line_circular> &cfg) {
+    detail::add_wire_chamber_options(desc, cfg);
+}
+/// @}
 
 /// Configure the detray wire chamber with wire cells
+/// @{
 template <>
-void configure_options<wire_chamber_config<detray::line_square>>(
-    boost::program_options::variables_map &vm,
-    wire_chamber_config<detray::line_square> &cfg) {
+void configure_options<wire_chamber_config<float, detray::line_square>>(
+    const boost::program_options::variables_map &vm,
+    wire_chamber_config<float, detray::line_square> &cfg) {
     detail::configure_wire_chamber_options(vm, cfg);
 }
+template <>
+void configure_options<wire_chamber_config<double, detray::line_square>>(
+    const boost::program_options::variables_map &vm,
+    wire_chamber_config<double, detray::line_square> &cfg) {
+    detail::configure_wire_chamber_options(vm, cfg);
+}
+/// @}
 
 /// Configure the detray wire chamber with straw tubes
+/// @{
 template <>
-void configure_options<wire_chamber_config<detray::line_circular>>(
-    boost::program_options::variables_map &vm,
-    wire_chamber_config<detray::line_circular> &cfg) {
+void configure_options<wire_chamber_config<float, detray::line_circular>>(
+    const boost::program_options::variables_map &vm,
+    wire_chamber_config<float, detray::line_circular> &cfg) {
     detail::configure_wire_chamber_options(vm, cfg);
 }
+template <>
+void configure_options<wire_chamber_config<double, detray::line_circular>>(
+    const boost::program_options::variables_map &vm,
+    wire_chamber_config<double, detray::line_circular> &cfg) {
+    detail::configure_wire_chamber_options(vm, cfg);
+}
+/// @}
 
 }  // namespace detray::options

--- a/tests/tools/src/cpu/detector_display.cpp
+++ b/tests/tools/src/cpu/detector_display.cpp
@@ -20,6 +20,7 @@
 // Detray test include(s)
 #include "detray/options/detector_io_options.hpp"
 #include "detray/options/parse_options.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -43,7 +44,8 @@ using namespace detray;
 int main(int argc, char** argv) {
 
     // Use the most general type to be able to read in all detector files
-    using detector_t = detray::detector<>;
+    using metadata_t = detray::test::default_metadata;
+    using detector_t = detray::detector<metadata_t>;
 
     // Visualization style to be applied to the svgs
     auto style = detray::svgtools::styling::tableau_colorblind::style;

--- a/tests/tools/src/cpu/detector_validation.cpp
+++ b/tests/tools/src/cpu/detector_validation.cpp
@@ -22,6 +22,7 @@
 #include "detray/test/cpu/detector_consistency.hpp"
 #include "detray/test/cpu/detector_scan.hpp"
 #include "detray/test/cpu/navigation_validation.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -44,8 +45,9 @@ using namespace detray;
 int main(int argc, char** argv) {
 
     // Use the most general type to be able to read in all detector files
-    using detector_t = detray::detector<>;
-    using scalar_t = typename detector_t::scalar_type;
+    using metadata_t = test::default_metadata;
+    using detector_t = detector<metadata_t>;
+    using scalar = dscalar<typename detector_t::algebra_type>;
 
     // Filter out the google test flags
     ::testing::InitGoogleTest(&argc, argv);
@@ -105,8 +107,8 @@ int main(int argc, char** argv) {
     hel_scan_cfg.name(det_name + "_helix_scan");
     hel_scan_cfg.whiteboard(white_board);
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    hel_scan_cfg.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
-                                 detray::detail::invalid_value<scalar_t>()});
+    hel_scan_cfg.mask_tolerance({detray::detail::invalid_value<scalar>(),
+                                 detray::detail::invalid_value<scalar>()});
     hel_scan_cfg.intersection_file(file_prefix + "_helix_scan_intersections");
     hel_scan_cfg.track_param_file(file_prefix + "_helix_scan_track_parameters");
 

--- a/tests/tools/src/cpu/generate_toy_detector.cpp
+++ b/tests/tools/src/cpu/generate_toy_detector.cpp
@@ -16,6 +16,7 @@
 #include "detray/options/parse_options.hpp"
 #include "detray/options/toy_detector_options.hpp"
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -30,7 +31,7 @@ using namespace detray;
 int main(int argc, char **argv) {
 
     // Configuration
-    detray::toy_det_config toy_cfg{};
+    detray::toy_det_config<test::scalar> toy_cfg{};
     detray::io::detector_writer_config writer_cfg{};
     writer_cfg.format(detray::io::format::json).replace_files(false);
     // Default output path
@@ -51,7 +52,8 @@ int main(int argc, char **argv) {
 
     // Build the geometry
     vecmem::host_memory_resource host_mr;
-    auto [toy_det, toy_names] = build_toy_detector(host_mr, toy_cfg);
+    auto [toy_det, toy_names] =
+        build_toy_detector<test::algebra>(host_mr, toy_cfg);
 
     // Write to file
     detray::io::write_detector(toy_det, toy_names, writer_cfg);

--- a/tests/tools/src/cpu/generate_wire_chamber.cpp
+++ b/tests/tools/src/cpu/generate_wire_chamber.cpp
@@ -17,6 +17,7 @@
 #include "detray/options/parse_options.hpp"
 #include "detray/options/wire_chamber_options.hpp"
 #include "detray/test/utils/detectors/build_wire_chamber.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -30,18 +31,19 @@ namespace po = boost::program_options;
 namespace detray::detail {
 
 /// Build and write the wire chamber according to command line options
-template <typename wire_shape_t>
+template <typename scalar_t, typename wire_shape_t>
 void write_wire_chamber(int argc, char **argv,
                         boost::program_options::options_description &desc,
                         vecmem::memory_resource *host_mr,
                         detray::io::detector_writer_config &writer_cfg) {
 
-    detray::wire_chamber_config<wire_shape_t> wire_cfg{};
+    detray::wire_chamber_config<scalar_t, wire_shape_t> wire_cfg{};
 
     po::variables_map vm_wire =
         detray::options::parse_options(desc, argc, argv, wire_cfg);
 
-    auto [wire_chamber, names] = build_wire_chamber(*host_mr, wire_cfg);
+    auto [wire_chamber, names] =
+        build_wire_chamber<test::algebra>(*host_mr, wire_cfg);
     detray::io::write_detector(wire_chamber, names, writer_cfg);
 }
 
@@ -83,10 +85,10 @@ int main(int argc, char **argv) {
     // Build the geometry
     vecmem::host_memory_resource host_mr;
     if (vm.count("straw_tubes")) {
-        detail::write_wire_chamber<detray::line_circular>(argc, argv, desc,
-                                                          &host_mr, writer_cfg);
+        detail::write_wire_chamber<detray::test::scalar, detray::line_circular>(
+            argc, argv, desc, &host_mr, writer_cfg);
     } else {
-        detail::write_wire_chamber<detray::line_square>(argc, argv, desc,
-                                                        &host_mr, writer_cfg);
+        detail::write_wire_chamber<detray::test::scalar, detray::line_square>(
+            argc, argv, desc, &host_mr, writer_cfg);
     }
 }

--- a/tests/tools/src/cpu/material_validation.cpp
+++ b/tests/tools/src/cpu/material_validation.cpp
@@ -21,6 +21,7 @@
 #include "detray/options/track_generator_options.hpp"
 #include "detray/test/common/detail/register_checks.hpp"
 #include "detray/test/cpu/material_scan.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -43,7 +44,8 @@ using namespace detray;
 int main(int argc, char **argv) {
 
     // Use the most general type to be able to read in all detector files
-    using detector_t = detray::detector<>;
+    using metadata_t = test::default_metadata;
+    using detector_t = detector<metadata_t>;
 
     // Filter out the google test flags
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/tools/src/cuda/detector_validation_cuda.cpp
+++ b/tests/tools/src/cuda/detector_validation_cuda.cpp
@@ -43,8 +43,9 @@ using namespace detray;
 int main(int argc, char** argv) {
 
     // Use the most general type to be able to read in all detector files
-    using detector_t = detray::detector<>;
-    using scalar_t = typename detector_t::scalar_type;
+    using metadata_t = test::default_metadata;
+    using detector_t = detector<metadata_t>;
+    using scalar = dscalar<typename detector_t::algebra_type>;
 
     // Filter out the google test flags
     ::testing::InitGoogleTest(&argc, argv);
@@ -94,8 +95,8 @@ int main(int argc, char** argv) {
     hel_scan_cfg.name(det_name + "_helix_scan_for_cuda");
     hel_scan_cfg.whiteboard(white_board);
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    hel_scan_cfg.mask_tolerance({detray::detail::invalid_value<scalar_t>(),
-                                 detray::detail::invalid_value<scalar_t>()});
+    hel_scan_cfg.mask_tolerance({detray::detail::invalid_value<scalar>(),
+                                 detray::detail::invalid_value<scalar>()});
     hel_scan_cfg.intersection_file(file_prefix + "_helix_scan_intersections");
     hel_scan_cfg.track_param_file(file_prefix + "_helix_scan_track_parameters");
 

--- a/tests/tools/src/cuda/material_validation_cuda.cpp
+++ b/tests/tools/src/cuda/material_validation_cuda.cpp
@@ -43,7 +43,8 @@ using namespace detray;
 int main(int argc, char **argv) {
 
     // Use the most general type to be able to read in all detector files
-    using detector_t = detray::detector<>;
+    using metadata_t = test::default_metadata;
+    using detector_t = detector<metadata_t>;
 
     // Filter out the google test flags
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/unit_tests/cpu/builders/detector_builder.cpp
+++ b/tests/unit_tests/cpu/builders/detector_builder.cpp
@@ -24,6 +24,7 @@
 
 namespace {
 
+using scalar = detray::test::scalar;
 using point3 = detray::test::point3;
 using vector3 = detray::test::vector3;
 using point2 = detray::test::point2;
@@ -34,8 +35,10 @@ using point2 = detray::test::point2;
 GTEST_TEST(detray_builders, detector_builder) {
     using namespace detray;
 
-    using detector_t = detector<>;
-    using transform3 = typename detector_t::transform3_type;
+    using metadata_t = test::default_metadata;
+    using detector_builder_t = detector_builder<metadata_t>;
+    using detector_t = typename detector_builder_t::detector_type;
+    using transform3 = dtransform3D<typename detector_t::algebra_type>;
     using mask_id = typename detector_t::masks::id;
 
     // Surface factories
@@ -44,7 +47,7 @@ GTEST_TEST(detray_builders, detector_builder) {
     // detector builder
     auto geo_ctx = typename detector_t::geometry_context{};
 
-    detector_builder<default_metadata> det_builder{};
+    detector_builder_t det_builder{};
 
     //
     // first volume builder
@@ -86,7 +89,7 @@ GTEST_TEST(detray_builders, detector_builder) {
     vbuilder2->add_volume_placement(t);
 
     // Add a portal box around the cuboid volume with a min distance of 'env'
-    constexpr auto env{0.1f * unit<detray::scalar>::mm};
+    constexpr auto env{0.1f * unit<scalar>::mm};
     auto portal_generator =
         std::make_shared<cuboid_portal_generator<detector_t>>(env);
 

--- a/tests/unit_tests/cpu/builders/homogeneous_material_builder.cpp
+++ b/tests/unit_tests/cpu/builders/homogeneous_material_builder.cpp
@@ -33,9 +33,11 @@ using namespace detray;
 
 namespace {
 
+using scalar = test::scalar;
 using point3 = test::point3;
 
-using detector_t = detector<>;
+using metadata_t = test::default_metadata;
+using detector_t = detector<metadata_t>;
 
 constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
 

--- a/tests/unit_tests/cpu/builders/homogeneous_volume_material_builder.cpp
+++ b/tests/unit_tests/cpu/builders/homogeneous_volume_material_builder.cpp
@@ -12,6 +12,9 @@
 #include "detray/definitions/detail/indexing.hpp"
 #include "detray/materials/predefined_materials.hpp"
 
+// Detray test include(s)
+#include "detray/test/utils/types.hpp"
+
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
 
@@ -25,10 +28,13 @@
 
 using namespace detray;
 
+using scalar = detray::test::scalar;
+
 /// Unittest: Test the construction of a collection of materials
 TEST(detray_tools, homogeneous_volume_material_builder) {
 
-    using detector_t = detector<>;
+    using metadata_t = test::default_metadata;
+    using detector_t = detector<metadata_t>;
 
     constexpr auto material_id{detector_t::materials::id::e_raw_material};
 

--- a/tests/unit_tests/cpu/builders/material_map_builder.cpp
+++ b/tests/unit_tests/cpu/builders/material_map_builder.cpp
@@ -35,9 +35,11 @@ using namespace detray;
 
 namespace {
 
+using scalar = test::scalar;
 using point3 = test::point3;
 
-using detector_t = detector<>;
+using metadata_t = test::default_metadata;
+using detector_t = detector<metadata_t>;
 using mat_id = typename detector_t::materials::id;
 using bin_index_t = axis::multi_bin<2u>;
 
@@ -69,8 +71,8 @@ auto add_material_data(const material_factory_t& mat_factory, mat_id id,
 /// Unittest: Test the construction of a collection of material maps
 TEST(detray_builders, material_map_factory) {
 
-    using transform3 = typename detector_t::transform3_type;
-    using scalar_t = typename detector_t::scalar_type;
+    using algebra_t = typename detector_t::algebra_type;
+    using transform3 = dtransform3D<algebra_t>;
 
     // Build rectangle surfaces with material slabs
     using rectangle_factory = surface_factory<detector_t, rectangle2D>;
@@ -87,14 +89,14 @@ TEST(detray_builders, material_map_factory) {
                             transform3(point3{0.f, 0.f, -1.f}), 1u,
                             std::vector<scalar>{10.f, 8.f}});
 
-    scalar_t t{1.f * unit<scalar_t>::mm};
+    scalar t{1.f * unit<scalar>::mm};
     add_material_data(mat_factory, mat_id::e_rectangle2_map, 0u, t,
-                      silicon<scalar_t>());
+                      silicon<scalar>());
 
     mat_factory->push_back({surface_id::e_sensitive,
                             transform3(point3{0.f, 0.f, 1.f}), 1u,
                             std::vector<scalar>{20.f, 16.f}});
-    t = 2.f * unit<scalar_t>::mm;
+    t = 2.f * unit<scalar>::mm;
     add_material_data(mat_factory, mat_id::e_rectangle2_map, 1u, t,
                       tungsten<scalar>());
 
@@ -102,7 +104,7 @@ TEST(detray_builders, material_map_factory) {
     mat_factory->push_back({surface_id::e_sensitive,
                             transform3(point3{0.f, 0.f, 1.f}), 1u,
                             std::vector<scalar>{20.f, 16.f}});
-    t = 3.f * unit<scalar_t>::mm;
+    t = 3.f * unit<scalar>::mm;
     add_material_data(
         mat_factory, mat_id::e_rectangle2_map, 2u, t,
         {3.344f * unit<scalar>::mm, 101.6f * unit<scalar>::mm, 196.97f, 79,

--- a/tests/unit_tests/cpu/builders/volume_builder.cpp
+++ b/tests/unit_tests/cpu/builders/volume_builder.cpp
@@ -27,9 +27,10 @@
 
 namespace {
 
+using scalar = detray::test::scalar;
 using point3 = detray::test::point3;
 
-constexpr detray::scalar tol{1e-7f};
+constexpr scalar tol{1e-7f};
 
 }  // anonymous namespace
 
@@ -38,15 +39,16 @@ GTEST_TEST(detray_builders, surface_factory) {
 
     using namespace detray;
 
-    using detector_t = detector<>;
-    using transform3 = typename detector_t::transform3_type;
+    using metadata_t = test::default_metadata;
+    using detector_t = detector<metadata_t>;
+    using transform3 = dtransform3D<typename detector_t::algebra_type>;
 
     //
     // check portal cylinder
     //
     using portal_cylinder_factory =
         surface_factory<detector_t,
-                        typename default_metadata::cylinder_portal::shape>;
+                        typename metadata_t::cylinder_portal::shape>;
 
     auto pt_cyl_factory = std::make_shared<portal_cylinder_factory>();
 
@@ -206,7 +208,8 @@ GTEST_TEST(detray_builders, volume_builder) {
 
     vecmem::host_memory_resource host_mr;
 
-    using detector_t = detector<>;
+    using metadata_t = test::default_metadata;
+    using detector_t = detector<metadata_t>;
 
     detector_t d(host_mr);
 

--- a/tests/unit_tests/cpu/core/detector.cpp
+++ b/tests/unit_tests/cpu/core/detector.cpp
@@ -13,6 +13,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/prefill_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -25,7 +26,8 @@ GTEST_TEST(detray_core, detector) {
 
     using namespace detray;
 
-    using detector_t = detector<>;
+    using metadata_t = test::default_metadata;
+    using detector_t = detector<metadata_t>;
     using mask_id = typename detector_t::masks::id;
     using material_id = typename detector_t::materials::id;
     using finder_id = typename detector_t::accel::id;

--- a/tests/unit_tests/cpu/core/mask_store.cpp
+++ b/tests/unit_tests/cpu/core/mask_store.cpp
@@ -26,6 +26,8 @@ GTEST_TEST(detray_core, static_mask_store) {
 
     using namespace detray;
 
+    using test_algebra = test::algebra;
+
     enum class mask_ids : unsigned int {
         e_rectangle2 = 0u,
         e_trapezoid2 = 1u,
@@ -35,12 +37,12 @@ GTEST_TEST(detray_core, static_mask_store) {
         e_single3 = 5u,
     };
 
-    using rectangle = mask<rectangle2D>;
-    using trapezoid = mask<trapezoid2D>;
-    using annulus = mask<annulus2D>;
-    using cylinder = mask<cylinder2D>;
-    using ring = mask<ring2D>;
-    using single = mask<single3D<>>;
+    using rectangle = mask<rectangle2D, test_algebra>;
+    using trapezoid = mask<trapezoid2D, test_algebra>;
+    using annulus = mask<annulus2D, test_algebra>;
+    using cylinder = mask<cylinder2D, test_algebra>;
+    using ring = mask<ring2D, test_algebra>;
+    using single = mask<single3D<>, test_algebra>;
 
     // Types must be sorted according to their id (here: masks/mask_identifier)
     using mask_container_t =

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -40,8 +40,9 @@ namespace detray {
 
 namespace {
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using vector3 = test::vector3;
-using algebra_t = test::algebra;
 
 // dummy propagator state
 template <typename stepping_t, typename navigation_t>
@@ -73,16 +74,16 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     using namespace detray;
 
     // Use rectangle surfaces
-    mask<rectangle2D> rectangle{0u, 20.f * unit<scalar>::mm,
-                                20.f * unit<scalar>::mm};
-    tel_det_config<> tel_cfg{rectangle};
+    mask<rectangle2D, test_algebra> rectangle{0u, 20.f * unit<scalar>::mm,
+                                              20.f * unit<scalar>::mm};
+    tel_det_config<test_algebra> tel_cfg{rectangle};
 
     using const_bfield_bknd_t =
         covfie::backend::constant<covfie::vector::vector_d<scalar, 3>,
                                   covfie::vector::vector_d<scalar, 3>>;
     using b_field_t = covfie::field<const_bfield_bknd_t>;
 
-    using rk_stepper_t = rk_stepper<b_field_t::view_t, algebra_t>;
+    using rk_stepper_t = rk_stepper<b_field_t::view_t, test_algebra>;
     using inspector_t = navigation::print_inspector;
     constexpr std::size_t cache_size{navigation::default_cache_size};
 
@@ -112,7 +113,8 @@ GTEST_TEST(detray_detectors, telescope_detector) {
                                      300.f, 350.f, 400.f, 450.f, 500.f};
     // Build telescope detector with unbounded planes
     const auto [z_tel_det1, z_tel_names1] =
-        build_telescope_detector(host_mr, tel_cfg.positions(positions));
+        build_telescope_detector<test_algebra>(host_mr,
+                                               tel_cfg.positions(positions));
 
     // Some general checks
     const auto vol0 = tracking_volume{z_tel_det1, 0u};
@@ -132,7 +134,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     // length/number of surfaces
     tel_cfg.positions({}).n_surfaces(11u).length(500.f * unit<scalar>::mm);
     const auto [z_tel_det2, z_tel_names2] =
-        build_telescope_detector(host_mr, tel_cfg);
+        build_telescope_detector<test_algebra>(host_mr, tel_cfg);
 
     // Check general consistency of the detector
     detail::check_consistency(z_tel_det2, verbose_check, z_tel_names2);
@@ -152,10 +154,12 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     //
 
     // Same telescope, but in x direction and created from custom stepper
-    detail::ray<algebra_t> x_track({0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f);
+    detail::ray<test_algebra> x_track({0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f},
+                                      -1.f);
 
     const auto [x_tel_det, x_tel_names] =
-        build_telescope_detector(host_mr, tel_cfg.pilot_track(x_track));
+        build_telescope_detector<test_algebra>(host_mr,
+                                               tel_cfg.pilot_track(x_track));
 
     // Check general consistency of the detector
     detail::check_consistency(x_tel_det, verbose_check, x_tel_names);
@@ -167,10 +171,10 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     // Telescope navigation should be symmetric in x and z
     vector3 pos = {0.f, 0.f, 0.f};
     vector3 mom = {0.f, 0.f, 1.f};
-    free_track_parameters<algebra_t> test_track_z1(pos, 0.f, mom, -1.f);
-    free_track_parameters<algebra_t> test_track_z2(pos, 0.f, mom, -1.f);
+    free_track_parameters<test_algebra> test_track_z1(pos, 0.f, mom, -1.f);
+    free_track_parameters<test_algebra> test_track_z2(pos, 0.f, mom, -1.f);
     mom = {1.f, 0.f, 0.f};
-    free_track_parameters<algebra_t> test_track_x(pos, 0.f, mom, -1.f);
+    free_track_parameters<test_algebra> test_track_x(pos, 0.f, mom, -1.f);
 
     // navigators
     navigator<decltype(z_tel_det1), cache_size, inspector_t> navigator_z1;
@@ -277,14 +281,14 @@ GTEST_TEST(detray_detectors, telescope_detector) {
     pos = {0.f, 0.f, 0.f};
     mom = {0.f, 1.f, 0.f};
 
-    auto pilot_track = free_track_parameters<algebra_t>(pos, 0.f, mom, -1.f);
+    auto pilot_track = free_track_parameters<test_algebra>(pos, 0.f, mom, -1.f);
 
-    detail::helix<algebra_t> helix_bz(pilot_track, &B_z);
+    detail::helix<test_algebra> helix_bz(pilot_track, &B_z);
 
     tel_det_config htel_cfg{rectangle, helix_bz};
     htel_cfg.n_surfaces(11u).length(500.f * unit<scalar>::mm);
     const auto [tel_detector, tel_names] =
-        build_telescope_detector(host_mr, htel_cfg);
+        build_telescope_detector<test_algebra>(host_mr, htel_cfg);
 
     // Check general consistency of the detector
     detail::check_consistency(tel_detector, verbose_check, tel_names);

--- a/tests/unit_tests/cpu/detectors/toy_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/toy_detector.cpp
@@ -21,16 +21,20 @@ using namespace detray;
 // This test check the building of the tml based toy geometry
 GTEST_TEST(detray_detectors, toy_detector) {
 
+    using test_algebra = test::algebra;
+
     vecmem::host_memory_resource host_mr;
 
-    toy_det_config toy_cfg{};
+    toy_det_config<test::scalar> toy_cfg{};
     toy_cfg.use_material_maps(false).do_check(true);
-    const auto [toy_det, names] = build_toy_detector(host_mr, toy_cfg);
+    const auto [toy_det, names] =
+        build_toy_detector<test_algebra>(host_mr, toy_cfg);
 
     EXPECT_TRUE(toy_detector_test(toy_det, names));
 
     toy_cfg.use_material_maps(true);
-    const auto [toy_det2, names2] = build_toy_detector(host_mr, toy_cfg);
+    const auto [toy_det2, names2] =
+        build_toy_detector<test_algebra>(host_mr, toy_cfg);
 
     EXPECT_TRUE(toy_detector_test(toy_det2, names2));
 }

--- a/tests/unit_tests/cpu/detectors/wire_chamber.cpp
+++ b/tests/unit_tests/cpu/detectors/wire_chamber.cpp
@@ -10,6 +10,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_wire_chamber.hpp"
+#include "detray/test/utils/types.hpp"
 
 // VecMem include(s).
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -23,8 +24,8 @@ GTEST_TEST(detray_detectors, wire_chamber) {
 
     vecmem::host_memory_resource host_mr;
 
-    wire_chamber_config<> cfg{};
-    auto [wire_det, names] = build_wire_chamber(host_mr, cfg);
+    wire_chamber_config<test::scalar> cfg{};
+    auto [wire_det, names] = build_wire_chamber<test::algebra>(host_mr, cfg);
 
     // Check general consistency of the detector
     detail::check_consistency(wire_det, true, names);

--- a/tests/unit_tests/cpu/geometry/coordinates/cartesian2D.cpp
+++ b/tests/unit_tests/cpu/geometry/coordinates/cartesian2D.cpp
@@ -18,6 +18,8 @@
 
 using namespace detray;
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point3 = test::point3;
 using vector3 = test::vector3;
 using transform3 = test::transform3;
@@ -36,7 +38,7 @@ GTEST_TEST(detray_coordinates, cartesian2D) {
     const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
 
-    const cartesian2D<test::algebra> c2;
+    const cartesian2D<test_algebra> c2;
 
     // Global to local transformation
     const point3 local = c2.global_to_local_3D(trf, global1, d);

--- a/tests/unit_tests/cpu/geometry/coordinates/cartesian3D.cpp
+++ b/tests/unit_tests/cpu/geometry/coordinates/cartesian3D.cpp
@@ -18,9 +18,12 @@
 
 using namespace detray;
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point3 = test::point3;
 using vector3 = test::vector3;
 using transform3 = test::transform3;
+
 const scalar isclose{1e-5f};
 
 // This test cartesian3D coordinate
@@ -35,7 +38,7 @@ GTEST_TEST(detray_coordinates, cartesian3D) {
     const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
 
-    const cartesian3D<test::algebra> c3;
+    const cartesian3D<test_algebra> c3;
 
     // Global to local transformation
     const point3 local = c3.global_to_local_3D(trf, global1, d);

--- a/tests/unit_tests/cpu/geometry/coordinates/cylindrical2D.cpp
+++ b/tests/unit_tests/cpu/geometry/coordinates/cylindrical2D.cpp
@@ -22,6 +22,8 @@
 
 using namespace detray;
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point3 = test::point3;
 using point2 = test::point2;
 using vector3 = test::vector3;
@@ -43,7 +45,7 @@ GTEST_TEST(detray_coordinates, cylindrical2D) {
     const vector3 d = vector::normalize(mom);
     const scalar r{2.f};
 
-    const cylindrical2D<test::algebra> c2;
+    const cylindrical2D<test_algebra> c2;
 
     // Global to local transformation
     const point3 local = c2.global_to_local_3D(trf, global1, d);
@@ -76,7 +78,7 @@ GTEST_TEST(detray_coordinates, concentric_cylindrical2D) {
                             9.f};
     const scalar r{2.f};
 
-    const concentric_cylindrical2D<test::algebra> c2;
+    const concentric_cylindrical2D<test_algebra> c2;
 
     // Global to local transformation
     const point3 local3 = c2.global_to_local_3D(trf, global1, {});

--- a/tests/unit_tests/cpu/geometry/coordinates/cylindrical3D.cpp
+++ b/tests/unit_tests/cpu/geometry/coordinates/cylindrical3D.cpp
@@ -18,6 +18,8 @@
 
 using namespace detray;
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point3 = test::point3;
 using vector3 = test::vector3;
 using transform3 = test::transform3;
@@ -36,7 +38,7 @@ GTEST_TEST(detray_coordinates, cylindrical3D) {
     const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
 
-    const cylindrical3D<test::algebra> c3;
+    const cylindrical3D<test_algebra> c3;
 
     // Global to local transformation
     const point3 local = c3.global_to_local_3D(trf, global1, d);

--- a/tests/unit_tests/cpu/geometry/coordinates/line2D.cpp
+++ b/tests/unit_tests/cpu/geometry/coordinates/line2D.cpp
@@ -18,6 +18,8 @@
 
 using namespace detray;
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point2 = test::point2;
 using point3 = test::point3;
 using vector3 = test::vector3;
@@ -38,7 +40,7 @@ GTEST_TEST(detray_coordinates, line2D_case1) {
     const vector3 mom = {0.f, 1.f, 1.f};
     const vector3 d = vector::normalize(mom);
 
-    const line2D<test::algebra> l2;
+    const line2D<test_algebra> l2;
 
     // Global to local transformation
     const point3 local = l2.global_to_local_3D(trf, global1, d);
@@ -69,7 +71,7 @@ GTEST_TEST(detray_coordinates, line2D_case2) {
     x = vector::normalize(x);
     const point3 t = {0.f, 0.f, 0.f};
     const transform3 trf(t, z, x);
-    const line2D<test::algebra> l2;
+    const line2D<test_algebra> l2;
     const point2 local1 = {1.f, 2.f};
     const vector3 mom = {1.f, 6.f, -2.f};
     const vector3 d = vector::normalize(mom);

--- a/tests/unit_tests/cpu/geometry/coordinates/polar2D.cpp
+++ b/tests/unit_tests/cpu/geometry/coordinates/polar2D.cpp
@@ -18,6 +18,8 @@
 
 using namespace detray;
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point3 = test::point3;
 using vector3 = test::vector3;
 using transform3 = test::transform3;
@@ -36,7 +38,7 @@ GTEST_TEST(detray_coordinates, polar2D) {
     const vector3 mom = {1.f, 2.f, 3.f};
     const vector3 d = vector::normalize(mom);
 
-    const polar2D<test::algebra> p2;
+    const polar2D<test_algebra> p2;
 
     // Global to local transformation
     const point3 local = p2.global_to_local_3D(trf, global1, d);

--- a/tests/unit_tests/cpu/geometry/masks/cylinder.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/cylinder.cpp
@@ -19,7 +19,10 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using point3_t = test::point3;
+
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+using point3 = test::point3;
 
 constexpr scalar tol{1e-4f};
 
@@ -28,13 +31,12 @@ constexpr scalar hz{4.f * unit<scalar>::mm};
 
 /// This tests the basic functionality of a 2D cylinder
 GTEST_TEST(detray_masks, cylinder2D) {
-    using point_t = point3_t;
 
-    point_t p2_in = {r, -1.f, r};
-    point_t p2_edge = {r, hz, r};
-    point_t p2_out = {3.5f, 4.5f, 3.5f};
+    point3 p2_in = {r, -1.f, r};
+    point3 p2_edge = {r, hz, r};
+    point3 p2_out = {3.5f, 4.5f, 3.5f};
 
-    mask<cylinder2D> c{0u, r, -hz, hz};
+    mask<cylinder2D, test_algebra> c{0u, r, -hz, hz};
 
     ASSERT_NEAR(c[cylinder2D::e_r], r, tol);
     ASSERT_NEAR(c[cylinder2D::e_lower_z], -hz, tol);
@@ -71,15 +73,16 @@ GTEST_TEST(detray_masks, cylinder2D) {
 GTEST_TEST(detray_masks, cylinder2D_ratio_test) {
 
     struct mask_check {
-        bool operator()(const test::point3 &p, const mask<cylinder2D> &cyl,
+        bool operator()(const point3 &p,
+                        const mask<cylinder2D, test_algebra> &cyl,
                         const test::transform3 &trf, const scalar t) {
 
-            const test::point3 loc_p{cyl.to_local_frame(trf, p)};
+            const point3 loc_p{cyl.to_local_frame(trf, p)};
             return cyl.is_inside(loc_p, t);
         }
     };
 
-    constexpr mask<cylinder2D> cyl{0u, r, 0.f, 5.f};
+    constexpr mask<cylinder2D, test_algebra> cyl{0u, r, 0.f, 5.f};
 
     constexpr scalar t{0.f};
     const test::transform3 trf{};
@@ -88,9 +91,8 @@ GTEST_TEST(detray_masks, cylinder2D_ratio_test) {
 
     // Make sure the test point is on the cylinder before calling the
     // mask(this is normally ensured by the intersector)
-    std::vector<test::point3> points =
-        test::generate_regular_points<cylinder2D>(n_points,
-                                                  {cyl[cylinder2D::e_r], size});
+    std::vector<point3> points = test::generate_regular_points<cylinder2D>(
+        n_points, {cyl[cylinder2D::e_r], size});
 
     scalar ratio = test::ratio_test<mask_check>(points, cyl, trf, t);
 
@@ -102,15 +104,14 @@ GTEST_TEST(detray_masks, cylinder2D_ratio_test) {
 
 /// This tests the basic functionality of a 3D cylinder
 GTEST_TEST(detray_masks, cylinder3D) {
-    using point_t = point3_t;
 
-    point_t p3_in = {r, 0.f, -1.f};
-    point_t p3_edge = {0.f, r, hz};
-    point_t p3_out = {r * constant<scalar>::inv_sqrt2,
-                      r * constant<scalar>::inv_sqrt2, 4.5f};
-    point_t p3_off = {1.f, 1.f, -9.f};
+    point3 p3_in = {r, 0.f, -1.f};
+    point3 p3_edge = {0.f, r, hz};
+    point3 p3_out = {r * constant<scalar>::inv_sqrt2,
+                     r * constant<scalar>::inv_sqrt2, 4.5f};
+    point3 p3_off = {1.f, 1.f, -9.f};
 
-    mask<cylinder3D> c{
+    mask<cylinder3D, test_algebra> c{
         0u, 0.f, -constant<scalar>::pi, -hz, r, constant<scalar>::pi, hz};
 
     ASSERT_NEAR(c[cylinder3D::e_min_r], 0.f, tol);
@@ -152,15 +153,16 @@ GTEST_TEST(detray_masks, cylinder3D) {
 GTEST_TEST(detray_masks, cylinder3D_ratio_test) {
 
     struct mask_check {
-        bool operator()(const test::point3 &p, const mask<cylinder3D> &cyl,
+        bool operator()(const point3 &p,
+                        const mask<cylinder3D, test_algebra> &cyl,
                         const test::transform3 &trf, const scalar t) {
 
-            const test::point3 loc_p{cyl.to_local_frame(trf, p)};
+            const point3 loc_p{cyl.to_local_frame(trf, p)};
             return cyl.is_inside(loc_p, t);
         }
     };
 
-    constexpr mask<cylinder3D> cyl{
+    constexpr mask<cylinder3D, test_algebra> cyl{
         0u, 1.f, -constant<scalar>::pi, 0.f, 3.f, constant<scalar>::pi, 5.f};
 
     constexpr scalar t{0.f};
@@ -168,7 +170,7 @@ GTEST_TEST(detray_masks, cylinder3D_ratio_test) {
     constexpr scalar size{10.f * unit<scalar>::mm};
     const auto n_points{static_cast<std::size_t>(std::pow(500, 3))};
 
-    std::vector<test::point3> points =
+    std::vector<point3> points =
         test::generate_regular_points<cuboid3D>(n_points, {size});
 
     scalar ratio = test::ratio_test<mask_check>(points, cyl, trf, t);

--- a/tests/unit_tests/cpu/geometry/masks/line.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/line.cpp
@@ -19,7 +19,10 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using point3_t = test::point3;
+
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+using point3 = test::point3;
 
 namespace {
 
@@ -33,14 +36,13 @@ constexpr scalar hz{50.f * unit<scalar>::mm};
 
 /// This tests the basic functionality of a line with a radial cross section
 GTEST_TEST(detray_masks, line_circular) {
-    using point_t = point3_t;
 
-    const point_t ln_in{0.09f, 0.5f, 0.f};
-    const point_t ln_edge{1.f, 50.f, 0.f};
-    const point_t ln_out1{1.2f, 0.f, 0.f};
-    const point_t ln_out2{0.09f, -51.f, 0.f};
+    const point3 ln_in{0.09f, 0.5f, 0.f};
+    const point3 ln_edge{1.f, 50.f, 0.f};
+    const point3 ln_out1{1.2f, 0.f, 0.f};
+    const point3 ln_out2{0.09f, -51.f, 0.f};
 
-    const mask<line_circular> ln{0u, cell_size, hz};
+    const mask<line_circular, test_algebra> ln{0u, cell_size, hz};
 
     ASSERT_NEAR(ln[line_circular::e_cross_section], 1.f * unit<scalar>::mm,
                 tol);
@@ -75,16 +77,17 @@ GTEST_TEST(detray_masks, line_circular) {
 GTEST_TEST(detray_masks, line_circular_ratio_test) {
 
     struct mask_check {
-        bool operator()(const test::point3 &p, const mask<line_circular> &st,
+        bool operator()(const point3 &p,
+                        const mask<line_circular, test_algebra> &st,
                         const test::transform3 &trf, const test::vector3 &dir,
                         const scalar t) {
 
-            const test::point3 loc_p{st.to_local_frame(trf, p, dir)};
+            const point3 loc_p{st.to_local_frame(trf, p, dir)};
             return st.is_inside(loc_p, t);
         }
     };
 
-    constexpr mask<line_circular> st{0u, 3.f, 5.f};
+    constexpr mask<line_circular, test_algebra> st{0u, 3.f, 5.f};
 
     constexpr scalar t{0.f};
     const test::transform3 trf{};
@@ -94,7 +97,7 @@ GTEST_TEST(detray_masks, line_circular_ratio_test) {
     constexpr scalar size{10.f * unit<scalar>::mm};
     const auto n_points{static_cast<std::size_t>(std::pow(500, 3))};
 
-    std::vector<test::point3> points =
+    std::vector<point3> points =
         test::generate_regular_points<cuboid3D>(n_points, {size});
 
     scalar ratio = test::ratio_test<mask_check>(points, st, trf, dir, t);
@@ -107,15 +110,14 @@ GTEST_TEST(detray_masks, line_circular_ratio_test) {
 
 /// This tests the basic functionality of a line with a square cross section
 GTEST_TEST(detray_masks, line_square) {
-    using point_t = point3_t;
 
-    const point_t ln_in{1.1f, 0.9f, constant<scalar>::pi_4};
-    const point_t ln_edge{1.f, 1.f, 0.f};
-    const point_t ln_out1{1.1f, 0.f, 0.f};
-    const point_t ln_out2{0.09f, -51.f, 0.f};
+    const point3 ln_in{1.1f, 0.9f, constant<scalar>::pi_4};
+    const point3 ln_edge{1.f, 1.f, 0.f};
+    const point3 ln_out1{1.1f, 0.f, 0.f};
+    const point3 ln_out2{0.09f, -51.f, 0.f};
 
     // 50 mm wire with 1 mm square cell sizes
-    const mask<line_square> ln{0u, cell_size, hz};
+    const mask<line_square, test_algebra> ln{0u, cell_size, hz};
 
     ASSERT_NEAR(ln[line_circular::e_cross_section], 1.f * unit<scalar>::mm,
                 tol);
@@ -151,16 +153,17 @@ GTEST_TEST(detray_masks, line_square) {
 GTEST_TEST(detray_masks, line_square_ratio_test) {
 
     struct mask_check {
-        bool operator()(const test::point3 &p, const mask<line_square> &dcl,
+        bool operator()(const point3 &p,
+                        const mask<line_square, test_algebra> &dcl,
                         const test::transform3 &trf, const test::vector3 &dir,
                         const scalar t) {
 
-            const test::point3 loc_p{dcl.to_local_frame(trf, p, dir)};
+            const point3 loc_p{dcl.to_local_frame(trf, p, dir)};
             return dcl.is_inside(loc_p, t);
         }
     };
 
-    constexpr mask<line_square> dcl{0u, 3.f, 5.f};
+    constexpr mask<line_square, test_algebra> dcl{0u, 3.f, 5.f};
 
     constexpr scalar t{0.f};
     const test::transform3 trf{};
@@ -170,7 +173,7 @@ GTEST_TEST(detray_masks, line_square_ratio_test) {
     constexpr scalar size{10.f * unit<scalar>::mm};
     const auto n_points{static_cast<std::size_t>(std::pow(500, 3))};
 
-    std::vector<test::point3> points =
+    std::vector<point3> points =
         test::generate_regular_points<cuboid3D>(n_points, {size});
 
     scalar ratio = test::ratio_test<mask_check>(points, dcl, trf, dir, t);

--- a/tests/unit_tests/cpu/geometry/masks/rectangle2D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/rectangle2D.cpp
@@ -19,7 +19,10 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using point3_t = test::point3;
+
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+using point3 = test::point3;
 
 constexpr scalar tol{1e-7f};
 
@@ -29,13 +32,12 @@ constexpr scalar hz{0.5f * unit<scalar>::mm};
 
 /// This tests the basic functionality of a rectangle
 GTEST_TEST(detray_masks, rectangle2D) {
-    using point_t = point3_t;
 
-    point_t p2_in = {0.5f, -9.f, 0.f};
-    point_t p2_edge = {1.f, 9.3f, 0.f};
-    point_t p2_out = {1.5f, -9.f, 0.f};
+    point3 p2_in = {0.5f, -9.f, 0.f};
+    point3 p2_edge = {1.f, 9.3f, 0.f};
+    point3 p2_out = {1.5f, -9.f, 0.f};
 
-    mask<rectangle2D> r2{0u, hx, hy};
+    mask<rectangle2D, test_algebra> r2{0u, hx, hy};
 
     ASSERT_NEAR(r2[rectangle2D::e_half_x], hx, tol);
     ASSERT_NEAR(r2[rectangle2D::e_half_y], hy, tol);
@@ -71,15 +73,16 @@ GTEST_TEST(detray_masks, rectangle2D) {
 GTEST_TEST(detray_masks, rectangle2D_ratio_test) {
 
     struct mask_check {
-        bool operator()(const test::point3 &p, const mask<rectangle2D> &r,
+        bool operator()(const point3 &p,
+                        const mask<rectangle2D, test_algebra> &r,
                         const test::transform3 &trf, const scalar t) {
 
-            const test::point3 loc_p{r.to_local_frame(trf, p)};
+            const point3 loc_p{r.to_local_frame(trf, p)};
             return r.is_inside(loc_p, t);
         }
     };
 
-    constexpr mask<rectangle2D> r{0u, 3.f, 4.f};
+    constexpr mask<rectangle2D, test_algebra> r{0u, 3.f, 4.f};
 
     constexpr scalar t{0.f};
     const test::transform3 trf{};
@@ -87,7 +90,7 @@ GTEST_TEST(detray_masks, rectangle2D_ratio_test) {
     const auto n_points{static_cast<std::size_t>(std::pow(500, 3))};
 
     // x- and y-coordinates yield a valid local position on the underlying plane
-    std::vector<test::point3> points =
+    std::vector<point3> points =
         test::generate_regular_points<cuboid3D>(n_points, {size});
 
     scalar ratio = test::ratio_test<mask_check>(points, r, trf, t);
@@ -100,13 +103,12 @@ GTEST_TEST(detray_masks, rectangle2D_ratio_test) {
 
 /// This tests the basic functionality of a cuboid3D
 GTEST_TEST(detray_masks, cuboid3D) {
-    using point_t = point3_t;
 
-    point_t p2_in = {0.5f, 8.0f, -0.4f};
-    point_t p2_edge = {1.f, 9.3f, 0.5f};
-    point_t p2_out = {1.5f, -9.f, 0.55f};
+    point3 p2_in = {0.5f, 8.0f, -0.4f};
+    point3 p2_edge = {1.f, 9.3f, 0.5f};
+    point3 p2_out = {1.5f, -9.f, 0.55f};
 
-    mask<cuboid3D> c3{0u, -hx, -hy, -hz, hx, hy, hz};
+    mask<cuboid3D, test_algebra> c3{0u, -hx, -hy, -hz, hx, hy, hz};
 
     ASSERT_NEAR(c3[cuboid3D::e_min_x], -hx, tol);
     ASSERT_NEAR(c3[cuboid3D::e_min_y], -hy, tol);
@@ -141,22 +143,22 @@ GTEST_TEST(detray_masks, cuboid3D) {
 GTEST_TEST(detray_masks, cuboid3D_ratio_test) {
 
     struct mask_check {
-        bool operator()(const test::point3 &p, const mask<cuboid3D> &cb,
+        bool operator()(const point3 &p, const mask<cuboid3D, test_algebra> &cb,
                         const test::transform3 &trf, const scalar t) {
 
-            const test::point3 loc_p{cb.to_local_frame(trf, p)};
+            const point3 loc_p{cb.to_local_frame(trf, p)};
             return cb.is_inside(loc_p, t);
         }
     };
 
-    constexpr mask<cuboid3D> cb{0u, 0.f, 0.f, 0.f, 3.f, 4.f, 1.f};
+    constexpr mask<cuboid3D, test_algebra> cb{0u, 0.f, 0.f, 0.f, 3.f, 4.f, 1.f};
 
     constexpr scalar t{0.f};
     const test::transform3 trf{};
     constexpr scalar size{10.f * unit<scalar>::mm};
     const auto n_points{static_cast<std::size_t>(std::pow(500, 3))};
 
-    std::vector<test::point3> points =
+    std::vector<point3> points =
         test::generate_regular_points<cuboid3D>(n_points, {size});
 
     scalar ratio = test::ratio_test<mask_check>(points, cb, trf, t);

--- a/tests/unit_tests/cpu/geometry/masks/ring2D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/ring2D.cpp
@@ -19,22 +19,24 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using point3_t = test::point3;
+
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+using point3 = test::point3;
 
 constexpr scalar tol{1e-5f};
 
 /// This tests the basic functionality of a ring
 GTEST_TEST(detray_masks, ring2D) {
-    using point_t = point3_t;
 
-    point_t p2_pl_in = {0.5f, -2.f, 0.f};
-    point_t p2_pl_edge = {0.f, 3.5f, 0.f};
-    point_t p2_pl_out = {3.6f, 5.f, 0.f};
+    point3 p2_pl_in = {0.5f, -2.f, 0.f};
+    point3 p2_pl_edge = {0.f, 3.5f, 0.f};
+    point3 p2_pl_out = {3.6f, 5.f, 0.f};
 
     constexpr scalar inner_r{0.f * unit<scalar>::mm};
     constexpr scalar outer_r{3.5f * unit<scalar>::mm};
 
-    mask<ring2D> r2{0u, inner_r, outer_r};
+    mask<ring2D, test_algebra> r2{0u, inner_r, outer_r};
 
     ASSERT_NEAR(r2[ring2D::e_inner_r], 0.f, tol);
     ASSERT_NEAR(r2[ring2D::e_outer_r], 3.5f, tol);
@@ -70,15 +72,15 @@ GTEST_TEST(detray_masks, ring2D) {
 GTEST_TEST(detray_masks, ring2D_ratio_test) {
 
     struct mask_check {
-        bool operator()(const test::point3 &p, const mask<ring2D> &r,
+        bool operator()(const point3 &p, const mask<ring2D, test_algebra> &r,
                         const test::transform3 &trf, const scalar t) {
 
-            const test::point3 loc_p{r.to_local_frame(trf, p)};
+            const point3 loc_p{r.to_local_frame(trf, p)};
             return r.is_inside(loc_p, t);
         }
     };
 
-    constexpr mask<ring2D> r{0u, 2.f, 5.f};
+    constexpr mask<ring2D, test_algebra> r{0u, 2.f, 5.f};
 
     constexpr scalar t{0.f};
     const test::transform3 trf{};
@@ -86,7 +88,7 @@ GTEST_TEST(detray_masks, ring2D_ratio_test) {
     const auto n_points{static_cast<std::size_t>(std::pow(500, 3))};
 
     // x- and y-coordinates yield a valid local position on the underlying plane
-    std::vector<test::point3> points =
+    std::vector<point3> points =
         test::generate_regular_points<cuboid3D>(n_points, {size});
 
     scalar ratio = test::ratio_test<mask_check>(points, r, trf, t);

--- a/tests/unit_tests/cpu/geometry/masks/single3D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/single3D.cpp
@@ -18,20 +18,22 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using point3_t = test::point3;
+
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+using point3 = test::point3;
 
 constexpr scalar tol{1e-7f};
 
 /// This tests the basic functionality of a single value mask (index 0)
 GTEST_TEST(detray_masks, single3_0) {
-    using point_t = point3_t;
 
-    point_t p3_in = {0.5f, -9.f, 0.f};
-    point_t p3_edge = {1.f, 9.3f, 2.f};
-    point_t p3_out = {1.5f, -9.8f, 8.f};
+    point3 p3_in = {0.5f, -9.f, 0.f};
+    point3 p3_edge = {1.f, 9.3f, 2.f};
+    point3 p3_out = {1.5f, -9.8f, 8.f};
 
     constexpr scalar h0{1.f * unit<scalar>::mm};
-    mask<single3D<>> m1_0{0u, -h0, h0};
+    mask<single3D<>, test_algebra> m1_0{0u, -h0, h0};
 
     ASSERT_NEAR(m1_0[single3D<>::e_lower], -h0, tol);
     ASSERT_NEAR(m1_0[single3D<>::e_upper], h0, tol);
@@ -63,14 +65,13 @@ GTEST_TEST(detray_masks, single3_0) {
 
 /// This tests the basic functionality of a single value mask (index 1)
 GTEST_TEST(detray_masks, single3_1) {
-    using point_t = point3_t;
 
-    point_t p3_in = {0.5f, -9.f, 0.f};
-    point_t p3_edge = {1.f, 9.3f, 2.f};
-    point_t p3_out = {1.5f, -9.8f, 8.f};
+    point3 p3_in = {0.5f, -9.f, 0.f};
+    point3 p3_edge = {1.f, 9.3f, 2.f};
+    point3 p3_out = {1.5f, -9.8f, 8.f};
 
     constexpr scalar h1{9.3f * unit<scalar>::mm};
-    mask<single3D<1>> m1_1{0u, -h1, h1};
+    mask<single3D<1>, test_algebra> m1_1{0u, -h1, h1};
 
     ASSERT_NEAR(m1_1[single3D<>::e_lower], -h1, tol);
     ASSERT_NEAR(m1_1[single3D<>::e_upper], h1, tol);
@@ -102,14 +103,13 @@ GTEST_TEST(detray_masks, single3_1) {
 
 /// This tests the basic functionality of a single value mask (index 2)
 GTEST_TEST(detray_masks, single3_2) {
-    using point_t = point3_t;
 
-    point_t p3_in = {0.5f, -9.f, 0.f};
-    point_t p3_edge = {1.f, 9.3f, 2.f};
-    point_t p3_out = {1.5f, -9.8f, 8.f};
+    point3 p3_in = {0.5f, -9.f, 0.f};
+    point3 p3_edge = {1.f, 9.3f, 2.f};
+    point3 p3_out = {1.5f, -9.8f, 8.f};
 
     constexpr scalar h2{2.f * unit<scalar>::mm};
-    mask<single3D<2>> m1_2{0u, -h2, h2};
+    mask<single3D<2>, test_algebra> m1_2{0u, -h2, h2};
 
     ASSERT_NEAR(m1_2[single3D<>::e_lower], -h2, tol);
     ASSERT_NEAR(m1_2[single3D<>::e_upper], h2, tol);

--- a/tests/unit_tests/cpu/geometry/masks/trapezoid2D.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/trapezoid2D.cpp
@@ -19,24 +19,26 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using point3_t = test::point3;
+
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+using point3 = test::point3;
 
 constexpr scalar tol{1e-7f};
 
 /// This tests the basic functionality of a trapezoid
 GTEST_TEST(detray_masks, trapezoid2D) {
-    using point_t = point3_t;
 
-    point_t p2_in = {1.f, -0.5f, 0.f};
-    point_t p2_edge = {2.5f, 1.f, 0.f};
-    point_t p2_out = {3.f, 1.5f, 0.f};
+    point3 p2_in = {1.f, -0.5f, 0.f};
+    point3 p2_edge = {2.5f, 1.f, 0.f};
+    point3 p2_out = {3.f, 1.5f, 0.f};
 
     constexpr scalar hx_miny{1.f * unit<scalar>::mm};
     constexpr scalar hx_maxy{3.f * unit<scalar>::mm};
     constexpr scalar hy{2.f * unit<scalar>::mm};
     constexpr scalar divisor{1.f / (2.f * hy)};
 
-    mask<trapezoid2D> t2{0u, hx_miny, hx_maxy, hy, divisor};
+    mask<trapezoid2D, test_algebra> t2{0u, hx_miny, hx_maxy, hy, divisor};
 
     ASSERT_NEAR(t2[trapezoid2D::e_half_length_0], hx_miny, tol);
     ASSERT_NEAR(t2[trapezoid2D::e_half_length_1], hx_maxy, tol);
@@ -73,15 +75,17 @@ GTEST_TEST(detray_masks, trapezoid2D) {
 GTEST_TEST(detray_masks, trapezoid2D_ratio_test) {
 
     struct mask_check {
-        bool operator()(const test::point3 &p, const mask<trapezoid2D> &tp,
+        bool operator()(const point3 &p,
+                        const mask<trapezoid2D, test_algebra> &tp,
                         const test::transform3 &trf, const scalar t) {
 
-            const test::point3 loc_p{tp.to_local_frame(trf, p)};
+            const point3 loc_p{tp.to_local_frame(trf, p)};
             return tp.is_inside(loc_p, t);
         }
     };
 
-    constexpr mask<trapezoid2D> tp{0u, 2.f, 3.f, 4.f, 1.f / (2.f * 4.f)};
+    constexpr mask<trapezoid2D, test_algebra> tp{0u, 2.f, 3.f, 4.f,
+                                                 1.f / (2.f * 4.f)};
 
     constexpr scalar t{0.f};
     const test::transform3 trf{};
@@ -89,7 +93,7 @@ GTEST_TEST(detray_masks, trapezoid2D_ratio_test) {
     const auto n_points{static_cast<std::size_t>(std::pow(500, 3))};
 
     // x- and y-coordinates yield a valid local position on the underlying plane
-    std::vector<test::point3> points =
+    std::vector<point3> points =
         test::generate_regular_points<cuboid3D>(n_points, {size});
 
     scalar ratio = test::ratio_test<mask_check>(points, tp, trf, t);

--- a/tests/unit_tests/cpu/geometry/masks/unbounded.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/unbounded.cpp
@@ -23,8 +23,11 @@
 #include <type_traits>
 
 using namespace detray;
-using point3_t = test::point3;
-using transform3_t = test::transform3;
+
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+using point3 = test::point3;
+using transform3 = test::transform3;
 
 constexpr scalar tol{1e-7f};
 
@@ -36,7 +39,7 @@ GTEST_TEST(detray_masks, unbounded) {
 
     constexpr scalar h{20.f * unit<scalar>::mm};
 
-    mask<unbounded_t> u{0u, h, h};
+    mask<unbounded_t, test_algebra> u{0u, h, h};
 
     // Test local typedefs
     static_assert(std::is_same_v<unbounded_t::shape, shape_t>,
@@ -44,8 +47,8 @@ GTEST_TEST(detray_masks, unbounded) {
     static_assert(std::is_same_v<unbounded_t::boundaries, shape_t::boundaries>,
                   "incorrect boundaries");
     static_assert(
-        std::is_same_v<unbounded_t::template local_frame_type<transform3_t>,
-                       shape_t::template local_frame_type<transform3_t>>,
+        std::is_same_v<unbounded_t::template local_frame_type<transform3>,
+                       shape_t::template local_frame_type<transform3>>,
         "incorrect local frame");
 
     // Test static members
@@ -53,7 +56,8 @@ GTEST_TEST(detray_masks, unbounded) {
                 std::string("unbounded rectangle2D"));
 
     // Test boundary check
-    typename mask<unbounded_t>::point3_type p2 = {0.5f, -9.f, 0.f};
+    typename mask<unbounded_t, test_algebra>::point3_type p2 = {0.5f, -9.f,
+                                                                0.f};
     ASSERT_TRUE(u.is_inside(p2, 0.f));
 
     // Check bounding box

--- a/tests/unit_tests/cpu/geometry/masks/unmasked.cpp
+++ b/tests/unit_tests/cpu/geometry/masks/unmasked.cpp
@@ -17,15 +17,18 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using point3_t = test::point3;
+
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+using point3 = test::point3;
 
 constexpr scalar tol{1e-7f};
 
 /// This tests the basic functionality of an unmasked plane
 GTEST_TEST(detray_masks, unmasked) {
-    point3_t p2 = {0.5f, -9.f, 0.f};
+    point3 p2 = {0.5f, -9.f, 0.f};
 
-    mask<unmasked<>> u{};
+    mask<unmasked<>, test_algebra> u{};
 
     ASSERT_TRUE(u.is_inside(p2, 0.f));
 

--- a/tests/unit_tests/cpu/geometry/tracking_volume.cpp
+++ b/tests/unit_tests/cpu/geometry/tracking_volume.cpp
@@ -81,10 +81,13 @@ GTEST_TEST(detray_geometry, tracking_volume) {
 
     using namespace detray;
 
-    constexpr detray::scalar tol{5e-5f};
+    using test_algebra = test::algebra;
+    using scalar = test::scalar;
+
+    constexpr scalar tol{5e-5f};
 
     vecmem::host_memory_resource host_mr;
-    const auto [toy_det, names] = build_toy_detector(host_mr);
+    const auto [toy_det, names] = build_toy_detector<test_algebra>(host_mr);
 
     //
     // Volume 7 is a barrrel layer with sensitive surfaces

--- a/tests/unit_tests/cpu/material/bethe_equation.cpp
+++ b/tests/unit_tests/cpu/material/bethe_equation.cpp
@@ -25,7 +25,9 @@
 #include <random>
 
 using namespace detray;
-using algebra_t = test::algebra;
+
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 
 // Test class for energy loss with Bethe function
 // Input tuple: < material, particle type, momentum, expected output >
@@ -483,7 +485,7 @@ TEST_P(LandauDistributionValidation, landau_distribution) {
     const scalar mass = ptc.mass();
 
     for (std::size_t i = 0u; i < n_samples; i++) {
-        const scalar new_p = random_scatterer<algebra_t>().attenuate(
+        const scalar new_p = random_scatterer<test_algebra>().attenuate(
             mpv, sigma, mass, p, generator);
         ASSERT_TRUE(new_p < p);
 

--- a/tests/unit_tests/cpu/material/bremsstrahlung.cpp
+++ b/tests/unit_tests/cpu/material/bremsstrahlung.cpp
@@ -18,7 +18,8 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using algebra_t = test::algebra;
+
+using scalar = test::scalar;
 
 // Test class for energy loss with Bremsstrahlung
 // Input tuple: < material, particle type, kinetic energy, expected output >

--- a/tests/unit_tests/cpu/material/material_maps.cpp
+++ b/tests/unit_tests/cpu/material/material_maps.cpp
@@ -12,17 +12,24 @@
 #include "detray/materials/detail/concepts.hpp"
 #include "detray/materials/material_map.hpp"
 
+// Detray test include(s)
+#include "detray/test/utils/types.hpp"
+
 // GTest include(s)
 #include <gtest/gtest.h>
 
 using namespace detray;
 using namespace detray::axis;
 
-using material_t = typename material_grid_factory<scalar>::bin_type::entry_type;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+
+using material_t =
+    typename material_grid_factory<test_algebra>::bin_type::entry_type;
 
 namespace {
 
-material_grid_factory<scalar> mat_map_factory{};
+material_grid_factory<test_algebra> mat_map_factory{};
 
 }  // anonymous namespace
 
@@ -34,7 +41,8 @@ GTEST_TEST(detray_material, annulus_map) {
     constexpr scalar minPhi{0.74195f};
     constexpr scalar maxPhi{1.33970f};
 
-    mask<annulus2D> ann2{0u, minR, maxR, minPhi, maxPhi, 0.f, -2.f, 2.f};
+    mask<annulus2D, test_algebra> ann2{0u,     minR, maxR, minPhi,
+                                       maxPhi, 0.f,  -2.f, 2.f};
 
     auto annulus_map = mat_map_factory.new_grid(ann2, {10u, 20u});
 
@@ -82,7 +90,7 @@ GTEST_TEST(detray_material, cylinder_map) {
     constexpr scalar r{3.f * unit<scalar>::mm};
     constexpr scalar hz{4.f * unit<scalar>::mm};
 
-    mask<cylinder2D> cyl{0u, r, -hz, hz};
+    mask<cylinder2D, test_algebra> cyl{0u, r, -hz, hz};
 
     auto cylinder_map = mat_map_factory.new_grid(cyl, {10u, 20u});
 
@@ -129,7 +137,7 @@ GTEST_TEST(detray_material, rectangle_map) {
     constexpr scalar hx{1.f * unit<scalar>::mm};
     constexpr scalar hy{9.3f * unit<scalar>::mm};
 
-    mask<rectangle2D> r2{0u, hx, hy};
+    mask<rectangle2D, test_algebra> r2{0u, hx, hy};
 
     auto rectangle_map = mat_map_factory.new_grid(r2, {10u, 20u});
 
@@ -176,7 +184,7 @@ GTEST_TEST(detray_material, disc_map) {
     constexpr scalar inner_r{0.f * unit<scalar>::mm};
     constexpr scalar outer_r{3.5f * unit<scalar>::mm};
 
-    mask<ring2D> r2{0u, inner_r, outer_r};
+    mask<ring2D, test_algebra> r2{0u, inner_r, outer_r};
 
     auto disc_map = mat_map_factory.new_grid(r2, {10u, 20u});
 
@@ -225,7 +233,7 @@ GTEST_TEST(detray_material, trapezoid_map) {
     constexpr scalar hy{2.f * unit<scalar>::mm};
     constexpr scalar divisor{1.f / (2.f * hy)};
 
-    mask<trapezoid2D> t2{0u, hx_miny, hx_maxy, hy, divisor};
+    mask<trapezoid2D, test_algebra> t2{0u, hx_miny, hx_maxy, hy, divisor};
 
     auto trapezoid_map = mat_map_factory.new_grid(t2, {10u, 20u});
 
@@ -277,7 +285,7 @@ GTEST_TEST(detray_material, material_grid_comparison) {
      */
     auto createGrid = [](const scalar hx, const scalar hy, unsigned int bx,
                          unsigned int by, bool distort_entries) {
-        mask<rectangle2D> r2{0u, hx, hy};
+        mask<rectangle2D, test_algebra> r2{0u, hx, hy};
         auto material_grid = mat_map_factory.new_grid(r2, {bx, by});
 
         // Fill the material grid with some data

--- a/tests/unit_tests/cpu/material/materials.cpp
+++ b/tests/unit_tests/cpu/material/materials.cpp
@@ -29,8 +29,8 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
-using scalar_t = test::scalar;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point2 = test::point2;
 using point3 = test::point3;
 using transform3 = test::transform3;
@@ -46,7 +46,7 @@ constexpr auto max_val{std::numeric_limits<scalar>::max()};
 // This tests the material functionalities
 GTEST_TEST(detray_material, materials) {
     // vacuum
-    constexpr vacuum<scalar_t> vac;
+    constexpr vacuum<scalar> vac;
 
     static_assert(concepts::material_params<decltype(vac)>);
     static_assert(concepts::homogeneous_material<decltype(vac)>);
@@ -56,13 +56,13 @@ GTEST_TEST(detray_material, materials) {
 
     EXPECT_EQ(vac.X0(), max_val);
     EXPECT_EQ(vac.L0(), max_val);
-    EXPECT_EQ(vac.Ar(), scalar_t{0});
-    EXPECT_EQ(vac.Z(), scalar_t{0});
-    EXPECT_EQ(vac.molar_density(), scalar_t{0});
-    EXPECT_EQ(vac.molar_electron_density(), scalar_t{0});
+    EXPECT_EQ(vac.Ar(), scalar{0});
+    EXPECT_EQ(vac.Z(), scalar{0});
+    EXPECT_EQ(vac.molar_density(), scalar{0});
+    EXPECT_EQ(vac.molar_electron_density(), scalar{0});
 
     // beryllium
-    constexpr beryllium_tml<scalar_t> beryll;
+    constexpr beryllium_tml<scalar> beryll;
 
     static_assert(concepts::material_params<decltype(beryll)>);
     static_assert(concepts::homogeneous_material<decltype(beryll)>);
@@ -70,9 +70,9 @@ GTEST_TEST(detray_material, materials) {
     static_assert(concepts::volume_material<decltype(beryll)>);
     static_assert(!concepts::material_map<decltype(beryll)>);
 
-    EXPECT_NEAR(beryll.X0(), static_cast<scalar_t>(352.8 * unit<double>::mm),
+    EXPECT_NEAR(beryll.X0(), static_cast<scalar>(352.8 * unit<double>::mm),
                 1e-4);
-    EXPECT_NEAR(beryll.L0(), static_cast<scalar_t>(407.0 * unit<double>::mm),
+    EXPECT_NEAR(beryll.L0(), static_cast<scalar>(407.0 * unit<double>::mm),
                 tol);
     EXPECT_NEAR(beryll.Ar(), 9.012f, tol);
     EXPECT_NEAR(beryll.Z(), 4.0f, tol);
@@ -80,12 +80,12 @@ GTEST_TEST(detray_material, materials) {
     // @note molar density is obtained by the following equation:
     // molar_density = mass_density [GeV/c²] / molar_mass [GeV/c²] * mol / cm³
     EXPECT_NEAR(beryll.molar_density(),
-                static_cast<scalar_t>(1.848 / beryllium_tml<double>().Ar() *
-                                      unit<double>::mol / unit<double>::cm3),
+                static_cast<scalar>(1.848 / beryllium_tml<double>().Ar() *
+                                    unit<double>::mol / unit<double>::cm3),
                 tol);
 
     // silicon
-    constexpr silicon_tml<scalar_t> silicon;
+    constexpr silicon_tml<scalar> silicon;
 
     static_assert(concepts::material_params<decltype(silicon)>);
     static_assert(concepts::homogeneous_material<decltype(silicon)>);
@@ -93,15 +93,15 @@ GTEST_TEST(detray_material, materials) {
     static_assert(concepts::volume_material<decltype(silicon)>);
     static_assert(!concepts::material_map<decltype(silicon)>);
 
-    EXPECT_NEAR(silicon.X0(), static_cast<scalar_t>(95.7 * unit<double>::mm),
+    EXPECT_NEAR(silicon.X0(), static_cast<scalar>(95.7 * unit<double>::mm),
                 1e-5);
-    EXPECT_NEAR(silicon.L0(), static_cast<scalar_t>(465.2 * unit<double>::mm),
+    EXPECT_NEAR(silicon.L0(), static_cast<scalar>(465.2 * unit<double>::mm),
                 1e-4);
     EXPECT_NEAR(silicon.Ar(), 28.03f, tol);
     EXPECT_NEAR(silicon.Z(), 14.f, tol);
     EXPECT_NEAR(silicon.molar_density(),
-                static_cast<scalar_t>(2.32 / silicon_tml<double>().Ar() *
-                                      unit<double>::mol / unit<double>::cm3),
+                static_cast<scalar>(2.32 / silicon_tml<double>().Ar() *
+                                    unit<double>::mol / unit<double>::cm3),
                 tol);
 }
 
@@ -109,9 +109,9 @@ GTEST_TEST(detray_material, mixture) {
 
     // Check if material property doesn't change after mixing with other
     // material of 0 ratio
-    constexpr oxygen_gas<scalar_t> pure_oxygen;
-    constexpr mixture<scalar_t, oxygen_gas<scalar_t>,
-                      aluminium<scalar_t, std::ratio<0, 1>>>
+    constexpr oxygen_gas<scalar> pure_oxygen;
+    constexpr mixture<scalar, oxygen_gas<scalar>,
+                      aluminium<scalar, std::ratio<0, 1>>>
         oxygen_mix;
 
     static_assert(concepts::material_params<decltype(oxygen_mix)>);
@@ -128,12 +128,12 @@ GTEST_TEST(detray_material, mixture) {
     EXPECT_NEAR(pure_oxygen.molar_density(), oxygen_mix.molar_density(), tol);
 
     // Air mixture check
-    constexpr mixture<scalar_t, carbon_gas<scalar_t, std::ratio<0, 100>>,
-                      nitrogen_gas<scalar_t, std::ratio<76, 100>>,
-                      oxygen_gas<scalar_t, std::ratio<23, 100>>,
-                      argon_gas<scalar_t, std::ratio<1, 100>>>
+    constexpr mixture<scalar, carbon_gas<scalar, std::ratio<0, 100>>,
+                      nitrogen_gas<scalar, std::ratio<76, 100>>,
+                      oxygen_gas<scalar, std::ratio<23, 100>>,
+                      argon_gas<scalar, std::ratio<1, 100>>>
         air_mix;
-    constexpr air<scalar_t> pure_air;
+    constexpr air<scalar> pure_air;
 
     static_assert(concepts::material_params<decltype(pure_air)>);
     static_assert(concepts::homogeneous_material<decltype(pure_air)>);
@@ -150,11 +150,11 @@ GTEST_TEST(detray_material, mixture) {
                 0.01f);
 
     // Vector check
-    material_slab<scalar_t> slab1(air_mix, 5.5f);
-    material_slab<scalar_t> slab2(pure_air, 2.3f);
-    material_slab<scalar_t> slab3(oxygen_gas<scalar_t>(), 2.f);
+    material_slab<scalar> slab1(air_mix, 5.5f);
+    material_slab<scalar> slab2(pure_air, 2.3f);
+    material_slab<scalar> slab3(oxygen_gas<scalar>(), 2.f);
 
-    std::vector<material_slab<scalar_t>> slab_vec;
+    std::vector<material_slab<scalar>> slab_vec;
 
     slab_vec.push_back(slab1);
     slab_vec.push_back(slab2);
@@ -170,8 +170,8 @@ GTEST_TEST(detray_material, mixture) {
 
 GTEST_TEST(detray_material, mixture2) {
 
-    constexpr mixture<scalar_t, silicon_with_ded<scalar_t, std::ratio<1, 3>>,
-                      cesium_iodide_with_ded<scalar_t, std::ratio<2, 3>>>
+    constexpr mixture<scalar, silicon_with_ded<scalar, std::ratio<1, 3>>,
+                      cesium_iodide_with_ded<scalar, std::ratio<2, 3>>>
         mix;
 
     static_assert(concepts::material_params<decltype(mix)>);
@@ -183,17 +183,17 @@ GTEST_TEST(detray_material, mixture2) {
     // For the moment, the mixture is not supposed to have density effect data
     // in any case
     EXPECT_EQ(mix.has_density_effect_data(), false);
-    EXPECT_EQ(mix.Ar(), silicon<scalar_t>().Ar() * 1.f / 3.f +
-                            cesium_iodide<scalar_t>().Ar() * 2.f / 3.f);
-    EXPECT_EQ(mix.Z(), silicon<scalar_t>().Z() * 1.f / 3.f +
-                           cesium_iodide<scalar_t>().Z() * 2.f / 3.f);
+    EXPECT_EQ(mix.Ar(), silicon<scalar>().Ar() * 1.f / 3.f +
+                            cesium_iodide<scalar>().Ar() * 2.f / 3.f);
+    EXPECT_EQ(mix.Z(), silicon<scalar>().Z() * 1.f / 3.f +
+                           cesium_iodide<scalar>().Z() * 2.f / 3.f);
 }
 
 // This tests the material slab functionalities
 GTEST_TEST(detray_material, material_slab) {
 
-    constexpr material_slab<scalar_t> slab(oxygen_gas<scalar_t>(),
-                                           2.f * unit<scalar_t>::mm);
+    constexpr material_slab<scalar> slab(oxygen_gas<scalar>(),
+                                         2.f * unit<scalar>::mm);
 
     static_assert(concepts::material_slab<decltype(slab)>);
     static_assert(concepts::homogeneous_material<decltype(slab)>);
@@ -201,9 +201,9 @@ GTEST_TEST(detray_material, material_slab) {
     static_assert(!concepts::volume_material<decltype(slab)>);
     static_assert(!concepts::material_map<decltype(slab)>);
 
-    const scalar_t cos_inc_ang{0.3f};
+    const scalar cos_inc_ang{0.3f};
 
-    EXPECT_NEAR(slab.path_segment(cos_inc_ang), 2.f * unit<scalar_t>::mm / 0.3f,
+    EXPECT_NEAR(slab.path_segment(cos_inc_ang), 2.f * unit<scalar>::mm / 0.3f,
                 tol);
     EXPECT_NEAR(slab.path_segment_in_X0(cos_inc_ang),
                 slab.path_segment(cos_inc_ang) / slab.get_material().X0(), tol);
@@ -215,8 +215,8 @@ GTEST_TEST(detray_material, material_slab) {
 GTEST_TEST(detray_material, material_rod) {
 
     // Rod with 1 mm radius
-    constexpr material_rod<scalar_t> rod(oxygen_gas<scalar_t>(),
-                                         1.f * unit<scalar_t>::mm);
+    constexpr material_rod<scalar> rod(oxygen_gas<scalar>(),
+                                       1.f * unit<scalar>::mm);
 
     static_assert(concepts::material_rod<decltype(rod)>);
     static_assert(concepts::homogeneous_material<decltype(rod)>);
@@ -233,18 +233,18 @@ GTEST_TEST(detray_material, material_rod) {
     // Create a track
     const point3 pos{-1.f / 6.f, -10.f, 0.f};
     const vector3 dir{0.f, 1.f, 3.f};
-    const free_track_parameters<algebra_t> trk(pos, 0.f, dir, -1.f);
+    const free_track_parameters<test_algebra> trk(pos, 0.f, dir, -1.f);
 
     // Infinite wire with 1 mm radial cell size
-    const mask<line_circular> ln{0u, 1.f * unit<scalar_t>::mm,
-                                 std::numeric_limits<scalar_t>::infinity()};
+    const mask<line_circular, test_algebra> ln{
+        0u, 1.f * unit<scalar>::mm, std::numeric_limits<scalar>::infinity()};
 
-    auto is = ray_intersector<line_circular, algebra_t, true>{}(
-        detail::ray<algebra_t>(trk), surface_descriptor<>{}, ln, tf);
+    auto is = ray_intersector<line_circular, test_algebra, true>{}(
+        detail::ray<test_algebra>(trk), surface_descriptor<>{}, ln, tf);
 
-    const scalar_t cos_inc_ang{std::abs(vector::dot(
-        line2D<algebra_t>::normal(tf, is.local), vector::normalize(dir)))};
-    const scalar_t approach{is.local[0]};
+    const scalar cos_inc_ang{std::abs(vector::dot(
+        line2D<test_algebra>::normal(tf, is.local), vector::normalize(dir)))};
+    const scalar approach{is.local[0]};
 
     EXPECT_NEAR(rod.path_segment(cos_inc_ang, approach),
                 2.f * std::sqrt(10.f - 10.f / 36.f), 1e-5f);

--- a/tests/unit_tests/cpu/material/stopping_power_derivative.cpp
+++ b/tests/unit_tests/cpu/material/stopping_power_derivative.cpp
@@ -18,6 +18,8 @@
 
 using namespace detray;
 
+using scalar = test::scalar;
+
 GTEST_TEST(detray_material, derivative_test_beta2) {
 
     const pdg_particle<scalar> ptc = muon<scalar>();

--- a/tests/unit_tests/cpu/navigation/brute_force_finder.cpp
+++ b/tests/unit_tests/cpu/navigation/brute_force_finder.cpp
@@ -28,6 +28,7 @@ namespace {
 vecmem::host_memory_resource host_mr;
 
 // Algebra definitions
+using scalar = test::scalar;
 using vector3 = test::vector3;
 
 /// A functor that performs some tests on a neighborhood of surfaces in a volume
@@ -100,7 +101,7 @@ GTEST_TEST(detray_navigation, brute_force_collection) {
 /// navigation
 GTEST_TEST(detray_navigation, brute_force_search) {
 
-    const auto [det, names] = build_toy_detector(host_mr);
+    const auto [det, names] = build_toy_detector<test::algebra>(host_mr);
 
     using detector_t = decltype(det);
     using context_t = detector_t::geometry_context;

--- a/tests/unit_tests/cpu/navigation/intersection/cuboid_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/cuboid_intersector.cpp
@@ -22,6 +22,8 @@ using namespace detray;
 
 namespace {
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using vector3 = test::vector3;
 using point3 = test::point3;
 
@@ -43,11 +45,12 @@ GTEST_TEST(detray_intersection, cuboid_aabb_intersector) {
     // Test ray
     const point3 pos{2.f, 1.f, 0.f};
     const vector3 mom{0.f, 0.f, 1.f};
-    const detail::ray<test::algebra> r(pos, 0.f, mom, 0.f);
+    const detail::ray<test_algebra> r(pos, 0.f, mom, 0.f);
 
     // The bounding box
-    mask<cuboid3D> c3{0u, x_min, y_min, z_min, x_max, y_max, z_max};
-    axis_aligned_bounding_volume<cuboid3D> aabb{c3, 0u, envelope};
+    mask<cuboid3D, test_algebra> c3{0u,    x_min, y_min, z_min,
+                                    x_max, y_max, z_max};
+    axis_aligned_bounding_volume<cuboid3D, test_algebra> aabb{c3, 0u, envelope};
 
     ASSERT_TRUE(aabb.intersect(r));
 }

--- a/tests/unit_tests/cpu/navigation/intersection/cylinder_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/cylinder_intersector.cpp
@@ -29,11 +29,12 @@ using namespace detray;
 namespace {
 
 // Three-dimensional definitions
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
 using transform3_t = test::transform3;
 using vector3 = test::vector3;
 using point3 = test::point3;
-using ray_t = detray::detail::ray<algebra_t>;
+using scalar = test::scalar;
+using ray_t = detray::detail::ray<test_algebra>;
 
 constexpr scalar not_defined = std::numeric_limits<scalar>::max();
 constexpr scalar tol{1e-5f};
@@ -47,7 +48,7 @@ const scalar hz{10.f};
 GTEST_TEST(detray_intersection, translated_cylinder) {
     // Create a translated cylinder and test untersection
     const transform3_t shifted(vector3{3.f, 2.f, 10.f});
-    ray_intersector<cylinder2D, algebra_t, true> ci;
+    ray_intersector<cylinder2D, test_algebra, true> ci;
 
     // Test ray
     const point3 ori = {3.f, 2.f, 5.f};
@@ -55,7 +56,8 @@ GTEST_TEST(detray_intersection, translated_cylinder) {
     ray_t ray(ori, 0.f, dir, 0.f);
 
     // Intersect:
-    mask<cylinder2D, std::uint_least16_t, algebra_t> cylinder{0u, r, -hz, hz};
+    mask<cylinder2D, test_algebra, std::uint_least16_t> cylinder{0u, r, -hz,
+                                                                 hz};
     const auto hits_bound =
         ci(ray, surface_descriptor<>{}, cylinder, shifted, tol, -not_defined);
 
@@ -99,10 +101,11 @@ GTEST_TEST(detray_intersection, cylinder_portal) {
 
     // Create a concentric cylinder and test intersection
     const transform3_t identity{};
-    mask<cylinder2D, std::uint_least16_t, algebra_t> cylinder{0u, r, -hz, hz};
+    mask<cylinder2D, test_algebra, std::uint_least16_t> cylinder{0u, r, -hz,
+                                                                 hz};
 
-    ray_intersector<cylinder2D, algebra_t, true> ci;
-    ray_intersector<concentric_cylinder2D, algebra_t, true> cpi;
+    ray_intersector<cylinder2D, test_algebra, true> ci;
+    ray_intersector<concentric_cylinder2D, test_algebra, true> cpi;
 
     // Intersect
     const auto hits_cylinrical =
@@ -143,10 +146,11 @@ GTEST_TEST(detray_intersection, concentric_cylinders) {
 
     // Create a concentric cylinder and test intersection
     const transform3_t identity{};
-    mask<cylinder2D, std::uint_least16_t, algebra_t> cylinder{0u, r, -hz, hz};
+    mask<cylinder2D, test_algebra, std::uint_least16_t> cylinder{0u, r, -hz,
+                                                                 hz};
 
-    ray_intersector<cylinder2D, algebra_t, true> ci;
-    ray_concentric_cylinder_intersector<algebra_t, true> cci;
+    ray_intersector<cylinder2D, test_algebra, true> ci;
+    ray_concentric_cylinder_intersector<test_algebra, true> cci;
 
     // Intersect
     const auto hits_cylinrical =

--- a/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
@@ -33,12 +33,13 @@ using namespace detray;
 namespace {
 
 // Three-dimensional definitions
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
 using transform3_t = test::transform3;
 using vector3 = test::vector3;
 using point3 = test::point3;
-using helix_t = detray::detail::helix<algebra_t>;
-using intersection_t = intersection2D<surface_descriptor<>, algebra_t, true>;
+using scalar = test::scalar;
+using helix_t = detray::detail::helix<test_algebra>;
+using intersection_t = intersection2D<surface_descriptor<>, test_algebra, true>;
 
 constexpr auto not_defined{detail::invalid_value<scalar>()};
 constexpr scalar tol{1e-4f};
@@ -47,7 +48,7 @@ constexpr scalar tol{1e-4f};
 const vector3 z_axis{0.f, 0.f, 1.f};
 
 // Track defined on origin point
-const free_track_parameters<algebra_t> free_trk(
+const free_track_parameters<test_algebra> free_trk(
     {0.f, 0.f, 0.f}, 0.f, {0.1f * unit<scalar>::GeV, 0.f, 0.f}, -1.f);
 
 // Magnetic field
@@ -77,11 +78,11 @@ GTEST_TEST(detray_intersection, helix_plane_intersector_no_bfield) {
     // Test helix
     const point3 pos{2.f, 1.f, 0.f};
     const vector3 mom{0.f, 0.f, 1.f};
-    const detail::helix<algebra_t> h({pos, 0.f, mom, -1.f}, &B_0);
+    const detail::helix<test_algebra> h({pos, 0.f, mom, -1.f}, &B_0);
 
     // The same test but bound to local frame
-    helix_intersector<unmasked<2>, algebra_t> pi;
-    mask<unmasked<2>> unmasked_bound{};
+    helix_intersector<unmasked<2>, test_algebra> pi;
+    mask<unmasked<2>, test_algebra> unmasked_bound{};
     const auto hit_bound =
         pi(h, surface_descriptor<>{}, unmasked_bound, shifted, tol);
 
@@ -97,7 +98,7 @@ GTEST_TEST(detray_intersection, helix_plane_intersector_no_bfield) {
     ASSERT_NEAR(hit_bound.local[1], -1.f, tol);
 
     // The same test but bound to local frame & masked - inside
-    mask<rectangle2D> rect_for_inside{0u, 3.f, 3.f};
+    mask<rectangle2D, test_algebra> rect_for_inside{0u, 3.f, 3.f};
     const auto hit_bound_inside =
         pi(h, surface_descriptor<>{}, rect_for_inside, shifted, tol);
     ASSERT_TRUE(hit_bound_inside.status);
@@ -112,7 +113,7 @@ GTEST_TEST(detray_intersection, helix_plane_intersector_no_bfield) {
     ASSERT_NEAR(hit_bound_inside.local[1], -1.f, tol);
 
     // The same test but bound to local frame & masked - outside
-    mask<rectangle2D> rect_for_outside{0u, 0.5f, 3.5f};
+    mask<rectangle2D, test_algebra> rect_for_outside{0u, 0.5f, 3.5f};
     const auto hit_bound_outside =
         pi(h, surface_descriptor<>{}, rect_for_outside, shifted, tol);
     ASSERT_FALSE(hit_bound_outside.status);
@@ -137,10 +138,10 @@ GTEST_TEST(detray_intersection, helix_plane_intersector) {
     const transform3_t trf(trl, w, v);
 
     // Rectangle surface
-    const mask<rectangle2D> rectangle{0u, 10.f * unit<scalar>::cm,
-                                      10.f * unit<scalar>::cm};
+    const mask<rectangle2D, test_algebra> rectangle{0u, 10.f * unit<scalar>::cm,
+                                                    10.f * unit<scalar>::cm};
 
-    const helix_intersector<rectangle2D, algebra_t> hpi;
+    const helix_intersector<rectangle2D, test_algebra> hpi;
 
     // Get the intersection on the next surface
     const auto is = hpi(hlx, surface_descriptor<>{}, rectangle, trf, tol);
@@ -165,7 +166,7 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector_no_bfield) {
 
     // Create a translated cylinder and test untersection
     const transform3_t shifted(vector3{3.f, 2.f, 10.f});
-    helix_intersector<cylinder2D, algebra_t> hi;
+    helix_intersector<cylinder2D, test_algebra> hi;
 
     // Test helix
     const point3 pos{3.f, 2.f, 5.f};
@@ -174,7 +175,8 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector_no_bfield) {
                     &B_0);
 
     // Intersect
-    mask<cylinder2D, std::uint_least16_t, algebra_t> cylinder{0u, r, -hz, hz};
+    mask<cylinder2D, test_algebra, std::uint_least16_t> cylinder{0u, r, -hz,
+                                                                 hz};
     const auto hits_bound =
         hi(h, surface_descriptor<>{}, cylinder, shifted, tol);
 
@@ -217,9 +219,9 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector) {
     // Cylinder surface (5 cm radius)
     const scalar r{4.f * unit<scalar>::cm};
     const scalar hz{10.f * unit<scalar>::cm};
-    const mask<cylinder2D> cylinder{0u, r, -hz, hz};
+    const mask<cylinder2D, test_algebra> cylinder{0u, r, -hz, hz};
 
-    const helix_intersector<cylinder2D, algebra_t> hci;
+    const helix_intersector<cylinder2D, test_algebra> hci;
 
     // Get the intersection on the next surface
     const auto is = hci(hlx, surface_descriptor<>{}, cylinder, trf, tol);
@@ -266,7 +268,7 @@ GTEST_TEST(detray_intersection,
 
     // Create a translated cylinder and test untersection
     const transform3_t identity{};
-    helix_intersector<concentric_cylinder2D, algebra_t> c_hi;
+    helix_intersector<concentric_cylinder2D, test_algebra> c_hi;
 
     // Test helix
     const point3 pos{0.f, 0.f, -5.f};
@@ -275,7 +277,7 @@ GTEST_TEST(detray_intersection,
                     &B_0);
 
     // Intersect
-    mask<concentric_cylinder2D, std::uint_least16_t, algebra_t> cylinder{
+    mask<concentric_cylinder2D, test_algebra, std::uint_least16_t> cylinder{
         0u, r, -hz, hz};
     const auto hits_bound =
         c_hi(h, surface_descriptor<>{}, cylinder, identity, tol);
@@ -316,7 +318,7 @@ GTEST_TEST(detray_intersection,
 GTEST_TEST(detray_intersection, helix_line_intersector) {
 
     // Intersector object
-    const helix_intersector<line_circular, algebra_t> hli;
+    const helix_intersector<line_circular, test_algebra> hli;
 
     // Get radius of track
     const scalar R{hlx.radius()};
@@ -329,10 +331,10 @@ GTEST_TEST(detray_intersection, helix_line_intersector) {
     const scalar half_z = std::numeric_limits<scalar>::max();
 
     // Straw wire
-    const mask<line_circular> straw_tube{0u, scope, half_z};
+    const mask<line_circular, test_algebra> straw_tube{0u, scope, half_z};
 
     // Cell wire
-    const mask<line_square> drift_cell{0u, scope, half_z};
+    const mask<line_square, test_algebra> drift_cell{0u, scope, half_z};
 
     // Offset to shift the translation of transform matrix
     const scalar offset = 1.f * unit<scalar>::cm;

--- a/tests/unit_tests/cpu/navigation/intersection/helix_trajectory.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/helix_trajectory.cpp
@@ -21,12 +21,14 @@
 
 using namespace detray;
 
+using scalar = test::scalar;
+
 constexpr const scalar tol{1e-5f};
 
 // This tests the base functionality of the Helix Gun
 GTEST_TEST(detray_intersection, helix_trajectory) {
 
-    using algebra_t = test::algebra;
+    using test_algebra = test::algebra;
     using vector3 = test::vector3;
     using point3 = test::point3;
 
@@ -36,7 +38,7 @@ GTEST_TEST(detray_intersection, helix_trajectory) {
     const scalar q{static_cast<scalar>(-1.) * unit<scalar>::e};
 
     // vertex
-    free_track_parameters<algebra_t> vertex(pos, time, mom, q);
+    free_track_parameters<test_algebra> vertex(pos, time, mom, q);
 
     // magnetic field
     const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
@@ -113,7 +115,7 @@ GTEST_TEST(detray_intersection, helix_trajectory) {
      * Same test with oppsite charge
      *********************************/
 
-    free_track_parameters<algebra_t> vertex2(pos, time, mom, -q);
+    free_track_parameters<test_algebra> vertex2(pos, time, mom, -q);
 
     // helix trajectory
     detail::helix helix_traj2(vertex2, &B);
@@ -171,7 +173,7 @@ GTEST_TEST(detray_intersection, helix_trajectory) {
 
 GTEST_TEST(detray_intersection, helix_trajectory_small_pT) {
 
-    using algebra_t = test::algebra;
+    using test_algebra = test::algebra;
     using vector3 = test::vector3;
     using point3 = test::point3;
 
@@ -181,7 +183,7 @@ GTEST_TEST(detray_intersection, helix_trajectory_small_pT) {
     const scalar q{static_cast<scalar>(-1.) * unit<scalar>::e};
 
     // vertex
-    free_track_parameters<algebra_t> vertex(pos, time, mom, q);
+    free_track_parameters<test_algebra> vertex(pos, time, mom, q);
 
     // magnetic field
     const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
@@ -203,7 +205,7 @@ GTEST_TEST(detray_intersection, helix_trajectory_small_pT) {
 
 GTEST_TEST(detray_intersection, helix_direction_stability) {
 
-    using algebra_t = test::algebra;
+    using test_algebra = test::algebra;
     using vector3 = test::vector3;
     using point3 = test::point3;
 
@@ -217,7 +219,7 @@ GTEST_TEST(detray_intersection, helix_direction_stability) {
     const scalar q{static_cast<scalar>(-1.) * unit<scalar>::e};
 
     // vertex
-    free_track_parameters<algebra_t> vertex(pos, time, mom, q);
+    free_track_parameters<test_algebra> vertex(pos, time, mom, q);
 
     // helix trajectory
     detail::helix hlx(vertex, &B);

--- a/tests/unit_tests/cpu/navigation/intersection/intersection2D.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection2D.cpp
@@ -22,6 +22,8 @@
 
 using namespace detray;
 
+using scalar = test::scalar;
+
 namespace {
 
 /// Define mask types
@@ -38,21 +40,22 @@ constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
 
 }  // namespace
 
-using algebra_t = test::algebra;
-using scalar_t = dscalar<algebra_t>;
+using test_algebra = test::algebra;
+using scalar_t = dscalar<test_algebra>;
 using point2 = test::point2;
 using vector3 = test::vector3;
 using point3 = test::point3;
 
 using mask_link_t = dtyped_index<mask_ids, dindex>;
 using material_link_t = dtyped_index<material_ids, dindex>;
-using surface_t = surface_descriptor<mask_link_t, material_link_t, algebra_t>;
+using surface_t =
+    surface_descriptor<mask_link_t, material_link_t, test_algebra>;
 
 // This tests the construction of a intresection
 GTEST_TEST(detray_intersection, intersection2D) {
 
-    using intersection_t = intersection2D<surface_t, algebra_t, true>;
-    using nominal_inters_t = intersection2D<surface_t, algebra_t, false>;
+    using intersection_t = intersection2D<surface_t, test_algebra, true>;
+    using nominal_inters_t = intersection2D<surface_t, test_algebra, false>;
 
     // Check memory layout of intersection struct
     static_assert(offsetof(nominal_inters_t, sf_desc) == 0);

--- a/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
@@ -27,14 +27,16 @@
 using namespace detray;
 
 // Three-dimensional definitions
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
 using transform3 = test::transform3;
 using cartesian = cartesian2D<transform3>;
 using vector3 = test::vector3;
 using point3 = test::point3;
 using point2 = test::point2;
-using intersection_t = intersection2D<surface_descriptor<>, algebra_t, true>;
-using line_intersector_type = ray_intersector<line_circular, algebra_t, true>;
+using scalar = test::scalar;
+using intersection_t = intersection2D<surface_descriptor<>, test_algebra, true>;
+using line_intersector_type =
+    ray_intersector<line_circular, test_algebra, true>;
 
 constexpr scalar tol{1e-5f};
 
@@ -44,7 +46,7 @@ GTEST_TEST(detray_intersection, line_intersector_case1) {
     const transform3 tf{};
 
     // Create a track
-    std::vector<free_track_parameters<algebra_t>> trks;
+    std::vector<free_track_parameters<test_algebra>> trks;
     trks.emplace_back(point3{1.f, -1.f, 0.f}, 0.f, vector3{0.f, 1.f, 0.f},
                       -1.f);
     trks.emplace_back(point3{-1.f, -1.f, 0.f}, 0.f, vector3{0.f, 1.f, 0.f},
@@ -53,8 +55,8 @@ GTEST_TEST(detray_intersection, line_intersector_case1) {
                       -1.f);
 
     // Infinite wire with 10 mm radial cell size
-    const mask<line_circular> ln{0u, 10.f,
-                                 std::numeric_limits<scalar>::infinity()};
+    const mask<line_circular, test_algebra> ln{
+        0u, 10.f, std::numeric_limits<scalar>::infinity()};
 
     // Test intersect
     std::vector<intersection_t> is(3u);
@@ -104,16 +106,16 @@ GTEST_TEST(detray_intersection, line_intersector_case2) {
     // Create a track
     const point3 pos{1.f, -1.f, 0.f};
     const vector3 dir{0.f, 1.f, 0.f};
-    const free_track_parameters<algebra_t> trk(pos, 0.f, dir, -1.f);
+    const free_track_parameters<test_algebra> trk(pos, 0.f, dir, -1.f);
 
     // Infinite wire with 10 mm
     // radial cell size
-    const mask<line_circular> ln{0u, 10.f,
-                                 std::numeric_limits<scalar>::infinity()};
+    const mask<line_circular, test_algebra> ln{
+        0u, 10.f, std::numeric_limits<scalar>::infinity()};
 
     // Test intersect
     const intersection_t is = line_intersector_type()(
-        detail::ray<algebra_t>(trk), surface_descriptor<>{}, ln, tf, tol);
+        detail::ray<test_algebra>(trk), surface_descriptor<>{}, ln, tf, tol);
 
     EXPECT_TRUE(is.status);
     EXPECT_NEAR(is.path, 2.f, tol);
@@ -131,7 +133,7 @@ GTEST_TEST(detray_intersection, line_intersector_square_scope) {
     const transform3 tf{};
 
     /// Create a track
-    std::vector<free_track_parameters<algebra_t>> trks;
+    std::vector<free_track_parameters<test_algebra>> trks;
     trks.emplace_back(point3{2.f, 0.f, 0.f}, 0.f, vector3{-1.f, 1.f, 0.f},
                       -1.f);
     trks.emplace_back(point3{1.9f, 0.f, 0.f}, 0.f, vector3{-1.f, 1.f, 0.f},
@@ -161,14 +163,15 @@ GTEST_TEST(detray_intersection, line_intersector_square_scope) {
                       -1.f);
 
     // Infinite wire with 1 mm square cell size
-    mask<line_square, std::uint_least16_t, algebra_t> ln{
+    mask<line_square, test_algebra, std::uint_least16_t> ln{
         0u, 1.f, std::numeric_limits<scalar>::infinity()};
 
     // Test intersect
     std::vector<intersection_t> is;
     for (const auto& trk : trks) {
-        is.push_back(line_intersector_type()(
-            detail::ray<algebra_t>(trk), surface_descriptor<>{}, ln, tf, tol));
+        is.push_back(line_intersector_type()(detail::ray<test_algebra>(trk),
+                                             surface_descriptor<>{}, ln, tf,
+                                             tol));
     }
 
     EXPECT_TRUE(is[0].status);

--- a/tests/unit_tests/cpu/navigation/intersection/plane_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/plane_intersector.cpp
@@ -26,9 +26,10 @@
 using namespace detray;
 
 // Three-dimensional definitions
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
 using vector3 = test::vector3;
 using point3 = test::point3;
+using scalar = test::scalar;
 using transform3 = test::transform3;
 
 constexpr scalar tol{std::numeric_limits<scalar>::epsilon()};
@@ -41,11 +42,11 @@ GTEST_TEST(detray_intersection, translated_plane_ray) {
     // Test ray
     const point3 pos{2.f, 1.f, 0.f};
     const vector3 mom{0.f, 0.f, 1.f};
-    const detail::ray<algebra_t> r(pos, 0.f, mom, 0.f);
+    const detail::ray<test_algebra> r(pos, 0.f, mom, 0.f);
 
     // The same test but bound to local frame
-    ray_intersector<unmasked<2>, algebra_t, true> pi;
-    mask<unmasked<2>> unmasked_bound{};
+    ray_intersector<unmasked<2>, test_algebra, true> pi;
+    mask<unmasked<2>, test_algebra> unmasked_bound{};
     const auto hit_bound =
         pi(r, surface_descriptor<>{}, unmasked_bound, shifted);
 
@@ -61,7 +62,7 @@ GTEST_TEST(detray_intersection, translated_plane_ray) {
     ASSERT_NEAR(hit_bound.local[1], -1.f, tol);
 
     // The same test but bound to local frame & masked - inside
-    mask<rectangle2D> rect_for_inside{0u, 3.f, 3.f};
+    mask<rectangle2D, test_algebra> rect_for_inside{0u, 3.f, 3.f};
     const auto hit_bound_inside =
         pi(r, surface_descriptor<>{}, rect_for_inside, shifted, tol);
     ASSERT_TRUE(hit_bound_inside.status);
@@ -76,7 +77,7 @@ GTEST_TEST(detray_intersection, translated_plane_ray) {
     ASSERT_NEAR(hit_bound_inside.local[1], -1.f, tol);
 
     // The same test but bound to local frame & masked - outside
-    mask<rectangle2D> rect_for_outside{0u, 0.5f, 3.5f};
+    mask<rectangle2D, test_algebra> rect_for_outside{0u, 0.5f, 3.5f};
     const auto hit_bound_outside =
         pi(r, surface_descriptor<>{}, rect_for_outside, shifted, tol);
     ASSERT_FALSE(hit_bound_outside.status);

--- a/tests/unit_tests/cpu/navigation/navigator.cpp
+++ b/tests/unit_tests/cpu/navigation/navigator.cpp
@@ -68,7 +68,7 @@ inline void check_on_surface(state_t &state, dindex vol_id,
     ASSERT_TRUE(state.status() == navigation::status::e_on_module ||
                 state.status() == navigation::status::e_on_portal);
     // Points towards next candidate
-    ASSERT_TRUE(std::abs(state()) >= 1.f * unit<scalar>::um);
+    ASSERT_TRUE(std::abs(state()) >= 1.f * unit<test::scalar>::um);
     ASSERT_EQ(state.volume(), vol_id);
     ASSERT_EQ(state.n_candidates(), std::min(n_candidates, cache_size - 1));
     ASSERT_EQ(state.barcode().volume(), vol_id);
@@ -124,7 +124,8 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
     using namespace detray;
     using namespace detray::navigation;
 
-    using algebra_t = test::algebra;
+    using test_algebra = test::algebra;
+    using scalar = test::scalar;
     using point3 = test::point3;
     using vector3 = test::vector3;
 
@@ -133,13 +134,13 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
     /// Tolerance for tests
     constexpr double tol{0.01};
 
-    auto [toy_det, names] = build_toy_detector(host_mr);
+    auto [toy_det, names] = build_toy_detector<test_algebra>(host_mr);
 
     using detector_t = decltype(toy_det);
     using inspector_t = navigation::print_inspector;
     using navigator_t = navigator<detector_t, cache_size, inspector_t>;
-    using constraint_t = constrained_step<>;
-    using stepper_t = line_stepper<algebra_t, constraint_t>;
+    using constraint_t = constrained_step<scalar>;
+    using stepper_t = line_stepper<test_algebra, constraint_t>;
 
     // State type in the nominal navigation (no inspectors)
     using nav_stat_t = navigator<detector_t, cache_size>::state;
@@ -152,7 +153,7 @@ GTEST_TEST(detray_navigation, navigator_toy_geometry) {
     // test track
     point3 pos{0.f, 0.f, 0.f};
     vector3 mom{1.f, 1.f, 0.f};
-    free_track_parameters<algebra_t> traj(pos, 0.f, mom, -1.f);
+    free_track_parameters<test_algebra> traj(pos, 0.f, mom, -1.f);
 
     stepper_t stepper;
     navigator_t nav;
@@ -324,7 +325,8 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
     using namespace detray;
     using namespace detray::navigation;
 
-    using algebra_t = test::algebra;
+    using test_algebra = test::algebra;
+    using scalar = test::scalar;
     using point3 = test::point3;
     using vector3 = test::vector3;
 
@@ -334,19 +336,20 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
     constexpr double tol{0.01};
 
     constexpr std::size_t n_layers{10};
-    wire_chamber_config<> wire_cfg{};
-    auto [wire_det, names] = build_wire_chamber(host_mr, wire_cfg);
+    wire_chamber_config<scalar> wire_cfg{};
+    auto [wire_det, names] =
+        build_wire_chamber<test_algebra>(host_mr, wire_cfg);
 
     using detector_t = decltype(wire_det);
     using inspector_t = navigation::print_inspector;
     using navigator_t = navigator<detector_t, cache_size, inspector_t>;
-    using constraint_t = constrained_step<>;
-    using stepper_t = line_stepper<algebra_t, constraint_t>;
+    using constraint_t = constrained_step<scalar>;
+    using stepper_t = line_stepper<test_algebra, constraint_t>;
 
     // test track
     point3 pos{0.f, 0.f, 0.f};
     vector3 mom{0.f, 1.f, 0.f};
-    free_track_parameters<algebra_t> traj(pos, 0.f, mom, -1.f);
+    free_track_parameters<test_algebra> traj(pos, 0.f, mom, -1.f);
 
     stepper_t stepper;
     navigator_t nav;

--- a/tests/unit_tests/cpu/navigation/volume_graph.cpp
+++ b/tests/unit_tests/cpu/navigation/volume_graph.cpp
@@ -26,12 +26,14 @@
 GTEST_TEST(detray_navigation, volume_graph) {
     using namespace detray;
 
+    using test_algebra = test::algebra;
+
     vecmem::host_memory_resource host_mr;
 
-    toy_det_config toy_cfg{};
+    toy_det_config<test::scalar> toy_cfg{};
     toy_cfg.n_edc_layers(1u);
 
-    auto [det, names] = build_toy_detector(host_mr, toy_cfg);
+    auto [det, names] = build_toy_detector<test_algebra>(host_mr, toy_cfg);
 
     using detector_t = decltype(det);
 

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -34,19 +34,21 @@
 using namespace detray;
 
 // Algebra types
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point2 = test::point2;
 using vector3 = test::vector3;
 
 // Mask types to be tested
 // @TODO: Remove unbounded tag
-using annulus_type = detray::mask<detray::unbounded<detray::annulus2D>>;
-using rectangle_type = detray::mask<detray::rectangle2D>;
-using trapezoid_type = detray::mask<detray::trapezoid2D>;
-using ring_type = detray::mask<detray::ring2D>;
-using cylinder_type = detray::mask<detray::cylinder2D>;
-using straw_tube_type = detray::mask<detray::line_circular>;
-using drift_cell_type = detray::mask<detray::line_square>;
+using annulus_type =
+    detray::mask<detray::unbounded<detray::annulus2D>, test_algebra>;
+using rectangle_type = detray::mask<detray::rectangle2D, test_algebra>;
+using trapezoid_type = detray::mask<detray::trapezoid2D, test_algebra>;
+using ring_type = detray::mask<detray::ring2D, test_algebra>;
+using cylinder_type = detray::mask<detray::cylinder2D, test_algebra>;
+using straw_tube_type = detray::mask<detray::line_circular, test_algebra>;
+using drift_cell_type = detray::mask<detray::line_square, test_algebra>;
 
 constexpr scalar tol{1e-6f};
 
@@ -55,43 +57,45 @@ GTEST_TEST(detray_propagator, covariance_transport) {
     vecmem::host_memory_resource host_mr;
 
     // Build in x-direction from given module positions
-    detail::ray<algebra_t> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
+    detail::ray<test_algebra> traj{{0.f, 0.f, 0.f}, 0.f, {1.f, 0.f, 0.f}, -1.f};
     std::vector<scalar> positions = {0.f, 10.f, 20.f, 30.f, 40.f, 50.f, 60.f};
 
-    tel_det_config<rectangle2D> tel_cfg{200.f * unit<scalar>::mm,
-                                        200.f * unit<scalar>::mm};
+    tel_det_config<test_algebra, rectangle2D> tel_cfg{200.f * unit<scalar>::mm,
+                                                      200.f * unit<scalar>::mm};
     tel_cfg.positions(positions).pilot_track(traj);
 
     // Build telescope detector with unbounded planes
-    const auto [det, names] = build_telescope_detector(host_mr, tel_cfg);
+    const auto [det, names] =
+        build_telescope_detector<test_algebra>(host_mr, tel_cfg);
 
     using navigator_t = navigator<decltype(det)>;
-    using cline_stepper_t = line_stepper<algebra_t>;
-    using actor_chain_t = actor_chain<dtuple, parameter_transporter<algebra_t>,
-                                      parameter_resetter<algebra_t>>;
+    using cline_stepper_t = line_stepper<test_algebra>;
+    using actor_chain_t =
+        actor_chain<dtuple, parameter_transporter<test_algebra>,
+                    parameter_resetter<test_algebra>>;
     using propagator_t =
         propagator<cline_stepper_t, navigator_t, actor_chain_t>;
 
     // Bound vector
-    bound_parameters_vector<algebra_t> bound_vector{};
+    bound_parameters_vector<test_algebra> bound_vector{};
     bound_vector.set_theta(constant<scalar>::pi_4);
     bound_vector.set_qop(-0.1f);
 
     // Bound covariance
     auto bound_cov = matrix::identity<
-        typename bound_track_parameters<algebra_t>::covariance_type>();
+        typename bound_track_parameters<test_algebra>::covariance_type>();
 
     // Note: Set angle error as ZERO, to constrain the loc0 and loc1 divergence
     getter::element(bound_cov, e_bound_phi, e_bound_phi) = 0.f;
     getter::element(bound_cov, e_bound_theta, e_bound_theta) = 0.f;
 
     // Bound track parameter
-    const bound_track_parameters<algebra_t> bound_param0(
+    const bound_track_parameters<test_algebra> bound_param0(
         geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
 
     // Actors
-    parameter_transporter<algebra_t>::state bound_updater{};
-    parameter_resetter<algebra_t>::state rst{};
+    parameter_transporter<test_algebra>::state bound_updater{};
+    parameter_resetter<test_algebra>::state rst{};
 
     propagation::config prop_cfg{};
     prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;

--- a/tests/unit_tests/cpu/propagator/jacobian_cartesian.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_cartesian.cpp
@@ -21,7 +21,8 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point3 = test::point3;
 using vector3 = test::vector3;
 using transform3 = test::transform3;
@@ -31,7 +32,7 @@ const scalar isclose{1e-5f};
 // This test cartesian2D coordinate
 GTEST_TEST(detray_propagator, jacobian_cartesian2D) {
 
-    using jac_engine = detail::jacobian_engine<cartesian2D<algebra_t>>;
+    using jac_engine = detail::jacobian_engine<cartesian2D<test_algebra>>;
 
     // Preparation work
     const vector3 z = {0.f, 0.f, 1.f};
@@ -44,14 +45,15 @@ GTEST_TEST(detray_propagator, jacobian_cartesian2D) {
     const scalar charge{-1.f};
 
     const scalar h{2.f};
-    mask<rectangle2D> rect{0u, h, h};
+    mask<rectangle2D, test_algebra> rect{0u, h, h};
 
     // Free track parameter
-    const free_track_parameters<algebra_t> free_params(global1, time, mom,
-                                                       charge);
+    const free_track_parameters<test_algebra> free_params(global1, time, mom,
+                                                          charge);
 
     const auto bound_vec =
-        detail::free_to_bound_vector<cartesian2D<algebra_t>>(trf, free_params);
+        detail::free_to_bound_vector<cartesian2D<test_algebra>>(trf,
+                                                                free_params);
     const auto free_params2 =
         detail::bound_to_free_vector(trf, rect, bound_vec);
 
@@ -69,7 +71,7 @@ GTEST_TEST(detray_propagator, jacobian_cartesian2D) {
     }
 
     // Test Jacobian transformation
-    const bound_matrix<algebra_t> J =
+    const bound_matrix<test_algebra> J =
         jac_engine::free_to_bound_jacobian(trf, free_params) *
         jac_engine::bound_to_free_jacobian(trf, rect, bound_vec);
 

--- a/tests/unit_tests/cpu/propagator/jacobian_cylindrical.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_cylindrical.cpp
@@ -24,7 +24,8 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point3 = test::point3;
 using vector3 = test::vector3;
 using transform3 = test::transform3;
@@ -34,7 +35,7 @@ constexpr scalar isclose{1e-5f};
 // This test cylindrical2D coordinate
 GTEST_TEST(detray_propagator, jacobian_cylindrical2D) {
 
-    using jac_engine = detail::jacobian_engine<cylindrical2D<algebra_t>>;
+    using jac_engine = detail::jacobian_engine<cylindrical2D<test_algebra>>;
 
     // Preparation work
     const vector3 z = {0.f, 0.f, 1.f};
@@ -49,15 +50,15 @@ GTEST_TEST(detray_propagator, jacobian_cylindrical2D) {
 
     const scalar r{2.f};
     const scalar hz{detail::invalid_value<scalar>()};
-    mask<cylinder2D> cyl{0u, r, -hz, hz};
+    mask<cylinder2D, test_algebra> cyl{0u, r, -hz, hz};
 
     // Free track parameter
-    const free_track_parameters<algebra_t> free_params(global1, time, mom,
-                                                       charge);
+    const free_track_parameters<test_algebra> free_params(global1, time, mom,
+                                                          charge);
 
     const auto bound_vec =
-        detail::free_to_bound_vector<cylindrical2D<algebra_t>>(trf,
-                                                               free_params);
+        detail::free_to_bound_vector<cylindrical2D<test_algebra>>(trf,
+                                                                  free_params);
     const auto free_params2 = detail::bound_to_free_vector(trf, cyl, bound_vec);
 
     // Check if the bound vector is correct
@@ -75,7 +76,7 @@ GTEST_TEST(detray_propagator, jacobian_cylindrical2D) {
     }
 
     // Test Jacobian transformation
-    const bound_matrix<algebra_t> J =
+    const bound_matrix<test_algebra> J =
         jac_engine::free_to_bound_jacobian(trf, free_params) *
         jac_engine::bound_to_free_jacobian(trf, cyl, bound_vec);
 

--- a/tests/unit_tests/cpu/propagator/jacobian_line.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_line.cpp
@@ -21,7 +21,8 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point2 = test::point2;
 using point3 = test::point3;
 using vector3 = test::vector3;
@@ -31,11 +32,11 @@ constexpr scalar isclose{1e-5f};
 
 const scalar r{2.f};
 const scalar hz{50.f};
-const mask<line<>> ln{0u, r, hz};
+const mask<line<>, test_algebra> ln{0u, r, hz};
 
 GTEST_TEST(detray_propagator, jacobian_line2D_case1) {
 
-    using jac_engine = detail::jacobian_engine<line2D<algebra_t>>;
+    using jac_engine = detail::jacobian_engine<line2D<test_algebra>>;
 
     // Preparation work
     vector3 z = {1.f, 1.f, 1.f};
@@ -50,11 +51,11 @@ GTEST_TEST(detray_propagator, jacobian_line2D_case1) {
     const scalar charge{-1.f};
 
     // Free track parameter
-    const free_track_parameters<algebra_t> free_params(global1, time, mom,
-                                                       charge);
+    const free_track_parameters<test_algebra> free_params(global1, time, mom,
+                                                          charge);
 
     const auto bound_vec =
-        detail::free_to_bound_vector<line2D<algebra_t>>(trf, free_params);
+        detail::free_to_bound_vector<line2D<test_algebra>>(trf, free_params);
     const auto free_params2 = detail::bound_to_free_vector(trf, ln, bound_vec);
 
     // Check if the bound vector is correct
@@ -73,7 +74,7 @@ GTEST_TEST(detray_propagator, jacobian_line2D_case1) {
     }
 
     // Test Jacobian transformation
-    const bound_matrix<algebra_t> J =
+    const bound_matrix<test_algebra> J =
         jac_engine::free_to_bound_jacobian(trf, free_params) *
         jac_engine::bound_to_free_jacobian(trf, ln, bound_vec);
 
@@ -90,7 +91,7 @@ GTEST_TEST(detray_propagator, jacobian_line2D_case1) {
 
 GTEST_TEST(detray_coordinates, jacobian_line2D_case2) {
 
-    using jac_engine = detail::jacobian_engine<line2D<algebra_t>>;
+    using jac_engine = detail::jacobian_engine<line2D<test_algebra>>;
 
     // Preparation work
     vector3 z = {1.f, 2.f, 3.f};
@@ -107,16 +108,16 @@ GTEST_TEST(detray_coordinates, jacobian_line2D_case2) {
     const point2 bound1 = {1.f, 2.f};
 
     const point3 global =
-        line2D<algebra_t>::local_to_global(trf, ln, bound1, d);
+        line2D<test_algebra>::local_to_global(trf, ln, bound1, d);
 
     // Free track parameter
-    const free_track_parameters<algebra_t> free_params(global, time, mom,
-                                                       charge);
+    const free_track_parameters<test_algebra> free_params(global, time, mom,
+                                                          charge);
     const auto bound_vec =
-        detail::free_to_bound_vector<line2D<algebra_t>>(trf, free_params);
+        detail::free_to_bound_vector<line2D<test_algebra>>(trf, free_params);
 
     // Test Jacobian transformation
-    const bound_matrix<algebra_t> J =
+    const bound_matrix<test_algebra> J =
         jac_engine::free_to_bound_jacobian(trf, free_params) *
         jac_engine::bound_to_free_jacobian(trf, ln, bound_vec);
 

--- a/tests/unit_tests/cpu/propagator/jacobian_polar.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_polar.cpp
@@ -21,7 +21,8 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point3 = test::point3;
 using vector3 = test::vector3;
 using transform3 = test::transform3;
@@ -31,7 +32,7 @@ const scalar isclose{1e-5f};
 // This test polar2D coordinate
 GTEST_TEST(detray_propagator, jacobian_polar2D) {
 
-    using jac_engine = detail::jacobian_engine<polar2D<algebra_t>>;
+    using jac_engine = detail::jacobian_engine<polar2D<test_algebra>>;
 
     // Preparation work
     const vector3 z = {0.f, 0.f, 1.f};
@@ -44,13 +45,13 @@ GTEST_TEST(detray_propagator, jacobian_polar2D) {
     const scalar charge{static_cast<scalar>(-1.)};
 
     const scalar r{2.f};
-    mask<ring2D> rng{0u, 0.f, r};
+    mask<ring2D, test_algebra> rng{0u, 0.f, r};
 
     // Free track parameter
-    const free_track_parameters<algebra_t> free_params(global1, time, mom,
-                                                       charge);
+    const free_track_parameters<test_algebra> free_params(global1, time, mom,
+                                                          charge);
     const auto bound_vec =
-        detail::free_to_bound_vector<polar2D<algebra_t>>(trf, free_params);
+        detail::free_to_bound_vector<polar2D<test_algebra>>(trf, free_params);
     const auto free_params2 = detail::bound_to_free_vector(trf, rng, bound_vec);
 
     // Check if the bound vector is correct
@@ -69,7 +70,7 @@ GTEST_TEST(detray_propagator, jacobian_polar2D) {
     }
 
     // Test Jacobian transformation
-    const bound_matrix<algebra_t> J =
+    const bound_matrix<test_algebra> J =
         jac_engine::free_to_bound_jacobian(trf, free_params) *
         jac_engine::bound_to_free_jacobian(trf, rng, bound_vec);
 

--- a/tests/unit_tests/cpu/propagator/line_stepper.cpp
+++ b/tests/unit_tests/cpu/propagator/line_stepper.cpp
@@ -20,7 +20,8 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using vector3 = test::vector3;
 using point3 = test::point3;
 using transform3 = test::transform3;
@@ -38,13 +39,14 @@ GTEST_TEST(detray_propagator, line_stepper) {
     using namespace step;
 
     // Line stepper with and without constrained stepping
-    using line_stepper_t = line_stepper<algebra_t>;
-    using cline_stepper_t = line_stepper<algebra_t, constrained_step<>>;
+    using line_stepper_t = line_stepper<test_algebra>;
+    using cline_stepper_t =
+        line_stepper<test_algebra, constrained_step<scalar>>;
 
     point3 pos{0.f, 0.f, 0.f};
     vector3 mom{1.f, 1.f, 0.f};
-    free_track_parameters<algebra_t> track(pos, 0.f, mom, -1.f);
-    free_track_parameters<algebra_t> c_track(pos, 0.f, mom, -1.f);
+    free_track_parameters<test_algebra> track(pos, 0.f, mom, -1.f);
+    free_track_parameters<test_algebra> c_track(pos, 0.f, mom, -1.f);
 
     line_stepper_t l_stepper;
     cline_stepper_t cl_stepper;

--- a/tests/unit_tests/cpu/propagator/rk_stepper.cpp
+++ b/tests/unit_tests/cpu/propagator/rk_stepper.cpp
@@ -31,26 +31,25 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
-using scalar_t = test::scalar;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using vector3 = test::vector3;
 using point3 = test::point3;
 
 /// Runge-Kutta stepper
 template <typename bfield_t>
-using rk_stepper_t = rk_stepper<typename bfield_t::view_t, algebra_t>;
+using rk_stepper_t = rk_stepper<typename bfield_t::view_t, test_algebra>;
 template <typename bfield_t>
-using crk_stepper_t =
-    rk_stepper<typename bfield_t::view_t, algebra_t, constrained_step<>>;
+using crk_stepper_t = rk_stepper<typename bfield_t::view_t, test_algebra,
+                                 constrained_step<scalar>>;
 
 namespace {
 
-constexpr scalar_t tol{1e-3f};
+constexpr scalar tol{1e-3f};
 
 const stepping::config step_cfg{};
-constexpr scalar_t step_size{1.f * unit<scalar_t>::mm};
-constexpr material<scalar_t> vol_mat{
-    detray::cesium_iodide_with_ded<scalar_t>()};
+constexpr scalar step_size{1.f * unit<scalar>::mm};
+constexpr material<scalar> vol_mat{detray::cesium_iodide_with_ded<scalar>()};
 
 }  // namespace
 
@@ -59,11 +58,11 @@ GTEST_TEST(detray_propagator, rk_stepper) {
     using namespace step;
 
     // Constant magnetic field
-    using bfield_t = bfield::const_field_t;
+    using bfield_t = bfield::const_field_t<scalar>;
 
-    vector3 B{1.f * unit<scalar_t>::T, 1.f * unit<scalar_t>::T,
-              1.f * unit<scalar_t>::T};
-    const bfield_t hom_bfield = bfield::create_const_field(B);
+    vector3 B{1.f * unit<scalar>::T, 1.f * unit<scalar>::T,
+              1.f * unit<scalar>::T};
+    const bfield_t hom_bfield = bfield::create_const_field<scalar>(B);
 
     // RK stepper
     rk_stepper_t<bfield_t> rk_stepper;
@@ -71,18 +70,19 @@ GTEST_TEST(detray_propagator, rk_stepper) {
 
     // RK stepper configurations
     constexpr unsigned int rk_steps = 100u;
-    constexpr scalar_t stepsize_constr{0.5f * unit<scalar_t>::mm};
+    constexpr scalar stepsize_constr{0.5f * unit<scalar>::mm};
 
     // Track generator configuration
-    const scalar_t p_mag{10.f * unit<scalar_t>::GeV};
+    const scalar p_mag{10.f * unit<scalar>::GeV};
     constexpr unsigned int theta_steps = 100u;
     constexpr unsigned int phi_steps = 100u;
 
     // Iterate through uniformly distributed momentum directions
-    for (auto track : uniform_track_generator<free_track_parameters<algebra_t>>(
+    for (auto track :
+         uniform_track_generator<free_track_parameters<test_algebra>>(
              phi_steps, theta_steps, p_mag)) {
         // Generate track state used for propagation with constrained step size
-        free_track_parameters<algebra_t> c_track(track);
+        free_track_parameters<test_algebra> c_track(track);
 
         // helix trajectory
         detail::helix helix(track, &B);
@@ -95,7 +95,7 @@ GTEST_TEST(detray_propagator, rk_stepper) {
         // crk_stepper will need twice as many steps
         crk_state.template set_constraint<constraint::e_user>(stepsize_constr);
         ASSERT_NEAR(crk_state.constraints().template size<>(),
-                    0.5f * unit<scalar_t>::mm, tol);
+                    0.5f * unit<scalar>::mm, tol);
 
         // Forward stepping
         for (unsigned int i_s = 0u; i_s < rk_steps; i_s++) {
@@ -123,7 +123,7 @@ GTEST_TEST(detray_propagator, rk_stepper) {
 
         // Roll the same track back to the origin
         // Use the same path length, since there is no overstepping
-        const scalar_t path_length = rk_state.path_length();
+        const scalar path_length = rk_state.path_length();
         for (unsigned int i_s = 0u; i_s < rk_steps; i_s++) {
             rk_stepper.step(-step_size, rk_state, step_cfg, true);
             crk_stepper.step(-step_size, crk_state, step_cfg, true);
@@ -152,8 +152,8 @@ TEST(detray_propagator, rk_stepper_inhomogeneous_bfield) {
     using namespace step;
 
     // Read the magnetic field map
-    using bfield_t = bfield::inhom_field_t;
-    bfield_t inhom_bfield = bfield::create_inhom_field();
+    using bfield_t = bfield::inhom_field_t<scalar>;
+    bfield_t inhom_bfield = bfield::create_inhom_field<scalar>();
 
     // RK stepper
     rk_stepper_t<bfield_t> rk_stepper;
@@ -161,18 +161,19 @@ TEST(detray_propagator, rk_stepper_inhomogeneous_bfield) {
 
     // RK stepper configurations
     constexpr unsigned int rk_steps = 100u;
-    constexpr scalar_t stepsize_constr{0.5f * unit<scalar_t>::mm};
+    constexpr scalar stepsize_constr{0.5f * unit<scalar>::mm};
 
     // Track generator configuration
-    const scalar_t p_mag{10.f * unit<scalar_t>::GeV};
+    const scalar p_mag{10.f * unit<scalar>::GeV};
     constexpr unsigned int theta_steps = 100u;
     constexpr unsigned int phi_steps = 100u;
 
     // Iterate through uniformly distributed momentum directions
-    for (auto track : uniform_track_generator<free_track_parameters<algebra_t>>(
+    for (auto track :
+         uniform_track_generator<free_track_parameters<test_algebra>>(
              phi_steps, theta_steps, p_mag)) {
         // Generate track state used for propagation with constrained step size
-        free_track_parameters<algebra_t> c_track(track);
+        free_track_parameters<test_algebra> c_track(track);
 
         // RK Stepping into forward direction
         rk_stepper_t<bfield_t>::state rk_state{track, inhom_bfield};
@@ -180,7 +181,7 @@ TEST(detray_propagator, rk_stepper_inhomogeneous_bfield) {
 
         crk_state.template set_constraint<constraint::e_user>(stepsize_constr);
         ASSERT_NEAR(crk_state.constraints().template size<>(),
-                    0.5f * unit<scalar_t>::mm, tol);
+                    0.5f * unit<scalar>::mm, tol);
 
         // Forward stepping
         for (unsigned int i_s = 0u; i_s < rk_steps; i_s++) {
@@ -190,7 +191,7 @@ TEST(detray_propagator, rk_stepper_inhomogeneous_bfield) {
         }
 
         // Make sure the steppers moved
-        const scalar_t path_length{rk_state.path_length()};
+        const scalar path_length{rk_state.path_length()};
         ASSERT_TRUE(path_length > 0.f);
         ASSERT_TRUE(crk_state.path_length() > 0.f);
 
@@ -223,25 +224,26 @@ TEST(detray_propagator, qop_derivative) {
     using namespace step;
 
     // Constant magnetic field
-    using bfield_t = bfield::const_field_t;
+    using bfield_t = bfield::const_field_t<scalar>;
 
-    vector3 B{0.f * unit<scalar_t>::T, 0.f * unit<scalar_t>::T,
-              2.f * unit<scalar_t>::T};
-    const bfield_t hom_bfield = bfield::create_const_field(B);
+    vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+              2.f * unit<scalar>::T};
+    const bfield_t hom_bfield = bfield::create_const_field<scalar>(B);
 
     // RK stepper
     rk_stepper_t<bfield_t> rk_stepper;
     constexpr unsigned int rk_steps = 1000u;
 
     // Theta phi for track generator
-    const scalar_t p_mag{10.f * unit<scalar_t>::GeV};
+    const scalar p_mag{10.f * unit<scalar>::GeV};
     constexpr unsigned int theta_steps = 10u;
     constexpr unsigned int phi_steps = 10u;
 
-    const scalar_t ds = 1e-2f * unit<scalar_t>::mm;
+    const scalar ds = 1e-2f * unit<scalar>::mm;
 
     // Iterate through uniformly distributed momentum directions
-    for (auto track : uniform_track_generator<free_track_parameters<algebra_t>>(
+    for (auto track :
+         uniform_track_generator<free_track_parameters<test_algebra>>(
              phi_steps, theta_steps, p_mag)) {
 
         // RK Stepping into forward direction
@@ -249,15 +251,15 @@ TEST(detray_propagator, qop_derivative) {
 
         for (unsigned int i_s = 0u; i_s < rk_steps; i_s++) {
 
-            const scalar_t qop1 = rk_state().qop();
-            const scalar_t d2qopdsdqop = rk_state.d2qopdsdqop(qop1, &vol_mat);
+            const scalar qop1 = rk_state().qop();
+            const scalar d2qopdsdqop = rk_state.d2qopdsdqop(qop1, &vol_mat);
 
-            const scalar_t dqopds1 = rk_state.dqopds(qop1, &vol_mat);
+            const scalar dqopds1 = rk_state.dqopds(qop1, &vol_mat);
 
             rk_stepper.step(ds, rk_state, step_cfg, true, &vol_mat);
 
-            const scalar_t qop2 = rk_state().qop();
-            const scalar_t dqopds2 = rk_state.dqopds(qop2, &vol_mat);
+            const scalar qop2 = rk_state().qop();
+            const scalar dqopds2 = rk_state.dqopds(qop2, &vol_mat);
 
             ASSERT_TRUE(qop1 > qop2);
             ASSERT_NEAR((qop2 - qop1) / ds, dqopds1, 1e-4);

--- a/tests/unit_tests/cpu/simulation/detector_scanner.cpp
+++ b/tests/unit_tests/cpu/simulation/detector_scanner.cpp
@@ -25,7 +25,8 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using vector3 = test::vector3;
 
 constexpr const scalar tol{1e-7f};
@@ -40,7 +41,7 @@ GTEST_TEST(detray_simulation, detector_scanner) {
 
     // Build the geometry
     vecmem::host_memory_resource host_mr;
-    auto [toy_det, names] = build_toy_detector(host_mr);
+    auto [toy_det, names] = build_toy_detector<test_algebra>(host_mr);
 
     unsigned int theta_steps{50u};
     unsigned int phi_steps{50u};
@@ -48,15 +49,16 @@ GTEST_TEST(detray_simulation, detector_scanner) {
     // Record ray tracing
     using detector_t = decltype(toy_det);
     using intersection_trace_t = typename detray::ray_scan<
-        algebra_t>::template intersection_trace_type<detector_t>;
+        test_algebra>::template intersection_trace_type<detector_t>;
 
     detector_t::geometry_context gctx{};
 
     std::vector<intersection_trace_t> expected;
 
     //  Iterate through uniformly distributed momentum directions with ray
-    for (const auto test_ray : uniform_track_generator<detail::ray<algebra_t>>(
-             phi_steps, theta_steps)) {
+    for (const auto test_ray :
+         uniform_track_generator<detail::ray<test_algebra>>(phi_steps,
+                                                            theta_steps)) {
 
         // Record all intersections and objects along the ray
         const auto intersection_record =
@@ -68,7 +70,7 @@ GTEST_TEST(detray_simulation, detector_scanner) {
     // Iterate through uniformly distributed momentum directions with helix
     std::size_t n_tracks{0u};
     for (const auto track :
-         uniform_track_generator<free_track_parameters<algebra_t>>(
+         uniform_track_generator<free_track_parameters<test_algebra>>(
              phi_steps, theta_steps)) {
         const detail::helix test_helix(track, &B);
 

--- a/tests/unit_tests/cpu/simulation/scattering.cpp
+++ b/tests/unit_tests/cpu/simulation/scattering.cpp
@@ -25,8 +25,8 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
-using scalar_t = test::scalar;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using vector3 = test::vector3;
 
 namespace {
@@ -40,7 +40,7 @@ GTEST_TEST(detray_simulation, scattering_helper) {
     generator.seed(0u);
 
     const vector3 dir{2.f, 2.f, 4.f};
-    const scalar_t scattering_angle{0.1f};
+    const scalar scattering_angle{0.1f};
 
     // xaxis of curvilinear plane
     const vector3 u = unit_vectors<vector3>().make_curvilinear_unit_u(dir);
@@ -48,28 +48,28 @@ GTEST_TEST(detray_simulation, scattering_helper) {
     // normal vector of the plane defined by u and dir
     const vector3 w = vector::cross(dir, u);
 
-    std::vector<scalar_t> angle_diffs;
+    std::vector<scalar> angle_diffs;
 
     std::size_t n_samples{100000u};
     for (std::size_t i = 0u; i < n_samples; i++) {
 
         // Scatter the input direction
         const vector3 new_dir =
-            scattering_helper<algebra_t>()(dir, scattering_angle, generator);
+            scattering_helper<test_algebra>()(dir, scattering_angle, generator);
 
         // Assign a plus sign if the dot product of new direction and w vector
         // is plus
-        const scalar_t sign = vector::dot(w, new_dir) > 0 ? 1.f : -1.f;
+        const scalar sign = vector::dot(w, new_dir) > 0 ? 1.f : -1.f;
 
         // the cosine of angle between original direction and new one
-        scalar_t cos_theta = vector::dot(dir, new_dir) /
-                             (vector::norm(dir) * vector::norm(new_dir));
+        scalar cos_theta = vector::dot(dir, new_dir) /
+                           (vector::norm(dir) * vector::norm(new_dir));
 
         // To prevent rounding error where cos_theta is out of [-1, 1]
-        cos_theta = std::clamp(cos_theta, scalar_t{-1.f}, scalar_t{1.f});
+        cos_theta = std::clamp(cos_theta, scalar{-1.f}, scalar{1.f});
 
         // Geht the angle between original direction and new one
-        const scalar_t angle = sign * std::acos(cos_theta);
+        const scalar angle = sign * std::acos(cos_theta);
 
         angle_diffs.push_back(angle);
     }
@@ -77,7 +77,7 @@ GTEST_TEST(detray_simulation, scattering_helper) {
     EXPECT_NEAR(statistics::mean(angle_diffs), 0.f, 1e-3f);
 
     // Tolerate upto 1% difference
-    const scalar_t stddev = std::sqrt(statistics::rms(angle_diffs, 0.f));
+    const scalar stddev = std::sqrt(statistics::rms(angle_diffs, 0.f));
     EXPECT_NEAR((stddev - scattering_angle) / scattering_angle, 0.f, 1e-2f);
 }
 
@@ -90,29 +90,29 @@ GTEST_TEST(detray_simulation, angle_update) {
     vector3 dir{1.f, 2.f, 3.f};
     dir = vector::normalize(dir);
 
-    const scalar_t phi0 = vector::phi(dir);
-    const scalar_t theta0 = vector::theta(dir);
+    const scalar phi0 = vector::phi(dir);
+    const scalar theta0 = vector::theta(dir);
 
     // Projected scattering angle (Tests will fail with relatively large angles)
-    const scalar_t projected_scattering_angle{0.01f};
+    const scalar projected_scattering_angle{0.01f};
 
     // Initial bound covariance
     auto bound_cov = matrix::zero<
-        typename bound_track_parameters<algebra_t>::covariance_type>();
+        typename bound_track_parameters<test_algebra>::covariance_type>();
 
     // We are comparing the bound covariances (var[phi] and var[theta]) to the
     // variance of samples taken by random scattering
 
     // Update the bound covariance with projected scattering angle
-    pointwise_material_interactor<algebra_t>().update_angle_variance(
+    pointwise_material_interactor<test_algebra>().update_angle_variance(
         bound_cov, dir, projected_scattering_angle);
 
     // Get the samples of phi and theta after the random scattering
-    std::vector<scalar_t> phis;
-    std::vector<scalar_t> thetas;
+    std::vector<scalar> phis;
+    std::vector<scalar> thetas;
     std::size_t n_samples{100000u};
     for (std::size_t i = 0u; i < n_samples; i++) {
-        const auto new_dir = random_scatterer<algebra_t>().scatter(
+        const auto new_dir = random_scatterer<test_algebra>().scatter(
             dir, projected_scattering_angle, generator);
         phis.push_back(vector::phi(new_dir));
         thetas.push_back(vector::theta(new_dir));

--- a/tests/unit_tests/cpu/simulation/track_generators.cpp
+++ b/tests/unit_tests/cpu/simulation/track_generators.cpp
@@ -21,43 +21,43 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
-using scalar_t = test::scalar;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using vector3 = test::vector3;
 using point3 = test::point3;
 
 GTEST_TEST(detray_simulation, uniform_track_generator) {
     using generator_t =
-        uniform_track_generator<free_track_parameters<algebra_t>>;
+        uniform_track_generator<free_track_parameters<test_algebra>>;
 
-    constexpr const scalar_t tol{1e-5f};
-    constexpr const scalar_t max_pi{generator_t::configuration::k_max_pi};
+    constexpr const scalar tol{1e-5f};
+    constexpr const scalar max_pi{generator_t::configuration::k_max_pi};
 
     constexpr std::size_t phi_steps{50u};
     constexpr std::size_t theta_steps{50u};
-    constexpr const scalar_t charge{-1.f};
+    constexpr const scalar charge{-1.f};
 
     std::array<vector3, phi_steps * theta_steps> momenta{};
 
     // Loop over theta values [0,pi)
     for (std::size_t itheta{0u}; itheta < theta_steps; ++itheta) {
-        const scalar_t theta{static_cast<scalar_t>(itheta) * max_pi /
-                             static_cast<scalar_t>(theta_steps - 1u)};
+        const scalar theta{static_cast<scalar>(itheta) * max_pi /
+                           static_cast<scalar>(theta_steps - 1u)};
 
         // Loop over phi values [-pi, pi)
         for (std::size_t iphi{0u}; iphi < phi_steps; ++iphi) {
             // The direction
-            const scalar_t phi{-constant<scalar_t>::pi +
-                               static_cast<scalar_t>(iphi) *
-                                   (constant<scalar_t>::pi + max_pi) /
-                                   static_cast<scalar_t>(phi_steps)};
+            const scalar phi{-constant<scalar>::pi +
+                             static_cast<scalar>(iphi) *
+                                 (constant<scalar>::pi + max_pi) /
+                                 static_cast<scalar>(phi_steps)};
 
             // intialize a track
             vector3 mom{std::cos(phi) * std::sin(theta),
                         std::sin(phi) * std::sin(theta), std::cos(theta)};
             mom = vector::normalize(mom);
-            free_track_parameters<algebra_t> traj({0.f, 0.f, 0.f}, 0.f, mom,
-                                                  -1.f);
+            free_track_parameters<test_algebra> traj({0.f, 0.f, 0.f}, 0.f, mom,
+                                                     -1.f);
 
             momenta[itheta * phi_steps + iphi] = traj.mom(-1.f);
         }
@@ -102,11 +102,11 @@ GTEST_TEST(detray_simulation, uniform_track_generator) {
     ASSERT_EQ(momenta.size(), n_tracks);
 
     // Generate helical trajectories
-    const vector3 B{0.f * unit<scalar_t>::T, 0.f * unit<scalar_t>::T,
-                    2.f * unit<scalar_t>::T};
+    const vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                    2.f * unit<scalar>::T};
     n_tracks = 0u;
     for (const auto track : generator_t(phi_steps, theta_steps)) {
-        detail::helix<algebra_t> helix_traj(track, &B);
+        detail::helix<test_algebra> helix_traj(track, &B);
         vector3& expected = momenta[n_tracks];
         vector3 result = helix_traj.dir(0.f);
 
@@ -124,11 +124,11 @@ GTEST_TEST(detray_simulation, uniform_track_generator) {
 
 GTEST_TEST(detray_simulation, uniform_track_generator_eta) {
     using generator_t =
-        uniform_track_generator<free_track_parameters<algebra_t>>;
+        uniform_track_generator<free_track_parameters<test_algebra>>;
 
-    constexpr const scalar_t tol{1e-5f};
-    constexpr const scalar_t max_pi{generator_t::configuration::k_max_pi};
-    constexpr const scalar_t charge{-1.f};
+    constexpr const scalar tol{1e-5f};
+    constexpr const scalar max_pi{generator_t::configuration::k_max_pi};
+    constexpr const scalar charge{-1.f};
 
     constexpr std::size_t phi_steps{50u};
     constexpr std::size_t eta_steps{50u};
@@ -137,24 +137,24 @@ GTEST_TEST(detray_simulation, uniform_track_generator_eta) {
 
     // Loop over eta values [-5, 5]
     for (std::size_t ieta{0u}; ieta < eta_steps; ++ieta) {
-        const scalar_t eta{-5.f + static_cast<scalar_t>(ieta) * 10.f /
-                                      static_cast<scalar_t>(eta_steps - 1u)};
-        const scalar_t theta{2.f * std::atan(std::exp(-eta))};
+        const scalar eta{-5.f + static_cast<scalar>(ieta) * 10.f /
+                                    static_cast<scalar>(eta_steps - 1u)};
+        const scalar theta{2.f * std::atan(std::exp(-eta))};
 
         // Loop over phi values [-pi, pi)
         for (std::size_t iphi{0u}; iphi < phi_steps; ++iphi) {
             // The direction
-            const scalar_t phi{-constant<scalar_t>::pi +
-                               static_cast<scalar_t>(iphi) *
-                                   (constant<scalar_t>::pi + max_pi) /
-                                   static_cast<scalar_t>(phi_steps)};
+            const scalar phi{-constant<scalar>::pi +
+                             static_cast<scalar>(iphi) *
+                                 (constant<scalar>::pi + max_pi) /
+                                 static_cast<scalar>(phi_steps)};
 
             // intialize a track
             vector3 mom{std::cos(phi) * std::sin(theta),
                         std::sin(phi) * std::sin(theta), std::cos(theta)};
             mom = vector::normalize(mom);
-            free_track_parameters<algebra_t> traj({0.f, 0.f, 0.f}, 0.f, mom,
-                                                  -1.f);
+            free_track_parameters<test_algebra> traj({0.f, 0.f, 0.f}, 0.f, mom,
+                                                     -1.f);
 
             momenta[ieta * phi_steps + iphi] = traj.mom(charge);
         }
@@ -185,11 +185,11 @@ GTEST_TEST(detray_simulation, uniform_track_generator_eta) {
 
 GTEST_TEST(detray_simulation, uniform_track_generator_with_range) {
     using generator_t =
-        uniform_track_generator<free_track_parameters<algebra_t>>;
+        uniform_track_generator<free_track_parameters<test_algebra>>;
 
-    constexpr const scalar_t tol{1e-5f};
+    constexpr const scalar tol{1e-5f};
 
-    std::vector<std::array<scalar_t, 2>> theta_phi;
+    std::vector<std::array<scalar, 2>> theta_phi;
 
     auto trk_gen_cfg = generator_t::configuration{};
     trk_gen_cfg.phi_range(-2.f, 2.f).phi_steps(4u);
@@ -224,13 +224,13 @@ GTEST_TEST(detray_simulation, random_track_generator_uniform) {
 
     // Use deterministic random number generator for testing
     using uniform_gen_t =
-        detail::random_numbers<scalar_t,
-                               std::uniform_real_distribution<scalar_t>>;
+        detail::random_numbers<scalar, std::uniform_real_distribution<scalar>>;
     using trk_generator_t =
-        random_track_generator<free_track_parameters<algebra_t>, uniform_gen_t>;
+        random_track_generator<free_track_parameters<test_algebra>,
+                               uniform_gen_t>;
 
     // Tolerance depends on sample size
-    constexpr scalar_t tol{0.02f};
+    constexpr scalar tol{0.02f};
 
     // Track counter
     std::size_t n_tracks{0u};
@@ -240,21 +240,20 @@ GTEST_TEST(detray_simulation, random_track_generator_uniform) {
     trk_generator_t::configuration trk_gen_cfg{};
     trk_gen_cfg.n_tracks(n_gen_tracks);
     trk_gen_cfg.seed(42u);
-    trk_gen_cfg.phi_range(-0.9f * constant<scalar_t>::pi,
-                          0.8f * constant<scalar_t>::pi);
+    trk_gen_cfg.phi_range(-0.9f * constant<scalar>::pi,
+                          0.8f * constant<scalar>::pi);
     trk_gen_cfg.eta_range(-4.f, 4.f);
-    trk_gen_cfg.mom_range(1.f * unit<scalar_t>::GeV, 2.f * unit<scalar_t>::GeV);
-    trk_gen_cfg.origin_stddev({0.1f * unit<scalar_t>::mm,
-                               0.f * unit<scalar_t>::mm,
-                               0.2f * unit<scalar_t>::mm});
+    trk_gen_cfg.mom_range(1.f * unit<scalar>::GeV, 2.f * unit<scalar>::GeV);
+    trk_gen_cfg.origin_stddev({0.1f * unit<scalar>::mm, 0.f * unit<scalar>::mm,
+                               0.2f * unit<scalar>::mm});
 
     // Catch the results
-    std::array<scalar_t, n_gen_tracks> x{};
-    std::array<scalar_t, n_gen_tracks> y{};
-    std::array<scalar_t, n_gen_tracks> z{};
-    std::array<scalar_t, n_gen_tracks> mom{};
-    std::array<scalar_t, n_gen_tracks> phi{};
-    std::array<scalar_t, n_gen_tracks> theta{};
+    std::array<scalar, n_gen_tracks> x{};
+    std::array<scalar, n_gen_tracks> y{};
+    std::array<scalar, n_gen_tracks> z{};
+    std::array<scalar, n_gen_tracks> mom{};
+    std::array<scalar, n_gen_tracks> phi{};
+    std::array<scalar, n_gen_tracks> theta{};
 
     for (const auto track : trk_generator_t{trk_gen_cfg}) {
         const auto pos = track.pos();
@@ -308,12 +307,13 @@ GTEST_TEST(detray_simulation, random_track_generator_normal) {
 
     // Use deterministic random number generator for testing
     using normal_gen_t =
-        detail::random_numbers<scalar_t, std::normal_distribution<scalar_t>>;
+        detail::random_numbers<scalar, std::normal_distribution<scalar>>;
     using trk_generator_t =
-        random_track_generator<free_track_parameters<algebra_t>, normal_gen_t>;
+        random_track_generator<free_track_parameters<test_algebra>,
+                               normal_gen_t>;
 
     // Tolerance depends on sample size
-    constexpr scalar_t tol{0.02f};
+    constexpr scalar tol{0.02f};
 
     // Track counter
     std::size_t n_tracks{0u};
@@ -323,22 +323,21 @@ GTEST_TEST(detray_simulation, random_track_generator_normal) {
     trk_generator_t::configuration trk_gen_cfg{};
     trk_gen_cfg.n_tracks(n_gen_tracks);
     trk_gen_cfg.seed(42u);
-    trk_gen_cfg.phi_range(-0.9f * constant<scalar_t>::pi,
-                          0.8f * constant<scalar_t>::pi);
+    trk_gen_cfg.phi_range(-0.9f * constant<scalar>::pi,
+                          0.8f * constant<scalar>::pi);
     trk_gen_cfg.eta_range(-4.f, 4.f);
-    trk_gen_cfg.mom_range(1.f * unit<scalar_t>::GeV, 2.f * unit<scalar_t>::GeV);
+    trk_gen_cfg.mom_range(1.f * unit<scalar>::GeV, 2.f * unit<scalar>::GeV);
     trk_gen_cfg.origin({0.f, 0.f, 0.f});
-    trk_gen_cfg.origin_stddev({0.1f * unit<scalar_t>::mm,
-                               0.5f * unit<scalar_t>::mm,
-                               0.3f * unit<scalar_t>::mm});
+    trk_gen_cfg.origin_stddev({0.1f * unit<scalar>::mm, 0.5f * unit<scalar>::mm,
+                               0.3f * unit<scalar>::mm});
 
     // Catch the results
-    std::array<scalar_t, n_gen_tracks> x{};
-    std::array<scalar_t, n_gen_tracks> y{};
-    std::array<scalar_t, n_gen_tracks> z{};
-    std::array<scalar_t, n_gen_tracks> mom{};
-    std::array<scalar_t, n_gen_tracks> phi{};
-    std::array<scalar_t, n_gen_tracks> theta{};
+    std::array<scalar, n_gen_tracks> x{};
+    std::array<scalar, n_gen_tracks> y{};
+    std::array<scalar, n_gen_tracks> z{};
+    std::array<scalar, n_gen_tracks> mom{};
+    std::array<scalar, n_gen_tracks> phi{};
+    std::array<scalar, n_gen_tracks> theta{};
 
     for (const auto track : trk_generator_t{trk_gen_cfg}) {
         const auto pos = track.pos();

--- a/tests/unit_tests/cpu/tracks/bound_track_parameters.cpp
+++ b/tests/unit_tests/cpu/tracks/bound_track_parameters.cpp
@@ -16,13 +16,14 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point2 = test::point2;
 using vector3 = test::vector3;
 using point3 = test::point3;
 
 using covariance_t =
-    typename bound_track_parameters<algebra_t>::covariance_type;
+    typename bound_track_parameters<test_algebra>::covariance_type;
 
 constexpr scalar tol{1e-5f};
 
@@ -39,12 +40,12 @@ GTEST_TEST(detray_tracks, bound_track_parameters) {
     scalar t{0.1f};
 
     // first track
-    bound_parameters_vector<algebra_t> bound_vec1{bound_local, phi, theta, qop,
-                                                  t};
+    bound_parameters_vector<test_algebra> bound_vec1{bound_local, phi, theta,
+                                                     qop, t};
 
     auto bound_cov1 = matrix::zero<covariance_t>();
 
-    bound_track_parameters<algebra_t> bound_param1(
+    bound_track_parameters<test_algebra> bound_param1(
         geometry::barcode{}.set_index(sf_idx1), bound_vec1, bound_cov1);
     EXPECT_NEAR(bound_param1.pT(charge),
                 1.f / std::abs(bound_vec1.qop()) * std::sin(bound_vec1.theta()),
@@ -63,14 +64,14 @@ GTEST_TEST(detray_tracks, bound_track_parameters) {
     qop = -1.f;
     t = 0.f;
 
-    bound_parameters_vector<algebra_t> bound_vec2{bound_local, phi, theta, qop,
-                                                  t};
+    bound_parameters_vector<test_algebra> bound_vec2{bound_local, phi, theta,
+                                                     qop, t};
 
     auto bound_cov2 = matrix::zero<covariance_t>();
 
-    bound_track_parameters<algebra_t> bound_param2(
+    bound_track_parameters<test_algebra> bound_param2(
         geometry::barcode{}.set_index(sf_idx2), bound_vec2, bound_cov2);
-    bound_track_parameters<algebra_t> bound_param3(
+    bound_track_parameters<test_algebra> bound_param3(
         geometry::barcode{}.set_index(sf_idx2), bound_vec2, bound_cov2);
 
     /// Check the elements

--- a/tests/unit_tests/cpu/tracks/free_track_parameters.cpp
+++ b/tests/unit_tests/cpu/tracks/free_track_parameters.cpp
@@ -16,11 +16,12 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using vector3 = test::vector3;
 using point3 = test::point3;
 
-using free_vector_t = typename free_track_parameters<algebra_t>::vector_type;
+using free_vector_t = typename free_track_parameters<test_algebra>::vector_type;
 
 constexpr scalar tol{1e-5f};
 
@@ -44,7 +45,7 @@ GTEST_TEST(detray_tracks, free_track_parameters) {
     getter::element(free_vec, e_free_qoverp, 0u) = charge / vector::norm(mom);
 
     // first constructor
-    free_track_parameters<algebra_t> free_param1(free_vec);
+    free_track_parameters<test_algebra> free_param1(free_vec);
     EXPECT_NEAR(free_param1.pos()[0], pos[0], tol);
     EXPECT_NEAR(free_param1.pos()[1], pos[1], tol);
     EXPECT_NEAR(free_param1.pos()[2], pos[2], tol);
@@ -67,7 +68,7 @@ GTEST_TEST(detray_tracks, free_track_parameters) {
                 free_param1.p(charge) * free_param1.dir()[2], tol);
 
     // second constructor
-    free_track_parameters<algebra_t> free_param2(pos, time, mom, charge);
+    free_track_parameters<test_algebra> free_param2(pos, time, mom, charge);
     EXPECT_NEAR(free_param2.pos()[0], pos[0], tol);
     EXPECT_NEAR(free_param2.pos()[1], pos[1], tol);
     EXPECT_NEAR(free_param2.pos()[2], pos[2], tol);

--- a/tests/unit_tests/cpu/utils/axis_rotation.cpp
+++ b/tests/unit_tests/cpu/utils/axis_rotation.cpp
@@ -18,8 +18,8 @@
 
 using namespace detray;
 
-using algebra_t = test::algebra;
-using scalar_t = test::scalar;
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 template <std::size_t ROWS, std::size_t COLS>
 using matrix_type = test::matrix<ROWS, COLS>;
 
@@ -32,19 +32,19 @@ GTEST_TEST(detray_utils, axis_rotation) {
     const test::vector3 v1{1.f, 0.f, 0.f};
 
     const auto u1 =
-        axis_rotation<algebra_t>(axis, constant<scalar_t>::pi_2)(v1);
+        axis_rotation<test_algebra>(axis, constant<scalar>::pi_2)(v1);
 
     EXPECT_NEAR(u1[0], 0.f, isclose);
     EXPECT_NEAR(u1[1], 1.f, isclose);
     EXPECT_NEAR(u1[2], 0.f, isclose);
 
     matrix_type<3, 1> v2;
-    getter::element(v2, 0, 0) = constant<scalar_t>::inv_sqrt2;
-    getter::element(v2, 1, 0) = constant<scalar_t>::inv_sqrt2;
+    getter::element(v2, 0, 0) = constant<scalar>::inv_sqrt2;
+    getter::element(v2, 1, 0) = constant<scalar>::inv_sqrt2;
     getter::element(v2, 2, 0) = 0.f;
 
     const auto u2 =
-        axis_rotation<algebra_t>(axis, constant<scalar_t>::pi_4)(v2);
+        axis_rotation<test_algebra>(axis, constant<scalar>::pi_4)(v2);
 
     EXPECT_NEAR(getter::element(u2, 0, 0), 0.f, isclose);
     EXPECT_NEAR(getter::element(u2, 1, 0), 1.f, isclose);
@@ -55,17 +55,17 @@ GTEST_TEST(detray_utils, axis_rotation) {
     const test::vector3 v3{1.f, 0.f, 0.f};
 
     const auto u3 =
-        axis_rotation<algebra_t>(axis, constant<scalar_t>::pi_4)(v3);
+        axis_rotation<test_algebra>(axis, constant<scalar>::pi_4)(v3);
 
-    EXPECT_NEAR(u3[0u], constant<scalar_t>::inv_sqrt2, isclose);
-    EXPECT_NEAR(u3[1u], constant<scalar_t>::inv_sqrt2, isclose);
+    EXPECT_NEAR(u3[0u], constant<scalar>::inv_sqrt2, isclose);
+    EXPECT_NEAR(u3[1u], constant<scalar>::inv_sqrt2, isclose);
     EXPECT_NEAR(u3[2u], 0.f, isclose);
 }
 
 GTEST_TEST(detray_utils, euler_rotation1) {
 
-    euler_rotation<algebra_t> euler_rot;
-    euler_rot.alpha = constant<scalar_t>::pi_2;
+    euler_rotation<test_algebra> euler_rot;
+    euler_rot.alpha = constant<scalar>::pi_2;
 
     auto [x1, z1] = euler_rot();
 
@@ -77,7 +77,7 @@ GTEST_TEST(detray_utils, euler_rotation1) {
     EXPECT_NEAR(z1[1], 0.f, isclose);
     EXPECT_NEAR(z1[2], 1.f, isclose);
 
-    euler_rot.beta = constant<scalar_t>::pi_2;
+    euler_rot.beta = constant<scalar>::pi_2;
 
     auto [x2, z2] = euler_rot();
     EXPECT_NEAR(x2[0], 0.f, isclose);
@@ -88,7 +88,7 @@ GTEST_TEST(detray_utils, euler_rotation1) {
     EXPECT_NEAR(z2[1], 0.f, isclose);
     EXPECT_NEAR(z2[2], 0.f, isclose);
 
-    euler_rot.gamma = constant<scalar_t>::pi_2;
+    euler_rot.gamma = constant<scalar>::pi_2;
 
     auto [x3, z3] = euler_rot();
     EXPECT_NEAR(x3[0], 0.f, isclose);
@@ -102,22 +102,22 @@ GTEST_TEST(detray_utils, euler_rotation1) {
 
 GTEST_TEST(detray_utils, euler_rotation2) {
 
-    euler_rotation<algebra_t> euler_rot;
-    euler_rot.alpha = constant<scalar_t>::pi / 6.f;
-    euler_rot.beta = constant<scalar_t>::pi_4;
-    euler_rot.gamma = constant<scalar_t>::pi_2;
+    euler_rotation<test_algebra> euler_rot;
+    euler_rot.alpha = constant<scalar>::pi / 6.f;
+    euler_rot.beta = constant<scalar>::pi_4;
+    euler_rot.gamma = constant<scalar>::pi_2;
 
     const test::vector3 v1{5.f, 7.f, 8.f};
     const test::vector3 v2 = euler_rot(v1);
 
     auto R = matrix::zero<matrix_type<3u, 3u>>();
 
-    const scalar_t s1 = static_cast<scalar_t>(math::sin(euler_rot.alpha));
-    const scalar_t c1 = static_cast<scalar_t>(math::cos(euler_rot.alpha));
-    const scalar_t s2 = static_cast<scalar_t>(math::sin(euler_rot.beta));
-    const scalar_t c2 = static_cast<scalar_t>(math::cos(euler_rot.beta));
-    const scalar_t s3 = static_cast<scalar_t>(math::sin(euler_rot.gamma));
-    const scalar_t c3 = static_cast<scalar_t>(math::cos(euler_rot.gamma));
+    const scalar s1 = static_cast<scalar>(math::sin(euler_rot.alpha));
+    const scalar c1 = static_cast<scalar>(math::cos(euler_rot.alpha));
+    const scalar s2 = static_cast<scalar>(math::sin(euler_rot.beta));
+    const scalar c2 = static_cast<scalar>(math::cos(euler_rot.beta));
+    const scalar s3 = static_cast<scalar>(math::sin(euler_rot.gamma));
+    const scalar c3 = static_cast<scalar>(math::cos(euler_rot.gamma));
 
     // From table of https://en.wikipedia.org/wiki/Euler_angles
     getter::element(R, 0u, 0u) = c1 * c3 - c2 * s1 * s3;

--- a/tests/unit_tests/cpu/utils/bounding_volume.cpp
+++ b/tests/unit_tests/cpu/utils/bounding_volume.cpp
@@ -19,7 +19,12 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using point_t = test::point3;
+
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+using point3 = test::point3;
+using vector3 = test::vector3;
+using transform3 = test::transform3;
 
 namespace {
 
@@ -39,13 +44,13 @@ GTEST_TEST(detray_tools, bounding_cuboid3D) {
     constexpr scalar hy{9.3f * unit<scalar>::mm};
     constexpr scalar hz{0.5f * unit<scalar>::mm};
 
-    point_t p2_in = {0.5f, 8.0f, -0.4f};
-    point_t p2_edge = {1.f, 9.3f, 0.5f};
-    point_t p2_out = {1.5f, -9.f, 0.55f};
+    point3 p2_in = {0.5f, 8.0f, -0.4f};
+    point3 p2_edge = {1.f, 9.3f, 0.5f};
+    point3 p2_out = {1.5f, -9.f, 0.55f};
 
-    mask<cuboid3D> c3{0u, -hx, -hy, -hz, hx, hy, hz};
+    mask<cuboid3D, test_algebra> c3{0u, -hx, -hy, -hz, hx, hy, hz};
 
-    axis_aligned_bounding_volume<cuboid3D> aabb{c3, 0u, envelope};
+    axis_aligned_bounding_volume<cuboid3D, test_algebra> aabb{c3, 0u, envelope};
 
     // Id of this instance
     ASSERT_EQ(aabb.id(), 0u);
@@ -73,13 +78,13 @@ GTEST_TEST(detray_tools, bounding_cylinder3D) {
     constexpr scalar r{3.f * unit<scalar>::mm};
     constexpr scalar hz{4.f * unit<scalar>::mm};
 
-    point_t p3_in = {r, 0.f, -1.f};
-    point_t p3_edge = {0.f, r, hz};
-    point_t p3_out = {r * constant<scalar>::inv_sqrt2,
-                      r * constant<scalar>::inv_sqrt2, 4.5f};
-    point_t p3_off = {1.f, 1.f, -9.f};
+    point3 p3_in = {r, 0.f, -1.f};
+    point3 p3_edge = {0.f, r, hz};
+    point3 p3_out = {r * constant<scalar>::inv_sqrt2,
+                     r * constant<scalar>::inv_sqrt2, 4.5f};
+    point3 p3_off = {1.f, 1.f, -9.f};
 
-    axis_aligned_bounding_volume<cylinder3D> aabc{
+    axis_aligned_bounding_volume<cylinder3D, test_algebra> aabc{
         0u, 0.f, -constant<scalar>::pi, -hz, r, constant<scalar>::pi, hz};
 
     // Id of this instance
@@ -105,26 +110,24 @@ GTEST_TEST(detray_tools, bounding_cylinder3D) {
 /// This tests the basic functionality of an aabb around a stereo annulus
 GTEST_TEST(detray_tools, annulus2D_aabb) {
 
-    using transform3_t = test::transform3;
-    using vector3_t = typename transform3_t::vector3;
-
     constexpr scalar minR{7.2f * unit<scalar>::mm};
     constexpr scalar maxR{12.0f * unit<scalar>::mm};
     constexpr scalar minPhi{0.74195f};
     constexpr scalar maxPhi{1.33970f};
-    typename transform3_t::point2 offset = {-2.f, 2.f};
+    typename transform3::point2 offset = {-2.f, 2.f};
 
-    mask<annulus2D> ann2{0u,     minR, maxR,      minPhi,
-                         maxPhi, 0.f,  offset[0], offset[1]};
+    mask<annulus2D, test_algebra> ann2{0u,     minR, maxR,      minPhi,
+                                       maxPhi, 0.f,  offset[0], offset[1]};
 
     // Construct local aabb around mask
-    axis_aligned_bounding_volume<cuboid3D> aabb{ann2, 0u, envelope};
+    axis_aligned_bounding_volume<cuboid3D, test_algebra> aabb{ann2, 0u,
+                                                              envelope};
 
     // rotate around z-axis by 90deg and then translate by 1mm in each direction
-    const vector3_t new_x{0.f, -1.f, 0.f};
-    const vector3_t new_z{0.f, 0.f, 1.f};
-    const vector3_t t{1.f, 2.f, 3.f};
-    const transform3_t trf{t, new_z, new_x};
+    const vector3 new_x{0.f, -1.f, 0.f};
+    const vector3 new_z{0.f, 0.f, 1.f};
+    const vector3 t{1.f, 2.f, 3.f};
+    const transform3 trf{t, new_z, new_x};
 
     const auto glob_aabb = aabb.transform(trf);
     ASSERT_NEAR(glob_aabb[cuboid3D::e_min_x], 2.39186f - envelope + t[0], tol);
@@ -139,22 +142,19 @@ GTEST_TEST(detray_tools, annulus2D_aabb) {
 /// This tests the basic functionality of an aabb around a cylinder
 GTEST_TEST(detray_tools, cylinder2D_aabb) {
 
-    using transform3_t = test::transform3;
-    using vector3_t = typename transform3_t::vector3;
-
     constexpr scalar r{3.f * unit<scalar>::mm};
     constexpr scalar hz{4.f * unit<scalar>::mm};
 
-    mask<cylinder2D> c{0u, r, -hz, hz};
+    mask<cylinder2D, test_algebra> c{0u, r, -hz, hz};
 
     // Construct local aabb around mask
-    axis_aligned_bounding_volume<cuboid3D> aabb{c, 0u, envelope};
+    axis_aligned_bounding_volume<cuboid3D, test_algebra> aabb{c, 0u, envelope};
 
     // rotate around z-axis by 90deg and then translate by 1mm in each direction
-    const vector3_t new_x{0.f, -1.f, 0.f};
-    const vector3_t new_z{0.f, 0.f, 1.f};
-    const vector3_t t{1.f, 2.f, 3.f};
-    const transform3_t trf{t, new_z, new_x};
+    const vector3 new_x{0.f, -1.f, 0.f};
+    const vector3 new_z{0.f, 0.f, 1.f};
+    const vector3 t{1.f, 2.f, 3.f};
+    const transform3 trf{t, new_z, new_x};
 
     const auto glob_aabb = aabb.transform(trf);
     ASSERT_NEAR(glob_aabb[cuboid3D::e_min_x], -(r + envelope) + t[0], tol);
@@ -168,24 +168,23 @@ GTEST_TEST(detray_tools, cylinder2D_aabb) {
 /// This tests the basic functionality of an aabb around a line
 GTEST_TEST(detray_tools, line2D_aabb) {
 
-    using transform3_t = test::transform3;
-    using vector3_t = typename transform3_t::vector3;
-
     constexpr scalar cell_size{1.f * unit<scalar>::mm};
     constexpr scalar hz{50.f * unit<scalar>::mm};
 
-    const mask<line_circular> ln_r{0u, cell_size, hz};
-    const mask<line_square> ln_sq{0u, cell_size, hz};
+    const mask<line_circular, test_algebra> ln_r{0u, cell_size, hz};
+    const mask<line_square, test_algebra> ln_sq{0u, cell_size, hz};
 
     // Construct local aabb around mask
-    axis_aligned_bounding_volume<cuboid3D> aabb_r{ln_r, 0u, envelope};
-    axis_aligned_bounding_volume<cuboid3D> aabb_sq{ln_sq, 0u, envelope};
+    axis_aligned_bounding_volume<cuboid3D, test_algebra> aabb_r{ln_r, 0u,
+                                                                envelope};
+    axis_aligned_bounding_volume<cuboid3D, test_algebra> aabb_sq{ln_sq, 0u,
+                                                                 envelope};
 
     // rotate around z-axis by 90deg and then translate by 1mm in each direction
-    const vector3_t new_x{0.f, -1.f, 0.f};
-    const vector3_t new_z{0.f, 0.f, 1.f};
-    const vector3_t t{1.f, 2.f, 3.f};
-    const transform3_t trf{t, new_z, new_x};
+    const vector3 new_x{0.f, -1.f, 0.f};
+    const vector3 new_z{0.f, 0.f, 1.f};
+    const vector3 t{1.f, 2.f, 3.f};
+    const transform3 trf{t, new_z, new_x};
 
     // Radial crossection
     const auto glob_aabb_r = aabb_r.transform(trf);
@@ -217,22 +216,19 @@ GTEST_TEST(detray_tools, line2D_aabb) {
 /// This tests the basic functionality of an aabb around a rectangle
 GTEST_TEST(detray_tools, rectangle2D_aabb) {
 
-    using transform3_t = test::transform3;
-    using vector3_t = typename transform3_t::vector3;
-
     constexpr scalar hx{1.f * unit<scalar>::mm};
     constexpr scalar hy{9.3f * unit<scalar>::mm};
 
-    mask<rectangle2D> r2{0u, hx, hy};
+    mask<rectangle2D, test_algebra> r2{0u, hx, hy};
 
     // Construct local aabb around mask
-    axis_aligned_bounding_volume<cuboid3D> aabb{r2, 0u, envelope};
+    axis_aligned_bounding_volume<cuboid3D, test_algebra> aabb{r2, 0u, envelope};
 
     // rotate around z-axis by 90deg and then translate by 1mm in each direction
-    const vector3_t new_x{0.f, -1.f, 0.f};
-    const vector3_t new_z{0.f, 0.f, 1.f};
-    const vector3_t t{1.f, 2.f, 3.f};
-    const transform3_t trf{t, new_z, new_x};
+    const vector3 new_x{0.f, -1.f, 0.f};
+    const vector3 new_z{0.f, 0.f, 1.f};
+    const vector3 t{1.f, 2.f, 3.f};
+    const transform3 trf{t, new_z, new_x};
 
     const auto glob_aabb = aabb.transform(trf);
     ASSERT_NEAR(glob_aabb[cuboid3D::e_min_x], -(hy + envelope) + t[0], tol);
@@ -246,22 +242,19 @@ GTEST_TEST(detray_tools, rectangle2D_aabb) {
 /// This tests the basic functionality of an aabb around a rectangle
 GTEST_TEST(detray_tools, ring2D_aabb) {
 
-    using transform3_t = test::transform3;
-    using vector3_t = typename transform3_t::vector3;
-
     constexpr scalar inner_r{0.f * unit<scalar>::mm};
     constexpr scalar outer_r{3.5f * unit<scalar>::mm};
 
-    mask<ring2D> r2{0u, inner_r, outer_r};
+    mask<ring2D, test_algebra> r2{0u, inner_r, outer_r};
 
     // Construct local aabb around mask
-    axis_aligned_bounding_volume<cuboid3D> aabb{r2, 0u, envelope};
+    axis_aligned_bounding_volume<cuboid3D, test_algebra> aabb{r2, 0u, envelope};
 
     // rotate around z-axis by 90deg and then translate by 1mm in each direction
-    const vector3_t new_x{0.f, -1.f, 0.f};
-    const vector3_t new_z{0.f, 0.f, 1.f};
-    const vector3_t t{1.f, 2.f, 3.f};
-    const transform3_t trf{t, new_z, new_x};
+    const vector3 new_x{0.f, -1.f, 0.f};
+    const vector3 new_z{0.f, 0.f, 1.f};
+    const vector3 t{1.f, 2.f, 3.f};
+    const transform3 trf{t, new_z, new_x};
 
     const auto glob_aabb = aabb.transform(trf);
     ASSERT_NEAR(glob_aabb[cuboid3D::e_min_x], -(outer_r + envelope) + t[0],
@@ -277,24 +270,21 @@ GTEST_TEST(detray_tools, ring2D_aabb) {
 /// This tests the basic functionality of an aabb around a rectangle
 GTEST_TEST(detray_tools, trapezoid2D_aabb) {
 
-    using transform3_t = test::transform3;
-    using vector3_t = typename transform3_t::vector3;
-
     constexpr scalar hx_miny{1.f * unit<scalar>::mm};
     constexpr scalar hx_maxy{3.f * unit<scalar>::mm};
     constexpr scalar hy{2.f * unit<scalar>::mm};
     constexpr scalar divisor{1.f / (2.f * hy)};
 
-    mask<trapezoid2D> t2{0u, hx_miny, hx_maxy, hy, divisor};
+    mask<trapezoid2D, test_algebra> t2{0u, hx_miny, hx_maxy, hy, divisor};
 
     // Construct local aabb around mask
-    axis_aligned_bounding_volume<cuboid3D> aabb{t2, 0u, envelope};
+    axis_aligned_bounding_volume<cuboid3D, test_algebra> aabb{t2, 0u, envelope};
 
     // rotate around z-axis by 90deg and then translate by 1mm in each direction
-    const vector3_t new_x{0.f, -1.f, 0.f};
-    const vector3_t new_z{0.f, 0.f, 1.f};
-    const vector3_t t{1.f, 2.f, 3.f};
-    const transform3_t trf{t, new_z, new_x};
+    const vector3 new_x{0.f, -1.f, 0.f};
+    const vector3 new_z{0.f, 0.f, 1.f};
+    const vector3 t{1.f, 2.f, 3.f};
+    const transform3 trf{t, new_z, new_x};
 
     const auto glob_aabb = aabb.transform(trf);
     ASSERT_NEAR(glob_aabb[cuboid3D::e_min_x], -(hy + envelope) + t[0], tol);
@@ -308,7 +298,8 @@ GTEST_TEST(detray_tools, trapezoid2D_aabb) {
 
 /// This tests wrapping a collection of cuboid bounding volumes
 GTEST_TEST(detray_tools, wrap_bounding_cuboid3D) {
-    using box_t = axis_aligned_bounding_volume<cuboid3D>;
+
+    using box_t = axis_aligned_bounding_volume<cuboid3D, test_algebra>;
 
     box_t b1{0u, -1.f, 0.f, -10.f, -0.5f, 1.f, 0.f};
     box_t b2{0u, -2.f, 3.f, 2.f, 2.f, 4.5f, 3.5f};

--- a/tests/unit_tests/cpu/utils/curvilinear_frame.cpp
+++ b/tests/unit_tests/cpu/utils/curvilinear_frame.cpp
@@ -15,10 +15,12 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
+
+using test_algebra = test::algebra;
 using transform3 = test::transform3;
 using vector3 = typename transform3::vector3;
-using algebra_t = test::algebra;
 using point3 = test::point3;
+using scalar = test::scalar;
 
 GTEST_TEST(detray_utils, curvilinear_frame) {
 
@@ -29,9 +31,9 @@ GTEST_TEST(detray_utils, curvilinear_frame) {
     vector3 mom = {10.f, 20.f, 30.f};
     constexpr scalar charge = -1.f;
 
-    free_track_parameters<algebra_t> free_params(pos, time, mom, charge);
+    free_track_parameters<test_algebra> free_params(pos, time, mom, charge);
 
-    curvilinear_frame<algebra_t> cf(free_params);
+    curvilinear_frame<test_algebra> cf(free_params);
 
     const auto bound_vec = cf.m_bound_vec;
 

--- a/tests/unit_tests/cpu/utils/grids/axis.cpp
+++ b/tests/unit_tests/cpu/utils/grids/axis.cpp
@@ -29,15 +29,17 @@ using namespace detray::axis;
 
 namespace {
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point3 = test::point3;
 
 // Alias for testing
 template <bool ownership, typename containers>
 using cartesian_3D =
-    multi_axis<ownership, cartesian3D<test::algebra>,
-               single_axis<closed<label::e_x>, regular<containers, scalar>>,
-               single_axis<closed<label::e_y>, regular<containers, scalar>>,
-               single_axis<closed<label::e_z>, regular<containers, scalar>>>;
+    multi_axis<ownership, cartesian3D<test_algebra>,
+               single_axis<closed<label::e_x>, regular<scalar, containers>>,
+               single_axis<closed<label::e_y>, regular<scalar, containers>>,
+               single_axis<closed<label::e_z>, regular<scalar, containers>>>;
 
 // Floating point comparison
 constexpr scalar tol{1e-5f};
@@ -57,7 +59,7 @@ GTEST_TEST(detray_grid, open_regular_axis) {
     const dindex_range edge_range = {2u, 10u};
 
     // An open regular x-axis
-    using x_axis_t = single_axis<open<label::e_x>, regular<>>;
+    using x_axis_t = single_axis<open<label::e_x>, regular<scalar>>;
     x_axis_t or_axis{edge_range, &bin_edges};
 
     static_assert(concepts::axis<x_axis_t>);
@@ -133,7 +135,7 @@ GTEST_TEST(detray_grid, closed_regular_axis) {
     const dindex_range edge_range = {2u, 10u};
 
     // A closed regular r-axis
-    using r_axis_t = single_axis<closed<label::e_r>, regular<>>;
+    using r_axis_t = single_axis<closed<label::e_r>, regular<scalar>>;
     r_axis_t cr_axis{edge_range, &bin_edges};
 
     static_assert(concepts::axis<r_axis_t>);
@@ -211,7 +213,7 @@ GTEST_TEST(detray_grid, circular_regular_axis) {
     const dindex_range edge_range = {1u, 36u};
 
     // A closed regular x-axis
-    using axis_t = single_axis<circular<>, regular<>>;
+    using axis_t = single_axis<circular<>, regular<scalar>>;
     axis_t cr_axis(edge_range, &bin_edges);
 
     static_assert(concepts::axis<axis_t>);
@@ -232,7 +234,8 @@ GTEST_TEST(detray_grid, circular_regular_axis) {
     EXPECT_EQ(cr_axis.bin(0), 18u);
 
     // Bin wrapping test
-    typename single_axis<circular<>, regular<>>::bounds_type circ_bounds{};
+    typename single_axis<circular<>, regular<scalar>>::bounds_type
+        circ_bounds{};
     EXPECT_EQ(circ_bounds.wrap(4, 36u), 4u);
     EXPECT_EQ(circ_bounds.wrap(0, 36u), 0u);
     EXPECT_EQ(circ_bounds.wrap(-1, 36u), 35u);
@@ -291,8 +294,8 @@ GTEST_TEST(detray_grid, closed_irregular_axis) {
     dindex_range edge_range = {1u, 6u};
 
     // A closed irregular z-axis
-    single_axis<closed<label::e_z>, irregular<>> cir_axis(edge_range,
-                                                          &bin_edges);
+    single_axis<closed<label::e_z>, irregular<scalar>> cir_axis(edge_range,
+                                                                &bin_edges);
 
     // Test axis bounds
     EXPECT_EQ(cir_axis.label(), axis::label::e_z);
@@ -383,12 +386,13 @@ void test_axis(const axis_type& /*unused*/) {
 GTEST_TEST(detray_grid, axis_comparison) {
 
     // Should be sufficient to test the comparison operators
-    using x_axis_op_r_t = single_axis<open<label::e_x>, regular<>>;
-    using x_axis_cl_r_t = single_axis<closed<label::e_x>, regular<>>;
-    using x_axis_ci_r_t = single_axis<circular<label::e_x>, regular<>>;
-    using x_axis_op_ir_t = single_axis<open<label::e_x>, irregular<>>;
-    using x_axis_cl_ir_t = single_axis<closed<label::e_x>, irregular<>>;
-    using x_axis_ci_orr_t = single_axis<circular<label::e_x>, irregular<>>;
+    using x_axis_op_r_t = single_axis<open<label::e_x>, regular<scalar>>;
+    using x_axis_cl_r_t = single_axis<closed<label::e_x>, regular<scalar>>;
+    using x_axis_ci_r_t = single_axis<circular<label::e_x>, regular<scalar>>;
+    using x_axis_op_ir_t = single_axis<open<label::e_x>, irregular<scalar>>;
+    using x_axis_cl_ir_t = single_axis<closed<label::e_x>, irregular<scalar>>;
+    using x_axis_ci_orr_t =
+        single_axis<circular<label::e_x>, irregular<scalar>>;
 
     std::tuple<x_axis_op_r_t, x_axis_cl_r_t, x_axis_ci_r_t, x_axis_op_ir_t,
                x_axis_cl_ir_t, x_axis_ci_orr_t>

--- a/tests/unit_tests/cpu/utils/grids/grid.cpp
+++ b/tests/unit_tests/cpu/utils/grids/grid.cpp
@@ -35,6 +35,8 @@ using namespace detray::axis;
 namespace {
 
 // Algebra definitions
+using test_algebra = test::algebra;
+using scalar = test::scalar;
 using point3 = test::point3;
 
 constexpr scalar inf{std::numeric_limits<scalar>::max()};
@@ -42,7 +44,8 @@ constexpr scalar tol{1e-7f};
 
 // Either a data owning or non-owning 3D cartesian multi-axis
 template <bool ownership = true, typename containers = host_container_types>
-using cartesian_3D = coordinate_axes<axes<cuboid3D>, ownership, containers>;
+using cartesian_3D =
+    coordinate_axes<axes<cuboid3D>, test_algebra, ownership, containers>;
 
 // non-owning multi-axis: Takes external containers
 bool constexpr is_owning = true;
@@ -86,14 +89,16 @@ void test_content(const grid_t& g, const point3& p, const content_t& expected) {
 GTEST_TEST(detray_grid, single_grid) {
 
     // Owning and non-owning, cartesian, 3-dimensional grids
-    using grid_owning_t = grid<axes<cuboid3D>, bins::single<scalar>>;
+    using grid_owning_t =
+        grid<test_algebra, axes<cuboid3D>, bins::single<scalar>>;
 
     using grid_n_owning_t =
-        grid<axes<cuboid3D>, bins::single<scalar>, simple_serializer,
-             host_container_types, false>;
+        grid<test_algebra, axes<cuboid3D>, bins::single<scalar>,
+             simple_serializer, host_container_types, false>;
 
-    using grid_device_t = grid<axes<cuboid3D>, bins::single<scalar>,
-                               simple_serializer, device_container_types>;
+    using grid_device_t =
+        grid<test_algebra, axes<cuboid3D>, bins::single<scalar>,
+             simple_serializer, device_container_types>;
 
     static_assert(concepts::grid<grid_owning_t>);
     static_assert(concepts::grid<grid_n_owning_t>);
@@ -136,7 +141,7 @@ GTEST_TEST(detray_grid, single_grid) {
     auto y_axis = grid_own.get_axis<label::e_y>();
     EXPECT_EQ(y_axis.nbins(), 40u);
     auto z_axis =
-        grid_own.get_axis<single_axis<closed<label::e_z>, regular<>>>();
+        grid_own.get_axis<single_axis<closed<label::e_z>, regular<scalar>>>();
     EXPECT_EQ(z_axis.nbins(), 50u);
 
     // Create non-owning grid
@@ -190,11 +195,12 @@ GTEST_TEST(detray_grid, single_grid) {
 
     static_assert(
         std::is_same_v<decltype(const_grid_view),
-                       typename grid<cartesian_3D<>, bins::single<const
-    scalar>>::view_type>, "Const grid view was not correctly constructed!");
+                       typename grid<test_algebra,cartesian_3D<>,
+    bins::single<const scalar>>::view_type>, "Const grid view was not correctly
+    constructed!");
 
-    grid<cartesian_3D<is_owning, device_container_types>, bins::single<const
-    scalar>> const_device_grid(const_grid_view);
+    grid<test_algebra,cartesian_3D<is_owning, device_container_types>,
+    bins::single<const scalar>> const_device_grid(const_grid_view);
 
     static_assert(
         std::is_same_v<typename decltype(const_device_grid)::bin_type,
@@ -206,14 +212,16 @@ GTEST_TEST(detray_grid, single_grid) {
 GTEST_TEST(detray_grid, dynamic_array) {
 
     // Owning and non-owning, cartesian, 3-dimensional grids
-    using grid_owning_t = grid<axes<cuboid3D>, bins::dynamic_array<scalar>>;
+    using grid_owning_t =
+        grid<test_algebra, axes<cuboid3D>, bins::dynamic_array<scalar>>;
 
     using grid_n_owning_t =
-        grid<axes<cuboid3D>, bins::dynamic_array<scalar>, simple_serializer,
-             host_container_types, false>;
+        grid<test_algebra, axes<cuboid3D>, bins::dynamic_array<scalar>,
+             simple_serializer, host_container_types, false>;
 
-    using grid_device_t = grid<axes<cuboid3D>, bins::dynamic_array<scalar>,
-                               simple_serializer, device_container_types>;
+    using grid_device_t =
+        grid<test_algebra, axes<cuboid3D>, bins::dynamic_array<scalar>,
+             simple_serializer, device_container_types>;
 
     static_assert(concepts::grid<grid_owning_t>);
     static_assert(concepts::grid<grid_n_owning_t>);
@@ -275,7 +283,7 @@ GTEST_TEST(detray_grid, dynamic_array) {
     auto y_axis = grid_own.get_axis<label::e_y>();
     EXPECT_EQ(y_axis.nbins(), 40u);
     auto z_axis =
-        grid_own.get_axis<single_axis<closed<label::e_z>, regular<>>>();
+        grid_own.get_axis<single_axis<closed<label::e_z>, regular<scalar>>>();
     EXPECT_EQ(z_axis.nbins(), 50u);
 
     // Check equality operator:
@@ -343,7 +351,7 @@ GTEST_TEST(detray_grid, dynamic_array) {
 GTEST_TEST(detray_grid, bin_view) {
 
     // Non-owning, 3D cartesian, replacing grid
-    using grid_t = grid<axes<cuboid3D>, bins::single<scalar>>;
+    using grid_t = grid<test_algebra, axes<cuboid3D>, bins::single<scalar>>;
 
     static_assert(concepts::grid<grid_t>);
 
@@ -478,7 +486,7 @@ GTEST_TEST(detray_grid, bin_view) {
 GTEST_TEST(detray_grid, replace_population) {
 
     // Non-owning, 3D cartesian  grid
-    using grid_t = grid<decltype(ax_n_own), bins::single<scalar>,
+    using grid_t = grid<test_algebra, decltype(ax_n_own), bins::single<scalar>,
                         simple_serializer, host_container_types, false>;
 
     static_assert(concepts::grid<grid_t>);
@@ -532,8 +540,9 @@ GTEST_TEST(detray_grid, replace_population) {
 GTEST_TEST(detray_grid, complete_population) {
 
     // Non-owning, 3D cartesian, completing grid (4 dims and sort)
-    using grid_t = grid<decltype(ax_n_own), bins::static_array<scalar, 4>,
-                        simple_serializer, host_container_types, false>;
+    using grid_t =
+        grid<test_algebra, decltype(ax_n_own), bins::static_array<scalar, 4>,
+             simple_serializer, host_container_types, false>;
     using bin_t = grid_t::bin_type;
     using bin_content_t = std::array<scalar, 4>;
 
@@ -618,8 +627,9 @@ GTEST_TEST(detray_grid, complete_population) {
 GTEST_TEST(detray_grid, regular_attach_population) {
 
     // Non-owning, 3D cartesian, completing grid (4 dims and sort)
-    using grid_t = grid<decltype(ax_n_own), bins::static_array<scalar, 4>,
-                        simple_serializer, host_container_types, false>;
+    using grid_t =
+        grid<test_algebra, decltype(ax_n_own), bins::static_array<scalar, 4>,
+             simple_serializer, host_container_types, false>;
     using bin_t = grid_t::bin_type;
     using bin_content_t = std::array<scalar, 4>;
 

--- a/tests/unit_tests/cpu/utils/grids/grid_collection.cpp
+++ b/tests/unit_tests/cpu/utils/grids/grid_collection.cpp
@@ -27,6 +27,9 @@
 using namespace detray;
 using namespace detray::axis;
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+
 namespace {
 
 // non-owning multi-axis: Takes external containers
@@ -54,8 +57,9 @@ struct bin_content_sequence {
 GTEST_TEST(detray_grid, grid_collection) {
 
     // Non-owning grid type with array<dindex, 3> as bin content
-    using grid_t = grid<axes<cylinder3D>, bins::static_array<dindex, 3>,
-                        simple_serializer, host_container_types, is_n_owning>;
+    using grid_t =
+        grid<test_algebra, axes<cylinder3D>, bins::static_array<dindex, 3>,
+             simple_serializer, host_container_types, is_n_owning>;
 
     // Build test data
     grid_t::bin_container_type bin_data{};
@@ -100,7 +104,7 @@ GTEST_TEST(detray_grid, grid_collection) {
     EXPECT_EQ(r_axis.nbins(), 1u);
     auto phi_axis = single_grid.get_axis<label::e_phi>();
     EXPECT_EQ(phi_axis.nbins(), 3u);
-    using z_axis_t = single_axis<closed<label::e_z>, regular<>>;
+    using z_axis_t = single_axis<closed<label::e_z>, regular<scalar>>;
     auto z_axis = single_grid.get_axis<z_axis_t>();
     EXPECT_EQ(z_axis.nbins(), 8u);
 
@@ -142,8 +146,9 @@ GTEST_TEST(detray_grid, grid_collection) {
 GTEST_TEST(detray_grid, grid_collection_dynamic_bin) {
 
     // Non-owning grid type with vector<dindex> as bin content
-    using grid_t = grid<axes<cylinder3D>, bins::dynamic_array<dindex>,
-                        simple_serializer, host_container_types, is_n_owning>;
+    using grid_t =
+        grid<test_algebra, axes<cylinder3D>, bins::dynamic_array<dindex>,
+             simple_serializer, host_container_types, is_n_owning>;
 
     // Build test data
     grid_t::bin_container_type bin_data{};
@@ -223,7 +228,7 @@ GTEST_TEST(detray_grid, grid_collection_dynamic_bin) {
     EXPECT_EQ(r_axis.nbins(), 1u);
     auto phi_axis = single_grid.get_axis<label::e_phi>();
     EXPECT_EQ(phi_axis.nbins(), 3u);
-    using z_axis_t = single_axis<closed<label::e_z>, regular<>>;
+    using z_axis_t = single_axis<closed<label::e_z>, regular<scalar>>;
     auto z_axis = single_grid.get_axis<z_axis_t>();
     EXPECT_EQ(z_axis.nbins(), 8u);
 

--- a/tests/unit_tests/cpu/utils/grids/serializers.cpp
+++ b/tests/unit_tests/cpu/utils/grids/serializers.cpp
@@ -29,21 +29,24 @@
 using namespace detray;
 using namespace detray::axis;
 
+using test_algebra = test::algebra;
+using scalar = test::scalar;
+
 namespace {
 
 // Axes types to be serialized
 
 // polar coordinate system with regular binning on both axes
 using polar_axes = multi_axis<
-    true, polar2D<test::algebra>,
-    single_axis<closed<label::e_r>, regular<host_container_types, scalar>>,
-    single_axis<circular<label::e_phi>, regular<host_container_types, scalar>>>;
+    true, polar2D<test_algebra>,
+    single_axis<closed<label::e_r>, regular<scalar, host_container_types>>,
+    single_axis<circular<label::e_phi>, regular<scalar, host_container_types>>>;
 // 3-dim cylindrical coordinate system with regular binning
 using cylinder_axes = multi_axis<
-    true, cylindrical3D<test::algebra>,
-    single_axis<closed<label::e_r>, regular<host_container_types, scalar>>,
-    single_axis<circular<label::e_phi>, regular<host_container_types, scalar>>,
-    single_axis<closed<label::e_z>, regular<host_container_types, scalar>>>;
+    true, cylindrical3D<test_algebra>,
+    single_axis<closed<label::e_r>, regular<scalar, host_container_types>>,
+    single_axis<circular<label::e_phi>, regular<scalar, host_container_types>>,
+    single_axis<closed<label::e_z>, regular<scalar, host_container_types>>>;
 
 }  // anonymous namespace
 

--- a/tests/unit_tests/cpu/utils/matrix_helper.cpp
+++ b/tests/unit_tests/cpu/utils/matrix_helper.cpp
@@ -15,9 +15,11 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
-using algebra_t = test::algebra;
+
+using test_algebra = test::algebra;
 using transform3 = test::transform3;
 using vector3 = typename transform3::vector3;
+using scalar = test::scalar;
 using matrix3_type = test::matrix<3, 3>;
 
 constexpr scalar tolerance = 1e-6f;
@@ -37,7 +39,7 @@ GTEST_TEST(detray_utils, column_wise_cross) {
 
     const vector3 u{1.f, 2.f, 3.f};
 
-    const auto Q = matrix_helper<algebra_t>().column_wise_cross(P, u);
+    const auto Q = matrix_helper<test_algebra>().column_wise_cross(P, u);
 
     EXPECT_NEAR(getter::element(Q, 0u, 0u), -3.f, tolerance);
     EXPECT_NEAR(getter::element(Q, 1u, 0u), 6.f, tolerance);
@@ -66,7 +68,7 @@ GTEST_TEST(detray_utils, column_wise_multiply) {
 
     const vector3 u{1.f, 2.f, 3.f};
 
-    const auto Q = matrix_helper<algebra_t>().column_wise_multiply(P, u);
+    const auto Q = matrix_helper<test_algebra>().column_wise_multiply(P, u);
 
     EXPECT_NEAR(getter::element(Q, 0u, 0u), 0.f, tolerance);
     EXPECT_NEAR(getter::element(Q, 0u, 1u), 1.f, tolerance);
@@ -84,8 +86,8 @@ GTEST_TEST(detray_utils, cross_matrix) {
     const vector3 u{1.f, 2.f, 3.f};
     const vector3 v{3.f, 4.f, 5.f};
 
-    const auto u_cross = matrix_helper<algebra_t>().cross_matrix(u);
-    const auto v_cross = matrix_helper<algebra_t>().cross_matrix(v);
+    const auto u_cross = matrix_helper<test_algebra>().cross_matrix(u);
+    const auto v_cross = matrix_helper<test_algebra>().cross_matrix(v);
 
     EXPECT_NEAR(getter::element(u_cross, 0u, 0u), 0.f, tolerance);
     EXPECT_NEAR(getter::element(u_cross, 0u, 1u), -3.f, tolerance);
@@ -114,7 +116,7 @@ GTEST_TEST(detray_utils, outer_product) {
     const vector3 u{1.f, 2.f, 3.f};
     const vector3 v{3.f, 4.f, 5.f};
 
-    const auto m33 = matrix_helper<algebra_t>().outer_product(u, v);
+    const auto m33 = matrix_helper<test_algebra>().outer_product(u, v);
 
     EXPECT_NEAR(getter::element(m33, 0u, 0u), 3.f, tolerance);
     EXPECT_NEAR(getter::element(m33, 0u, 1u), 4.f, tolerance);
@@ -142,7 +144,7 @@ GTEST_TEST(detray_utils, cholesky_decomposition) {
     getter::element(A, 2u, 2u) = 98.f;
 
     // Get L that satisfies A = L * L^T and check if it is the expected value
-    const matrix3_type L = matrix_helper<algebra_t>().cholesky_decompose(A);
+    const matrix3_type L = matrix_helper<test_algebra>().cholesky_decompose(A);
 
     EXPECT_FLOAT_EQ(static_cast<float>(getter::element(L, 0u, 0u)), 2.f);
     EXPECT_FLOAT_EQ(static_cast<float>(getter::element(L, 0u, 1u)), 0.f);

--- a/tests/unit_tests/cpu/utils/quadratic_equation.cpp
+++ b/tests/unit_tests/cpu/utils/quadratic_equation.cpp
@@ -19,6 +19,8 @@
 
 using namespace detray;
 
+using scalar = test::scalar;
+
 // This tests the convenience quadratic equation class
 GTEST_TEST(detray_utils, quadratic_equation) {
 

--- a/tests/unit_tests/cpu/utils/unit_vectors.cpp
+++ b/tests/unit_tests/cpu/utils/unit_vectors.cpp
@@ -15,8 +15,10 @@
 #include <gtest/gtest.h>
 
 using namespace detray;
+
 using transform3 = test::transform3;
 using vector3 = typename transform3::vector3;
+using scalar = test::scalar;
 
 GTEST_TEST(detray_utils, curvilinear_unit_vectors) {
 

--- a/tests/unit_tests/device/cuda/detector_cuda.cpp
+++ b/tests/unit_tests/device/cuda/detector_cuda.cpp
@@ -29,7 +29,7 @@ TEST(detector_cuda, detector) {
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // create toy geometry
-    auto [toy_det, names] = build_toy_detector(mng_mr);
+    auto [toy_det, names] = build_toy_detector<test::algebra>(mng_mr);
 
     auto ctx0 = typename detector_host_t::geometry_context();
 

--- a/tests/unit_tests/device/cuda/detector_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/detector_cuda_kernel.hpp
@@ -10,14 +10,17 @@
 // Projetc include(s)
 #include "detray/core/detector.hpp"
 #include "detray/definitions/detail/algebra.hpp"
-#include "detray/detectors/toy_metadata.hpp"
 #include "detray/utils/ranges.hpp"
+
+// Detray test include(s)
+#include "detray/test/utils/types.hpp"
 
 namespace detray {
 
 // some useful type declarations
-using detector_host_t = detector<toy_metadata, host_container_types>;
-using detector_device_t = detector<toy_metadata, device_container_types>;
+using metadata_t = test::toy_metadata;
+using detector_host_t = detector<metadata_t, host_container_types>;
+using detector_device_t = detector<metadata_t, device_container_types>;
 
 using det_volume_t = typename detector_host_t::volume_type;
 using det_surface_t = typename detector_host_t::surface_type;

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda.cpp
@@ -32,9 +32,9 @@ TEST(grids_cuda, grid2_replace_populator) {
     axis2::regular<> yaxis{6u, 0.f, 6.f, mng_mr};
 
     auto x_interval =
-        (xaxis.max - xaxis.min) / static_cast<detray::scalar>(xaxis.n_bins);
+        (xaxis.max - xaxis.min) / static_cast<scalar>(xaxis.n_bins);
     auto y_interval =
-        (yaxis.max - yaxis.min) / static_cast<detray::scalar>(yaxis.n_bins);
+        (yaxis.max - yaxis.min) / static_cast<scalar>(yaxis.n_bins);
 
     // declare host grid
     host_grid2_replace g2(std::move(xaxis), std::move(yaxis), mng_mr,
@@ -59,7 +59,7 @@ TEST(grids_cuda, grid2_replace_populator) {
     // post-check
     for (unsigned int i_x = 0u; i_x < xaxis.bins(); i_x++) {
         for (unsigned int i_y = 0u; i_y < yaxis.bins(); i_y++) {
-            auto bin_id = static_cast<detray::scalar>(i_x + i_y * xaxis.bins());
+            auto bin_id = static_cast<scalar>(i_x + i_y * xaxis.bins());
             const auto& data = g2.bin(i_x, i_y);
 
             test::point3 tp({xaxis.min + bin_id * x_interval,
@@ -79,7 +79,7 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     axis2::irregular<> iaxis{{1.f, 3.f, 9.f, 27.f, 81.f}, mng_mr};
 
     auto x_interval =
-        (caxis.max - caxis.min) / static_cast<detray::scalar>(caxis.n_bins);
+        (caxis.max - caxis.min) / static_cast<scalar>(caxis.n_bins);
 
     // declare host grid
     host_grid2_replace_ci g2(std::move(caxis), std::move(iaxis), mng_mr,
@@ -105,7 +105,7 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
     for (unsigned int i_x = 0u; i_x < caxis.bins(); i_x++) {
         for (unsigned int i_y = 0u; i_y < iaxis.bins(); i_y++) {
             auto y_interval = iaxis.boundaries[i_y + 1] - iaxis.boundaries[i_y];
-            auto bin_id = static_cast<detray::scalar>(i_x + i_y * caxis.bins());
+            auto bin_id = static_cast<scalar>(i_x + i_y * caxis.bins());
 
             const auto& data = g2.bin(i_x, i_y);
 
@@ -150,9 +150,9 @@ TEST(grids_cuda, grid2_complete_populator) {
     grid_complete_test(g2_data);
 
     auto x_interval =
-        (xaxis.max - xaxis.min) / static_cast<detray::scalar>(xaxis.n_bins);
+        (xaxis.max - xaxis.min) / static_cast<scalar>(xaxis.n_bins);
     auto y_interval =
-        (yaxis.max - yaxis.min) / static_cast<detray::scalar>(yaxis.n_bins);
+        (yaxis.max - yaxis.min) / static_cast<scalar>(yaxis.n_bins);
 
     // post-check
     for (unsigned int i_y = 0u; i_y < yaxis.bins(); i_y++) {
@@ -164,8 +164,7 @@ TEST(grids_cuda, grid2_complete_populator) {
                 auto& pt = data[i_p];
 
                 auto bin_id = i_x + i_y * xaxis.bins();
-                auto gid =
-                    static_cast<detray::scalar>(i_p + bin_id * data.size());
+                auto gid = static_cast<scalar>(i_p + bin_id * data.size());
 
                 test::point3 tp({xaxis.min + gid * x_interval,
                                  yaxis.min + gid * y_interval, 0.5f});
@@ -185,9 +184,9 @@ TEST(grids_cuda, grid2_attach_populator) {
     axis2::regular<> yaxis{2u, 0.f, 6.f, mng_mr};
 
     auto x_interval =
-        (xaxis.max - xaxis.min) / static_cast<detray::scalar>(xaxis.n_bins);
+        (xaxis.max - xaxis.min) / static_cast<scalar>(xaxis.n_bins);
     auto y_interval =
-        (yaxis.max - yaxis.min) / static_cast<detray::scalar>(yaxis.n_bins);
+        (yaxis.max - yaxis.min) / static_cast<scalar>(yaxis.n_bins);
 
     host_grid2_attach g2(xaxis, yaxis, mng_mr, test::point3{0.f, 0.f, 0.f});
 
@@ -197,7 +196,7 @@ TEST(grids_cuda, grid2_attach_populator) {
             for (unsigned int i_p = 0u; i_p < 100u; i_p++) {
 
                 auto bin_id = i_x + i_y * xaxis.bins();
-                auto gid = static_cast<detray::scalar>(i_p + bin_id * 100u);
+                auto gid = static_cast<scalar>(i_p + bin_id * 100u);
 
                 test::point3 tp({xaxis.min + gid * x_interval,
                                  yaxis.min + gid * y_interval, 0.5f});

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda_kernel.cu
@@ -186,9 +186,8 @@ __global__ void grid_attach_fill_test_kernel(
     device_grid2_attach g2_device(grid_view);
 
     // Fill with 100 points
-    auto pt = test::point3{detray::scalar(1.) * threadIdx.x,
-                           detray::scalar(1.) * threadIdx.x,
-                           detray::scalar(1.) * threadIdx.x};
+    auto pt = test::point3{scalar(1.) * threadIdx.x, scalar(1.) * threadIdx.x,
+                           scalar(1.) * threadIdx.x};
     g2_device.populate(blockIdx.x, blockIdx.y, std::move(pt));
 
     __syncthreads();
@@ -231,9 +230,8 @@ __global__ void grid_attach_assign_test_kernel(
     auto pts = g2_device.bin(threadIdx.x, threadIdx.y);
 
     for (std::size_t i = 0u; i < pts.size(); i++) {
-        pts[i] = {static_cast<detray::scalar>(i),
-                  static_cast<detray::scalar>(i + 1u),
-                  static_cast<detray::scalar>(i + 2u)};
+        pts[i] = {static_cast<scalar>(i), static_cast<scalar>(i + 1u),
+                  static_cast<scalar>(i + 2u)};
     }
 }
 

--- a/tests/unit_tests/device/cuda/grids_grid2_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/grids_grid2_cuda_kernel.hpp
@@ -19,6 +19,8 @@
 
 namespace detray {
 
+using scalar = test::scalar;
+
 static constexpr int n_points = 3;
 
 using host_grid2_replace =

--- a/tests/unit_tests/device/cuda/mask_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda.cpp
@@ -59,7 +59,7 @@ TEST(mask_store_cuda, mask_store) {
 
     std::random_device rd;
     std::mt19937_64 gen(rd());
-    std::uniform_real_distribution<dscalar<algebra_t>> dist(0.f, 9.9f);
+    std::uniform_real_distribution<dscalar<test_algebra>> dist(0.f, 9.9f);
     for (unsigned int i = 0u; i < n_points; i++) {
         point3 rand_point3 = {dist(gen), dist(gen), dist(gen)};
         input_point3[i] = rand_point3;

--- a/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/mask_store_cuda_kernel.hpp
@@ -13,6 +13,9 @@
 #include "detray/geometry/mask.hpp"
 #include "detray/geometry/shapes.hpp"
 
+// Detray test include(s)
+#include "detray/test/utils/types.hpp"
+
 // Vecmem include(s)
 #include <vecmem/containers/data/jagged_vector_buffer.hpp>
 #include <vecmem/containers/device_vector.hpp>
@@ -21,17 +24,17 @@
 
 namespace detray {
 
-using algebra_t = ALGEBRA_PLUGIN<detray::scalar>;
-using point3 = detray::dpoint3D<algebra_t>;
-using transform3 = detray::dtransform3D<algebra_t>;
+using test_algebra = test::algebra;
+using point3 = dpoint3D<test_algebra>;
+using transform3 = dtransform3D<test_algebra>;
 const int n_points = 1000;
 
-using annulus = mask<annulus2D>;
-using cylinder = mask<cylinder2D>;
-using rectangle = mask<rectangle2D>;
-using ring = mask<ring2D>;
-using single = mask<single3D<>>;
-using trapezoid = mask<trapezoid2D>;
+using annulus = mask<annulus2D, test_algebra>;
+using cylinder = mask<cylinder2D, test_algebra>;
+using rectangle = mask<rectangle2D, test_algebra>;
+using ring = mask<ring2D, test_algebra>;
+using single = mask<single3D<>, test_algebra>;
+using trapezoid = mask<trapezoid2D, test_algebra>;
 
 /// Enumerate different mask types for convenience
 enum class mask_ids : unsigned int {

--- a/tests/unit_tests/device/cuda/navigator_cuda.cpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda.cpp
@@ -23,8 +23,6 @@ using namespace detray;
 
 TEST(navigator_cuda, navigator) {
 
-    using scalar_t = dscalar<algebra_t>;
-
     // Helper object for performing memory copies.
     vecmem::cuda::copy copy;
 
@@ -33,7 +31,7 @@ TEST(navigator_cuda, navigator) {
     vecmem::cuda::device_memory_resource dev_mr;
 
     // Create detector
-    auto [det, names] = build_toy_detector(mng_mr);
+    auto [det, names] = build_toy_detector<test_algebra>(mng_mr);
 
     // Create navigator
     navigator_host_t nav;
@@ -43,14 +41,15 @@ TEST(navigator_cuda, navigator) {
     stepping::config step_cfg{};
 
     // Create the vector of initial track parameters
-    vecmem::vector<free_track_parameters<algebra_t>> tracks_host(&mng_mr);
-    vecmem::vector<free_track_parameters<algebra_t>> tracks_device(&mng_mr);
+    vecmem::vector<free_track_parameters<test_algebra>> tracks_host(&mng_mr);
+    vecmem::vector<free_track_parameters<test_algebra>> tracks_device(&mng_mr);
 
     // Magnitude of total momentum of tracks
-    const scalar_t p_mag{10.f * unit<scalar_t>::GeV};
+    const scalar p_mag{10.f * unit<scalar>::GeV};
 
     // Iterate through uniformly distributed momentum directions
-    for (auto track : uniform_track_generator<free_track_parameters<algebra_t>>(
+    for (auto track :
+         uniform_track_generator<free_track_parameters<test_algebra>>(
              phi_steps, theta_steps, p_mag)) {
         tracks_host.push_back(track);
         tracks_device.push_back(track);

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.cu
@@ -15,14 +15,15 @@ namespace detray {
 __global__ void navigator_test_kernel(
     typename detector_host_t::view_type det_data, navigation::config nav_cfg,
     stepping::config step_cfg,
-    vecmem::data::vector_view<free_track_parameters<algebra_t>> tracks_data,
+    vecmem::data::vector_view<free_track_parameters<test_algebra>> tracks_data,
     vecmem::data::jagged_vector_view<dindex> volume_records_data,
     vecmem::data::jagged_vector_view<point3> position_records_data) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
 
     detector_device_t det(det_data);
-    vecmem::device_vector<free_track_parameters<algebra_t>> tracks(tracks_data);
+    vecmem::device_vector<free_track_parameters<test_algebra>> tracks(
+        tracks_data);
     vecmem::jagged_device_vector<dindex> volume_records(volume_records_data);
     vecmem::jagged_device_vector<point3> position_records(
         position_records_data);
@@ -70,7 +71,7 @@ __global__ void navigator_test_kernel(
 void navigator_test(
     typename detector_host_t::view_type det_data, navigation::config& nav_cfg,
     stepping::config& step_cfg,
-    vecmem::data::vector_view<free_track_parameters<algebra_t>>& tracks_data,
+    vecmem::data::vector_view<free_track_parameters<test_algebra>>& tracks_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,
     vecmem::data::jagged_vector_view<point3>& position_records_data) {
 

--- a/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/navigator_cuda_kernel.hpp
@@ -10,29 +10,30 @@
 // Project include(s)
 #include "detray/definitions/detail/algebra.hpp"
 #include "detray/definitions/units.hpp"
-#include "detray/detectors/toy_metadata.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/line_stepper.hpp"
 #include "detray/propagator/propagation_config.hpp"
 
 // Detray test include(s)
 #include "detray/test/utils/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/types.hpp"
 
 namespace detray {
 
-using algebra_t = ALGEBRA_PLUGIN<detray::scalar>;
-using point3 = dpoint3D<algebra_t>;
-
 // some useful type declarations
-using detector_host_t = detector<toy_metadata, host_container_types>;
-using detector_device_t = detector<toy_metadata, device_container_types>;
+using metadata_t = test::toy_metadata;
+using test_algebra = metadata_t::algebra_type;
+using scalar = dscalar<test_algebra>;
+using point3 = dpoint3D<test_algebra>;
+using detector_host_t = detector<metadata_t, host_container_types>;
+using detector_device_t = detector<metadata_t, device_container_types>;
 
 using intersection_t =
-    intersection2D<typename detector_device_t::surface_type, algebra_t>;
+    intersection2D<typename detector_device_t::surface_type, test_algebra>;
 
 using navigator_host_t = navigator<detector_host_t>;
 using navigator_device_t = navigator<detector_device_t>;
-using stepper_t = line_stepper<algebra_t>;
+using stepper_t = line_stepper<test_algebra>;
 
 // detector configuration
 constexpr std::size_t n_brl_layers{4u};
@@ -42,7 +43,7 @@ constexpr std::size_t n_edc_layers{3u};
 constexpr unsigned int theta_steps{100u};
 constexpr unsigned int phi_steps{100u};
 
-constexpr dscalar<algebra_t> pos_diff_tolerance{1e-3f};
+constexpr scalar pos_diff_tolerance{1e-3f};
 
 // dummy propagator state
 template <typename navigation_t>
@@ -57,7 +58,7 @@ struct prop_state {
 void navigator_test(
     typename detector_host_t::view_type det_data, navigation::config& nav_cfg,
     stepping::config& step_cfg,
-    vecmem::data::vector_view<free_track_parameters<algebra_t>>& tracks_data,
+    vecmem::data::vector_view<free_track_parameters<test_algebra>>& tracks_data,
     vecmem::data::jagged_vector_view<dindex>& volume_records_data,
     vecmem::data::jagged_vector_view<point3>& position_records_data);
 

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
@@ -103,7 +103,7 @@ TEST(grids_cuda, grid3_replace_populator) {
 
                 const auto& bin = g3.bin(gbin);
 
-                const detray::scalar gbin_f{static_cast<detray::scalar>(gbin)};
+                const scalar gbin_f{static_cast<scalar>(gbin)};
                 const point3 tp{axis_x.min() + gbin_f * axis_x.bin_width(),
                                 axis_y.min() + gbin_f * axis_y.bin_width(),
                                 axis_z.min() + gbin_f * axis_z.bin_width()};
@@ -165,7 +165,7 @@ TEST(grids_cuda, grid2_replace_populator_ci) {
             const dindex gbin = g2.serialize({i_r, i_phi});
             const auto& bin = g2.bin(gbin);
 
-            const detray::scalar gbin_f{static_cast<detray::scalar>(gbin)};
+            const scalar gbin_f{static_cast<scalar>(gbin)};
             const point3 tp{axis_r.min() + gbin_f * axis_r.bin_width(i_r),
                             axis_phi.min() + gbin_f * axis_phi.bin_width(),
                             0.5f};
@@ -232,7 +232,7 @@ TEST(grids_cuda, grid2_complete_populator) {
             const auto& bin = g2.bin(gbin);
 
             // Other point with which the bin has been completed
-            const detray::scalar gbin_f{static_cast<detray::scalar>(gbin)};
+            const scalar gbin_f{static_cast<scalar>(gbin)};
             const point3 tp{axis_r.min() + gbin_f * width_r,
                             axis_phi.min() + gbin_f * width_phi, 0.5};
 
@@ -310,7 +310,7 @@ TEST(grids_cuda, grid2_attach_populator) {
             const auto& bin = g2.bin(gbin);
 
             // Other point with which the bin has been completed
-            const detray::scalar gbin_f{static_cast<detray::scalar>(gbin)};
+            const scalar gbin_f{static_cast<scalar>(gbin)};
             const point3 tp{axis_r.min() + gbin_f * width_r,
                             axis_phi.min() + gbin_f * width_phi, 0.5};
 
@@ -420,7 +420,7 @@ TEST(grids_cuda, grid2_dynamic_attach_populator) {
             const auto& bin = g2.bin(gbin);
 
             // Other point with which the bin has been completed
-            const detray::scalar gbin_f{static_cast<detray::scalar>(gbin)};
+            const scalar gbin_f{static_cast<scalar>(gbin)};
             const point3 tp{axis_r.min() + gbin_f * width_r,
                             axis_phi.min() + gbin_f * width_phi, 0.5};
 

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda_kernel.hpp
@@ -16,11 +16,15 @@
 #include "detray/utils/grid/populators.hpp"
 #include "detray/utils/grid/serializers.hpp"
 
+// Detray test include(s)
+#include "detray/test/utils/types.hpp"
+
 namespace detray {
 
 // type definitions
-using algebra_t = ALGEBRA_PLUGIN<detray::scalar>;
-using point3 = detray::dpoint3D<algebra_t>;
+using test_algebra = test::algebra;
+using scalar = detray::dscalar<test_algebra>;
+using point3 = detray::dpoint3D<test_algebra>;
 
 using namespace axis;
 
@@ -31,38 +35,41 @@ inline constexpr bool is_owning{true};
 // host and device grid definitions
 
 // replacer
-using host_grid3_single = grid<axes<cuboid3D>, bins::single<point3>>;
+using host_grid3_single =
+    grid<test_algebra, axes<cuboid3D>, bins::single<point3>>;
 
-using device_grid3_single = grid<axes<cuboid3D>, bins::single<point3>,
-                                 simple_serializer, device_container_types>;
+using device_grid3_single =
+    grid<test_algebra, axes<cuboid3D>, bins::single<point3>, simple_serializer,
+         device_container_types>;
 
 using host_grid2_single_ci =
-    grid<axes<ring2D, bounds::e_closed, irregular>, bins::single<point3>>;
+    grid<test_algebra, axes<ring2D, bounds::e_closed, irregular>,
+         bins::single<point3>>;
 
 using device_grid2_single_ci =
-    grid<axes<ring2D, bounds::e_closed, irregular>, bins::single<point3>,
-         simple_serializer, device_container_types>;
+    grid<test_algebra, axes<ring2D, bounds::e_closed, irregular>,
+         bins::single<point3>, simple_serializer, device_container_types>;
 
 // completer/attacher
 using host_grid2_array =
-    grid<axes<ring2D>, bins::static_array<point3, n_points>>;
+    grid<test_algebra, axes<ring2D>, bins::static_array<point3, n_points>>;
 
 using device_grid2_array =
-    grid<axes<ring2D>, bins::static_array<point3, n_points>, simple_serializer,
-         device_container_types>;
+    grid<test_algebra, axes<ring2D>, bins::static_array<point3, n_points>,
+         simple_serializer, device_container_types>;
 
 using host_grid2_dynamic_array =
-    grid<axes<ring2D>, bins::dynamic_array<point3>>;
+    grid<test_algebra, axes<ring2D>, bins::dynamic_array<point3>>;
 
 using device_grid2_dynamic_array =
-    grid<axes<ring2D>, bins::dynamic_array<point3>, simple_serializer,
-         device_container_types>;
+    grid<test_algebra, axes<ring2D>, bins::dynamic_array<point3>,
+         simple_serializer, device_container_types>;
 
 // grid collection
 template <typename containers>
-using cylinder3D_grid =
-    grid<axes<cylinder3D, bounds::e_open>, bins::static_array<dindex, n_points>,
-         simple_serializer, containers, !is_owning>;
+using cylinder3D_grid = grid<test_algebra, axes<cylinder3D, bounds::e_open>,
+                             bins::static_array<dindex, n_points>,
+                             simple_serializer, containers, !is_owning>;
 
 using n_own_host_grid3_array = cylinder3D_grid<host_container_types>;
 using n_own_device_grid3_array = cylinder3D_grid<device_container_types>;

--- a/tests/unit_tests/device/cuda/transform_store_cuda.cpp
+++ b/tests/unit_tests/device/cuda/transform_store_cuda.cpp
@@ -25,10 +25,6 @@ using namespace detray;
 
 TEST(transform_store_cuda, transform_store) {
 
-    using algebra_t = ALGEBRA_PLUGIN<detray::scalar>;
-    using point3 = detray::dpoint3D<algebra_t>;
-    using transform3 = detray::dtransform3D<algebra_t>;
-
     // memory resource
     vecmem::cuda::managed_memory_resource mng_mr;
 

--- a/tests/unit_tests/device/cuda/transform_store_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/transform_store_cuda_kernel.hpp
@@ -11,14 +11,18 @@
 #include "detray/core/detail/single_store.hpp"
 #include "detray/definitions/detail/algebra.hpp"
 
+// Detray test inclue(s)
+#include "detray/test/utils/types.hpp"
+
 // Vecmem include(s)
 #include <vecmem/containers/device_vector.hpp>
 
 namespace detray {
 
-using algebra_t = ALGEBRA_PLUGIN<detray::scalar>;
-using point3 = dpoint3D<algebra_t>;
-using transform3 = dtransform3D<algebra_t>;
+using test_algebra = test::algebra;
+using scalar = dscalar<test_algebra>;
+using point3 = dpoint3D<test_algebra>;
+using transform3 = dtransform3D<test_algebra>;
 
 using host_transform_store_t = single_store<transform3, vecmem::vector>;
 

--- a/tests/unit_tests/svgtools/detectors.cpp
+++ b/tests/unit_tests/svgtools/detectors.cpp
@@ -14,6 +14,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -44,7 +45,8 @@ GTEST_TEST(svgtools, detector) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::test::algebra>(host_mr);
 
     // Creating the svg generator for the detector.
     detray::svgtools::illustrator il{det, names};

--- a/tests/unit_tests/svgtools/grids.cpp
+++ b/tests/unit_tests/svgtools/grids.cpp
@@ -14,6 +14,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -31,7 +32,8 @@ GTEST_TEST(svgtools, grids) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::test::algebra>(host_mr);
 
     // Creating the view.
     const actsvg::views::x_y view;

--- a/tests/unit_tests/svgtools/groups.cpp
+++ b/tests/unit_tests/svgtools/groups.cpp
@@ -16,6 +16,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -42,7 +43,8 @@ GTEST_TEST(svgtools, groups) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::test::algebra>(host_mr);
 
     // Creating the svg generator for the detector.
     const detray::svgtools::illustrator il{det, names};

--- a/tests/unit_tests/svgtools/intersections.cpp
+++ b/tests/unit_tests/svgtools/intersections.cpp
@@ -16,6 +16,7 @@
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
 #include "detray/test/utils/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/types.hpp"
 #include "detray/test/validation/detector_scanner.hpp"
 #include "detray/test/validation/svg_display.hpp"
 #include "detray/tracks/tracks.hpp"
@@ -51,10 +52,11 @@ GTEST_TEST(svgtools, intersections) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::test::algebra>(host_mr);
 
     using detector_t = decltype(det);
-    using algebra_t = typename detector_t::algebra_type;
+    using test_algebra = typename detector_t::algebra_type;
 
     detector_t::geometry_context gctx{};
 
@@ -66,7 +68,7 @@ GTEST_TEST(svgtools, intersections) {
 
     // Creating the rays.
     using generator_t =
-        detray::uniform_track_generator<detray::detail::ray<algebra_t>>;
+        detray::uniform_track_generator<detray::detail::ray<test_algebra>>;
     auto trk_gen_cfg = generator_t::configuration{};
     trk_gen_cfg.origin({0.f, 0.f, 100.f}).phi_steps(10u).theta_steps(10u);
 

--- a/tests/unit_tests/svgtools/landmarks.cpp
+++ b/tests/unit_tests/svgtools/landmarks.cpp
@@ -14,6 +14,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -40,7 +41,8 @@ GTEST_TEST(svgtools, landmarks) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::test::algebra>(host_mr);
     using detector_t = decltype(det);
 
     using point = typename detector_t::point3_type;

--- a/tests/unit_tests/svgtools/masks.cpp
+++ b/tests/unit_tests/svgtools/masks.cpp
@@ -16,6 +16,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -39,8 +40,9 @@ GTEST_TEST(svgtools, masks) {
     const auto axes = actsvg::draw::x_y_axes("axes", {-250, 250}, {-250, 250},
                                              actsvg::style::stroke());
 
-    using toy_detector_t = detray::detector<detray::toy_metadata>;
-    using transform_t = typename toy_detector_t::transform3_type;
+    using toy_detector_t = detray::detector<detray::test::toy_metadata>;
+    using algebra_t = typename toy_detector_t::algebra_type;
+    using transform_t = detray::dtransform3D<algebra_t>;
 
     const typename transform_t::vector3 tr{50.f, 100.f, 0.f};
     const typename toy_detector_t::transform3_type transform(tr);
@@ -49,8 +51,8 @@ GTEST_TEST(svgtools, masks) {
     // Visualize a 2D annulus.
     // e_min_r, e_max_r, e_min_phi_rel, e_max_phi_rel, e_average_phi, e_shift_x,
     // e_shift_y
-    detray::mask<detray::annulus2D> ann2D{0u,   100.f, 200.f, -0.5f,
-                                          0.5f, 0.f,   4.f,   30.f};
+    detray::mask<detray::annulus2D, algebra_t> ann2D{0u,   100.f, 200.f, -0.5f,
+                                                     0.5f, 0.f,   4.f,   30.f};
     const auto ann2D_proto =
         detray::svgtools::conversion::surface(transform, ann2D);
     const auto ann2D_svg = actsvg::display::surface("", ann2D_proto, view);
@@ -58,7 +60,7 @@ GTEST_TEST(svgtools, masks) {
 
     // Visualize a 2D cylinder.
     // e_r, e_lower_z, e_upper_z
-    detray::mask<detray::cylinder2D> cyl2D{0u, 100.f, -10.f, 10.f};
+    detray::mask<detray::cylinder2D, algebra_t> cyl2D{0u, 100.f, -10.f, 10.f};
     const auto cyl2D_proto =
         detray::svgtools::conversion::surface(transform, cyl2D);
     const auto cyl2D_svg = actsvg::display::surface("", cyl2D_proto, view);
@@ -66,7 +68,7 @@ GTEST_TEST(svgtools, masks) {
 
     // Visualize a 2D rectangle.
     // e_half_x, e_half_y
-    detray::mask<detray::rectangle2D> rec2D{0u, 100.f, 100.f};
+    detray::mask<detray::rectangle2D, algebra_t> rec2D{0u, 100.f, 100.f};
     const auto rec2D_proto =
         detray::svgtools::conversion::surface(transform, rec2D);
     const auto rec2D_svg = actsvg::display::surface("", rec2D_proto, view);
@@ -74,7 +76,7 @@ GTEST_TEST(svgtools, masks) {
 
     // Visualize a 2D ring.
     // e_inner_r, e_outer_r
-    detray::mask<detray::ring2D> rin2D{0u, 50.f, 100.f};
+    detray::mask<detray::ring2D, algebra_t> rin2D{0u, 50.f, 100.f};
     const auto rin2D_proto =
         detray::svgtools::conversion::surface(transform, rin2D);
     const auto rin2D_svg = actsvg::display::surface("", rin2D_proto, view);
@@ -82,8 +84,8 @@ GTEST_TEST(svgtools, masks) {
 
     // Visualize a 2D trapezoid.
     // e_half_length_0, e_half_length_1, e_half_length_2, e_divisor
-    detray::mask<detray::trapezoid2D> tra2D{0u, 100.f, 50.f, 200.f,
-                                            1.f / 400.f};
+    detray::mask<detray::trapezoid2D, algebra_t> tra2D{0u, 100.f, 50.f, 200.f,
+                                                       1.f / 400.f};
     const auto tra2D_proto =
         detray::svgtools::conversion::surface(transform, tra2D);
     const auto tra2D_svg = actsvg::display::surface("", tra2D_proto, view);
@@ -91,7 +93,7 @@ GTEST_TEST(svgtools, masks) {
 
     // Visualize a line.
     // e_cross_section, e_half_z
-    detray::mask<detray::line_circular> lin2D{0u, 10.f, 100.f};
+    detray::mask<detray::line_circular, algebra_t> lin2D{0u, 10.f, 100.f};
     const auto lin2D_proto =
         detray::svgtools::conversion::surface(transform, lin2D);
     const auto lin2D_svg = actsvg::display::surface("", lin2D_proto, view);

--- a/tests/unit_tests/svgtools/material.cpp
+++ b/tests/unit_tests/svgtools/material.cpp
@@ -14,6 +14,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -43,9 +44,10 @@ GTEST_TEST(svgtools, material) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    detray::toy_det_config toy_cfg{};
+    detray::toy_det_config<detray::test::scalar> toy_cfg{};
     toy_cfg.use_material_maps(true).cyl_map_bins(20, 20).disc_map_bins(5, 20);
-    const auto [det, names] = detray::build_toy_detector(host_mr, toy_cfg);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::test::algebra>(host_mr, toy_cfg);
 
     // Creating the svg generator for the detector.
     detray::svgtools::illustrator il{det, names};

--- a/tests/unit_tests/svgtools/surfaces.cpp
+++ b/tests/unit_tests/svgtools/surfaces.cpp
@@ -14,6 +14,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -46,7 +47,8 @@ GTEST_TEST(svgtools, surfaces) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::test::algebra>(host_mr);
 
     // Creating the svg generator for the detector.
     const detray::svgtools::illustrator il{det, names};

--- a/tests/unit_tests/svgtools/trajectories.cpp
+++ b/tests/unit_tests/svgtools/trajectories.cpp
@@ -17,6 +17,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 #include "detray/test/validation/detector_scanner.hpp"
 #include "detray/test/validation/svg_display.hpp"
 
@@ -51,7 +52,8 @@ GTEST_TEST(svgtools, trajectories) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::test::algebra>(host_mr);
     using detector_t = decltype(det);
 
     detector_t::geometry_context gctx{};
@@ -64,13 +66,14 @@ GTEST_TEST(svgtools, trajectories) {
         il.draw_volumes(std::vector{7u, 9u, 11u, 13u}, view);
 
     // Creating a ray.
-    using algebra_t = typename detector_t::algebra_type;
-    using vector3 = typename detector_t::vector3_type;
+    using test_algebra = typename detector_t::algebra_type;
+    using scalar = detray::dscalar<test_algebra>;
+    using vector3 = detray::dvector3D<test_algebra>;
 
     const typename detector_t::point3_type ori{0.f, 0.f, 80.f};
     const typename detector_t::point3_type dir{0, 1.f, 1.f};
 
-    const detray::detail::ray<algebra_t> ray(ori, 0.f, dir, 0.f);
+    const detray::detail::ray<test_algebra> ray(ori, 0.f, dir, 0.f);
     const auto ray_ir =
         detray::detector_scanner::run<detray::ray_scan>(gctx, det, ray);
 
@@ -88,11 +91,10 @@ GTEST_TEST(svgtools, trajectories) {
     // Creating a helix trajectory.
 
     // Constant magnetic field
-    vector3 B{0.f * detray::unit<detray::scalar>::T,
-              0.f * detray::unit<detray::scalar>::T,
-              1.f * detray::unit<detray::scalar>::T};
+    vector3 B{0.f * detray::unit<scalar>::T, 0.f * detray::unit<scalar>::T,
+              1.f * detray::unit<scalar>::T};
 
-    const detray::detail::helix<algebra_t> helix(
+    const detray::detail::helix<test_algebra> helix(
         ori, 0.f, detray::vector::normalize(dir), -8.f, &B);
     const auto helix_ir =
         detray::detector_scanner::run<detray::helix_scan>(gctx, det, helix);

--- a/tests/unit_tests/svgtools/volumes.cpp
+++ b/tests/unit_tests/svgtools/volumes.cpp
@@ -14,6 +14,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/host_memory_resource.hpp>
@@ -46,7 +47,8 @@ GTEST_TEST(svgtools, volumes) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::test::algebra>(host_mr);
 
     // Creating the svg generator for the detector.
     detray::svgtools::illustrator il{det, names};

--- a/tests/unit_tests/svgtools/web.cpp
+++ b/tests/unit_tests/svgtools/web.cpp
@@ -16,6 +16,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/types.hpp"
 #include "detray/test/validation/detector_scanner.hpp"
 #include "detray/test/validation/svg_display.hpp"
 
@@ -49,11 +50,13 @@ GTEST_TEST(svgtools, web) {
 
     // Creating the detector and geomentry context.
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::test::algebra>(host_mr);
     using detector_t = decltype(det);
 
-    using algebra_t = typename detector_t::algebra_type;
-    using vector3 = typename detector_t::vector3_type;
+    using test_algebra = typename detector_t::algebra_type;
+    using scalar = detray::dscalar<test_algebra>;
+    using vector3 = detray::dvector3D<test_algebra>;
 
     detector_t::geometry_context gctx{};
 
@@ -83,11 +86,10 @@ GTEST_TEST(svgtools, web) {
 
         // Create the helix trajectory.
         // Constant magnetic field
-        vector3 B{0.f * detray::unit<detray::scalar>::T,
-                  0.f * detray::unit<detray::scalar>::T,
-                  1.f * detray::unit<detray::scalar>::T};
+        vector3 B{0.f * detray::unit<scalar>::T, 0.f * detray::unit<scalar>::T,
+                  1.f * detray::unit<scalar>::T};
 
-        const detray::detail::helix<algebra_t> helix(
+        const detray::detail::helix<test_algebra> helix(
             ori, 0.f, detray::vector::normalize(dir), static_cast<float>(qop),
             &B);
         const auto helix_ir =

--- a/tutorials/include/detray/tutorial/detector_metadata.hpp
+++ b/tutorials/include/detray/tutorial/detector_metadata.hpp
@@ -45,17 +45,17 @@ namespace tutorial {
 using nav_link = std::uint_least16_t;
 
 /// The mask types for the detector sensitive/passive surfaces
-using square = mask<square2D, nav_link>;
-using trapezoid = mask<trapezoid2D, nav_link>;
+using square = mask<square2D, detray::tutorial::algebra_t, nav_link>;
+using trapezoid = mask<trapezoid2D, detray::tutorial::algebra_t, nav_link>;
 // Types for portals
-using rectangle = mask<rectangle2D, nav_link>;
+using rectangle = mask<rectangle2D, detray::tutorial::algebra_t, nav_link>;
 
 //
 // Material Description
 //
 
 /// The material types to be mapped onto the surfaces: Here homogeneous material
-using slab = material_slab<detray::scalar>;
+using slab = material_slab<scalar>;
 
 //
 // Detector
@@ -150,7 +150,8 @@ struct my_metadata {
     /// given position. Here: Uniform grid with a 3D cylindrical shape
     template <typename container_t = host_container_types>
     using volume_finder =
-        grid<axes<cylinder3D, axis::bounds::e_open, axis::irregular,
+        grid<algebra_type,
+             axes<cylinder3D, axis::bounds::e_open, axis::irregular,
                   axis::regular, axis::irregular>,
              bins::single<dindex>, simple_serializer, container_t>;
 };

--- a/tutorials/include/detray/tutorial/square_surface_generator.hpp
+++ b/tutorials/include/detray/tutorial/square_surface_generator.hpp
@@ -29,7 +29,7 @@ class square_surface_generator final
 
     public:
     using detector_t = detector<tutorial::my_metadata>;
-    using scalar_t = typename detector_t::scalar_type;
+    using scalar_t = dscalar<typename detector_t::algebra_type>;
 
     /// Generate @param n square surfaces with half length @param hl .
     DETRAY_HOST

--- a/tutorials/include/detray/tutorial/types.hpp
+++ b/tutorials/include/detray/tutorial/types.hpp
@@ -16,6 +16,11 @@
 #include "detray/definitions/detail/algebra.hpp"
 #include "detray/plugins/algebra/array_definitions.hpp"
 
+// Detray detector include(s)
+#include "detray/detectors/default_metadata.hpp"
+#include "detray/detectors/telescope_metadata.hpp"
+#include "detray/detectors/toy_metadata.hpp"
+
 namespace detray::tutorial {
 
 using algebra_t = detray::array<DETRAY_CUSTOM_SCALARTYPE>;
@@ -24,5 +29,11 @@ using point2 = detray::dpoint2D<algebra_t>;
 using point3 = detray::dpoint3D<algebra_t>;
 using vector3 = detray::dvector3D<algebra_t>;
 using transform3 = detray::dtransform3D<algebra_t>;
+
+// Test detector types
+using default_metadata = detray::default_metadata<algebra_t>;
+using toy_metadata = detray::toy_metadata<algebra_t>;
+using default_telescope_metadata =
+    detray::telescope_metadata<algebra_t, rectangle2D>;
 
 }  // namespace detray::tutorial

--- a/tutorials/src/cpu/detector/detector_ray_scan.cpp
+++ b/tutorials/src/cpu/detector/detector_ray_scan.cpp
@@ -34,12 +34,15 @@ constexpr std::size_t root_hash = 11359580520962287982ul;
 /// 'tests/common/tools/ray_detector_scan_utils.hpp'.
 int main() {
 
+    using algebra_t = detray::tutorial::algebra_t;
+    using scalar = detray::tutorial::scalar;
+
     // Can also be performed with helices
-    using ray_t = detray::detail::ray<detray::tutorial::algebra_t>;
+    using ray_t = detray::detail::ray<algebra_t>;
 
     // Build the geometry
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] = detray::build_toy_detector<algebra_t>(host_mr);
 
     // The current geometry context
     using detector_t = decltype(det);
@@ -62,11 +65,11 @@ int main() {
     std::size_t n_rays{0u};
 
     // Generate a number of random rays
-    using generator_t = detray::detail::random_numbers<
-        detray::scalar, std::uniform_real_distribution<detray::scalar>>;
+    using generator_t =
+        detray::detail::random_numbers<scalar,
+                                       std::uniform_real_distribution<scalar>>;
     auto ray_generator = detray::random_track_generator<ray_t, generator_t>{};
-    ray_generator.config().n_tracks(10000).p_T(
-        1.f * detray::unit<detray::scalar>::GeV);
+    ray_generator.config().n_tracks(10000).p_T(1.f * detray::unit<scalar>::GeV);
 
     // Run the check
     std::cout << "\nScanning " << det.name(names) << " ("

--- a/tutorials/src/cpu/detector/detector_to_dot.cpp
+++ b/tutorials/src/cpu/detector/detector_to_dot.cpp
@@ -7,7 +7,6 @@
 
 // Project include(s)
 #include "detray/core/detector.hpp"
-#include "detray/detectors/toy_metadata.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/volume_graph.hpp"
 
@@ -35,7 +34,8 @@ int main(int argc, char** argv) {
     }
 
     // Read a toy detector
-    using detector_t = detray::detector<detray::toy_metadata>;
+    using metadata_t = detray::tutorial::toy_metadata;
+    using detector_t = detray::detector<metadata_t>;
 
     // Create an empty detector to be filled
     vecmem::host_memory_resource host_mr;

--- a/tutorials/src/cpu/detector/do_it_yourself_detector.cpp
+++ b/tutorials/src/cpu/detector/do_it_yourself_detector.cpp
@@ -18,7 +18,6 @@
 #include "detray/definitions/geometry.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/io/frontend/detector_writer.hpp"
-#include "detray/test/utils/detectors/build_toy_detector.hpp"
 
 // Example include(s)
 #include "detray/tutorial/detector_metadata.hpp"
@@ -34,6 +33,8 @@
 
 /// Write a dector using the json IO
 int main() {
+
+    using scalar = detray::tutorial::scalar;
 
     // The new detector type
     using detector_t = detray::detector<detray::tutorial::my_metadata>;
@@ -54,22 +55,21 @@ int main() {
 
     // Add a square that is 20x20mm large, links back to its mother volume (0)
     // and is placed with a translation of (x = 1mm, y = 2mm, z = 3mm)
-    detray::tutorial::vector3 translation{
-        1.f * detray::unit<detray::scalar>::mm,
-        2.f * detray::unit<detray::scalar>::mm,
-        3.f * detray::unit<detray::scalar>::mm};
+    detray::tutorial::vector3 translation{1.f * detray::unit<scalar>::mm,
+                                          2.f * detray::unit<scalar>::mm,
+                                          3.f * detray::unit<scalar>::mm};
     sq_factory->push_back({detray::surface_id::e_sensitive,
                            detray::tutorial::transform3{translation},
                            0u,
-                           {20.f * detray::unit<detray::scalar>::mm}});
+                           {20.f * detray::unit<scalar>::mm}});
 
     // Add some programmatically generated square surfaces
     auto sq_generator =
         std::make_shared<detray::tutorial::square_surface_generator>(
-            10, 10.f * detray::unit<detray::scalar>::mm);
+            10, 10.f * detray::unit<scalar>::mm);
 
     // Add a portal box around the cuboid volume with a min distance of 'env'
-    constexpr auto env{0.1f * detray::unit<detray::scalar>::mm};
+    constexpr auto env{0.1f * detray::unit<scalar>::mm};
     auto portal_generator =
         std::make_shared<detray::cuboid_portal_generator<detector_t>>(env);
 

--- a/tutorials/src/cpu/detector/read_detector_from_file.cpp
+++ b/tutorials/src/cpu/detector/read_detector_from_file.cpp
@@ -7,7 +7,6 @@
 
 // Project include(s)
 #include "detray/core/detector.hpp"
-#include "detray/detectors/toy_metadata.hpp"
 #include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/volume_graph.hpp"
 
@@ -35,7 +34,8 @@ int main(int argc, char** argv) {
     }
 
     // Read a toy detector
-    using detector_t = detray::detector<>;
+    using metadata_t = detray::tutorial::default_metadata;
+    using detector_t = detray::detector<metadata_t>;
 
     // Create an empty detector to be filled
     vecmem::host_memory_resource host_mr;

--- a/tutorials/src/cpu/detector/track_geometry_changes.cpp
+++ b/tutorials/src/cpu/detector/track_geometry_changes.cpp
@@ -33,7 +33,8 @@ int main() {
 
     // Get an example detector
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::tutorial::algebra_t>(host_mr);
 
     // Build the graph and get its adjacency matrix
     detray::volume_graph graph(det);

--- a/tutorials/src/cpu/detector/write_detector_to_file.cpp
+++ b/tutorials/src/cpu/detector/write_detector_to_file.cpp
@@ -20,7 +20,8 @@ int main() {
 
     // First, create an example detector in in host memory to be written to disk
     vecmem::host_memory_resource host_mr;
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] =
+        detray::build_toy_detector<detray::tutorial::algebra_t>(host_mr);
 
     // Configuration for the writer:
     //     - use json format

--- a/tutorials/src/cpu/propagation/navigation_inspection.cpp
+++ b/tutorials/src/cpu/propagation/navigation_inspection.cpp
@@ -31,12 +31,14 @@
 /// of the encountered surfaces (using the navigation inspectors)
 int main() {
     // Toy detector
-    using toy_detector_t = detray::detector<detray::toy_metadata>;
+    using metadata_t = detray::tutorial::toy_metadata;
+    using toy_detector_t = detray::detector<metadata_t>;
+    using algebra_t = typename toy_detector_t::algebra_type;
 
     /// Type that holds the intersection information
     using intersection_t =
-        detray::intersection2D<typename toy_detector_t::surface_type,
-                               detray::tutorial::algebra_t, true>;
+        detray::intersection2D<typename toy_detector_t::surface_type, algebra_t,
+                               true>;
 
     /// Inspector that records all encountered surfaces
     using object_tracer_t = detray::navigation::object_tracer<
@@ -58,14 +60,14 @@ int main() {
     using navigator_t = detray::navigator<toy_detector_t, cache_size,
                                           inspector_t, intersection_t>;
     // Line stepper
-    using stepper_t = detray::line_stepper<detray::tutorial::algebra_t>;
+    using stepper_t = detray::line_stepper<algebra_t>;
     // Propagator with empty actor chain
     using propagator_t =
         detray::propagator<stepper_t, navigator_t, detray::actor_chain<>>;
 
     vecmem::host_memory_resource host_mr;
 
-    const auto [det, names] = detray::build_toy_detector(host_mr);
+    const auto [det, names] = detray::build_toy_detector<algebra_t>(host_mr);
 
     typename toy_detector_t::geometry_context gctx{};
 
@@ -75,7 +77,7 @@ int main() {
 
     // Track generation config
     // Trivial example: Single track escapes through beampipe
-    using ray_type = detray::detail::ray<detray::tutorial::algebra_t>;
+    using ray_type = detray::detail::ray<algebra_t>;
     constexpr std::size_t theta_steps{1};
     constexpr std::size_t phi_steps{1};
 
@@ -89,8 +91,8 @@ int main() {
 
         // Now follow that ray with the same track and check, if we find
         // the same volumes and distances along the way
-        detray::free_track_parameters<detray::tutorial::algebra_t> track(
-            ray.pos(), 0.f, ray.dir(), -1.f);
+        detray::free_track_parameters<algebra_t> track(ray.pos(), 0.f,
+                                                       ray.dir(), -1.f);
         propagator_t::state propagation(track, det, prop_cfg.context);
 
         // Run the actual propagation

--- a/tutorials/src/device/cuda/detector_construction.cpp
+++ b/tutorials/src/device/cuda/detector_construction.cpp
@@ -22,6 +22,9 @@
 
 /// Prepare the data and move it to device
 int main() {
+
+    using algebra_t = detray::tutorial::algebra_t;
+
     // memory resource(s)
     vecmem::host_memory_resource host_mr;
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -35,7 +38,7 @@ int main() {
     //
 
     // create toy geometry with vecmem managed memory resouce
-    auto [det_mng, names_mng] = detray::build_toy_detector(mng_mr);
+    auto [det_mng, names_mng] = detray::build_toy_detector<algebra_t>(mng_mr);
 
     // Get the view onto the detector data directly
     auto det_mng_data = detray::get_data(det_mng);
@@ -49,7 +52,8 @@ int main() {
     //
 
     // create toy geometry in host memory
-    auto [det_host, names_host] = detray::build_toy_detector(host_mr);
+    auto [det_host, names_host] =
+        detray::build_toy_detector<algebra_t>(host_mr);
 
     // Copy the detector data to device (synchronous copy, fixed size buffers)
     auto det_fixed_buff = detray::get_buffer(det_host, dev_mr, cuda_cpy);

--- a/tutorials/src/device/cuda/detector_construction.hpp
+++ b/tutorials/src/device/cuda/detector_construction.hpp
@@ -10,15 +10,14 @@
 // Project include(s).
 #include "detray/core/detector.hpp"
 #include "detray/definitions/units.hpp"
-#include "detray/detectors/toy_metadata.hpp"
 #include "detray/tutorial/types.hpp"
 
 namespace detray::tutorial {
 
 // Detector
-using detector_host_t = detector<detray::toy_metadata, host_container_types>;
-using detector_device_t =
-    detector<detray::toy_metadata, device_container_types>;
+using metadata_t = detray::tutorial::toy_metadata;
+using detector_host_t = detector<metadata_t, host_container_types>;
+using detector_device_t = detector<metadata_t, device_container_types>;
 
 using mask_id = typename detector_host_t::masks::id;
 using acc_id = typename detector_host_t::accel::id;

--- a/tutorials/src/device/cuda/propagation.cpp
+++ b/tutorials/src/device/cuda/propagation.cpp
@@ -20,14 +20,17 @@
 
 /// Prepare the data and move it to device
 int main() {
+
     // VecMem memory resource(s)
     vecmem::cuda::managed_memory_resource mng_mr;
 
     // Create the host bfield
-    auto bfield = detray::bfield::create_inhom_field();
+    auto bfield =
+        detray::bfield::create_inhom_field<detray::tutorial::scalar>();
 
     // Create the toy geometry
-    auto [det, names] = detray::build_toy_detector(mng_mr);
+    auto [det, names] =
+        detray::build_toy_detector<detray::tutorial::algebra_t>(mng_mr);
 
     // Create the vector of initial track parameters
     vecmem::vector<detray::free_track_parameters<detray::tutorial::algebra_t>>
@@ -37,7 +40,8 @@ int main() {
     constexpr unsigned int theta_steps{10u};
     constexpr unsigned int phi_steps{10u};
     // Set momentum of tracks
-    const detray::scalar p_mag{10.f * detray::unit<detray::scalar>::GeV};
+    const detray::tutorial::scalar p_mag{
+        10.f * detray::unit<detray::tutorial::scalar>::GeV};
 
     // Genrate the tracks
     for (auto track : detray::uniform_track_generator<


### PR DESCRIPTION
Remove the global scalar type and default ```ALGEBRA_PLUGIN``` macro and instead hand the templates type through everywhere