### PR TITLE
CUDA 12.8 Compatibility, main branch (2025.02.18.)

### DIFF
--- a/core/include/detray/builders/surface_factory.hpp
+++ b/core/include/detray/builders/surface_factory.hpp
@@ -159,10 +159,9 @@ class surface_factory : public surface_factory_interface<detector_t> {
             return {surfaces_offset, surfaces_offset};
         }
 
-        if constexpr (constexpr auto mask_id =
-                          detector_t::masks::template get_id<
-                              mask<mask_shape_t, algebra_t, volume_link_t>>();
-                      static_cast<std::size_t>(mask_id) >=
+        constexpr auto mask_id = detector_t::masks::template get_id<
+            mask<mask_shape_t, algebra_t, volume_link_t>>();
+        if constexpr (static_cast<std::size_t>(mask_id) >=
                       detector_t::masks::n_types) {
 
             throw std::invalid_argument(


### PR DESCRIPTION
Work around bug in the CUDA 12.8 compiler frontend, so that it would accept this piece of code. 😉 Even if the current version of the code is technically better...