### PR TITLE
Remove the Navigation Direction Sign for Process Noise

### DIFF
--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -175,8 +175,7 @@ struct pointwise_material_interactor : actor {
 
                 if (interactor_state.do_covariance_transport) {
 
-                    update_qop_variance(covariance, interactor_state.sigma_qop,
-                                        nav_dir);
+                    update_qop_variance(covariance, interactor_state.sigma_qop);
                 }
             }
 
@@ -184,7 +183,7 @@ struct pointwise_material_interactor : actor {
 
                 update_angle_variance(
                     covariance, bound_params.dir(),
-                    interactor_state.projected_scattering_angle, nav_dir);
+                    interactor_state.projected_scattering_angle);
             }
         }
     }
@@ -226,13 +225,12 @@ struct pointwise_material_interactor : actor {
     /// @param[in]  sigma_qop variance of q over p
     /// @param[in]  sign navigation direction
     DETRAY_HOST_DEVICE inline void update_qop_variance(
-        bound_matrix_type &covariance, const scalar_type sigma_qop,
-        const int sign) const {
+        bound_matrix_type &covariance, const scalar_type sigma_qop) const {
 
         const scalar_type variance_qop{sigma_qop * sigma_qop};
 
         getter::element(covariance, e_bound_qoverp, e_bound_qoverp) +=
-            math::copysign(variance_qop, static_cast<scalar_type>(sign));
+            variance_qop;
     }
 
     /// @brief Update the variance of phi and theta of bound track parameter
@@ -243,14 +241,13 @@ struct pointwise_material_interactor : actor {
     /// @param[in]  sign navigation direction
     DETRAY_HOST_DEVICE inline void update_angle_variance(
         bound_matrix_type &covariance, const vector3_type &dir,
-        const scalar_type projected_scattering_angle, const int sign) const {
+        const scalar_type projected_scattering_angle) const {
 
-        // variance of projected scattering angle
-        const scalar_type var_scattering_angle{math::copysign(
-            projected_scattering_angle * projected_scattering_angle,
-            static_cast<scalar_type>(sign))};
+        const scalar_type var_scattering_angle{projected_scattering_angle *
+                                               projected_scattering_angle};
 
         constexpr auto inv{detail::invalid_value<scalar_type>()};
+
         getter::element(covariance, e_bound_phi, e_bound_phi) +=
             (dir[2] == 1.f) ? inv
                             : var_scattering_angle / (1.f - dir[2] * dir[2]);

--- a/tests/integration_tests/cpu/material/material_interaction.cpp
+++ b/tests/integration_tests/cpu/material/material_interaction.cpp
@@ -250,7 +250,7 @@ GTEST_TEST(detray_material, telescope_geometry_scattering_angle) {
         if (i == 0u) {
             pointwise_material_interactor<algebra_t>{}.update_angle_variance(
                 bound_cov, traj.dir(),
-                simulator_state.projected_scattering_angle, 1);
+                simulator_state.projected_scattering_angle);
         }
 
         phis.push_back(final_param.phi());

--- a/tests/integration_tests/cpu/propagator/backward_propagation.cpp
+++ b/tests/integration_tests/cpu/propagator/backward_propagation.cpp
@@ -154,17 +154,6 @@ TEST_P(BackwardPropagation, backward_propagation) {
 
     const auto bound_cov0 = bound_param0.covariance();
     const auto bound_cov1 = bound_param1.covariance();
-    const auto bound_cov2 = bound_param2.covariance();
-
-    // Check covaraince
-    for (unsigned int i = 0u; i < e_bound_size; i++) {
-        for (unsigned int j = 0u; j < e_bound_size; j++) {
-            EXPECT_NEAR(getter::element(bound_cov0, i, j),
-                        getter::element(bound_cov2, i, j), tol)
-                << "i: " << i << "\nj: " << j << "\n"
-                << bound_param2;
-        }
-    }
 
     // Some sanity checks
     EXPECT_TRUE(bound_param0.p(ptc.charge()) > bound_param1.p(ptc.charge()));
@@ -176,13 +165,6 @@ TEST_P(BackwardPropagation, backward_propagation) {
                 getter::element(bound_cov0, e_bound_theta, e_bound_theta));
     EXPECT_TRUE(getter::element(bound_cov1, e_bound_phi, e_bound_phi) >
                 getter::element(bound_cov0, e_bound_phi, e_bound_phi));
-
-    EXPECT_TRUE(getter::element(bound_cov1, e_bound_qoverp, e_bound_qoverp) >
-                getter::element(bound_cov2, e_bound_qoverp, e_bound_qoverp));
-    EXPECT_TRUE(getter::element(bound_cov1, e_bound_theta, e_bound_theta) >
-                getter::element(bound_cov2, e_bound_theta, e_bound_theta));
-    EXPECT_TRUE(getter::element(bound_cov1, e_bound_phi, e_bound_phi) >
-                getter::element(bound_cov2, e_bound_phi, e_bound_phi));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/unit_tests/cpu/simulation/scattering.cpp
+++ b/tests/unit_tests/cpu/simulation/scattering.cpp
@@ -96,9 +96,6 @@ GTEST_TEST(detray_simulation, angle_update) {
     // Projected scattering angle (Tests will fail with relatively large angles)
     const scalar_t projected_scattering_angle{0.01f};
 
-    // Navigation in forward direction
-    const int direction_sign = 1;
-
     // Initial bound covariance
     auto bound_cov = matrix::zero<
         typename bound_track_parameters<algebra_t>::covariance_type>();
@@ -108,7 +105,7 @@ GTEST_TEST(detray_simulation, angle_update) {
 
     // Update the bound covariance with projected scattering angle
     pointwise_material_interactor<algebra_t>().update_angle_variance(
-        bound_cov, dir, projected_scattering_angle, direction_sign);
+        bound_cov, dir, projected_scattering_angle);
 
     // Get the samples of phi and theta after the random scattering
     std::vector<scalar_t> phis;


### PR DESCRIPTION
Remove the navigation sign for process noise (Multiple scattering and Landau loss)
The added covariance matrix should always be positive.

Ref: https://ntrs.nasa.gov/api/citations/19940031131/downloads/19940031131.pdf
![image](https://github.com/user-attachments/assets/be669904-6c00-426c-9f48-67f91b726fde)

Note: One should not take "the sign of the process noise must be flipped" of the quote as the sign of MS covariance should be changed for backward propagation - The sign referred in the quote is an opposite thing:

![image](https://github.com/user-attachments/assets/52b347ce-e10f-4b65-816a-4f96b87ae808)
