### PR TITLE
Fix navigation print inspector

### DIFF
--- a/core/include/detray/navigation/detail/print_state.hpp
+++ b/core/include/detray/navigation/detail/print_state.hpp
@@ -1,0 +1,197 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/algebra.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/math.hpp"
+#include "detray/definitions/units.hpp"
+#include "detray/geometry/surface.hpp"
+#include "detray/navigation/detail/print_state.hpp"
+#include "detray/navigation/navigation_config.hpp"
+
+// System include(s)
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+namespace detray::navigation {
+
+/// Print basic information about the state of a navigation stream @param state
+template <typename state_type>
+DETRAY_HOST inline std::string print_state(const state_type &state) {
+
+    // Gathers navigation information accross navigator update calls
+    std::stringstream debug_stream{};
+    // Column width in output
+    constexpr int cw{20};
+
+    debug_stream << std::left << std::setw(cw) << "Volume:" << state.volume()
+                 << std::endl;
+
+    // Navigation direction
+    debug_stream << std::setw(cw) << "direction:";
+    switch (state.direction()) {
+        using enum direction;
+        case e_backward:
+            debug_stream << "backward";
+            break;
+        case e_forward:
+            debug_stream << "forward";
+            break;
+        default:
+            break;
+    }
+    debug_stream << std::endl;
+
+    // Navigation status
+    debug_stream << std::setw(cw) << "status:";
+    switch (state.status()) {
+        using enum status;
+        case e_abort:
+            debug_stream << "abort";
+            break;
+        case e_on_target:
+            debug_stream << "on_target";
+            break;
+        case e_unknown:
+            debug_stream << "unknowm";
+            break;
+        case e_towards_object:
+            debug_stream << "towards_object";
+            break;
+        case e_on_module:
+            debug_stream << "on_object";
+            break;
+        case e_on_portal:
+            debug_stream << "on_portal";
+            break;
+        default:
+            break;
+    }
+    debug_stream << std::endl;
+
+    // Navigation trust level
+    debug_stream << std::setw(cw) << "trust:";
+    switch (state.trust_level()) {
+        using enum trust_level;
+        case e_no_trust:
+            debug_stream << "no_trust";
+            break;
+        case e_fair:
+            debug_stream << "fair_trust";
+            break;
+        case e_high:
+            debug_stream << "high_trust";
+            break;
+        case e_full:
+            debug_stream << "full_trust";
+            break;
+        default:
+            break;
+    }
+    debug_stream << std::endl;
+
+    // Number of reachable candidates
+    debug_stream << std::setw(cw) << "No. reachable:" << state.n_candidates()
+                 << std::endl;
+
+    // Current surface
+    debug_stream << std::setw(cw) << "current object:";
+    if (state.is_on_surface()) {
+        // If "exit" is called twice, the state has been cleared
+        debug_stream << state.barcode() << std::endl;
+    } else if (state.status() == status::e_on_target) {
+        debug_stream << "exited" << std::endl;
+    } else {
+        debug_stream << "undefined" << std::endl;
+    }
+
+    // Next surface
+    if (!state.candidates().empty()) {
+        debug_stream << std::setw(cw) << "next object:";
+        if (state.n_candidates() == 0u) {
+            debug_stream << "exhausted" << std::endl;
+        } else {
+            debug_stream << state.next_surface().barcode() << std::endl;
+        }
+    }
+
+    // Distance to next
+    debug_stream << std::setw(cw) << "distance to next:";
+    if (!state.is_exhausted() && state.is_on_surface()) {
+        debug_stream << "on obj (within tol)" << std::endl;
+    } else if (state.is_exhausted()) {
+        debug_stream << "no target" << std::endl;
+    } else {
+        debug_stream << state() << std::endl;
+    }
+
+    return debug_stream.str();
+}
+
+/// Print candidate and cofiguration information of a navigation state
+///
+/// @param state the state object of the navigation stream
+/// @param cfg the navigation confuration object
+/// @param track_pos the current track position
+/// @param track_dir the current track direction
+template <typename state_type, concepts::point3D point3_t,
+          concepts::vector3D vector3_t>
+DETRAY_HOST inline std::string print_candidates(const state_type &state,
+                                                const navigation::config &cfg,
+                                                const point3_t &track_pos,
+                                                const vector3_t &track_dir) {
+
+    using detector_t = typename state_type::detector_type;
+    using geo_ctx_t = typename detector_t::geometry_context;
+    using scalar_t = typename detector_t::scalar_type;
+
+    // Gathers navigation information accross navigator update calls
+    std::stringstream debug_stream{};
+    // Column width in output
+    constexpr int cw{20};
+
+    debug_stream << std::left << std::setw(cw) << "Overstep tol.:"
+                 << cfg.overstep_tolerance / detray::unit<scalar_t>::mm << " mm"
+                 << std::endl;
+
+    debug_stream << std::setw(cw) << "Track:"
+                 << "pos: [r = " << vector::perp(track_pos)
+                 << ", z = " << track_pos[2] << "]," << std::endl;
+
+    debug_stream << std::setw(cw) << " "
+                 << "dir: [" << track_dir[0] << ", " << track_dir[1] << ", "
+                 << track_dir[2] << "]" << std::endl;
+
+    debug_stream << "Surface candidates: " << std::endl;
+
+    for (const auto &sf_cand : state) {
+
+        debug_stream << std::left << std::setw(6) << "-> " << sf_cand;
+
+        assert(!sf_cand.sf_desc.barcode().is_invalid());
+
+        // Use additional debug information that was gathered on the cand.
+        if constexpr (state_type::value_type::is_debug()) {
+            const auto &local = sf_cand.local;
+            if (!sf_cand.sf_desc.barcode().is_invalid()) {
+                point3_t pos =
+                    geometry::surface{state.detector(), sf_cand.sf_desc}
+                        .local_to_global(geo_ctx_t{}, local, track_dir);
+                debug_stream << " glob: [r = " << vector::perp(pos)
+                             << ", z = " << pos[2] << "]" << std::endl;
+            }
+        }
+    }
+
+    return debug_stream.str();
+}
+
+}  // namespace detray::navigation

