### PR TITLE
ref: Clean up tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ The following cmake options are available and can also be specified explicitly f
 | DETRAY_VC_SOA_PLUGIN | Build Vc based SoA math plugin (currently only supports the ray-surface intersectors) | OFF |
 | DETRAY_SVG_DISPLAY | Build ActSVG display module | OFF |
 
+## Tutorials
+
+In the `tutorials` folder of the repository, there are a number of standalone executables that showcase different tasks:
+- Building a detector (either a predefined one or designing a detector from scatch)
+- Detector file IO
+- Additional debugging options, like performing a ray scan or obtaining
+extra navigation tracing information
+- Moving a detector to device
+- Host and device track propagation
 
 ## Detector Validation
 

--- a/core/include/detray/builders/volume_builder.hpp
+++ b/core/include/detray/builders/volume_builder.hpp
@@ -54,12 +54,6 @@ class volume_builder : public volume_builder_interface<detector_t> {
             detector_t::accel::id::e_default, 0);
     };
 
-    /// Adds the @param name of the volume to a @param name_map
-    template <typename name_map>
-    DETRAY_HOST void add_name(const name_map& names, std::string&& name) {
-        names.at(vol_index()) = std::move(name);
-    }
-
     /// @returns the volume index in the detector volume container
     DETRAY_HOST
     auto vol_index() const -> dindex override { return m_volume.index(); }
