### PR TITLE
Fixed spelling and opted for explicit typing

### DIFF
--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -86,7 +86,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, do_debug> {
         }
 
         // vector from track position to line center
-        const vector3_type t2l = _t - _p;
+        const point3_type t2l = _t - _p;
 
         // t2l projection on line direction
         const scalar_type t2l_on_line{vector::dot(t2l, _z)};

--- a/core/include/detray/navigation/intersection/ray_line_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_line_intersector.hpp
@@ -86,7 +86,7 @@ struct ray_intersector_impl<line2D<algebra_t>, algebra_t, do_debug> {
         }
 
         // vector from track position to line center
-        const auto t2l = _t - _p;
+        const vector3_type t2l = _t - _p;
 
         // t2l projection on line direction
         const scalar_type t2l_on_line{vector::dot(t2l, _z)};

--- a/tests/benchmarks/cpu/intersect_surfaces.cpp
+++ b/tests/benchmarks/cpu/intersect_surfaces.cpp
@@ -212,7 +212,7 @@ BENCHMARK(BM_INTERSECT_PORTAL_CYLINDERS)
     ->Unit(benchmark::kMillisecond);
 
 /// This benchmark runs intersection with the concentric cylinder intersector
-void BM_INTERSECT_CONCETRIC_CYLINDERS(benchmark::State &state) {
+void BM_INTERSECT_CONCENTRIC_CYLINDERS(benchmark::State &state) {
     unsigned int sfhit = 0u;
     unsigned int sfmiss = 0u;
 
@@ -256,7 +256,7 @@ void BM_INTERSECT_CONCETRIC_CYLINDERS(benchmark::State &state) {
     }
 }
 
-BENCHMARK(BM_INTERSECT_CONCETRIC_CYLINDERS)
+BENCHMARK(BM_INTERSECT_CONCENTRIC_CYLINDERS)
 #ifdef DETRAY_BENCHMARK_MULTITHREAD
     ->ThreadRange(1, benchmark::CPUInfo::Get().num_cpus)
 #endif

--- a/tests/benchmarks/cpu/intersectors.cpp
+++ b/tests/benchmarks/cpu/intersectors.cpp
@@ -366,7 +366,7 @@ BENCHMARK(BM_INTERSECT_CYLINDERS_SOA)
     ->Unit(benchmark::kMillisecond);
 
 /// This benchmark runs intersection with the concentric cylinder intersector
-void BM_INTERSECT_CONCETRIC_CYLINDERS_AOS(benchmark::State& state) {
+void BM_INTERSECT_CONCENTRIC_CYLINDERS_AOS(benchmark::State& state) {
 
     using transform3_t = dtransform3D<algebra_s>;
     using scalar_t = dscalar<algebra_s>;
@@ -421,14 +421,14 @@ void BM_INTERSECT_CONCETRIC_CYLINDERS_AOS(benchmark::State& state) {
 #endif  // DETRAY_BENCHMARK_PRINTOUTS
 }
 
-BENCHMARK(BM_INTERSECT_CONCETRIC_CYLINDERS_AOS)
+BENCHMARK(BM_INTERSECT_CONCENTRIC_CYLINDERS_AOS)
 #ifdef DETRAY_BENCHMARK_MULTITHREAD
     ->ThreadRange(1, benchmark::CPUInfo::Get().num_cpus)
 #endif
     ->Unit(benchmark::kMillisecond);
 
 /// This benchmark runs intersection with the concentric cylinder intersector
-void BM_INTERSECT_CONCETRIC_CYLINDERS_SOA(benchmark::State& state) {
+void BM_INTERSECT_CONCENTRIC_CYLINDERS_SOA(benchmark::State& state) {
 
     using transform3_t = dtransform3D<algebra_v>;
     using scalar_t = dscalar<algebra_v>;
@@ -479,7 +479,7 @@ void BM_INTERSECT_CONCETRIC_CYLINDERS_SOA(benchmark::State& state) {
 #endif
 }
 
-BENCHMARK(BM_INTERSECT_CONCETRIC_CYLINDERS_SOA)
+BENCHMARK(BM_INTERSECT_CONCENTRIC_CYLINDERS_SOA)
 #ifdef DETRAY_BENCHMARK_MULTITHREAD
     ->ThreadRange(1, benchmark::CPUInfo::Get().num_cpus)
 #endif


### PR DESCRIPTION
While adding the Fastor backend to `detray`, I found some spelling mistakes in some of the benchmark names, which I fixed.

In `core/include/detray/navigation/intersection/ray_line_intersector.hpp`, there is a line which uses `auto` for type deduction, which was giving me problems with Fastor, because `auto` was resolving to an expression template and then causing compilation errors further down the line. I changed it to an explicit type (`vector3_type`) to force evaluation.

This shouldn't be too controversial, as it works for all math backends (including Fastor), and makes the intent of the line clearer.

The Fastor PR is going to be big, so that's why I wanted to make this separate, smaller PR first.