### PR TITLE
fix: Use explicit types in cartesian product dereferencing

### DIFF
--- a/core/include/detray/utils/grid/detail/bin_storage.hpp
+++ b/core/include/detray/utils/grid/detail/bin_storage.hpp
@@ -246,7 +246,7 @@ class bin_storage<is_owning, detray::bins::dynamic_array<entry_t>, containers>
             typename std::iterator_traits<bin_itr_t>::difference_type;
         using value_type = bin_t;
         using pointer = bin_t*;
-        using reference = bin_t&;
+        using reference = bin_t;
         using iterator_category =
             typename std::iterator_traits<bin_itr_t>::iterator_category;
 

--- a/core/include/detray/utils/grid/detail/bin_view.hpp
+++ b/core/include/detray/utils/grid/detail/bin_view.hpp
@@ -106,7 +106,7 @@ struct bin_iterator {
     using difference_type = std::ptrdiff_t;
     using value_type = typename grid_t::bin_type;
     using pointer = value_type *;
-    using reference = const value_type &;
+    using reference = value_type;
     using iterator_category = detray::ranges::bidirectional_iterator_tag;
 
     /// Default constructor required by LegacyIterator trait

--- a/core/include/detray/utils/ranges/cartesian_product.hpp
+++ b/core/include/detray/utils/ranges/cartesian_product.hpp
@@ -39,7 +39,7 @@ struct cartesian_product_view : public detray::ranges::view_interface<
     using iterator_t = detray::ranges::detail::cartesian_product_iterator<
         detray::ranges::iterator_t<range_ts>...>;
     using value_type = detray::tuple<typename std::iterator_traits<
-        detray::ranges::iterator_t<range_ts>>::value_type &...>;
+        detray::ranges::iterator_t<range_ts>>::reference...>;
 
     /// Default constructor
     constexpr cartesian_product_view() = default;
@@ -121,9 +121,10 @@ struct cartesian_product_iterator {
 
     using difference_type = std::ptrdiff_t;
     using value_type =
-        std::tuple<typename std::iterator_traits<iterator_ts>::value_type...>;
+        std::tuple<typename std::iterator_traits<iterator_ts>::reference...>;
     using pointer = value_type *;
-    using reference = value_type &;
+    using reference = value_type;
+    // TODO: Adapt to the weakest iterator category in pack
     using iterator_category = detray::ranges::bidirectional_iterator_tag;
 
     /// Default constructor required by LegacyIterator trait
@@ -219,7 +220,9 @@ struct cartesian_product_iterator {
     template <std::size_t... I>
     DETRAY_HOST_DEVICE constexpr auto unroll_values(
         std::index_sequence<I...>) const {
-        return std::tuple(*detray::get<I>(m_itrs)...);
+        return std::tuple<
+            typename std::iterator_traits<iterator_ts>::reference...>(
+            *detray::get<I>(m_itrs)...);
     }
 
     /// Global range collection of begin and end iterators

--- a/core/include/detray/utils/ranges/enumerate.hpp
+++ b/core/include/detray/utils/ranges/enumerate.hpp
@@ -50,7 +50,7 @@ class enumerate_view : public detray::ranges::view_interface<
             typename std::iterator_traits<range_itr_t>::difference_type;
         using value_type = std::pair<incr_t, itr_ref_t>;
         using pointer = value_type *;
-        using reference = const value_type &;
+        using reference = value_type;
         using iterator_category =
             typename std::iterator_traits<range_itr_t>::iterator_category;
 

--- a/core/include/detray/utils/ranges/iota.hpp
+++ b/core/include/detray/utils/ranges/iota.hpp
@@ -38,7 +38,7 @@ class iota_view : public detray::ranges::view_interface<iota_view<incr_t>> {
         using difference_type = std::ptrdiff_t;
         using value_type = incr_t;
         using pointer = incr_t *;
-        using reference = incr_t &;
+        using reference = incr_t;
         using iterator_category = detray::ranges::bidirectional_iterator_tag;
 
         constexpr iterator() requires std::default_initializable<incr_t> =

--- a/core/include/detray/utils/ranges/pick.hpp
+++ b/core/include/detray/utils/ranges/pick.hpp
@@ -60,7 +60,7 @@ class pick_view : public detray::ranges::view_interface<
             std::pair<typename std::iterator_traits<sequence_itr_t>::value_type,
                       itr_ref_t>;
         using pointer = value_type *;
-        using reference = const value_type &;
+        using reference = value_type;
         using iterator_category =
             typename std::iterator_traits<sequence_itr_t>::iterator_category;
 


### PR DESCRIPTION
Fix a compilation error by providing explicit iterator value types to the tuple that is returned from the cartesian product range.