### PR TITLE
Implementing direct navigator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Set up the project.
 cmake_minimum_required(VERSION 3.11)
-project(detray VERSION 0.87.0 LANGUAGES CXX)
+project(detray VERSION 0.91.0 LANGUAGES CXX)
 
 # Set up the used C++ standard(s).
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "The (host) C++ standard to use")

--- a/core/include/detray/navigation/direct_navigator.hpp
+++ b/core/include/detray/navigation/direct_navigator.hpp
@@ -1,0 +1,364 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/core/detector.hpp"
+#include "detray/definitions/algorithms.hpp"
+#include "detray/definitions/containers.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/indexing.hpp"
+#include "detray/definitions/units.hpp"
+#include "detray/geometry/barcode.hpp"
+#include "detray/navigation/intersection/intersection.hpp"
+#include "detray/navigation/intersection/ray_intersector.hpp"
+#include "detray/navigation/intersection_kernel.hpp"
+#include "detray/navigation/navigation_config.hpp"
+#include "detray/navigation/navigator.hpp"
+#include "detray/tracks/ray.hpp"
+#include "detray/utils/ranges.hpp"
+
+namespace detray {
+
+template <typename detector_t>
+class direct_navigator {
+
+    public:
+    using detector_type = detector_t;
+    using context_type = detector_type::geometry_context;
+    using algebra_type = typename detector_type::algebra_type;
+    using scalar_type = dscalar<algebra_type>;
+    using intersection_type =
+        intersection2D<typename detector_t::surface_type,
+                       typename detector_t::algebra_type, false>;
+
+    class state {
+
+        friend struct intersection_update<ray_intersector>;
+
+        using candidate_t = intersection_type;
+
+        public:
+        using sequence_t = vecmem::device_vector<detray::geometry::barcode>;
+        using detector_type = direct_navigator::detector_type;
+        using nav_link_type =
+            typename detector_type::surface_type::navigation_link;
+        using view_type = dvector_view<detray::geometry::barcode>;
+
+        state() = delete;
+
+        DETRAY_HOST_DEVICE explicit state(const detector_t &det,
+                                          const view_type &sequence)
+            : m_detector(&det), m_sequence(sequence) {
+
+            m_it = m_sequence.begin();
+            m_it_rev = m_sequence.rbegin();
+        }
+
+        /// Scalar representation of the navigation state,
+        /// @returns distance to next
+        DETRAY_HOST_DEVICE
+        scalar_type operator()() const {
+            return static_cast<scalar_type>(direction()) * target().path;
+        }
+
+        /// @returns a pointer of detector
+        DETRAY_HOST_DEVICE
+        const detector_type &detector() const { return (*m_detector); }
+
+        /// @returns the navigation heartbeat
+        DETRAY_HOST_DEVICE
+        bool is_alive() const { return m_heartbeat; }
+
+        /// @returns current/previous object that was reached
+        DETRAY_HOST_DEVICE
+        inline auto current() const -> const candidate_t & {
+            return m_candidate_prev;
+        }
+
+        /// @returns next object that we want to reach (current target) - const
+        DETRAY_HOST_DEVICE
+        inline auto target() const -> const candidate_t & {
+            return m_candidate;
+        }
+
+        DETRAY_HOST_DEVICE
+        inline auto target() -> candidate_t & { return m_candidate; }
+
+        DETRAY_HOST_DEVICE
+        void update_candidate(bool update_candidate_prev = true) {
+
+            if (update_candidate_prev) {
+                m_candidate_prev = m_candidate;
+            }
+
+            if (!is_complete()) {
+                m_candidate.sf_desc = m_detector->surface(get_target_barcode());
+                m_candidate.volume_link =
+                    tracking_surface{*m_detector, m_candidate.sf_desc}
+                        .volume_link();
+                m_candidate.path = std::numeric_limits<scalar_type>::max();
+                set_volume(m_candidate.volume_link);
+            }
+        }
+
+        /// @returns current detector surface the navigator is on
+        /// (cannot be used when not on surface) - const
+        DETRAY_HOST_DEVICE
+        inline auto get_surface() const -> tracking_surface<detector_type> {
+            assert(is_on_surface());
+            return tracking_surface<detector_type>{*m_detector,
+                                                   current().sf_desc};
+        }
+
+        /// @returns current navigation status - const
+        DETRAY_HOST_DEVICE
+        inline auto status() const -> navigation::status { return m_status; }
+
+        DETRAY_HOST_DEVICE
+        inline bool is_init() {
+            if (m_direction == navigation::direction::e_forward) {
+                return m_it == m_sequence.begin();
+            } else {
+                return m_it_rev == m_sequence.rbegin();
+            }
+        }
+
+        DETRAY_HOST_DEVICE
+        detray::geometry::barcode get_target_barcode() const {
+            if (m_direction == navigation::direction::e_forward) {
+                return *m_it;
+            } else {
+                return *m_it_rev;
+            }
+        }
+
+        DETRAY_HOST_DEVICE
+        detray::geometry::barcode get_current_barcode() const {
+            if (m_direction == navigation::direction::e_forward) {
+                return *(m_it - 1);
+            } else {
+                return *(m_it_rev - 1);
+            }
+        }
+
+        /// Advance the iterator
+        DETRAY_HOST_DEVICE
+        void next() {
+            if (m_direction == navigation::direction::e_forward) {
+                m_it++;
+            } else {
+                m_it_rev++;
+            }
+        }
+
+        /// @return true if the iterator reaches the end of vector
+        DETRAY_HOST_DEVICE
+        bool is_complete() {
+            if ((m_direction == navigation::direction::e_forward) &&
+                m_it == m_sequence.end()) {
+                return true;
+            } else if ((m_direction == navigation::direction::e_backward) &&
+                       m_it_rev == m_sequence.rend()) {
+                return true;
+            }
+            return false;
+        }
+
+        /// @returns current navigation direction - const
+        DETRAY_HOST_DEVICE
+        inline auto direction() const -> navigation::direction {
+            return m_direction;
+        }
+
+        /// Helper method to check the track has reached a module surface
+        DETRAY_HOST_DEVICE
+        inline auto is_on_surface() const -> bool {
+            return (m_status == navigation::status::e_on_module ||
+                    m_status == navigation::status::e_on_portal);
+        }
+
+        /// Helper method to check if a candidate lies on a surface - const
+        DETRAY_HOST_DEVICE inline auto is_on_surface(
+            const intersection_type &candidate,
+            const navigation::config &cfg) const -> bool {
+            return (math::fabs(candidate.path) < cfg.path_tolerance);
+        }
+
+        /// Helper method to check the track has encountered material
+        DETRAY_HOST_DEVICE
+        inline auto encountered_sf_material() const -> bool {
+            return (is_on_surface()) && (current().sf_desc.material().id() !=
+                                         detector_t::materials::id::e_none);
+        }
+
+        /// Helper method to check the track has reached a sensitive surface
+        DETRAY_HOST_DEVICE
+        inline auto is_on_sensitive() const -> bool {
+            return (m_status == navigation::status::e_on_module) &&
+                   (get_current_barcode().id() == surface_id::e_sensitive);
+        }
+
+        DETRAY_HOST_DEVICE
+        inline auto barcode() const -> geometry::barcode {
+            return m_candidate.sf_desc.barcode();
+        }
+
+        /// @returns current volume (index) - const
+        DETRAY_HOST_DEVICE
+        inline auto volume() const -> nav_link_type { return m_volume_index; }
+
+        /// Set start/new volume
+        DETRAY_HOST_DEVICE
+        inline void set_volume(dindex v) {
+            assert(detail::is_invalid_value(static_cast<nav_link_type>(v)) ||
+                   v < detector().volumes().size());
+            m_volume_index = static_cast<nav_link_type>(v);
+        }
+
+        /// @returns current detector volume of the navigation stream
+        DETRAY_HOST_DEVICE
+        inline auto get_volume() const {
+            return tracking_volume<detector_type>{*m_detector, m_volume_index};
+        }
+
+        /// Set direction
+        DETRAY_HOST_DEVICE
+        inline void set_direction(const navigation::direction dir) {
+            m_direction = dir;
+        }
+
+        DETRAY_HOST_DEVICE
+        inline void set_no_trust() { return; }
+
+        DETRAY_HOST_DEVICE
+        inline void set_full_trust() { return; }
+
+        DETRAY_HOST_DEVICE
+        inline void set_high_trust() { return; }
+
+        DETRAY_HOST_DEVICE
+        inline void set_fair_trust() { return; }
+
+        /// Intersection candidate
+        candidate_t m_candidate;
+        candidate_t m_candidate_prev;
+
+        /// Detector pointer
+        const detector_type *m_detector{nullptr};
+
+        /// Index in the detector volume container of current navigation volume
+        nav_link_type m_volume_index{0u};
+
+        /// Target surfaces
+        sequence_t m_sequence;
+
+        // iterator for forward direction
+        typename sequence_t::iterator m_it;
+
+        // iterator for backward direction
+        typename sequence_t::reverse_iterator m_it_rev;
+
+        /// The navigation direction
+        navigation::direction m_direction{navigation::direction::e_forward};
+
+        /// The navigation status
+        navigation::status m_status{navigation::status::e_unknown};
+
+        /// Step size when the valid intersection is not found for the target
+        scalar_type safe_step_size = 10.f * unit<scalar_type>::mm;
+
+        /// Heartbeat of this navigation flow signals navigation is alive
+        bool m_heartbeat{false};
+    };
+
+    template <typename track_t>
+    DETRAY_HOST_DEVICE inline void init(const track_t &track, state &navigation,
+                                        const navigation::config &cfg,
+                                        const context_type &ctx) const {
+        if (navigation.is_complete()) {
+            navigation.m_heartbeat = false;
+            return;
+        }
+
+        navigation.m_heartbeat = true;
+        navigation.update_candidate(!navigation.is_init());
+        update_intersection(track, navigation, cfg, ctx);
+
+        return;
+    }
+
+    template <typename track_t>
+    DETRAY_HOST_DEVICE inline bool update(const track_t &track,
+                                          state &navigation,
+                                          const navigation::config &cfg,
+                                          const context_type &ctx = {}) const {
+
+        if (navigation.is_complete()) {
+            navigation.m_heartbeat = false;
+            return true;
+        }
+
+        assert(!navigation.get_target_barcode().is_invalid());
+        update_intersection(track, navigation, cfg, ctx);
+
+        if (navigation.is_on_surface(navigation.target(), cfg)) {
+            navigation.m_status = (navigation.target().sf_desc.is_portal())
+                                      ? navigation::status::e_on_portal
+                                      : navigation::status::e_on_module;
+            navigation.next();
+            navigation.update_candidate(true);
+            assert(navigation.is_on_surface(navigation.current(), cfg));
+
+            if (!navigation.is_complete()) {
+                update_intersection(track, navigation, cfg, ctx);
+            }
+
+            // Return true to reset the step size
+            return true;
+        } else {
+            // Otherwise the track is moving towards a surface
+            navigation.m_status = navigation::status::e_towards_object;
+
+            // Return false to scale the step size with RK4
+            return false;
+        }
+    }
+
+    template <typename track_t>
+    DETRAY_HOST_DEVICE inline void update_intersection(
+        const track_t &track, state &navigation, const navigation::config &cfg,
+        const context_type &ctx = {}) const {
+
+        const auto &det = navigation.detector();
+        const auto sf = tracking_surface{det, navigation.target().sf_desc};
+
+        const bool res =
+            sf.template visit_mask<intersection_update<ray_intersector>>(
+                detail::ray<algebra_type>(
+                    track.pos(),
+                    static_cast<scalar_type>(navigation.direction()) *
+                        track.dir()),
+                navigation.target(), det.transform_store(), ctx,
+                darray<scalar_type, 2>{cfg.min_mask_tolerance,
+                                       cfg.max_mask_tolerance},
+                static_cast<scalar_type>(cfg.mask_tolerance_scalor),
+                static_cast<scalar_type>(cfg.overstep_tolerance));
+
+        // If an intersection is not found, proceed the track with safe step
+        // size
+        if (!res) {
+            const auto path = navigation.target().path;
+            navigation.update_candidate(false);
+            navigation.target().path =
+                math::copysign(navigation.safe_step_size, path);
+        }
+    }
+};
+
+}  // namespace detray

