### PR TITLE
feat: abort messages

### DIFF
--- a/core/include/detray/navigation/direct_navigator.hpp
+++ b/core/include/detray/navigation/direct_navigator.hpp
@@ -222,10 +222,16 @@ class direct_navigator {
         }
 
         DETRAY_HOST_DEVICE
-        inline auto abort() -> bool {
+        inline auto abort(const char * = nullptr) -> bool {
             m_status = navigation::status::e_abort;
             m_heartbeat = false;
             return m_heartbeat;
+        }
+
+        template <typename debug_msg_generator_t>
+        DETRAY_HOST_DEVICE inline auto abort(const debug_msg_generator_t &)
+            -> bool {
+            return abort();
         }
 
         DETRAY_HOST_DEVICE

--- a/core/include/detray/propagator/actors/aborters.hpp
+++ b/core/include/detray/propagator/actors/aborters.hpp
@@ -58,7 +58,8 @@ struct pathlimit_aborter : actor {
         // Check the path limit
         if (step_limit <= 0.f) {
             // Stop navigation
-            prop_state._heartbeat &= nav_state.abort();
+            prop_state._heartbeat &=
+                nav_state.abort("Aborter: Maximal path length reached");
         }
 
         // Don't go over the path limit in the next step
@@ -123,7 +124,8 @@ struct momentum_aborter : actor {
 
         if (mag <= abrt_state.p_limit()) {
             // Stop navigation
-            prop_state._heartbeat &= nav_state.abort();
+            prop_state._heartbeat &=
+                nav_state.abort("Aborter: Minimum momentum reached");
         }
     }
 };
@@ -153,7 +155,8 @@ struct target_aborter : actor {
         if (navigation.is_on_surface() &&
             (navigation.barcode() == abrt_state._target_surface) &&
             (stepping.path_length() > 0.f)) {
-            prop_state._heartbeat &= navigation.abort();
+            prop_state._heartbeat &=
+                navigation.abort("Aborter: Reached target surface");
         }
     }
 };

--- a/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -1074,10 +1074,10 @@ auto compare_to_navigation(
 
         // Fatal propagation error: Data unreliable
         if (!success) {
-            std::cout << "ERROR: Propagation failure" << std::endl;
+            std::cout << "ERROR: Propagation aborted! "
+                      << nav_printer.fata_error_msg << std::endl;
 
-            *debug_file << "ERROR: Propagation failure:\n"
-                        << "TEST TRACK " << i;
+            *debug_file << "ERROR: Propagation aborted:" << std::endl;
 
             n_fatal_error++;
         }


### PR DESCRIPTION
Allow to pass additional messages to the navigator abort function that contain the reason for the failure. This will make it easier to debug, because it can be seen right away from where `abort` was called and why. The reason for the error is also preserved in the print inspector, which makes it easier to print it to the user in tests outside the debug file.