### PR TITLE
Implement first in-place matrix multiplications

### DIFF
--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -180,11 +180,21 @@ class base_stepper {
             return m_jac_transport;
         }
 
+        /// @returns the current transport Jacbian.
+        DETRAY_HOST_DEVICE
+        inline free_matrix_type &transport_jacobian() {
+            return m_jac_transport;
+        }
+
         /// @returns the current full Jacbian.
         DETRAY_HOST_DEVICE
         inline const bound_matrix_type &full_jacobian() const {
             return m_full_jacobian;
         }
+
+        /// @returns the current full Jacbian.
+        DETRAY_HOST_DEVICE
+        inline bound_matrix_type &full_jacobian() { return m_full_jacobian; }
 
         /// Set new full Jacbian.
         DETRAY_HOST_DEVICE

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -68,8 +68,8 @@ class line_stepper final
 
             /// NOTE: Let's skip the element for d(time)/d(qoverp) for the
             /// moment..
-
-            this->set_transport_jacobian(D * this->transport_jacobian());
+            algebra::generic::math::set_inplace_product_left(
+                this->transport_jacobian(), D);
         }
 
         DETRAY_HOST_DEVICE

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -331,7 +331,8 @@ DETRAY_HOST_DEVICE inline void detray::rk_stepper<
     getter::set_block(D, dFdqop, 0u, 7u);
     getter::set_block(D, dGdqop, 4u, 7u);
 
-    this->set_transport_jacobian(D * this->transport_jacobian());
+    algebra::generic::math::set_inplace_product_left(this->transport_jacobian(),
+                                                     D);
 }
 
 template <typename magnetic_field_t, typename algebra_t, typename constraint_t,


### PR DESCRIPTION
This is the first round of implementations of the new in-place matrix operations introduced in algebra-plugins. While it doesn't necessarily make the code more readable, it does increase performance quite significantly. More to come later.