### PR TITLE
Use approximate equality checks for 3D point tests

### DIFF
--- a/tests/include/detray/test/common/assert.hpp
+++ b/tests/include/detray/test/common/assert.hpp
@@ -1,0 +1,17 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#pragma once
+
+#define EXPECT_POINT3_NEAR(point1, point2, abs_error) \
+    do {                                              \
+        EXPECT_NEAR(point1[0], point2[0], abs_error); \
+        EXPECT_NEAR(point1[1], point2[1], abs_error); \
+        EXPECT_NEAR(point1[2], point2[2], abs_error); \
+    } while (false)

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
@@ -6,6 +6,8 @@
  */
 
 // Detray test include(s)
+#include <detray/test/common/assert.hpp>
+
 #include "sf_finders_grid_cuda_kernel.hpp"
 
 // VecMem include(s).
@@ -316,11 +318,11 @@ TEST(grids_cuda, grid2_attach_populator) {
             int pt_idx{0};
             for (const auto& pt : bin) {
                 if (pt_idx == 0) {
-                    EXPECT_EQ(pt, first_tp);
+                    EXPECT_POINT3_NEAR(pt, first_tp, 1e-6);
                 } else if (pt_idx == 1) {
-                    EXPECT_EQ(pt, tp);
+                    EXPECT_POINT3_NEAR(pt, tp, 1e-6);
                 } else {
-                    EXPECT_EQ(pt, invalid_tp);
+                    EXPECT_POINT3_NEAR(pt, invalid_tp, 1e-6);
                 }
                 pt_idx++;
             }
@@ -426,11 +428,11 @@ TEST(grids_cuda, grid2_dynamic_attach_populator) {
             int pt_idx{0};
             for (const auto& e : bin) {
                 if (pt_idx == 0) {
-                    EXPECT_EQ(e, first_tp) << pt_idx;
+                    EXPECT_POINT3_NEAR(e, first_tp, 1e-6);
                 } else if (pt_idx == 1) {
-                    EXPECT_EQ(e, tp) << pt_idx;
+                    EXPECT_POINT3_NEAR(e, tp, 1e-6);
                 } else {
-                    EXPECT_EQ(e, invalid_tp) << pt_idx;
+                    EXPECT_POINT3_NEAR(e, invalid_tp, 1e-6);
                 }
                 pt_idx++;
             }


### PR DESCRIPTION
Currently, we require exact equality on floating point 3D vectors, which is unreasonable. This commit changes the code such that the equality is instead defined with an epsilon value of 1E-6.