--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -15,9 +15,8 @@
 // Project include(s)
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/math.hpp"
-#include "detray/geometry/surface.hpp"
+#include "detray/navigation/detail/print_state.hpp"
 #include "detray/navigation/navigation_config.hpp"
-#include "detray/navigation/navigator.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/propagator/base_stepper.hpp"
 #include "detray/propagator/stepping_config.hpp"
@@ -70,6 +69,19 @@ struct aggregate_inspector {
         if constexpr (current_id <
                       std::tuple_size<inspector_tuple_t>::value - 1) {
             return operator()<current_id + 1>(state, cfg, pos, dir, message);
+        }
+    }
+
+    /// Inspector interface
+    template <unsigned int current_id = 0, typename state_type>
+    DETRAY_HOST_DEVICE auto operator()(state_type &state, const char *message) {
+        // Call inspector
+        std::get<current_id>(_inspectors)(state, message);
+
+        // Next inspector
+        if constexpr (current_id <
+                      std::tuple_size<inspector_tuple_t>::value - 1) {
+            return operator()<current_id + 1>(state, message);
         }
     }
 
@@ -202,6 +214,13 @@ struct object_tracer {
         }
     }
 
+    /// Inspector interface
+    template <typename state_type>
+    DETRAY_HOST_DEVICE auto operator()(
+        const state_type & /*state*/,
+        const char * /*message*/) { /* Do nothing*/
+    }
+
     /// @returns a specific candidate from the trace
     DETRAY_HOST_DEVICE
     constexpr const candidate_record_t &operator[](std::size_t i) const {
@@ -263,112 +282,30 @@ struct print_inspector {
                     const point3_t &track_pos, const vector3_t &track_dir,
                     const char *message) {
         std::string msg(message);
-        std::string tabs = "\t\t\t\t";
-
         debug_stream << msg << std::endl;
+        debug_stream << "----------------------------------------" << std::endl;
 
-        debug_stream << "Volume" << tabs << state.volume() << std::endl;
-        debug_stream << "Overstep tol:\t\t\t" << cfg.overstep_tolerance
-                     << std::endl;
-        debug_stream << "Track pos: [r:" << vector::perp(track_pos)
-                     << ", z:" << track_pos[2] << "], dir: [" << track_dir[0]
-                     << ", " << track_dir[1] << ", " << track_dir[2] << "]"
-                     << std::endl;
-        debug_stream << "No. reachable\t\t\t" << state.n_candidates()
-                     << std::endl;
+        debug_stream << navigation::print_state(state);
+        debug_stream << navigation::print_candidates(state, cfg, track_pos,
+                                                     track_dir);
 
-        debug_stream << "Surface candidates: " << std::endl;
+        debug_stream << std::endl << std::endl;
+    }
 
-        using geo_ctx_t = typename state_type::detector_type::geometry_context;
-        for (const auto &sf_cand : state) {
+    /// Inspector interface. Print basic state information
+    template <typename state_type>
+    auto operator()(const state_type &state, const char *message) {
+        std::string msg(message);
+        debug_stream << msg << std::endl;
+        debug_stream << "----------------------------------------" << std::endl;
 
-            debug_stream << sf_cand;
+        debug_stream << navigation::print_state(state);
 
-            // Use additional debug information that was gathered on the cand.
-            if constexpr (state_type::value_type::is_debug()) {
-                const auto &local = sf_cand.local;
-                const auto pos =
-                    geometry::surface{state.detector(), sf_cand.sf_desc}
-                        .local_to_global(geo_ctx_t{}, local, track_dir);
-                debug_stream << ", glob: [r:" << vector::perp(pos)
-                             << ", z:" << pos[2] << "]" << std::endl;
-            }
-        }
-        if (!state.candidates().empty()) {
-            debug_stream << "=> next: ";
-            if (state.is_exhausted()) {
-                debug_stream << "exhausted" << std::endl;
-            } else {
-                debug_stream << " -> " << state.next_surface().barcode()
-                             << std::endl;
-            }
-        }
-
-        switch (state.status()) {
-            using enum status;
-            case e_abort:
-                debug_stream << "status" << tabs << "abort" << std::endl;
-                break;
-            case e_on_target:
-                debug_stream << "status" << tabs << "e_on_target" << std::endl;
-                break;
-            case e_unknown:
-                debug_stream << "status" << tabs << "unknowm" << std::endl;
-                break;
-            case e_towards_object:
-                debug_stream << "status" << tabs << "towards_surface"
-                             << std::endl;
-                break;
-            case e_on_module:
-                debug_stream << "status" << tabs << "on_module" << std::endl;
-                break;
-            case e_on_portal:
-                debug_stream << "status" << tabs << "on_portal" << std::endl;
-                break;
-            default:
-                break;
-        }
-
-        debug_stream << "current object\t\t\t";
-        if (state.is_on_surface() || state.status() == status::e_on_target) {
-            debug_stream << state.barcode() << std::endl;
-        } else {
-            debug_stream << "undefined" << std::endl;
-        }
-
-        debug_stream << "distance to next\t\t";
-        if (!state.is_exhausted() &&
-            math::fabs(state()) < static_cast<decltype(math::fabs(state()))>(
-                                      cfg.path_tolerance)) {
-            debug_stream << "on obj (within tol)" << std::endl;
-        } else if (state.is_exhausted()) {
-            debug_stream << "no target" << std::endl;
-        } else {
-            debug_stream << state() << std::endl;
-        }
-
-        switch (state.trust_level()) {
-            using enum trust_level;
-            case e_no_trust:
-                debug_stream << "trust" << tabs << "no_trust" << std::endl;
-                break;
-            case e_fair:
-                debug_stream << "trust" << tabs << "fair_trust" << std::endl;
-                break;
-            case e_high:
-                debug_stream << "trust" << tabs << "high_trust" << std::endl;
-                break;
-            case e_full:
-                debug_stream << "trust" << tabs << "full_trust" << std::endl;
-                break;
-            default:
-                break;
-        }
-        debug_stream << std::endl;
+        debug_stream << std::endl << std::endl;
     }
 
     /// @returns a string representation of the gathered information
-    std::string to_string() { return debug_stream.str(); }
+    std::string to_string() const { return debug_stream.str(); }
 };
 
 }  // namespace navigation


### PR DESCRIPTION
Fix a few bugs in the print inspector and make navigation state printing available outside the inspector. This way it can be printed with `std::cout` during host side debugging