### PR TITLE
feat: plot cpu scaling

### DIFF
--- a/tests/benchmarks/include/detray/benchmarks/propagation_benchmark_utils.hpp
+++ b/tests/benchmarks/include/detray/benchmarks/propagation_benchmark_utils.hpp
@@ -149,7 +149,7 @@ inline void register_benchmark(
     vecmem::memory_resource *dev_mr = nullptr,
     const std::vector<int> &n_host_threads = {static_cast<int>(
         std::thread::hardware_concurrency())},
-    int openmp_sched = 2) {
+    int max_chunk_size = 1, int openmp_sched = 2) {
 
     using algebra_t = typename detector_t::algebra_type;
     using propagation_benchmark_t =
@@ -187,11 +187,11 @@ inline void register_benchmark(
                           const detector_t *, const bfield_bknd_t *,
                           typename propagator_t::actor_chain_type::state_tuple
                               *,
-                          int, int>) {
+                          int, int, int>) {
             // Cpu benchmark
-            ::benchmark::RegisterBenchmark(bench_name.c_str(), prop_benchmark,
-                                           &tracks, &det, &bfield, actor_states,
-                                           host_threads, openmp_sched)
+            ::benchmark::RegisterBenchmark(
+                bench_name.c_str(), prop_benchmark, &tracks, &det, &bfield,
+                actor_states, host_threads, max_chunk_size, openmp_sched)
                 ->UseRealTime();
         } else {
             // Device benchmark
@@ -224,14 +224,14 @@ inline void register_benchmark(
     const std::vector<int> &n_samples = {10000},
     const std::vector<int> &n_host_threads = {static_cast<int>(
         std::thread::hardware_concurrency())},
-    int openmp_sched = 2) {
+    int max_chunk_size = 1, int openmp_sched = 2) {
 
     using propagator_t =
         propagator<stepper_t, navigator<detector_t>, actor_chain_t>;
     register_benchmark<benchmark_t, propagator_t, detector_t, bfield_bknd_t,
                        kOPT>(name, bench_cfg, prop_cfg, det, bfield,
                              actor_states, tracks, n_samples, nullptr,
-                             n_host_threads, openmp_sched);
+                             n_host_threads, max_chunk_size, openmp_sched);
 }
 
 }  // namespace detray::benchmarks

--- a/tests/benchmarks/include/detray/benchmarks/propagation_benchmark_utils.hpp
+++ b/tests/benchmarks/include/detray/benchmarks/propagation_benchmark_utils.hpp
@@ -191,14 +191,14 @@ inline void register_benchmark(
             // Cpu benchmark
             ::benchmark::RegisterBenchmark(bench_name.c_str(), prop_benchmark,
                                            &tracks, &det, &bfield, actor_states,
-                                           host_threads, openmp_sched);
-            //->MeasureProcessCPUTime();
+                                           host_threads, openmp_sched)
+                ->UseRealTime();
         } else {
             // Device benchmark
             ::benchmark::RegisterBenchmark(bench_name.c_str(), prop_benchmark,
                                            dev_mr, &tracks, &det, &bfield,
-                                           actor_states);
-            //->MeasureProcessCPUTime();
+                                           actor_states)
+                ->UseRealTime();
         }
     }
 }

