### PR TITLE
Prevent CMake flags from propagating to parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ With the geometry description comes a fully featured, GPU-ready track state prop
 - The CUDA Toolkit version must be greater than major version 11
 
 #### Dependencies:
-- CMake (version >= 3.14, version >= 3.18 for CUDA)
+- CMake (version >= 3.21)
 
 
 ## Getting started

--- a/cmake/detray-compiler-options-cpp.cmake
+++ b/cmake/detray-compiler-options-cpp.cmake
@@ -4,52 +4,57 @@
 #
 # Mozilla Public License Version 2.0
 
-# Include the helper function(s).
-include(detray-functions)
+cmake_minimum_required(VERSION 3.21)
 
-# Turn on the correct setting for the __cplusplus macro with MSVC.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
-    detray_add_flag(CMAKE_CXX_FLAGS "/Zc:__cplusplus")
-endif()
+# Only set these compiler flags if we are the top level project.
+if(PROJECT_IS_TOP_LEVEL)
+    # Include the helper function(s).
+    include(detray-functions)
 
-# Respect infinity expressions for IntelLLVM
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "IntelLLVM")
-    detray_add_flag(CMAKE_CXX_FLAGS "-fhonor-infinities")
-endif()
-
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    detray_add_flag(CMAKE_CXX_FLAGS "-Wshorten-64-to-32")
-endif()
-
-# Turn on a number of warnings for the "known compilers".
-if(
-    ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-    OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "IntelLLVM")
-)
-    # Basic flags for all build modes.
-    detray_add_flag(CMAKE_CXX_FLAGS "-Wall")
-    detray_add_flag(CMAKE_CXX_FLAGS "-Wextra")
-    detray_add_flag(CMAKE_CXX_FLAGS "-Wshadow")
-    detray_add_flag(CMAKE_CXX_FLAGS "-Wunused-local-typedefs")
-    detray_add_flag(CMAKE_CXX_FLAGS "-Wzero-as-null-pointer-constant")
-    detray_add_flag(CMAKE_CXX_FLAGS "-Wnull-dereference")
-    detray_add_flag(CMAKE_CXX_FLAGS "-Wold-style-cast")
-    detray_add_flag(CMAKE_CXX_FLAGS "-pedantic")
-    # No implicit single to double conversions from floating point literals
-    detray_add_flag(CMAKE_CXX_FLAGS "-Wconversion")
-
-    # Fail on warnings, if asked for that behaviour.
-    if(DETRAY_FAIL_ON_WARNINGS)
-        detray_add_flag(CMAKE_CXX_FLAGS "-Werror")
+    # Turn on the correct setting for the __cplusplus macro with MSVC.
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+        detray_add_flag(CMAKE_CXX_FLAGS "/Zc:__cplusplus")
     endif()
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
-    # Basic flags for all build modes.
-    string(REGEX REPLACE "/W[0-9]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    detray_add_flag(CMAKE_CXX_FLAGS "/W4")
 
-    # Fail on warnings, if asked for that behaviour.
-    if(DETRAY_FAIL_ON_WARNINGS)
-        detray_add_flag(CMAKE_CXX_FLAGS "/WX")
+    # Respect infinity expressions for IntelLLVM
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "IntelLLVM")
+        detray_add_flag(CMAKE_CXX_FLAGS "-fhonor-infinities")
+    endif()
+
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        detray_add_flag(CMAKE_CXX_FLAGS "-Wshorten-64-to-32")
+    endif()
+
+    # Turn on a number of warnings for the "known compilers".
+    if(
+        ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+        OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "IntelLLVM")
+    )
+        # Basic flags for all build modes.
+        detray_add_flag(CMAKE_CXX_FLAGS "-Wall")
+        detray_add_flag(CMAKE_CXX_FLAGS "-Wextra")
+        detray_add_flag(CMAKE_CXX_FLAGS "-Wshadow")
+        detray_add_flag(CMAKE_CXX_FLAGS "-Wunused-local-typedefs")
+        detray_add_flag(CMAKE_CXX_FLAGS "-Wzero-as-null-pointer-constant")
+        detray_add_flag(CMAKE_CXX_FLAGS "-Wnull-dereference")
+        detray_add_flag(CMAKE_CXX_FLAGS "-Wold-style-cast")
+        detray_add_flag(CMAKE_CXX_FLAGS "-pedantic")
+        # No implicit single to double conversions from floating point literals
+        detray_add_flag(CMAKE_CXX_FLAGS "-Wconversion")
+
+        # Fail on warnings, if asked for that behaviour.
+        if(DETRAY_FAIL_ON_WARNINGS)
+            detray_add_flag(CMAKE_CXX_FLAGS "-Werror")
+        endif()
+    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+        # Basic flags for all build modes.
+        string(REGEX REPLACE "/W[0-9]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        detray_add_flag(CMAKE_CXX_FLAGS "/W4")
+
+        # Fail on warnings, if asked for that behaviour.
+        if(DETRAY_FAIL_ON_WARNINGS)
+            detray_add_flag(CMAKE_CXX_FLAGS "/WX")
+        endif()
     endif()
 endif()

--- a/cmake/detray-compiler-options-cuda.cmake
+++ b/cmake/detray-compiler-options-cuda.cmake
@@ -4,46 +4,48 @@
 #
 # Mozilla Public License Version 2.0
 
-# FindCUDAToolkit needs at least CMake 3.17.
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.21)
 
-# Include the helper function(s).
-include(detray-functions)
+# Only set these compiler flags if we are the top level project.
+if(PROJECT_IS_TOP_LEVEL)
+    # Include the helper function(s).
+    include(detray-functions)
 
