### PR TITLE
Enable backward propagation

### DIFF
--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -231,7 +231,13 @@ class navigator {
         /// Scalar representation of the navigation state,
         /// @returns distance to next
         DETRAY_HOST_DEVICE
-        scalar_type operator()() const { return target().path; }
+        scalar_type operator()() const {
+            if (direction() == navigation::direction::e_forward) {
+                return target().path;
+            } else {
+                return -1.f * target().path;
+            }
+        }
 
         /// @returns current volume (index) - const
         DETRAY_HOST_DEVICE
@@ -611,9 +617,14 @@ class navigator {
 
             const auto sf = tracking_surface{det, sf_descr};
 
+            auto track_cpy = track;
+            if (nav_state.direction() == navigation::direction::e_backward) {
+                track_cpy.set_dir(-1.f * track_cpy.dir());
+            }
+
             sf.template visit_mask<intersection_initialize<ray_intersector>>(
-                nav_state, detail::ray(track), sf_descr, det.transform_store(),
-                ctx,
+                nav_state, detail::ray(track_cpy), sf_descr,
+                det.transform_store(), ctx,
                 sf.is_portal() ? std::array<scalar_type, 2>{0.f, 0.f}
                                : mask_tol,
                 mask_tol_scalor, overstep_tol);
@@ -775,7 +786,8 @@ class navigator {
         // - do this only when the navigation state is still coherent
         if (navigation.trust_level() == navigation::trust_level::e_high) {
             // Update next candidate: If not reachable, 'high trust' is broken
-            if (!update_candidate(navigation.target(), track, det, cfg, ctx)) {
+            if (!update_candidate(navigation.direction(), navigation.target(),
+                                  track, det, cfg, ctx)) {
                 navigation.m_status = navigation::status::e_unknown;
                 navigation.set_fair_trust();
             } else {
@@ -797,7 +809,8 @@ class navigator {
 
                 // Else: Track is on module.
                 // Ready the next candidate after the current module
-                if (update_candidate(navigation.target(), track, det, cfg,
+                if (update_candidate(navigation.direction(),
+                                     navigation.target(), track, det, cfg,
                                      ctx)) {
                     return false;
                 }
@@ -815,7 +828,8 @@ class navigator {
 
             for (auto &candidate : navigation) {
                 // Disregard this candidate if it is not reachable
-                if (!update_candidate(candidate, track, det, cfg, ctx)) {
+                if (!update_candidate(navigation.direction(), candidate, track,
+                                      det, cfg, ctx)) {
                     // Forcefully set dist to numeric max for sorting
                     candidate.path = std::numeric_limits<scalar_type>::max();
                 }
@@ -897,9 +911,9 @@ class navigator {
     /// @returns whether the track can reach this candidate.
     template <typename track_t>
     DETRAY_HOST_DEVICE inline bool update_candidate(
-        intersection_type &candidate, const track_t &track,
-        const detector_type &det, const navigation::config &cfg,
-        const context_type &ctx) const {
+        const navigation::direction &nav_dir, intersection_type &candidate,
+        const track_t &track, const detector_type &det,
+        const navigation::config &cfg, const context_type &ctx) const {
 
         if (candidate.sf_desc.barcode().is_invalid()) {
             return false;
@@ -907,9 +921,14 @@ class navigator {
 
         const auto sf = tracking_surface{det, candidate.sf_desc};
 
+        auto track_cpy = track;
+        if (nav_dir == navigation::direction::e_backward) {
+            track_cpy.set_dir(-1.f * track_cpy.dir());
+        }
+
         // Check whether this candidate is reachable by the track
         return sf.template visit_mask<intersection_update<ray_intersector>>(
-            detail::ray(track), candidate, det.transform_store(), ctx,
+            detail::ray(track_cpy), candidate, det.transform_store(), ctx,
             sf.is_portal() ? std::array<scalar_type, 2>{0.f, 0.f}
                            : std::array<scalar_type, 2>{cfg.min_mask_tolerance,
                                                         cfg.max_mask_tolerance},

--- a/tests/integration_tests/cpu/CMakeLists.txt
+++ b/tests/integration_tests/cpu/CMakeLists.txt
@@ -13,6 +13,7 @@ macro(detray_add_cpu_test algebra)
        "builders/material_map_builder.cpp"
        "builders/volume_builder.cpp"
        "material/material_interaction.cpp"
+       "propagator/backward_propagation.cpp"
        "propagator/covariance_transport.cpp"
        "propagator/guided_navigator.cpp"
        "propagator/propagator.cpp"


### PR DESCRIPTION
Make the backward propagation work by flipping the direction of ray in navigator depending on its direction.
Step size is also negative for the backward direction

It seems working for the round trip propagation test