### PR TITLE
Fix device declarations for HIP compilation and use DETRAY_NO_DEVICE consistently

### DIFF
--- a/core/include/detray/definitions/algorithms.hpp
+++ b/core/include/detray/definitions/algorithms.hpp
@@ -23,8 +23,7 @@ template <std::random_access_iterator rand_iter_t,
           std::sentinel_for<rand_iter_t> sentinel_t>
 DETRAY_HOST_DEVICE inline void sequential_sort(rand_iter_t first,
                                                sentinel_t last) {
-#if defined(__CUDACC__) || defined(CL_SYCL_LANGUAGE_VERSION) || \
-    defined(SYCL_LANGUAGE_VERSION)
+#if !defined(DETRAY_NO_DEVICE)
     detray::detail::selection_sort(first, last);
 #else
     std::ranges::sort(first, last);
@@ -50,8 +49,7 @@ template <std::forward_iterator forw_iter_t,
           std::sentinel_for<forw_iter_t> sentinel_t, typename Value>
 DETRAY_HOST_DEVICE inline auto lower_bound(forw_iter_t first, sentinel_t last,
                                            const Value& value) {
-#if defined(__CUDACC__) || defined(CL_SYCL_LANGUAGE_VERSION) || \
-    defined(SYCL_LANGUAGE_VERSION)
+#if !defined(DETRAY_NO_DEVICE)
     return detray::detail::lower_bound(first, last, value);
 #else
     return std::ranges::lower_bound(first, last, value);
@@ -63,8 +61,7 @@ template <std::forward_iterator forw_iter_t,
           std::sentinel_for<forw_iter_t> sentinel_t, typename Value>
 DETRAY_HOST_DEVICE inline auto upper_bound(forw_iter_t first, sentinel_t last,
                                            const Value& value) {
-#if defined(__CUDACC__) || defined(CL_SYCL_LANGUAGE_VERSION) || \
-    defined(SYCL_LANGUAGE_VERSION)
+#if !defined(DETRAY_NO_DEVICE)
     return detray::detail::upper_bound(first, last, value);
 #else
     return std::ranges::upper_bound(first, last, value);

--- a/core/include/detray/definitions/detail/qualifiers.hpp
+++ b/core/include/detray/definitions/detail/qualifiers.hpp
@@ -31,3 +31,11 @@
 #else
 #define DETRAY_ALIGN(x) alignas(x)
 #endif
+
+#if defined(__CUDACC__) || defined(__HIP__) || \
+    defined(CL_SYCL_LANGUAGE_VERSION) || \
+    defined(SYCL_LANGUAGE_VERSION)
+#define DETRAY_ON_DEVICE 1
+#else 
+#define DETRAY_ON_DEVICE 0
+#endif

--- a/core/include/detray/definitions/detail/qualifiers.hpp
+++ b/core/include/detray/definitions/detail/qualifiers.hpp
@@ -31,11 +31,3 @@
 #else
 #define DETRAY_ALIGN(x) alignas(x)
 #endif
-
-#if defined(__CUDACC__) || defined(__HIP__) || \
-    defined(CL_SYCL_LANGUAGE_VERSION) || \
-    defined(SYCL_LANGUAGE_VERSION)
-#define DETRAY_ON_DEVICE 1
-#else 
-#define DETRAY_ON_DEVICE 0
-#endif


### PR DESCRIPTION
Missing some `if defined(__HIP__)`: since DETRAY_NO_DEVICE defines these, use it consistently instead.