### PR TITLE
Add Ubuntu 22.04 clang CI job

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -59,6 +59,10 @@ jobs:
             CXX_STANDARD: "20"
             CONTAINER: "ghcr.io/acts-project/ubuntu2404:56"
             OPTIONS: -DDETRAY_EIGEN_PLUGIN=ON -DDETRAY_SMATRIX_PLUGIN=ON -DDETRAY_VC_AOS_PLUGIN=ON -DDETRAY_VC_SOA_PLUGIN=ON
+          - NAME: "HOST"
+            CXX_STANDARD: "20"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2204:71"
+            OPTIONS: -DCMAKE_CXX_COMPILER=clang++
 
     # The system to run on.
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a CI job for the Ubuntu 22.04 platform with the clang compiler. This configuration has proven to be a headache in ACTS in https://github.com/acts-project/acts/pull/4068 and https://github.com/acts-project/acts/pull/4125, so it would be nice to protect against errors in the detray CI.