### PR TITLE
Change default overstep tolerance to -1 mm

### DIFF
--- a/core/include/detray/navigation/navigation_config.hpp
+++ b/core/include/detray/navigation/navigation_config.hpp
@@ -39,7 +39,7 @@ struct config {
     /// Maximal absolute path distance for a track to be considered 'on surface'
     float path_tolerance{1.f * unit<float>::um};
     /// How far behind the track position to look for candidates
-    float overstep_tolerance{-300.f * unit<float>::um};
+    float overstep_tolerance{-1000.f * unit<float>::um};
     /// Search window size for grid based acceleration structures
     /// (0, 0): only look at current bin
     darray<dindex, 2> search_window = {0u, 0u};


### PR DESCRIPTION
From the study of https://github.com/acts-project/traccc/pull/869
Also this seems working better with traccc tests when I just use default propagation config.

In case of initializing the candidate search at the new volume or beginning of the propagation, the path tolerance is used instead of overstep tolerance. Currently, there is a bug that track goes backward if it finds surface in opposite direction when `navigator::init` is called at the very beginning of propagation

For example, in the telescope geometry whose envelope size is less than 1 mm, if I start the propagation at the first module, the track will just go back to the portal and terminate the propagation.
