### PR TITLE
ref: New iterator type alias

### DIFF
--- a/core/include/detray/navigation/volume_graph.hpp
+++ b/core/include/detray/navigation/volume_graph.hpp
@@ -109,12 +109,10 @@ class volume_graph {
             using volume_iter =
                 detray::ranges::const_iterator_t<volume_container_t>;
 
-            using difference_type =
-                typename std::iterator_traits<volume_iter>::difference_type;
+            using difference_type = std::iter_difference_t<volume_iter>;
             using value_type = node;
             using pointer = typename std::iterator_traits<volume_iter>::pointer;
-            using reference =
-                typename std::iterator_traits<volume_iter>::reference;
+            using reference = std::iter_reference_t<volume_iter>;
             using iterator_category =
                 typename std::iterator_traits<volume_iter>::iterator_category;
 

--- a/core/include/detray/utils/find_bound.hpp
+++ b/core/include/detray/utils/find_bound.hpp
@@ -24,8 +24,7 @@ DETRAY_HOST_DEVICE constexpr iterator_t upper_bound(iterator_t first,
                                                     iterator_t last,
                                                     const T& value) {
 
-    using difference_t =
-        typename std::iterator_traits<iterator_t>::difference_type;
+    using difference_t = std::iter_difference_t<iterator_t>;
 
     difference_t len{detray::ranges::distance(first, last)};
 
@@ -53,8 +52,7 @@ DETRAY_HOST_DEVICE constexpr iterator_t lower_bound(iterator_t first,
                                                     iterator_t last,
                                                     const T& value) {
 
-    using difference_t =
-        typename std::iterator_traits<iterator_t>::difference_type;
+    using difference_t = std::iter_difference_t<iterator_t>;
 
     difference_t len{detray::ranges::distance(first, last)};
 

--- a/core/include/detray/utils/grid/detail/axis_binning.hpp
+++ b/core/include/detray/utils/grid/detail/axis_binning.hpp
@@ -193,8 +193,8 @@ struct irregular {
     using container_types = dcontainers;
     template <typename T>
     using vector_type = typename dcontainers::template vector_type<T>;
-    using index_type = typename std::iterator_traits<
-        typename vector_type<scalar_type>::iterator>::difference_type;
+    using index_type =
+        std::iter_difference_t<typename vector_type<scalar_type>::iterator>;
 
     static constexpr binning type = binning::e_irregular;
 

--- a/core/include/detray/utils/grid/detail/bin_storage.hpp
+++ b/core/include/detray/utils/grid/detail/bin_storage.hpp
@@ -242,8 +242,7 @@ class bin_storage<is_owning, detray::bins::dynamic_array<entry_t>, containers>
     /// initialized bin instance
     template <typename bin_itr_t>
     struct iterator_adapter {
-        using difference_type =
-            typename std::iterator_traits<bin_itr_t>::difference_type;
+        using difference_type = std::iter_difference_t<bin_itr_t>;
         using value_type = bin_t;
         using pointer = bin_t*;
         using reference = bin_t;

--- a/core/include/detray/utils/grid/detail/bin_view.hpp
+++ b/core/include/detray/utils/grid/detail/bin_view.hpp
@@ -44,7 +44,7 @@ struct bin_view : public detray::ranges::view_interface<bin_view<grid_t>> {
 
     using iterator_t =
         bin_iterator<grid_t, detray::ranges::iterator_t<bin_indexer_t>>;
-    using value_t = typename std::iterator_traits<iterator_t>::value_type;
+    using value_t = std::iter_value_t<iterator_t>;
 
     /// Default constructor
     constexpr bin_view() = default;

--- a/core/include/detray/utils/ranges/cartesian_product.hpp
+++ b/core/include/detray/utils/ranges/cartesian_product.hpp
@@ -38,8 +38,8 @@ struct cartesian_product_view : public detray::ranges::view_interface<
         detray::tuple<detray::ranges::iterator_t<range_ts>...>;
     using iterator_t = detray::ranges::detail::cartesian_product_iterator<
         detray::ranges::iterator_t<range_ts>...>;
-    using value_type = detray::tuple<typename std::iterator_traits<
-        detray::ranges::iterator_t<range_ts>>::reference...>;
+    using value_type = detray::tuple<
+        std::iter_reference_t<detray::ranges::iterator_t<range_ts>>...>;
 
     /// Default constructor
     constexpr cartesian_product_view() = default;
@@ -120,8 +120,7 @@ template <std::input_iterator... iterator_ts>
 struct cartesian_product_iterator {
 
     using difference_type = std::ptrdiff_t;
-    using value_type =
-        std::tuple<typename std::iterator_traits<iterator_ts>::reference...>;
+    using value_type = std::tuple<std::iter_reference_t<iterator_ts>...>;
     using pointer = value_type *;
     using reference = value_type;
     // TODO: Adapt to the weakest iterator category in pack
@@ -220,8 +219,7 @@ struct cartesian_product_iterator {
     template <std::size_t... I>
     DETRAY_HOST_DEVICE constexpr auto unroll_values(
         std::index_sequence<I...>) const {
-        return std::tuple<
-            typename std::iterator_traits<iterator_ts>::reference...>(
+        return std::tuple<std::iter_reference_t<iterator_ts>...>(
             *detray::get<I>(m_itrs)...);
     }
 

--- a/core/include/detray/utils/ranges/detail/iterator_functions.hpp
+++ b/core/include/detray/utils/ranges/detail/iterator_functions.hpp
@@ -85,11 +85,9 @@ using std::empty;
 /// @{
 // used by every iterator up to and including bidirectional iterators
 template <std::input_iterator iterator_t>
-DETRAY_HOST_DEVICE constexpr
-    typename std::iterator_traits<iterator_t>::difference_type
-    distance_impl(iterator_t first, iterator_t last,
-                  detray::ranges::input_iterator_tag) {
-    typename std::iterator_traits<iterator_t>::difference_type d{0};
+DETRAY_HOST_DEVICE constexpr std::iter_difference_t<iterator_t> distance_impl(
+    iterator_t first, iterator_t last, detray::ranges::input_iterator_tag) {
+    std::iter_difference_t<iterator_t> d{0};
     // simply count
     while (first != last) {
         ++first;
@@ -100,18 +98,16 @@ DETRAY_HOST_DEVICE constexpr
 
 // random access iterators specialization
 template <std::random_access_iterator iterator_t>
-DETRAY_HOST_DEVICE constexpr
-    typename std::iterator_traits<iterator_t>::difference_type
-    distance_impl(iterator_t first, iterator_t last,
-                  detray::ranges::random_access_iterator_tag) {
+DETRAY_HOST_DEVICE constexpr std::iter_difference_t<iterator_t> distance_impl(
+    iterator_t first, iterator_t last,
+    detray::ranges::random_access_iterator_tag) {
     // use operator-
     return last - first;
 }
 
 template <std::input_iterator iterator_t>
-DETRAY_HOST_DEVICE constexpr
-    typename std::iterator_traits<iterator_t>::difference_type
-    distance(iterator_t first, iterator_t last) {
+DETRAY_HOST_DEVICE constexpr std::iter_difference_t<iterator_t> distance(
+    iterator_t first, iterator_t last) {
     return distance_impl(
         first, last,
         typename std::iterator_traits<iterator_t>::iterator_category{});
@@ -166,16 +162,14 @@ DETRAY_HOST_DEVICE constexpr void advance(iterator_t& itr, dist_t d) {
 /// @{
 template <std::input_iterator iterator_t>
 DETRAY_HOST_DEVICE constexpr iterator_t next(
-    iterator_t itr,
-    typename std::iterator_traits<iterator_t>::difference_type d = 1) {
+    iterator_t itr, std::iter_difference_t<iterator_t> d = 1) {
     detray::ranges::detail::advance(itr, d);
     return itr;
 }
 
 template <std::bidirectional_iterator iterator_t>
 DETRAY_HOST_DEVICE constexpr iterator_t prev(
-    iterator_t itr,
-    typename std::iterator_traits<iterator_t>::difference_type d = 1) {
+    iterator_t itr, std::iter_difference_t<iterator_t> d = 1) {
     detray::ranges::detail::advance(itr, -d);
     return itr;
 }

--- a/core/include/detray/utils/ranges/enumerate.hpp
+++ b/core/include/detray/utils/ranges/enumerate.hpp
@@ -41,13 +41,11 @@ class enumerate_view : public detray::ranges::view_interface<
     /// returned using structured binding.
     struct iterator {
 
-        using itr_value_t =
-            typename std::iterator_traits<range_itr_t>::value_type;
-        using itr_ref_t = typename std::iterator_traits<range_itr_t>::reference;
+        using itr_value_t = std::iter_value_t<range_itr_t>;
+        using itr_ref_t = std::iter_reference_t<range_itr_t>;
         using itr_ptr_t = typename std::iterator_traits<range_itr_t>::pointer;
 
-        using difference_type =
-            typename std::iterator_traits<range_itr_t>::difference_type;
+        using difference_type = std::iter_difference_t<range_itr_t>;
         using value_type = std::pair<incr_t, itr_ref_t>;
         using pointer = value_type *;
         using reference = value_type;
@@ -233,9 +231,9 @@ class enumerate_view : public detray::ranges::view_interface<
 namespace views {
 
 template <std::input_iterator range_itr_t, std::incrementable incr_t = dindex>
-requires std::convertible_to<
-    typename std::iterator_traits<range_itr_t>::difference_type,
-    incr_t> struct enumerate : public enumerate_view<range_itr_t, incr_t> {
+requires std::convertible_to<std::iter_difference_t<range_itr_t>,
+                             incr_t> struct enumerate
+    : public enumerate_view<range_itr_t, incr_t> {
 
     using base_type = enumerate_view<range_itr_t, incr_t>;
 

--- a/core/include/detray/utils/ranges/join.hpp
+++ b/core/include/detray/utils/ranges/join.hpp
@@ -50,7 +50,7 @@ struct join_view : public detray::ranges::view_interface<join_view<range_t>> {
     using inner_iterator_t = detray::ranges::iterator_t<outer_value_t>;
 
     using iterator_t = detray::ranges::detail::join_iterator<range_t>;
-    using value_t = typename std::iterator_traits<iterator_t>::value_type;
+    using value_t = std::iter_value_t<iterator_t>;
 
     /// Default constructor
     constexpr join_view() = default;
@@ -149,11 +149,10 @@ struct join_iterator {
         detray::ranges::iterator_t<outer_value_t>>;
 
     using iterator_t = inner_iterator_t;
-    using difference_type =
-        typename std::iterator_traits<iterator_t>::difference_type;
-    using value_type = typename std::iterator_traits<iterator_t>::value_type;
+    using difference_type = std::iter_difference_t<iterator_t>;
+    using value_type = std::iter_value_t<iterator_t>;
     using pointer = typename std::iterator_traits<iterator_t>::pointer;
-    using reference = typename std::iterator_traits<iterator_t>::reference;
+    using reference = std::iter_reference_t<iterator_t>;
     using iterator_category =
         typename std::iterator_traits<iterator_t>::iterator_category;
 
@@ -210,7 +209,7 @@ struct join_iterator {
         requires std::bidirectional_iterator<inner_iterator_t>
             &&std::bidirectional_iterator<outer_iterator_t> {
         auto tmp(*this);
-        ++(*this);
+        --(*this);
         return tmp;
     }
     /// @}

--- a/core/include/detray/utils/ranges/pick.hpp
+++ b/core/include/detray/utils/ranges/pick.hpp
@@ -35,10 +35,9 @@ class pick_view : public detray::ranges::view_interface<
                       pick_view<range_itr_t, sequence_itr_t>> {
 
     private:
-    using index_t = typename std::iterator_traits<sequence_itr_t>::value_type;
-    using value_t = typename std::iterator_traits<range_itr_t>::value_type;
-    using difference_t =
-        typename std::iterator_traits<range_itr_t>::difference_type;
+    using index_t = std::iter_value_t<sequence_itr_t>;
+    using value_t = std::iter_value_t<range_itr_t>;
+    using difference_t = std::iter_difference_t<range_itr_t>;
 
     /// @brief Nested iterator to randomly index the elements of a range.
     ///
@@ -49,16 +48,13 @@ class pick_view : public detray::ranges::view_interface<
     ///       needed.
     struct iterator {
 
-        using itr_value_t =
-            typename std::iterator_traits<range_itr_t>::value_type;
-        using itr_ref_t = typename std::iterator_traits<range_itr_t>::reference;
+        using itr_value_t = std::iter_value_t<range_itr_t>;
+        using itr_ref_t = std::iter_reference_t<range_itr_t>;
         using itr_ptr_t = typename std::iterator_traits<range_itr_t>::pointer;
 
-        using difference_type =
-            typename std::iterator_traits<range_itr_t>::difference_type;
+        using difference_type = std::iter_difference_t<range_itr_t>;
         using value_type =
-            std::pair<typename std::iterator_traits<sequence_itr_t>::value_type,
-                      itr_ref_t>;
+            std::pair<std::iter_value_t<sequence_itr_t>, itr_ref_t>;
         using pointer = value_type *;
         using reference = value_type;
         using iterator_category =

--- a/core/include/detray/utils/ranges/ranges.hpp
+++ b/core/include/detray/utils/ranges/ranges.hpp
@@ -73,16 +73,16 @@ template <class R>
 using range_size_t = decltype(detray::ranges::size(std::declval<R&>()));
 
 template <class R>
-using range_difference_t = typename std::iterator_traits<
-    detray::ranges::iterator_t<std::remove_cvref_t<R>>>::difference_type;
+using range_difference_t =
+    std::iter_difference_t<detray::ranges::iterator_t<std::remove_cvref_t<R>>>;
 
 template <class R>
-using range_value_t = typename std::iterator_traits<
-    detray::ranges::iterator_t<std::remove_cvref_t<R>>>::value_type;
+using range_value_t =
+    std::iter_value_t<detray::ranges::iterator_t<std::remove_cvref_t<R>>>;
 
 template <class R>
-using range_reference_t = typename std::iterator_traits<
-    detray::ranges::iterator_t<std::remove_cvref_t<R>>>::reference;
+using range_reference_t =
+    std::iter_reference_t<detray::ranges::iterator_t<std::remove_cvref_t<R>>>;
 
 template <class R>
 using range_const_reference_t = const range_reference_t<R>;

--- a/core/include/detray/utils/ranges/static_join.hpp
+++ b/core/include/detray/utils/ranges/static_join.hpp
@@ -47,7 +47,7 @@ struct static_join_view
     using iterator_coll_t = darray<range_itr_t, I>;
     using iterator_t =
         detray::ranges::detail::static_join_iterator<iterator_coll_t>;
-    using value_t = typename std::iterator_traits<iterator_t>::value_type;
+    using value_t = std::iter_value_t<iterator_t>;
 
     /// Default constructor
     constexpr static_join_view() = default;
@@ -163,11 +163,10 @@ requires std::input_iterator<
 
     using iterator_t = detray::detail::get_value_t<iterator_coll_t>;
 
-    using difference_type =
-        typename std::iterator_traits<iterator_t>::difference_type;
-    using value_type = typename std::iterator_traits<iterator_t>::value_type;
+    using difference_type = std::iter_difference_t<iterator_t>;
+    using value_type = std::iter_value_t<iterator_t>;
     using pointer = typename std::iterator_traits<iterator_t>::pointer;
-    using reference = typename std::iterator_traits<iterator_t>::reference;
+    using reference = std::iter_reference_t<iterator_t>;
     using iterator_category =
         typename std::iterator_traits<iterator_t>::iterator_category;
 

--- a/tests/include/detray/test/validation/detector_scan_utils.hpp
+++ b/tests/include/detray/test/validation/detector_scan_utils.hpp
@@ -91,7 +91,7 @@ inline bool check_connectivity(
     // function it should be sorted, which is the stronger constraint
     using vector_t = decltype(trace);
     using records_iterator_t = typename vector_t::iterator;
-    using index_t = typename vector_t::difference_type;
+    using index_t = std::iter_difference_t<records_iterator_t>;
     std::function<records_iterator_t(index_t)> get_connected_record;
     if constexpr (check_sorted_trace) {
         // Get the next record


### PR DESCRIPTION
In c++20, there are new type aliases for iterator member types, which are both more succinct and safer to use