-# Figure out the properties of CUDA being used.
-find_package(CUDAToolkit REQUIRED)
+    # Figure out the properties of CUDA being used.
+    find_package(CUDAToolkit REQUIRED)
 
-# Turn on the correct setting for the __cplusplus macro with MSVC.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
-    detray_add_flag( CMAKE_CUDA_FLAGS "-Xcompiler /Zc:__cplusplus" )
-endif()
+    # Turn on the correct setting for the __cplusplus macro with MSVC.
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+        detray_add_flag( CMAKE_CUDA_FLAGS "-Xcompiler /Zc:__cplusplus" )
+    endif()
 
-# Set the CUDA architecture to build code for.
-set(CMAKE_CUDA_ARCHITECTURES
-    "52"
-    CACHE STRING
-    "CUDA architectures to build device code for"
-)
-
-if("${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA")
-    # Allow to use functions in device code that are constexpr, even if they are
-    # not marked with __device__.
-    detray_add_flag( CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr" )
-endif()
-
-# Make CUDA generate debug symbols for the device code as well in a debug
-# build.
-detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G -src-in-ptx" )
-detray_add_flag( CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-lineinfo -src-in-ptx" )
-
-# Fail on warnings, if asked for that behaviour.
-if(DETRAY_FAIL_ON_WARNINGS)
-    if(
-        ("${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2")
-        AND ("${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA")
+    # Set the CUDA architecture to build code for.
+    set(CMAKE_CUDA_ARCHITECTURES
+        "52"
+        CACHE STRING
+        "CUDA architectures to build device code for"
     )
-        detray_add_flag( CMAKE_CUDA_FLAGS "-Werror all-warnings" )
-    elseif("${CMAKE_CUDA_COMPILER_ID}" MATCHES "Clang")
-        detray_add_flag( CMAKE_CUDA_FLAGS "-Werror" )
+
+    if("${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA")
+        # Allow to use functions in device code that are constexpr, even if they are
+        # not marked with __device__.
+        detray_add_flag( CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr" )
+    endif()
+
+    # Make CUDA generate debug symbols for the device code as well in a debug
+    # build.
+    detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G -src-in-ptx" )
+    detray_add_flag( CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-lineinfo -src-in-ptx" )
+
+    # Fail on warnings, if asked for that behaviour.
+    if(DETRAY_FAIL_ON_WARNINGS)
+        if(
+            ("${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2")
+            AND ("${CMAKE_CUDA_COMPILER_ID}" MATCHES "NVIDIA")
+        )
+            detray_add_flag( CMAKE_CUDA_FLAGS "-Werror all-warnings" )
+        elseif("${CMAKE_CUDA_COMPILER_ID}" MATCHES "Clang")
+            detray_add_flag( CMAKE_CUDA_FLAGS "-Werror" )
+        endif()
     endif()
 endif()

--- a/cmake/detray-compiler-options-sycl.cmake
+++ b/cmake/detray-compiler-options-sycl.cmake
@@ -4,27 +4,32 @@
 #
 # Mozilla Public License Version 2.0
 
-# Include the helper function(s).
-include(detray-functions)
+cmake_minimum_required(VERSION 3.21)
 
-# Basic flags for all build modes.
-detray_add_flag( CMAKE_SYCL_FLAGS "-Wall" )
-detray_add_flag( CMAKE_SYCL_FLAGS "-Wextra" )
-detray_add_flag( CMAKE_SYCL_FLAGS "-Wno-unknown-cuda-version" )
-detray_add_flag( CMAKE_SYCL_FLAGS "-Wshadow" )
-detray_add_flag( CMAKE_SYCL_FLAGS "-Wunused-local-typedefs" )
-if(NOT WIN32)
-    detray_add_flag( CMAKE_SYCL_FLAGS "-pedantic" )
-endif()
+# Only set these compiler flags if we are the top level project.
+if(PROJECT_IS_TOP_LEVEL)
+    # Include the helper function(s).
+    include(detray-functions)
 
-# Avoid issues coming from MSVC<->DPC++ argument differences.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
-    detray_add_flag(CMAKE_SYCL_FLAGS
-      "-Wno-unused-command-line-argument"
-    )
-endif()
+    # Basic flags for all build modes.
+    detray_add_flag( CMAKE_SYCL_FLAGS "-Wall" )
+    detray_add_flag( CMAKE_SYCL_FLAGS "-Wextra" )
+    detray_add_flag( CMAKE_SYCL_FLAGS "-Wno-unknown-cuda-version" )
+    detray_add_flag( CMAKE_SYCL_FLAGS "-Wshadow" )
+    detray_add_flag( CMAKE_SYCL_FLAGS "-Wunused-local-typedefs" )
+    if(NOT WIN32)
+        detray_add_flag( CMAKE_SYCL_FLAGS "-pedantic" )
+    endif()
 
-# Fail on warnings, if asked for that behaviour.
-if(DETRAY_FAIL_ON_WARNINGS)
-    detray_add_flag( CMAKE_SYCL_FLAGS "-Werror" )
+    # Avoid issues coming from MSVC<->DPC++ argument differences.
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+        detray_add_flag(CMAKE_SYCL_FLAGS
+          "-Wno-unused-command-line-argument"
+        )
+    endif()
+
+    # Fail on warnings, if asked for that behaviour.
+    if(DETRAY_FAIL_ON_WARNINGS)
+        detray_add_flag( CMAKE_SYCL_FLAGS "-Werror" )
+    endif()
 endif()


### PR DESCRIPTION
Due to the poor design of CMake's FetchContent module, detray's compilation flags are leaking into its parents projects. In particular, some important flags like the CUDA architecture flags are being overwritten by detray. In order to prevent that problem, this PR ensures that detray's build system only adds compiler flags to the global CMake variables if it is the top level project.