### PR TITLE
Remove full jacobian from stepper

### DIFF
--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -94,26 +94,12 @@ struct parameter_transporter : actor {
         // from curvilinear frame)
         if (!bound_params.surface_link().is_invalid()) {
 
-            // Previous surface
-            tracking_surface prev_sf{navigation.detector(),
-                                     bound_params.surface_link()};
-
-            const bound_to_free_matrix_t bound_to_free_jacobian =
-                prev_sf.bound_to_free_jacobian(gctx, bound_params);
-
-            auto vol = navigation.get_volume();
-            const auto vol_mat_ptr =
-                vol.has_material() ? vol.material_parameters(stepping().pos())
-                                   : nullptr;
-            stepping.set_full_jacobian(
-                sf.template visit_mask<get_full_jacobian_kernel>(
-                    sf.transform(gctx), bound_to_free_jacobian, vol_mat_ptr,
-                    propagation._stepping));
+            const auto full_jacobian = get_full_jacobian(propagation);
 
             // Calculate surface-to-surface covariance transport
-            const bound_matrix_t new_cov =
-                stepping.full_jacobian() * bound_params.covariance() *
-                matrix::transpose(stepping.full_jacobian());
+            const bound_matrix_t new_cov = full_jacobian *
+                                           bound_params.covariance() *
+                                           matrix::transpose(full_jacobian);
 
             stepping.bound_params().set_covariance(new_cov);
         }
@@ -124,6 +110,39 @@ struct parameter_transporter : actor {
 
         // Set surface link
         bound_params.set_surface_link(sf.barcode());
+    }
+
+    template <typename propagator_state_t>
+    DETRAY_HOST_DEVICE inline bound_matrix_t get_full_jacobian(
+        propagator_state_t& propagation) const {
+
+        const auto& stepping = propagation._stepping;
+        const auto& navigation = propagation._navigation;
+
+        // Geometry context for this track
+        const auto& gctx = propagation._context;
+
+        // Current Surface
+        const auto sf = navigation.get_surface();
+
+        // Bound track params of departure surface
+        auto& bound_params = stepping.bound_params();
+
+        // Previous surface
+        tracking_surface prev_sf{navigation.detector(),
+                                 bound_params.surface_link()};
+
+        const bound_to_free_matrix_t bound_to_free_jacobian =
+            prev_sf.bound_to_free_jacobian(gctx, bound_params);
+
+        auto vol = navigation.get_volume();
+        const auto vol_mat_ptr = vol.has_material()
+                                     ? vol.material_parameters(stepping().pos())
+                                     : nullptr;
+
+        return sf.template visit_mask<get_full_jacobian_kernel>(
+            sf.transform(gctx), bound_to_free_jacobian, vol_mat_ptr,
+            propagation._stepping);
     }
 
 };  // namespace detray

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -181,18 +181,6 @@ class base_stepper {
             return m_jac_transport;
         }
 
