### PR TITLE
fix: out of bounds error in detector display tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ detray-build/bin/detray_propagation_benchmark_<backend>_<algebra> \
 ```
 For every algebra-plugin that was built, a corresponding benchmark executable will be present. The CPU-backend benchmark is built by default and the CUDA-backend benchmark will be available if detray was built with CUDA enabled (`-DDETRAY_BUILD_CUDA=ON`). This executable can additionally be configured with any arguments targeted at [google benchmark](https://github.com/google/benchmark/blob/main/docs/user_guide.md).
 
-If the data is dumped into json files using the options `--benchmark_repetitions=N` (N standing for the number of repitions), `--benchmark_display_aggregates_only=true`, as well as `--benchmark_out_format=json` and `--benchmark_out=<some_file_name>.json`, it can afterwards be plotted with e.g.:
+If the data is dumped into json files using the options `--benchmark_repetitions=N` (N standing for the number of repetitions), `--benchmark_display_aggregates_only=true`, as well as `--benchmark_out_format=json` and `--benchmark_out=<some_file_name>.json`, it can afterwards be plotted with e.g.:
 ```shell
 python3 detray/tests/tools/python/propagation_benchmarks.py \
     --geometry_file ./toy_detector/toy_detector_geometry.json \

--- a/core/include/detray/builders/cuboid_portal_generator.hpp
+++ b/core/include/detray/builders/cuboid_portal_generator.hpp
@@ -113,7 +113,7 @@ class cuboid_portal_generator final
 
         // The material will be added in a later step
         constexpr auto no_material = surface_t::material_id::e_none;
