### PR TITLE
Explicitly disable git pager in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,4 @@ repos:
     - id: leftover_conflict_markers
       name: Leftover conflict markers
       language: system
-      entry: git diff --staged --check
+      entry: git --no-pager diff --staged --check


### PR DESCRIPTION
This is a copy of https://github.com/acts-project/acts/pull/3928; long story short, if git doesn't properly detect that it is not in a TTY, it will hang pre-commit. Therefore, this explicitly disables paging.