-        /// @returns the current full Jacbian.
-        DETRAY_HOST_DEVICE
-        inline const bound_matrix_type &full_jacobian() const {
-            return m_full_jacobian;
-        }
-
-        /// Set new full Jacbian.
-        DETRAY_HOST_DEVICE
-        inline void set_full_jacobian(const bound_matrix_type &jac) {
-            m_full_jacobian = jac;
-        }
-
         /// Reset transport Jacbian.
         DETRAY_HOST_DEVICE
         inline void reset_transport_jacobian() {
@@ -229,10 +217,6 @@ class base_stepper {
         private:
         /// Jacobian transport matrix
         free_matrix_type m_jac_transport = matrix::identity<free_matrix_type>();
-
-        /// Full jacobian
-        bound_matrix_type m_full_jacobian =
-            matrix::identity<bound_matrix_type>();
 
         /// Bound covariance
         bound_track_parameters_type m_bound_params;

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -438,7 +438,9 @@ struct bound_getter : actor {
             actor_state.m_path_length = stepping.path_length();
             actor_state.m_abs_path_length = stepping.abs_path_length();
             actor_state.m_param_destination = stepping.bound_params();
-            actor_state.m_jacobi = stepping.full_jacobian();
+            actor_state.m_jacobi =
+                parameter_transporter<algebra_t>().get_full_jacobian(
+                    propagation);
 
             // Stop navigation if the destination surface found
             propagation._heartbeat &= navigation.exit();


### PR DESCRIPTION
Redo #832 again as full jacobian won't be required after acts-project/traccc#926

#### PR
```
Running ./bin/detray_benchmark_cuda_propagation_array
Run on (32 X 3000 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 16384 KiB (x8)
Load Average: 2.05, 2.06, 1.23
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                    Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------------------------
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_64_TRACKS/real_time        2243223 ns      2242860 ns          247 TracksPropagated=28.5304k/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_256_TRACKS/real_time       2272092 ns      2271993 ns          308 TracksPropagated=112.671k/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_1024_TRACKS/real_time      2340488 ns      2340463 ns          299 TracksPropagated=437.516k/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_4096_TRACKS/real_time      2356486 ns      2356430 ns          298 TracksPropagated=1.73818M/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_16384_TRACKS/real_time     4421445 ns      4421175 ns          158 TracksPropagated=3.70558M/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_65536_TRACKS/real_time    10401300 ns     10401004 ns           67 TracksPropagated=6.30075M/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_262144_TRACKS/real_time   33332079 ns     33329535 ns           21 TracksPropagated=7.86462M/s
BM_PROPAGATION_TOY_DETECTOR_64_TRACKS/real_time                        1437758 ns      1437697 ns          484 TracksPropagated=44.5137k/s
BM_PROPAGATION_TOY_DETECTOR_256_TRACKS/real_time                       1425598 ns      1425527 ns          491 TracksPropagated=179.574k/s
BM_PROPAGATION_TOY_DETECTOR_1024_TRACKS/real_time                      1397717 ns      1397615 ns          502 TracksPropagated=732.623k/s
BM_PROPAGATION_TOY_DETECTOR_4096_TRACKS/real_time                      1409020 ns      1409020 ns          497 TracksPropagated=2.90699M/s
BM_PROPAGATION_TOY_DETECTOR_16384_TRACKS/real_time                     2139071 ns      2139043 ns          327 TracksPropagated=7.6594M/s
BM_PROPAGATION_TOY_DETECTOR_65536_TRACKS/real_time                     4850915 ns      4850880 ns          144 TracksPropagated=13.51M/s
BM_PROPAGATION_TOY_DETECTOR_262144_TRACKS/real_time                   15233131 ns     15232775 ns           46 TracksPropagated=17.2088M/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_64_TRACKS/real_time        2381879 ns      2381879 ns          294 TracksPropagated=26.8695k/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_256_TRACKS/real_time       2756127 ns      2755949 ns          254 TracksPropagated=92.884k/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_1024_TRACKS/real_time      3199708 ns      3199623 ns          219 TracksPropagated=320.029k/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_4096_TRACKS/real_time      3381070 ns      3381069 ns          207 TracksPropagated=1.21145M/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_16384_TRACKS/real_time     4808644 ns      4808590 ns          146 TracksPropagated=3.4072M/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_65536_TRACKS/real_time    11593311 ns     11592546 ns           60 TracksPropagated=5.65291M/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_262144_TRACKS/real_time   36233254 ns     36231142 ns           19 TracksPropagated=7.2349M/s
BM_PROPAGATION_WIRE_CHAMBER_64_TRACKS/real_time                        1372153 ns      1372091 ns          508 TracksPropagated=46.642k/s
BM_PROPAGATION_WIRE_CHAMBER_256_TRACKS/real_time                       1517079 ns      1517033 ns          461 TracksPropagated=168.745k/s
BM_PROPAGATION_WIRE_CHAMBER_1024_TRACKS/real_time                      1847485 ns      1847450 ns          376 TracksPropagated=554.267k/s
BM_PROPAGATION_WIRE_CHAMBER_4096_TRACKS/real_time                      1957723 ns      1957705 ns          357 TracksPropagated=2.09223M/s
BM_PROPAGATION_WIRE_CHAMBER_16384_TRACKS/real_time                     2201014 ns      2200946 ns          318 TracksPropagated=7.44384M/s
BM_PROPAGATION_WIRE_CHAMBER_65536_TRACKS/real_time                     4370730 ns      4370684 ns          159 TracksPropagated=14.9943M/s
BM_PROPAGATION_WIRE_CHAMBER_262144_TRACKS/real_time                   14498564 ns     14497435 ns           48 TracksPropagated=18.0807M/s
```

#### Main 
```
------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                    Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------------------------
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_64_TRACKS/real_time        2245684 ns      2245591 ns          236 TracksPropagated=28.4991k/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_256_TRACKS/real_time       2285181 ns      2285182 ns          307 TracksPropagated=112.026k/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_1024_TRACKS/real_time      2351586 ns      2351489 ns          298 TracksPropagated=435.451k/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_4096_TRACKS/real_time      2398959 ns      2398932 ns          293 TracksPropagated=1.70741M/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_16384_TRACKS/real_time     4507381 ns      4507243 ns          155 TracksPropagated=3.63493M/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_65536_TRACKS/real_time    10643302 ns     10643061 ns           67 TracksPropagated=6.15749M/s
BM_PROPAGATION_TOY_DETECTOR_W_COV_TRANSPORT_262144_TRACKS/real_time   34117901 ns     34117889 ns           21 TracksPropagated=7.68347M/s
BM_PROPAGATION_TOY_DETECTOR_64_TRACKS/real_time                        1438366 ns      1438367 ns          487 TracksPropagated=44.4949k/s
BM_PROPAGATION_TOY_DETECTOR_256_TRACKS/real_time                       1423061 ns      1423023 ns          492 TracksPropagated=179.894k/s
BM_PROPAGATION_TOY_DETECTOR_1024_TRACKS/real_time                      1394086 ns      1394087 ns          502 TracksPropagated=734.532k/s
BM_PROPAGATION_TOY_DETECTOR_4096_TRACKS/real_time                      1407212 ns      1407142 ns          496 TracksPropagated=2.91072M/s
BM_PROPAGATION_TOY_DETECTOR_16384_TRACKS/real_time                     2141578 ns      2141496 ns          327 TracksPropagated=7.65043M/s
BM_PROPAGATION_TOY_DETECTOR_65536_TRACKS/real_time                     4866878 ns      4866826 ns          144 TracksPropagated=13.4657M/s
BM_PROPAGATION_TOY_DETECTOR_262144_TRACKS/real_time                   15267697 ns     15267402 ns           46 TracksPropagated=17.1698M/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_64_TRACKS/real_time        2399660 ns      2399552 ns          292 TracksPropagated=26.6704k/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_256_TRACKS/real_time       2837721 ns      2837723 ns          247 TracksPropagated=90.2132k/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_1024_TRACKS/real_time      3288451 ns      3288283 ns          213 TracksPropagated=311.393k/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_4096_TRACKS/real_time      3483936 ns      3483879 ns          201 TracksPropagated=1.17568M/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_16384_TRACKS/real_time     5070341 ns      5069737 ns          100 TracksPropagated=3.23134M/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_65536_TRACKS/real_time    12059286 ns     12059292 ns           58 TracksPropagated=5.43448M/s
BM_PROPAGATION_WIRE_CHAMBER_W_COV_TRANSPORT_262144_TRACKS/real_time   37523764 ns     37523484 ns           19 TracksPropagated=6.98608M/s
BM_PROPAGATION_WIRE_CHAMBER_64_TRACKS/real_time                        1375898 ns      1375894 ns          507 TracksPropagated=46.5151k/s
BM_PROPAGATION_WIRE_CHAMBER_256_TRACKS/real_time                       1528572 ns      1528501 ns          458 TracksPropagated=167.477k/s
BM_PROPAGATION_WIRE_CHAMBER_1024_TRACKS/real_time                      1846810 ns      1846772 ns          379 TracksPropagated=554.47k/s
BM_PROPAGATION_WIRE_CHAMBER_4096_TRACKS/real_time                      1962956 ns      1962921 ns          356 TracksPropagated=2.08665M/s
BM_PROPAGATION_WIRE_CHAMBER_16384_TRACKS/real_time                     2206532 ns      2206481 ns          317 TracksPropagated=7.42523M/s
BM_PROPAGATION_WIRE_CHAMBER_65536_TRACKS/real_time                     4404361 ns      4404200 ns          158 TracksPropagated=14.8798M/s
BM_PROPAGATION_WIRE_CHAMBER_262144_TRACKS/real_time                   14526082 ns     14525359 ns           48 TracksPropagated=18.0464M/s
```