### PR TITLE
ref: update random scatter only when material is non-zero

### DIFF
--- a/tests/include/detray/test/utils/simulation/random_scatterer.hpp
+++ b/tests/include/detray/test/utils/simulation/random_scatterer.hpp
@@ -149,30 +149,32 @@ struct random_scatterer : actor {
                                                   bound_params.dir(),
                                                   bound_params.bound_local())};
 
-        sf.template visit_material<kernel>(simulator_state, ptc, bound_params,
-                                           cos_inc_angle,
-                                           bound_params.bound_local()[0]);
+        const bool success = sf.template visit_material<kernel>(
+            simulator_state, ptc, bound_params, cos_inc_angle,
+            bound_params.bound_local()[0]);
 
-        // Get the new momentum
-        const auto new_mom =
-            attenuate(simulator_state.e_loss_mpv, simulator_state.e_loss_sigma,
-                      ptc.mass(), bound_params.p(ptc.charge()),
-                      simulator_state.generator);
+        if (success) {
+            // Get the new momentum
+            const auto new_mom = attenuate(
+                simulator_state.e_loss_mpv, simulator_state.e_loss_sigma,
+                ptc.mass(), bound_params.p(ptc.charge()),
+                simulator_state.generator);
 
-        // Update Qop
-        bound_params.set_qop(ptc.charge() / new_mom);
+            // Update Qop
+            bound_params.set_qop(ptc.charge() / new_mom);
 
-        // Get the new direction from random scattering
-        const auto new_dir = scatter(bound_params.dir(),
-                                     simulator_state.projected_scattering_angle,
-                                     simulator_state.generator);
+            // Get the new direction from random scattering
+            const auto new_dir = scatter(
+                bound_params.dir(), simulator_state.projected_scattering_angle,
+                simulator_state.generator);
 
-        // Update Phi and Theta
-        stepping.bound_params().set_phi(vector::phi(new_dir));
-        stepping.bound_params().set_theta(vector::theta(new_dir));
+            // Update Phi and Theta
+            stepping.bound_params().set_phi(vector::phi(new_dir));
+            stepping.bound_params().set_theta(vector::theta(new_dir));
 
-        // Flag renavigation of the current candidate
-        prop_state._navigation.set_high_trust();
+            // Flag renavigation of the current candidate
+            prop_state._navigation.set_high_trust();
+        }
     }
 
     /// @brief Get the new momentum from the landau distribution


### PR DESCRIPTION
Update the track momentum and trigger re-navigation only when the surface has material with non-zero thickness.