### PR TITLE
ref: Allow to construct helices from all b field types

### DIFF
--- a/core/include/detray/navigation/intersection/helix_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/helix_line_intersector.hpp
@@ -132,7 +132,7 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
 
                 // dtds = d^2r/ds^2 = qop * (t X b_field)
                 const vector3_type dtds =
-                    h.qop() * vector::cross(t, *h._mag_field);
+                    h.qop() * vector::cross(t, h.b_field());
                 // dwds = t - (t * l)l
                 const vector3_type dwds = t - vector::dot(t, l) * l;
 
@@ -236,7 +236,7 @@ struct helix_intersector_impl<line2D<algebra_t>, algebra_t> {
 
                 // dtds = d^2r/ds^2 = qop * (t X b_field)
                 const vector3_type dtds =
-                    h.qop() * vector::cross(t, *h._mag_field);
+                    h.qop() * vector::cross(t, h.b_field());
                 // dwds = t - (t * l)l
                 const vector3_type dwds = t - vector::dot(t, l) * l;
 

--- a/tests/include/detray/test/cpu/detector_scan.hpp
+++ b/tests/include/detray/test/cpu/detector_scan.hpp
@@ -254,7 +254,7 @@ class detector_scan : public test::fixture_base<> {
             test_traj = std::make_unique<trajectory_type>(track);
         } else {
             test_traj =
-                std::make_unique<trajectory_type>(track, &(m_cfg.B_vector()));
+                std::make_unique<trajectory_type>(track, m_cfg.B_vector());
         }
         return *(test_traj.release());
     }

--- a/tests/include/detray/test/cpu/navigation_validation.hpp
+++ b/tests/include/detray/test/cpu/navigation_validation.hpp
@@ -313,7 +313,7 @@ class navigation_validation : public test::fixture_base<> {
             test_traj = std::make_unique<trajectory_type>(track);
         } else {
             test_traj =
-                std::make_unique<trajectory_type>(track, &(m_cfg.B_vector()));
+                std::make_unique<trajectory_type>(track, m_cfg.B_vector());
         }
         return *(test_traj.release());
     }

--- a/tests/include/detray/test/device/cuda/navigation_validation.hpp
+++ b/tests/include/detray/test/device/cuda/navigation_validation.hpp
@@ -441,7 +441,7 @@ class navigation_validation : public test::fixture_base<> {
             test_traj = std::make_unique<trajectory_type>(track);
         } else {
             test_traj =
-                std::make_unique<trajectory_type>(track, &(m_cfg.B_vector()));
+                std::make_unique<trajectory_type>(track, m_cfg.B_vector());
         }
         return *(test_traj.release());
     }

