### PR TITLE
Simplify random access iterator advancement

### DIFF
--- a/core/include/detray/utils/ranges/detail/iterator_functions.hpp
+++ b/core/include/detray/utils/ranges/detail/iterator_functions.hpp
@@ -131,7 +131,7 @@ DETRAY_HOST_DEVICE constexpr void advance_impl(
     }
 }
 
-// random access iterators specialization
+// bidirectional iterators specialization
 template <std::bidirectional_iterator iterator_t, typename dist_t>
 DETRAY_HOST_DEVICE constexpr void advance_impl(
     iterator_t& itr, dist_t d, detray::ranges::bidirectional_iterator_tag) {
@@ -152,17 +152,7 @@ template <std::random_access_iterator iterator_t, typename dist_t>
 DETRAY_HOST_DEVICE constexpr void advance_impl(
     iterator_t& itr, dist_t d, detray::ranges::random_access_iterator_tag) {
     static_assert(std::is_integral_v<dist_t>);
-    if (d == static_cast<dist_t>(1)) {
-        ++itr;
-    } else {
-        if constexpr (std::is_signed_v<dist_t>) {
-            if (d == static_cast<dist_t>(-1)) {
-                --itr;
-                return;
-            }
-        }
-        itr += d;
-    }
+    itr += d;
 }
 
 template <std::input_iterator iterator_t, typename dist_t>


### PR DESCRIPTION
I was surprised while profiling the detray code to find that a surprisingly large amount of time is spent in the random access iterator advance function. This is somewhat inefficiently implemented as it is full of if statements. I have decided to simplify the function, which leads to a small but noticeable performance improvement of around 4% in the detray benchmarks.