--- a/tests/include/detray/test/utils/simulation/event_generator/random_numbers.hpp
+++ b/tests/include/detray/test/utils/simulation/event_generator/random_numbers.hpp
@@ -75,7 +75,9 @@ struct random_numbers {
 
     /// Explicit normal distribution around a @param mean and @param stddev
     DETRAY_HOST auto normal(const scalar_t mean, const scalar_t stddev) {
-        return std::normal_distribution<scalar_t>(mean, stddev)(m_engine);
+        return stddev == scalar_t{0}
+                   ? mean
+                   : std::normal_distribution<scalar_t>(mean, stddev)(m_engine);
     }
 
     /// 50:50 coin toss

--- a/tests/tools/python/impl/__init__.py
+++ b/tests/tools/python/impl/__init__.py
@@ -3,6 +3,7 @@ from .plot_benchmark_results import (
     prepare_benchmark_data,
     plot_benchmark_case,
     plot_benchmark_data,
+    plot_scaling_data,
 )
 from .plot_navigation_validation import (
     read_scan_data,

--- a/tests/tools/python/impl/plot_benchmark_results.py
+++ b/tests/tools/python/impl/plot_benchmark_results.py
@@ -11,20 +11,36 @@ import plotting
 from collections import namedtuple
 import json
 import itertools
+import math
+import numpy as np
 import os
 import pandas as pd
 import sys
+
+
+# Plot types for benchmarks
+benchmark_plots = namedtuple(
+    "benchmark_plots",
+    "latency throughput, weak_scaling, strong_scaling",
+    defaults=[None, None, None, None],
+)
 
 # How to label plots
 label_data = namedtuple("label_data", "title label x_axis y_axis")
 
 # Define labels for google benchmark data collections
 label_dict = {
-    "real_time": label_data(
+    "latency": label_data(
         "Propagation Latency", "", "No. tracks", r"t $[\mathrm{ms}]$"
     ),
-    "TracksPropagated": label_data(
+    "throughput": label_data(
         "Propagation Throughout", "", "No. tracks", r"Prop. rate $[\mathrm{MHz}]$"
+    ),
+    "weak_scaling": label_data(
+        "Propagation Weak Scaling", "", "No. threads", "Efficiency"
+    ),
+    "strong_scaling": label_data(
+        "Propagation Strong Scaling", "", "No. threads", "Speedup"
     ),
 }
 
@@ -63,7 +79,7 @@ def add_track_multiplicity_column(df):
     ), "Benchmark case name not correctly formatted: (BM_PROPAGATION_<detector name>_<#tracks>_TRACKS)"
 
     # The number of tracks is the second last part of the benchmark name
-    find_track_multiplicity = lambda n: (int(n.split("_")[-2]))
+    find_track_multiplicity = lambda n: (int(n.split("_")[-3]))
 
     # Add new column based on benchmark case name
     df["x"] = df["run_name"].apply(find_track_multiplicity)
@@ -101,6 +117,27 @@ def prepare_benchmark_data(logging, input_dir, file):
     return context, data
 
 
+""" Filter the data frame for a specific type of data """
+
+
+def filter_benchmark_data(df, data_type):
+
+    assert len(df["x"]) != 0, "Data frame has to provide column 'x'"
+    assert len(df[data_type]) != 0, f"Data frame has to provide column '{data_type}'"
+
+    # Filter the relevant data from the frame
+    median = lambda data_frame: (data_frame["aggregate_name"] == "mean")
+    stddev = lambda data_frame: (data_frame["aggregate_name"] == "stddev")
+
+    data, n_tracks = plotting.filter_data(
+        data=df, filter=median, variables=[data_type, "x"]
+    )
+
+    err = plotting.filter_data(data=df, filter=stddev, variables=[data_type])
+
+    return n_tracks, data, err
+
+
 """
 Plot the benchmark latency and throughout for different hardware backends and
 algebra plugins
@@ -108,49 +145,41 @@ algebra plugins
 
 
 def plot_benchmark_case(
-    context,
-    df,
     plot_factory,
+    x,
+    y,
     label,
+    y_error=[],
+    plot_type="latency",
     title="",
-    data_type="real_time",
     marker=".",
     plot=None,
+    xaxis_format=None,
     yaxis_format=None,
+    log_scale=10,
 ):
-
-    assert len(df["x"]) != 0, "Data frame has to provide column 'x'"
-    assert len(df[data_type]) != 0, f"Data frame has to provide column '{data_type}'"
-
-    # Filter the relevant data from the frame
-    median = lambda data_frame: (data_frame["aggregate_name"] == "median")
-    stddev = lambda data_frame: (data_frame["aggregate_name"] == "stddev")
-
-    data, n_tracks = plotting.filter_data(
-        data=df, filter=median, variables=[data_type, "x"]
-    )
-
-    stddev = plotting.filter_data(data=df, filter=stddev, variables=[data_type])
-
     if plot is None:
         # Create new plot
         lgd_ops = plotting.legend_options(
             loc=ldg_loc, horiz_anchor=1.0, vert_anchor=1.02
         )
 
-        labels = label_dict[data_type]
+        labels = label_dict[plot_type]
         x_axis_opts = plotting.axis_options(
-            label=labels.x_axis, log_scale=True, tick_positions=n_tracks
+            label=labels.x_axis,
+            log_scale=log_scale,
+            tick_positions=x,
+            label_format=xaxis_format,
         )
         y_axis_opts = plotting.axis_options(
-            label=labels.y_axis, log_scale=True, label_format=yaxis_format
+            label=labels.y_axis, log_scale=log_scale, label_format=yaxis_format
         )
 
         # Plot the propagation latency against the number of tracks
         plot_data = plot_factory.graph(
-            x=n_tracks,
-            y=data,
-            y_errors=stddev,
+            x=x,
+            y=y,
+            y_errors=y_error,
             x_axis=x_axis_opts,
             y_axis=y_axis_opts,
             title=title,
@@ -163,9 +192,9 @@ def plot_benchmark_case(
         # Add new data to exiting plot
         plot_data = plot_factory.add_graph(
             plot=plot,
-            x=n_tracks,
-            y=data,
-            y_errors=stddev,
+            x=x,
+            y=y,
+            y_errors=y_error,
             label=label,
             marker=marker,
             color=None,
@@ -191,66 +220,67 @@ def plot_benchmark_data(
 
     # Cylce through marker styles per plot
     marker_styles = ["o", "x", "*", "v", "s", "^", "<", ">"]
-
-    # Plot types for benchmarks
-    benchmark_plots = namedtuple("benchmark_plots", "latency throughput")
+    marker_style_cycle = itertools.cycle(marker_styles)
 
     # Save the different plots per hardware backend
-    plots = benchmark_plots(None, None)
-    marker_style_cycle = itertools.cycle(marker_styles)
+    plots = benchmark_plots()
 
     # Go through all benchmark data files in the list and make a comparison plot
     for i, file in enumerate(file_list):
         # Get the data for the next benchmark case
-        context, data = prepare_benchmark_data(logging, input_dir, file)
+        _, df = prepare_benchmark_data(logging, input_dir, file)
         marker = next(marker_style_cycle)
+
+        n_tracks, latency, latency_sigma = filter_benchmark_data(df, "real_time")
+        _, throughput, throughput_sigma = filter_benchmark_data(df, "TracksPropagated")
 
         # Initialize plots
         if i == 0:
-
             # Plot the data against the number of tracks
             latency_plot = plot_benchmark_case(
-                context=context,
-                df=data,
                 plot_factory=plot_factory,
+                plot_type="latency",
                 label=label_list[i],
-                data_type="real_time",
+                x=n_tracks,
+                y=latency,
+                y_error=latency_sigma,
                 marker=marker,
                 title=title,
-                yaxis_format=None,
             )
 
             throughput_plot = plot_benchmark_case(
-                context=context,
-                df=data,
                 plot_factory=plot_factory,
+                plot_type="throughput",
                 label=label_list[i],
-                data_type="TracksPropagated",
+                x=n_tracks,
+                y=throughput,
+                y_error=throughput_sigma,
                 marker=marker,
                 title=title,
-                yaxis_format="{x:3.2f}",
             )
 
-            plots = benchmark_plots(latency_plot, throughput_plot)
+            plots = benchmark_plots(latency=latency_plot, throughput=throughput_plot)
 
         # Add new data to plots
         else:
             plot_benchmark_case(
-                context=context,
-                df=data,
                 plot_factory=plot_factory,
+                plot_type="latency",
                 label=label_list[i],
-                data_type="real_time",
+                x=n_tracks,
+                y=latency,
+                y_error=latency_sigma,
                 marker=marker,
                 plot=plots.latency,
             )
 
             plot_benchmark_case(
-                context=context,
-                df=data,
                 plot_factory=plot_factory,
+                plot_type="throughput",
                 label=label_list[i],
-                data_type="TracksPropagated",
+                x=n_tracks,
+                y=throughput,
+                y_error=throughput_sigma,
                 marker=marker,
                 plot=plots.throughput,
             )
@@ -262,4 +292,150 @@ def plot_benchmark_data(
 
     plot_factory.write_plot(
         plots.throughput, f"{det_name}_{plot_series_name}_throughput", out_format
+    )
+
+
+""" Plot weak and strong scaling data """
+
+
+def plot_scaling_data(
+    logging,
+    input_dir,
+    det_name,
+    file_list,
+    label_list,
+    title,
+    plot_factory,
+    out_format,
+):
+    # TODO: Hard-coded for now
+    # Number of threads per benchmark case
+    n_threads = [1, 2, 4, 8, 16, 32, 64, 128, 256]
+
+    # Cylce through marker styles per plot
+    marker_styles = ["o", "x", "*", "v", "s", "^", "<", ">"]
+    marker_style_cycle = itertools.cycle(marker_styles)
+
+    # Save the different plots per algebra plugin
+    plots = benchmark_plots()
+
+    # Go through all benchmark data files in the list and make a comparison plot
+    for i, file in enumerate(file_list):
+        # Get the data for the next benchmark case
+        _, df = prepare_benchmark_data(logging, input_dir, file)
+        marker = next(marker_style_cycle)
+
+        # Filter the relevant data
+        _, latency, latency_sigma = filter_benchmark_data(df, "real_time")
+
+        # Split the data set
+        weak_sc_latency = latency[: len(n_threads)]
+        strong_sc_latency = latency[len(n_threads) :]
+
+        # Calculate speedups and efficiencies
+        weak_sc_efficiency = weak_sc_latency[0] / weak_sc_latency
+        strong_sc_speedup = strong_sc_latency[0] / strong_sc_latency
+
+        weak_sc_stddev = latency_sigma[: len(n_threads)]
+        strong_sc_stddev = latency_sigma[len(n_threads) :]
+
+        # Gaussian error propagation x/y_i
+        err_prob = lambda x, y, err_x, err_y: np.sqrt(
+            np.power(err_x / y, 2) + np.power((x * err_y) / np.power(y, 2), 2)
+        )
+
+        weak_sc_stddev = err_prob(
+            weak_sc_latency[0], weak_sc_latency, weak_sc_stddev[0], weak_sc_stddev
+        )
+        strong_sc_stddev = err_prob(
+            strong_sc_latency[0],
+            strong_sc_latency,
+            strong_sc_stddev[0],
+            strong_sc_stddev,
+        )
+
+        # Initialize plots
+        if i == 0:
+            # Plot the data against the number of tracks
+            weak_sc_plot = plot_benchmark_case(
+                plot_factory=plot_factory,
+                plot_type="weak_scaling",
+                label=label_list[i],
+                x=n_threads,
+                y=weak_sc_efficiency,
+                y_error=weak_sc_stddev,
+                marker=marker,
+                title=title,
+                log_scale=2,
+                xaxis_format="{x:3.0f}",
+                yaxis_format="{x:3.2f}",
+            )
+
+            strong_sc_plot = plot_benchmark_case(
+                plot_factory=plot_factory,
+                plot_type="strong_scaling",
+                label=label_list[i],
+                x=n_threads,
+                y=strong_sc_speedup,
+                y_error=strong_sc_stddev,
+                marker=marker,
+                title=title,
+                log_scale=2,
+                xaxis_format="{x:3.0f}",
+                yaxis_format="{x:3.0f}",
+            )
+
+            plots = benchmark_plots(
+                weak_scaling=weak_sc_plot, strong_scaling=strong_sc_plot
+            )
+
+        # Add new data to plots
+        else:
+            plot_benchmark_case(
+                plot_factory=plot_factory,
+                plot_type="weak_scaling",
+                label=label_list[i],
+                x=n_threads,
+                y=weak_sc_efficiency,
+                y_error=weak_sc_stddev,
+                marker=marker,
+                plot=plots.weak_scaling,
+            )
+
+            plot_benchmark_case(
+                plot_factory=plot_factory,
+                plot_type="strong_scaling",
+                label=label_list[i],
+                x=n_threads,
+                y=strong_sc_speedup,
+                y_error=strong_sc_stddev,
+                marker=marker,
+                plot=plots.strong_scaling,
+            )
+
+    # Ideal weak scaling
+    plot_factory.add_graph(
+        plot=plots.weak_scaling,
+        x=n_threads,
+        y=[1] * len(n_threads),
+        marker="",
+        color="r",
+        label="ideal scaling",
+    )
+
+    # Ideal strong scaling
+    plot_factory.add_graph(
+        plot=plots.strong_scaling,
+        x=n_threads,
+        y=n_threads,
+        marker="",
+        color="r",
+        label="ideal scaling",
+    )
+
+    # Write to disk
+    plot_factory.write_plot(plots.weak_scaling, f"{det_name}_weak_scaling", out_format)
+
+    plot_factory.write_plot(
+        plots.strong_scaling, f"{det_name}_strong_scaling", out_format
     )

--- a/tests/tools/python/impl/plot_track_params.py
+++ b/tests/tools/python/impl/plot_track_params.py
@@ -81,7 +81,7 @@ def plot_track_params(opts, detector, track_type, plot_factory, out_format, df):
         x=p,
         bins=100,
         x_axis=x_axis_opts,
-        y_axis=y_axis_opts._replace(log_scale=True),
+        y_axis=y_axis_opts._replace(log_scale=10),
         suffix="p_dist",
     )
 
@@ -307,7 +307,7 @@ def plot_track_pos_dist(
         x=filtered_dist,
         bins=100,
         x_axis=plotting.axis_options(label=r"$d\,\mathrm{[mm]}$"),
-        y_axis=plotting.axis_options(label="", log_scale=True),
+        y_axis=plotting.axis_options(label="", log_scale=10),
         figsize=(8.5, 8.5),
         lgd_ops=lgd_ops,
     )

--- a/tests/tools/python/plotting/plot_helpers.py
+++ b/tests/tools/python/plotting/plot_helpers.py
@@ -53,4 +53,4 @@ def filter_data(data, filter=lambda df: [], variables=[]):
         for var in variables:
             data_coll.append(filtered[var].to_numpy(dtype=np.double))
 
-    return tuple(data_coll)
+    return data_coll[0] if len(data_coll) == 1 else tuple(data_coll)

--- a/tests/tools/python/plotting/pyplot_factory.py
+++ b/tests/tools/python/plotting/pyplot_factory.py
@@ -149,23 +149,27 @@ class pyplot_factory:
         ax.set_ylabel(y_axis.label)
         ax.grid(True, alpha=0.25)
 
-        # Format of tick labels
-        # self.__set_label_format(x_axis.label_format, ax.xaxis)
-        self.__set_label_format(y_axis.label_format, ax.yaxis)
-
         # Plot log scale
-        if x_axis.log_scale:
-            ax.set_xscale("log")
-        if y_axis.log_scale:
-            ax.set_yscale("log")
+        if x_axis.log_scale is not None:
+            ax.set_xscale("log", base=x_axis.log_scale)
+        if y_axis.log_scale is not None:
+            ax.set_yscale("log", base=x_axis.log_scale)
 
         if x_axis.tick_positions is not None:
             ax.set_xticks(x_axis.tick_positions)
             ax.tick_params(axis="x", which="major", pad=7)
 
+        if y_axis.tick_positions is not None:
+            ax.set_yticks(y_axis.tick_positions)
+            ax.tick_params(axis="y", which="major", pad=7)
+
         # Restrict x and y ranges
         x = self.__apply_boundary(x, x_axis.min, x_axis.max)
         y = self.__apply_boundary(y, y_axis.min, y_axis.max)
+
+        # Format of tick labels
+        self.__set_label_format(x_axis.label_format, ax.xaxis)
+        self.__set_label_format(y_axis.label_format, ax.yaxis)
 
         # Nothing left to do
         if len(x) == 0:
@@ -261,10 +265,10 @@ class pyplot_factory:
         ax.grid(True, alpha=0.25)
 
         # Plot log scale
-        if x_axis.log_scale:
-            ax.set_xscale("log")
-        if y_axis.log_scale:
-            ax.set_yscale("log")
+        if x_axis.log_scale is not None:
+            ax.set_xscale("log", base=x_axis.log_scale)
+        if y_axis.log_scale is not None:
+            ax.set_yscale("log", base=x_axis.log_scale)
 
         # Leave x-axis with default formatter for 1D histograms
         ax.xaxis.set_major_formatter(ticker.ScalarFormatter())

--- a/tests/tools/src/cpu/CMakeLists.txt
+++ b/tests/tools/src/cpu/CMakeLists.txt
@@ -57,35 +57,39 @@ if(DETRAY_BUILD_BENCHMARKS)
     find_package(OpenMP)
 
     # Build the propagation benchmark executable.
-    macro(detray_add_propagation_benchmark algebra)
-        detray_add_executable(propagation_benchmark_cpu_${algebra}
-                            "propagation_benchmark.cpp"
+    macro(detray_add_propagation_benchmark algebra type)
+        detray_add_executable(propagation_${type}_cpu_${algebra}
+                            "propagation_${type}.cpp"
                             LINK_LIBRARIES Boost::program_options benchmark::benchmark benchmark::benchmark_main vecmem::core detray::benchmark_cpu detray::core_${algebra} detray::tools detray::detectors
         )
 
         if(OpenMP_CXX_FOUND)
             target_link_libraries(
-                detray_propagation_benchmark_cpu_${algebra}
+                detray_propagation_${type}_cpu_${algebra}
                 PRIVATE OpenMP::OpenMP_CXX
             )
         endif()
     endmacro()
 
     # Build the array benchmark.
-    detray_add_propagation_benchmark( array )
+    detray_add_propagation_benchmark( array benchmark )
+    detray_add_propagation_benchmark( array scaling )
 
     # Build the Eigen benchmark executable.
     if(DETRAY_EIGEN_PLUGIN)
-        detray_add_propagation_benchmark( eigen )
+        detray_add_propagation_benchmark( eigen benchmark )
+        detray_add_propagation_benchmark( eigen scaling )
     endif()
 
     # Build the SMatrix benchmark executable.
     if(DETRAY_SMATRIX_PLUGIN)
-        detray_add_propagation_benchmark( smatrix )
+        detray_add_propagation_benchmark( smatrix benchmark )
+        detray_add_propagation_benchmark( smatrix scaling )
     endif()
 
     # Build the Vc benchmark executable.
     if(DETRAY_VC_AOS_PLUGIN)
-        detray_add_propagation_benchmark( vc_aos )
+        detray_add_propagation_benchmark( vc_aos benchmark )
+        detray_add_propagation_benchmark( vc_aos scaling )
     endif()
 endif()

--- a/tests/tools/src/cpu/propagation_scaling.cpp
+++ b/tests/tools/src/cpu/propagation_scaling.cpp
@@ -1,0 +1,212 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/detectors/bfield.hpp"
+#include "detray/navigation/navigator.hpp"
+#include "detray/propagator/actor_chain.hpp"
+#include "detray/propagator/actors/aborters.hpp"
+#include "detray/propagator/actors/parameter_resetter.hpp"
+#include "detray/propagator/actors/parameter_transporter.hpp"
+#include "detray/propagator/actors/pointwise_material_interactor.hpp"
+#include "detray/propagator/rk_stepper.hpp"
+#include "detray/tracks/tracks.hpp"
+#include "detray/utils/type_list.hpp"
+
+// Detray IO include(s)
+#include "detray/io/frontend/detector_reader.hpp"
+
+// Detray benchmark include(s)
+#include "detray/benchmarks/cpu/propagation_benchmark.hpp"
+
+// Detray test include(s).
+#include "detray/test/utils/simulation/event_generator/track_generators.hpp"
+#include "detray/test/utils/types.hpp"
+
+// Detray tools include(s)
+#include "detray/options/detector_io_options.hpp"
+#include "detray/options/parse_options.hpp"
+#include "detray/options/propagation_options.hpp"
+#include "detray/options/track_generator_options.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// System include(s)
+#include <algorithm>
+#include <string>
+#include <thread>
+
+namespace po = boost::program_options;
+
+using namespace detray;
+
+int main(int argc, char** argv) {
+
+    // Use the most general type to be able to read in all detector files
+    using detector_t = detray::detector<test::default_metadata>;
+    using test_algebra = typename detector_t::algebra_type;
+    using scalar = dscalar<test_algebra>;
+    using vector3 = dvector3D<test_algebra>;
+
+    using free_track_parameters_t = free_track_parameters<test_algebra>;
+    using uniform_gen_t =
+        detail::random_numbers<scalar, std::uniform_real_distribution<scalar>>;
+    using track_generator_t =
+        random_track_generator<free_track_parameters_t, uniform_gen_t>;
+
+    using field_t = bfield::const_field_t<scalar>;
+    using stepper_t = rk_stepper<typename field_t::view_t, test_algebra>;
+    using empty_chain_t = actor_chain<>;
+    using default_chain =
+        actor_chain<parameter_transporter<test_algebra>,
+                    pointwise_material_interactor<test_algebra>,
+                    parameter_resetter<test_algebra>>;
+
+    // Code for the openMP scheduling scheme,
+    // @see https://www.openmp.org/spec-html/5.0/openmpsu121.html
+    // omp_sched_static = 0x1,
+    // omp_sched_dynamic = 0x2,
+    // omp_sched_guided = 0x3,
+    // omp_sched_auto = 0x4,
+    //
+    // schedule modifier
+    // omp_sched_monotonic = 0x80000000u
+    constexpr int sched_policy{1};
+    // Number of tracks per thread in weak scaling
+    constexpr int chunk_size{1000};
+
+    // Host memory resource
+    vecmem::host_memory_resource host_mr;
+
+    // Constant magnetic field
+    vector3 B{0.f, 0.f, 2.f * unit<scalar>::T};
+
+    // Number of tracks for weak scaling
+    std::vector<int> n_threads{1,  2,  3,  4,  5,  6,  7,   8,   12,
+                               16, 24, 32, 48, 64, 96, 128, 192, 256};
+    std::vector<int> n_tracks_weak_sc;
+    // Ensure that number of tracks is divisible by nu,ber of threads
+    for (const int n : n_threads) {
+        n_tracks_weak_sc.push_back(n * chunk_size);
+    }
+    const std::size_t n_tracks_strong_sc{50'000};
+
+    //
+    // Configuration
+    //
+
+    // Google benchmark specific options
+    ::benchmark::Initialize(&argc, argv);
+
+    // Specific options for this test
+    po::options_description desc("\ndetray propagation scaling options");
+
+    desc.add_options()("context", po::value<dindex>(),
+                       "Index of the geometry context");
+
+    // Configs to be filled
+    detray::io::detector_reader_config reader_cfg{};
+    track_generator_t::configuration trk_cfg{};
+    propagation::config prop_cfg{};
+    detray::benchmarks::benchmark_base::configuration bench_cfg{};
+
+    // Read options from commandline
+    po::variables_map vm = detray::options::parse_options(
+        desc, argc, argv, reader_cfg, trk_cfg, prop_cfg);
+
+    // The geometry context to be used
+    detector_t::geometry_context gctx;
+    if (vm.count("context")) {
+        gctx = detector_t::geometry_context{vm["context"].as<dindex>()};
+    }
+
+    //
+    // Prepare data
+    //
+
+    // Read the detector geometry
+    reader_cfg.do_check(true);
+
+    const auto [det, names] =
+        detray::io::read_detector<detector_t>(host_mr, reader_cfg);
+    const std::string& det_name = det.name(names);
+
+    // Generate the track samples for weak scaling
+    auto track_samples_weak_sc =
+        detray::benchmarks::generate_track_samples<track_generator_t>(
+            &host_mr, n_tracks_weak_sc, trk_cfg, false);
+
+    // Generate track sample size for strong scaling
+    trk_cfg.n_tracks(n_tracks_strong_sc);
+    auto single_sample = detray::benchmarks::generate_tracks<track_generator_t>(
+        &host_mr, trk_cfg, false);
+    std::vector<dvector<free_track_parameters_t>> track_samples_strong_sc{
+        std::move(single_sample)};
+
+    // Create a constant b-field
+    auto bfield = bfield::create_const_field<scalar>(B);
+
+    // Build actor states
+    dtuple<> empty_state{};
+
+    parameter_transporter<test_algebra>::state transporter_state{};
+    pointwise_material_interactor<test_algebra>::state interactor_state{};
+    parameter_resetter<test_algebra>::state resetter_state{};
+
+    auto actor_states = detail::make_tuple<dtuple>(
+        transporter_state, interactor_state, resetter_state);
+
+    //
+    // Register benchmarks
+    //
+
+    // Number of warmup tracks
+    const int n_max_tracks{*std::ranges::max_element(n_tracks_weak_sc)};
+    bench_cfg.n_warmup(
+        static_cast<int>(std::ceil(0.1f * static_cast<float>(n_max_tracks))));
+
+    if (prop_cfg.stepping.do_covariance_transport) {
+        // Number of track to be sampled and number of threads are the same
+        detray::benchmarks::register_benchmark<
+            detray::benchmarks::host_propagation_bm, stepper_t, default_chain>(
+            det_name + "_W_COV_TRANSPORT_WEAK-SCALING", bench_cfg, prop_cfg,
+            det, bfield, &actor_states, track_samples_weak_sc, n_tracks_weak_sc,
+            n_threads, sched_policy);
+
+        // Number of tracks is increased on a fixed size sample
+        detray::benchmarks::register_benchmark<
+            detray::benchmarks::host_propagation_bm, stepper_t, default_chain>(
+            det_name + "_W_COV_TRANSPORT_STRONG-SCALING", bench_cfg, prop_cfg,
+            det, bfield, &actor_states, track_samples_strong_sc,
+            {n_tracks_strong_sc}, n_threads, sched_policy);
+    } else {
+        detray::benchmarks::register_benchmark<
+            detray::benchmarks::host_propagation_bm, stepper_t, empty_chain_t>(
+            det_name + "_WEAK-SCALING", bench_cfg, prop_cfg, det, bfield,
+            &empty_state, track_samples_weak_sc, n_tracks_weak_sc, n_threads,
+            sched_policy);
+
+        detray::benchmarks::register_benchmark<
+            detray::benchmarks::host_propagation_bm, stepper_t, empty_chain_t>(
+            det_name + "_STRONG-SCALING", bench_cfg, prop_cfg, det, bfield,
+            &empty_state, track_samples_strong_sc, {n_tracks_strong_sc},
+            n_threads, sched_policy);
+    }
+
+    // These fields are needed by the plotting scripts, even if undefined
+    ::benchmark::AddCustomContext("Backend", "CPU");
+    ::benchmark::AddCustomContext("Name", "unknown");
+    ::benchmark::AddCustomContext(
+        "Max no. Threads", std::to_string(std::thread::hardware_concurrency()));
+    ::benchmark::AddCustomContext("Plugin",
+                                  detray::types::get_name<test_algebra>());
+
+    // Run benchmarks
+    ::benchmark::RunSpecifiedBenchmarks();
+    ::benchmark::Shutdown();
+}


### PR DESCRIPTION
Add a job that benchmarks CPU weak and strong scaling and makes plots from it across different algebra plugins. I also checked the throughput and realized that this was computed incorrectly by google benchmark in mulitthreaded benchmarks, unless we configure it to measure wall clock time internally. Contains a small fix for the track generator standard deviation that somehow did not make it into a previous PR.