### PR TITLE
fix: Type printing

### DIFF
--- a/core/include/detray/utils/type_list.hpp
+++ b/core/include/detray/utils/type_list.hpp
@@ -165,7 +165,8 @@ std::string get_name(bool full = false) {
     // Remove the template argument list
     dvector<std::string> tokens{};
     for (const auto t : std::views::split(tp_str, '<')) {
-        tokens.emplace_back(t.begin(), t.end());
+        // The std::string constructor does not work with std::sentinel_t
+        tokens.emplace_back(std::string_view(t.begin(), t.end()));
     }
 
     // Split a the first ocurrence of '<'
@@ -174,7 +175,7 @@ std::string get_name(bool full = false) {
 
     // Strip the namespaces and qualifiers
     for (const auto t : std::views::split(tp_str, ':')) {
-        tokens.emplace_back(t.begin(), t.end());
+        tokens.emplace_back(std::string_view(t.begin(), t.end()));
     }
 
     // Split at the last occurrence of ':'

--- a/tests/unit_tests/cpu/utils/type_list.cpp
+++ b/tests/unit_tests/cpu/utils/type_list.cpp
@@ -11,6 +11,9 @@
 // Google Test include(s).
 #include <gtest/gtest.h>
 
+// System include(s)
+#include <iostream>
+
 // Test type list implementation
 GTEST_TEST(detray_utils, type_list) {
     using namespace detray;
@@ -37,6 +40,10 @@ GTEST_TEST(detray_utils, type_list) {
                   "Failed access type");
 
     types::print<list>();
-
     types::print<list>(false);
+
+    // Print with template params
+    std::cout << types::get_name<list>(true) << std::endl;
+    // Print without template params
+    std::cout << types::get_name<list>() << std::endl;
 }


### PR DESCRIPTION
Don't use std::sentinel_t in type printing, since the two iterators that std::string can be constructed from need to have the same type. Unfortunately, the detray cuda CI builds are running gcc 13.x, which did not catch this, and the gitlab CUDA CI, which is using gcc 11.4 and could catch this, is not compiling the detector reader but only unit and integration tests