### PR TITLE
ref: Make plotting script work without running the benchmarks from python first

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Detray is part of the [ACTS project](https://github.com/acts-project/acts) (R&D line for parallelization).
 
-This is a C++20 header-only library providing a GPU-friendly tracking detector description using different [linear algebra](https://github.com/acts-project/algebra-plugins) libraries. It follows the navigation and propagation concept of ACTS, implementing a geometry using a flat memory layout and no abstract interfaces (virtual functions). A detray detector can therefore be constructed on the host and copied to an accelerator device in a straight-forward way.
+This is a modern, C++20 header-only library providing a GPU-friendly tracking detector description using different [linear algebra](https://github.com/acts-project/algebra-plugins) libraries. It follows the navigation and propagation concept of ACTS, implementing a geometry using a flat memory layout and no abstract interfaces (virtual functions). A detray detector can therefore be constructed on the host and copied to an accelerator device in a straight-forward way.
 
 With the geometry description comes a fully featured, GPU-ready track state propagation implementation in inhomogeneous magnetic fields (vector field description using [covfie](https://github.com/acts-project/covfie)), with track parameter covariance transport including material interactions.
 
@@ -125,23 +125,16 @@ detray-build/bin/detray_propagation_benchmark_<backend>_<algebra> \
     --grid_file ./toy_detector/toy_detector_surface_grids.json \
     --material_file ./toy_detector/toy_detector_homogeneous_material.json \
     --sort_tracks --randomize_charge --eta_range -3 3 --pT_range 0.5 100 \
-    --search_window 3 3 --covariance_transport
+    --search_window 3 3 --covariance_transport --bknd_name [HW_BACKEND_NAME]
 ```
 For every algebra-plugin that was built, a corresponding benchmark executable will be present. The CPU-backend benchmark is built by default and the CUDA-backend benchmark will be available if detray was built with CUDA enabled (`-DDETRAY_BUILD_CUDA=ON`). This executable can additionally be configured with any arguments targeted at [google benchmark](https://github.com/google/benchmark/blob/main/docs/user_guide.md).
 
-If the data is dumped into json files using the options `--benchmark_out_format=json` and `--benchmark_out=<detector_name>_benchmark_data_<backend>_<algebra>.json`, it can afterwards be plotted with e.g.:
+If the data is dumped into json files using the options `--benchmark_repetitions=N` (N standing for the number of repitions), `--benchmark_display_aggregates_only=true`, as well as `--benchmark_out_format=json` and `--benchmark_out=<some_file_name>.json`, it can afterwards be plotted with e.g.:
 ```shell
 python3 detray/tests/tools/python/propagation_benchmarks.py \
     --geometry_file ./toy_detector/toy_detector_geometry.json \
-    --algebra_plugins array eigen \
-    --cuda \
-    --data_files ./toy_detector_benchmark_data_cpu_array.json \
-    ./toy_detector_benchmark_data_cpu_eigen.json \
-    ./toy_detector_benchmark_data_cuda_array.json \
-    ./toy_detector_benchmark_data_cuda_eigen.json
+    --data_files [FILES]...
 ```
-
-using the *std::array* and [*Eigen3*](https://eigen.tuxfamily.org) based linear algebra plugins with CUDA backend as an example.
 
 ### Continuous benchmark
 

--- a/tests/tools/python/impl/plot_benchmark_results.py
+++ b/tests/tools/python/impl/plot_benchmark_results.py
@@ -37,7 +37,7 @@ ldg_loc = "upper left"
 
 def read_benchmark_data(logging, input_path, benchmark_file):
 
-    file_path = input_path + benchmark_file
+    file_path = os.path.join(input_path, benchmark_file)
     with open(file_path, "r") as file:
         logging.debug(f"Reading file '{file_path}'")
 

--- a/tests/tools/src/cpu/propagation_benchmark.cpp
+++ b/tests/tools/src/cpu/propagation_benchmark.cpp
@@ -88,6 +88,7 @@ int main(int argc, char** argv) {
 
     desc.add_options()("context", po::value<dindex>(),
                        "Index of the geometry context")(
+        "bknd_name", po::value<std::string>(), "Name of the Processor")(
         "sort_tracks", "Sort track samples by theta angle");
 
     // Configs to be filled
@@ -107,6 +108,10 @@ int main(int argc, char** argv) {
     detector_t::geometry_context gctx;
     if (vm.count("context")) {
         gctx = detector_t::geometry_context{vm["context"].as<dindex>()};
+    }
+    std::string proc_name{"unknown"};
+    if (vm.count("bknd_name")) {
+        proc_name = vm["bknd_name"].as<std::string>();
     }
 
     //
@@ -161,8 +166,8 @@ int main(int argc, char** argv) {
 
     // These fields are needed by the plotting scripts, even if undefined
     ::benchmark::AddCustomContext("Backend", "CPU");
-    ::benchmark::AddCustomContext("Name", "unknown");
-    ::benchmark::AddCustomContext("Plugin",
+    ::benchmark::AddCustomContext("Backend Name", proc_name);
+    ::benchmark::AddCustomContext("Algebra-plugin",
                                   detray::types::get_name<test_algebra>());
 
     // Run benchmarks

--- a/tests/tools/src/cuda/propagation_benchmark_cuda.cpp
+++ b/tests/tools/src/cuda/propagation_benchmark_cuda.cpp
@@ -83,6 +83,7 @@ int main(int argc, char** argv) {
 
     desc.add_options()("context", po::value<dindex>(),
                        "Index of the geometry context")(
+        "bknd_name", po::value<std::string>(), "Name of the Processor")(
         "sort_tracks", "Sort track samples by theta angle");
 
     // Configs to be filled
@@ -102,6 +103,10 @@ int main(int argc, char** argv) {
     detector_t::geometry_context gctx;
     if (vm.count("context")) {
         gctx = detector_t::geometry_context{vm["context"].as<dindex>()};
+    }
+    std::string proc_name{"unknown"};
+    if (vm.count("bknd_name")) {
+        proc_name = vm["bknd_name"].as<std::string>();
     }
 
     //
@@ -162,8 +167,8 @@ int main(int argc, char** argv) {
 
     // These fields are needed by the plotting scripts, even if undefined
     ::benchmark::AddCustomContext("Backend", "CUDA");
-    ::benchmark::AddCustomContext("Name", "unknown");
-    ::benchmark::AddCustomContext("Plugin",
+    ::benchmark::AddCustomContext("Backend Name", proc_name);
+    ::benchmark::AddCustomContext("Algebra-plugin",
                                   detray::types::get_name<test_algebra>());
 
     // Run benchmarks


### PR DESCRIPTION
This way the benchmark can be run e.g. from a bash script of manually first, calling the plotting script in a second step (the plotting has a lot of dependencies and may not work everywhere). This mainly changes how the files to be plotted are registered in the python tool and that some additional data needs to be added to the benchmarks context. This will be used to e.g. distinguish the different algebra plugins and to set the plot labels correctly.
Also removed the 'interleave' option again, as that makes mostly sense for microbenchmarks and would need an additional sorting step to work correctly