### PR TITLE
feat: improve vectorization by changing the order of evaluation

### DIFF
--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -64,8 +64,9 @@ struct parameter_transporter : actor {
             const free_matrix_t correction_term =
                 matrix::identity<free_matrix_t>() + path_correction;
 
-            return free_to_bound_jacobian * correction_term *
-                   stepping.transport_jacobian() * bound_to_free_jacobian;
+            return free_to_bound_jacobian *
+                   (correction_term *
+                    (stepping.transport_jacobian() * bound_to_free_jacobian));
         }
     };
 


### PR DESCRIPTION
Go from evaluating 6x8 matrices to evaluating 8x6 matrices. Since our matrices are stored column wise, it is easier to fill larger vector registers this way (each column fits into an avx register in single precision)

~Edit: Also adds the precision for printing matrices when using the streaming operators in conjunction with google test error outputs (which seem to manipulate the stream state?)~