### PR TITLE
Reenable FMA in CUDA builds

### DIFF
--- a/cmake/detray-compiler-options-cuda.cmake
+++ b/cmake/detray-compiler-options-cuda.cmake
@@ -29,9 +29,6 @@ if("${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA")
     # Allow to use functions in device code that are constexpr, even if they are
     # not marked with __device__.
     detray_add_flag( CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr" )
-
-    # Turn off fast math for the device code.
-    detray_add_flag( CMAKE_CUDA_FLAGS "-fmad=false" )
 endif()
 
 # Make CUDA generate debug symbols for the device code as well in a debug


### PR DESCRIPTION
This might be controversial, but we're kneecapping the CUDA build by turning off FMA. I think it's high time to turn it back on. Also removes an inaccurate comment, as FMA doesn't have anything to do with fast math; FMA is well specified in IEEE 754-2008.