### PR TITLE
ref: remove old template types on containers

### DIFF
--- a/core/include/detray/builders/bin_fillers.hpp
+++ b/core/include/detray/builders/bin_fillers.hpp
@@ -128,7 +128,7 @@ struct bin_associator {
         // Fill the surfaces into the grid by matching their contour onto the
         // grid bins
         bin_association(ctx, surfaces, transforms, masks, grid,
-                        std::array<scalar_t, 2>{0.1f, 0.1f}, false);
+                        darray<scalar_t, 2>{0.1f, 0.1f}, false);
     }
 };
 

--- a/core/include/detray/builders/detail/bin_association.hpp
+++ b/core/include/detray/builders/detail/bin_association.hpp
@@ -21,7 +21,6 @@
 #include "detray/utils/ranges.hpp"
 
 // System include(s)
-#include <array>
 #include <vector>
 
 namespace detray::detail {
@@ -44,7 +43,7 @@ static inline void bin_association(const context_t & /*context*/,
                                    const transform_container_t &transforms,
                                    const mask_container_t &surface_masks,
                                    grid_t &grid,
-                                   const std::array<scalar_t, 2> &bin_tolerance,
+                                   const darray<scalar_t, 2> &bin_tolerance,
                                    bool absolute_tolerance = true) {
 
     using algebra_t = typename grid_t::local_frame_type::algebra_type;

--- a/core/include/detray/builders/detail/volume_connector.hpp
+++ b/core/include/detray/builders/detail/volume_connector.hpp
@@ -24,8 +24,6 @@ namespace detray {
 /// @param volume_grid [in] the indexed volume grid
 ///
 template <typename detector_t,
-          template <typename, std::size_t> class array_type = darray,
-          template <typename...> class tuple_type = dtuple,
           template <typename...> class vector_type = dvector>
 void connect_cylindrical_volumes(
     detector_t &d, const typename detector_t::volume_finder &volume_grid) {
@@ -35,7 +33,7 @@ void connect_cylindrical_volumes(
 
     // The grid is populated, now create portal surfaces
     // Start from left bottom corner (0,0)
-    vector_type<array_type<dindex, 2>> seeds = {{0, 0}};
+    vector_type<darray<dindex, 2>> seeds = {{0, 0}};
     dmap<dindex, dindex> seed_map;
 
     // The axes are used quite a bit
@@ -51,7 +49,7 @@ void connect_cylindrical_volumes(
      *
      * @note seeds are only set in bottom left corners of blocks
      **/
-    auto add_new_seed = [&](const array_type<dindex, 2> &seed,
+    auto add_new_seed = [&](const darray<dindex, 2> &seed,
                             dindex volume_index) -> void {
         if (volume_index == dindex_invalid) {
             return;
@@ -78,14 +76,10 @@ void connect_cylindrical_volumes(
         auto &volume = d.volume(ref);
 
         // Collect portals per seed
-        vector_type<tuple_type<array_type<scalar_t, 2>, dindex>>
-            left_portals_info;
-        vector_type<tuple_type<array_type<scalar_t, 2>, dindex>>
-            upper_portals_info;
-        vector_type<tuple_type<array_type<scalar_t, 2>, dindex>>
-            right_portals_info;
-        vector_type<tuple_type<array_type<scalar_t, 2>, dindex>>
-            lower_portals_info;
+        vector_type<dtuple<darray<scalar_t, 2>, dindex>> left_portals_info;
+        vector_type<dtuple<darray<scalar_t, 2>, dindex>> upper_portals_info;
+        vector_type<dtuple<darray<scalar_t, 2>, dindex>> right_portals_info;
+        vector_type<dtuple<darray<scalar_t, 2>, dindex>> lower_portals_info;
 
         /// Helper method for walking up along the bins
         ///
@@ -96,12 +90,11 @@ void connect_cylindrical_volumes(
         ///
         /// @return the end position of the the walk (inside position)
         auto walk_up =
-            [&](array_type<dindex, 2> start_bin,
-                vector_type<tuple_type<array_type<scalar_t, 2>, dindex>>
-                    &portals_info,
-                int peek, bool add_seed = false) -> array_type<dindex, 2> {
+            [&](darray<dindex, 2> start_bin,
+                vector_type<dtuple<darray<scalar_t, 2>, dindex>> &portals_info,
+                int peek, bool add_seed = false) -> darray<dindex, 2> {
             auto running_bin = start_bin;
-            array_type<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
+            darray<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
             // Test entry
             auto test = volume_grid.bin(running_bin[0], running_bin[1]);
             // Low/high
@@ -161,13 +154,12 @@ void connect_cylindrical_volumes(
         ///
         /// @return the end position of the the walk (inside position)
         auto walk_right =
-            [&](const array_type<dindex, 2> &start_bin,
-                vector_type<tuple_type<array_type<scalar_t, 2>, dindex>>
-                    &portals_info,
+            [&](const darray<dindex, 2> &start_bin,
+                vector_type<dtuple<darray<scalar_t, 2>, dindex>> &portals_info,
                 int peek, bool add_seed = false,
-                bool walk_only = false) -> array_type<dindex, 2> {
+                bool walk_only = false) -> darray<dindex, 2> {
             auto running_bin = start_bin;
-            array_type<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
+            darray<dindex, 2> last_added = {dindex_invalid, dindex_invalid};
 
             // Test, low and high at seed position
             auto test = volume_grid.bin(running_bin[0], running_bin[1]);
@@ -245,8 +237,7 @@ void connect_cylindrical_volumes(
          *
          **/
         auto add_disc_portals =
-            [&](vector_type<tuple_type<array_type<scalar_t, 2>, dindex>>
-                    &portals_info,
+            [&](vector_type<dtuple<darray<scalar_t, 2>, dindex>> &portals_info,
                 dindex bound_index) -> void {
             using portal_t = typename detector_t::surface_type;
             using volume_link_t = typename portal_t::volume_link_type;
@@ -296,8 +287,7 @@ void connect_cylindrical_volumes(
          * @param bound_index
          **/
         auto add_cylinder_portal =
-            [&](vector_type<tuple_type<array_type<scalar_t, 2>, dindex>>
-                    &portals_info,
+            [&](vector_type<dtuple<darray<scalar_t, 2>, dindex>> &portals_info,
                 dindex bound_index) -> void {
             using portal_t = typename detector_t::surface_type;
             using volume_link_t = typename portal_t::volume_link_type;

--- a/core/include/detray/builders/detector_builder.hpp
+++ b/core/include/detray/builders/detector_builder.hpp
@@ -126,9 +126,9 @@ class detector_builder {
                 0u,      0.f,   -constant<scalar_type>::pi,
                 -2000.f, 180.f, constant<scalar_type>::pi,
                 2000.f};
-            std::array<std::size_t, 3> n_vgrid_bins{1u, 1u, 1u};
+            darray<std::size_t, 3> n_vgrid_bins{1u, 1u, 1u};
 
-            std::array<std::vector<scalar_type>, 3UL> bin_edges{
+            darray<std::vector<scalar_type>, 3UL> bin_edges{
                 std::vector<scalar_type>{0.f, 180.f},
                 std::vector<scalar_type>{-constant<scalar_type>::pi,
                                          constant<scalar_type>::pi},

--- a/core/include/detray/builders/grid_builder.hpp
+++ b/core/include/detray/builders/grid_builder.hpp
@@ -18,7 +18,6 @@
 #include "detray/utils/grid/detail/concepts.hpp"
 
 // System include(s)
-#include <array>
 #include <cassert>
 #include <memory>
 #include <vector>
@@ -80,11 +79,11 @@ class grid_builder : public volume_decorator<detector_t> {
     template <typename grid_shape_t>
     DETRAY_HOST void init_grid(
         const mask<grid_shape_t, algebra_type> &m,
-        const std::array<std::size_t, grid_t::dim> &n_bins,
+        const darray<std::size_t, grid_t::dim> &n_bins,
         const std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, grid_t::dim> &ax_bin_edges =
-            std::array<std::vector<scalar_type>, grid_t::dim>()) {
+        const darray<std::vector<scalar_type>, grid_t::dim> &ax_bin_edges =
+            darray<std::vector<scalar_type>, grid_t::dim>()) {
 
         static_assert(
             std::is_same_v<typename grid_shape_t::template local_frame_type<

--- a/core/include/detray/builders/grid_factory.hpp
+++ b/core/include/detray/builders/grid_factory.hpp
@@ -79,13 +79,13 @@ class grid_factory {
         typename phi_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(r_bounds::label)> auto new_grid(
         const mask<annulus2D, algebra_type> &grid_bounds,
-        const std::array<std::size_t, 2UL> n_bins,
+        const darray<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<annulus2D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
-            std::array<std::vector<scalar_type>, 2UL>(),
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
-            std::array<std::vector<scalar_type>, 2UL>()) const {
+        const darray<std::vector<scalar_type>, 2UL> &bin_edges =
+            darray<std::vector<scalar_type>, 2UL>(),
+        const darray<std::vector<scalar_type>, 2UL> &axis_spans =
+            darray<std::vector<scalar_type>, 2UL>()) const {
 
         static_assert(
             std::is_same_v<phi_bounds, axis::circular<>>,
@@ -137,13 +137,13 @@ class grid_factory {
         typename z_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(x_bounds::label)> auto new_grid(
         const mask<cuboid3D, algebra_type> &grid_bounds,
-        const std::array<std::size_t, 3UL> n_bins,
+        const darray<std::size_t, 3UL> n_bins,
         const std::vector<std::pair<loc_bin_index<cuboid3D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 3UL> &bin_edges =
-            std::array<std::vector<scalar_type>, 3UL>(),
-        const std::array<std::vector<scalar_type>, 3UL> &axis_spans =
-            std::array<std::vector<scalar_type>, 3UL>()) const {
+        const darray<std::vector<scalar_type>, 3UL> &bin_edges =
+            darray<std::vector<scalar_type>, 3UL>(),
+        const darray<std::vector<scalar_type>, 3UL> &axis_spans =
+            darray<std::vector<scalar_type>, 3UL>()) const {
         // Axes boundaries and local indices
         using boundary = cuboid3D::boundaries;
         using axes_t = axes<cuboid3D>::template type<algebra_t>;
@@ -193,13 +193,13 @@ class grid_factory {
         typename z_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(rphi_bounds::label)> auto new_grid(
         const mask<cylinder2D, algebra_type> &grid_bounds,
-        const std::array<std::size_t, 2UL> n_bins,
+        const darray<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<cylinder2D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
-            std::array<std::vector<scalar_type>, 2UL>(),
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
-            std::array<std::vector<scalar_type>, 2UL>()) const {
+        const darray<std::vector<scalar_type>, 2UL> &bin_edges =
+            darray<std::vector<scalar_type>, 2UL>(),
+        const darray<std::vector<scalar_type>, 2UL> &axis_spans =
+            darray<std::vector<scalar_type>, 2UL>()) const {
 
         static_assert(
             std::is_same_v<rphi_bounds, axis::circular<axis::label::e_rphi>>,
@@ -239,13 +239,13 @@ class grid_factory {
         typename z_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(rphi_bounds::label)> auto new_grid(
         const mask<concentric_cylinder2D, algebra_type> &grid_bounds,
-        const std::array<std::size_t, 2UL> n_bins,
+        const darray<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<concentric_cylinder2D>,
                                     dindex>> &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
-            std::array<std::vector<scalar_type>, 2UL>(),
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
-            std::array<std::vector<scalar_type>, 2UL>()) const {
+        const darray<std::vector<scalar_type>, 2UL> &bin_edges =
+            darray<std::vector<scalar_type>, 2UL>(),
+        const darray<std::vector<scalar_type>, 2UL> &axis_spans =
+            darray<std::vector<scalar_type>, 2UL>()) const {
 
         static_assert(
             std::is_same_v<rphi_bounds, axis::circular<axis::label::e_rphi>>,
@@ -287,13 +287,13 @@ class grid_factory {
         typename z_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(r_bounds::label)> auto new_grid(
         const mask<cylinder3D, algebra_type> &grid_bounds,
-        const std::array<std::size_t, 3UL> n_bins,
+        const darray<std::size_t, 3UL> n_bins,
         const std::vector<std::pair<loc_bin_index<cylinder3D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 3UL> &bin_edges =
-            std::array<std::vector<scalar_type>, 3UL>(),
-        const std::array<std::vector<scalar_type>, 3UL> &axis_spans =
-            std::array<std::vector<scalar_type>, 3UL>()) const {
+        const darray<std::vector<scalar_type>, 3UL> &bin_edges =
+            darray<std::vector<scalar_type>, 3UL>(),
+        const darray<std::vector<scalar_type>, 3UL> &axis_spans =
+            darray<std::vector<scalar_type>, 3UL>()) const {
 
         static_assert(
             std::is_same_v<phi_bounds, axis::circular<>>,
@@ -350,13 +350,13 @@ class grid_factory {
         typename phi_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(r_bounds::label)> auto new_grid(
         const mask<ring2D, algebra_type> &grid_bounds,
-        const std::array<std::size_t, 2UL> n_bins,
+        const darray<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<ring2D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
-            std::array<std::vector<scalar_type>, 2UL>(),
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
-            std::array<std::vector<scalar_type>, 2UL>()) const {
+        const darray<std::vector<scalar_type>, 2UL> &bin_edges =
+            darray<std::vector<scalar_type>, 2UL>(),
+        const darray<std::vector<scalar_type>, 2UL> &axis_spans =
+            darray<std::vector<scalar_type>, 2UL>()) const {
 
         static_assert(std::is_same_v<phi_bounds, axis::circular<>>,
                       "Phi axis bounds need to be circular for ring shape");
@@ -396,13 +396,13 @@ class grid_factory {
         typename y_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(x_bounds::label)> auto new_grid(
         const mask<rectangle2D, algebra_type> &grid_bounds,
-        const std::array<std::size_t, 2UL> n_bins,
+        const darray<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<rectangle2D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
-            std::array<std::vector<scalar_type>, 2UL>(),
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
-            std::array<std::vector<scalar_type>, 2UL>()) const {
+        const darray<std::vector<scalar_type>, 2UL> &bin_edges =
+            darray<std::vector<scalar_type>, 2UL>(),
+        const darray<std::vector<scalar_type>, 2UL> &axis_spans =
+            darray<std::vector<scalar_type>, 2UL>()) const {
         // Axes boundaries and local indices
         using boundary = rectangle2D::boundaries;
         using axes_t = axes<rectangle2D>::template type<algebra_t>;
@@ -441,13 +441,13 @@ class grid_factory {
         typename y_binning = axis::regular<scalar_type, host_container_types>>
     requires std::is_enum_v<decltype(x_bounds::label)> auto new_grid(
         const mask<trapezoid2D, algebra_type> &grid_bounds,
-        const std::array<std::size_t, 2UL> n_bins,
+        const darray<std::size_t, 2UL> n_bins,
         const std::vector<std::pair<loc_bin_index<trapezoid2D>, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, 2UL> &bin_edges =
-            std::array<std::vector<scalar_type>, 2UL>(),
-        const std::array<std::vector<scalar_type>, 2UL> &axis_spans =
-            std::array<std::vector<scalar_type>, 2UL>()) const {
+        const darray<std::vector<scalar_type>, 2UL> &bin_edges =
+            darray<std::vector<scalar_type>, 2UL>(),
+        const darray<std::vector<scalar_type>, 2UL> &axis_spans =
+            darray<std::vector<scalar_type>, 2UL>()) const {
         // Axes boundaries and local indices
         using boundary = trapezoid2D::boundaries;
         using axes_t = axes<trapezoid2D>::template type<algebra_t>;
@@ -538,11 +538,11 @@ class grid_factory {
     template <concepts::grid grid_t, typename grid_shape_t>
     auto new_grid(
         const mask<grid_shape_t, algebra_type> &m,
-        const std::array<std::size_t, grid_t::dim> &n_bins,
+        const darray<std::size_t, grid_t::dim> &n_bins,
         const std::vector<std::pair<typename grid_t::loc_bin_index, dindex>>
             &bin_capacities = {},
-        const std::array<std::vector<scalar_type>, grid_t::dim> &ax_bin_edges =
-            {}) const {
+        const darray<std::vector<scalar_type>, grid_t::dim> &ax_bin_edges = {})
+        const {
 
         return new_grid(m, n_bins, bin_capacities, ax_bin_edges,
                         typename grid_t::axes_type::bounds{},
@@ -558,11 +558,11 @@ class grid_factory {
         std::enable_if_t<std::is_enum_v<typename grid_shape_t::boundaries>,
                          bool> = true>
     auto new_grid(const mask<grid_shape_t, algebra_type> &m,
-                  const std::array<std::size_t, grid_shape_t::dim> &n_bins,
+                  const darray<std::size_t, grid_shape_t::dim> &n_bins,
                   const std::vector<
                       std::pair<axis::multi_bin<sizeof...(bound_ts)>, dindex>>
                       &bin_capacities = {},
-                  const std::array<std::vector<scalar_type>, grid_shape_t::dim>
+                  const darray<std::vector<scalar_type>, grid_shape_t::dim>
                       &ax_bin_edges = {},
                   const types::list<bound_ts...> & = {},
                   const types::list<binning_ts...> & = {}) const {

--- a/core/include/detray/builders/material_map_builder.hpp
+++ b/core/include/detray/builders/material_map_builder.hpp
@@ -17,7 +17,6 @@
 #include "detray/materials/material_map.hpp"
 
 // System include(s)
-#include <array>
 #include <cassert>
 #include <map>
 #include <memory>
@@ -118,7 +117,7 @@ class material_map_builder final : public volume_decorator<detector_t> {
             }
 
             // Construct and append the material map for a given surface shape
-            std::array<std::vector<scalar_type>, DIM> axis_spans{};
+            darray<std::vector<scalar_type>, DIM> axis_spans{};
             auto axis_spans_itr = m_axis_spans.find(sf_idx);
             if (axis_spans_itr != m_axis_spans.end()) {
                 axis_spans = axis_spans_itr->second;
@@ -195,9 +194,9 @@ class material_map_builder final : public volume_decorator<detector_t> {
     /// The surface this material map belongs to (index is volume local)
     std::map<dindex, std::vector<bin_data_type>> m_bin_data;
     /// Number of bins for the material grid axes
-    std::map<dindex, std::array<std::size_t, DIM>> m_n_bins{};
+    std::map<dindex, darray<std::size_t, DIM>> m_n_bins{};
     /// The Axis spans for the material grid axes
-    std::map<dindex, std::array<std::vector<scalar_type>, DIM>> m_axis_spans{};
+    std::map<dindex, darray<std::vector<scalar_type>, DIM>> m_axis_spans{};
     /// Helper to generate empty grids
     mat_map_factory_t m_factory{};
 };
@@ -227,9 +226,8 @@ struct add_sf_material_map {
         [[maybe_unused]] const index_t& index,
         [[maybe_unused]] const mat_factory_t& mat_factory,
         [[maybe_unused]] std::vector<bin_data_t>& bin_data,
-        [[maybe_unused]] const std::array<std::size_t, DIM>& n_bins,
-        [[maybe_unused]] const std::array<std::vector<scalar_t>, DIM>&
-            axis_spans,
+        [[maybe_unused]] const darray<std::size_t, DIM>& n_bins,
+        [[maybe_unused]] const darray<std::vector<scalar_t>, DIM>& axis_spans,
         [[maybe_unused]] material_store_t& mat_store) const {
 
         using mask_shape_t = typename coll_t::value_type::shape;

--- a/core/include/detray/builders/material_map_factory.hpp
+++ b/core/include/detray/builders/material_map_factory.hpp
@@ -144,8 +144,8 @@ class material_map_factory final : public factory_decorator<detector_t> {
     DETRAY_HOST auto operator()(
         typename detector_t::surface_lookup_container &surfaces,
         std::map<dindex, std::vector<bin_data_t>> &material_map,
-        std::map<dindex, std::array<std::size_t, N>> &n_bins,
-        std::map<dindex, std::array<std::vector<scalar_type>, N>> &axis_spans) {
+        std::map<dindex, darray<std::size_t, N>> &n_bins,
+        std::map<dindex, darray<std::vector<scalar_type>, N>> &axis_spans) {
 
         using link_t = typename detector_t::surface_type::material_link;
 
@@ -168,7 +168,7 @@ class material_map_factory final : public factory_decorator<detector_t> {
                                 n_bins.at(sf_idx).begin());
 
             // Copy the axis spans to the builder (if present)
-            axis_spans[sf_idx] = std::array<std::vector<scalar_type>, N>{};
+            axis_spans[sf_idx] = darray<std::vector<scalar_type>, N>{};
             for (std::size_t in = 0; in < N; ++in) {
                 if (m_axis_spans.at(sf_idx).size() > in) {
                     axis_spans.at(sf_idx).at(in) =

--- a/core/include/detray/builders/material_map_generator.hpp
+++ b/core/include/detray/builders/material_map_generator.hpp
@@ -23,7 +23,6 @@
 #include "detray/utils/ranges.hpp"
 
 // System include(s)
-#include <array>
 #include <functional>
 #include <map>
 #include <memory>
@@ -87,7 +86,7 @@ struct material_map_config {
         /// Type id value of the material map in a given detector
         dindex map_id{dindex_invalid};
         /// Number of bins for material maps
-        std::array<std::size_t, 2> n_bins{20u, 20u};
+        darray<std::size_t, 2> n_bins{20u, 20u};
         /// Along which of the two axes to scale the material
         std::size_t axis_index{0u};
         /// Material to be filled into the maps
@@ -198,7 +197,7 @@ class material_map_generator final : public factory_decorator<detector_t> {
         typename detector_t::surface_lookup_container &surfaces,
         const typename detector_t::mask_container &masks,
         std::map<dindex, std::vector<bin_data_t>> &material_map,
-        std::map<dindex, std::array<std::size_t, N>> &n_bins) {
+        std::map<dindex, darray<std::size_t, N>> &n_bins) {
 
         static_assert(N == 2u, "This generator only supports 2D material maps");
 

--- a/core/include/detray/builders/surface_factory.hpp
+++ b/core/include/detray/builders/surface_factory.hpp
@@ -23,7 +23,6 @@
 #include <cassert>
 #include <exception>
 #include <memory>
-#include <tuple>
 #include <type_traits>
 #include <vector>
 

--- a/core/include/detray/builders/volume_builder_interface.hpp
+++ b/core/include/detray/builders/volume_builder_interface.hpp
@@ -31,8 +31,6 @@ class volume_builder_interface {
     public:
     using algebra_type = typename detector_t::algebra_type;
     using scalar_type = dscalar<algebra_type>;
-    template <typename T, std::size_t N>
-    using array_type = typename detector_t::template array_type<T, N>;
 
     virtual ~volume_builder_interface() = default;
 
@@ -105,8 +103,6 @@ class volume_decorator : public volume_builder_interface<detector_t> {
 
     public:
     using scalar_t = dscalar<typename detector_t::algebra_type>;
-    template <typename T, std::size_t N>
-    using array_type = typename detector_t::template array_type<T, N>;
 
     DETRAY_HOST
     explicit volume_decorator(

--- a/core/include/detray/core/detail/container_views.hpp
+++ b/core/include/detray/core/detail/container_views.hpp
@@ -24,8 +24,7 @@ namespace detray {
 
 /// Container types used in device code
 using device_container_types =
-    container_types<vecmem::device_vector, detray::tuple, darray,
-                    vecmem::jagged_device_vector>;
+    container_types<vecmem::device_vector, vecmem::jagged_device_vector>;
 
 /// Specialized view for @c vecmem::vector containers
 template <typename T>

--- a/core/include/detray/core/detail/indexing.hpp
+++ b/core/include/detray/core/detail/indexing.hpp
@@ -45,7 +45,7 @@ template <typename index_t, std::size_t DIM>
 struct multi_index {
     using index_type = index_t;
 
-    std::array<index_t, DIM> indices{};
+    darray<index_t, DIM> indices{};
 
     /// @returns the number of conatined indices
     DETRAY_HOST_DEVICE

--- a/core/include/detray/core/detector.hpp
+++ b/core/include/detray/core/detector.hpp
@@ -75,6 +75,10 @@ class detector {
         detector<metadata_t, container_t> &,
         const dtransform3D<typename metadata_t::algebra_type> &, unsigned int);
 
+    /// Raw container types
+    template <typename T>
+    using vector_type = typename container_t::template vector_type<T>;
+
     public:
     /// Main definition of geometry types
     using metadata = metadata_t;
@@ -86,17 +90,6 @@ class detector {
     using point3_type = dpoint3D<algebra_type>;
     using vector3_type = dvector3D<algebra_type>;
     using transform3_type = dtransform3D<algebra_type>;
-
-    /// Raw container types
-    template <typename T, std::size_t N>
-    using array_type = typename container_t::template array_type<T, N>;
-    template <typename T>
-    using vector_type = typename container_t::template vector_type<T>;
-    template <typename... T>
-    using tuple_type = typename container_t::template tuple_type<T...>;
-    template <typename T>
-    using jagged_vector_type =
-        typename container_t::template jagged_vector_type<T>;
 
     /// In case the detector needs to be printed
     using name_map = std::map<dindex, std::string>;
@@ -115,19 +108,18 @@ class detector {
     using geometry_context = typename transform_container::context_type;
 
     /// Forward mask types that are present in this detector
-    using mask_container =
-        typename metadata::template mask_store<tuple_type, vector_type>;
+    using mask_container = typename metadata::template mask_store<vector_type>;
     using masks = typename mask_container::value_types;
 
-    /// Forward mask types that are present in this detector
+    /// Forward material types that are present in this detector
     using material_container =
-        typename metadata::template material_store<tuple_type, container_t>;
+        typename metadata::template material_store<container_t>;
     using materials = typename material_container::value_types;
 
     /// Surface Finders: structures that enable neigborhood searches in the
     /// detector geometry during navigation. Can be different in each volume
     using accelerator_container =
-        typename metadata::template accelerator_store<tuple_type, container_t>;
+        typename metadata::template accelerator_store<container_t>;
     using accel = typename accelerator_container::value_types;
 
     /// Volume type

--- a/core/include/detray/definitions/detail/containers.hpp
+++ b/core/include/detray/definitions/detail/containers.hpp
@@ -16,7 +16,6 @@
 #include <vecmem/containers/vector.hpp>
 
 // System include(s)
-#include <array>
 #include <map>
 #include <type_traits>
 #include <vector>

--- a/core/include/detray/definitions/detail/containers.hpp
+++ b/core/include/detray/definitions/detail/containers.hpp
@@ -40,8 +40,6 @@ using dtuple = detray::tuple<types...>;
 
 /// @brief Bundle container type definitions
 template <template <typename...> class vector_t = dvector,
-          template <typename...> class tuple_t = dtuple,
-          template <typename, std::size_t> class array_t = darray,
           template <typename...> class jagged_vector_t = djagged_vector,
           template <typename, typename> class map_t = dmap>
 struct container_types {
@@ -49,10 +47,10 @@ struct container_types {
     using vector_type = vector_t<T>;
 
     template <class... T>
-    using tuple_type = tuple_t<T...>;
+    using tuple_type = dtuple<T...>;
 
     template <typename T, std::size_t kDIM>
-    using array_type = array_t<T, kDIM>;
+    using array_type = darray<T, kDIM>;
 
     template <typename T>
     using jagged_vector_type = jagged_vector_t<T>;

--- a/core/include/detray/geometry/shapes/unbounded.hpp
+++ b/core/include/detray/geometry/shapes/unbounded.hpp
@@ -15,7 +15,6 @@
 #include "detray/utils/string_view_concat.hpp"
 
 // System include(s)
-#include <array>
 #include <limits>
 #include <ostream>
 #include <string>

--- a/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_cylinder_intersector.hpp
@@ -61,17 +61,17 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
     ///
     /// @return the intersection
     template <typename surface_descr_t, typename mask_t>
-    DETRAY_HOST_DEVICE inline std::array<intersection_type<surface_descr_t>, 2>
+    DETRAY_HOST_DEVICE inline darray<intersection_type<surface_descr_t>, 2>
     operator()(const helix_type &h, const surface_descr_t &sf_desc,
                const mask_t &mask, const transform3_type &trf,
-               const std::array<scalar_type, 2u> mask_tolerance =
+               const darray<scalar_type, 2u> mask_tolerance =
                    {detail::invalid_value<scalar_type>(),
                     detail::invalid_value<scalar_type>()},
                const scalar_type = 0.f, const scalar_type = 0.f) const {
         assert((mask_tolerance[0] == mask_tolerance[1]) &&
                "Helix intersectors use only one mask tolerance value");
 
-        std::array<intersection_type<surface_descr_t>, 2> ret{};
+        darray<intersection_type<surface_descr_t>, 2> ret{};
 
         if (!run_rtsafe) {
             // Get the surface placement
@@ -95,7 +95,7 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
             const scalar_type default_s{r * vector::perp(h_dir)};
 
             // Initial helix path length parameter
-            std::array<scalar_type, 2> paths{default_s, default_s};
+            darray<scalar_type, 2> paths{default_s, default_s};
 
             // try to guess good starting path by calculating the intersection
             // path of the helix tangential with the cylinder. This only has a
@@ -207,7 +207,7 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
             const scalar_type default_s{r * vector::perp(h_dir)};
 
             // Initial helix path length parameter
-            std::array<scalar_type, 2> paths{default_s, default_s};
+            darray<scalar_type, 2> paths{default_s, default_s};
 
             // try to guess good starting path by calculating the intersection
             // path of the helix tangential with the cylinder. This only has a
@@ -273,7 +273,7 @@ struct helix_intersector_impl<cylindrical2D<algebra_t>, algebra_t>
 
     /// Interface to use fixed mask tolerance
     template <typename surface_descr_t, typename mask_t>
-    DETRAY_HOST_DEVICE inline std::array<intersection_type<surface_descr_t>, 2>
+    DETRAY_HOST_DEVICE inline darray<intersection_type<surface_descr_t>, 2>
     operator()(const helix_type &h, const surface_descr_t &sf_desc,
                const mask_t &mask, const transform3_type &trf,
                const scalar_type mask_tolerance, const scalar_type = 0.f,

--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -58,7 +58,7 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const helix_type &h, const surface_descr_t &sf_desc, const mask_t &mask,
         const transform3_type &trf,
-        const std::array<scalar_type, 2u> mask_tolerance =
+        const darray<scalar_type, 2u> mask_tolerance =
             {detail::invalid_value<scalar_type>(),
              detail::invalid_value<scalar_type>()},
         const scalar_type = 0.f, const scalar_type = 0.f) const {

--- a/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_plane_intersector.hpp
@@ -60,7 +60,7 @@ struct helix_intersector_impl<cartesian2D<algebra_t>, algebra_t> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const helix_type &h, const surface_descr_t &sf_desc, const mask_t &mask,
         const transform3_type &trf,
-        const std::array<scalar_type, 2u> mask_tolerance =
+        const darray<scalar_type, 2u> mask_tolerance =
             {detail::invalid_value<scalar_type>(),
              detail::invalid_value<scalar_type>()},
         const scalar_type = 0.f, const scalar_type = 0.f) const {

--- a/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_concentric_cylinder_intersector.hpp
@@ -59,7 +59,7 @@ struct ray_concentric_cylinder_intersector {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const ray_type &ray, const surface_descr_t &sf, const mask_t &mask,
         const transform3_type & /*trf*/,
-        const std::array<scalar_type, 2u> mask_tolerance =
+        const darray<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
@@ -86,8 +86,8 @@ struct ray_concentric_cylinder_intersector {
 
         if (qe.solutions() > 0) {
             const scalar_type overstep_tolerance{overstep_tol};
-            std::array<point3_type, 2> candidates;
-            std::array<scalar_type, 2> t01 = {0.f, 0.f};
+            darray<point3_type, 2> candidates;
+            darray<scalar_type, 2> t01 = {0.f, 0.f};
 
             candidates[0][_x] = qe.smaller();
             candidates[0][_y] = k * qe.smaller() + d;
@@ -158,7 +158,7 @@ struct ray_concentric_cylinder_intersector {
     DETRAY_HOST_DEVICE inline void update(
         const ray_type &ray, intersection_type<surface_descr_t> &sfi,
         const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance =
+        const darray<scalar_type, 2u> &mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {

--- a/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
@@ -57,10 +57,10 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
     ///
     /// @return the intersections.
     template <typename surface_descr_t, typename mask_t>
-    DETRAY_HOST_DEVICE inline std::array<intersection_type<surface_descr_t>, 2>
+    DETRAY_HOST_DEVICE inline darray<intersection_type<surface_descr_t>, 2>
     operator()(const ray_type &ray, const surface_descr_t &sf,
                const mask_t &mask, const transform3_type &trf,
-               const std::array<scalar_type, 2u> mask_tolerance =
+               const darray<scalar_type, 2u> mask_tolerance =
                    {0.f, 100.f * unit<scalar_type>::um},
                const scalar_type mask_tol_scalor = 0.f,
                const scalar_type overstep_tol = 0.f) const {
@@ -68,7 +68,7 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
         // One or both of these solutions might be invalid
         const auto qe = solve_intersection(ray, mask, trf);
 
-        std::array<intersection_type<surface_descr_t>, 2> ret;
+        darray<intersection_type<surface_descr_t>, 2> ret;
         switch (qe.solutions()) {
             case 2:
                 ret[1] = build_candidate<surface_descr_t>(
@@ -98,7 +98,7 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
 
     /// Interface to use fixed mask tolerance
     template <typename surface_descr_t, typename mask_t>
-    DETRAY_HOST_DEVICE inline std::array<intersection_type<surface_descr_t>, 2>
+    DETRAY_HOST_DEVICE inline darray<intersection_type<surface_descr_t>, 2>
     operator()(const ray_type &ray, const surface_descr_t &sf,
                const mask_t &mask, const transform3_type &trf,
                const scalar_type mask_tolerance,
@@ -121,7 +121,7 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
     DETRAY_HOST_DEVICE inline void update(
         const ray_type &ray, intersection_type<surface_descr_t> &sfi,
         const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> mask_tolerance =
+        const darray<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
@@ -175,7 +175,7 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t>
     build_candidate(const ray_type &ray, mask_t &mask,
                     const transform3_type &trf, const scalar_type path,
-                    const std::array<scalar_type, 2u> mask_tolerance,
+                    const darray<scalar_type, 2u> mask_tolerance,
                     const scalar_type mask_tol_scalor,
                     const scalar_type overstep_tol) const {
 

--- a/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
@@ -68,7 +68,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const ray_type &ray, const surface_descr_t &sf, const mask_t &mask,
         const transform3_type &trf,
-        const std::array<scalar_type, 2u> mask_tolerance =
+        const darray<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
@@ -120,7 +120,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
     DETRAY_HOST_DEVICE inline void update(
         const ray_type &ray, intersection_type<surface_descr_t> &sfi,
         const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance =
+        const darray<scalar_type, 2u> &mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {

--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -55,7 +55,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, do_debug> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const ray_type &ray, const surface_descr_t &sf, const mask_t &mask,
         const transform3_type &trf,
-        const std::array<scalar_type, 2u> mask_tolerance =
+        const darray<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
@@ -145,7 +145,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, do_debug> {
     DETRAY_HOST_DEVICE inline void update(
         const ray_type &ray, intersection_type<surface_descr_t> &sfi,
         const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance =
+        const darray<scalar_type, 2u> &mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {

--- a/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_plane_intersector.hpp
@@ -59,7 +59,7 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, do_debug> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const ray_type &ray, const surface_descr_t &sf, const mask_t &mask,
         const transform3_type &trf,
-        const std::array<scalar_type, 2u> mask_tolerance =
+        const darray<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
@@ -128,7 +128,7 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, do_debug> {
     DETRAY_HOST_DEVICE inline void update(
         const ray_type &ray, intersection_type<surface_descr_t> &sfi,
         const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance =
+        const darray<scalar_type, 2u> &mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_intersector.hpp
@@ -55,18 +55,18 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
     /// @return the intersections.
     template <typename surface_descr_t, typename mask_t,
               typename other_algebra_t>
-    DETRAY_HOST_DEVICE inline std::array<intersection_type<surface_descr_t>, 2>
+    DETRAY_HOST_DEVICE inline darray<intersection_type<surface_descr_t>, 2>
     operator()(const detail::ray<other_algebra_t> &ray,
                const surface_descr_t &sf, const mask_t &mask,
                const transform3_type &trf,
-               const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+               const darray<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
                const scalar_type mask_tol_scalor = 0.f,
                const scalar_type overstep_tol = 0.f) const {
 
         // One or both of these solutions might be invalid
         const auto qe = solve_intersection(ray, mask, trf);
 
-        std::array<intersection_type<surface_descr_t>, 2> ret;
+        darray<intersection_type<surface_descr_t>, 2> ret;
         ret[1] = build_candidate<surface_descr_t>(
             ray, mask, trf, qe.larger(), mask_tolerance, mask_tol_scalor,
             overstep_tol);
@@ -98,7 +98,7 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
         const detail::ray<other_algebra_t> &ray,
         intersection_type<surface_descr_t> &sfi, const mask_t &mask,
         const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const darray<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
@@ -158,7 +158,7 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t>
     build_candidate(const detail::ray<other_algebra_t> &ray, const mask_t &mask,
                     const transform3_type &trf, const scalar_type path,
-                    const std::array<scalar_type, 2u> &mask_tolerance =
+                    const darray<scalar_type, 2u> &mask_tolerance =
                         {0.f, 1.f * unit<scalar_type>::mm},
                     const scalar_type mask_tol_scalor = 0.f,
                     const scalar_type overstep_tol = 0.f) const {

--- a/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_cylinder_portal_intersector.hpp
@@ -61,7 +61,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const detail::ray<other_algebra_t> &ray, const surface_descr_t &sf,
         const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const darray<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
@@ -107,7 +107,7 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
         const detail::ray<other_algebra_t> &ray,
         intersection_type<surface_descr_t> &sfi, const mask_t &mask,
         const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const darray<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
         sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,

--- a/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_line_intersector.hpp
@@ -56,7 +56,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, do_debug> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const detail::ray<other_algebra_t> &ray, const surface_descr_t &sf,
         const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const darray<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
@@ -138,7 +138,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, do_debug> {
         const detail::ray<other_algebra_t> &ray,
         intersection_type<surface_descr_t> &sfi, const mask_t &mask,
         const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const darray<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
         sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,

--- a/core/include/detray/navigation/intersection/soa/ray_plane_intersector.hpp
+++ b/core/include/detray/navigation/intersection/soa/ray_plane_intersector.hpp
@@ -57,7 +57,7 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, do_debug> {
     DETRAY_HOST_DEVICE inline intersection_type<surface_descr_t> operator()(
         const detail::ray<other_algebra_t> &ray, const surface_descr_t &sf,
         const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const darray<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
 
@@ -126,7 +126,7 @@ struct ray_intersector_impl<cartesian2D<algebra_t>, algebra_t, do_debug> {
         const detail::ray<other_algebra_t> &ray,
         intersection_type<surface_descr_t> &sfi, const mask_t &mask,
         const transform3_type &trf,
-        const std::array<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
+        const darray<scalar_type, 2u> &mask_tolerance = {0.f, 1.f},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
         sfi = this->operator()(ray, sfi.sf_desc, mask, trf, mask_tolerance,

--- a/core/include/detray/navigation/intersection_kernel.hpp
+++ b/core/include/detray/navigation/intersection_kernel.hpp
@@ -48,8 +48,8 @@ struct intersection_initialize {
         const surface_t &surface,
         const transform_container_t &contextual_transforms,
         const typename transform_container_t::context_type &ctx,
-        const std::array<scalar_t, 2u> &mask_tolerance =
-            {0.f, 1.f * unit<scalar_t>::mm},
+        const darray<scalar_t, 2u> &mask_tolerance = {0.f,
+                                                      1.f * unit<scalar_t>::mm},
         const scalar_t mask_tol_scalor = 0.f,
         const scalar_t overstep_tol = 0.f) const {
 
@@ -87,7 +87,7 @@ struct intersection_initialize {
 
     template <typename is_container_t>
     DETRAY_HOST_DEVICE bool place_in_collection(
-        std::array<typename is_container_t::value_type, 2> &&solutions,
+        darray<typename is_container_t::value_type, 2> &&solutions,
         is_container_t &intersections) const {
         bool is_valid = false;
         for (auto &sfi : std::move(solutions)) {
@@ -140,8 +140,8 @@ struct intersection_update {
         const traj_t &traj, intersection_t &sfi,
         const transform_container_t &contextual_transforms,
         const typename transform_container_t::context_type &ctx,
-        const std::array<scalar_t, 2u> &mask_tolerance =
-            {0.f, 1.f * unit<scalar_t>::mm},
+        const darray<scalar_t, 2u> &mask_tolerance = {0.f,
+                                                      1.f * unit<scalar_t>::mm},
         const scalar_t mask_tol_scalor = 0.f,
         const scalar_t overstep_tol = 0.f) const {
 

--- a/core/include/detray/navigation/intersector.hpp
+++ b/core/include/detray/navigation/intersector.hpp
@@ -42,7 +42,7 @@ struct intersector {
     DETRAY_HOST_DEVICE inline decltype(auto) operator()(
         const detail::ray<algebra_t> &ray, const surface_descr_t &sf,
         const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> mask_tolerance =
+        const darray<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type mask_tol_scalor = 0.f,
         const scalar_type overstep_tol = 0.f) const {
@@ -56,7 +56,7 @@ struct intersector {
     DETRAY_HOST_DEVICE inline decltype(auto) operator()(
         const detail::helix<algebra_t> &h, const surface_descr_t &sf,
         const mask_t &mask, const transform3_type &trf,
-        const std::array<scalar_type, 2u> mask_tolerance =
+        const darray<scalar_type, 2u> mask_tolerance =
             {0.f, 1.f * unit<scalar_type>::mm},
         const scalar_type = 0.f, const scalar_type = 0.f) const {
 

--- a/core/include/detray/navigation/navigation_config.hpp
+++ b/core/include/detray/navigation/navigation_config.hpp
@@ -42,7 +42,7 @@ struct config {
     float overstep_tolerance{-300.f * unit<float>::um};
     /// Search window size for grid based acceleration structures
     /// (0, 0): only look at current bin
-    std::array<dindex, 2> search_window = {0u, 0u};
+    darray<dindex, 2> search_window = {0u, 0u};
 
     /// Print the navigation configuration
     DETRAY_HOST

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -146,7 +146,7 @@ class navigator {
         friend struct intersection_update<ray_intersector>;
 
         using candidate_t = intersection_type;
-        using candidate_cache_t = std::array<candidate_t, k_cache_capacity>;
+        using candidate_cache_t = darray<candidate_t, k_cache_capacity>;
         using candidate_itr_t = typename candidate_cache_t::iterator;
         using candidate_const_itr_t =
             typename candidate_cache_t::const_iterator;
@@ -607,7 +607,7 @@ class navigator {
             const typename detector_type::surface_type &sf_descr,
             const detector_type &det, const context_type &ctx,
             const track_t &track, state &nav_state,
-            const std::array<scalar_type, 2> mask_tol,
+            const darray<scalar_type, 2> mask_tol,
             const scalar_type mask_tol_scalor,
             const scalar_type overstep_tol) const {
 
@@ -620,8 +620,7 @@ class navigator {
                     static_cast<scalar_type>(nav_state.direction()) *
                         track.dir()),
                 sf_descr, det.transform_store(), ctx,
-                sf.is_portal() ? std::array<scalar_type, 2>{0.f, 0.f}
-                               : mask_tol,
+                sf.is_portal() ? darray<scalar_type, 2>{0.f, 0.f} : mask_tol,
                 mask_tol_scalor, overstep_tol);
         }
     };
@@ -652,8 +651,8 @@ class navigator {
         // Search for neighboring surfaces and fill candidates into cache
         volume.template visit_neighborhood<candidate_search>(
             track, cfg, ctx, det, ctx, track, navigation,
-            std::array<scalar_type, 2u>{cfg.min_mask_tolerance,
-                                        cfg.max_mask_tolerance},
+            darray<scalar_type, 2u>{cfg.min_mask_tolerance,
+                                    cfg.max_mask_tolerance},
             static_cast<scalar_type>(cfg.mask_tolerance_scalor),
             static_cast<scalar_type>(cfg.overstep_tolerance));
 
@@ -921,9 +920,9 @@ class navigator {
             detail::ray<algebra_type>(
                 track.pos(), static_cast<scalar_type>(nav_dir) * track.dir()),
             candidate, det.transform_store(), ctx,
-            sf.is_portal() ? std::array<scalar_type, 2>{0.f, 0.f}
-                           : std::array<scalar_type, 2>{cfg.min_mask_tolerance,
-                                                        cfg.max_mask_tolerance},
+            sf.is_portal() ? darray<scalar_type, 2>{0.f, 0.f}
+                           : darray<scalar_type, 2>{cfg.min_mask_tolerance,
+                                                    cfg.max_mask_tolerance},
             static_cast<scalar_type>(cfg.mask_tolerance_scalor),
             static_cast<scalar_type>(cfg.overstep_tolerance));
     }

--- a/core/include/detray/propagator/actor_chain.hpp
+++ b/core/include/detray/propagator/actor_chain.hpp
@@ -26,16 +26,15 @@ namespace detray {
 /// It can hold both simple actors, as well as an actor with its observers.
 /// The states of the actors need to be passed to the chain in an external tuple
 ///
-/// @tparam tuple_t tuple type used to resolve the actor types
 /// @tparam actors_t the types of the actors in the chain.
-template <template <typename...> class tuple_t = dtuple, typename... actors_t>
+template <typename... actors_t>
 class actor_chain {
 
     public:
     /// Types of the actors that are registered in the chain
-    using actor_list_type = tuple_t<actors_t...>;
+    using actor_list_type = dtuple<actors_t...>;
     // Type of states tuple that is used in the propagator
-    using state = tuple_t<typename actors_t::state &...>;
+    using state = dtuple<typename actors_t::state &...>;
 
     /// Call all actors in the chain.
     ///
@@ -60,7 +59,7 @@ class actor_chain {
         // Only possible if each state is default initializable
         if constexpr ((std::default_initializable<typename actors_t::state> &&
                        ...)) {
-            return tuple_t<typename actors_t::state...>{};
+            return dtuple<typename actors_t::state...>{};
         } else {
             return std::nullopt;
         }
@@ -68,7 +67,7 @@ class actor_chain {
 
     /// @returns a tuple of reference for every state in the tuple @param t
     DETRAY_HOST_DEVICE static constexpr state make_ref_tuple(
-        tuple_t<typename actors_t::state...> &t) {
+        dtuple<typename actors_t::state...> &t) {
         return make_ref_tuple(t,
                               std::make_index_sequence<sizeof...(actors_t)>{});
     }
@@ -112,7 +111,7 @@ class actor_chain {
     /// @returns a tuple of reference for every state in the tuple @param t
     template <std::size_t... indices>
     DETRAY_HOST_DEVICE static constexpr state make_ref_tuple(
-        tuple_t<typename actors_t::state...> &t,
+        dtuple<typename actors_t::state...> &t,
         std::index_sequence<indices...> /*ids*/) {
         return detray::tie(detail::get<indices>(t)...);
     }

--- a/core/include/detray/propagator/base_actor.hpp
+++ b/core/include/detray/propagator/base_actor.hpp
@@ -33,12 +33,10 @@ struct actor {
 /// The composition represents an actor together with its observers. In
 /// addition to running its own implementation, it notifies its observing actors
 ///
-/// @tparam tuple_t the tuple used to unroll observer types.
 /// @tparam actor_impl_t the actor the compositions implements itself.
 /// @tparam observers a pack of observing actors that get called on the updated
 ///         actor state of the compositions actor implementation.
-template <template <typename...> class tuple_t = dtuple,
-          class actor_impl_t = actor, typename... observers>
+template <class actor_impl_t = actor, typename... observers>
 class composite_actor final : public actor_impl_t {
 
     public:
@@ -125,7 +123,7 @@ class composite_actor final : public actor_impl_t {
     template <std::size_t... indices, typename actor_states_t,
               typename actor_impl_state_t, typename propagator_state_t>
     DETRAY_HOST_DEVICE inline void notify(
-        const tuple_t<observers...> &observer_list, actor_states_t &states,
+        const dtuple<observers...> &observer_list, actor_states_t &states,
         actor_impl_state_t &actor_state, propagator_state_t &p_state,
         std::index_sequence<indices...> /*ids*/) const {
 
@@ -135,7 +133,7 @@ class composite_actor final : public actor_impl_t {
     }
 
     /// Keep the observers (might be composites again)
-    tuple_t<observers...> m_observers = {};
+    dtuple<observers...> m_observers = {};
 };
 
 }  // namespace detray

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -53,13 +53,13 @@ class rk_stepper final
         vector3_type b_middle{0.f, 0.f, 0.f};
         vector3_type b_last{0.f, 0.f, 0.f};
         // t = tangential direction = dr/ds
-        std::array<vector3_type, 4u> t;
+        darray<vector3_type, 4u> t;
         // q/p
-        std::array<scalar_type, 4u> qop;
+        darray<scalar_type, 4u> qop;
         // dt/ds = d^2r/ds^2 = q/p ( t X B )
-        std::array<vector3_type, 4u> dtds;
+        darray<vector3_type, 4u> dtds;
         // d(q/p)/ds
-        std::array<scalar_type, 4u> dqopds;
+        darray<scalar_type, 4u> dqopds;
     };
 
     struct state : public base_type::state {

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -93,10 +93,10 @@ DETRAY_HOST_DEVICE inline void detray::rk_stepper<
     const auto I33 = matrix::identity<matrix_type<3, 3>>();
 
     // Initialize derivatives
-    std::array<matrix_type<3u, 3u>, 4u> dkndt{I33, I33, I33, I33};
-    std::array<vector3_type, 4u> dkndqop;
-    std::array<matrix_type<3u, 3u>, 4u> dkndr;
-    std::array<scalar_type, 4u> dqopn_dqop{1.f, 1.f, 1.f, 1.f};
+    darray<matrix_type<3u, 3u>, 4u> dkndt{I33, I33, I33, I33};
+    darray<vector3_type, 4u> dkndqop;
+    darray<matrix_type<3u, 3u>, 4u> dkndr;
+    darray<scalar_type, 4u> dqopn_dqop{1.f, 1.f, 1.f, 1.f};
 
     /*---------------------------------------------------------------------------
      *  dk_n/dt1

--- a/core/include/detray/utils/bounding_volume.hpp
+++ b/core/include/detray/utils/bounding_volume.hpp
@@ -80,7 +80,7 @@ class axis_aligned_bounding_volume {
                 axis_aligned_bounding_volume<other_shape_t, algebra_t>>& aabbs,
             std::size_t box_id, const scalar_t env) {
 
-        using loc_point_t = std::array<scalar_t, other_shape_t::dim>;
+        using loc_point_t = darray<scalar_t, other_shape_t::dim>;
 
         // Find min/max extent of the local aabb in local coordinates
         constexpr scalar_t inv{detail::invalid_value<scalar_t>()};
@@ -265,7 +265,7 @@ class axis_aligned_bounding_volume {
 
         // Transform the old min and max points to the global frame and
         // construct all corner points of the local aabb in global coordinates
-        std::array<point3_t, 8> glob_c_points;
+        darray<point3_t, 8> glob_c_points;
         glob_c_points[0] = glob_min(trf);
         glob_c_points[1] = glob_max(trf);
         glob_c_points[2] = glob_c_points[0] + new_box_x;

--- a/core/include/detray/utils/grid/detail/axis.hpp
+++ b/core/include/detray/utils/grid/detail/axis.hpp
@@ -64,8 +64,6 @@ struct single_axis {
     using container_types = typename binning_type::container_types;
     template <typename T>
     using vector_type = typename binning_type::template vector_type<T>;
-    template <typename T, std::size_t N>
-    using array_type = typename binning_type::template array_type<T, N>;
     /// @}
 
     /// Defines the geometrical bounds of the axis as a service:
@@ -151,13 +149,13 @@ struct single_axis {
     /// @returns a dindex_range around the bin index.
     template <typename neighbor_t>
     DETRAY_HOST_DEVICE bin_range
-    range(const scalar_type v, const array_type<neighbor_t, 2> &nhood) const {
+    range(const scalar_type v, const darray<neighbor_t, 2> &nhood) const {
         return m_bounds.map(m_binning.range(v, nhood), m_binning.nbins());
     }
 
     /// @returns the bin edges for a given @param ibin .
     DETRAY_HOST_DEVICE
-    array_type<scalar_type, 2> bin_edges(const dindex ibin) const {
+    darray<scalar_type, 2> bin_edges(const dindex ibin) const {
         return m_binning.bin_edges(ibin);
     }
 
@@ -167,7 +165,7 @@ struct single_axis {
 
     /// @returns the axis span [min, max).
     DETRAY_HOST_DEVICE
-    array_type<scalar_type, 2> span() const { return m_binning.span(); }
+    darray<scalar_type, 2> span() const { return m_binning.span(); }
 
     /// @returns the axis span [min, max).
     DETRAY_HOST_DEVICE

--- a/core/include/detray/utils/grid/detail/axis.hpp
+++ b/core/include/detray/utils/grid/detail/axis.hpp
@@ -36,7 +36,7 @@ struct multi_bin : public dmulti_index<index_t, DIM> {};
 
 /// @brief Helper to tie two bin indices to a range.
 /// @note Cannot use dindex_range for signed integer bin indices.
-using bin_range = std::array<int, 2>;
+using bin_range = darray<int, 2>;
 
 /// @brief Multi-bin-range: contains bin index ranges from multiple axes
 template <std::size_t DIM>
@@ -383,7 +383,7 @@ class multi_axis {
     ///          every axis in the corresponding entry (e.g. rng_x in entry 0)
     template <typename neighbor_t>
     DETRAY_HOST_DEVICE multi_bin_range<dim> bin_ranges(
-        const point_type &p, const std::array<neighbor_t, 2> &nhood) const {
+        const point_type &p, const darray<neighbor_t, 2> &nhood) const {
         // Empty bin ranges to be filled
         multi_bin_range<dim> bin_ranges{};
         // Run the range resolution for every axis in this multi-axis type
@@ -473,7 +473,7 @@ class multi_axis {
     template <typename axis_t, typename neighbor_t>
     DETRAY_HOST_DEVICE void get_axis_bin_ranges(
         const axis_t &ax, const point_type &p,
-        const std::array<neighbor_t, 2> &nhood,
+        const darray<neighbor_t, 2> &nhood,
         multi_bin_range<dim> &bin_ranges) const {
         // Get the index corresponding to the axis label (e.g. bin_range_x = 0)
         constexpr auto loc_idx{axis_reg::to_index(axis_t::bounds_type::label)};

--- a/core/include/detray/utils/grid/detail/axis_binning.hpp
+++ b/core/include/detray/utils/grid/detail/axis_binning.hpp
@@ -22,7 +22,7 @@ namespace detray::axis {
 
 /// @brief Helper to tie two bin indices to a range.
 /// @note Cannot use dindex_range for signed integer bin indices.
-using bin_range = std::array<int, 2>;
+using bin_range = darray<int, 2>;
 
 /// @brief A regular binning scheme.
 ///
@@ -36,8 +36,6 @@ struct regular {
     using container_types = dcontainers;
     template <typename T>
     using vector_type = typename dcontainers::template vector_type<T>;
-    template <typename T, std::size_t N>
-    using array_type = typename dcontainers::template array_type<T, N>;
 
     static constexpr binning type = binning::e_regular;
 
@@ -91,8 +89,7 @@ struct regular {
     ///
     /// @returns the corresponding range of bin indices
     DETRAY_HOST_DEVICE
-    bin_range range(const scalar_type v,
-                    const array_type<dindex, 2> &nhood) const {
+    bin_range range(const scalar_type v, const darray<dindex, 2> &nhood) const {
         const int ibin{bin(v)};
         const int ibinmin{ibin - static_cast<int>(nhood[0])};
         const int ibinmax{ibin + static_cast<int>(nhood[1])};
@@ -110,13 +107,13 @@ struct regular {
     /// @returns the corresponding range of bin indices
     DETRAY_HOST_DEVICE
     bin_range range(const scalar_type v,
-                    const array_type<scalar_type, 2> &nhood) const {
+                    const darray<scalar_type, 2> &nhood) const {
         return {bin(v - nhood[0]), bin(v + nhood[1])};
     }
 
     /// @return the bin edges for a given @param ibin
     DETRAY_HOST_DEVICE
-    array_type<scalar_type, 2> bin_edges(const dindex ibin) const {
+    darray<scalar_type, 2> bin_edges(const dindex ibin) const {
         const scalar_type width{bin_width()};
         const scalar_type lower_edge{span()[0] +
                                      static_cast<scalar_type>(ibin) * width};
@@ -133,7 +130,7 @@ struct regular {
         detray::detail::call_reserve(edges, nbins());
 
         // Calculate bin edges from number of bins and axis span
-        const array_type<scalar_type, 2> sp = span();
+        const darray<scalar_type, 2> sp = span();
         const scalar_type step{bin_width()};
 
         for (dindex ib = 0; ib <= nbins(); ++ib) {
@@ -159,7 +156,7 @@ struct regular {
     /// @return the span of the binning (equivalent to the span of the axis:
     /// [min, max) )
     DETRAY_HOST_DEVICE
-    array_type<scalar_type, 2> span() const {
+    darray<scalar_type, 2> span() const {
         // Get the binning information
         const scalar_type min{(*m_bin_edges)[m_offset]};
         const scalar_type max{(*m_bin_edges)[m_offset + 1]};
@@ -196,8 +193,6 @@ struct irregular {
     using container_types = dcontainers;
     template <typename T>
     using vector_type = typename dcontainers::template vector_type<T>;
-    template <typename T, std::size_t N>
-    using array_type = typename dcontainers::template array_type<T, N>;
     using index_type = typename std::iterator_traits<
         typename vector_type<scalar_type>::iterator>::difference_type;
 
@@ -253,8 +248,7 @@ struct irregular {
     ///
     /// @returns the corresponding range of bin indices
     DETRAY_HOST_DEVICE
-    bin_range range(const scalar_type v,
-                    const array_type<dindex, 2> &nhood) const {
+    bin_range range(const scalar_type v, const darray<dindex, 2> &nhood) const {
         const int ibin{bin(v)};
         const int ibinmin{ibin - static_cast<int>(nhood[0])};
         const int ibinmax{ibin + static_cast<int>(nhood[1])};
@@ -270,13 +264,13 @@ struct irregular {
     /// @returns the corresponding range of bin indices
     DETRAY_HOST_DEVICE
     bin_range range(const scalar_type v,
-                    const array_type<scalar_type, 2> &nhood) const {
+                    const darray<scalar_type, 2> &nhood) const {
         return {bin(v - nhood[0]), bin(v + nhood[1])};
     }
 
     /// @return the bin edges for a given @param ibin
     DETRAY_HOST_DEVICE
-    array_type<scalar_type, 2> bin_edges(const dindex ibin) const {
+    darray<scalar_type, 2> bin_edges(const dindex ibin) const {
         return {(*m_bin_edges)[m_offset + ibin],
                 (*m_bin_edges)[m_offset + ibin + 1u]};
     }
@@ -302,7 +296,7 @@ struct irregular {
     scalar_type bin_width(const dindex ibin) const {
 
         // Get the binning information
-        const array_type<scalar_type, 2> edges = bin_edges(ibin);
+        const darray<scalar_type, 2> edges = bin_edges(ibin);
 
         return edges[1] - edges[0];
     }
@@ -310,7 +304,7 @@ struct irregular {
     /// @return the span of the binning (equivalent to the span of the axis:
     /// [min, max) )
     DETRAY_HOST_DEVICE
-    array_type<scalar_type, 2> span() const {
+    darray<scalar_type, 2> span() const {
         // Get the binning information
         const scalar_type min{(*m_bin_edges)[m_offset]};
         const scalar_type max{(*m_bin_edges)[m_offset + m_n_bins]};

--- a/core/include/detray/utils/grid/detail/axis_bounds.hpp
+++ b/core/include/detray/utils/grid/detail/axis_bounds.hpp
@@ -18,7 +18,7 @@ namespace detray::axis {
 
 /// @brief Helper to tie two bin indices to a range.
 /// @note Cannot use dindex_range for signed integer bin indices.
-using bin_range = std::array<int, 2>;
+using bin_range = darray<int, 2>;
 
 /// @brief Describes the behaviour of an open axis.
 ///

--- a/core/include/detray/utils/grid/detail/concepts.hpp
+++ b/core/include/detray/utils/grid/detail/concepts.hpp
@@ -15,7 +15,6 @@
 #include "detray/utils/concepts.hpp"
 
 // System include(s)
-#include <array>
 #include <concepts>
 #include <utility>
 
@@ -43,23 +42,23 @@ concept axis = requires(const A ax) {
     { ax.bin(typename A::scalar_type()) }
     ->std::same_as<dindex>;
 
-    { ax.range(typename A::scalar_type(), std::array<dindex, 2>()) }
-    ->std::same_as<std::array<int, 2>>;
+    { ax.range(typename A::scalar_type(), darray<dindex, 2>()) }
+    ->std::same_as<darray<int, 2>>;
 
     {
         ax.range(typename A::scalar_type(),
-                 std::array<typename A::scalar_type, 2>())
+                 darray<typename A::scalar_type, 2>())
     }
-    ->std::same_as<std::array<int, 2>>;
+    ->std::same_as<darray<int, 2>>;
 
     { ax.bin_edges(dindex()) }
-    ->std::same_as<std::array<typename A::scalar_type, 2>>;
+    ->std::same_as<darray<typename A::scalar_type, 2>>;
 
     { ax.bin_edges() }
     ->concepts::range_of<typename A::scalar_type>;
 
     { ax.span() }
-    ->std::same_as<std::array<typename A::scalar_type, 2>>;
+    ->std::same_as<darray<typename A::scalar_type, 2>>;
 
     { ax.min() }
     ->std::same_as<typename A::scalar_type>;

--- a/core/include/detray/utils/grid/detail/grid_bins.hpp
+++ b/core/include/detray/utils/grid/detail/grid_bins.hpp
@@ -71,9 +71,8 @@ template <typename entry_t, std::size_t N>
 class static_array
     : public detray::ranges::view_interface<static_array<entry_t, N>> {
 
-    using bin_view_t = detray::ranges::subrange<std::array<entry_t, N>>;
-    using const_bin_view_t =
-        detray::ranges::subrange<const std::array<entry_t, N>>;
+    using bin_view_t = detray::ranges::subrange<darray<entry_t, N>>;
+    using const_bin_view_t = detray::ranges::subrange<const darray<entry_t, N>>;
     using bin_iterator_t = typename detray::ranges::iterator_t<bin_view_t>;
     using const_bin_iterator_t =
         typename detray::ranges::const_iterator_t<const_bin_view_t>;
@@ -150,7 +149,7 @@ class static_array
     ///
     /// @returns Access to the initialized bin
     DETRAY_HOST_DEVICE
-    constexpr auto init(std::array<entry_t, N> content) -> static_array& {
+    constexpr auto init(darray<entry_t, N> content) -> static_array& {
 
         m_content = content;
         m_size = 0u;
@@ -187,7 +186,7 @@ class static_array
     /// Number of valid elements in the bin
     dindex m_size{0u};
     /// Bin entry container
-    std::array<entry_t, N> m_content{};
+    darray<entry_t, N> m_content{};
 };
 
 /// @brief Bin that views a collection of entries it does not own.

--- a/core/include/detray/utils/grid/detail/simple_serializer.hpp
+++ b/core/include/detray/utils/grid/detail/simple_serializer.hpp
@@ -35,8 +35,7 @@ struct simple_serializer<1> {
     }
 
     /// @returns the global bin, which is also the axis local bin
-    template <typename multi_axis_t,
-              template <typename, std::size_t> class array_t = darray>
+    template <typename multi_axis_t>
     DETRAY_HOST_DEVICE auto operator()(multi_axis_t & /*axes*/,
                                        dindex gbin) const ->
         typename multi_axis_t::loc_bin_index {

--- a/core/include/detray/utils/grid/grid.hpp
+++ b/core/include/detray/utils/grid/grid.hpp
@@ -22,7 +22,6 @@
 #include <vecmem/memory/memory_resource.hpp>
 
 // System include(s).
-#include <array>
 #include <cstddef>
 #include <type_traits>
 
@@ -63,7 +62,7 @@ class grid_impl {
 
     /// How to define a neighborhood for this grid
     template <typename neighbor_t>
-    using neighborhood_type = std::array<neighbor_t, dim>;
+    using neighborhood_type = darray<neighbor_t, dim>;
 
     /// Backend storage type for the grid
     using bin_storage =
@@ -314,7 +313,7 @@ class grid_impl {
     /// @return the sequence of values
     template <typename neighbor_t>
     DETRAY_HOST_DEVICE auto search(
-        const point_type &p, const std::array<neighbor_t, 2> &win_size) const {
+        const point_type &p, const darray<neighbor_t, 2> &win_size) const {
 
         // Return iterable over bins in the search window
         auto search_window = axes().bin_ranges(p, win_size);

--- a/core/include/detray/utils/quadratic_equation.hpp
+++ b/core/include/detray/utils/quadratic_equation.hpp
@@ -84,8 +84,8 @@ requires std::is_arithmetic_v<scalar_t> class quadratic_equation<scalar_t> {
     /// Number of solutions of the equation
     int m_solutions{0};
     /// The solutions
-    std::array<scalar_t, 2> m_values{detail::invalid_value<scalar_t>(),
-                                     detail::invalid_value<scalar_t>()};
+    darray<scalar_t, 2> m_values{detail::invalid_value<scalar_t>(),
+                                 detail::invalid_value<scalar_t>()};
 };
 
 /// Class to solve a quadratic equation of type a * x^2 + b * x + c = 0

--- a/core/include/detray/utils/ranges/static_join.hpp
+++ b/core/include/detray/utils/ranges/static_join.hpp
@@ -44,7 +44,7 @@ template <std::size_t I, std::input_iterator range_itr_t>
 struct static_join_view
     : public detray::ranges::view_interface<static_join_view<I, range_itr_t>> {
 
-    using iterator_coll_t = std::array<range_itr_t, I>;
+    using iterator_coll_t = darray<range_itr_t, I>;
     using iterator_t =
         detray::ranges::detail::static_join_iterator<iterator_coll_t>;
     using value_t = typename std::iterator_traits<iterator_t>::value_type;

--- a/core/include/detray/utils/root_finding.hpp
+++ b/core/include/detray/utils/root_finding.hpp
@@ -9,6 +9,7 @@
 
 // Project include(s).
 #include "detray/definitions/detail/algebra.hpp"
+#include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/math.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/units.hpp"
@@ -16,12 +17,10 @@
 
 // System include(s).
 #include <algorithm>
-#include <array>
 #include <iostream>
 #include <limits>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 
 namespace detray {
 
@@ -39,7 +38,7 @@ namespace detray {
 template <concepts::scalar scalar_t, typename function_t>
 DETRAY_HOST_DEVICE inline bool expand_bracket(const scalar_t a,
                                               const scalar_t b, function_t &f,
-                                              std::array<scalar_t, 2> &bracket,
+                                              darray<scalar_t, 2> &bracket,
                                               const scalar_t k = 1.f) {
 
     if (a == b) {
@@ -113,7 +112,7 @@ DETRAY_HOST_DEVICE inline std::pair<scalar_t, scalar_t> newton_raphson_safe(
     // Initial bracket
     scalar_t a{math::fabs(s) == 0.f ? -0.1f : 0.9f * s};
     scalar_t b{math::fabs(s) == 0.f ? 0.1f : 1.1f * s};
-    std::array<scalar_t, 2> br{};
+    darray<scalar_t, 2> br{};
     bool is_bracketed = expand_bracket(a, b, f, br);
 
     // Update initial guess on the root after bracketing
@@ -270,7 +269,7 @@ template <concepts::scalar scalar_t, typename intersection_t,
 DETRAY_HOST_DEVICE inline void build_intersection(
     const trajectory_t &traj, intersection_t &sfi, const scalar_t s,
     const scalar_t ds, const surface_descr_t sf_desc, const mask_t &mask,
-    const transform3_t &trf, const std::array<scalar_t, 2> &mask_tolerance) {
+    const transform3_t &trf, const darray<scalar_t, 2> &mask_tolerance) {
 
     // Build intersection struct from test trajectory, if the distance is valid
     if (!detail::is_invalid_value(s)) {

--- a/core/include/detray/utils/unit_vectors.hpp
+++ b/core/include/detray/utils/unit_vectors.hpp
@@ -9,10 +9,8 @@
 
 // Project include(s).
 #include "detray/definitions/detail/algebra.hpp"
+#include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
-
-// System include(s)
-#include <array>
 
 namespace detray {
 
@@ -67,10 +65,10 @@ struct unit_vectors {
     ///
     /// with the additional condition that `U` is located in the global x-y
     /// plane.
-    DETRAY_HOST_DEVICE inline std::array<vector3_t, 2>
+    DETRAY_HOST_DEVICE inline darray<vector3_t, 2>
     make_curvilinear_unit_vectors(const vector3_t& dir) {
 
-        std::array<vector3_t, 2> uv;
+        darray<vector3_t, 2> uv;
         uv[0] = make_curvilinear_unit_u(dir);
         uv[1] = vector::normalize(vector::cross(dir, uv[0]));
 

--- a/detectors/include/detray/detectors/default_metadata.hpp
+++ b/detectors/include/detray/detectors/default_metadata.hpp
@@ -107,7 +107,7 @@ struct default_metadata {
     /// bin boundaries, serializers)?
     /// @{
 
-    // surface grid definition: bin-content: std::array<surface_type, 9>
+    // surface grid definition: bin-content: darray<surface_type, 9>
     template <typename axes_t, typename bin_entry_t, typename container_t>
     using surface_grid_t =
         grid<algebra_type, axes_t, bins::dynamic_array<bin_entry_t>,

--- a/detectors/include/detray/detectors/default_metadata.hpp
+++ b/detectors/include/detray/detectors/default_metadata.hpp
@@ -183,9 +183,8 @@ struct default_metadata {
     };
 
     /// How to store masks
-    template <template <typename...> class tuple_t = dtuple,
-              template <typename...> class vector_t = dvector>
-    using mask_store = regular_multi_store<mask_ids, empty_context, tuple_t,
+    template <template <typename...> class vector_t = dvector>
+    using mask_store = regular_multi_store<mask_ids, empty_context, dtuple,
                                            vector_t, rectangle, trapezoid,
                                            annulus, cylinder, cylinder_portal,
                                            disc, straw_tube, drift_cell /*,
@@ -216,10 +215,9 @@ unbounded_cell, unmasked_plane*/>;
     };
 
     /// How to store materials
-    template <template <typename...> class tuple_t = dtuple,
-              typename container_t = host_container_types>
+    template <typename container_t = host_container_types>
     using material_store = multi_store<
-        material_ids, empty_context, tuple_t,
+        material_ids, empty_context, dtuple,
         grid_collection<disc_map_t<container_t>>,
         grid_collection<concentric_cylinder2_map_t<container_t>>,
         grid_collection<cylinder2_map_t<container_t>>,
@@ -268,10 +266,9 @@ unbounded_cell, unmasked_plane*/>;
         dmulti_index<dtyped_index<accel_ids, dindex>, geo_objects::e_size>;
 
     /// How to store the acceleration data structures
-    template <template <typename...> class tuple_t = dtuple,
-              typename container_t = host_container_types>
+    template <typename container_t = host_container_types>
     using accelerator_store =
-        multi_store<accel_ids, empty_context, tuple_t,
+        multi_store<accel_ids, empty_context, dtuple,
                     brute_force_collection<surface_type, container_t>,
                     grid_collection<disc_sf_grid<surface_type, container_t>>,
                     grid_collection<

--- a/detectors/include/detray/detectors/itk_metadata.hpp
+++ b/detectors/include/detray/detectors/itk_metadata.hpp
@@ -98,10 +98,9 @@ struct itk_metadata {
     /// This is the mask collections tuple (in the detector called 'mask store')
     /// the @c regular_multi_store is a vecemem-ready tuple of vectors of
     /// the detector masks.
-    template <template <typename...> class tuple_t = dtuple,
-              template <typename...> class vector_t = dvector>
+    template <template <typename...> class vector_t = dvector>
     using mask_store =
-        regular_multi_store<mask_ids, empty_context, tuple_t, vector_t,
+        regular_multi_store<mask_ids, empty_context, dtuple, vector_t,
                             rectangle, annulus, cylinder_portal, disc_portal>;
 
     /// Similar to the mask store, there is a material store, which
@@ -116,10 +115,9 @@ struct itk_metadata {
 
     /// How to store and link materials. The material does not make use of
     /// conditions data ( @c empty_context )
-    template <template <typename...> class tuple_t = dtuple,
-              typename container_t = host_container_types>
+    template <typename container_t = host_container_types>
     using material_store =
-        multi_store<material_ids, empty_context, tuple_t,
+        multi_store<material_ids, empty_context, dtuple,
                     grid_collection<disc_map_t<container_t>>,
                     grid_collection<cylinder_map_t<container_t>>,
                     grid_collection<rectangular_map_t<container_t>>,
@@ -161,10 +159,9 @@ struct itk_metadata {
     /// volumes. Every collection of accelerationdata structures defines its
     /// own container and view type. Does not make use of conditions data
     /// ( @c empty_context )
-    template <template <typename...> class tuple_t = dtuple,
-              typename container_t = host_container_types>
+    template <typename container_t = host_container_types>
     using accelerator_store =
-        multi_store<accel_ids, empty_context, tuple_t,
+        multi_store<accel_ids, empty_context, dtuple,
                     brute_force_collection<surface_type, container_t>>;
 
     /// Data structure that allows to find the current detector volume from a

--- a/detectors/include/detray/detectors/telescope_metadata.hpp
+++ b/detectors/include/detray/detectors/telescope_metadata.hpp
@@ -74,13 +74,12 @@ struct telescope_metadata {
     };
 
     /// How to store masks
-    template <template <typename...> class tuple_t = dtuple,
-              template <typename...> class vector_t = dvector>
+    template <template <typename...> class vector_t = dvector>
     using mask_store = std::conditional_t<
         std::is_same_v<mask<mask_shape_t, algebra_type, nav_link>, rectangle>,
-        regular_multi_store<mask_ids, empty_context, tuple_t, vector_t,
+        regular_multi_store<mask_ids, empty_context, dtuple, vector_t,
                             rectangle>,
-        regular_multi_store<mask_ids, empty_context, tuple_t, vector_t,
+        regular_multi_store<mask_ids, empty_context, dtuple, vector_t,
                             rectangle,
                             mask<mask_shape_t, algebra_type, nav_link>>>;
 
@@ -93,16 +92,15 @@ struct telescope_metadata {
     };
 
     /// How to store materials
-    template <template <typename...> class tuple_t = dtuple,
-              typename container_t = host_container_types>
+    template <typename container_t = host_container_types>
     using material_store = std::conditional_t<
         std::is_same_v<mask<mask_shape_t, algebra_type, nav_link>, drift_cell> |
             std::is_same_v<mask<mask_shape_t, algebra_type, nav_link>,
                            straw_tube>,
-        regular_multi_store<material_ids, empty_context, tuple_t,
+        regular_multi_store<material_ids, empty_context, dtuple,
                             container_t::template vector_type, slab,
                             material<scalar_t>, rod>,
-        regular_multi_store<material_ids, empty_context, tuple_t,
+        regular_multi_store<material_ids, empty_context, dtuple,
                             container_t::template vector_type, slab,
                             material<scalar_t>>>;
 
@@ -133,10 +131,9 @@ struct telescope_metadata {
         dmulti_index<dtyped_index<accel_ids, dindex>, geo_objects::e_size>;
 
     /// How to store the brute force search data structure
-    template <template <typename...> class tuple_t = dtuple,
-              typename container_t = host_container_types>
+    template <typename container_t = host_container_types>
     using accelerator_store =
-        multi_store<accel_ids, empty_context, tuple_t,
+        multi_store<accel_ids, empty_context, dtuple,
                     brute_force_collection<surface_type, container_t>>;
 
     /// Volume search (only one volume exists)

--- a/detectors/include/detray/detectors/toy_metadata.hpp
+++ b/detectors/include/detray/detectors/toy_metadata.hpp
@@ -64,7 +64,7 @@ struct toy_metadata {
     /// Surface grid types (regular, open binning)
     /// @{
 
-    // Surface grid definition: bin-content: std::array<sf_descriptor, 1>
+    // Surface grid definition: bin-content: darray<sf_descriptor, 1>
     template <typename axes_t, typename bin_entry_t, typename container_t>
     using surface_grid_t =
         grid<algebra_type, axes_t, bins::static_array<bin_entry_t, 1>,

--- a/detectors/include/detray/detectors/toy_metadata.hpp
+++ b/detectors/include/detray/detectors/toy_metadata.hpp
@@ -96,10 +96,9 @@ struct toy_metadata {
     };
 
     /// How to store masks
-    template <template <typename...> class tuple_t = dtuple,
-              template <typename...> class vector_t = dvector>
+    template <template <typename...> class vector_t = dvector>
     using mask_store =
-        regular_multi_store<mask_ids, empty_context, tuple_t, vector_t,
+        regular_multi_store<mask_ids, empty_context, dtuple, vector_t,
                             rectangle, trapezoid, cylinder_portal, disc_portal>;
 
     /// Material type ids
@@ -112,10 +111,9 @@ struct toy_metadata {
     };
 
     /// How to store materials
-    template <template <typename...> class tuple_t = dtuple,
-              typename container_t = host_container_types>
+    template <typename container_t = host_container_types>
     using material_store =
-        multi_store<material_ids, empty_context, tuple_t,
+        multi_store<material_ids, empty_context, dtuple,
                     grid_collection<disc_map_t<container_t>>,
                     grid_collection<cylinder_map_t<container_t>>,
                     grid_collection<rectangular_map_t<container_t>>,
@@ -151,10 +149,9 @@ struct toy_metadata {
         dmulti_index<dtyped_index<accel_ids, dindex>, geo_objects::e_size>;
 
     /// How to store the acceleration data structures
-    template <template <typename...> class tuple_t = dtuple,
-              typename container_t = host_container_types>
+    template <typename container_t = host_container_types>
     using accelerator_store = multi_store<
-        accel_ids, empty_context, tuple_t,
+        accel_ids, empty_context, dtuple,
         brute_force_collection<surface_type, container_t>,
         grid_collection<disc_sf_grid<surface_type, container_t>>,
         grid_collection<cylinder_sf_grid<surface_type, container_t>>>;

--- a/io/include/detray/io/common/detail/grid_writer.hpp
+++ b/io/include/detray/io/common/detail/grid_writer.hpp
@@ -18,7 +18,6 @@
 
 // System include(s)
 #include <algorithm>
-#include <array>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -68,8 +67,7 @@ class grid_writer {
         grid_data.grid_link = detail::basic_converter::convert(type, idx);
 
         // Convert the multi-axis into single axis payloads
-        const std::array<axis_payload, grid_t::dim> axes_data =
-            convert(gr.axes());
+        const darray<axis_payload, grid_t::dim> axes_data = convert(gr.axes());
 
         grid_data.axes.resize(axes_data.size());
         std::ranges::copy(axes_data, std::begin(grid_data.axes));
@@ -91,7 +89,7 @@ class grid_writer {
         const axis::multi_axis<ownership, local_frame_t, axis_ts...>& axes) {
 
         // Convert every single axis and construct array from their payloads
-        std::array<axis_payload, sizeof...(axis_ts)> axes_data{
+        darray<axis_payload, sizeof...(axis_ts)> axes_data{
             convert(axes.template get_axis<axis_ts>())...};
 
         return axes_data;

--- a/io/include/detray/io/frontend/detector_reader_config.hpp
+++ b/io/include/detray/io/frontend/detector_reader_config.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 // System include(s)
-#include <array>
 #include <ostream>
 #include <string>
 #include <vector>

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
@@ -24,7 +24,6 @@
 #include <algorithm>
 #include <optional>
 #include <string>
-#include <tuple>
 #include <vector>
 
 namespace detray::svgtools::conversion {

--- a/tests/benchmarks/cpu/benchmark_propagator.cpp
+++ b/tests/benchmarks/cpu/benchmark_propagator.cpp
@@ -56,7 +56,7 @@ using navigator_host_type = navigator<detector_host_type>;
 using navigator_device_type = navigator<detector_device_type>;
 using field_type = bfield::const_field_t<scalar>;
 using rk_stepper_type = rk_stepper<field_type::view_t, algebra_t>;
-using actor_chain_t = actor_chain<tuple, parameter_transporter<algebra_t>,
+using actor_chain_t = actor_chain<parameter_transporter<algebra_t>,
                                   pointwise_material_interactor<algebra_t>,
                                   parameter_resetter<algebra_t>>;
 using propagator_host_type =

--- a/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
+++ b/tests/benchmarks/cuda/benchmark_propagator_cuda_kernel.hpp
@@ -41,8 +41,7 @@ using navigator_device_type = detray::navigator<detector_device_type>;
 using field_type = detray::bfield::const_field_t<scalar>;
 using rk_stepper_type = detray::rk_stepper<field_type::view_t, test_algebra>;
 using actor_chain_t =
-    detray::actor_chain<detray::tuple,
-                        detray::parameter_transporter<test_algebra>,
+    detray::actor_chain<detray::parameter_transporter<test_algebra>,
                         detray::pointwise_material_interactor<test_algebra>,
                         detray::parameter_resetter<test_algebra>>;
 using propagator_host_type =

--- a/tests/include/detray/test/common/detector_scan_config.hpp
+++ b/tests/include/detray/test/common/detector_scan_config.hpp
@@ -38,7 +38,7 @@ struct detector_scan_config : public test::fixture_base<>::configuration {
     std::string m_intersection_file{"truth_intersections"};
     std::string m_track_param_file{"truth_trk_parameters"};
     /// Mask tolerance for the intersectors
-    std::array<scalar_type, 2> m_mask_tol{
+    darray<scalar_type, 2> m_mask_tol{
         std::numeric_limits<scalar_type>::epsilon(),
         std::numeric_limits<scalar_type>::epsilon()};
     /// B-field vector for helix
@@ -57,7 +57,7 @@ struct detector_scan_config : public test::fixture_base<>::configuration {
     const std::string &name() const { return m_name; }
     const std::string &intersection_file() const { return m_intersection_file; }
     const std::string &track_param_file() const { return m_track_param_file; }
-    std::array<scalar_type, 2> mask_tolerance() const { return m_mask_tol; }
+    darray<scalar_type, 2> mask_tolerance() const { return m_mask_tol; }
     const vector3_type &B_vector() { return m_B; }
     std::shared_ptr<test::whiteboard> whiteboard() { return m_white_board; }
     std::shared_ptr<test::whiteboard> whiteboard() const {
@@ -83,7 +83,7 @@ struct detector_scan_config : public test::fixture_base<>::configuration {
         m_track_param_file = f;
         return *this;
     }
-    detector_scan_config &mask_tolerance(const std::array<scalar_type, 2> tol) {
+    detector_scan_config &mask_tolerance(const darray<scalar_type, 2> tol) {
         m_mask_tol = tol;
         return *this;
     }

--- a/tests/include/detray/test/device/cuda/material_validation.cu
+++ b/tests/include/detray/test/device/cuda/material_validation.cu
@@ -40,10 +40,11 @@ __global__ void material_validation_kernel(
     using material_tracer_t =
         material_validator::material_tracer<scalar_t, vecmem::device_vector>;
     using pathlimit_aborter_t = pathlimit_aborter<scalar_t>;
-    using actor_chain_t = actor_chain<
-        tuple, pathlimit_aborter_t, parameter_transporter<algebra_t>,
-        parameter_resetter<algebra_t>, pointwise_material_interactor<algebra_t>,
-        material_tracer_t>;
+    using actor_chain_t =
+        actor_chain<pathlimit_aborter_t, parameter_transporter<algebra_t>,
+                    parameter_resetter<algebra_t>,
+                    pointwise_material_interactor<algebra_t>,
+                    material_tracer_t>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     detector_device_t det(det_data);

--- a/tests/include/detray/test/device/cuda/navigation_validation.cu
+++ b/tests/include/detray/test/device/cuda/navigation_validation.cu
@@ -60,8 +60,7 @@ __global__ void navigation_validation_kernel(
     using material_tracer_t =
         material_validator::material_tracer<scalar_t, vecmem::device_vector>;
     using pathlimit_aborter_t = pathlimit_aborter<scalar_t>;
-    using actor_chain_t =
-        actor_chain<tuple, pathlimit_aborter_t, material_tracer_t>;
+    using actor_chain_t = actor_chain<pathlimit_aborter_t, material_tracer_t>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     detector_device_t det(det_data);

--- a/tests/include/detray/test/device/propagator_test.hpp
+++ b/tests/include/detray/test/device/propagator_test.hpp
@@ -38,7 +38,6 @@
 
 // System include(s)
 #include <stdexcept>
-#include <tuple>
 
 namespace detray {
 

--- a/tests/include/detray/test/device/propagator_test.hpp
+++ b/tests/include/detray/test/device/propagator_test.hpp
@@ -82,12 +82,12 @@ using step_tracer_host_t = step_tracer<test_algebra, vecmem::vector>;
 using step_tracer_device_t = step_tracer<test_algebra, vecmem::device_vector>;
 using pathlimit_aborter_t = pathlimit_aborter<scalar>;
 using actor_chain_host_t =
-    actor_chain<tuple, step_tracer_host_t, pathlimit_aborter_t,
+    actor_chain<step_tracer_host_t, pathlimit_aborter_t,
                 parameter_transporter<test_algebra>,
                 pointwise_material_interactor<test_algebra>,
                 parameter_resetter<test_algebra>>;
 using actor_chain_device_t =
-    actor_chain<tuple, step_tracer_device_t, pathlimit_aborter_t,
+    actor_chain<step_tracer_device_t, pathlimit_aborter_t,
                 parameter_transporter<test_algebra>,
                 pointwise_material_interactor<test_algebra>,
                 parameter_resetter<test_algebra>>;

--- a/tests/include/detray/test/utils/detectors/build_toy_detector.hpp
+++ b/tests/include/detray/test/utils/detectors/build_toy_detector.hpp
@@ -231,10 +231,10 @@ struct toy_det_config {
     constexpr auto &cyl_material_map() { return m_cyl_map_cfg; }
     constexpr const auto &disc_material_map() const { return m_disc_map_cfg; }
     constexpr auto &disc_material_map() { return m_disc_map_cfg; }
-    constexpr const std::array<std::size_t, 2> &cyl_map_bins() const {
+    constexpr const darray<std::size_t, 2> &cyl_map_bins() const {
         return m_cyl_map_cfg.n_bins;
     }
-    constexpr const std::array<std::size_t, 2> &disc_map_bins() const {
+    constexpr const darray<std::size_t, 2> &disc_map_bins() const {
         return m_disc_map_cfg.n_bins;
     }
     constexpr scalar_t material_map_min_thickness() const {

--- a/tests/include/detray/test/utils/detectors/factories/telescope_generator.hpp
+++ b/tests/include/detray/test/utils/detectors/factories/telescope_generator.hpp
@@ -45,7 +45,7 @@ class telescope_generator final : public surface_factory_interface<detector_t> {
     DETRAY_HOST
     telescope_generator(
         std::vector<scalar_t> positions,
-        std::array<scalar_t, mask_shape_t::boundaries::e_size> boundaries,
+        darray<scalar_t, mask_shape_t::boundaries::e_size> boundaries,
         trajectory_t traj)
         : m_traj{traj}, m_positions{positions}, m_boundaries{boundaries} {}
 
@@ -57,7 +57,7 @@ class telescope_generator final : public surface_factory_interface<detector_t> {
     DETRAY_HOST
     telescope_generator(
         scalar_t length, std::size_t n_surfaces,
-        std::array<scalar_t, mask_shape_t::boundaries::e_size> boundaries,
+        darray<scalar_t, mask_shape_t::boundaries::e_size> boundaries,
         trajectory_t traj)
         : m_traj{traj}, m_positions{}, m_boundaries{boundaries} {
         scalar_t pos{0.f};
@@ -211,7 +211,7 @@ class telescope_generator final : public surface_factory_interface<detector_t> {
     /// Positions of the surfaces in the telescope along the pilot track
     std::vector<scalar_t> m_positions;
     /// The boundary values for the surface mask
-    std::array<scalar_t, mask_shape_t::boundaries::e_size> m_boundaries;
+    darray<scalar_t, mask_shape_t::boundaries::e_size> m_boundaries;
 };
 
 }  // namespace detray

--- a/tests/include/detray/test/utils/simulation/event_generator/random_numbers.hpp
+++ b/tests/include/detray/test/utils/simulation/event_generator/random_numbers.hpp
@@ -51,7 +51,7 @@ struct random_numbers {
         : m_engine(std::move(other.m_engine)) {}
 
     /// Generate random numbers in a given range
-    DETRAY_HOST auto operator()(const std::array<scalar_t, 2> range = {
+    DETRAY_HOST auto operator()(const darray<scalar_t, 2> range = {
                                     -std::numeric_limits<scalar_t>::max(),
                                     std::numeric_limits<scalar_t>::max()}) {
         const scalar_t min{range[0]};

--- a/tests/include/detray/test/utils/simulation/event_generator/random_track_generator.hpp
+++ b/tests/include/detray/test/utils/simulation/event_generator/random_track_generator.hpp
@@ -19,7 +19,6 @@
 
 // System include(s)
 #include <algorithm>
-#include <array>
 #include <limits>
 #include <memory>
 #include <random>
@@ -132,7 +131,7 @@ class random_track_generator
                   vector::normalize(mom);
 
             // Randomly flip the charge sign
-            std::array<double, 2> signs{1., -1.};
+            darray<double, 2> signs{1., -1.};
             const auto sign{static_cast<scalar_t>(
                 signs[m_cfg.randomize_charge() ? m_rnd_numbers->coin_toss()
                                                : 0u])};
@@ -174,8 +173,8 @@ class random_track_generator
     DETRAY_HOST_DEVICE
     random_track_generator(
         std::size_t n_tracks,
-        std::array<scalar_t, 2> mom_range = {1.f * unit<scalar_t>::GeV,
-                                             1.f * unit<scalar_t>::GeV},
+        darray<scalar_t, 2> mom_range = {1.f * unit<scalar_t>::GeV,
+                                         1.f * unit<scalar_t>::GeV},
         scalar_t charge = -1.f * unit<scalar_t>::e)
         : m_gen{std::make_shared<generator_t>()}, m_cfg{} {
         m_cfg.n_tracks(n_tracks);

--- a/tests/include/detray/test/utils/simulation/event_generator/random_track_generator_config.hpp
+++ b/tests/include/detray/test/utils/simulation/event_generator/random_track_generator_config.hpp
@@ -18,7 +18,6 @@
 
 // System include(s)
 #include <algorithm>
-#include <array>
 #include <limits>
 #include <ostream>
 #include <random>
@@ -41,19 +40,19 @@ struct random_track_generator_config {
     std::size_t m_n_tracks{10u};
 
     /// Range for phi [-pi, pi) and theta [0, pi)
-    std::array<scalar_t, 2> m_phi_range{-constant<scalar_t>::pi,
-                                        constant<scalar_t>::pi};
-    std::array<scalar_t, 2> m_theta_range{0.f, constant<scalar_t>::pi};
+    darray<scalar_t, 2> m_phi_range{-constant<scalar_t>::pi,
+                                    constant<scalar_t>::pi};
+    darray<scalar_t, 2> m_theta_range{0.f, constant<scalar_t>::pi};
 
     /// Momentum range
-    std::array<scalar_t, 2> m_mom_range{1.f * unit<scalar_t>::GeV,
-                                        1.f * unit<scalar_t>::GeV};
+    darray<scalar_t, 2> m_mom_range{1.f * unit<scalar_t>::GeV,
+                                    1.f * unit<scalar_t>::GeV};
     /// Whether to interpret the momentum @c m_mom_range as p_T
     bool m_is_pT{false};
 
     /// Track origin
-    std::array<scalar_t, 3> m_origin{0.f, 0.f, 0.f};
-    std::array<scalar_t, 3> m_origin_stddev{0.f, 0.f, 0.f};
+    darray<scalar_t, 3> m_origin{0.f, 0.f, 0.f};
+    darray<scalar_t, 3> m_origin_stddev{0.f, 0.f, 0.f};
 
     /// Randomly flip the charge sign?
     bool m_randomize_charge{false};
@@ -92,7 +91,7 @@ struct random_track_generator_config {
     }
     template <typename o_scalar_t>
     DETRAY_HOST_DEVICE random_track_generator_config& phi_range(
-        std::array<o_scalar_t, 2> r) {
+        darray<o_scalar_t, 2> r) {
         phi_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
@@ -108,7 +107,7 @@ struct random_track_generator_config {
     }
     template <typename o_scalar_t>
     DETRAY_HOST_DEVICE random_track_generator_config& theta_range(
-        std::array<o_scalar_t, 2> r) {
+        darray<o_scalar_t, 2> r) {
         theta_range(static_cast<o_scalar_t>(r[0]),
                     static_cast<o_scalar_t>(r[1]));
         return *this;
@@ -131,7 +130,7 @@ struct random_track_generator_config {
     }
     template <typename o_scalar_t>
     DETRAY_HOST_DEVICE random_track_generator_config& eta_range(
-        std::array<o_scalar_t, 2> r) {
+        darray<o_scalar_t, 2> r) {
         eta_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
@@ -145,7 +144,7 @@ struct random_track_generator_config {
     }
     template <typename o_scalar_t>
     DETRAY_HOST_DEVICE random_track_generator_config& mom_range(
-        std::array<o_scalar_t, 2> r) {
+        darray<o_scalar_t, 2> r) {
         mom_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
@@ -159,7 +158,7 @@ struct random_track_generator_config {
     }
     template <typename o_scalar_t>
     DETRAY_HOST_DEVICE random_track_generator_config& pT_range(
-        std::array<o_scalar_t, 2> r) {
+        darray<o_scalar_t, 2> r) {
         pT_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
@@ -218,16 +217,14 @@ struct random_track_generator_config {
     DETRAY_HOST_DEVICE constexpr std::size_t n_tracks() const {
         return m_n_tracks;
     }
-    DETRAY_HOST_DEVICE constexpr const std::array<scalar_t, 2>& phi_range()
-        const {
+    DETRAY_HOST_DEVICE constexpr const darray<scalar_t, 2>& phi_range() const {
         return m_phi_range;
     }
-    DETRAY_HOST_DEVICE constexpr const std::array<scalar_t, 2>& theta_range()
+    DETRAY_HOST_DEVICE constexpr const darray<scalar_t, 2>& theta_range()
         const {
         return m_theta_range;
     }
-    DETRAY_HOST_DEVICE constexpr const std::array<scalar_t, 2>& mom_range()
-        const {
+    DETRAY_HOST_DEVICE constexpr const darray<scalar_t, 2>& mom_range() const {
         return m_mom_range;
     }
     DETRAY_HOST_DEVICE constexpr const auto& origin() const { return m_origin; }

--- a/tests/include/detray/test/utils/simulation/event_generator/uniform_track_generator.hpp
+++ b/tests/include/detray/test/utils/simulation/event_generator/uniform_track_generator.hpp
@@ -19,7 +19,6 @@
 
 // System include(s)
 #include <algorithm>
-#include <cmath>
 #include <limits>
 #include <memory>
 
@@ -164,7 +163,7 @@ class uniform_track_generator
             const auto& ori = m_cfg.origin();
 
             // Randomly flip the charge sign
-            std::array<double, 2> signs{1., -1.};
+            darray<double, 2> signs{1., -1.};
             const auto sign{static_cast<scalar_t>(
                 signs[m_cfg.randomize_charge() ? m_rnd_numbers->coin_toss()
                                                : 0u])};

--- a/tests/include/detray/test/utils/simulation/event_generator/uniform_track_generator_config.hpp
+++ b/tests/include/detray/test/utils/simulation/event_generator/uniform_track_generator_config.hpp
@@ -17,7 +17,6 @@
 
 // System include(s)
 #include <algorithm>
-#include <array>
 #include <limits>
 #include <ostream>
 
@@ -37,9 +36,9 @@ struct uniform_track_generator_config {
         constant<scalar_t>::pi - std::numeric_limits<scalar_t>::epsilon()};
 
     /// Range for phi [-pi, pi) and theta [0, pi)
-    std::array<scalar_t, 2> m_phi_range{-constant<scalar_t>::pi, k_max_pi};
-    std::array<scalar_t, 2> m_theta_range{0.f, k_max_pi};
-    std::array<scalar_t, 2> m_eta_range{-5.f, 5.f};
+    darray<scalar_t, 2> m_phi_range{-constant<scalar_t>::pi, k_max_pi};
+    darray<scalar_t, 2> m_theta_range{0.f, k_max_pi};
+    darray<scalar_t, 2> m_eta_range{-5.f, 5.f};
 
     /// Angular step size
     std::size_t m_phi_steps{50u};
@@ -50,7 +49,7 @@ struct uniform_track_generator_config {
     bool m_uniform_eta{false};
 
     /// Track origin
-    std::array<scalar_t, 3> m_origin{0.f, 0.f, 0.f};
+    darray<scalar_t, 3> m_origin{0.f, 0.f, 0.f};
 
     /// Magnitude of momentum: Default is one to keep directions normalized
     /// if no momentum information is needed (e.g. for a ray)
@@ -83,7 +82,7 @@ struct uniform_track_generator_config {
     }
     template <typename o_scalar_t>
     DETRAY_HOST_DEVICE uniform_track_generator_config& phi_range(
-        std::array<o_scalar_t, 2> r) {
+        darray<o_scalar_t, 2> r) {
         phi_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
@@ -100,7 +99,7 @@ struct uniform_track_generator_config {
     }
     template <typename o_scalar_t>
     DETRAY_HOST_DEVICE uniform_track_generator_config& theta_range(
-        std::array<o_scalar_t, 2> r) {
+        darray<o_scalar_t, 2> r) {
         theta_range(static_cast<o_scalar_t>(r[0]),
                     static_cast<o_scalar_t>(r[1]));
         return *this;
@@ -120,7 +119,7 @@ struct uniform_track_generator_config {
     }
     template <typename o_scalar_t>
     DETRAY_HOST_DEVICE uniform_track_generator_config& eta_range(
-        std::array<o_scalar_t, 2> r) {
+        darray<o_scalar_t, 2> r) {
         eta_range(static_cast<o_scalar_t>(r[0]), static_cast<o_scalar_t>(r[1]));
         return *this;
     }
@@ -191,13 +190,13 @@ struct uniform_track_generator_config {
     DETRAY_HOST_DEVICE constexpr std::size_t n_tracks() const {
         return phi_steps() * theta_steps();
     }
-    DETRAY_HOST_DEVICE constexpr std::array<scalar_t, 2> phi_range() const {
+    DETRAY_HOST_DEVICE constexpr darray<scalar_t, 2> phi_range() const {
         return m_phi_range;
     }
-    DETRAY_HOST_DEVICE constexpr std::array<scalar_t, 2> theta_range() const {
+    DETRAY_HOST_DEVICE constexpr darray<scalar_t, 2> theta_range() const {
         return m_theta_range;
     }
-    DETRAY_HOST_DEVICE constexpr std::array<scalar_t, 2> eta_range() const {
+    DETRAY_HOST_DEVICE constexpr darray<scalar_t, 2> eta_range() const {
         return m_eta_range;
     }
     DETRAY_HOST_DEVICE constexpr std::size_t phi_steps() const {

--- a/tests/include/detray/test/utils/simulation/landau_distribution.hpp
+++ b/tests/include/detray/test/utils/simulation/landau_distribution.hpp
@@ -9,11 +9,10 @@
 
 // Project include(s).
 #include "detray/definitions/detail/algebra.hpp"
+#include "detray/definitions/detail/containers.hpp"
 #include "detray/definitions/detail/math.hpp"
 
 // System include(s).
-#include <array>
-#include <cmath>
 #include <limits>
 #include <random>
 
@@ -54,7 +53,7 @@ class landau_distribution {
     private:
     scalar_type quantile(const scalar_type z) const {
 
-        static const std::array<double, 982> f{
+        static const darray<double, 982> f{
             0.,        0.,        0.,        0.,        0.,        -2.244733,
             -2.204365, -2.168163, -2.135219, -2.104898, -2.076740, -2.050397,
             -2.025605, -2.002150, -1.979866, -1.958612, -1.938275, -1.918760,

--- a/tests/include/detray/test/validation/detector_scan_utils.hpp
+++ b/tests/include/detray/test/validation/detector_scan_utils.hpp
@@ -18,7 +18,6 @@
 
 // System include(s)
 #include <algorithm>
-#include <cmath>
 #include <functional>
 #include <iostream>
 #include <iterator>

--- a/tests/include/detray/test/validation/detector_scanner.hpp
+++ b/tests/include/detray/test/validation/detector_scanner.hpp
@@ -59,7 +59,7 @@ struct brute_force_scan {
     template <typename detector_t>
     inline auto operator()(const typename detector_t::geometry_context ctx,
                            const detector_t &detector, const trajectory_t &traj,
-                           const std::array<typename detector_t::scalar_type, 2>
+                           const darray<typename detector_t::scalar_type, 2>
                                mask_tolerance = {0.f, 0.f},
                            const typename detector_t::scalar_type p =
                                1.f *
@@ -89,7 +89,7 @@ struct brute_force_scan {
             const auto sf = tracking_surface{detector, sf_desc};
             sf.template visit_mask<intersection_kernel_t>(
                 intersections, traj, sf_desc, trf_store, ctx,
-                sf.is_portal() ? std::array<scalar_t, 2>{0.f, 0.f}
+                sf.is_portal() ? darray<scalar_t, 2>{0.f, 0.f}
                                : mask_tolerance);
 
             // Candidate is invalid if it lies in the opposite direction

--- a/tests/include/detray/test/validation/material_validation_utils.hpp
+++ b/tests/include/detray/test/validation/material_validation_utils.hpp
@@ -243,10 +243,11 @@ inline auto record_material(
     using material_tracer_t =
         material_validator::material_tracer<scalar_t, vecmem::vector>;
     using pathlimit_aborter_t = pathlimit_aborter<scalar_t>;
-    using actor_chain_t = actor_chain<
-        dtuple, pathlimit_aborter_t, parameter_transporter<algebra_t>,
-        parameter_resetter<algebra_t>, pointwise_material_interactor<algebra_t>,
-        material_tracer_t>;
+    using actor_chain_t =
+        actor_chain<pathlimit_aborter_t, parameter_transporter<algebra_t>,
+                    parameter_resetter<algebra_t>,
+                    pointwise_material_interactor<algebra_t>,
+                    material_tracer_t>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     // Propagator

--- a/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -72,8 +72,8 @@ inline auto record_propagation(
     using pathlimit_aborter_t = pathlimit_aborter<scalar_t>;
     using material_tracer_t =
         material_validator::material_tracer<scalar_t, dvector>;
-    using actor_chain_t = actor_chain<dtuple, pathlimit_aborter_t,
-                                      step_tracer_t, material_tracer_t>;
+    using actor_chain_t =
+        actor_chain<pathlimit_aborter_t, step_tracer_t, material_tracer_t>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     // Propagator

--- a/tests/integration_tests/cpu/material/material_interaction.cpp
+++ b/tests/integration_tests/cpu/material/material_interaction.cpp
@@ -78,9 +78,8 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
     using interactor_t = pointwise_material_interactor<test_algebra>;
     using pathlimit_aborter_t = pathlimit_aborter<scalar>;
     using actor_chain_t =
-        actor_chain<dtuple, pathlimit_aborter_t,
-                    parameter_transporter<test_algebra>, interactor_t,
-                    parameter_resetter<test_algebra>>;
+        actor_chain<pathlimit_aborter_t, parameter_transporter<test_algebra>,
+                    interactor_t, parameter_resetter<test_algebra>>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     // Propagator is built from the stepper and navigator
@@ -202,9 +201,8 @@ GTEST_TEST(detray_material, telescope_geometry_scattering_angle) {
     using simulator_t = random_scatterer<test_algebra>;
     using pathlimit_aborter_t = pathlimit_aborter<scalar>;
     using actor_chain_t =
-        actor_chain<dtuple, pathlimit_aborter_t,
-                    parameter_transporter<test_algebra>, simulator_t,
-                    parameter_resetter<test_algebra>>;
+        actor_chain<pathlimit_aborter_t, parameter_transporter<test_algebra>,
+                    simulator_t, parameter_resetter<test_algebra>>;
     using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
 
     // Propagator is built from the stepper and navigator
@@ -291,7 +289,7 @@ GTEST_TEST(detray_material, telescope_geometry_volume_material) {
     using bfield_t = bfield::const_field_t<scalar>;
     using stepper_t = rk_stepper<bfield_t::view_t, test_algebra>;
     using pathlimit_aborter_t = pathlimit_aborter<scalar>;
-    using actor_chain_t = actor_chain<dtuple, pathlimit_aborter_t>;
+    using actor_chain_t = actor_chain<pathlimit_aborter_t>;
     using vector3 = test::vector3;
 
     // Bfield setup

--- a/tests/integration_tests/cpu/propagator/backward_propagation.cpp
+++ b/tests/integration_tests/cpu/propagator/backward_propagation.cpp
@@ -71,7 +71,7 @@ TEST_P(BackwardPropagation, backward_propagation) {
     using navigator_t = navigator<decltype(det)>;
     using rk_stepper_t = rk_stepper<bfield_t::view_t, test_algebra>;
     using actor_chain_t =
-        actor_chain<dtuple, parameter_transporter<test_algebra>,
+        actor_chain<parameter_transporter<test_algebra>,
                     pointwise_material_interactor<test_algebra>,
                     parameter_resetter<test_algebra>>;
     using propagator_t = propagator<rk_stepper_t, navigator_t, actor_chain_t>;

--- a/tests/integration_tests/cpu/propagator/guided_navigator.cpp
+++ b/tests/integration_tests/cpu/propagator/guided_navigator.cpp
@@ -67,7 +67,7 @@ GTEST_TEST(detray_navigation, guided_navigator) {
     using guided_navigator =
         navigator<detector_t, navigation::default_cache_size, inspector_t>;
     using pathlimit_aborter_t = pathlimit_aborter<scalar>;
-    using actor_chain_t = actor_chain<dtuple, pathlimit_aborter_t>;
+    using actor_chain_t = actor_chain<pathlimit_aborter_t>;
     using propagator_t =
         propagator<runge_kutta_stepper, guided_navigator, actor_chain_t>;
 

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -1571,10 +1571,9 @@ int main(int argc, char** argv) {
     const inhom_bfield_t inhom_bfield = bfield::create_inhom_field<scalar>();
 
     // Actor chain type
-    using actor_chain_t =
-        actor_chain<dtuple, parameter_transporter<test_algebra>,
-                    bound_getter<test_algebra>,
-                    parameter_resetter<test_algebra>>;
+    using actor_chain_t = actor_chain<parameter_transporter<test_algebra>,
+                                      bound_getter<test_algebra>,
+                                      parameter_resetter<test_algebra>>;
 
     // Iterate over reference (pilot) tracks for a rectangular telescope
     // geometry and Jacobian calculation

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -209,7 +209,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
         rk_stepper<bfield_t::view_t, test_algebra, constraints_t, policy_t>;
     // Include helix actor to check track position/covariance
     using actor_chain_t =
-        actor_chain<dtuple, helix_inspector, pathlimit_aborter<scalar>,
+        actor_chain<helix_inspector, pathlimit_aborter<scalar>,
                     parameter_transporter<test_algebra>,
                     pointwise_material_interactor<test_algebra>,
                     parameter_resetter<test_algebra>>;
@@ -319,7 +319,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
         rk_stepper<bfield_t::view_t, test_algebra, constraints_t, policy_t>;
     // Include helix actor to check track position/covariance
     using actor_chain_t =
-        actor_chain<dtuple, pathlimit_aborter<scalar>,
+        actor_chain<pathlimit_aborter<scalar>,
                     parameter_transporter<test_algebra>,
                     pointwise_material_interactor<test_algebra>,
                     parameter_resetter<test_algebra>>;

--- a/tests/unit_tests/cpu/navigation/intersection/cylinder_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/cylinder_intersector.cpp
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 
 // System include(s)
-#include <cmath>
 #include <limits>
 
 using namespace detray;

--- a/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
@@ -25,7 +25,6 @@
 #include <gtest/gtest.h>
 
 // System include(s)
-#include <cmath>
 #include <limits>
 
 using namespace detray;

--- a/tests/unit_tests/cpu/navigation/intersection/helix_trajectory.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/helix_trajectory.cpp
@@ -16,9 +16,6 @@
 // GTest include(s)
 #include <gtest/gtest.h>
 
-// System include(s)
-#include <cmath>
-
 using namespace detray;
 
 using scalar = test::scalar;

--- a/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 
 // System include(s)
-#include <cmath>
 #include <limits>
 
 using namespace detray;

--- a/tests/unit_tests/cpu/navigation/intersection/plane_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/plane_intersector.cpp
@@ -20,7 +20,6 @@
 #include <gtest/gtest.h>
 
 // System include(s)
-#include <cmath>
 #include <limits>
 
 using namespace detray;

--- a/tests/unit_tests/cpu/propagator/actor_chain.cpp
+++ b/tests/unit_tests/cpu/propagator/actor_chain.cpp
@@ -84,14 +84,13 @@ struct example_actor : detray::actor {
 
 using example_actor_t = example_actor<std::vector>;
 // Implements example_actor with two print observers
-using composite1 =
-    composite_actor<dtuple, example_actor_t, print_actor, print_actor>;
+using composite1 = composite_actor<example_actor_t, print_actor, print_actor>;
 // Implements example_actor with one print observer
-using composite2 = composite_actor<dtuple, example_actor_t, print_actor>;
+using composite2 = composite_actor<example_actor_t, print_actor>;
 // Implements example_actor through composite2 and has composite1 as observer
-using composite3 = composite_actor<dtuple, example_actor_t, composite1>;
+using composite3 = composite_actor<example_actor_t, composite1>;
 // Implements example_actor through composite2<-composite3 with composite1 obs.
-using composite4 = composite_actor<dtuple, example_actor_t, composite1>;
+using composite4 = composite_actor<example_actor_t, composite1>;
 
 /* Test chaining of multiple actors
  * The chain goes as follows (depth first):
@@ -106,11 +105,11 @@ using composite4 = composite_actor<dtuple, example_actor_t, composite1>;
  *               4.|
  *               print
  */
-using observer_lvl3 = composite_actor<dtuple, example_actor_t, print_actor>;
-using observer_lvl2 = composite_actor<dtuple, example_actor_t, observer_lvl3,
+using observer_lvl3 = composite_actor<example_actor_t, print_actor>;
+using observer_lvl2 = composite_actor<example_actor_t, observer_lvl3,
                                       example_actor_t, print_actor>;
-using observer_lvl1 = composite_actor<dtuple, print_actor, observer_lvl2>;
-using chain = composite_actor<dtuple, example_actor_t, observer_lvl1>;
+using observer_lvl1 = composite_actor<print_actor, observer_lvl2>;
+using chain = composite_actor<example_actor_t, observer_lvl1>;
 
 // Test the actor chain on some dummy actor types
 GTEST_TEST(detray_propagator, actor_chain) {
@@ -127,8 +126,8 @@ GTEST_TEST(detray_propagator, actor_chain) {
     empty_prop_state prop_state{};
 
     // Chain of actors
-    using actor_chain_t = actor_chain<dtuple, example_actor_t, composite1,
-                                      composite2, composite3, composite4>;
+    using actor_chain_t = actor_chain<example_actor_t, composite1, composite2,
+                                      composite3, composite4>;
     // Run
     actor_chain_t run_actors{};
     run_actors(actor_states, prop_state);
@@ -147,7 +146,7 @@ GTEST_TEST(detray_propagator, actor_chain) {
     printer_state.stream.clear();
 
     // Run the chain
-    actor_chain<dtuple, chain> run_chain{};
+    actor_chain<chain> run_chain{};
     run_chain(actor_states, prop_state);
 
     ASSERT_TRUE(printer_state.to_string().compare(

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -70,9 +70,8 @@ GTEST_TEST(detray_propagator, covariance_transport) {
 
     using navigator_t = navigator<decltype(det)>;
     using cline_stepper_t = line_stepper<test_algebra>;
-    using actor_chain_t =
-        actor_chain<dtuple, parameter_transporter<test_algebra>,
-                    parameter_resetter<test_algebra>>;
+    using actor_chain_t = actor_chain<parameter_transporter<test_algebra>,
+                                      parameter_resetter<test_algebra>>;
     using propagator_t =
         propagator<cline_stepper_t, navigator_t, actor_chain_t>;
 

--- a/tests/unit_tests/cpu/utils/hash_tree.cpp
+++ b/tests/unit_tests/cpu/utils/hash_tree.cpp
@@ -11,9 +11,6 @@
 // GTest include(s)
 #include <gtest/gtest.h>
 
-// System include(s)
-#include <cmath>
-
 namespace {
 
 template <typename hasher_t, typename digest_collection_t>

--- a/tutorials/include/detray/tutorial/detector_metadata.hpp
+++ b/tutorials/include/detray/tutorial/detector_metadata.hpp
@@ -100,10 +100,9 @@ struct my_metadata {
     /// This is the mask collections tuple (in the detector called 'mask store')
     /// the @c regular_multi_store is a vecemem-ready tuple of vectors of
     /// the detector masks.
-    template <template <typename...> class tuple_t = dtuple,
-              template <typename...> class vector_t = dvector>
+    template <template <typename...> class vector_t = dvector>
     using mask_store =
-        regular_multi_store<mask_ids, empty_context, tuple_t, vector_t, square,
+        regular_multi_store<mask_ids, empty_context, dtuple, vector_t, square,
                             trapezoid, rectangle>;
 
     /// Similar to the mask store, there is a material store, which
@@ -114,10 +113,9 @@ struct my_metadata {
 
     /// How to store and link materials. The material does not make use of
     /// conditions data ( @c empty_context )
-    template <template <typename...> class tuple_t = dtuple,
-              typename container_t = host_container_types>
+    template <typename container_t = host_container_types>
     using material_store =
-        multi_store<material_ids, empty_context, tuple_t,
+        multi_store<material_ids, empty_context, dtuple,
                     typename container_t::template vector_type<slab>>;
 
     /// Surface descriptor type used for sensitives, passives and portals
@@ -140,10 +138,9 @@ struct my_metadata {
     /// volumes. Every collection of accelerationdata structures defines its
     /// own container and view type. Does not make use of conditions data
     /// ( @c empty_context )
-    template <template <typename...> class tuple_t = dtuple,
-              typename container_t = host_container_types>
+    template <typename container_t = host_container_types>
     using accelerator_store =
-        multi_store<accel_ids, empty_context, tuple_t,
+        multi_store<accel_ids, empty_context, dtuple,
                     brute_force_collection<surface_type, container_t>>;
 
     /// Data structure that allows to find the current detector volume from a

--- a/tutorials/include/detray/tutorial/my_square2D.hpp
+++ b/tutorials/include/detray/tutorial/my_square2D.hpp
@@ -72,8 +72,7 @@ class square2D {
     /// @returns and array of coordinates that contains the lower point (first
     /// three values) and the upper point (latter three values) .
     template <concepts::algebra algebra_t>
-    DETRAY_HOST_DEVICE inline std::array<dscalar<algebra_t>, 6>
-    local_min_bounds(
+    DETRAY_HOST_DEVICE inline darray<dscalar<algebra_t>, 6> local_min_bounds(
         const bounds_type<dscalar<algebra_t>> &bounds,
         const dscalar<algebra_t> env =
             std::numeric_limits<dscalar<algebra_t>>::epsilon()) const {

--- a/tutorials/src/cpu/detector/build_predefined_detectors.cpp
+++ b/tutorials/src/cpu/detector/build_predefined_detectors.cpp
@@ -22,7 +22,6 @@
 #include <vecmem/memory/host_memory_resource.hpp>
 
 // System include(s)
-#include <cmath>
 #include <cstdlib>
 #include <iostream>
 

--- a/tutorials/src/cpu/propagation/define_an_actor.cpp
+++ b/tutorials/src/cpu/propagation/define_an_actor.cpp
@@ -87,8 +87,8 @@ int main() {
 
     using example_actor_t = example_actor<std::vector>;
     // Implements example_actor with two print observers
-    using composite = detray::composite_actor<detray::dtuple, example_actor_t,
-                                              print_actor, print_actor>;
+    using composite =
+        detray::composite_actor<example_actor_t, print_actor, print_actor>;
 
     example_actor_t::state example_state{};
     print_actor::state printer_state{};
@@ -97,8 +97,7 @@ int main() {
     auto actor_states = detray::tie(example_state, printer_state);
 
     // Chain of actors
-    using actor_chain_t =
-        detray::actor_chain<detray::dtuple, example_actor_t, composite>;
+    using actor_chain_t = detray::actor_chain<example_actor_t, composite>;
     // Run
     actor_chain_t run_actors{};
     run_actors(actor_states, prop_state);
@@ -121,15 +120,12 @@ int main() {
      *               4.|
      *               print
      */
-    using observer_lvl3 =
-        detray::composite_actor<detray::dtuple, example_actor_t, print_actor>;
+    using observer_lvl3 = detray::composite_actor<example_actor_t, print_actor>;
     using observer_lvl2 =
-        detray::composite_actor<detray::dtuple, example_actor_t, observer_lvl3,
-                                example_actor_t, print_actor>;
-    using observer_lvl1 =
-        detray::composite_actor<detray::dtuple, print_actor, observer_lvl2>;
-    using chain =
-        detray::composite_actor<detray::dtuple, example_actor_t, observer_lvl1>;
+        detray::composite_actor<example_actor_t, observer_lvl3, example_actor_t,
+                                print_actor>;
+    using observer_lvl1 = detray::composite_actor<print_actor, observer_lvl2>;
+    using chain = detray::composite_actor<example_actor_t, observer_lvl1>;
 
     // Reset example actor state
     example_state.buffer.clear();
@@ -137,7 +133,7 @@ int main() {
     printer_state.stream.clear();
 
     // Run the chain
-    detray::actor_chain<detray::dtuple, chain> run_chain{};
+    detray::actor_chain<chain> run_chain{};
     run_chain(actor_states, prop_state);
 
     std::cout << "actor chain: " << printer_state.to_string() << std::endl;

--- a/tutorials/src/device/cuda/propagation.hpp
+++ b/tutorials/src/device/cuda/propagation.hpp
@@ -56,9 +56,10 @@ using device_field_t =
 using stepper_t = rk_stepper<device_field_t::view_t, algebra_t>;
 
 // Actors
-using actor_chain_t = actor_chain<
-    tuple, pathlimit_aborter<scalar>, parameter_transporter<algebra_t>,
-    pointwise_material_interactor<algebra_t>, parameter_resetter<algebra_t>>;
+using actor_chain_t =
+    actor_chain<pathlimit_aborter<scalar>, parameter_transporter<algebra_t>,
+                pointwise_material_interactor<algebra_t>,
+                parameter_resetter<algebra_t>>;
 
 // Propagator
 using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;


### PR DESCRIPTION
Remove container template types that are not really used and rename ```std::array``` to ```darray``` everywhere in the core library. Also removes some leftover ```cmath``` includes