--- a/tests/integration_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/integration_tests/cpu/propagator/covariance_transport.cpp
@@ -101,7 +101,7 @@ class detray_propagation_HelixCovarianceTransportValidation
 
         // Step size between two neighbor planes
         const scalar S{2.f * constant<scalar>::pi /
-                       std::abs(reference_helix._K)};
+                       std::abs(reference_helix.qop() * reference_helix.B())};
         const scalar step_size = S / static_cast<scalar>(n_planes);
 
         for (std::size_t i = 0u; i < n_planes; i++) {
@@ -175,7 +175,7 @@ class detray_propagation_HelixCovarianceTransportValidation
             detail::bound_to_free_vector(trf_0, mask_0, bound_vec_0);
 
         // Helix from the departure surface
-        detail::helix<algebra_type> hlx(free_trk_0, &B);
+        detail::helix<algebra_type> hlx(free_trk_0, B);
 
         // Bound-to-free jacobian at the departure surface
         const bound_to_free_matrix_t bound_to_free_jacobi =
@@ -278,7 +278,7 @@ TYPED_TEST(detray_propagation_HelixCovarianceTransportValidation,
     free_track_parameters<test_algebra> free_trk(
         {0.f, 0.f, 0.f}, 0.f, {0.1f * unit<scalar>::GeV, 0.f, 0.f}, -1.f);
 
-    detail::helix<test_algebra> reference_helix(free_trk, &this->B);
+    detail::helix<test_algebra> reference_helix(free_trk, this->B);
 
     const std::size_t n_planes = 10u;
     std::vector<transform3> trfs =
@@ -341,7 +341,8 @@ TYPED_TEST(detray_propagation_HelixCovarianceTransportValidation,
     // Check if the total path length is the expected value
     ASSERT_TRUE(total_path_length > 1e-3);
     ASSERT_NEAR(total_path_length,
-                2.f * constant<scalar>::pi / std::abs(reference_helix._K),
+                2.f * constant<scalar>::pi /
+                    std::abs(reference_helix.qop() * reference_helix.B()),
                 this->tolerance);
 
     ASSERT_EQ(sfis.size(), n_planes);

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -611,7 +611,7 @@ bound_track_parameters<test_algebra> get_initial_parameter(
     const vector3& field, const scalar helix_tolerance) {
 
     // Helix from the vertex
-    detail::helix<test_algebra> hlx(vertex, &field);
+    detail::helix<test_algebra> hlx(vertex, field);
 
     const auto& departure_sf = det.surface(0u);
     const auto& trf_link = departure_sf.transform();
@@ -642,7 +642,7 @@ bound_track_parameters<test_algebra> get_initial_parameter(
     const auto pos = hlx(path_length);
     const auto dir = hlx.dir(path_length);
 
-    const free_track_parameters<test_algebra> free_par(pos, 0, dir, hlx._qop);
+    const free_track_parameters<test_algebra> free_par(pos, 0, dir, hlx.qop());
 
     const auto bound_vec =
         tracking_surface{det, departure_sf}.free_to_bound_vector({}, free_par);
@@ -989,7 +989,7 @@ bound_param_vector_type get_displaced_bound_vector_helix(
     dvec[target_index] += displacement;
     const auto free_vec =
         tracking_surface{det, departure_sf}.bound_to_free_vector({}, dvec);
-    detail::helix<test_algebra> hlx(free_vec, &field);
+    detail::helix<test_algebra> hlx(free_vec, field);
 
     using mask_t =
         typename detector_t::mask_container::template get_type<mask_id>;
@@ -1003,7 +1003,7 @@ bound_param_vector_type get_displaced_bound_vector_helix(
     const auto dir = hlx.dir(path_length);
 
     const free_track_parameters<test_algebra> new_free_par(pos, 0, dir,
-                                                           hlx._qop);
+                                                           hlx.qop());
     auto new_bound_vec =
         tracking_surface{det, destination_sf}.free_to_bound_vector(
             {}, new_free_par);
@@ -1038,7 +1038,7 @@ void evaluate_jacobian_difference_helix(
         tracking_surface{det, departure_sf}.bound_to_free_vector({}, track);
 
     // Helix from the departure surface
-    detail::helix<test_algebra> hlx(free_vec, &field);
+    detail::helix<test_algebra> hlx(free_vec, field);
 
     const auto& destination_sf = det.surface(1u);
     const auto& trf_link = destination_sf.transform();
@@ -1069,7 +1069,7 @@ void evaluate_jacobian_difference_helix(
 
     const auto pos = hlx(path_length);
     const auto dir = hlx.dir(path_length);
-    const auto qop = hlx._qop;
+    const auto qop = hlx.qop();
 
     // Get correction term
     const auto correction_term =
@@ -1621,7 +1621,7 @@ int main(int argc, char** argv) {
         mt2.seed(track_count);
 
         // Pilot track
-        detail::helix<test_algebra> helix_bz(track, &B_z);
+        detail::helix<test_algebra> helix_bz(track, B_z);
 
         // Make a telescope geometry with rectagular surface
         const scalar detector_length = rand_length(mt1);

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -96,7 +96,7 @@ struct helix_inspector : actor {
             stepping.field().at(last_pos[0], last_pos[1], last_pos[2]);
         const vector3 b{bvec[0], bvec[1], bvec[2]};
 
-        detail::helix<test_algebra> hlx(free_params, &b);
+        detail::helix<test_algebra> hlx(free_params, b);
 
         const auto true_pos = hlx(inspector_state.path_from_surface);
 

--- a/tests/tools/src/cpu/generate_telescope_detector.cpp
+++ b/tests/tools/src/cpu/generate_telescope_detector.cpp
@@ -98,7 +98,7 @@ void write_telecope(const po::variables_map &vm,
 
             const auto p{vm["p"].as<scalar_t>() * unit<scalar_t>::GeV};
             detray::detail::helix<algebra_t> h{
-                {0.f, 0.f, 0.f}, 0.f, dir, 1.f / p, &B};
+                {0.f, 0.f, 0.f}, 0.f, dir, 1.f / p, B};
 
             write_telecope<mask_shape_t>(vm, writer_cfg, mask_params, h);
         } else {

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -283,7 +283,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
 
     auto pilot_track = free_track_parameters<test_algebra>(pos, 0.f, mom, -1.f);
 
-    detail::helix<test_algebra> helix_bz(pilot_track, &B_z);
+    detail::helix<test_algebra> helix_bz(pilot_track, B_z);
 
     tel_det_config htel_cfg{rectangle, helix_bz};
     htel_cfg.n_surfaces(11u).length(500.f * unit<scalar>::mm);

--- a/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/helix_intersector.cpp
@@ -56,7 +56,7 @@ const vector3 B_0{0.f * unit<scalar>::T, tol* unit<scalar>::T,
                   tol* unit<scalar>::T};
 
 // Test helix
-const helix_t hlx(free_trk, &B);
+const helix_t hlx(free_trk, B);
 
 // Path along the helix
 const scalar path = 10.f * unit<scalar>::cm;
@@ -77,7 +77,7 @@ GTEST_TEST(detray_intersection, helix_plane_intersector_no_bfield) {
     // Test helix
     const point3 pos{2.f, 1.f, 0.f};
     const vector3 mom{0.f, 0.f, 1.f};
-    const detail::helix<test_algebra> h({pos, 0.f, mom, -1.f}, &B_0);
+    const detail::helix<test_algebra> h({pos, 0.f, mom, -1.f}, B_0);
 
     // The same test but bound to local frame
     helix_intersector<unmasked<2>, test_algebra> pi;
@@ -171,7 +171,7 @@ GTEST_TEST(detray_intersection, helix_cylinder_intersector_no_bfield) {
     const point3 pos{3.f, 2.f, 5.f};
     const vector3 mom{1.f, 0.f, 0.f};
     const helix_t h({pos, 0.f * unit<scalar>::s, mom, -1 * unit<scalar>::e},
-                    &B_0);
+                    B_0);
 
     // Intersect
     mask<cylinder2D, test_algebra, std::uint_least16_t> cylinder{0u, r, -hz,
@@ -273,7 +273,7 @@ GTEST_TEST(detray_intersection,
     const point3 pos{0.f, 0.f, -5.f};
     const vector3 mom{1.f, 0.f, 0.f};
     const helix_t h({pos, 0.f * unit<scalar>::s, mom, -1 * unit<scalar>::e},
-                    &B_0);
+                    B_0);
 
     // Intersect
     mask<concentric_cylinder2D, test_algebra, std::uint_least16_t> cylinder{

--- a/tests/unit_tests/cpu/navigation/intersection/helix_trajectory.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/helix_trajectory.cpp
@@ -46,7 +46,7 @@ GTEST_TEST(detray_intersection, helix_trajectory) {
     const scalar pt{std::sqrt(p_mag * p_mag - pz_along * pz_along)};
 
     // helix trajectory
-    detail::helix helix_traj(vertex, &B);
+    detail::helix helix_traj(vertex, B);
     EXPECT_NEAR(helix_traj.time(), 0.f, tol);
     EXPECT_NEAR(helix_traj.qop(), -constant<scalar>::inv_sqrt2, tol);
 
@@ -115,7 +115,7 @@ GTEST_TEST(detray_intersection, helix_trajectory) {
     free_track_parameters<test_algebra> vertex2(pos, time, mom, -q);
 
     // helix trajectory
-    detail::helix helix_traj2(vertex2, &B);
+    detail::helix helix_traj2(vertex2, B);
 
     EXPECT_NEAR(R, helix_traj2.radius(), tol);
 
@@ -186,7 +186,7 @@ GTEST_TEST(detray_intersection, helix_trajectory_small_pT) {
     const vector3 B{0.f, 0.f, 1.f * unit<scalar>::T};
 
     // helix trajectory
-    detail::helix helix_traj(vertex, &B);
+    detail::helix helix_traj(vertex, B);
     EXPECT_NEAR(helix_traj.time(), 0.f, tol);
     EXPECT_NEAR(helix_traj.qop(), -1.f, tol);
 
@@ -219,7 +219,7 @@ GTEST_TEST(detray_intersection, helix_direction_stability) {
     free_track_parameters<test_algebra> vertex(pos, time, mom, q);
 
     // helix trajectory
-    detail::helix hlx(vertex, &B);
+    detail::helix hlx(vertex, B);
 
     for (int i = 0; i < 100; i++) {
         const auto d = hlx.dir(scalar(i) * 10.f);

--- a/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/intersection_kernel.cpp
@@ -279,7 +279,7 @@ GTEST_TEST(detray_intersection, intersection_kernel_helix) {
     const vector3 mom{0.01f, 0.01f, 10.f};
     const vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
                     tol * unit<scalar>::T};
-    const detail::helix<test_algebra> h({pos, 0.f, mom, -1.f}, &B);
+    const detail::helix<test_algebra> h({pos, 0.f, mom, -1.f}, B);
 
     // Validation data
     const point3 expected_rectangle{0.01f, 0.01f, 10.f};

--- a/tests/unit_tests/cpu/propagator/rk_stepper.cpp
+++ b/tests/unit_tests/cpu/propagator/rk_stepper.cpp
@@ -85,7 +85,7 @@ GTEST_TEST(detray_propagator, rk_stepper) {
         free_track_parameters<test_algebra> c_track(track);
 
         // helix trajectory
-        detail::helix helix(track, &B);
+        detail::helix helix(track, B);
 
         // RK Stepping into forward direction
         rk_stepper_t<bfield_t>::state rk_state{track, hom_bfield};

--- a/tests/unit_tests/cpu/simulation/detector_scanner.cpp
+++ b/tests/unit_tests/cpu/simulation/detector_scanner.cpp
@@ -72,7 +72,7 @@ GTEST_TEST(detray_simulation, detector_scanner) {
     for (const auto track :
          uniform_track_generator<free_track_parameters<test_algebra>>(
              phi_steps, theta_steps)) {
-        const detail::helix test_helix(track, &B);
+        const detail::helix test_helix(track, B);
 
         // Record all intersections and objects along the ray
         const auto intersection_trace =

--- a/tests/unit_tests/cpu/simulation/track_generators.cpp
+++ b/tests/unit_tests/cpu/simulation/track_generators.cpp
@@ -106,7 +106,7 @@ GTEST_TEST(detray_simulation, uniform_track_generator) {
                     2.f * unit<scalar>::T};
     n_tracks = 0u;
     for (const auto track : generator_t(phi_steps, theta_steps)) {
-        detail::helix<test_algebra> helix_traj(track, &B);
+        detail::helix<test_algebra> helix_traj(track, B);
         vector3& expected = momenta[n_tracks];
         vector3 result = helix_traj.dir(0.f);
 

--- a/tests/unit_tests/svgtools/trajectories.cpp
+++ b/tests/unit_tests/svgtools/trajectories.cpp
@@ -95,7 +95,7 @@ GTEST_TEST(svgtools, trajectories) {
               1.f * detray::unit<scalar>::T};
 
     const detray::detail::helix<test_algebra> helix(
-        ori, 0.f, detray::vector::normalize(dir), -8.f, &B);
+        ori, 0.f, detray::vector::normalize(dir), -8.f, B);
     const auto helix_ir =
         detray::detector_scanner::run<detray::helix_scan>(gctx, det, helix);
 

--- a/tests/unit_tests/svgtools/web.cpp
+++ b/tests/unit_tests/svgtools/web.cpp
@@ -91,7 +91,7 @@ GTEST_TEST(svgtools, web) {
 
         const detray::detail::helix<test_algebra> helix(
             ori, 0.f, detray::vector::normalize(dir), static_cast<float>(qop),
-            &B);
+            B);
         const auto helix_ir =
             detray::detector_scanner::run<detray::helix_scan>(gctx, det, helix);
 

--- a/tutorials/src/cpu/detector/build_predefined_detectors.cpp
+++ b/tutorials/src/cpu/detector/build_predefined_detectors.cpp
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
     // Helix in a constant B-field 1T in z-direction
     using helix_t = detray::detail::helix<algebra_t>;
     detray::tutorial::vector3 B_z{0.f, 0.f, 1.f * detray::unit<scalar>::T};
-    helix_t helix(y_track, &B_z);
+    helix_t helix(y_track, B_z);
 
     detray::tel_det_config htrp_cfg{trapezoid, helix};
     htrp_cfg.positions(positions);


### PR DESCRIPTION
Adds a constructor that samples the B field direction from covfie and constructs a helix around. This way, a helix can be constructed directly from a constant covfie field