-        material_link_t material_link{no_material, 0u};
+        material_link_t material_link{no_material, dindex_invalid};
 
         // Max distance in case of infinite bounds
         constexpr scalar_type max_shift{

--- a/core/include/detray/builders/cylinder_portal_generator.hpp
+++ b/core/include/detray/builders/cylinder_portal_generator.hpp
@@ -306,7 +306,7 @@ class cylinder_portal_generator final
         mask_link_t mask_link{
             mask_id::e_portal_cylinder2,
             masks.template size<mask_id::e_portal_cylinder2>() - 1u};
-        material_link_t material_link{material_id::e_none, 0u};
+        material_link_t material_link{material_id::e_none, dindex_invalid};
 
         surfaces.push_back(
             {static_cast<dindex>(transforms.size(ctx) - 1u), mask_link,
@@ -346,7 +346,7 @@ class cylinder_portal_generator final
         mask_link_t mask_link{
             mask_id::e_portal_ring2,
             masks.template size<mask_id::e_portal_ring2>() - 1u};
-        material_link_t material_link{material_id::e_none, 0u};
+        material_link_t material_link{material_id::e_none, dindex_invalid};
 
         surfaces.push_back(
             {static_cast<dindex>(transforms.size(ctx) - 1u), mask_link,

--- a/core/include/detray/builders/surface_factory.hpp
+++ b/core/include/detray/builders/surface_factory.hpp
@@ -208,7 +208,7 @@ class surface_factory : public surface_factory_interface<detector_t> {
                 mask_link_t mask_link{mask_id,
                                       masks.template size<mask_id>() - 1u};
                 // If material is present, it is added in a later step
-                material_link_t material_link{no_material, 0u};
+                material_link_t material_link{no_material, dindex_invalid};
 
                 // Add the surface descriptor at the position given by 'sf_idx'
                 this->insert_in_container(

--- a/core/include/detray/builders/volume_builder.hpp
+++ b/core/include/detray/builders/volume_builder.hpp
@@ -45,7 +45,7 @@ class volume_builder : public volume_builder_interface<detector_t> {
     volume_builder(const volume_id id, const dindex idx = 0) : m_volume{id} {
 
         m_volume.set_index(idx);
-        m_volume.set_material(volume_type::material_id::e_none, 0u);
+        m_volume.set_material(volume_type::material_id::e_none, dindex_invalid);
 
         // The first acceleration data structure in every volume is a brute
         // force method that will at least contain the portals

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface.hpp
@@ -232,7 +232,7 @@ auto surface(const typename detector_t::geometry_context& context,
 
     svgtools::styling::apply_style(p_surface, style);
 
-    if (!hide_material) {
+    if (!hide_material && d_surface.has_material()) {
         p_surface._material = svgtools::conversion::surface_material(
             detector, d_surface, view, style._material_style);
     }

--- a/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
@@ -107,6 +107,11 @@ class illustrator {
         const dindex index, const view_t& view,
         const typename detector_t::geometry_context& gctx = {}) const {
 
+        if (index >= _detector.surfaces().size()) {
+            throw std::invalid_argument("Surface index too large: " +
+                                        std::to_string(index));
+        }
+
         const auto surface =
             detray::geometry::surface<detector_t>{_detector, index};
 
@@ -207,6 +212,11 @@ class illustrator {
     inline auto draw_surface_material(const dindex index,
                                       const view_t& view) const {
 
+        if (index >= _detector.surfaces().size()) {
+            throw std::invalid_argument("Surface index too large: " +
+                                        std::to_string(index));
+        }
+
         const auto surface =
             detray::geometry::surface<detector_t>{_detector, index};
 
@@ -286,6 +296,11 @@ class illustrator {
     inline auto draw_volume(
         const dindex index, const view_t& view,
         const typename detector_t::geometry_context& gctx = {}) const {
+
+        if (index >= _detector.volumes().size()) {
+            throw std::invalid_argument("Volume index too large: " +
+                                        std::to_string(index));
+        }
 
         const auto d_volume = tracking_volume{_detector, index};
 

--- a/tests/include/detray/test/common/factories/barrel_generator.hpp
+++ b/tests/include/detray/test/common/factories/barrel_generator.hpp
@@ -214,7 +214,7 @@ class barrel_generator final : public surface_factory_interface<detector_t> {
 
             // Surfaces with the linking into the local containers
             mask_link_t mask_link = {mask_id, masks.template size<mask_id>()};
-            material_link_t material_link{no_material, 0u};
+            material_link_t material_link{no_material, dindex_invalid};
             const auto trf_index = transforms.size(ctx);
 
             surfaces.push_back({trf_index, mask_link, material_link, volume_idx,

--- a/tests/include/detray/test/common/factories/endcap_generator.hpp
+++ b/tests/include/detray/test/common/factories/endcap_generator.hpp
@@ -265,7 +265,7 @@ class endcap_generator final : public surface_factory_interface<detector_t> {
             for (const point3_t &mod_position : module_positions) {
                 // Module mask
                 mask_link_t mask_link{mask_id, masks.template size<mask_id>()};
-                material_link_t material_link{no_material, 0u};
+                material_link_t material_link{no_material, dindex_invalid};
 
                 // Surface descriptor
                 surfaces.push_back(

--- a/tests/include/detray/test/common/factories/telescope_generator.hpp
+++ b/tests/include/detray/test/common/factories/telescope_generator.hpp
@@ -136,7 +136,7 @@ class telescope_generator final : public surface_factory_interface<detector_t> {
 
             // Surfaces with the linking into the local containers
             mask_link_t mask_link{mask_id, masks.template size<mask_id>()};
-            material_link_t material_link{no_material, 0u};
+            material_link_t material_link{no_material, dindex_invalid};
 
             const auto trf_index = transforms.size(ctx);
             surfaces.push_back({trf_index, mask_link, material_link, volume_idx,

--- a/tests/include/detray/test/common/factories/wire_layer_generator.hpp
+++ b/tests/include/detray/test/common/factories/wire_layer_generator.hpp
@@ -164,7 +164,8 @@ class wire_layer_generator final
             // Mask link for the cell
             mask_link_t mask_link{mask_id, masks.template size<mask_id>()};
             // The material will be added in a later step
-            material_link_t material_link{surface_t::material_id::e_none, 0u};
+            material_link_t material_link{surface_t::material_id::e_none,
+                                          dindex_invalid};
             // Link the placement transform to the surface
             const auto trf_index = transforms.size(ctx);
 

--- a/tests/include/detray/test/cpu/toy_detector_test.hpp
+++ b/tests/include/detray/test/cpu/toy_detector_test.hpp
@@ -145,7 +145,7 @@ inline bool toy_detector_test(
 
     // Link to outer world (leaving detector)
     constexpr auto leaving_world{detail::invalid_value<nav_link_t>()};
-    constexpr auto inv_link{0u};
+    constexpr auto inv_link{detail::invalid_value<dindex>()};
     const bool has_grids =
         (accel.template size<accel_ids::e_cylinder2_grid>() != 0u) ||
         (accel.template size<accel_ids::e_disc_grid>() != 0u);

--- a/tests/include/detray/test/validation/detector_scanner.hpp
+++ b/tests/include/detray/test/validation/detector_scanner.hpp
@@ -125,8 +125,9 @@ struct brute_force_scan {
         start_intersection.sf_desc = first_record.intersection.sf_desc;
         start_intersection.sf_desc.set_id(surface_id::e_passive);
         start_intersection.sf_desc.set_index(dindex_invalid);
-        start_intersection.sf_desc.material().set_id(
-            detector_t::materials::id::e_none);
+        start_intersection.sf_desc.material()
+            .set_id(detector_t::materials::id::e_none)
+            .set_index(dindex_invalid);
         start_intersection.path = 0.f;
         start_intersection.local = {0.f, 0.f, 0.f};
         start_intersection.volume_link =

--- a/tests/integration_tests/cpu/builders/material_map_builder.cpp
+++ b/tests/integration_tests/cpu/builders/material_map_builder.cpp
@@ -224,7 +224,7 @@ GTEST_TEST(detray_builders, decorator_material_map_builder) {
                 EXPECT_TRUE(sf_desc.index() == 3u)
                     << "No material on: " << sf_desc;
                 EXPECT_TRUE(mat_link.id() == mat_id::e_none) << sf_desc;
-                EXPECT_TRUE(mat_link.index() == 0) << sf_desc;
+                EXPECT_TRUE(mat_link.is_invalid()) << sf_desc;
                 break;
             }
             default: {

--- a/tutorials/include/detray/tutorial/square_surface_generator.hpp
+++ b/tutorials/include/detray/tutorial/square_surface_generator.hpp
@@ -95,7 +95,7 @@ class square_surface_generator final
 
             // Add surface with all links set (relative to the given containers)
             mask_link_t mask_link{mask_id, masks.template size<mask_id>() - 1u};
-            material_link_t material_link{no_material, 0u};
+            material_link_t material_link{no_material, dindex_invalid};
             surfaces.push_back(
                 {transforms.size(ctx) - 1u, mask_link, material_link,
                  volume.index(), surface_id::e_sensitive},


### PR DESCRIPTION
During surface construction, the material link was not set such that `is_invalid` would be true for a surface with no material. This lead to an incorrect material access in the SVG illustrator when trying to display surface material. Also added some additional checks in the illustrator for too large volume and surface indices that can be requested by the user.