### PR TITLE
fix: extract shift as constexpr instead of consteval

### DIFF
--- a/core/include/detray/utils/bit_encoder.hpp
+++ b/core/include/detray/utils/bit_encoder.hpp
@@ -60,7 +60,7 @@ class bit_encoder {
     ///
     /// @note undefined behaviour for mask == 0 which we should not have.
     DETRAY_HOST_DEVICE
-    static consteval int extract_shift(value_t mask) noexcept {
+    static constexpr int extract_shift(value_t mask) noexcept {
         return __builtin_ctzll(mask);
     }
 };


### PR DESCRIPTION
llvm does not seem to like the consteval keyword here (I think it is a compiler bug though)