--- a/core/include/detray/navigation/direct_navigator.hpp
+++ b/core/include/detray/navigation/direct_navigator.hpp
@@ -221,6 +221,13 @@ class direct_navigator {
             m_volume_index = static_cast<nav_link_type>(v);
         }
 
+        DETRAY_HOST_DEVICE
+        inline auto abort() -> bool {
+            m_status = navigation::status::e_abort;
+            m_heartbeat = false;
+            return m_heartbeat;
+        }
+
         /// @returns current detector volume of the navigation stream
         DETRAY_HOST_DEVICE
         inline auto get_volume() const {

--- a/core/include/detray/navigation/direct_navigator.hpp
+++ b/core/include/detray/navigation/direct_navigator.hpp
@@ -206,7 +206,7 @@ class direct_navigator {
 
         DETRAY_HOST_DEVICE
         inline auto barcode() const -> geometry::barcode {
-            return m_candidate.sf_desc.barcode();
+            return m_candidate_prev.sf_desc.barcode();
         }
 
         /// @returns current volume (index) - const

--- a/core/include/detray/navigation/direct_navigator.hpp
+++ b/core/include/detray/navigation/direct_navigator.hpp
@@ -288,6 +288,7 @@ class direct_navigator {
     DETRAY_HOST_DEVICE inline void init(const track_t &track, state &navigation,
                                         const navigation::config &cfg,
                                         const context_type &ctx) const {
+
         if (navigation.is_complete()) {
             navigation.m_heartbeat = false;
             return;
@@ -295,9 +296,7 @@ class direct_navigator {
 
         navigation.m_heartbeat = true;
         navigation.update_candidate(!navigation.is_init());
-        update_intersection(track, navigation, cfg, ctx);
-
-        return;
+        update(track, navigation, cfg, ctx);
     }
 
     template <typename track_t>

--- a/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_intersector.hpp
@@ -187,8 +187,7 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
             const point3_type &ro = ray.pos();
             const vector3_type &rd = ray.dir();
 
-            is.path = path;
-            const point3_type p3 = ro + is.path * rd;
+            const point3_type p3 = ro + path * rd;
 
             const auto loc{mask_t::to_local_frame(trf, p3)};
             if constexpr (intersection_type<surface_descr_t>::is_debug()) {
@@ -196,16 +195,16 @@ struct ray_intersector_impl<cylindrical2D<algebra_t>, algebra_t, do_debug> {
             }
             // Tolerance: per mille of the distance
             is.status = mask.is_inside(
-                loc,
-                math::max(mask_tolerance[0],
-                          math::min(mask_tolerance[1],
-                                    mask_tol_scalor * math::fabs(is.path))));
-            is.direction = !detail::signbit(is.path);
+                loc, math::max(mask_tolerance[0],
+                               math::min(mask_tolerance[1],
+                                         mask_tol_scalor * math::fabs(path))));
+            is.direction = !detail::signbit(path);
             is.volume_link = mask.volume_link();
         } else {
             is.status = false;
         }
 
+        is.path = path;
         return is;
     }
 };

--- a/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
@@ -80,11 +80,15 @@ struct ray_intersector_impl<concentric_cylindrical2D<algebra_t>, algebra_t,
         const auto qe = this->solve_intersection(ray, mask, trf);
 
         // Find the closest valid intersection
-        if (qe.solutions() > 0 && qe.larger() > overstep_tol) {
+        if (qe.solutions() > 0) {
+
             // Only the closest intersection that is outside the overstepping
             // tolerance is needed
-            const scalar_type t{(qe.smaller() > overstep_tol) ? qe.smaller()
-                                                              : qe.larger()};
+            scalar_type t = qe.smaller();
+            if ((qe.smaller() < overstep_tol) && (qe.solutions() == 2u)) {
+                t = qe.larger();
+            }
+
             is = this->template build_candidate<surface_descr_t>(
                 ray, mask, trf, t, mask_tolerance, mask_tol_scalor,
                 overstep_tol);

--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -691,10 +691,10 @@ class navigator {
     ///
     /// @returns a heartbeat to indicate if the navigation is still alive
     template <typename track_t>
-    DETRAY_HOST_DEVICE inline bool update(const track_t &track,
-                                          state &navigation,
-                                          const navigation::config &cfg,
-                                          const context_type &ctx = {}) const {
+    DETRAY_HOST_DEVICE inline bool update(
+        const track_t &track, state &navigation, const navigation::config &cfg,
+        const context_type &ctx = {},
+        [[maybe_unused]] const bool is_before_actor = true) const {
         // Candidates are re-evaluated based on the current trust level.
         // Should result in 'full trust'
         bool is_init = update_kernel(track, navigation, cfg, ctx);

--- a/core/include/detray/propagator/actors.hpp
+++ b/core/include/detray/propagator/actors.hpp
@@ -10,6 +10,7 @@
 // Include all core actors
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/actors/aborters.hpp"
+#include "detray/propagator/actors/barcode_sequencer.hpp"
 #include "detray/propagator/actors/parameter_resetter.hpp"
 #include "detray/propagator/actors/parameter_transporter.hpp"
 #include "detray/propagator/actors/pointwise_material_interactor.hpp"

--- a/core/include/detray/propagator/actors/barcode_sequencer.hpp
+++ b/core/include/detray/propagator/actors/barcode_sequencer.hpp
@@ -1,0 +1,53 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s).
+#include "detray/definitions/algebra.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/geometry/barcode.hpp"
+#include "detray/propagator/base_actor.hpp"
+
+// Vecmem include(s)
+#include <vecmem/containers/device_vector.hpp>
+
+namespace detray {
+
+struct barcode_sequencer : actor {
+
+    struct state {
+
+        using sequence_t = vecmem::device_vector<detray::geometry::barcode>;
+        sequence_t _sequence;
+
+        /// Constructor with the vector of track states
+        DETRAY_HOST_DEVICE
+        explicit state(sequence_t seq) : _sequence(seq) {}
+    };
+
+    template <typename propagator_state_t>
+    DETRAY_HOST_DEVICE void operator()(state& actor_state,
+                                       propagator_state_t& propagation) const {
+
+        const auto& navigation = propagation._navigation;
+
+        if (!(navigation.is_on_sensitive() ||
+              navigation.encountered_sf_material())) {
+            return;
+        }
+
+        const auto& bcd = navigation.current().sf_desc.barcode();
+        assert(!bcd.is_invalid());
+
+        actor_state._sequence.push_back(bcd);
+
+        return;
+    }
+};
+
+}  // namespace detray

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -232,8 +232,8 @@ struct propagator {
         run_actors(actor_state_refs, propagation);
 
         // And check the status
-        is_init |=
-            m_navigator.update(track, navigation, m_cfg.navigation, context);
+        is_init |= m_navigator.update(track, navigation, m_cfg.navigation,
+                                      context, false);
         propagation._heartbeat &= navigation.is_alive();
 
 #if defined(__NO_DEVICE__)
@@ -349,8 +349,8 @@ struct propagator {
                     run_actors(actor_state_refs, propagation);
 
                     // And check the status
-                    is_init |= m_navigator.update(track, navigation,
-                                                  m_cfg.navigation, context);
+                    is_init |= m_navigator.update(
+                        track, navigation, m_cfg.navigation, context, false);
                     propagation._heartbeat &= navigation.is_alive();
                 }
             }
@@ -362,7 +362,7 @@ struct propagator {
 
                 // And check the status
                 is_init |= m_navigator.update(track, navigation,
-                                              m_cfg.navigation, context);
+                                              m_cfg.navigation, context, false);
                 propagation._heartbeat &= navigation.is_alive();
             }
 

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "detray/definitions/detail/macros.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/navigation/direct_navigator.hpp"
 #include "detray/navigation/intersection/intersection.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/actor_chain.hpp"
@@ -106,7 +107,9 @@ struct propagator {
         DETRAY_HOST_DEVICE state(const bound_track_parameters_type &param,
                                  const detector_type &det,
                                  const context_type &ctx = {})
-            : _stepping(param, det, ctx), _navigation(det), _context(ctx) {}
+            : _stepping(param, det, ctx), _navigation(det), _context(ctx) {
+            _navigation.set_volume(param.surface_link().volume());
+        }
 
         /// Construct the propagation state with bound parameter
         template <typename field_t>
@@ -116,7 +119,23 @@ struct propagator {
                                  const context_type &ctx = {})
             : _stepping(param, magnetic_field, det, ctx),
               _navigation(det),
-              _context(ctx) {}
+              _context(ctx) {
+            _navigation.set_volume(param.surface_link().volume());
+        }
+
+        /// Construct the propagation state with bound parameter and navigator
+        /// state view
+        template <typename field_t>
+        DETRAY_HOST_DEVICE state(
+            const bound_track_parameters_type &param,
+            const field_t &magnetic_field, const detector_type &det,
+            typename navigator_type::state::view_type nav_view,
+            const context_type &ctx = {})
+            : _stepping(param, magnetic_field, det, ctx),
+              _navigation(det, nav_view),
+              _context(ctx) {
+            _navigation.set_volume(param.surface_link().volume());
+        }
 
         /// Set the particle hypothesis
         DETRAY_HOST_DEVICE

--- a/tests/integration_tests/cpu/material/material_interaction.cpp
+++ b/tests/integration_tests/cpu/material/material_interaction.cpp
@@ -94,7 +94,8 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
 
     // bound track parameter at first physical plane
     const bound_track_parameters<test_algebra> bound_param(
-        geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
+        geometry::barcode{}.set_index(0u).set_volume(0u), bound_vector,
+        bound_cov);
 
     pathlimit_aborter_t::state aborter_state{};
     interactor_t::state interactor_state{};
@@ -215,7 +216,8 @@ GTEST_TEST(detray_material, telescope_geometry_scattering_angle) {
 
     // bound track parameter
     const bound_track_parameters<test_algebra> bound_param(
-        geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
+        geometry::barcode{}.set_index(0u).set_volume(0u), bound_vector,
+        bound_cov);
 
     std::size_t n_samples{100000u};
     std::vector<scalar> phis;
@@ -297,7 +299,8 @@ GTEST_TEST(detray_material, telescope_geometry_volume_material) {
 
     // bound track parameter at first physical plane
     const bound_track_parameters<test_algebra> bound_param(
-        geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
+        geometry::barcode{}.set_index(0u).set_volume(0u), bound_vector,
+        bound_cov);
 
     // Create actor states tuples
     const scalar path_limit = 100 * unit<scalar>::mm;

--- a/tests/integration_tests/cpu/propagator/backward_propagation.cpp
+++ b/tests/integration_tests/cpu/propagator/backward_propagation.cpp
@@ -87,7 +87,8 @@ TEST_P(BackwardPropagation, backward_propagation) {
 
     // Bound track parameter
     const bound_track_parameters<test_algebra> bound_param0(
-        geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
+        geometry::barcode{}.set_index(0u).set_volume(0u), bound_vector,
+        bound_cov);
 
     // Actors
     pointwise_material_interactor<test_algebra>::state interactor{};
@@ -113,7 +114,7 @@ TEST_P(BackwardPropagation, backward_propagation) {
     const auto& bound_param1 = fw_state._stepping.bound_params();
 
     // Check if the track reaches the final surface
-    EXPECT_EQ(bound_param0.surface_link().volume(), 4095u);
+    EXPECT_EQ(bound_param0.surface_link().volume(), 0u);
     EXPECT_EQ(bound_param0.surface_link().index(), 0u);
     EXPECT_EQ(bound_param1.surface_link().volume(), 0u);
     EXPECT_EQ(bound_param1.surface_link().id(), surface_id::e_sensitive);

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -537,8 +537,7 @@ TEST_P(PropagatorWithRkStepperDirectNavigator, direct_navigator) {
 
             // The initial momentum should be higher than the momentum at the
             // last surface
-            ASSERT_GE(track.p(q),
-                      static_cast<float>(state._stepping.bound_params().p(q)));
+            ASSERT_TRUE(track.p(q) > state._stepping.bound_params().p(q));
             ASSERT_FLOAT_EQ(
                 static_cast<float>(state._stepping.bound_params().p(q)),
                 static_cast<float>(
@@ -557,11 +556,13 @@ TEST_P(PropagatorWithRkStepperDirectNavigator, direct_navigator) {
 
             // @TODO: Need to investigate why there is a discrepancy of =< 0.1%
             // in the initial momentum
-            EXPECT_NEAR(
+            ASSERT_NEAR(
                 static_cast<float>(track.p(q)),
                 static_cast<float>(
                     direct_backward_state._stepping.bound_params().p(q)),
                 static_cast<float>(track.p(q)) * 0.001f);
+            ASSERT_TRUE(direct_backward_state._stepping.bound_params().p(q) >
+                        direct_forward_state._stepping.bound_params().p(q));
         }
     }
 }

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -22,6 +22,7 @@
 
 // Detray test include(s)
 #include "detray/test/utils/detectors/build_toy_detector.hpp"
+#include "detray/test/utils/detectors/build_wire_chamber.hpp"
 #include "detray/test/utils/inspectors.hpp"
 #include "detray/test/utils/simulation/event_generator/track_generators.hpp"
 #include "detray/test/utils/types.hpp"
@@ -416,12 +417,12 @@ INSTANTIATE_TEST_SUITE_P(
                                               1.f * unit<scalar>::T,
                                               1.f * unit<scalar>::T})));
 
-/// Fixture for Runge-Kutta Propagation
-class PropagatorWithRkStepperDirectNavigator
+/// Fixture for Runge-Kutta Propagation with direct navigator and toy detector
+class PropagatorWithRkStepperDirectNavigatorToyDetector
     : public ::testing::TestWithParam<std::tuple<scalar, test::vector3>> {};
 
 /// Test propagation in a constant magnetic field using a Runge-Kutta stepper
-TEST_P(PropagatorWithRkStepperDirectNavigator, direct_navigator) {
+TEST_P(PropagatorWithRkStepperDirectNavigatorToyDetector, direct_navigator) {
 
     // Memory resource
     vecmem::host_memory_resource host_mr;
@@ -462,13 +463,15 @@ TEST_P(PropagatorWithRkStepperDirectNavigator, direct_navigator) {
     using direct_propagator_t =
         propagator<stepper_t, direct_navigator_t, direct_actor_chain_t>;
 
-    // Build detector and magnetic field
+    // Build toy detector
     toy_det_config<scalar> toy_cfg =
         toy_det_config<scalar>{}.n_brl_layers(4u).n_edc_layers(7u);
 
     toy_cfg.use_material_maps(false);
     const auto [det, names] =
         build_toy_detector<test_algebra>(host_mr, toy_cfg);
+
+    // Build mangetic field
     const bfield_t bfield =
         bfield::create_const_field<scalar>(std::get<1>(GetParam()));
 
@@ -599,7 +602,206 @@ TEST_P(PropagatorWithRkStepperDirectNavigator, direct_navigator) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    detray_propagator_direct_navigator, PropagatorWithRkStepperDirectNavigator,
+    detray_propagator_direct_navigator_toy_detector,
+    PropagatorWithRkStepperDirectNavigatorToyDetector,
+    ::testing::Values(
+        std::make_tuple(-100.f * unit<scalar>::um,
+                        vector3{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                                2.f * unit<scalar>::T}),
+        std::make_tuple(-400.f * unit<scalar>::um,
+                        vector3{0.f * unit<scalar>::T, 1.f * unit<scalar>::T,
+                                1.f * unit<scalar>::T}),
+        std::make_tuple(-400.f * unit<scalar>::um,
+                        vector3{1.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                                1.f * unit<scalar>::T}),
+        std::make_tuple(-600.f * unit<scalar>::um,
+                        vector3{1.f * unit<scalar>::T, 1.f * unit<scalar>::T,
+                                1.f * unit<scalar>::T})));
+
+/// Fixture for Runge-Kutta Propagation with direct navigator and wire chamber
+class PropagatorWithRkStepperDirectNavigatorWireChamber
+    : public ::testing::TestWithParam<std::tuple<scalar, test::vector3>> {};
+
+/// Test propagation in a constant magnetic field using a Runge-Kutta stepper
+TEST_P(PropagatorWithRkStepperDirectNavigatorWireChamber, direct_navigator) {
+
+    // Memory resource
+    vecmem::host_memory_resource host_mr;
+
+    // Track generator configuration
+    using generator_t =
+        uniform_track_generator<free_track_parameters<test_algebra>>;
+
+    generator_t::configuration trk_gen_cfg{};
+    trk_gen_cfg.phi_steps(50u).theta_steps(50u);
+    trk_gen_cfg.p_tot(10.f * unit<scalar>::GeV);
+
+    // Constant magnetic field type
+    using bfield_t = bfield::const_field_t<scalar>;
+
+    // Toy detector
+    using detector_t = detector<test::default_metadata>;
+
+    // Runge-Kutta propagation
+    using navigator_t =
+        navigator<detector_t, cache_size, navigation::print_inspector>;
+    using constraints_t = constrained_step<scalar>;
+    using policy_t = stepper_rk_policy<scalar>;
+    using stepper_t =
+        rk_stepper<bfield_t::view_t, test_algebra, constraints_t, policy_t>;
+    // Include helix actor to check track position/covariance
+    using actor_chain_t =
+        actor_chain<parameter_transporter<test_algebra>,
+                    pointwise_material_interactor<test_algebra>,
+                    parameter_resetter<test_algebra>, barcode_sequencer>;
+    using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
+
+    using direct_navigator_t = direct_navigator<detector_t>;
+    using direct_actor_chain_t =
+        actor_chain<parameter_transporter<test_algebra>,
+                    pointwise_material_interactor<test_algebra>,
+                    parameter_resetter<test_algebra>, barcode_sequencer>;
+    using direct_propagator_t =
+        propagator<stepper_t, direct_navigator_t, direct_actor_chain_t>;
+
+    // Build wire chamber
+    wire_chamber_config<scalar> wire_cfg{};
+    auto [det, names] = build_wire_chamber<test::algebra>(host_mr, wire_cfg);
+
+    // Build mangetic field
+    const bfield_t bfield =
+        bfield::create_const_field<scalar>(std::get<1>(GetParam()));
+
+    // Propagation configuration
+    propagation::config cfg{};
+    cfg.navigation.overstep_tolerance =
+        static_cast<float>(std::get<0>(GetParam()));
+    cfg.navigation.search_window = {5u, 5u};
+    propagation::config direct_cfg{};
+    direct_cfg.navigation.min_mask_tolerance = 10.f * unit<float>::mm;
+    direct_cfg.navigation.max_mask_tolerance = 10.f * unit<float>::mm;
+    propagator_t p{cfg};
+    direct_propagator_t direct_p{direct_cfg};
+
+    // Iterate through uniformly distributed momentum directions
+    for (auto track : generator_t{trk_gen_cfg}) {
+
+        // Build actor states: the helix inspector can be shared
+        parameter_transporter<test_algebra>::state transporter_state{};
+        pointwise_material_interactor<test_algebra>::state interactor_state{};
+        parameter_resetter<test_algebra>::state resetter_state{};
+        vecmem::data::vector_buffer<detray::geometry::barcode> seqs_buffer{
+            100u, host_mr, vecmem::data::buffer_type::resizable};
+        vecmem::data::vector_buffer<detray::geometry::barcode>
+            seqs_forward_buffer{100u, host_mr,
+                                vecmem::data::buffer_type::resizable};
+        vecmem::data::vector_buffer<detray::geometry::barcode>
+            seqs_backward_buffer{100u, host_mr,
+                                 vecmem::data::buffer_type::resizable};
+        vecmem::copy m_copy;
+        m_copy.setup(seqs_buffer)->wait();
+        m_copy.setup(seqs_forward_buffer)->wait();
+        m_copy.setup(seqs_backward_buffer)->wait();
+
+        vecmem::device_vector<detray::geometry::barcode> seqs_device(
+            seqs_buffer);
+        vecmem::device_vector<detray::geometry::barcode> seqs_forward_device(
+            seqs_forward_buffer);
+        vecmem::device_vector<detray::geometry::barcode> seqs_backward_device(
+            seqs_backward_buffer);
+
+        barcode_sequencer::state sequencer_state(seqs_device);
+        barcode_sequencer::state sequencer_forward_state(seqs_forward_device);
+        barcode_sequencer::state sequencer_backward_state(seqs_backward_device);
+
+        auto actor_states = detray::tie(transporter_state, interactor_state,
+                                        resetter_state, sequencer_state);
+
+        propagator_t::state state(track, bfield, det);
+
+        // Propagate the entire detector
+        // state.do_debug = true;
+        ASSERT_TRUE(p.propagate(state, actor_states));
+        // std::cout << "Normal Navigation" << std::endl;
+        // std::cout << state.debug_stream.str() << std::endl;
+
+        if (seqs_device.size() > 0) {
+
+            auto direct_forward_actor_states =
+                detray::tie(transporter_state, interactor_state, resetter_state,
+                            sequencer_forward_state);
+            auto direct_backward_actor_states =
+                detray::tie(transporter_state, interactor_state, resetter_state,
+                            sequencer_backward_state);
+
+            direct_propagator_t::state direct_forward_state(track, bfield, det,
+                                                            seqs_buffer);
+
+            // direct_forward_state.do_debug = true;
+            ASSERT_TRUE(direct_p.propagate(direct_forward_state,
+                                           direct_forward_actor_states));
+            // std::cout << "Direct navigaiton in forward direction" <<
+            // std::endl; std::cout << direct_forward_state.debug_stream.str()
+            // << std::endl;
+
+            // Check if all surfaces in the sequence are encountered
+            ASSERT_TRUE(direct_forward_state._navigation.is_complete());
+            ASSERT_EQ(sequencer_state._sequence.size(),
+                      sequencer_forward_state._sequence.size());
+            for (unsigned int i = 0; i < sequencer_state._sequence.size();
+                 i++) {
+                ASSERT_EQ(sequencer_state._sequence.at(i),
+                          sequencer_forward_state._sequence.at(i));
+            }
+
+            const auto ptc = state._stepping.particle_hypothesis();
+            ASSERT_EQ(
+                ptc.pdg_num(),
+                direct_forward_state._stepping.particle_hypothesis().pdg_num());
+            const auto q = ptc.charge();
+
+            // The initial momentum should be higher than or equal to the
+            // momentum at the last surface
+            ASSERT_GE(track.p(q), state._stepping.bound_params().p(q));
+            ASSERT_FLOAT_EQ(
+                static_cast<float>(state._stepping.bound_params().p(q)),
+                static_cast<float>(
+                    direct_forward_state._stepping.bound_params().p(q)));
+
+            direct_propagator_t::state direct_backward_state(
+                direct_forward_state._stepping.bound_params(), bfield, det,
+                seqs_buffer);
+            direct_backward_state._navigation.set_direction(
+                detray::navigation::direction::e_backward);
+
+            ASSERT_TRUE(direct_p.propagate(direct_backward_state,
+                                           direct_backward_actor_states));
+
+            // Check if all surfaces in the sequence are encountered
+            ASSERT_TRUE(direct_backward_state._navigation.is_complete());
+            ASSERT_EQ(sequencer_state._sequence.size(),
+                      sequencer_backward_state._sequence.size());
+            for (unsigned int i = 0; i < sequencer_state._sequence.size();
+                 i++) {
+                unsigned int j = sequencer_state._sequence.size() - 1 - i;
+                ASSERT_EQ(sequencer_state._sequence.at(i),
+                          sequencer_backward_state._sequence.at(j));
+            }
+
+            ASSERT_NEAR(
+                static_cast<float>(track.p(q)),
+                static_cast<float>(
+                    direct_backward_state._stepping.bound_params().p(q)),
+                static_cast<float>(track.p(q)) * 0.0002f);
+            ASSERT_GE(direct_backward_state._stepping.bound_params().p(q),
+                      direct_forward_state._stepping.bound_params().p(q));
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    detray_propagator_direct_navigator_wire_chamber,
+    PropagatorWithRkStepperDirectNavigatorWireChamber,
     ::testing::Values(
         std::make_tuple(-100.f * unit<scalar>::um,
                         vector3{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/units.hpp"
 #include "detray/detectors/bfield.hpp"
 #include "detray/geometry/tracking_surface.hpp"
+#include "detray/navigation/direct_navigator.hpp"
 #include "detray/navigation/navigator.hpp"
 #include "detray/propagator/actors.hpp"
 #include "detray/propagator/base_actor.hpp"
@@ -414,3 +415,169 @@ INSTANTIATE_TEST_SUITE_P(
                                       vector3{1.f * unit<scalar>::T,
                                               1.f * unit<scalar>::T,
                                               1.f * unit<scalar>::T})));
+
+/// Fixture for Runge-Kutta Propagation
+class PropagatorWithRkStepperDirectNavigator
+    : public ::testing::TestWithParam<std::tuple<scalar, test::vector3>> {};
+
+/// Test propagation in a constant magnetic field using a Runge-Kutta stepper
+TEST_P(PropagatorWithRkStepperDirectNavigator, direct_navigator) {
+
+    // Memory resource
+    vecmem::host_memory_resource host_mr;
+
+    // Track generator configuration
+    using generator_t =
+        uniform_track_generator<free_track_parameters<test_algebra>>;
+
+    generator_t::configuration trk_gen_cfg{};
+    trk_gen_cfg.phi_steps(50u).theta_steps(50u);
+    trk_gen_cfg.p_tot(10.f * unit<scalar>::GeV);
+
+    // Constant magnetic field type
+    using bfield_t = bfield::const_field_t<scalar>;
+
+    // Toy detector
+    using detector_t = detector<test::toy_metadata>;
+
+    // Runge-Kutta propagation
+    using navigator_t =
+        navigator<detector_t, cache_size, navigation::print_inspector>;
+    using constraints_t = constrained_step<scalar>;
+    using policy_t = stepper_rk_policy<scalar>;
+    using stepper_t =
+        rk_stepper<bfield_t::view_t, test_algebra, constraints_t, policy_t>;
+    // Include helix actor to check track position/covariance
+    using actor_chain_t =
+        actor_chain<parameter_transporter<test_algebra>,
+                    pointwise_material_interactor<test_algebra>,
+                    parameter_resetter<test_algebra>, barcode_sequencer>;
+    using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
+
+    using direct_navigator_t = direct_navigator<detector_t>;
+    using direct_actor_chain_t =
+        actor_chain<parameter_transporter<test_algebra>,
+                    pointwise_material_interactor<test_algebra>,
+                    parameter_resetter<test_algebra>>;
+    using direct_propagator_t =
+        propagator<stepper_t, direct_navigator_t, direct_actor_chain_t>;
+
+    // Build detector and magnetic field
+    toy_det_config<scalar> toy_cfg =
+        toy_det_config<scalar>{}.n_brl_layers(4u).n_edc_layers(7u);
+
+    toy_cfg.use_material_maps(false);
+    const auto [det, names] =
+        build_toy_detector<test_algebra>(host_mr, toy_cfg);
+    const bfield_t bfield =
+        bfield::create_const_field<scalar>(std::get<1>(GetParam()));
+
+    // Propagation configuration
+    propagation::config cfg{};
+    cfg.navigation.overstep_tolerance =
+        static_cast<float>(std::get<0>(GetParam()));
+    cfg.navigation.search_window = {3u, 3u};
+    propagation::config direct_cfg{};
+    direct_cfg.navigation.min_mask_tolerance = 1.f * unit<float>::mm;
+    direct_cfg.navigation.max_mask_tolerance = 1.f * unit<float>::mm;
+    propagator_t p{cfg};
+    direct_propagator_t direct_p{direct_cfg};
+
+    // Iterate through uniformly distributed momentum directions
+    for (auto track : generator_t{trk_gen_cfg}) {
+
+        // Build actor states: the helix inspector can be shared
+        parameter_transporter<test_algebra>::state transporter_state{};
+        pointwise_material_interactor<test_algebra>::state interactor_state{};
+        parameter_resetter<test_algebra>::state resetter_state{};
+        vecmem::data::vector_buffer<detray::geometry::barcode> seqs_buffer{
+            100u, host_mr, vecmem::data::buffer_type::resizable};
+        vecmem::copy m_copy;
+        m_copy.setup(seqs_buffer)->wait();
+
+        vecmem::device_vector<detray::geometry::barcode> seqs_device(
+            seqs_buffer);
+
+        barcode_sequencer::state sequencer_state(seqs_device);
+
+        auto actor_states = detray::tie(transporter_state, interactor_state,
+                                        resetter_state, sequencer_state);
+
+        propagator_t::state state(track, bfield, det);
+
+        // Propagate the entire detector
+        // state.do_debug = true;
+        ASSERT_TRUE(p.propagate(state, actor_states));
+        // std::cout << "Normal Navigation" << std::endl;
+        // std::cout << state.debug_stream.str() << std::endl;
+
+        if (seqs_device.size() > 0) {
+
+            auto direct_actor_states = detray::tie(
+                transporter_state, interactor_state, resetter_state);
+
+            direct_propagator_t::state direct_forward_state(track, bfield, det,
+                                                            seqs_buffer);
+
+            // direct_forward_state.do_debug = true;
+            ASSERT_TRUE(
+                direct_p.propagate(direct_forward_state, direct_actor_states));
+            // std::cout << "Direct navigaiton in forward direction" <<
+            // std::endl; std::cout << direct_forward_state.debug_stream.str()
+            // << std::endl;
+
+            // Check if all surfaces in the sequence are encountered
+            ASSERT_TRUE(direct_forward_state._navigation.is_complete());
+
+            const auto ptc = state._stepping.particle_hypothesis();
+            ASSERT_EQ(
+                ptc.pdg_num(),
+                direct_forward_state._stepping.particle_hypothesis().pdg_num());
+            const auto q = ptc.charge();
+
+            // The initial momentum should be higher than the momentum at the
+            // last surface
+            ASSERT_GE(track.p(q),
+                      static_cast<float>(state._stepping.bound_params().p(q)));
+            ASSERT_FLOAT_EQ(
+                static_cast<float>(state._stepping.bound_params().p(q)),
+                static_cast<float>(
+                    direct_forward_state._stepping.bound_params().p(q)));
+
+            direct_propagator_t::state direct_backward_state(
+                direct_forward_state._stepping.bound_params(), bfield, det,
+                seqs_buffer);
+            direct_backward_state._navigation.set_direction(
+                detray::navigation::direction::e_backward);
+
+            ASSERT_TRUE(
+                direct_p.propagate(direct_backward_state, direct_actor_states));
+            // Check if all surfaces in the sequence are encountered
+            ASSERT_TRUE(direct_backward_state._navigation.is_complete());
+
+            // @TODO: Need to investigate why there is a discrepancy of =< 0.1%
+            // in the initial momentum
+            EXPECT_NEAR(
+                static_cast<float>(track.p(q)),
+                static_cast<float>(
+                    direct_backward_state._stepping.bound_params().p(q)),
+                static_cast<float>(track.p(q)) * 0.001f);
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    detray_propagator_direct_navigator, PropagatorWithRkStepperDirectNavigator,
+    ::testing::Values(
+        std::make_tuple(-100.f * unit<scalar>::um,
+                        vector3{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                                2.f * unit<scalar>::T}),
+        std::make_tuple(-400.f * unit<scalar>::um,
+                        vector3{0.f * unit<scalar>::T, 1.f * unit<scalar>::T,
+                                1.f * unit<scalar>::T}),
+        std::make_tuple(-400.f * unit<scalar>::um,
+                        vector3{1.f * unit<scalar>::T, 0.f * unit<scalar>::T,
+                                1.f * unit<scalar>::T}),
+        std::make_tuple(-600.f * unit<scalar>::um,
+                        vector3{1.f * unit<scalar>::T, 1.f * unit<scalar>::T,
+                                1.f * unit<scalar>::T})));

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -763,10 +763,12 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorWireChamber, direct_navigator) {
             // The initial momentum should be higher than or equal to the
             // momentum at the last surface
             ASSERT_GE(track.p(q), state._stepping.bound_params().p(q));
-            ASSERT_FLOAT_EQ(
+            ASSERT_NEAR(
                 static_cast<float>(state._stepping.bound_params().p(q)),
                 static_cast<float>(
-                    direct_forward_state._stepping.bound_params().p(q)));
+                    direct_forward_state._stepping.bound_params().p(q)),
+                static_cast<float>(state._stepping.bound_params().p(q)) *
+                    1e-6f);
 
             direct_propagator_t::state direct_backward_state(
                 direct_forward_state._stepping.bound_params(), bfield, det,

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -90,7 +90,8 @@ GTEST_TEST(detray_propagator, covariance_transport) {
 
     // Bound track parameter
     const bound_track_parameters<test_algebra> bound_param0(
-        geometry::barcode{}.set_index(0u), bound_vector, bound_cov);
+        geometry::barcode{}.set_index(0u).set_volume(0u), bound_vector,
+        bound_cov);
 
     propagation::config prop_cfg{};
     prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
@@ -104,7 +105,7 @@ GTEST_TEST(detray_propagator, covariance_transport) {
     const auto& bound_param1 = propagation._stepping.bound_params();
 
     // Check if the track reaches the final surface
-    EXPECT_EQ(bound_param0.surface_link().volume(), 4095u);
+    EXPECT_EQ(bound_param0.surface_link().volume(), 0u);
     EXPECT_EQ(bound_param0.surface_link().index(), 0u);
     EXPECT_EQ(bound_param1.surface_link().volume(), 0u);
     EXPECT_EQ(bound_param1.surface_link().id(), surface_id::e_sensitive);


### PR DESCRIPTION
This PR implements direct navigator.
The direct navigator runs on the input surface sequence which include all types of surfaces (passive, sensitive and portals)
The input sequence can be collected from previous run of propagator using `barcode_sequencer` actor
It is also designed to work with both forward and backward directions.

The PR also fixes the bug that `path` is not written in the cylinder intersections when `path < overstep tolerance`, which occasionally killed the propagation with direct navigator and small overstep tolerance.

Also This PR sets the volume in the propagator constructor with bound parameter inputs.