@@ -71,6 +65,20 @@ class volume_builder : public volume_builder_interface<detector_t> {
     /// @returns whether sensitive surfaces are added to the brute force method
     DETRAY_HOST
     bool has_accel() const override { return m_has_accel; }
+
+    /// Sets the name @param volume_name for the volume
+    DETRAY_HOST void set_name(std::string volume_name) override {
+        m_volume_name = std::move(volume_name);
+    }
+
+    /// @returns the name of the volume
+    DETRAY_HOST std::string_view name() override {
+        if (m_volume_name.empty()) {
+            // Consistent default after volume index is known
+            m_volume_name = "volume_" + std::to_string(vol_index());
+        }
+        return m_volume_name;
+    }
 
     /// Access to the volume under construction - const
     DETRAY_HOST
@@ -269,6 +277,9 @@ class volume_builder : public volume_builder_interface<detector_t> {
     private:
     /// Whether the volume will get an acceleration structure
     bool m_has_accel{false};
+
+    /// The name of the volume
+    std::string m_volume_name{};
 
     /// Volume descriptor of the volume under construction
     typename detector_t::volume_type m_volume{};

--- a/core/include/detray/builders/volume_builder_interface.hpp
+++ b/core/include/detray/builders/volume_builder_interface.hpp
@@ -12,6 +12,8 @@
 
 // System include(s)
 #include <memory>
+#include <string>
+#include <string_view>
 
 namespace detray {
 
@@ -46,6 +48,14 @@ class volume_builder_interface {
     /// @returns whether sensitive surfaces are added to the brute force method
     DETRAY_HOST
     virtual bool has_accel() const = 0;
+
+    /// Sets the name @param volume_name for the volume
+    DETRAY_HOST
+    virtual void set_name(std::string volume_name) = 0;
+
+    /// @returns the name of the volume
+    DETRAY_HOST
+    virtual std::string_view name() = 0;
 
     /// @returns reading access to the volume
     DETRAY_HOST
@@ -130,6 +140,13 @@ class volume_decorator : public volume_builder_interface<detector_t> {
 
     DETRAY_HOST
     bool has_accel() const override { return m_builder->has_accel(); }
+
+    DETRAY_HOST
+    void set_name(std::string volume_name) override {
+        return m_builder->set_name(volume_name);
+    }
+
+    DETRAY_HOST std::string_view name() override { return m_builder->name(); }
 
     DETRAY_HOST
     auto build(detector_t &det,

--- a/io/include/detray/io/backend/concepts.hpp
+++ b/io/include/detray/io/backend/concepts.hpp
@@ -19,18 +19,14 @@ namespace detray::io::concepts {
 /// Concept for detray io reader backends
 template <typename D, typename R>
 concept reader_backend =
-    requires(const R rb, detector_builder<typename D::metadata> det_builder,
-             typename D::name_map names) {
+    requires(const R rb, detector_builder<typename D::metadata> det_builder) {
 
     typename R::payload_type;
 
     { R::tag }
     ->std::same_as<const std::string_view&>;
 
-    {
-        R::template from_payload<D>(det_builder, names,
-                                    typename R::payload_type())
-    }
+    { R::template from_payload<D>(det_builder, typename R::payload_type()) }
     ->std::same_as<void>;
 };
 

--- a/io/include/detray/io/backend/geometry_reader.hpp
+++ b/io/include/detray/io/backend/geometry_reader.hpp
@@ -55,11 +55,9 @@ class geometry_reader {
     using payload_type = detector_payload;
 
     /// Convert a detector @param det from its io payload @param det_data
-    /// and add the volume names to @param name_map
     template <class detector_t>
     static void from_payload(detector_builder<typename detector_t::metadata,
                                               volume_builder>& det_builder,
-                             typename detector_t::name_map& name_map,
                              const payload_type& det_data) {
 
         // Can hold all types of surface fatory needed for the detector
@@ -72,7 +70,7 @@ class geometry_reader {
             auto vbuilder = det_builder.new_volume(vol_data.type);
 
             // Set the volume name
-            name_map[vbuilder->vol_index() + 1u] = vol_data.name;
+            vbuilder->set_name(vol_data.name);
 
             // Volume placement
             vbuilder->add_volume_placement(

--- a/io/include/detray/io/backend/homogeneous_material_reader.hpp
+++ b/io/include/detray/io/backend/homogeneous_material_reader.hpp
@@ -47,7 +47,6 @@ class homogeneous_material_reader {
     template <class detector_t>
     static void from_payload(detector_builder<typename detector_t::metadata,
                                               volume_builder>& det_builder,
-                             typename detector_t::name_map& /*name_map*/,
                              const payload_type& det_mat_data) {
 
         using scalar_t = dscalar<typename detector_t::algebra_type>;

--- a/io/include/detray/io/backend/material_map_reader.hpp
+++ b/io/include/detray/io/backend/material_map_reader.hpp
@@ -50,7 +50,6 @@ class material_map_reader {
     template <typename detector_t>
     static void from_payload(detector_builder<typename detector_t::metadata,
                                               volume_builder> &det_builder,
-                             typename detector_t::name_map &,
                              payload_type &&grids_data) {
 
         using scalar_t = dscalar<typename detector_t::algebra_type>;

--- a/io/include/detray/io/backend/surface_grid_reader.hpp
+++ b/io/include/detray/io/backend/surface_grid_reader.hpp
@@ -46,7 +46,6 @@ class surface_grid_reader
     template <typename detector_t>
     static void from_payload(detector_builder<typename detector_t::metadata,
                                               volume_builder> &det_builder,
-                             typename detector_t::name_map &,
                              const payload_type &grids_data) {
 
         grid_reader_t::template from_payload<detector_t>(det_builder,

--- a/io/include/detray/io/frontend/detail/detector_components_reader.hpp
+++ b/io/include/detray/io/frontend/detail/detector_components_reader.hpp
@@ -38,13 +38,13 @@ class detector_components_reader final {
     /// Create a new reader of type @tparam reader_t
     template <class reader_t>
     requires std::is_base_of_v<reader_interface<detector_t>, reader_t> void add(
-        const std::string& name) {
-        add(std::make_unique<reader_t>(), name);
+        const std::string& file_name) {
+        add(std::make_unique<reader_t>(), file_name);
     }
 
     /// Attach an existing reader via @param r_ptr to the readers
-    void add(reader_ptr_t&& r_ptr, const std::string& name) {
-        m_readers[name] = std::move(r_ptr);
+    void add(reader_ptr_t&& r_ptr, const std::string& file_name) {
+        m_readers[file_name] = std::move(r_ptr);
     }
 
     /// @returns the number of readers that are registered
@@ -59,19 +59,18 @@ class detector_components_reader final {
     /// Reads the full detector into @param det by calling the readers, while
     /// using the name map @param volume_names for to write the volume names.
     void read(detector_builder<typename detector_t::metadata, volume_builder>&
-                  det_builder,
-              typename detector_t::name_map& volume_names) {
+                  det_builder) {
 
         // We have to at least read a geometry
         assert(size() != 0u &&
                "No readers registered! Need at least a geometry reader");
 
         // Set the detector name in the name map
-        volume_names.emplace(0u, m_det_name);
+        det_builder.set_name(m_det_name);
 
         // Call the read method on all readers
-        for (const auto& [name, reader] : m_readers) {
-            reader->read(det_builder, volume_names, name);
+        for (const auto& [file_name, reader] : m_readers) {
+            reader->read(det_builder, file_name);
         }
     }
 

--- a/io/include/detray/io/frontend/detector_reader.hpp
+++ b/io/include/detray/io/frontend/detector_reader.hpp
@@ -29,12 +29,10 @@ namespace detray::io {
 ///
 /// @param file_names list of files to be read
 /// @param det_builder detector builder to be filled
-/// @param name_map detector and volume name map
 template <class detector_t, std::size_t CAP = 0u, std::size_t DIM = 2u>
 void read_components_from_file(const std::vector<std::string>& file_names,
                                detector_builder<typename detector_t::metadata,
-                                                volume_builder>& det_builder,
-                               typename detector_t::name_map& name_map) {
+                                                volume_builder>& det_builder) {
     // Hold all required readers (one for every component)
     detail::detector_components_reader<detector_t> readers;
 
@@ -52,7 +50,7 @@ void read_components_from_file(const std::vector<std::string>& file_names,
     }
 
     // Read the data into the detector builder
-    readers.read(det_builder, name_map);
+    readers.read(det_builder);
 }
 
 /// @brief Reader function for detray detectors.
@@ -80,11 +78,10 @@ auto read_detector(vecmem::memory_resource& resc,
 
     // Register readers for the respective detector component and file format
     // and read the data into the detector_builder
-    read_components_from_file<detector_t, CAP, DIM>(cfg.files(), det_builder,
-                                                    names);
+    read_components_from_file<detector_t, CAP, DIM>(cfg.files(), det_builder);
 
     // Build and return the detector
-    auto det = det_builder.build(resc);
+    auto det = det_builder.build(resc, names);
 
     if (cfg.do_check()) {
         // This will throw an exception in case of inconsistencies

--- a/io/include/detray/io/frontend/reader_interface.hpp
+++ b/io/include/detray/io/frontend/reader_interface.hpp
@@ -40,7 +40,7 @@ class reader_interface {
     /// filled.
     virtual void read(
         detector_builder<typename detector_t::metadata, volume_builder>&,
-        typename detector_t::name_map&, const std::string&) = 0;
+        const std::string&) = 0;
 
     private:
     /// Extension that matches the file format of the respective reader

--- a/io/include/detray/io/json/json_converter.hpp
+++ b/io/include/detray/io/json/json_converter.hpp
@@ -49,7 +49,6 @@ requires concepts::reader_backend<detector_t, backend_t> class json_converter<
     /// Writes the geometry to file with a given name
     void read(detector_builder<typename detector_t::metadata, volume_builder>&
                   det_builder,
-              typename detector_t::name_map& name_map,
               const std::string& file_name) override {
 
         // Read json from file
@@ -61,7 +60,7 @@ requires concepts::reader_backend<detector_t, backend_t> class json_converter<
         *file >> in_json;
 
         // Add the data from the payload to the detray detector builder
-        io_backend::template from_payload<detector_t>(det_builder, name_map,
+        io_backend::template from_payload<detector_t>(det_builder,
                                                       in_json["data"]);
     }
 };

--- a/tests/include/detray/test/common/build_telescope_detector.hpp
+++ b/tests/include/detray/test/common/build_telescope_detector.hpp
@@ -199,14 +199,12 @@ inline auto build_telescope_detector(
     using builder_t = detector_builder<metadata_t, volume_builder>;
     using detector_t = typename builder_t::detector_type;
 
-    // Detector and volume names
-    typename detector_t::name_map name_map = {{0u, "telescope_detector"},
-                                              {1u, "telescope_world_0"}};
-
     builder_t det_builder;
+    det_builder.set_name("telescope_detector");
 
     // Create an empty cuboid volume
     auto v_builder = det_builder.new_volume(volume_id::e_cuboid);
+    v_builder->set_name("telescope_world_0");
 
     // Identity transform (volume is centered at origin)
     v_builder->add_volume_placement();
@@ -277,8 +275,9 @@ inline auto build_telescope_detector(
         }
     }
 
-    // Build and return the detector
-    auto det = det_builder.build(resource);
+    // Build and return the detector and fill the name map
+    typename detector_t::name_map name_map{};
+    auto det = det_builder.build(resource, name_map);
 
     if (cfg.do_check()) {
         const bool verbose_check{false};

--- a/tests/include/detray/test/common/build_wire_chamber.hpp
+++ b/tests/include/detray/test/common/build_wire_chamber.hpp
@@ -155,9 +155,8 @@ inline auto build_wire_chamber(
 
     // Wire chamber detector builder
     builder_t det_builder;
+    det_builder.set_name("wire_chamber");
 
-    // Detector and volume names
-    typename detector_t::name_map name_map = {{0u, "wire_chamber"}};
     // Geometry context object
     typename detector_t::geometry_context gctx{};
 
@@ -197,7 +196,7 @@ inline auto build_wire_chamber(
     auto inner_v_builder = det_builder.new_volume(volume_id::e_cylinder);
     inner_v_builder->add_volume_placement(/*identity*/);
     const dindex inner_vol_idx{inner_v_builder->vol_index()};
-    name_map[1u] = "inner_vol_" + std::to_string(inner_vol_idx);
+    inner_v_builder->set_name("inner_vol_" + std::to_string(inner_vol_idx));
 
     // Configure the portal factory
     // TODO: Add material maps that model the silicon detector budget
@@ -239,7 +238,7 @@ inline auto build_wire_chamber(
                     v_builder);
 
         const dindex vol_idx{vm_builder->vol_index()};
-        name_map[vol_idx + 1u] = "layer_vol_" + std::to_string(vol_idx);
+        vm_builder->set_name("layer_vol_" + std::to_string(vol_idx));
 
         // The barrel volumes are centered at the origin
         vm_builder->add_volume_placement(/*identity*/);
@@ -313,8 +312,9 @@ inline auto build_wire_chamber(
                                capacities);
     }
 
-    // Build and return the detector
-    auto det = det_builder.build(resource);
+    // Build and return the detector and fill name map
+    typename detector_t::name_map name_map{};
+    auto det = det_builder.build(resource, name_map);
 
     if (cfg.do_check()) {
         const bool verbose_check{false};

--- a/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -1199,7 +1199,7 @@ auto compare_to_navigation(
         static_cast<double>(trk_stats.n_max_extra_per_trk)};
 
     // Self check
-    if (n_holes > n_tracks_w_holes) {
+    if (static_cast<double>(n_holes) > n_tracks_w_holes) {
         throw std::runtime_error(
             "Number of tracks with holes is underestimated!");
     }

--- a/tests/integration_tests/io/io_json_detector_roundtrip.cpp
+++ b/tests/integration_tests/io/io_json_detector_roundtrip.cpp
@@ -204,8 +204,8 @@ GTEST_TEST(io, json_toy_geometry) {
     // Read the detector back in
     detector_builder<metadata_t> toy_builder;
     io::json_converter<detector_t, io::geometry_reader> geo_reader;
-    geo_reader.read(toy_builder, volume_name_map, file_name);
-    auto det = toy_builder.build(host_mr);
+    geo_reader.read(toy_builder, file_name);
+    auto det = toy_builder.build(host_mr, volume_name_map);
 
     // @TODO: Will only work again after IO can perform data deduplication
     // EXPECT_TRUE(toy_detector_test(det, volume_name_map));
@@ -215,8 +215,8 @@ GTEST_TEST(io, json_toy_geometry) {
     detector_builder<default_metadata_t> comp_builder;
     io::json_converter<detector<default_metadata_t>, io::geometry_reader>
         comp_geo_reader;
-    comp_geo_reader.read(comp_builder, volume_name_map, file_name);
-    auto comp_det = comp_builder.build(host_mr);
+    comp_geo_reader.read(comp_builder, file_name);
+    auto comp_det = comp_builder.build(host_mr, volume_name_map);
 
     using mask_id = detector<default_metadata_t>::masks::id;
     const auto& masks = comp_det.mask_store();

--- a/tests/unit_tests/cpu/builders/grid_builder.cpp
+++ b/tests/unit_tests/cpu/builders/grid_builder.cpp
@@ -47,6 +47,9 @@ struct mock_volume_builder : public volume_builder_interface<detector_t> {
     void has_accel(bool) override { /*Do nothing*/
     }
     bool has_accel() const override { return false; }
+    void set_name(std::string) override { /*Do nothing*/
+    }
+    std::string_view name() override { return "test_volume_0"; }
     auto operator()() const -> const
         typename detector_t::volume_type& override {
         return m_vol;

--- a/tutorials/include/detray/tutorial/my_square2D.hpp
+++ b/tutorials/include/detray/tutorial/my_square2D.hpp
@@ -47,7 +47,7 @@ class square2D {
     ///
     /// @note the point is expected to be given in local coordinates by the
     /// caller. For the conversion from global cartesian coordinates, the
-    /// nested @c shape struct can be used.
+    /// nested @c local_frame_type struct can be used.
     ///
     /// @param bounds the boundary values for this shape
     /// @param loc_p the point to be checked in the local coordinate system

--- a/tutorials/include/detray/tutorial/square_surface_generator.hpp
+++ b/tutorials/include/detray/tutorial/square_surface_generator.hpp
@@ -23,7 +23,7 @@
 
 namespace detray::tutorial {
 
-/// @brief Generates a sequence of square surfaces for the example detector
+/// @brief Generates a sequence of square surfaces for the tutorial detector
 class square_surface_generator final
     : public surface_factory_interface<detector<tutorial::my_metadata>> {
 
@@ -40,6 +40,8 @@ class square_surface_generator final
     DETRAY_HOST
     auto size() const -> dindex override { return m_n_squares; }
 
+    /// Generator, does not aggregate any data
+    /// @{
     DETRAY_HOST
     void clear() override{/*Do nothing*/};
 
@@ -50,11 +52,12 @@ class square_surface_generator final
     auto push_back(std::vector<surface_data<detector_t>> &&)
         -> void override { /*Do nothing*/
     }
+    /// @}
 
     /// Generate the surfaces and add them to given data collections.
     ///
-    /// @param volume the volume they will be added to in the detector.
-    /// @param surfaces the resulting surface objects.
+    /// @param volume the volume that will be added to the detector.
+    /// @param surfaces the resulting surface descriptors.
     /// @param transforms the transforms of the surfaces.
     /// @param masks the masks of the surfaces (all of the same shape).
     /// @param ctx the geometry context.
@@ -69,13 +72,13 @@ class square_surface_generator final
         using mask_link_t = typename surface_t::mask_link;
         using material_link_t = typename surface_t::material_link;
 
-        // Position in the tuple for square surface masks
+        // Position in the detector mask tuple for square surface masks
         constexpr auto mask_id{detector_t::masks::id::e_square2};
         // The material will be added in a later step
         constexpr auto no_material = surface_t::material_id::e_none;
         // In case the surfaces container is prefilled with other surfaces
         auto surfaces_offset = static_cast<dindex>(surfaces.size());
-
+        // No ACTS source surface
         constexpr auto invalid_src_link{detail::invalid_value<std::uint64_t>()};
 
         // Produce a series of square surfaces,
@@ -93,15 +96,18 @@ class square_surface_generator final
             masks.template emplace_back<mask_id>(empty_context{},
                                                  volume.index(), m_half_length);
 
-            // Add surface with all links set (relative to the given containers)
+            // Add surface descriptor with all links set (relative to the given
+            // containers)
             mask_link_t mask_link{mask_id, masks.template size<mask_id>() - 1u};
             material_link_t material_link{no_material, dindex_invalid};
+
             surfaces.push_back(
                 {transforms.size(ctx) - 1u, mask_link, material_link,
                  volume.index(), surface_id::e_sensitive},
                 invalid_src_link);
         }
 
+        // The range of surfaces that was added to the volume builder
         return {surfaces_offset, static_cast<dindex>(surfaces.size())};
     }
 

--- a/tutorials/src/cpu/CMakeLists.txt
+++ b/tutorials/src/cpu/CMakeLists.txt
@@ -22,6 +22,7 @@ set(source_files
     "detector/track_geometry_changes.cpp"
     "detector/write_detector_to_file.cpp"
     "propagation/navigation_inspection.cpp"
+    "propagation/propagation.cpp"
 )
 
 foreach(file ${source_files})

--- a/tutorials/src/cpu/detector/build_predefined_detectors.cpp
+++ b/tutorials/src/cpu/detector/build_predefined_detectors.cpp
@@ -8,7 +8,6 @@
 // Project include(s)
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/mask.hpp"
-#include "detray/materials/predefined_materials.hpp"
 #include "detray/navigation/volume_graph.hpp"
 #include "detray/test/common/build_telescope_detector.hpp"
 #include "detray/test/common/build_toy_detector.hpp"
@@ -29,12 +28,13 @@
 ///
 /// Toy detector: Pixel section of the ACTS Generic detector (TrackML).
 ///
-/// Telescope detector: Array of surfaces of a given type in a bounding portal
-///                     box.
+/// Telescope detector: Array of surfaces of a given type in a portal box.
 int main(int argc, char** argv) {
 
     using algebra_t = detray::tutorial::algebra_t;
     using scalar = detray::tutorial::scalar;
+
+    std::cout << "Detector Tutorial\n=================\n\n";
 
     // Memory resource to allocate the detector data stores
     vecmem::host_memory_resource host_mr;
@@ -76,19 +76,9 @@ int main(int argc, char** argv) {
     // distances. The world portals are constructed from a bounding box around
     // the test surfaces (the envelope is configurable).
 
-    // Mask with a rectangular shape (20x20 mm)
-
-    detray::mask<detray::rectangle2D, algebra_t> rectangle{
-        0u, 20.f * detray::unit<scalar>::mm, 20.f * detray::unit<scalar>::mm};
-
-    // Mask with a trapezoid shape
-    using trapezoid_t = detray::mask<detray::trapezoid2D, algebra_t>;
-
-    constexpr scalar hx_min_y{10.f * detray::unit<scalar>::mm};
-    constexpr scalar hx_max_y{30.f * detray::unit<scalar>::mm};
-    constexpr scalar hy{20.f * detray::unit<scalar>::mm};
-    constexpr scalar divisor{10.f / (20.f * hy)};
-    trapezoid_t trapezoid{0u, hx_min_y, hx_max_y, hy, divisor};
+    // Volume link of the sensitive mask that is resolved during navigation:
+    // belongs to volume zero
+    constexpr detray::dindex vol_nav_link{0u};
 
     // Build from given module positions (places 11 surfaces)
     std::vector<scalar> positions = {
@@ -114,6 +104,16 @@ int main(int argc, char** argv) {
     //
     // Case 2: Straight telescope in z-direction, 15 trapezoid surfaces, 2000mm
     //         in length, modules evenly spaced, silicon material (80mm)
+
+    // Mask with a trapezoid shape
+    using trapezoid_t = detray::mask<detray::trapezoid2D, algebra_t>;
+
+    constexpr scalar hx_min_y{10.f * detray::unit<scalar>::mm};
+    constexpr scalar hx_max_y{30.f * detray::unit<scalar>::mm};
+    constexpr scalar hy{20.f * detray::unit<scalar>::mm};
+    constexpr scalar divisor{10.f / (20.f * hy)};
+    trapezoid_t trapezoid{vol_nav_link, hx_min_y, hx_max_y, hy, divisor};
+
     detray::tel_det_config trp_cfg{trapezoid};
     trp_cfg.n_surfaces(15).length(2000.f * detray::unit<scalar>::mm);
 
@@ -128,6 +128,11 @@ int main(int argc, char** argv) {
     // Case 3: Straight telescope in x-direction, 11 rectangle surfaces, 2000mm
     //         in length, modules places according to 'positions',
     //         silicon material (80mm)
+
+    // Mask with a rectangular shape (20x20 mm)
+    detray::mask<detray::rectangle2D, algebra_t> rectangle{
+        vol_nav_link, 20.f * detray::unit<scalar>::mm,
+        20.f * detray::unit<scalar>::mm};
 
     // Pilot trajectory in x-direction
     detray::detail::ray<algebra_t> x_track{

--- a/tutorials/src/cpu/detector/detector_ray_scan.cpp
+++ b/tutorials/src/cpu/detector/detector_ray_scan.cpp
@@ -42,6 +42,8 @@ int main() {
     // Can also be performed with helices
     using ray_t = detray::detail::ray<algebra_t>;
 
+    std::cout << "Ray Scan Tutorial\n=================\n\n";
+
     // Build the geometry
     vecmem::host_memory_resource host_mr;
     const auto [det, names] = detray::build_toy_detector<algebra_t>(host_mr);
@@ -50,11 +52,11 @@ int main() {
     using detector_t = decltype(det);
     const detector_t::geometry_context gctx{};
 
-    // Visualization style to be applied to the svgs
+    // Visualization style to be applied to the SVGs
     detray::svgtools::styling::style svg_style =
         detray::svgtools::styling::tableau_colorblind::style;
 
-    // Get the volume adjaceny matrix from ray scan
+    // Optional: get the volume adjaceny matrix from ray scan
     detray::volume_graph graph(det);
     const auto &adj_mat = graph.adjacency_matrix();  // < need this for the size
     detray::dvector<detray::dindex> adj_mat_scan(adj_mat.size(), 0);

--- a/tutorials/src/cpu/detector/detector_to_dot.cpp
+++ b/tutorials/src/cpu/detector/detector_to_dot.cpp
@@ -7,8 +7,11 @@
 
 // Project include(s)
 #include "detray/core/detector.hpp"
-#include "detray/io/frontend/detector_reader.hpp"
 #include "detray/navigation/volume_graph.hpp"
+
+// Detray IO inlcude(s)
+#include "detray/io/frontend/detector_reader.hpp"
+#include "detray/io/utils/file_handle.hpp"
 
 // Example linear algebra plugin: std::array
 #include "detray/tutorial/types.hpp"
@@ -17,13 +20,16 @@
 #include <vecmem/memory/host_memory_resource.hpp>
 
 // System include(s)
+#include <ios>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 
-/// Read a detector from file. For now: Read in the geometry by calling the
-/// json geometry reader directly.
+/// Read a detector from file and transform its volumes and navigation links to
+/// a graph in dot format
 int main(int argc, char** argv) {
+
+    std::cout << "Detector Graph Tutorial\n=======================\n";
 
     // Input data file
     auto reader_cfg = detray::io::detector_reader_config{};
@@ -32,6 +38,8 @@ int main(int argc, char** argv) {
     } else {
         throw std::runtime_error("Please specify an input file name!");
     }
+
+    std::cout << reader_cfg << std::endl;
 
     // Read a toy detector
     using metadata_t = detray::tutorial::toy_metadata;
@@ -46,5 +54,12 @@ int main(int argc, char** argv) {
 
     // Display the detector volume graph
     detray::volume_graph graph(det);
-    std::cout << graph.to_dot_string() << std::endl;
+
+    const std::string file_stem{det.name(names) + "_dot"};
+    const std::ios_base::openmode io_mode{std::ios::out | std::ios::trunc};
+    detray::io::file_handle out_file{file_stem, ".txt", io_mode};
+
+    *out_file << graph.to_dot_string() << std::endl;
+
+    std::cout << "\nWrote file: " << file_stem + ".txt" << std::endl;
 }

--- a/tutorials/src/cpu/detector/read_detector_from_file.cpp
+++ b/tutorials/src/cpu/detector/read_detector_from_file.cpp
@@ -25,6 +25,8 @@
 /// json geometry reader directly.
 int main(int argc, char** argv) {
 
+    std::cout << "Detector IO Tutorial\n====================\n";
+
     // Input data file
     auto reader_cfg = detray::io::detector_reader_config{};
     if (argc == 2) {
@@ -32,6 +34,8 @@ int main(int argc, char** argv) {
     } else {
         throw std::runtime_error("Please specify an input file name!");
     }
+
+    std::cout << reader_cfg << std::endl;
 
     // Read a toy detector
     using metadata_t = detray::tutorial::default_metadata;

--- a/tutorials/src/cpu/detector/track_geometry_changes.cpp
+++ b/tutorials/src/cpu/detector/track_geometry_changes.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 
 // Hash of the "correct" geometry
-constexpr std::size_t root_hash = 3458765454686814475ul;
+constexpr std::size_t root_hash = 9563506807235398581ul;
 
 ///
 /// Work in progress (!)
@@ -32,6 +32,8 @@ constexpr std::size_t root_hash = 3458765454686814475ul;
 /// changes that might affect the navigation.
 /// This could be useful in a CI job, but is poorly tested at this point (!).
 int main() {
+
+    std::cout << "Volume Graph Tutorial\n=====================\n\n";
 
     // Get an example detector
     vecmem::host_memory_resource host_mr;
@@ -49,7 +51,8 @@ int main() {
     if (geo_checker.root() == root_hash) {
         std::cout << "Geometry links are consistent" << std::endl;
     } else {
-        std::cerr << "\nGeometry linking has changed! Please check:\n"
+        std::cerr << "\nGeometry linking has changed! Root hash is "
+                  << geo_checker.root() << ". Please check geometry:\n"
                   << graph.to_string() << std::endl;
     }
 }

--- a/tutorials/src/cpu/detector/write_detector_to_file.cpp
+++ b/tutorials/src/cpu/detector/write_detector_to_file.cpp
@@ -20,6 +20,8 @@
 /// Write a dector using the json IO
 int main() {
 
+    std::cout << "Detector IO Tutorial\n====================\n\n";
+
     // First, create an example detector in in host memory to be written to disk
     vecmem::host_memory_resource host_mr;
     const auto [det, names] =
@@ -31,6 +33,8 @@ int main() {
     auto writer_cfg = detray::io::detector_writer_config{}
                           .format(detray::io::format::json)
                           .replace_files(true);
+
+    std::cout << writer_cfg << std::endl;
 
     // Takes the detector 'det', a volume name map (only entry here the
     // detector name) and the writer config

--- a/tutorials/src/cpu/propagation/define_an_actor.cpp
+++ b/tutorials/src/cpu/propagation/define_an_actor.cpp
@@ -47,7 +47,7 @@ struct print_actor : detray::actor {
     }
 };
 
-/// Example actor that couts the number of elements in its buffer
+/// Example actor that counts the number of elements in its buffer
 template <template <typename...> class vector_t>
 struct example_actor : detray::actor {
 
@@ -89,6 +89,8 @@ int main() {
     // Implements example_actor with two print observers
     using composite =
         detray::composite_actor<example_actor_t, print_actor, print_actor>;
+
+    std::cout << "Actor Definition Tutorial\n=========================\n";
 
     example_actor_t::state example_state{};
     print_actor::state printer_state{};

--- a/tutorials/src/cpu/propagation/navigation_inspection.cpp
+++ b/tutorials/src/cpu/propagation/navigation_inspection.cpp
@@ -67,6 +67,9 @@ int main() {
     using propagator_t =
         detray::propagator<stepper_t, navigator_t, detray::actor_chain<>>;
 
+    std::cout << "Navigation Instepction "
+                 "Tutorial\n===============================\n\n";
+
     vecmem::host_memory_resource host_mr;
 
     const auto [det, names] = detray::build_toy_detector<algebra_t>(host_mr);
@@ -76,6 +79,8 @@ int main() {
     // Build the propagator
     detray::propagation::config prop_cfg{};
     propagator_t prop{prop_cfg};
+
+    std::cout << prop_cfg;
 
     // Track generation config
     // Trivial example: Single track escapes through beampipe
@@ -105,18 +110,21 @@ int main() {
         auto &obj_tracer = inspector.template get<object_tracer_t>();
         auto &debug_printer = inspector.template get<nav_print_inspector_t>();
 
-        std::cout << debug_printer.to_string();
+        std::cout
+            << "\nNavigation Debug Output:\n----------------------------\n\n"
+            << debug_printer.to_string();
 
         // Compare ray trace to object tracer
         std::stringstream debug_stream;
-        for (std::size_t intr_idx = 0; intr_idx < intersection_trace.size();
+        for (std::size_t intr_idx = 1u; intr_idx < intersection_trace.size();
              ++intr_idx) {
             debug_stream << "-------Intersection trace\n"
-                         << "ray gun: "
-                         << "found in vol: "
-                         << intersection_trace[intr_idx].vol_idx << ",\n\t"
+                         << "Volume: " << intersection_trace[intr_idx].vol_idx
+                         << "\n\nray gun: "
                          << intersection_trace[intr_idx].intersection;
-            debug_stream << "\nnavig.:\t" << obj_tracer[intr_idx].intersection;
+            // Object tracer does not save extra intersection at origin
+            debug_stream << "\n\nnavig.:  "
+                         << obj_tracer[intr_idx - 1u].intersection;
         }
         std::cout << debug_stream.str() << std::endl;
 

--- a/tutorials/src/cpu/propagation/propagation.cpp
+++ b/tutorials/src/cpu/propagation/propagation.cpp
@@ -1,0 +1,120 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s)
+#include "detray/definitions/pdg_particle.hpp"
+#include "detray/definitions/units.hpp"
+#include "detray/navigation/navigator.hpp"
+#include "detray/propagator/actors.hpp"
+#include "detray/propagator/propagator.hpp"
+#include "detray/propagator/rk_stepper.hpp"
+#include "detray/tracks/tracks.hpp"
+
+// Detray test include(s)
+#include "detray/test/common/bfield.hpp"
+#include "detray/test/common/build_toy_detector.hpp"
+#include "detray/test/common/track_generators.hpp"
+
+// Example linear algebra plugin: std::array
+#include "detray/tutorial/types.hpp"
+
+// Vecmem include(s)
+#include <vecmem/memory/host_memory_resource.hpp>
+
+// System include(s)
+#include <sstream>
+
+/// Run the host-propagation
+int main() {
+    // Toy detector
+    using metadata_t = detray::tutorial::toy_metadata;
+    using toy_detector_t = detray::detector<metadata_t>;
+
+    using algebra_t = metadata_t::algebra_type;
+    using scalar = detray::tutorial::scalar;
+
+    // Navigation
+    using navigator_t = detray::navigator<toy_detector_t>;
+    // Runge-Kutta-Nystrom stepper (field integration)
+    using bfield_t = covfie::field<detray::bfield::const_bknd_t<scalar>>;
+    using stepper_t = detray::rk_stepper<bfield_t::view_t, algebra_t>;
+
+    // Actors
+    using actor_chain_t =
+        detray::actor_chain<detray::pathlimit_aborter<scalar>,
+                            detray::parameter_transporter<algebra_t>,
+                            detray::pointwise_material_interactor<algebra_t>,
+                            detray::parameter_resetter<algebra_t>>;
+
+    // Propagator with empty actor chain
+    using propagator_t =
+        detray::propagator<stepper_t, navigator_t, actor_chain_t>;
+
+    vecmem::host_memory_resource host_mr;
+
+    std::cout << "Propagation Tutorial\n====================\n\n";
+    std::cout << "Building toy detector:\n" << std::endl;
+
+    const auto [det, _] = detray::build_toy_detector<algebra_t>(host_mr);
+
+    typename toy_detector_t::geometry_context gctx{};
+
+    // Create the bfield
+    detray::tutorial::vector3 B{0.f, 0.f, 2.f * detray::unit<scalar>::T};
+    const bfield_t bfield = detray::create_const_field<scalar>(B);
+
+    // Build the propagator
+    detray::propagation::config prop_cfg{};
+    // Particle hypothesis (default: muon)
+    constexpr auto ptc = detray::muon<scalar>{};
+
+    propagator_t prop{prop_cfg};
+
+    // Track generation config
+    using track_t = detray::free_track_parameters<algebra_t>;
+    using track_generator_t = detray::random_track_generator<track_t>;
+
+    track_generator_t::configuration trck_cfg{};
+    trck_cfg.n_tracks(1000);
+    trck_cfg.eta_range(-3.f, 3.f);
+    trck_cfg.pT_range(1.f * detray::unit<scalar>::GeV,
+                      100.f * detray::unit<scalar>::GeV);
+
+    std::cout << prop_cfg;
+    std::cout << trck_cfg << std::endl;
+
+    // Iterate through uniformly distributed momentum directions
+    bool success{true};
+    prop_cfg.context = gctx;
+    for (auto track : track_generator_t{trck_cfg}) {
+
+        propagator_t::state propagation(track, bfield, det, prop_cfg.context);
+
+        propagation.set_particle(
+            detray::update_particle_hypothesis(ptc, track));
+
+        // Prepare actor states
+        detray::pathlimit_aborter<scalar>::state aborter_state{
+            5.f * detray::unit<scalar>::m};
+        detray::pointwise_material_interactor<algebra_t>::state
+            interactor_state{};
+
+        auto actor_states = detray::tie(aborter_state, interactor_state);
+
+        // Run the actual propagation
+        prop.propagate(propagation, actor_states);
+        success &= prop.is_complete(propagation);
+    }
+
+    if (success) {
+        std::cout << "Successfully propagated " << trck_cfg.n_tracks()
+                  << " tracks!" << std::endl;
+    } else {
+        std::cout << "ERROR: Propagation did not complete successfully!"
+                  << std::endl;
+    }
+}

--- a/tutorials/src/device/cuda/detector_construction.cpp
+++ b/tutorials/src/device/cuda/detector_construction.cpp
@@ -35,6 +35,9 @@ int main() {
     // Helper object for performing memory copies to CUDA devices
     vecmem::cuda::copy cuda_cpy;
 
+    std::cout
+        << "Detector Device Construction Tutorial\n====================\n\n";
+
     //
     // Managed Memory
     //

--- a/tutorials/src/device/cuda/propagation.cpp
+++ b/tutorials/src/device/cuda/propagation.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,6 +21,8 @@
 /// Prepare the data and move it to device
 int main() {
 
+    std::cout << "Device Propagation Tutorial\n====================\n\n";
+
     // VecMem memory resource(s)
     vecmem::cuda::managed_memory_resource mng_mr;
 
@@ -32,8 +34,7 @@ int main() {
         detray::build_toy_detector<detray::tutorial::algebra_t>(mng_mr);
 
     // Create the vector of initial track parameters
-    vecmem::vector<detray::free_track_parameters<detray::tutorial::algebra_t>>
-        tracks(&mng_mr);
+    vecmem::vector<detray::tutorial::track_t> tracks(&mng_mr);
 
     // Track directions to be generated
     constexpr unsigned int theta_steps{10u};
@@ -43,8 +44,8 @@ int main() {
         10.f * detray::unit<detray::tutorial::scalar>::GeV};
 
     // Genrate the tracks
-    for (auto track : detray::uniform_track_generator<
-             detray::free_track_parameters<detray::tutorial::algebra_t>>(
+    for (auto track :
+         detray::uniform_track_generator<detray::tutorial::track_t>(
              phi_steps, theta_steps, p_mag)) {
         // Put it into vector of tracks
         tracks.push_back(track);

--- a/tutorials/src/device/cuda/propagation.hpp
+++ b/tutorials/src/device/cuda/propagation.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -45,7 +45,6 @@ using inhom_bknd_t = covfie::backend::affine<covfie::backend::linear<
 
 // Navigator
 using navigator_t = navigator<detector_device_t>;
-using intersection_t = navigator_t::intersection_type;
 
 // Stepper
 using host_field_t = covfie::field<detray::bfield::inhom_bknd_t<scalar>>;
@@ -61,6 +60,9 @@ using actor_chain_t =
 
 // Propagator
 using propagator_t = propagator<stepper_t, navigator_t, actor_chain_t>;
+
+// Free track parameters
+using track_t = detray::free_track_parameters<detray::tutorial::algebra_t>;
 
 /// Propagation tutorial function
 void propagation(

--- a/tutorials/src/device/cuda/propagation_kernel.cu
+++ b/tutorials/src/device/cuda/propagation_kernel.cu
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -17,14 +17,12 @@ inline constexpr scalar path_limit{2.f * detray::unit<scalar>::m};
 __global__ void propagation_kernel(
     typename detray::tutorial::detector_host_t::view_type det_data,
     typename detray::tutorial::device_field_t::view_t field_data,
-    const vecmem::data::vector_view<detray::free_track_parameters<algebra_t>>
-        tracks_data) {
+    const vecmem::data::vector_view<detray::tutorial::track_t> tracks_data) {
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
 
     // Setup device-side track collection
-    vecmem::device_vector<detray::free_track_parameters<algebra_t>> tracks(
-        tracks_data);
+    vecmem::device_vector<detray::tutorial::track_t> tracks(tracks_data);
 
     if (gid >= tracks.size()) {
         return;
@@ -51,11 +49,9 @@ __global__ void propagation_kernel(
     p.propagate(state, actor_states);
 }
 
-void propagation(
-    typename detray::tutorial::detector_host_t::view_type det_data,
-    typename detray::tutorial::device_field_t::view_t field_data,
-    const vecmem::data::vector_view<detray::free_track_parameters<algebra_t>>
-        tracks_data) {
+void propagation(typename detray::tutorial::detector_host_t::view_type det_data,
+                 typename detray::tutorial::device_field_t::view_t field_data,
+                 const vecmem::data::vector_view<track_t> tracks_data) {
 
     int thread_dim = 2 * WARP_SIZE;
     int block_dim = tracks_data.size() / thread_dim + 1;


### PR DESCRIPTION
Update the tutorials, in particular:
- Mention tutorials in README
- Update comments
- Add more printouts
- Use the detector builder in the detector construction tutorial and simplify it by filling the name map automatically
- Add simpler host propagation tutorial