### PR TITLE
Fix: Calculation of surface finding efficiency per type

### DIFF
--- a/tests/include/detray/test/cpu/navigation_validation.hpp
+++ b/tests/include/detray/test/cpu/navigation_validation.hpp
@@ -95,9 +95,16 @@ class navigation_validation : public test::fixture_base<> {
         const std::string truth_data_name{
             k_use_rays ? det_name + "_ray_scan" : det_name + "_helix_scan"};
 
-        /// Collect some statistics
-        std::size_t n_tracks{0u}, n_surfaces{0u}, n_miss_nav{0u},
-            n_miss_truth{0u}, n_matching_error{0u}, n_fatal{0u};
+        // Collect some statistics
+        std::size_t n_tracks{0u};
+        std::size_t n_matching_error{0u};
+        std::size_t n_fatal{0u};
+        // Total number of encountered surfaces
+        navigation_validator::surface_stats n_surfaces{};
+        // Missed by navigator
+        navigation_validator::surface_stats n_miss_nav{};
+        // Missed by truth finder
+        navigation_validator::surface_stats n_miss_truth{};
 
         std::cout << "\nINFO: Fetching data from white board..." << std::endl;
         if (!m_cfg.whiteboard()->exists(truth_data_name)) {
@@ -219,8 +226,33 @@ class navigation_validation : public test::fixture_base<> {
 
             ++n_tracks;
 
+            // After dummy records insertion, traces should have the same size
             ASSERT_EQ(truth_trace.size(), recorded_traces.back().size());
-            n_surfaces += truth_trace.size();
+
+            // Count the number of different surface types on this trace
+            navigation_validator::surface_stats n_truth{};
+            navigation_validator::surface_stats n_nav{};
+            for (std::size_t i = 0; i < truth_trace.size(); ++i) {
+                n_truth.count(truth_trace[i].intersection.sf_desc);
+                n_nav.count(recorded_traces.back()[i].intersection.sf_desc);
+            }
+
+            // Take max count, since either trace might have skipped surfaces
+            const std::size_t n_portals{
+                math::max(n_truth.n_portals, n_nav.n_portals)};
+            const std::size_t n_sensitives{
+                math::max(n_truth.n_sensitives, n_nav.n_sensitives)};
+            // The first record is for bookkeeping and not a real passive
+            const std::size_t n_passives{
+                math::max(n_truth.n_passives, n_nav.n_passives) - 1u};
+            const std::size_t n{n_portals + n_sensitives + n_passives};
+
+            // Cannot have more surfaces than truth intersections after matching
+            ASSERT_EQ(n, truth_trace.size() - 1u);
+
+            n_surfaces.n_portals += n_portals;
+            n_surfaces.n_sensitives += n_sensitives;
+            n_surfaces.n_passives += n_passives;
         }
 
         // Calculate and display the result

--- a/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -8,25 +8,37 @@
 #pragma once
 
 // Project include(s)
+#include "detray/geometry/barcode.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/actors/aborters.hpp"
 #include "detray/propagator/propagator.hpp"
 #include "detray/tracks/free_track_parameters.hpp"
+#include "detray/tracks/helix.hpp"
 
 // Detray IO include(s)
+#include "detray/io/csv/intersection2D.hpp"
+#include "detray/io/csv/track_parameters.hpp"
 #include "detray/io/utils/file_handle.hpp"
 
 // Detray test include(s)
 #include "detray/test/utils/inspectors.hpp"
+#include "detray/test/validation/detector_scan_utils.hpp"
 #include "detray/test/validation/material_validation_utils.hpp"
 #include "detray/test/validation/step_tracer.hpp"
+
+// Detray plugin include(s)
+#include "detray/plugins/svgtools/styling/styling.hpp"
+
+// GTest include(s).
+#include <gtest/gtest.h>
 
 // System include(s)
 #include <algorithm>
 #include <iomanip>
 #include <iterator>
 #include <memory>
+#include <ranges>
 #include <sstream>
 
 namespace detray::navigation_validator {
@@ -47,9 +59,14 @@ struct surface_stats {
 
     /// Count a surface depending on its type
     /// @returns true of the surface type was recognized
+    /// @{
     template <typename sf_descriptor_t>
     bool count(const sf_descriptor_t &sf_desc) {
-        switch (sf_desc.id()) {
+        return count(sf_desc.barcode());
+    }
+
+    bool count(geometry::barcode bcd) {
+        switch (bcd.id()) {
             using enum surface_id;
             case e_portal: {
                 n_portals++;
@@ -66,8 +83,9 @@ struct surface_stats {
             default: {
                 return false;
             }
-        };
+        }
     }
+    /// @}
 
     /// Count up
     surface_stats &operator+=(const surface_stats &other) {
@@ -77,6 +95,16 @@ struct surface_stats {
 
         return *this;
     }
+};
+
+/// Statistics on tracks with holes and extra surfaces
+struct track_statistics {
+    std::size_t n_tracks{0u};
+    std::size_t n_tracks_w_holes{0u};  //< Number of tracks with missing surface
+    std::size_t n_tracks_w_extra{0u};  //< Number of tracks with extra surfaces
+    std::size_t n_good_tracks{0u};     //< Number of tracks that match exactly
+    std::size_t n_max_missed_per_trk{0u};  //< Max hole count
+    std::size_t n_max_extra_per_trk{0u};   //< Max count of additional sf
 };
 
 /// Run the propagation and record test data along the way
@@ -161,23 +189,350 @@ inline auto record_propagation(
         std::move(nav_printer), std::move(step_printer));
 }
 
-/// Compare the recorded intersection trace to the truth trace
+/// Compare the recorded intersection trace in @param recorded_trace
+/// to the truth trace in @param truth_trace
+///
+/// This function gathers and displays some statistics about missed and
+/// additional surfaces in the recorded trace and provides detailed outputs
+/// in case the traces do not match. If a hole is discovered in either trace,
+/// a dummy record is added, so that both traces have the same length in the
+/// end.
+///
+/// @param traj initial track parameters at the bginning of the track
+/// @param trk_no number of the track in the sample
+/// @param total_n_trks total number of tracks in the sample
+/// @param debug_file where to output debugging information to
+///
+/// @returns the counts on missed and additional surfaces, matching errorsm
+/// as well as the collections of the intersections that did not match
 template <typename truth_trace_t, typename recorded_trace_t, typename traj_t>
 auto compare_traces(truth_trace_t &truth_trace,
                     recorded_trace_t &recorded_trace, const traj_t &traj,
                     std::size_t trk_no, std::size_t total_n_trks,
-                    std::fstream *debug_file = nullptr) {
+                    std::fstream *debug_file = nullptr,
+                    const bool fail_on_diff = true, const bool verbose = true) {
 
     using nav_record_t = typename recorded_trace_t::value_type;
     using truth_record_t = typename truth_trace_t::value_type;
     using intersection_t = typename truth_record_t::intersection_type;
 
+    // Current number of entries to compare (may become more if both traces
+    // missed several surfaces)
+    std::size_t max_entries{
+        math::max(recorded_trace.size(), truth_trace.size())};
+
+    // Catch some debug output
     std::stringstream debug_stream;
     std::stringstream matching_stream;
-    std::size_t n_inters_nav{recorded_trace.size()};
-    std::size_t max_entries{math::max(n_inters_nav, truth_trace.size())};
 
-    // Fill the debug stream with the information from both traces
+    // Collect some statistics and additional data
+    surface_stats n_miss_nav{};
+    surface_stats n_miss_truth{};
+    bool matching_traces{true};
+    std::size_t n_errors{0u};
+    std::vector<intersection_t> missed_intersections{};
+
+    // An error might have occured occured
+    auto handle_counting_error = [&matching_stream,
+                                  &n_errors](const bool is_OK) {
+        if (!is_OK) {
+            matching_stream << "FATAL: Encountered surface of "
+                               "unknown type in intersection "
+                               "trace. Validate the geometry";
+            ++n_errors;
+        }
+    };
+
+    // Iterate until 'max_entries', because dummy records will be added to the
+    // shorter trace
+    for (long i = 0; i < static_cast<long>(max_entries); ++i) {
+
+        // Check the records at the current index
+        const auto idx{static_cast<std::size_t>(i)};
+
+        // If only sensitives are collected and the recorded trace has one
+        // entry less than the truth trace, the navigator missed the last
+        // sensitive surface
+        const bool nav_has_next = (idx < recorded_trace.size());
+        detray::geometry::barcode nav_inters{};
+        if (nav_has_next) {
+            nav_inters = recorded_trace[idx].intersection.sf_desc.barcode();
+        }
+
+        const bool truth_has_next = (idx < truth_trace.size());
+        detray::geometry::barcode truth_inters{};
+        if (truth_has_next) {
+            truth_inters = truth_trace[idx].intersection.sf_desc.barcode();
+        }
+
+        // Check if size of traces is still in sync and records match
+        bool found_same_surfaces =
+            (nav_has_next && truth_has_next && (nav_inters == truth_inters));
+
+        matching_traces &= found_same_surfaces;
+
+        if (!found_same_surfaces) {
+
+            // Save number of missed surfaces in the navigation trace so far
+            long missed_pt_nav{static_cast<long>(n_miss_nav.n_portals)};
+            long missed_sn_nav{static_cast<long>(n_miss_nav.n_sensitives)};
+            long missed_ps_nav{static_cast<long>(n_miss_nav.n_passives)};
+
+            // Save number of missed surfaces in the truth trace so far
+            long missed_pt_tr{static_cast<long>(n_miss_truth.n_portals)};
+            long missed_sn_tr{static_cast<long>(n_miss_truth.n_sensitives)};
+            long missed_ps_tr{static_cast<long>(n_miss_truth.n_passives)};
+
+            // Intersection records at portal boundary might be flipped
+            // (the portals overlap completely)
+            auto is_swapped_portals = [&recorded_trace,
+                                       &truth_trace](const long j) {
+                const auto idx_j{static_cast<std::size_t>(j)};
+                const std::size_t next_idx{idx_j + 1u};
+
+                if (next_idx < truth_trace.size() &&
+                    next_idx < recorded_trace.size()) {
+
+                    const auto &current_nav_inters =
+                        recorded_trace[idx_j].intersection.sf_desc.barcode();
+                    const auto &current_truth_inters =
+                        truth_trace[idx_j].intersection.sf_desc.barcode();
+
+                    const auto &next_nav_inters =
+                        recorded_trace[next_idx].intersection.sf_desc.barcode();
+                    const auto &next_truth_inters =
+                        truth_trace[next_idx].intersection.sf_desc.barcode();
+
+                    return ((current_nav_inters == next_truth_inters) &&
+                            (next_nav_inters == current_truth_inters));
+                } else {
+                    return false;
+                }
+            };
+
+            // Compare two traces and insert dummy records for any skipped cand.
+            auto compare_and_equalize =
+                [&i, &handle_counting_error, &is_swapped_portals,
+                 &missed_intersections]<typename trace_t,
+                                        typename other_trace_t>(
+                    trace_t &trace, typename trace_t::iterator last_missed_itr,
+                    other_trace_t &other_trace, surface_stats &n_miss_stat,
+                    long int &missed_pt, long int &missed_sn,
+                    long int &missed_ps) {
+                    // The navigator missed a(multiple) surface(s)
+                    auto first_missed = std::begin(trace) + i;
+                    const auto n_check{
+                        std::distance(first_missed, last_missed_itr)};
+                    assert(n_check > 0);
+
+                    // Check and record surfaces that were missed: Insert dummy
+                    // records until traces align again
+                    for (long j = i; j < i + n_check; ++j) {
+                        const auto &sfi =
+                            trace[static_cast<std::size_t>(j)].intersection;
+
+                        // Portals may be swapped and wrongfully included in the
+                        // range of missed surfaces - skip them
+                        if (sfi.sf_desc.is_portal() && is_swapped_portals(j)) {
+                            ++j;
+                            continue;
+                        }
+                        // Record the missed intersections fro later analysis
+                        missed_intersections.push_back(sfi);
+                        // Insert dummy record to match the truth trace size
+                        using record_t = typename other_trace_t::value_type;
+                        other_trace.insert(other_trace.begin() + i, record_t{});
+
+                        // Count this missed intersection depending on sf. type
+                        const bool valid{n_miss_stat.count(sfi.sf_desc)};
+                        handle_counting_error(valid);
+                    }
+
+                    // Number of misses on this track
+                    missed_pt =
+                        static_cast<long>(n_miss_stat.n_portals) - missed_pt;
+                    missed_sn =
+                        static_cast<long>(n_miss_stat.n_sensitives) - missed_sn;
+                    missed_ps =
+                        static_cast<long>(n_miss_stat.n_passives) - missed_ps;
+
+                    assert(missed_pt >= 0);
+                    assert(missed_sn >= 0);
+                    assert(missed_ps >= 0);
+
+                    const long n_missed{missed_pt + missed_sn + missed_ps};
+                    // We landed here because something was missed
+                    assert(n_missed > 0);
+
+                    // Continue checking where trace might match again
+                    i += (n_missed - 1);
+                };
+
+            // Set the missed surface to one and resolve the type
+            auto count_one_missed = []<typename insers_t>(const insers_t &intr,
+                                                          long int &missed_pt,
+                                                          long int &missed_sn,
+                                                          long int &missed_ps) {
+                switch (intr.id()) {
+                    using enum surface_id;
+                    case e_portal: {
+                        missed_pt = 1;
+                        break;
+                    }
+                    case e_sensitive: {
+                        missed_sn = 1;
+                        break;
+                    }
+                    case e_passive: {
+                        missed_ps = 1;
+                        break;
+                    }
+                    default: {
+                        throw std::runtime_error(
+                            "Unkown surface type during counting");
+                    }
+                }
+            };
+
+            // Match the barcodes to find how many surfaces were skipped
+            //
+            // If the current nav_inters can be found on the truth trace at a
+            // later place, the navigator potentially missed the surfaces that
+            // lie in between (except for swapped portals)
+            auto search_nav_on_truth = [nav_inters](const truth_record_t &tr) {
+                return tr.intersection.sf_desc.barcode() == nav_inters;
+            };
+            // As above, but this time check if the navigator found additional
+            // surfaces
+            auto search_truth_on_nav = [truth_inters](const nav_record_t &nr) {
+                return nr.intersection.sf_desc.barcode() == truth_inters;
+            };
+
+            // Check if the portal order is swapped or the surface appears
+            // later in the truth/navigation trace (this means one or
+            // multiple surfaces were skipped respectively)
+            if (is_swapped_portals(i)) {
+                // Was not wrong after all
+                matching_traces = true;
+                // Have already checked the next record
+                ++i;
+            } else if (auto last_missed_nav = std::ranges::find_if(
+                           std::ranges::begin(truth_trace) + i,
+                           std::ranges::end(truth_trace), search_nav_on_truth);
+                       last_missed_nav != std::end(truth_trace)) {
+
+                // The navigator missed a(multiple) surface(s)
+                compare_and_equalize(truth_trace, last_missed_nav,
+                                     recorded_trace, n_miss_nav, missed_pt_nav,
+                                     missed_sn_nav, missed_ps_nav);
+
+            } else if (auto last_missed_tr = std::ranges::find_if(
+                           std::ranges::begin(recorded_trace) + i,
+                           std::ranges::end(recorded_trace),
+                           search_truth_on_nav);
+                       last_missed_tr != std::end(recorded_trace)) {
+
+                // The navigator found a(multiple) extra surface(s)
+                compare_and_equalize(recorded_trace, last_missed_tr,
+                                     truth_trace, n_miss_truth, missed_pt_tr,
+                                     missed_sn_tr, missed_ps_tr);
+
+            } else if (!truth_has_next) {
+
+                // The nav_inters could not be found on the truth trace, because
+                // it does not have anymore records left to check: The surface
+                // was missed
+                truth_trace.push_back(truth_record_t{});
+
+                const bool valid{n_miss_truth.count(nav_inters)};
+                handle_counting_error(valid);
+                if (valid) {
+                    count_one_missed(nav_inters, missed_pt_tr, missed_sn_tr,
+                                     missed_ps_tr);
+                }
+            } else if (!nav_has_next) {
+
+                // The truth_inters could not be found on the recorded trace,
+                // because it does not have any records left to check
+                recorded_trace.push_back(nav_record_t{});
+
+                const bool valid{n_miss_nav.count(truth_inters)};
+                handle_counting_error(valid);
+
+                if (valid) {
+                    count_one_missed(truth_inters, missed_pt_nav, missed_sn_nav,
+                                     missed_ps_nav);
+                }
+            } else {
+
+                // Both missed a surface at the same time and the record cannot
+                // be found in each others traces
+                bool valid{n_miss_truth.count(nav_inters)};
+                valid &= n_miss_nav.count(truth_inters);
+                handle_counting_error(valid);
+
+                if (valid) {
+                    count_one_missed(truth_inters, missed_pt_nav, missed_sn_nav,
+                                     missed_ps_nav);
+
+                    count_one_missed(nav_inters, missed_pt_tr, missed_sn_tr,
+                                     missed_ps_tr);
+                }
+            }
+
+            // Print error statements for the user
+            auto print_err_extra_sf = [&matching_stream, max_entries, i](
+                                          const std::string &sf_type,
+                                          long n_sf) {
+                matching_stream << "\nERROR: Detray navigator found " << n_sf
+                                << " additional " << sf_type << "(s) at: " << i
+                                << "/" << max_entries
+                                << " (Inserted dummy record(s))";
+            };
+
+            auto print_err_missed = [&matching_stream, max_entries, i](
+                                        const std::string &sf_type, long n_sf) {
+                matching_stream << "\nERROR: Detray navigator missed " << n_sf
+                                << " " << sf_type << "(s) at: " << i << "/"
+                                << max_entries << ": "
+                                << " (Inserted dummy record(s))";
+            };
+
+            if (missed_pt_tr > 0) {
+                print_err_extra_sf("portal", missed_pt_tr);
+            }
+            if (missed_sn_tr > 0) {
+                print_err_extra_sf("sensitive", missed_sn_tr);
+            }
+            if (missed_ps_tr > 0) {
+                print_err_extra_sf("passive", missed_ps_tr);
+            }
+
+            if (missed_pt_nav > 0) {
+                print_err_missed("portal", missed_pt_nav);
+            }
+            if (missed_sn_nav > 0) {
+                print_err_missed("sensitive", missed_sn_nav);
+            }
+            if (missed_ps_nav > 0) {
+                print_err_missed("passive", missed_ps_nav);
+            }
+
+            // Something must have been missed
+            assert(missed_pt_tr + missed_sn_tr + missed_ps_tr + missed_pt_nav +
+                       missed_sn_nav + missed_ps_nav >
+                   0);
+        }
+
+        // Re-evaluate the size after dummy records were added
+        max_entries = math::max(recorded_trace.size(), truth_trace.size());
+    }
+
+    matching_stream << "\n\nDetray navigator skipped " << n_miss_nav.n_total()
+                    << " surface and found " << n_miss_truth.n_total()
+                    << " extra surfaces.";
+
+    // Fill the debug stream with the final information from both traces
     for (std::size_t intr_idx = 0u; intr_idx < max_entries; ++intr_idx) {
         debug_stream << "-------Intersection ( " << intr_idx << " )\n";
         if (intr_idx < truth_trace.size()) {
@@ -197,230 +552,11 @@ auto compare_traces(truth_trace_t &truth_trace,
         }
     }
 
-    // Check every single recorded intersection
-    surface_stats n_missed_nav{};
-    surface_stats n_missed_truth{};
-    std::size_t n_errors{0u};
-    std::vector<intersection_t> missed_intersections{};
-    // Iterate until 'max_entries', because dummy records will be added to the
-    // shorter trace
-    for (long i = 0; i < static_cast<long>(max_entries); ++i) {
-
-        const auto idx{static_cast<std::size_t>(i)};
-        const auto &nav_inters =
-            recorded_trace[idx].intersection.sf_desc.barcode();
-        const auto &truth_inters =
-            truth_trace[idx].intersection.sf_desc.barcode();
-
-        const bool found_same_surfaces{nav_inters == truth_inters};
-
-        if (!found_same_surfaces) {
-            // Intersection records at portal boundary might be flipped
-            // (the portals overlap completely)
-            auto is_swapped_portals = [&recorded_trace,
-                                       &truth_trace](const long j) {
-                const auto idx_j{static_cast<std::size_t>(j)};
-
-                const auto &current_nav_inters =
-                    recorded_trace[idx_j].intersection.sf_desc.barcode();
-                const auto &current_truth_inters =
-                    truth_trace[idx_j].intersection.sf_desc.barcode();
-
-                const std::size_t next_idx{idx_j + 1u};
-                if (next_idx < truth_trace.size() &&
-                    next_idx < recorded_trace.size()) {
-
-                    const auto &next_nav_inters =
-                        recorded_trace[next_idx].intersection.sf_desc.barcode();
-                    const auto &next_truth_inters =
-                        truth_trace[next_idx].intersection.sf_desc.barcode();
-
-                    return ((current_nav_inters == next_truth_inters) &&
-                            (next_nav_inters == current_truth_inters));
-                } else {
-                    return false;
-                }
-            };
-
-            // Match the barcodes
-            auto is_matched_nav = [truth_inters](const nav_record_t &nr) {
-                return nr.intersection.sf_desc.barcode() == truth_inters;
-            };
-            auto is_matched_truth = [nav_inters](const truth_record_t &tr) {
-                return tr.intersection.sf_desc.barcode() == nav_inters;
-            };
-
-            // Check if the portal order is swapped or the surface appears
-            // later in the truth/navigation trace (this means one or
-            // multiple surfaces were skipped respectively)
-            if (is_swapped_portals(i)) {
-                // Have already checked the next record
-                ++i;
-            } else if (auto last_missed_tr = std::ranges::find_if(
-                           std::ranges::begin(truth_trace) + i,
-                           std::ranges::end(truth_trace), is_matched_truth);
-                       last_missed_tr != std::end(truth_trace)) {
-
-                // The navigator missed a(multiple) surface(s)
-                auto first_missed = std::begin(truth_trace) + i;
-                const auto n_check{std::distance(first_missed, last_missed_tr)};
-                // Number of missed surfaces so far
-                long missed_pt{static_cast<long>(n_missed_nav.n_portals)};
-                long missed_sn{static_cast<long>(n_missed_nav.n_sensitives)};
-                long missed_ps{static_cast<long>(n_missed_nav.n_passives)};
-
-                // Check and record surfaces that were missed: Insert dummy
-                // records until traces align again
-                for (long j = i; j < i + n_check; ++j) {
-                    const auto &truth_sfi =
-                        truth_trace[static_cast<std::size_t>(j)].intersection;
-
-                    // Portals may be swapped and wrongfully included in the
-                    // range of missed surfaces - skip them
-                    if (truth_sfi.sf_desc.is_portal() &&
-                        is_swapped_portals(j)) {
-                        ++j;
-                        continue;
-                    }
-                    missed_intersections.push_back(truth_sfi);
-                    // Insert dummy records to match the truth trace size
-                    recorded_trace.insert(recorded_trace.begin() + i,
-                                          nav_record_t{});
-
-                    // Count per surface type
-                    const bool valid{n_missed_nav.count(truth_sfi.sf_desc)};
-                    if (!valid) {
-                        matching_stream << "ERROR: Encountered surface of "
-                                           "unknown type in intersection "
-                                           "trace. Validate the geometry";
-                        ++n_errors;
-                    }
-                }
-
-                auto print_err = [&matching_stream, max_entries, i](
-                                     const std::string &sf_type, long n_sf) {
-                    matching_stream << "\nERROR: Detray navigator missed "
-                                    << n_sf << " " << sf_type << "(s) at: " << i
-                                    << "/" << max_entries << ": "
-                                    << " (Inserted dummy record(s))";
-                };
-
-                // Number of misses on this track
-                missed_pt =
-                    static_cast<long>(n_missed_nav.n_portals) - missed_pt;
-                missed_sn =
-                    static_cast<long>(n_missed_nav.n_sensitives) - missed_sn;
-                missed_ps =
-                    static_cast<long>(n_missed_nav.n_passives) - missed_ps;
-
-                assert(missed_pt >= 0);
-                assert(missed_sn >= 0);
-                assert(missed_ps >= 0);
-
-                if (missed_pt > 0) {
-                    print_err("portal", missed_pt);
-                }
-                if (missed_sn > 0) {
-                    print_err("sensitive", missed_sn);
-                }
-                if (missed_ps > 0) {
-                    print_err("passive", missed_ps);
-                }
-
-                // Continue checking where trace might match again
-                const long n{missed_pt + missed_sn + missed_ps};
-                i += (n - 1);
-
-            } else if (auto last_missed_nav = std::ranges::find_if(
-                           std::ranges::begin(recorded_trace) + i,
-                           std::ranges::end(recorded_trace), is_matched_nav);
-                       last_missed_nav != std::end(recorded_trace)) {
-                // The detector scanner missed a(multiple) surface(s)
-                auto first_missed = std::begin(recorded_trace) + i;
-                const auto n_check{
-                    std::distance(first_missed, last_missed_nav)};
-                // Number of missed surfaces so far
-                long missed_pt{static_cast<long>(n_missed_truth.n_portals)};
-                long missed_sn{static_cast<long>(n_missed_truth.n_sensitives)};
-                long missed_ps{static_cast<long>(n_missed_truth.n_passives)};
-
-                // Check and record surfaces that were missed
-                for (long j = i; j < i + n_check; ++j) {
-                    const auto &rec_sfi =
-                        recorded_trace[static_cast<std::size_t>(j)]
-                            .intersection;
-
-                    // Portals may be swapped and wrongfully included in the
-                    // range of missed surfaces - skip them
-                    if (rec_sfi.sf_desc.is_portal() && is_swapped_portals(j)) {
-                        ++j;
-                        continue;
-                    }
-                    missed_intersections.push_back(rec_sfi);
-                    // Insert dummy records to match the truth trace size
-                    truth_trace.insert(truth_trace.begin() + i,
-                                       truth_record_t{});
-
-                    // Count per surface type
-                    const bool valid{n_missed_truth.count(rec_sfi.sf_desc)};
-                    if (!valid) {
-                        matching_stream << "ERROR: Encountered surface of "
-                                           "unknown type in intersection "
-                                           "trace. Validate the geometry";
-                        ++n_errors;
-                    }
-                }
-
-                auto print_err = [&matching_stream, max_entries, i](
-                                     const std::string &sf_type, long n_sf) {
-                    matching_stream << "\nERROR: Detray navigator found "
-                                    << n_sf << " additional " << sf_type
-                                    << "(s) at: " << i << "/" << max_entries
-                                    << " (Inserted dummy record(s))";
-                };
-
-                // Number of misses on this track
-                missed_pt =
-                    static_cast<long>(n_missed_truth.n_portals) - missed_pt;
-                missed_sn =
-                    static_cast<long>(n_missed_truth.n_sensitives) - missed_sn;
-                missed_ps =
-                    static_cast<long>(n_missed_truth.n_passives) - missed_ps;
-
-                assert(missed_pt >= 0);
-                assert(missed_sn >= 0);
-                assert(missed_ps >= 0);
-
-                if (missed_pt > 0) {
-                    print_err("portal", missed_pt);
-                }
-                if (missed_sn > 0) {
-                    print_err("sensitive", missed_sn);
-                }
-                if (missed_ps > 0) {
-                    print_err("passive", missed_ps);
-                }
-
-                // Continue checking where trace might match again
-                const long n{missed_pt + missed_sn + missed_ps};
-                i += (n - 1);
-            } else {
-                // None of the above: Error!
-                matching_stream << "\nERROR: More than one consecutive "
-                                   "surfaces is unmatched! "
-                                << i << "/" << max_entries;
-
-                ++n_errors;
-                break;
-            }
-        }
-    }
-
-    const bool any_error{(n_missed_nav.n_total() != 0u) ||
-                         (n_missed_truth.n_total() != 0u) || (n_errors != 0u)};
+    const bool any_error{(n_miss_nav.n_total() != 0u) ||
+                         (n_miss_truth.n_total() != 0u) || (n_errors != 0u)};
 
     // Fail the test with some extra information
-    EXPECT_TRUE(!any_error)
+    EXPECT_TRUE(!any_error || !fail_on_diff)
         << "\n--------\n"
         << "Track no. " << trk_no << "/" << total_n_trks << ":\n"
         << traj << matching_stream.str() << "\n--------";
@@ -436,34 +572,54 @@ auto compare_traces(truth_trace_t &truth_trace,
 
     // Multiple missed surfaces are a hint that something might be off with this
     // track
-    if (n_missed_nav.n_total() > 1u) {
+    if ((n_miss_nav.n_total() > 1u) && verbose) {
         std::cout << "WARNING: Detray navigator skipped multiple surfaces: "
-                  << n_missed_nav.n_total() << "\n"
+                  << n_miss_nav.n_total() << "\n"
                   << std::endl;
     }
-    if (n_missed_truth.n_total() > 1u) {
+    if ((n_miss_truth.n_total() > 1u) && verbose) {
         std::cout << "WARNING: Detray navigator found multiple extra surfaces: "
-                  << n_missed_truth.n_total() << "\n"
+                  << n_miss_truth.n_total() << "\n"
                   << std::endl;
     }
+
     // Unknown error occured during matching
     EXPECT_TRUE(n_errors == 0u)
-        << "ERROR: Errors during matching: " << n_errors;
+        << "FATAL: Errors during matching: " << n_errors;
 
     // After inserting the placeholders, do a final check on the trace sizes
     const bool is_size{recorded_trace.size() == truth_trace.size()};
     EXPECT_TRUE(is_size)
-        << "ERROR: Intersection traces have different number "
+        << "FATAL: Intersection traces have different number "
            "of surfaces after matching! Please check unmatched elements\n"
+        << "Truth: " << truth_trace.size()
+        << "\nNav. : " << recorded_trace.size() << "\n"
         << debug_stream.str();
 
-    if (!is_size || (n_missed_nav.n_total() != 0u) ||
-        (n_missed_truth.n_total() != 0u) || (n_errors != 0u)) {
-        return std::make_tuple(false, n_missed_nav, n_missed_truth, n_errors,
+    if (!is_size || (n_miss_nav.n_total() != 0u) ||
+        (n_miss_truth.n_total() != 0u) || (n_errors != 0u)) {
+        return std::make_tuple(false, n_miss_nav, n_miss_truth, n_errors,
                                missed_intersections);
     }
 
-    return std::make_tuple(true, n_missed_nav, n_missed_truth, n_errors,
+    // Make sure the failure was at least counted
+    if (!matching_traces &&
+        (n_miss_nav.n_total() + n_miss_truth.n_total() == 0)) {
+        if (debug_file) {
+            *debug_file << "\n>>>>>>>>>>>>>>>>>>\nFAILURE\n<<<<<<<<<<<<<<<<<<\n"
+                        << "\nSUMMARY:\n--------\n"
+                        << "Track no. " << trk_no << "/" << total_n_trks
+                        << ":\n"
+                        << traj << matching_stream.str() << "\n--------\n"
+                        << "\nFull Trace:\n\n"
+                        << debug_stream.str();
+        }
+
+        throw std::runtime_error(
+            "Difference to truth trace was not counted correctly");
+    }
+
+    return std::make_tuple(true, n_miss_nav, n_miss_truth, n_errors,
                            missed_intersections);
 }
 
@@ -537,19 +693,18 @@ auto write_dist_to_boundary(
 }
 
 /// Calculate and print the navigation efficiency
-/// @NOTE: WIP
 inline auto print_efficiency(std::size_t n_tracks,
                              const surface_stats &n_surfaces,
                              const surface_stats &n_miss_nav,
                              const surface_stats &n_miss_truth,
-                             std::size_t n_fatal,
+                             std::size_t n_fatal_error,
                              std::size_t n_matching_error) {
     // Column width in output
     constexpr int cw{20};
 
     // Print general information
     if (n_miss_nav.n_total() > 0u || n_miss_truth.n_total() > 0u ||
-        n_fatal > 0u || n_matching_error > 0u) {
+        n_fatal_error > 0u || n_matching_error > 0u) {
 
         std::cout
             << std::left << "-----------------------------------"
@@ -570,7 +725,7 @@ inline auto print_efficiency(std::size_t n_tracks,
             << std::setw(cw)
             << "\n      sensitives: " << n_miss_truth.n_sensitives
             << std::setw(cw) << "\n      passives: " << n_miss_truth.n_passives
-            << "\n\nFatal propagation failures:   " << n_fatal
+            << "\n\nFatal propagation failures:   " << n_fatal_error
             << "\nErrors during truth matching: " << n_matching_error;
     } else {
         std::cout << "-----------------------------------\n"
@@ -612,13 +767,23 @@ inline auto print_efficiency(std::size_t n_tracks,
     };
 
     std::cout << std::endl;
-    print_eff("Portal sf.", n_surfaces.n_portals, n_miss_nav.n_portals);
-    print_eff("Sensitive sf.", n_surfaces.n_sensitives,
-              n_miss_nav.n_sensitives);
-    print_eff("Passive sf.", n_surfaces.n_passives, n_miss_nav.n_passives);
+    if (n_surfaces.n_portals != 0u) {
+        print_eff("Portal sf.", n_surfaces.n_portals, n_miss_nav.n_portals);
+    }
+    if (n_surfaces.n_sensitives != 0u) {
+        print_eff("Sensitive sf.", n_surfaces.n_sensitives,
+                  n_miss_nav.n_sensitives);
+    }
+    if (n_surfaces.n_passives != 0u) {
+        print_eff("Passive sf.", n_surfaces.n_passives, n_miss_nav.n_passives);
+    }
 
     std::cout << std::endl;
-    print_eff("Surface", n_surfaces.n_total(), n_miss_nav.n_total());
+    if (n_surfaces.n_total() != 0u) {
+        print_eff("Surface", n_surfaces.n_total(), n_miss_nav.n_total());
+    } else {
+        std::cout << "ERROR: No surfaces found in truth data!" << std::endl;
+    }
 
     std::cout << "\n-----------------------------------\n" << std::endl;
 }


### PR DESCRIPTION
Fix a couple of bugs:
 - don't check for swapped portals on the last record (out of bounds exception)
 - don't count the initial intersection record into the total number of surfaces (it exists only to capture the initial track state)
 - iterate over all elements of the larger intersection trace, since the smaller intersection trace will be filled with dummy elements until it has the same length

Apart from that, it allows to count the total and missed number of surfaces per surface type now. This can help identifying if a problem lies e.g. with the portal finding or the acceleration structures.