### PR TITLE
fix: Add homogenous material out of order

### DIFF
--- a/core/include/detray/builders/cuboid_portal_generator.hpp
+++ b/core/include/detray/builders/cuboid_portal_generator.hpp
@@ -85,7 +85,7 @@ class cuboid_portal_generator final
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {})
-        -> dindex_range override {
+        -> dvector<dindex> override {
 
         using point3_t = dpoint3D<algebra_type>;
         using vector3_t = dvector3D<algebra_type>;

--- a/core/include/detray/builders/cylinder_portal_generator.hpp
+++ b/core/include/detray/builders/cylinder_portal_generator.hpp
@@ -182,7 +182,7 @@ class cylinder_portal_generator final
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {})
-        -> dindex_range override {
+        -> dvector<dindex> override {
 
         using aabb_t = axis_aligned_bounding_volume<cuboid3D, algebra_t>;
 

--- a/core/include/detray/builders/surface_factory_interface.hpp
+++ b/core/include/detray/builders/surface_factory_interface.hpp
@@ -122,7 +122,7 @@ class surface_factory_interface {
         typename detector_t::surface_lookup_container &surfaces,
         typename detector_t::transform_container &transforms,
         typename detector_t::mask_container &masks,
-        typename detector_t::geometry_context ctx = {}) -> dindex_range = 0;
+        typename detector_t::geometry_context ctx = {}) -> dvector<dindex> = 0;
 
     protected:
     /// Insert a value in a container at a specific index
@@ -134,7 +134,7 @@ class surface_factory_interface {
     ///
     /// @returns the position where the value has been copied.
     template <typename container_t, typename... Args>
-    DETRAY_HOST dindex insert_in_container(
+    DETRAY_HOST dindex insert_into_container(
         container_t &cont, const typename container_t::value_type value,
         const dindex idx, Args &&... args) const {
         // If no valid position is given, perform push back
@@ -203,7 +203,7 @@ class factory_decorator : public surface_factory_interface<detector_t> {
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {})
-        -> dindex_range override {
+        -> dvector<dindex> override {
         return (*m_factory)(volume, surfaces, transforms, masks, ctx);
     }
     /// @}

--- a/io/include/detray/io/backend/detail/grid_reader.hpp
+++ b/io/include/detray/io/backend/detail/grid_reader.hpp
@@ -393,6 +393,7 @@ class grid_reader {
                 }
 
                 // For now assume surfaces ids as the only grid input
+                // TODO: Write bin content converter
                 for (const auto c : bin_data.content) {
                     if (detray::detail::is_invalid_value(
                             static_cast<dindex>(c))) {

--- a/io/include/detray/io/backend/detail/grid_writer.hpp
+++ b/io/include/detray/io/backend/detail/grid_writer.hpp
@@ -145,7 +145,9 @@ class grid_writer {
     ///
     /// @param store the data store of grids (tuple of grid collections)
     /// @param grid_link type and index of the grid
-    /// @param owner_idx inder of the owner of the grid (e.g. volume index)
+    /// @param vol_idx type and index of volume the grid belongs to
+    /// @param owner_idx inder of the owner of the grid (can be identical to
+    /// vol_idx or volume-local surface index)
     /// @param grid_data the grid payload to be filled
     /// @param converter callable that can convert a grid bin entry into its
     /// respective IO payload (of type @tparam content_t)
@@ -171,8 +173,8 @@ class grid_writer {
         inline void operator()(
             [[maybe_unused]] const grid_group_t& coll,
             [[maybe_unused]] const index_t& index,
-            [[maybe_unused]] std::size_t vol_link,
-            [[maybe_unused]] std::size_t owner_link,
+            [[maybe_unused]] std::size_t vol_idx,
+            [[maybe_unused]] std::size_t owner_idx,
             [[maybe_unused]] detector_grids_payload<content_t, grid_id_t>&
                 grids_data,
             [[maybe_unused]] converter_t& converter) const {
@@ -184,15 +186,15 @@ class grid_writer {
                 using value_t = typename coll_value_t::value_type;
 
                 auto gr_pyload = to_payload<content_t, value_t>(
-                    owner_link, io::detail::get_id<coll_value_t>(), index,
+                    owner_idx, io::detail::get_id<coll_value_t>(), index,
                     coll[index], converter);
 
                 auto& grids_map = grids_data.grids;
-                auto search = grids_map.find(vol_link);
+                auto search = grids_map.find(vol_idx);
                 if (search != grids_map.end()) {
-                    grids_map.at(vol_link).push_back(std::move(gr_pyload));
+                    grids_map.at(vol_idx).push_back(std::move(gr_pyload));
                 } else {
-                    grids_map[vol_link] = {std::move(gr_pyload)};
+                    grids_map[vol_idx] = {std::move(gr_pyload)};
                 }
             }
         }

--- a/io/include/detray/io/backend/homogeneous_material_writer.hpp
+++ b/io/include/detray/io/backend/homogeneous_material_writer.hpp
@@ -121,13 +121,10 @@ class homogeneous_material_writer {
                         : material_slab_payload{};
                 mslp.type == material_type::slab) {
                 mslp.index_in_coll = slab_idx++;
-                mv_data.mat_slabs.push_back(mslp);
+                mv_data.surface_mat.push_back(mslp);
             } else if (mslp.type == material_type::rod) {
-                if (!mv_data.mat_rods.has_value()) {
-                    mv_data.mat_rods.emplace();
-                }
                 mslp.index_in_coll = rod_idx++;
-                mv_data.mat_rods->push_back(mslp);
+                mv_data.surface_mat.push_back(mslp);
             } else { /* material maps are handled by another writer */
             }
             ++sf_idx;
@@ -138,8 +135,8 @@ class homogeneous_material_writer {
 
     /// Convert surface material @param mat into its io payload
     template <class scalar_t>
-    static material_payload to_payload(const material<scalar_t>& mat) {
-        material_payload mat_data;
+    static material_param_payload to_payload(const material<scalar_t>& mat) {
+        material_param_payload mat_data;
 
         mat_data.params = {mat.X0(),
                            mat.L0(),

--- a/io/include/detray/io/backend/material_map_reader.hpp
+++ b/io/include/detray/io/backend/material_map_reader.hpp
@@ -117,7 +117,7 @@ class material_map_reader {
                     }
                     loc_bins.push_back(std::move(mbin));
 
-                    // For now assume surfaces ids as the only grid input
+                    // Add the material slab per bin
                     for (const auto &slab_data : bin_data.content) {
                         mat_data.append(
                             material_reader_t::template from_payload<scalar_t>(

--- a/io/include/detray/io/json/detail/json_grids_io.hpp
+++ b/io/include/detray/io/json/detail/json_grids_io.hpp
@@ -87,10 +87,6 @@ inline void to_json(nlohmann::ordered_json& j,
         jbins.push_back(bin);
     }
     j["bins"] = jbins;
-
-    if (g.transform.has_value()) {
-        j["transform"] = g.transform.value();
-    }
 }
 
 template <typename content_t, typename grid_id_t>
@@ -109,11 +105,6 @@ inline void from_json(const nlohmann::ordered_json& j,
     for (auto jbin : jbins) {
         grid_bin_payload<content_t> b = jbin;
         g.bins.push_back(std::move(b));
-    }
-
-    if (j.find("transform") != j.end()) {
-        g.transform.emplace();
-        g.transform = j["transform"];
     }
 }
 

--- a/io/include/detray/io/json/detail/json_material_io.hpp
+++ b/io/include/detray/io/json/detail/json_material_io.hpp
@@ -43,11 +43,13 @@ inline void from_json(const nlohmann::ordered_json& j,
     }
 }
 
-inline void to_json(nlohmann::ordered_json& j, const material_payload& m) {
+inline void to_json(nlohmann::ordered_json& j,
+                    const material_param_payload& m) {
     j["params"] = m.params;
 }
 
-inline void from_json(const nlohmann::ordered_json& j, material_payload& m) {
+inline void from_json(const nlohmann::ordered_json& j,
+                      material_param_payload& m) {
     m.params = j["params"].get<std::array<real_io, 7>>();
 }
 
@@ -76,19 +78,12 @@ inline void to_json(nlohmann::ordered_json& j,
                     const material_volume_payload& mv) {
     j["volume_link"] = mv.volume_link;
 
-    if (!mv.mat_slabs.empty()) {
+    if (!mv.surface_mat.empty()) {
         nlohmann::ordered_json jmats;
-        for (const auto& m : mv.mat_slabs) {
+        for (const auto& m : mv.surface_mat) {
             jmats.push_back(m);
         }
-        j["material_slabs"] = jmats;
-    }
-    if (mv.mat_rods.has_value() && !mv.mat_rods->empty()) {
-        nlohmann::ordered_json jmats;
-        for (const auto& m : mv.mat_rods.value()) {
-            jmats.push_back(m);
-        }
-        j["material_rods"] = jmats;
+        j["surface_material"] = jmats;
     }
 }
 
@@ -96,17 +91,10 @@ inline void from_json(const nlohmann::ordered_json& j,
                       material_volume_payload& mv) {
     mv.volume_link = j["volume_link"];
 
-    if (j.find("material_slabs") != j.end()) {
-        for (auto jmats : j["material_slabs"]) {
+    if (j.find("surface_material") != j.end()) {
+        for (auto jmats : j["surface_material"]) {
             material_slab_payload mslp = jmats;
-            mv.mat_slabs.push_back(mslp);
-        }
-    }
-    if (j.find("material_rods") != j.end()) {
-        mv.mat_rods.emplace();
-        for (auto jmats : j["material_rods"]) {
-            material_slab_payload mslp = jmats;
-            mv.mat_rods->push_back(mslp);
+            mv.surface_mat.push_back(mslp);
         }
     }
 }

--- a/tests/include/detray/test/common/factories/barrel_generator.hpp
+++ b/tests/include/detray/test/common/factories/barrel_generator.hpp
@@ -147,7 +147,7 @@ class barrel_generator final : public surface_factory_interface<detector_t> {
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {})
-        -> dindex_range override {
+        -> dvector<dindex> override {
 
         using surface_t = typename detector_t::surface_type;
         using nav_link_t = typename surface_t::navigation_link;

--- a/tests/include/detray/test/common/factories/endcap_generator.hpp
+++ b/tests/include/detray/test/common/factories/endcap_generator.hpp
@@ -177,7 +177,7 @@ class endcap_generator final : public surface_factory_interface<detector_t> {
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {})
-        -> dindex_range override {
+        -> dvector<dindex> override {
 
         using surface_t = typename detector_t::surface_type;
         using nav_link_t = typename surface_t::navigation_link;

--- a/tests/include/detray/test/common/factories/telescope_generator.hpp
+++ b/tests/include/detray/test/common/factories/telescope_generator.hpp
@@ -107,7 +107,7 @@ class telescope_generator final : public surface_factory_interface<detector_t> {
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {})
-        -> dindex_range override {
+        -> dvector<dindex> override {
 
         using surface_t = typename detector_t::surface_type;
         using nav_link_t = typename surface_t::navigation_link;

--- a/tests/include/detray/test/common/factories/wire_layer_generator.hpp
+++ b/tests/include/detray/test/common/factories/wire_layer_generator.hpp
@@ -125,7 +125,7 @@ class wire_layer_generator final
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {})
-        -> dindex_range override {
+        -> dvector<dindex> override {
 
         using surface_t = typename detector_t::surface_type;
         using nav_link_t = typename surface_t::navigation_link;

--- a/tests/include/detray/test/utils/prefill_detector.hpp
+++ b/tests/include/detray/test/utils/prefill_detector.hpp
@@ -58,7 +58,8 @@ void prefill_detector(detector_t& d,
                                   vol_link, std::vector<scalar_t>{-3.f, 3.f}});
     rectangle_factory->add_material(
         material_id::e_slab,
-        {3.f * unit<scalar_t>::mm, detray::gold<scalar_t>()});
+        {0u, 3.f * unit<scalar_t>::mm, detray::gold<scalar_t>()});
+
     // Surface 1
     auto annulus_factory =
         std::make_shared<homogeneous_material_factory<detector_t>>(
@@ -69,7 +70,7 @@ void prefill_detector(detector_t& d,
          vol_link, std::vector<scalar_t>{1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f}});
     annulus_factory->add_material(
         material_id::e_slab,
-        {12.f * unit<scalar_t>::mm, detray::tungsten<scalar_t>()});
+        {1u, 12.f * unit<scalar_t>::mm, detray::tungsten<scalar_t>()});
 
     // Surface 2
     auto trapezoid_factory =
@@ -81,7 +82,7 @@ void prefill_detector(detector_t& d,
          vol_link, std::vector<scalar_t>{1.f, 2.f, 3.f, 1.f / 6.f}});
     trapezoid_factory->add_material(
         material_id::e_rod,
-        {4.f * unit<scalar_t>::mm, detray::aluminium<scalar_t>()});
+        {2u, 4.f * unit<scalar_t>::mm, detray::aluminium<scalar_t>()});
 
     // Build the volume with three surfaces and homogenenous material
     v_mat_builder.add_surfaces(rectangle_factory, ctx);

--- a/tests/unit_tests/cpu/builders/homogeneous_material_builder.cpp
+++ b/tests/unit_tests/cpu/builders/homogeneous_material_builder.cpp
@@ -65,36 +65,44 @@ TEST(detray_builders, homogeneous_material_factory) {
     EXPECT_TRUE(mat_factory->materials().empty());
     EXPECT_TRUE(mat_factory->thickness().empty());
 
-    // Add material for a few rectangle surfaces
+    // Add some rectangle surfaces
     mat_factory->push_back({surface_id::e_sensitive,
                             transform3(point3{0.f, 0.f, -1.f}), 1u,
                             std::vector<scalar>{10.f, 8.f}});
-    mat_factory->add_material(material_id::e_slab,
-                              {1.f * unit<scalar>::mm, silicon<scalar>()});
     mat_factory->push_back({surface_id::e_sensitive,
                             transform3(point3{0.f, 0.f, 1.f}), 1u,
                             std::vector<scalar>{20.f, 16.f}});
+    mat_factory->push_back({surface_id::e_sensitive,
+                            transform3(point3{0.f, 0.f, 10.f}), 1u,
+                            std::vector<scalar>{20.f, 16.f}});
+    mat_factory->push_back({surface_id::e_passive,
+                            transform3(point3{0.f, 0.f, 20.f}), 1u,
+                            std::vector<scalar>{20.f, 16.f}});
+    mat_factory->push_back({surface_id::e_sensitive,
+                            transform3(point3{0.f, 0.f, 50.f}), 1u,
+                            std::vector<scalar>{20.f, 16.f}});
+
+    // Add material for a few rectangle surfaces
     mat_factory->add_material(material_id::e_slab,
-                              {10.f * unit<scalar>::mm, tungsten<scalar>()});
+                              {0u, 1.f * unit<scalar>::mm, silicon<scalar>()});
+    mat_factory->add_material(
+        material_id::e_slab, {3u, 10.f * unit<scalar>::mm, tungsten<scalar>()});
     // Pass the parameters for 'gold'
-    mat_factory->push_back({surface_id::e_sensitive,
-                            transform3(point3{0.f, 0.f, 1.f}), 1u,
-                            std::vector<scalar>{20.f, 16.f}});
     mat_factory->add_material(
         material_id::e_rod,
-        {0.1f * unit<scalar>::mm,
+        {4u, 0.1f * unit<scalar>::mm,
          std::vector<scalar>{
              3.344f * unit<scalar>::mm, 101.6f * unit<scalar>::mm, 196.97f, 79,
              19.32f * unit<scalar>::g / (1.f * unit<scalar>::cm3)},
          material_state::e_solid});
 
-    EXPECT_EQ(mat_factory->size(), 3u);
+    EXPECT_EQ(mat_factory->size(), 5u);
 
     // Test the material data
-    EXPECT_NEAR(mat_factory->thickness()[0], 1.f * unit<scalar>::mm, tol);
-    EXPECT_NEAR(mat_factory->thickness()[1], 10.f * unit<scalar>::mm, tol);
-    EXPECT_NEAR(mat_factory->thickness()[2], 0.1f * unit<scalar>::mm, tol);
-    EXPECT_EQ(mat_factory->materials()[0], silicon<scalar>());
-    EXPECT_EQ(mat_factory->materials()[1], tungsten<scalar>());
-    EXPECT_EQ(mat_factory->materials()[2], gold<scalar>());
+    EXPECT_NEAR(mat_factory->thickness().at(0), 1.f * unit<scalar>::mm, tol);
+    EXPECT_NEAR(mat_factory->thickness().at(3), 10.f * unit<scalar>::mm, tol);
+    EXPECT_NEAR(mat_factory->thickness().at(4), 0.1f * unit<scalar>::mm, tol);
+    EXPECT_EQ(mat_factory->materials().at(0), silicon<scalar>());
+    EXPECT_EQ(mat_factory->materials().at(3), tungsten<scalar>());
+    EXPECT_EQ(mat_factory->materials().at(4), gold<scalar>());
 }

--- a/tutorials/include/detray/tutorial/square_surface_generator.hpp
+++ b/tutorials/include/detray/tutorial/square_surface_generator.hpp
@@ -67,7 +67,7 @@ class square_surface_generator final
                     typename detector_t::transform_container &transforms,
                     typename detector_t::mask_container &masks,
                     typename detector_t::geometry_context ctx = {})
-        -> dindex_range override {
+        -> dvector<dindex> override {
         using surface_t = typename detector_t::surface_type;
         using mask_link_t = typename surface_t::mask_link;
         using material_link_t = typename surface_t::material_link;


### PR DESCRIPTION
Allows to add the material in the homogeneous material build in any order. Also adds new comments to the payloads and removes some spurious members