### PR TITLE
ref: CLI tools cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,9 @@ option(
     FALSE
 )
 
-# Need test functionality and svg display for command line tools
+# Need test utils for the example detector generation
 if(DETRAY_BUILD_CLI_TOOLS)
-    set(DETRAY_BUILD_TESTING ON)
-    set(DETRAY_SVG_DISPLAY ON)
+    set(DETRAY_BUILD_TEST_UTILS ON)
 endif()
 
 # Convenience option to build tests
@@ -110,7 +109,7 @@ if(DETRAY_BUILD_ALL_TESTS)
     set(DETRAY_BUILD_INTEGRATIONTESTS ON)
 endif()
 
-# Alias flag to build the tests
+# Alias flag to enable tests in detray (pulls in google test and triggers the build of executables that depend on it)
 if(BUILD_TESTING AND (DETRAY_BUILD_UNITTESTS OR DETRAY_BUILD_INTEGRATIONTESTS))
     set(DETRAY_BUILD_TESTING ON)
 endif()
@@ -308,7 +307,16 @@ cmake_dependent_option(
     "BUILD_TESTING AND DETRAY_BUILD_TESTING"
     OFF
 )
-if(DETRAY_BUILD_TESTING OR DETRAY_BUILD_TEST_UTILS)
+
+# Test utils and validation tools can also be required standalone
+# (e.g. in ACTS detray plugin)
+if(
+    DETRAY_BUILD_TESTING
+    OR DETRAY_BUILD_TEST_UTILS
+    OR DETRAY_BUILD_VALIDATION_TOOLS
+    OR DETRAY_BUILD_BENCHMARKS
+    OR DETRAY_BUILD_CLI_TOOLS
+)
     add_subdirectory(tests)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -96,7 +96,7 @@ if(DETRAY_BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
 endif()
 
-# Build tool executables
+# Build test executables
 if(DETRAY_BUILD_TESTING)
     # Build host and device specific test code
     add_subdirectory(include/detray/test/cpu)
@@ -111,13 +111,13 @@ if(DETRAY_BUILD_TESTING)
     if(DETRAY_BUILD_INTEGRATIONTESTS)
         add_subdirectory(integration_tests)
     endif()
+endif()
 
-    # Build the command line tools (also required for the host jacobian
-    # validation integration test)
-    if(
-        (DETRAY_BUILD_INTEGRATIONTESTS AND DETRAY_BUILD_HOST)
-        OR DETRAY_BUILD_CLI_TOOLS
-    )
-        add_subdirectory(tools)
-    endif()
+# Build the command line tools (also required for the host jacobian
+# validation integration test)
+if(
+    (DETRAY_BUILD_INTEGRATIONTESTS AND DETRAY_BUILD_HOST)
+    OR DETRAY_BUILD_CLI_TOOLS
+)
+    add_subdirectory(tools)
 endif()

--- a/tests/include/detray/test/device/cuda/material_validation.hpp
+++ b/tests/include/detray/test/device/cuda/material_validation.hpp
@@ -12,7 +12,6 @@
 #include "detray/tracks/tracks.hpp"
 
 // Detray test include(s)
-#include "detray/test/common/fixture_base.hpp"
 #include "detray/test/common/material_validation_config.hpp"
 #include "detray/test/cpu/material_validation.hpp"
 #include "detray/test/validation/material_validation_utils.hpp"

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,13 +18,7 @@ target_include_directories(
 
 target_link_libraries(
     detray_tools
-    INTERFACE
-        Boost::program_options
-        vecmem::core
-        detray::test_common
-        detray::io
-        detray::csv_io
-        detray::test_utils
+    INTERFACE Boost::program_options vecmem::core detray::io detray::test_utils
 )
 
 add_subdirectory(src)

--- a/tests/tools/src/cpu/CMakeLists.txt
+++ b/tests/tools/src/cpu/CMakeLists.txt
@@ -1,6 +1,6 @@
 #Detray library, part of the ACTS project(R& D line)
 #
-#(c) 2023-2024 CERN for the benefit of the ACTS project
+#(c) 2023-2025 CERN for the benefit of the ACTS project
 #
 #Mozilla Public License Version 2.0
 
@@ -29,28 +29,30 @@ detray_add_executable(generate_telescope_detector
                       detray::io detray::test_utils detray::core_array
 )
 
-# Build the visualization executable.
-detray_add_executable(detector_display
-                      "detector_display.cpp"
-                      LINK_LIBRARIES Boost::program_options  detray::core_array detray::tools
-                      detray::svgtools
-)
+if(DETRAY_SVG_DISPLAY)
+    # Build the visualization executable.
+    detray_add_executable(detector_display
+                        "detector_display.cpp"
+                        LINK_LIBRARIES Boost::program_options detray::core_array detray::io detray::tools
+                        detray::svgtools
+    )
+endif()
 
-# Build the detector validation executable.
-detray_add_executable(detector_validation
-                      "detector_validation.cpp"
-                      LINK_LIBRARIES GTest::gtest GTest::gtest_main
-                      Boost::program_options detray::core_array detray::tools detray::test_utils
-                      detray::svgtools
-)
+if(DETRAY_BUILD_TESTING)
+    # Build the detector validation executable.
+    detray_add_executable(detector_validation
+                        "detector_validation.cpp"
+                        LINK_LIBRARIES GTest::gtest GTest::gtest_main
+                        Boost::program_options detray::core_array detray::test_cpu detray::tools
+    )
 
-# Build the material validation executable.
-detray_add_executable(material_validation
-                      "material_validation.cpp"
-                      LINK_LIBRARIES GTest::gtest GTest::gtest_main
-                      Boost::program_options detray::core_array detray::tools detray::test_utils
-                      detray::svgtools
-)
+    # Build the material validation executable.
+    detray_add_executable(material_validation
+                        "material_validation.cpp"
+                        LINK_LIBRARIES GTest::gtest GTest::gtest_main
+                        Boost::program_options detray::core_array detray::test_cpu detray::tools
+    )
+endif()
 
 if(DETRAY_BUILD_BENCHMARKS)
     # Look for openMP, which is used for the CPU propagation benchmark

--- a/tests/tools/src/cuda/CMakeLists.txt
+++ b/tests/tools/src/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 #Detray library, part of the ACTS project(R& D line)
 #
-#(c) 2024 CERN for the benefit of the ACTS project
+#(c) 2024-2025 CERN for the benefit of the ACTS project
 #
 #Mozilla Public License Version 2.0
 
@@ -13,30 +13,34 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Boost COMPONENTS program_options REQUIRED)
 
-# Build the detector validation executable.
-detray_add_executable(detector_validation_cuda
-                      "detector_validation_cuda.cpp"
-                      LINK_LIBRARIES GTest::gtest GTest::gtest_main
-                      Boost::program_options detray::test_cuda detray::tools
-)
+if(DETRAY_BUILD_TESTING)
+    # Build the detector validation executable.
+    detray_add_executable(detector_validation_cuda
+                        "detector_validation_cuda.cpp"
+                        LINK_LIBRARIES GTest::gtest GTest::gtest_main
+                        Boost::program_options detray::test_cuda detray::tools
+    )
 
-# Build the material cuda validation executable.
-detray_add_executable(material_validation_cuda
-                      "material_validation_cuda.cpp"
-                      LINK_LIBRARIES GTest::gtest GTest::gtest_main
-                      Boost::program_options detray::test_cuda detray::tools
-)
-
-# Build benchmarks for multiple algebra plugins
-# Currently vc and smatrix is not supported on device
-set(algebra_plugins "array")
-if(DETRAY_EIGEN_PLUGIN)
-    list(APPEND algebra_plugins "eigen")
+    # Build the material cuda validation executable.
+    detray_add_executable(material_validation_cuda
+                        "material_validation_cuda.cpp"
+                        LINK_LIBRARIES GTest::gtest GTest::gtest_main
+                        Boost::program_options detray::test_cuda detray::tools
+    )
 endif()
 
-foreach(algebra ${algebra_plugins})
-    detray_add_executable(propagation_benchmark_cuda_${algebra}
-      "propagation_benchmark_cuda.cpp"
-       LINK_LIBRARIES detray::benchmark_cuda_${algebra} vecmem::cuda detray::tools detray::test_utils
-    )
-endforeach()
+if(DETRAY_BUILD_BENCHMARKS)
+    # Build benchmarks for multiple algebra plugins
+    # Currently vc and smatrix is not supported on device
+    set(algebra_plugins "array")
+    if(DETRAY_EIGEN_PLUGIN)
+        list(APPEND algebra_plugins "eigen")
+    endif()
+
+    foreach(algebra ${algebra_plugins})
+        detray_add_executable(propagation_benchmark_cuda_${algebra}
+        "propagation_benchmark_cuda.cpp"
+        LINK_LIBRARIES detray::benchmark_cuda_${algebra} vecmem::cuda detray::tools detray::test_utils
+        )
+    endforeach()
+endif()


### PR DESCRIPTION
Grant more fine grained control of how the CLI tools are built, e.g. if only benchmarks are required, don't build the validation tools and vice versa. Also allows to build the CLI validation tools without building unit and integration CI tests. 
This will be helpful in order to set up the benchmarks across different hardware platforms with minimal dependencies.