### PR TITLE
Enable line information in RelWithDebInfo

### DIFF
--- a/cmake/detray-compiler-options-cuda.cmake
+++ b/cmake/detray-compiler-options-cuda.cmake
@@ -37,6 +37,7 @@ endif()
 # Make CUDA generate debug symbols for the device code as well in a debug
 # build.
 detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G -src-in-ptx" )
+detray_add_flag( CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-lineinfo -src-in-ptx" )
 
 # Fail on warnings, if asked for that behaviour.
 if(DETRAY_FAIL_ON_WARNINGS)


### PR DESCRIPTION
This allows us to get line information in profilers without having to disable optimizations in the code.