### PR TITLE
Fix potential null dereference warning in tests

### DIFF
--- a/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
+++ b/tests/unit_tests/cpu/navigation/intersection/line_intersector.cpp
@@ -174,6 +174,8 @@ GTEST_TEST(detray_intersection, line_intersector_square_scope) {
                                              tol));
     }
 
+    ASSERT_TRUE(is.size() >= 12);
+
     EXPECT_TRUE(is[0].status);
     EXPECT_NEAR(is[0].path, constant<scalar>::sqrt2, tol);
     const auto local0 = ln.to_local_frame(


### PR DESCRIPTION
The gcc 14.2 null-pointer dereference warning seems to be _very_ good, and so it started to shout about this line intersector test which accesses intersections in a vector without first checking the size of the vector. Adding the size check makes the warning go away.