### PR TITLE
fix: state tuple type and remove empty states

### DIFF
--- a/core/include/detray/propagator/actor_chain.hpp
+++ b/core/include/detray/propagator/actor_chain.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/propagator/base_actor.hpp"
+#include "detray/utils/tuple.hpp"
 #include "detray/utils/tuple_helpers.hpp"
 
 // System include(s)
@@ -32,11 +33,14 @@ class actor_chain {
 
     public:
     /// Types of the actors that are registered in the chain
-    using actor_list_type = dtuple<actors_t...>;
-    // Tuple of actor states
-    using state_tuple = dtuple<typename actors_t::state...>;
-    // Type of states tuple that is used in the propagator
-    using state = dtuple<typename actors_t::state &...>;
+    using actor_tuple = dtuple<actors_t...>;
+
+    // Tuple of actor states (including states of observing actors, if present)
+    using state_tuple = detail::tuple_cat_t<detail::state_tuple_t<actors_t>...>;
+
+    // Tuple of state references that is used in the propagator
+    using state_ref_tuple =
+        detail::tuple_cat_t<detail::state_ref_tuple_t<actors_t>...>;
 
     /// Call all actors in the chain.
     ///
@@ -50,27 +54,26 @@ class actor_chain {
     }
 
     /// @returns the actor list
-    DETRAY_HOST_DEVICE const actor_list_type &actors() const {
+    DETRAY_HOST_DEVICE constexpr const actor_tuple &actors() const {
         return m_actors;
     }
 
     /// @returns a tuple of default constructible actor states
     DETRAY_HOST_DEVICE
-    static constexpr auto make_actor_states() {
+    static constexpr auto make_default_actor_states() {
         // Only possible if each state is default initializable
-        if constexpr ((std::default_initializable<typename actors_t::state> &&
-                       ...)) {
-            return dtuple<typename actors_t::state...>{};
+        if constexpr (std::default_initializable<state_tuple>) {
+            return state_tuple{};
         } else {
             return std::nullopt;
         }
     }
 
     /// @returns a tuple of reference for every state in the tuple @param t
-    DETRAY_HOST_DEVICE static constexpr state setup_actor_states(
-        dtuple<typename actors_t::state...> &t) {
+    DETRAY_HOST_DEVICE static constexpr state_ref_tuple setup_actor_states(
+        state_tuple &t) {
         return setup_actor_states(
-            t, std::make_index_sequence<sizeof...(actors_t)>{});
+            t, std::make_index_sequence<detail::tuple_size_v<state_tuple>>{});
     }
 
     private:
@@ -99,7 +102,7 @@ class actor_chain {
 
     /// Resolve the actor calls.
     ///
-    /// @param states states of all actors (only bare actors)
+    /// @param states states of all actors
     /// @param p_state the state of the propagator (stepper and navigator)
     template <typename actor_states_t, typename propagator_state_t,
               std::size_t... indices>
@@ -111,14 +114,13 @@ class actor_chain {
 
     /// @returns a tuple of reference for every state in the tuple @param t
     template <std::size_t... indices>
-    DETRAY_HOST_DEVICE static constexpr state setup_actor_states(
-        dtuple<typename actors_t::state...> &t,
-        std::index_sequence<indices...> /*ids*/) {
+    DETRAY_HOST_DEVICE static constexpr state_ref_tuple setup_actor_states(
+        state_tuple &t, std::index_sequence<indices...> /*ids*/) {
         return detray::tie(detail::get<indices>(t)...);
     }
 
     /// Tuple of actors
-    actor_list_type m_actors = {};
+    [[no_unique_address]] actor_tuple m_actors = {};
 };
 
 /// Empty actor chain (placeholder)
@@ -126,7 +128,10 @@ template <>
 class actor_chain<> {
 
     public:
+    using actor_tuple = dtuple<>;
     using state_tuple = dtuple<>;
+    using state_ref_tuple = dtuple<>;
+
     /// Empty states replaces a real actor states container
     struct state {};
 
@@ -135,13 +140,13 @@ class actor_chain<> {
     /// @param states the states of the actors.
     /// @param p_state the propagation state.
     template <typename actor_states_t, typename propagator_state_t>
-    DETRAY_HOST_DEVICE void operator()(actor_states_t & /*states*/,
-                                       propagator_state_t & /*p_state*/) const {
+    DETRAY_HOST_DEVICE constexpr void operator()(
+        actor_states_t & /*states*/, propagator_state_t & /*p_state*/) const {
         /*Do nothing*/
     }
 
     /// @returns an empty state
-    DETRAY_HOST_DEVICE static constexpr state setup_actor_states(
+    DETRAY_HOST_DEVICE static constexpr state_ref_tuple setup_actor_states(
         const state_tuple &) {
         return {};
     }

--- a/core/include/detray/propagator/base_actor.hpp
+++ b/core/include/detray/propagator/base_actor.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -28,25 +28,80 @@ struct actor {
     struct state {};
 };
 
+namespace detail {
+/// Extrac the tuple of actor states from an actor type
+/// @{
+// Simple actor: No observers
+template <typename actor_t>
+struct get_state_tuple {
+    private:
+    using state_t = typename actor_t::state;
+
+    // Remove empty default state of base actor type from tuple
+    using principal = std::conditional_t<std::same_as<state_t, actor::state>,
+                                         dtuple<>, dtuple<state_t>>;
+    using principal_ref =
+        std::conditional_t<std::same_as<state_t, actor::state>, dtuple<>,
+                           dtuple<state_t &>>;
+
+    public:
+    using type = principal;
+    using ref_type = principal_ref;
+};
+
+// Composite actor: Has observers
+template <typename actor_t>
+requires(!std::same_as<typename std::remove_cvref_t<actor_t>::observer_states,
+                       void>) struct get_state_tuple<actor_t> {
+    private:
+    using principal_actor_t = typename actor_t::actor_type;
+
+    using principal = typename get_state_tuple<principal_actor_t>::type;
+    using principal_ref = typename get_state_tuple<principal_actor_t>::ref_type;
+
+    using observers = typename actor_t::observer_states;
+    using observer_refs = typename actor_t::observer_state_refs;
+
+    public:
+    using type = detail::tuple_cat_t<principal, observers>;
+    using ref_type = detail::tuple_cat_t<principal_ref, observer_refs>;
+};
+
+/// Tuple of state types
+template <typename actor_t>
+using state_tuple_t = get_state_tuple<actor_t>::type;
+
+/// Tuple of references
+template <typename actor_t>
+using state_ref_tuple_t = get_state_tuple<actor_t>::ref_type;
+/// @}
+
+}  // namespace detail
+
 /// Composition of actors
 ///
 /// The composition represents an actor together with its observers. In
 /// addition to running its own implementation, it notifies its observing actors
 ///
-/// @tparam actor_impl_t the actor the compositions implements itself.
+/// @tparam principal_actor_t the actor the compositions implements itself.
 /// @tparam observers a pack of observing actors that get called on the updated
 ///         actor state of the compositions actor implementation.
-template <class actor_impl_t = actor, typename... observers>
-class composite_actor final : public actor_impl_t {
+template <class principal_actor_t = actor, typename... observers>
+class composite_actor final : public principal_actor_t {
 
     public:
     /// Tag whether this is a composite type (hides the def in the actor)
     struct is_comp_actor : public std::true_type {};
 
-    /// The composite is an actor in itself. For simplicity, it cannot be
-    /// derived from another composition (final).
-    using actor_type = actor_impl_t;
+    /// The composite is an actor in itself.
+    using actor_type = principal_actor_t;
     using state = typename actor_type::state;
+
+    /// Tuple of states of observing actors
+    using observer_states =
+        detail::tuple_cat_t<detail::state_tuple_t<observers>...>;
+    using observer_state_refs =
+        detail::tuple_cat_t<detail::state_ref_tuple_t<observers>...>;
 
     /// Call to the implementation of the actor (the actor possibly being an
     /// observer itself)
@@ -133,7 +188,7 @@ class composite_actor final : public actor_impl_t {
     }
 
     /// Keep the observers (might be composites again)
-    dtuple<observers...> m_observers = {};
+    [[no_unique_address]] dtuple<observers...> m_observers = {};
 };
 
 }  // namespace detray

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -150,9 +150,9 @@ struct propagator {
     ///
     /// @note If the return value of this function is true, a propagation step
     /// can be taken afterwards.
+    template <typename actor_states_t>
     DETRAY_HOST_DEVICE void propagate_init(
-        state &propagation,
-        typename actor_chain_t::state actor_state_refs) const {
+        state &propagation, actor_states_t actor_state_refs) const {
         auto &navigation = propagation._navigation;
         auto &stepping = propagation._stepping;
         auto &context = propagation._context;
@@ -179,9 +179,10 @@ struct propagator {
     ///
     /// @note If the return value of this function is true, another step can
     /// be taken afterwards.
+    template <typename actor_states_t>
     DETRAY_HOST_DEVICE bool propagate_step(
         state &propagation, bool is_init,
-        typename actor_chain_t::state actor_state_refs) const {
+        actor_states_t actor_state_refs) const {
         auto &navigation = propagation._navigation;
         auto &stepping = propagation._stepping;
         auto &context = propagation._context;
@@ -242,9 +243,10 @@ struct propagator {
     /// @param actor_state_refs tuple containing refences to the actor states
     ///
     /// @return propagation success.
+    template <typename actor_states_t>
     DETRAY_HOST_DEVICE bool propagate(
         state &propagation,
-        typename actor_chain_t::state actor_state_refs) const {
+        actor_states_t actor_state_refs = dtuple<>{}) const {
 
         propagate_init(propagation, actor_state_refs);
         bool is_init = true;
@@ -278,9 +280,9 @@ struct propagator {
     /// @param actor_states the actor state
     ///
     /// @return propagation success.
+    template <typename actor_states_t>
     DETRAY_HOST_DEVICE bool propagate_sync(
-        state &propagation,
-        typename actor_chain_t::state actor_state_refs) const {
+        state &propagation, actor_states_t actor_state_refs) const {
 
         propagate_init(propagation, actor_state_refs);
         bool is_init = true;

--- a/core/include/detray/utils/tuple_helpers.hpp
+++ b/core/include/detray/utils/tuple_helpers.hpp
@@ -168,4 +168,35 @@ template <typename T, class tuple_t>
 constexpr bool has_type_v = has_type<T, tuple_t>::value;
 ///@}
 
+/// Concatenate tuple types
+/// @{
+template <typename... tuple_ts>
+struct tuple_cat_type {};
+
+template <typename... Args>
+struct tuple_cat_type<std::tuple<Args...>> {
+    using type = std::tuple<Args...>;
+};
+
+template <typename... Args1, typename... Args2, typename... tuple_ts>
+struct tuple_cat_type<std::tuple<Args1...>, std::tuple<Args2...>, tuple_ts...> {
+    using type = typename tuple_cat_type<std::tuple<Args1..., Args2...>,
+                                         tuple_ts...>::type;
+};
+
+template <typename... Args>
+struct tuple_cat_type<dtuple<Args...>> {
+    using type = dtuple<Args...>;
+};
+
+template <typename... Args1, typename... Args2, typename... tuple_ts>
+struct tuple_cat_type<dtuple<Args1...>, dtuple<Args2...>, tuple_ts...> {
+    using type =
+        typename tuple_cat_type<dtuple<Args1..., Args2...>, tuple_ts...>::type;
+};
+
+template <typename... tuple_ts>
+using tuple_cat_t = typename tuple_cat_type<tuple_ts...>::type;
+/// @}
+
 }  // namespace detray::detail

--- a/tests/benchmarks/cpu/propagation.cpp
+++ b/tests/benchmarks/cpu/propagation.cpp
@@ -112,12 +112,9 @@ int main(int argc, char** argv) {
 
     dtuple<> empty_state{};
 
-    parameter_transporter<test_algebra>::state transporter_state{};
     pointwise_material_interactor<test_algebra>::state interactor_state{};
-    parameter_resetter<test_algebra>::state resetter_state{};
 
-    auto actor_states = detail::make_tuple<dtuple>(
-        transporter_state, interactor_state, resetter_state);
+    auto actor_states = detail::make_tuple<dtuple>(interactor_state);
 
     //
     // Register benchmarks

--- a/tests/benchmarks/cuda/propagation.cpp
+++ b/tests/benchmarks/cuda/propagation.cpp
@@ -107,12 +107,9 @@ int main(int argc, char** argv) {
 
     dtuple<> empty_state{};
 
-    parameter_transporter<test_algebra>::state transporter_state{};
     pointwise_material_interactor<test_algebra>::state interactor_state{};
-    parameter_resetter<test_algebra>::state resetter_state{};
 
-    auto actor_states = detail::make_tuple<dtuple>(
-        transporter_state, interactor_state, resetter_state);
+    auto actor_states = detail::make_tuple<dtuple>(interactor_state);
 
     //
     // Register benchmarks

--- a/tests/benchmarks/include/detray/benchmarks/cpu/propagation_benchmark.hpp
+++ b/tests/benchmarks/include/detray/benchmarks/cpu/propagation_benchmark.hpp
@@ -105,7 +105,7 @@ struct host_propagation_bm : public benchmark_base {
             // Fresh copy of actor states
             actor_states_t actor_states(*input_actor_states);
             // Tuple of references to pass to the propagator
-            typename actor_chain_t::state actor_state_refs =
+            typename actor_chain_t::state_ref_tuple actor_state_refs =
                 actor_chain_t::setup_actor_states(actor_states);
 
             typename propagator_t::state p_state(track, *bfield, *det);

--- a/tests/include/detray/test/device/cuda/material_validation.cu
+++ b/tests/include/detray/test/device/cuda/material_validation.cu
@@ -62,14 +62,11 @@ __global__ void material_validation_kernel(
 
     // Create the actor states
     typename pathlimit_aborter_t::state aborter_state{cfg.stepping.path_limit};
-    typename parameter_transporter<algebra_t>::state transporter_state{};
-    typename parameter_resetter<algebra_t>::state resetter_state{};
     typename pointwise_material_interactor<algebra_t>::state interactor_state{};
     typename material_tracer_t::state mat_tracer_state{mat_steps.at(trk_id)};
 
     auto actor_states =
-        ::detray::tie(aborter_state, transporter_state, resetter_state,
-                      interactor_state, mat_tracer_state);
+        ::detray::tie(aborter_state, interactor_state, mat_tracer_state);
 
     // Run propagation
     typename navigator_t::state::view_type nav_view{};

--- a/tests/include/detray/test/device/propagator_test.hpp
+++ b/tests/include/detray/test/device/propagator_test.hpp
@@ -134,12 +134,9 @@ inline auto run_propagation_host(vecmem::memory_resource *mr,
         tracer_state.collect_only_on_surface(true);
         typename pathlimit_aborter_t::state pathlimit_state{
             cfg.stepping.path_limit};
-        parameter_transporter<test_algebra>::state transporter_state{};
         pointwise_material_interactor<test_algebra>::state interactor_state{};
-        parameter_resetter<test_algebra>::state resetter_state{};
         auto actor_states =
-            detray::tie(tracer_state, pathlimit_state, transporter_state,
-                        interactor_state, resetter_state);
+            detray::tie(tracer_state, pathlimit_state, interactor_state);
 
         typename propagator_host_t::state state(trk, field, det);
 

--- a/tests/include/detray/test/utils/simulation/random_scatterer.hpp
+++ b/tests/include/detray/test/utils/simulation/random_scatterer.hpp
@@ -67,13 +67,11 @@ struct random_scatterer : actor {
     /// Material store visitor
     struct kernel {
 
-        using state = typename random_scatterer::state;
-
         template <typename mat_group_t, typename index_t>
         DETRAY_HOST_DEVICE inline bool operator()(
             [[maybe_unused]] const mat_group_t& material_group,
             [[maybe_unused]] const index_t& mat_index,
-            [[maybe_unused]] state& s,
+            [[maybe_unused]] typename random_scatterer::state& s,
             [[maybe_unused]] const pdg_particle<scalar_type>& ptc,
             [[maybe_unused]] const bound_track_parameters<algebra_t>&
                 bound_params,

--- a/tests/include/detray/test/validation/material_validation_utils.hpp
+++ b/tests/include/detray/test/validation/material_validation_utils.hpp
@@ -183,10 +183,9 @@ struct material_tracer : detray::actor {
 
         // Get the local track position from the bound track parameters,
         // if covariance transport is enabled in the propagation
-        if constexpr (detail::has_type_v<
-                          typename parameter_transporter<algebra_t>::state &,
-                          typename propagator_state_t::actor_chain_type::
-                              state>) {
+        if constexpr (detail::has_type_v<parameter_transporter<algebra_t>,
+                                         typename propagator_state_t::
+                                             actor_chain_type::actor_tuple>) {
             const auto &track_param = prop_state._stepping.bound_params();
             loc_pos = track_param.bound_local();
         } else {
@@ -251,14 +250,11 @@ inline auto record_material(
     // Build actor and propagator states
     typename pathlimit_aborter_t::state pathlimit_aborter_state{
         cfg.stepping.path_limit};
-    typename parameter_transporter<algebra_t>::state transporter_state{};
-    typename parameter_resetter<algebra_t>::state resetter_state{};
     typename pointwise_material_interactor<algebra_t>::state interactor_state{};
     typename material_tracer_t::state mat_tracer_state{*host_mr};
 
-    auto actor_states =
-        detray::tie(pathlimit_aborter_state, transporter_state, resetter_state,
-                    interactor_state, mat_tracer_state);
+    auto actor_states = detray::tie(pathlimit_aborter_state, interactor_state,
+                                    mat_tracer_state);
 
     typename propagator_t::state propagation{track, det, cfg.context};
 

--- a/tests/integration_tests/cpu/material/material_interaction.cpp
+++ b/tests/integration_tests/cpu/material/material_interaction.cpp
@@ -97,13 +97,10 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
         geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
 
     pathlimit_aborter_t::state aborter_state{};
-    parameter_transporter<test_algebra>::state bound_updater{};
     interactor_t::state interactor_state{};
-    parameter_resetter<test_algebra>::state parameter_resetter_state{};
 
     // Create actor states tuples
-    auto actor_states = detray::tie(aborter_state, bound_updater,
-                                    interactor_state, parameter_resetter_state);
+    auto actor_states = detray::tie(aborter_state, interactor_state);
 
     propagator_t::state state(bound_param, det);
     state.do_debug = true;
@@ -227,16 +224,12 @@ GTEST_TEST(detray_material, telescope_geometry_scattering_angle) {
     for (std::size_t i = 0u; i < n_samples; i++) {
 
         pathlimit_aborter_t::state aborter_state{};
-        parameter_transporter<test_algebra>::state bound_updater{};
         // Seed = sample id
         simulator_t::state simulator_state{i};
         simulator_state.do_energy_loss = false;
-        parameter_resetter<test_algebra>::state parameter_resetter_state{};
 
         // Create actor states tuples
-        auto actor_states =
-            detray::tie(aborter_state, bound_updater, simulator_state,
-                        parameter_resetter_state);
+        auto actor_states = detray::tie(aborter_state, simulator_state);
 
         propagator_t::state state(bound_param, det);
         state.do_debug = true;

--- a/tests/integration_tests/cpu/propagator/backward_propagation.cpp
+++ b/tests/integration_tests/cpu/propagator/backward_propagation.cpp
@@ -90,9 +90,7 @@ TEST_P(BackwardPropagation, backward_propagation) {
         geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
 
     // Actors
-    parameter_transporter<test_algebra>::state bound_updater{};
     pointwise_material_interactor<test_algebra>::state interactor{};
-    parameter_resetter<test_algebra>::state rst{};
 
     propagation::config prop_cfg{};
     prop_cfg.stepping.rk_error_tol = 1e-12f * unit<float>::mm;
@@ -106,7 +104,7 @@ TEST_P(BackwardPropagation, backward_propagation) {
     fw_state.do_debug = true;
 
     // Run propagator
-    p.propagate(fw_state, detray::tie(bound_updater, interactor, rst));
+    p.propagate(fw_state, detray::tie(interactor));
 
     // Print the debug stream
     // std::cout << fw_state.debug_stream.str() << std::endl;
@@ -129,7 +127,7 @@ TEST_P(BackwardPropagation, backward_propagation) {
     bw_state._navigation.set_direction(navigation::direction::e_backward);
 
     // Run propagator
-    p.propagate(bw_state, detray::tie(bound_updater, interactor, rst));
+    p.propagate(bw_state, detray::tie(interactor));
 
     // Print the debug stream
     // std::cout << bw_state.debug_stream.str() << std::endl;

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -473,13 +473,10 @@ bound_getter<test_algebra>::state evaluate_bound_param(
     propagator_t p(cfg);
 
     // Actor states
-    parameter_transporter<test_algebra>::state transporter_state{};
     bound_getter<test_algebra>::state bound_getter_state{};
     bound_getter_state.track_ID = trk_count;
     bound_getter_state.m_min_path_length = detector_length * 0.75f;
-    parameter_resetter<test_algebra>::state resetter_state{};
-    auto actor_states =
-        detray::tie(transporter_state, bound_getter_state, resetter_state);
+    auto actor_states = detray::tie(bound_getter_state);
 
     // Init propagator states for the reference track
     typename propagator_t::state state(initial_param, field, det);
@@ -524,14 +521,11 @@ bound_param_vector_type get_displaced_bound_vector(
     typename propagator_t::state dstate(dparam, field, det);
 
     // Actor states
-    parameter_transporter<test_algebra>::state transporter_state{};
-    parameter_resetter<test_algebra>::state resetter_state{};
     bound_getter<test_algebra>::state bound_getter_state{};
     bound_getter_state.track_ID = trk_count;
     bound_getter_state.m_min_path_length = detector_length * 0.75f;
 
-    auto actor_states =
-        detray::tie(transporter_state, bound_getter_state, resetter_state);
+    auto actor_states = detray::tie(bound_getter_state);
     dstate.set_particle(ptc);
     dstate._stepping
         .template set_constraint<detray::step::constraint::e_accuracy>(

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -235,9 +235,9 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
         track_t lim_track(track);
 
         // Build actor states: the helix inspector can be shared
-        auto actor_states = actor_chain_t::make_actor_states();
-        auto actor_states_lim = actor_chain_t::make_actor_states();
-        auto actor_states_sync = actor_chain_t::make_actor_states();
+        auto actor_states = actor_chain_t::make_default_actor_states();
+        auto actor_states_lim = actor_chain_t::make_default_actor_states();
+        auto actor_states_sync = actor_chain_t::make_default_actor_states();
 
         // Make sure the lim state is being terminated
         auto& pathlimit_aborter_state =
@@ -341,17 +341,13 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
         // Build actor states: the helix inspector can be shared
         pathlimit_aborter<scalar>::state unlimted_aborter_state{};
         pathlimit_aborter<scalar>::state pathlimit_aborter_state{path_limit};
-        parameter_transporter<test_algebra>::state transporter_state{};
         pointwise_material_interactor<test_algebra>::state interactor_state{};
-        parameter_resetter<test_algebra>::state resetter_state{};
 
         // Create actor states tuples
         auto actor_states =
-            detray::tie(unlimted_aborter_state, transporter_state,
-                        interactor_state, resetter_state);
+            detray::tie(unlimted_aborter_state, interactor_state);
         auto lim_actor_states =
-            detray::tie(pathlimit_aborter_state, transporter_state,
-                        interactor_state, resetter_state);
+            detray::tie(pathlimit_aborter_state, interactor_state);
 
         // Init propagator states
         propagator_t::state state(track, bfield, det);

--- a/tests/integration_tests/device/cuda/propagator_cuda_kernel.cu
+++ b/tests/integration_tests/device/cuda/propagator_cuda_kernel.cu
@@ -51,14 +51,11 @@ __global__ void propagator_test_kernel(
     step_tracer_device_t::state tracer_state(steps.at(gid));
     tracer_state.collect_only_on_surface(true);
     pathlimit_aborter_t::state aborter_state{cfg.stepping.path_limit};
-    parameter_transporter<test_algebra>::state transporter_state{};
     pointwise_material_interactor<test_algebra>::state interactor_state{};
-    parameter_resetter<test_algebra>::state resetter_state{};
 
     // Create the actor states
     auto actor_states =
-        ::detray::tie(tracer_state, aborter_state, transporter_state,
-                      interactor_state, resetter_state);
+        ::detray::tie(tracer_state, aborter_state, interactor_state);
     // Create the propagator state
     typename propagator_device_t::state state(tracks[gid], field_data, det);
 

--- a/tests/integration_tests/device/sycl/propagator_kernel.sycl
+++ b/tests/integration_tests/device/sycl/propagator_kernel.sycl
@@ -66,15 +66,12 @@ void propagator_test(
                 tracer_state.collect_only_on_surface(true);
                 pathlimit_aborter_t::state aborter_state{
                     cfg.stepping.path_limit};
-                parameter_transporter<test_algebra>::state transporter_state{};
                 pointwise_material_interactor<test_algebra>::state
                     interactor_state{};
-                parameter_resetter<test_algebra>::state resetter_state{};
 
                 // Create the actor states
                 auto actor_states = ::detray::tie(
-                    tracer_state, aborter_state, transporter_state,
-                    interactor_state, resetter_state);
+                    tracer_state, aborter_state, interactor_state);
                 // Create the propagator state
                 typename propagator_device_t::state state(tracks[gid],
                                                           field_data, dev_det);

--- a/tests/tools/src/cpu/propagation_benchmark.cpp
+++ b/tests/tools/src/cpu/propagation_benchmark.cpp
@@ -149,12 +149,9 @@ int main(int argc, char** argv) {
     // Build actor states
     dtuple<> empty_state{};
 
-    parameter_transporter<test_algebra>::state transporter_state{};
     pointwise_material_interactor<test_algebra>::state interactor_state{};
-    parameter_resetter<test_algebra>::state resetter_state{};
 
-    auto actor_states = detail::make_tuple<dtuple>(
-        transporter_state, interactor_state, resetter_state);
+    auto actor_states = detail::make_tuple<dtuple>(interactor_state);
 
     //
     // Register benchmarks

--- a/tests/tools/src/cpu/propagation_scaling.cpp
+++ b/tests/tools/src/cpu/propagation_scaling.cpp
@@ -177,12 +177,9 @@ int main(int argc, char** argv) {
     // Build actor states
     dtuple<> empty_state{};
 
-    parameter_transporter<test_algebra>::state transporter_state{};
     pointwise_material_interactor<test_algebra>::state interactor_state{};
-    parameter_resetter<test_algebra>::state resetter_state{};
 
-    auto actor_states = detail::make_tuple<dtuple>(
-        transporter_state, interactor_state, resetter_state);
+    auto actor_states = detail::make_tuple<dtuple>(interactor_state);
 
     //
     // Register benchmarks

--- a/tests/tools/src/cuda/propagation_benchmark_cuda.cpp
+++ b/tests/tools/src/cuda/propagation_benchmark_cuda.cpp
@@ -144,12 +144,9 @@ int main(int argc, char** argv) {
     // Build actor states
     dtuple<> empty_state{};
 
-    parameter_transporter<test_algebra>::state transporter_state{};
     pointwise_material_interactor<test_algebra>::state interactor_state{};
-    parameter_resetter<test_algebra>::state resetter_state{};
 
-    auto actor_states = detail::make_tuple<dtuple>(
-        transporter_state, interactor_state, resetter_state);
+    auto actor_states = detail::make_tuple<dtuple>(interactor_state);
 
     //
     // Register benchmarks

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -92,17 +92,13 @@ GTEST_TEST(detray_propagator, covariance_transport) {
     const bound_track_parameters<test_algebra> bound_param0(
         geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
 
-    // Actors
-    parameter_transporter<test_algebra>::state bound_updater{};
-    parameter_resetter<test_algebra>::state rst{};
-
     propagation::config prop_cfg{};
     prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
     propagator_t p{prop_cfg};
     propagator_t::state propagation(bound_param0, det, prop_cfg.context);
 
     // Run propagator
-    p.propagate(propagation, detray::tie(bound_updater, rst));
+    p.propagate(propagation);
 
     // Bound state after one turn propagation
     const auto& bound_param1 = propagation._stepping.bound_params();

--- a/tutorials/src/device/cuda/propagation_kernel.cu
+++ b/tutorials/src/device/cuda/propagation_kernel.cu
@@ -40,12 +40,9 @@ __global__ void propagation_kernel(
 
     // Create actor states
     detray::pathlimit_aborter<scalar>::state aborter_state{path_limit};
-    detray::parameter_transporter<algebra_t>::state transporter_state{};
     detray::pointwise_material_interactor<algebra_t>::state interactor_state{};
-    detray::parameter_resetter<algebra_t>::state resetter_state{};
 
-    auto actor_states = detray::tie(aborter_state, transporter_state,
-                                    interactor_state, resetter_state);
+    auto actor_states = detray::tie(aborter_state, interactor_state);
 
     // Create the propagator state for the track
     detray::tutorial::propagator_t::state state(tracks[gid], field_data, det);


### PR DESCRIPTION
This PR ensures that the local state tuple type in the actor chain also contains the states of all observing actors in a flattened tuple. At the same time, it makes sure that empty default states are not included and therefore also do not need to be passed to the propagator. Consequently, the empty states were removed everywhere now.
In the propagator the actor state tuple type is auto deduced, so that we do not depend on the order of actors in the chain anymore (this will simplify the KF in traccc).