### PR TITLE
Infrastructure for more bound parameter types

### DIFF
--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -57,14 +57,14 @@ struct pointwise_material_interactor : actor {
 
         using state = typename pointwise_material_interactor::state;
 
-        template <typename mat_group_t, typename index_t>
+        template <typename mat_group_t, typename index_t,
+                  typename bound_track_parameters_t>
         DETRAY_HOST_DEVICE inline bool operator()(
             [[maybe_unused]] const mat_group_t &material_group,
             [[maybe_unused]] const index_t &mat_index,
             [[maybe_unused]] state &s,
             [[maybe_unused]] const pdg_particle<scalar_type> &ptc,
-            [[maybe_unused]] const bound_track_parameters<algebra_t>
-                &bound_params,
+            [[maybe_unused]] const bound_track_parameters_t &bound_params,
             [[maybe_unused]] const scalar_type cos_inc_angle,
             [[maybe_unused]] const scalar_type approach) const {
 
@@ -149,11 +149,12 @@ struct pointwise_material_interactor : actor {
     /// @param[out] interactor_state actor state
     /// @param[in]  nav_dir navigation direction
     /// @param[in]  sf the surface
-    template <typename context_t, typename surface_t>
+    template <typename context_t, typename surface_t,
+              typename bound_track_parameters_t>
     DETRAY_HOST_DEVICE inline void update(
         const context_t gctx, const pdg_particle<scalar_type> &ptc,
-        bound_track_parameters<algebra_t> &bound_params,
-        state &interactor_state, const int nav_dir, const surface_t &sf) const {
+        bound_track_parameters_t &bound_params, state &interactor_state,
+        const int nav_dir, const surface_t &sf) const {
 
         // Closest approach of the track to a line surface. Otherwise this is
         // ignored.
@@ -166,7 +167,7 @@ struct pointwise_material_interactor : actor {
 
         if (succeed) {
 
-            auto &covariance = bound_params.covariance();
+            auto covariance = bound_params.covariance();
 
             if (interactor_state.do_energy_loss) {
 
@@ -184,6 +185,8 @@ struct pointwise_material_interactor : actor {
                     covariance, bound_params.dir(),
                     interactor_state.projected_scattering_angle);
             }
+
+            bound_params.set_covariance(covariance);
         }
 
         assert(!bound_params.is_invalid());

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -46,7 +46,8 @@ class base_stepper {
     using scalar_type = dscalar<algebra_t>;
 
     using free_track_parameters_type = free_track_parameters<algebra_t>;
-    using bound_track_parameters_type = bound_track_parameters<algebra_t>;
+    using bound_track_parameters_type =
+        udu_decomposed_bound_track_parameters<algebra_t>;
     using free_matrix_type = free_matrix<algebra_t>;
     using bound_matrix_type = bound_matrix<algebra_t>;
 

--- a/core/include/detray/propagator/constrained_step.hpp
+++ b/core/include/detray/propagator/constrained_step.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // detray definitions
+#include "detray/core/concepts.hpp"
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/containers.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"

--- a/core/include/detray/tracks/bound_track_parameters.hpp
+++ b/core/include/detray/tracks/bound_track_parameters.hpp
@@ -17,7 +17,9 @@
 #include "detray/geometry/barcode.hpp"
 
 // System include(s)
+#include <condition_variable>
 #include <ostream>
+#include <variant>
 
 namespace detray {
 
@@ -270,9 +272,80 @@ struct bound_parameters_vector {
 /// Combine the bound track parameter vector with the covariance and associated
 /// surface
 template <concepts::algebra algebra_t>
-struct bound_track_parameters : public bound_parameters_vector<algebra_t> {
+struct bound_track_parameters_base : public bound_parameters_vector<algebra_t> {
 
     using base_type = bound_parameters_vector<algebra_t>;
+
+    /// @name Type definitions for the struct
+    /// @{
+    using algebra_type = algebra_t;
+    using scalar_type = dscalar<algebra_t>;
+    using point2_type = dpoint2D<algebra_t>;
+    using vector3_type = dvector3D<algebra_t>;
+
+    // Shorthand vector/matrix types related to bound track parameters.
+    using parameter_vector_type = bound_parameters_vector<algebra_t>;
+    using covariance_type = bound_matrix<algebra_t>;
+
+    /// @}
+
+    /// Default constructor sets the covaraicne to zero
+    bound_track_parameters_base() = default;
+
+    DETRAY_HOST_DEVICE bound_track_parameters_base(
+        const geometry::barcode sf_idx, const parameter_vector_type& vec)
+        : base_type(vec), m_barcode(sf_idx) {}
+
+    /// @param rhs is the left hand side params for comparison
+    DETRAY_HOST_DEVICE
+    bool operator==(const bound_track_parameters_base& rhs) const {
+        if (m_barcode != rhs.surface_link()) {
+            return false;
+        }
+
+        if (!base_type::operator==(rhs)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// @returns the barcode of the associated surface
+    DETRAY_HOST_DEVICE
+    const geometry::barcode& surface_link() const { return m_barcode; }
+
+    /// Set the barcode of the associated surface
+    DETRAY_HOST_DEVICE
+    void set_surface_link(geometry::barcode link) { m_barcode = link; }
+
+    /// Set the track parameter vector
+    DETRAY_HOST_DEVICE
+    void set_parameter_vector(const parameter_vector_type& v,
+                              const bool skip_check = false) {
+        this->set_vector(v.vector(), skip_check);
+    }
+
+    /// @param do_check toggle checking (e.g. don't trigger assertions for
+    /// documented errors)
+    /// @returns true if the parameter vector contains invalid elements
+    DETRAY_HOST_DEVICE
+    constexpr bool is_invalid(const bool do_check = true) const {
+        if (!do_check) {
+            return false;
+        }
+        return base_type::is_invalid();
+    }
+
+    private:
+    geometry::barcode m_barcode{};
+};
+
+/// Combine the bound track parameter vector with the covariance and associated
+/// surface
+template <concepts::algebra algebra_t>
+struct bound_track_parameters : public bound_track_parameters_base<algebra_t> {
+
+    using base_type = bound_track_parameters_base<algebra_t>;
 
     /// @name Type definitions for the struct
     /// @{
@@ -294,15 +367,11 @@ struct bound_track_parameters : public bound_parameters_vector<algebra_t> {
     bound_track_parameters(const geometry::barcode sf_idx,
                            const parameter_vector_type& vec,
                            const covariance_type& cov)
-        : base_type(vec), m_covariance(cov), m_barcode(sf_idx) {}
+        : base_type(sf_idx, vec), m_covariance(cov) {}
 
     /// @param rhs is the left hand side params for comparison
     DETRAY_HOST_DEVICE
     bool operator==(const bound_track_parameters& rhs) const {
-        if (m_barcode != rhs.surface_link()) {
-            return false;
-        }
-
         if (!base_type::operator==(rhs)) {
             return false;
         }
@@ -322,25 +391,6 @@ struct bound_track_parameters : public bound_parameters_vector<algebra_t> {
         return true;
     }
 
-    /// @returns the barcode of the associated surface
-    DETRAY_HOST_DEVICE
-    const geometry::barcode& surface_link() const { return m_barcode; }
-
-    /// Set the barcode of the associated surface
-    DETRAY_HOST_DEVICE
-    void set_surface_link(geometry::barcode link) { m_barcode = link; }
-
-    /// Set the track parameter vector
-    DETRAY_HOST_DEVICE
-    void set_parameter_vector(const parameter_vector_type& v,
-                              const bool skip_check = false) {
-        this->set_vector(v.vector(), skip_check);
-    }
-
-    /// @returns the track parameter covariance - non-const
-    DETRAY_HOST_DEVICE
-    covariance_type& covariance() { return m_covariance; }
-
     /// @returns the track parameter covariance - const
     DETRAY_HOST_DEVICE
     const covariance_type& covariance() const { return m_covariance; }
@@ -348,6 +398,11 @@ struct bound_track_parameters : public bound_parameters_vector<algebra_t> {
     /// Set the track parameter covariance
     DETRAY_HOST_DEVICE
     void set_covariance(const covariance_type& c) { m_covariance = c; }
+
+    DETRAY_HOST_DEVICE
+    void update_covariance(const bound_matrix<algebra_t>& jac) {
+        m_covariance = m_covariance * jac;
+    }
 
     /// @param do_check toggle checking (e.g. don't trigger assertions for
     /// documented errors)
@@ -379,7 +434,6 @@ struct bound_track_parameters : public bound_parameters_vector<algebra_t> {
     }
 
     covariance_type m_covariance = matrix::zero<covariance_type>();
-    geometry::barcode m_barcode{};
 };
 
 }  // namespace detray

--- a/tests/include/detray/test/utils/simulation/random_scatterer.hpp
+++ b/tests/include/detray/test/utils/simulation/random_scatterer.hpp
@@ -67,14 +67,14 @@ struct random_scatterer : actor {
     /// Material store visitor
     struct kernel {
 
-        template <typename mat_group_t, typename index_t>
+        template <typename mat_group_t, typename index_t,
+                  typename bound_track_parameters_t>
         DETRAY_HOST_DEVICE inline bool operator()(
             [[maybe_unused]] const mat_group_t& material_group,
             [[maybe_unused]] const index_t& mat_index,
             [[maybe_unused]] typename random_scatterer::state& s,
             [[maybe_unused]] const pdg_particle<scalar_type>& ptc,
-            [[maybe_unused]] const bound_track_parameters<algebra_t>&
-                bound_params,
+            [[maybe_unused]] const bound_track_parameters_t& bound_params,
             [[maybe_unused]] const scalar_type cos_inc_angle,
             [[maybe_unused]] const scalar_type approach) const {
 

--- a/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -219,8 +219,12 @@ inline auto record_propagation(
                     bound_param[i], stddevs[i])(generator);
             }
 
-            getter::element(bound_param.covariance(), i, i) =
-                stddevs[i] * stddevs[i];
+            auto cov = matrix::zero<typename std::decay_t<decltype(
+                bound_param)>::covariance_type>();
+
+            getter::element(cov, i, i) = stddevs[i] * stddevs[i];
+
+            bound_param.set_covariance(cov);
         }
     }
 

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -93,7 +93,7 @@ GTEST_TEST(detray_propagator, covariance_transport) {
     getter::element(bound_cov, e_bound_theta, e_bound_theta) = 0.f;
 
     // Bound track parameter
-    const bound_track_parameters<test_algebra> bound_param0(
+    const propagator_t::bound_track_parameters_type bound_param0(
         det.surface(0u).barcode(), bound_vector, bound_cov);
 
     propagation::config prop_cfg{};


### PR DESCRIPTION
I would like to investigate the addition of different bound parameter type storage methods, like e.g. ones with square root decompositions and UDU decompositions. This will require us to add new bound parameter types (some of which will not have built-in covariance matrices). This commit adds the necessary changes to make this happen, lifting the common parts of the track parameter type into a base type and allowing that to be extended. Code using the bound track parameters are, where necessary, updated to be templated.