### PR TITLE
Reduce thread divergence in covariance transport

### DIFF
--- a/core/include/detray/geometry/tracking_surface.hpp
+++ b/core/include/detray/geometry/tracking_surface.hpp
@@ -100,6 +100,17 @@ class tracking_surface : public geometry::surface<detector_t> {
         return this->template visit_mask<typename kernels::path_correction>(
             this->transform(ctx), pos, dir, dtds, dqopds);
     }
+
+    /// @returns the free to path derivative
+    DETRAY_HOST_DEVICE
+    constexpr auto free_to_path_derivative(const context &ctx,
+                                           const vector3_type &pos,
+                                           const vector3_type &dir,
+                                           const vector3_type &dtds) const {
+        return this
+            ->template visit_mask<typename kernels::free_to_path_derivative>(
+                this->transform(ctx), pos, dir, dtds);
+    }
 };
 
 template <typename detector_t, typename descr_t>

--- a/core/include/detray/propagator/detail/jacobian_engine.hpp
+++ b/core/include/detray/propagator/detail/jacobian_engine.hpp
@@ -22,15 +22,12 @@
 namespace detray::detail {
 
 /// @brief Generate Jacobians
-template <typename frame_t>
-requires std::is_object_v<typename frame_t::loc_point> struct jacobian_engine {
+template <typename algebra_t>
+struct jacobian_engine {
 
     /// @name Type definitions for the struct
     /// @{
-    using frame_type = frame_t;
-    using jacobian_t = jacobian<frame_t>;
-
-    using algebra_type = typename frame_t::algebra_type;
+    using algebra_type = algebra_t;
     using transform3_type = dtransform3D<algebra_type>;
     using scalar_type = dscalar<algebra_type>;
     using point3_type = dpoint3D<algebra_type>;
@@ -42,38 +39,34 @@ requires std::is_object_v<typename frame_t::loc_point> struct jacobian_engine {
     using path_to_free_matrix_type = path_to_free_matrix<algebra_type>;
     /// @}
 
-    template <typename mask_t>
-    DETRAY_HOST_DEVICE static inline bound_to_free_matrix_type
-    bound_to_free_jacobian(
-        const transform3_type& trf3, const mask_t& mask,
-        const bound_parameters_vector<algebra_type>& bound_vec) {
-
-        // Declare jacobian for bound to free coordinate transform
-        bound_to_free_matrix_type jac_to_global =
-            matrix::zero<bound_to_free_matrix_type>();
-
-        // Get trigonometric values
-        const scalar_type theta{bound_vec.theta()};
-        const scalar_type phi{bound_vec.phi()};
-
-        const scalar_type cos_theta{math::cos(theta)};
-        const scalar_type sin_theta{math::sin(theta)};
-        const scalar_type cos_phi{math::cos(phi)};
-        const scalar_type sin_phi{math::sin(phi)};
-
-        // Global position and direction
-        const free_track_parameters<algebra_type> free_params =
-            bound_to_free_vector(trf3, mask, bound_vec);
-
-        const vector3_type pos = free_params.pos();
-        const vector3_type dir = free_params.dir();
+    template <typename frame_t>
+    requires concepts::point<typename frame_t::loc_point>
+        DETRAY_HOST_DEVICE static inline void
+        bound_to_free_jacobian_set_dfree_dlocal(
+            bound_to_free_matrix_type& jac_to_global,
+            const transform3_type& trf3, const vector3_type& pos,
+            const vector3_type& dir) {
+        using jacobian_t = jacobian<frame_t>;
 
         // Set d(x,y,z)/d(loc0, loc1)
         jacobian_t::set_bound_pos_to_free_pos_derivative(jac_to_global, trf3,
                                                          pos, dir);
+    }
 
+    DETRAY_HOST_DEVICE static inline void
+    bound_to_free_jacobian_set_dfree_dir_dangle(
+        bound_to_free_matrix_type& jac_to_global,
+        const bound_parameters_vector<algebra_type>& bound_vec) {
         // Set d(bound time)/d(free time)
         getter::element(jac_to_global, e_free_time, e_bound_time) = 1.f;
+
+        // Get trigonometric values
+        const scalar_type theta{bound_vec.theta()};
+        const scalar_type phi{bound_vec.phi()};
+        const scalar_type cos_theta{math::cos(theta)};
+        const scalar_type sin_theta{math::sin(theta)};
+        const scalar_type cos_phi{math::cos(phi)};
+        const scalar_type sin_phi{math::sin(phi)};
 
         // Set d(n_x,n_y,n_z)/d(phi, theta)
         getter::element(jac_to_global, e_free_dir0, e_bound_phi) =
@@ -86,26 +79,67 @@ requires std::is_object_v<typename frame_t::loc_point> struct jacobian_engine {
             cos_theta * sin_phi;
         getter::element(jac_to_global, e_free_dir2, e_bound_theta) = -sin_theta;
         getter::element(jac_to_global, e_free_qoverp, e_bound_qoverp) = 1.f;
+    }
+
+    template <typename frame_t>
+    requires concepts::point<typename frame_t::loc_point>
+        DETRAY_HOST_DEVICE static inline void
+        bound_to_free_jacobian_set_dfree_dangle(
+            bound_to_free_matrix_type& jac_to_global,
+            const transform3_type& trf3, const vector3_type& pos,
+            const vector3_type& dir) {
+        using jacobian_t = jacobian<frame_t>;
 
         // Set d(x,y,z)/d(phi, theta)
         jacobian_t::set_bound_angle_to_free_pos_derivative(jac_to_global, trf3,
                                                            pos, dir);
+    }
+
+    template <typename frame_t, typename mask_t>
+    requires concepts::point<typename frame_t::loc_point>
+        DETRAY_HOST_DEVICE static inline bound_to_free_matrix_type
+        bound_to_free_jacobian(
+            const transform3_type& trf3, const mask_t& mask,
+            const bound_parameters_vector<algebra_type>& bound_vec) {
+        bound_to_free_matrix_type jac_to_global =
+            matrix::zero<bound_to_free_matrix_type>();
+
+        // Global position and direction
+        const free_track_parameters<algebra_type> free_params =
+            bound_to_free_vector(trf3, mask, bound_vec);
+
+        const vector3_type pos = free_params.pos();
+        const vector3_type dir = free_params.dir();
+
+        bound_to_free_jacobian_set_dfree_dlocal<frame_t>(jac_to_global, trf3,
+                                                         pos, dir);
+        bound_to_free_jacobian_set_dfree_dir_dangle(jac_to_global, bound_vec);
+        bound_to_free_jacobian_set_dfree_dangle<frame_t>(jac_to_global, trf3,
+                                                         pos, dir);
 
         return jac_to_global;
     }
 
-    DETRAY_HOST_DEVICE
-    static inline free_to_bound_matrix_type free_to_bound_jacobian(
-        const transform3_type& trf3,
-        const free_track_parameters<algebra_type>& free_params) {
+    template <typename frame_t>
+    requires concepts::point<typename frame_t::loc_point>
+        DETRAY_HOST_DEVICE static inline void
+        free_to_bound_jacobian_set_dlocal_dfree(
+            free_to_bound_matrix_type& jac_to_local,
+            const transform3_type& trf3, const vector3_type& pos,
+            const vector3_type& dir) {
+        using jacobian_t = jacobian<frame_t>;
 
-        // Declare jacobian for bound to free coordinate transform
-        free_to_bound_matrix_type jac_to_local =
-            matrix::zero<free_to_bound_matrix_type>();
+        // Set d(loc0, loc1)/d(x,y,z)
+        jacobian_t::set_free_pos_to_bound_pos_derivative(jac_to_local, trf3,
+                                                         pos, dir);
+    }
 
-        // Global position and direction
-        const vector3_type pos = free_params.pos();
-        const vector3_type dir = free_params.dir();
+    DETRAY_HOST_DEVICE static inline void
+    free_to_bound_jacobian_set_dangle_dfree_dir(
+        free_to_bound_matrix_type& jac_to_local, const vector3_type& dir) {
+
+        // Set d(free time)/d(bound time)
+        getter::element(jac_to_local, e_bound_time, e_free_time) = 1.f;
 
         const scalar_type theta{vector::theta(dir)};
         const scalar_type phi{vector::phi(dir)};
@@ -114,13 +148,6 @@ requires std::is_object_v<typename frame_t::loc_point> struct jacobian_engine {
         const scalar_type sin_theta{math::sin(theta)};
         const scalar_type cos_phi{math::cos(phi)};
         const scalar_type sin_phi{math::sin(phi)};
-
-        // Set d(loc0, loc1)/d(x,y,z)
-        jacobian_t::set_free_pos_to_bound_pos_derivative(jac_to_local, trf3,
-                                                         pos, dir);
-
-        // Set d(free time)/d(bound time)
-        getter::element(jac_to_local, e_bound_time, e_free_time) = 1.f;
 
         // Set d(phi, theta)/d(n_x, n_y, n_z)
         // @note This codes have a serious bug when theta is equal to zero...
@@ -136,17 +163,45 @@ requires std::is_object_v<typename frame_t::loc_point> struct jacobian_engine {
 
         // Set d(Free Qop)/d(Bound Qop)
         getter::element(jac_to_local, e_bound_qoverp, e_free_qoverp) = 1.f;
+    }
+
+    template <typename frame_t>
+    requires concepts::point<typename frame_t::loc_point>
+        DETRAY_HOST_DEVICE static inline free_to_bound_matrix_type
+        free_to_bound_jacobian(
+            const transform3_type& trf3,
+            const free_track_parameters<algebra_type>& free_params) {
+
+        // Declare jacobian for bound to free coordinate transform
+        free_to_bound_matrix_type jac_to_local =
+            matrix::zero<free_to_bound_matrix_type>();
+
+        // Global position and direction
+        const vector3_type pos = free_params.pos();
+        const vector3_type dir = free_params.dir();
+
+        free_to_bound_jacobian_set_dlocal_dfree<frame_t>(jac_to_local, trf3,
+                                                         pos, dir);
+        free_to_bound_jacobian_set_dangle_dfree_dir(jac_to_local, dir);
 
         return jac_to_local;
     }
 
-    DETRAY_HOST_DEVICE static inline free_matrix<algebra_type> path_correction(
-        const vector3_type& pos, const vector3_type& dir,
-        const vector3_type& dtds, const scalar_type dqopds,
-        const transform3_type& trf3) {
+    template <typename frame_t>
+    requires concepts::point<typename frame_t::loc_point>
+        DETRAY_HOST_DEVICE static inline free_to_path_matrix_type
+        free_to_path_derivative(const vector3_type& pos,
+                                const vector3_type& dir,
+                                const vector3_type& dtds,
+                                const transform3_type& trf3) {
+        using jacobian_t = jacobian<frame_t>;
 
-        free_to_path_matrix_type path_derivative =
-            jacobian_t::path_derivative(trf3, pos, dir, dtds);
+        return jacobian_t::path_derivative(trf3, pos, dir, dtds);
+    }
+
+    DETRAY_HOST_DEVICE static inline path_to_free_matrix_type
+    path_to_free_derivative(const vector3_type& dir, const vector3_type& dtds,
+                            const scalar_type dqopds) {
 
         path_to_free_matrix_type derivative =
             matrix::zero<path_to_free_matrix_type>();
@@ -158,7 +213,18 @@ requires std::is_object_v<typename frame_t::loc_point> struct jacobian_engine {
         getter::element(derivative, e_free_dir2, 0u) = dtds[2];
         getter::element(derivative, e_free_qoverp, 0u) = dqopds;
 
-        return derivative * path_derivative;
+        return derivative;
+    }
+
+    template <typename frame_t>
+    requires concepts::point<typename frame_t::loc_point>
+        DETRAY_HOST_DEVICE static inline free_matrix<algebra_type>
+        path_correction(const vector3_type& pos, const vector3_type& dir,
+                        const vector3_type& dtds, const scalar_type dqopds,
+                        const transform3_type& trf3) {
+
+        return path_to_free_derivative(dir, dtds, dqopds) *
+               free_to_path_derivative<frame_t>(pos, dir, dtds, trf3);
     }
 };
 

--- a/core/include/detray/utils/curvilinear_frame.hpp
+++ b/core/include/detray/utils/curvilinear_frame.hpp
@@ -27,8 +27,7 @@ struct curvilinear_frame {
     using unit_vectors_type = unit_vectors<vector3>;
     using bound_to_free_matrix_type = bound_to_free_matrix<algebra_t>;
     using bound_vector_type = bound_parameters_vector<algebra_t>;
-    using jacobian_engine_type =
-        detail::jacobian_engine<cartesian2D<algebra_t>>;
+    using jacobian_engine_type = detail::jacobian_engine<algebra_t>;
     using free_track_parameters_type = free_track_parameters<algebra_t>;
 
     DETRAY_HOST_DEVICE
@@ -47,8 +46,9 @@ struct curvilinear_frame {
 
     DETRAY_HOST_DEVICE
     bound_to_free_matrix_type bound_to_free_jacobian() const {
-        return jacobian_engine_type().bound_to_free_jacobian(
-            m_trf, mask<rectangle2D, algebra_t>{}, m_bound_vec);
+        return jacobian_engine_type()
+            .template bound_to_free_jacobian<cartesian2D<algebra_t>>(
+                m_trf, mask<rectangle2D, algebra_t>{}, m_bound_vec);
     }
 
     transform3_type m_trf{};

--- a/tests/integration_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/integration_tests/cpu/propagator/covariance_transport.cpp
@@ -162,10 +162,7 @@ class detray_propagation_HelixCovarianceTransportValidation
         using departure_frame = typename departure_mask_type::local_frame;
         using destination_frame = typename destination_mask_type::local_frame;
 
-        using departure_jacobian_engine =
-            detail::jacobian_engine<departure_frame>;
-        using destination_jacobian_engine =
-            detail::jacobian_engine<destination_frame>;
+        using jacobian_engine = detail::jacobian_engine<algebra_type>;
 
         const bound_param_vector_t& bound_vec_0 = bound_params;
         const bound_matrix_t& bound_cov_0 = bound_params.covariance();
@@ -179,8 +176,8 @@ class detray_propagation_HelixCovarianceTransportValidation
 
         // Bound-to-free jacobian at the departure surface
         const bound_to_free_matrix_t bound_to_free_jacobi =
-            departure_jacobian_engine::bound_to_free_jacobian(trf_0, mask_0,
-                                                              bound_vec_0);
+            jacobian_engine::template bound_to_free_jacobian<departure_frame>(
+                trf_0, mask_0, bound_vec_0);
 
         // Get the intersection on the next surface
         helix_intersector<typename destination_mask_type::shape, algebra_type>
@@ -222,8 +219,8 @@ class detray_propagation_HelixCovarianceTransportValidation
 
         // Path correction
         const free_matrix_t path_correction =
-            destination_jacobian_engine::path_correction(r, t, dtds, dqopds,
-                                                         trf_1);
+            jacobian_engine::template path_correction<destination_frame>(
+                r, t, dtds, dqopds, trf_1);
 
         // Correction term for the path variation
         const free_matrix_t correction_term =
@@ -231,8 +228,8 @@ class detray_propagation_HelixCovarianceTransportValidation
 
         // Free-to-bound jacobian at the destination surface
         const free_to_bound_matrix_t free_to_bound_jacobi =
-            destination_jacobian_engine::free_to_bound_jacobian(trf_1,
-                                                                free_trk_1);
+            jacobian_engine::template free_to_bound_jacobian<destination_frame>(
+                trf_1, free_trk_1);
 
         // Bound vector at the destination surface
         const bound_param_vector_t bound_vec_1 =

--- a/tests/unit_tests/cpu/propagator/jacobian_cartesian.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_cartesian.cpp
@@ -32,7 +32,8 @@ const scalar isclose{1e-5f};
 // This test cartesian2D coordinate
 GTEST_TEST(detray_propagator, jacobian_cartesian2D) {
 
-    using jac_engine = detail::jacobian_engine<cartesian2D<test_algebra>>;
+    using jac_engine = detail::jacobian_engine<test_algebra>;
+    using frame_type = cartesian2D<test_algebra>;
 
     // Preparation work
     const vector3 z = {0.f, 0.f, 1.f};
@@ -72,8 +73,8 @@ GTEST_TEST(detray_propagator, jacobian_cartesian2D) {
 
     // Test Jacobian transformation
     const bound_matrix<test_algebra> J =
-        jac_engine::free_to_bound_jacobian(trf, free_params) *
-        jac_engine::bound_to_free_jacobian(trf, rect, bound_vec);
+        jac_engine::free_to_bound_jacobian<frame_type>(trf, free_params) *
+        jac_engine::bound_to_free_jacobian<frame_type>(trf, rect, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {
         for (unsigned int j = 0u; j < 6u; j++) {

--- a/tests/unit_tests/cpu/propagator/jacobian_cylindrical.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_cylindrical.cpp
@@ -35,7 +35,8 @@ constexpr scalar isclose{1e-5f};
 // This test cylindrical2D coordinate
 GTEST_TEST(detray_propagator, jacobian_cylindrical2D) {
 
-    using jac_engine = detail::jacobian_engine<cylindrical2D<test_algebra>>;
+    using jac_engine = detail::jacobian_engine<test_algebra>;
+    using frame_type = cylindrical2D<test_algebra>;
 
     // Preparation work
     const vector3 z = {0.f, 0.f, 1.f};
@@ -77,8 +78,8 @@ GTEST_TEST(detray_propagator, jacobian_cylindrical2D) {
 
     // Test Jacobian transformation
     const bound_matrix<test_algebra> J =
-        jac_engine::free_to_bound_jacobian(trf, free_params) *
-        jac_engine::bound_to_free_jacobian(trf, cyl, bound_vec);
+        jac_engine::free_to_bound_jacobian<frame_type>(trf, free_params) *
+        jac_engine::bound_to_free_jacobian<frame_type>(trf, cyl, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {
         for (unsigned int j = 0u; j < 6u; j++) {

--- a/tests/unit_tests/cpu/propagator/jacobian_line.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_line.cpp
@@ -36,7 +36,8 @@ const mask<line<>, test_algebra> ln{0u, r, hz};
 
 GTEST_TEST(detray_propagator, jacobian_line2D_case1) {
 
-    using jac_engine = detail::jacobian_engine<line2D<test_algebra>>;
+    using jac_engine = detail::jacobian_engine<test_algebra>;
+    using frame_type = line2D<test_algebra>;
 
     // Preparation work
     vector3 z = {1.f, 1.f, 1.f};
@@ -75,8 +76,8 @@ GTEST_TEST(detray_propagator, jacobian_line2D_case1) {
 
     // Test Jacobian transformation
     const bound_matrix<test_algebra> J =
-        jac_engine::free_to_bound_jacobian(trf, free_params) *
-        jac_engine::bound_to_free_jacobian(trf, ln, bound_vec);
+        jac_engine::free_to_bound_jacobian<frame_type>(trf, free_params) *
+        jac_engine::bound_to_free_jacobian<frame_type>(trf, ln, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {
         for (unsigned int j = 0u; j < 6u; j++) {
@@ -91,7 +92,8 @@ GTEST_TEST(detray_propagator, jacobian_line2D_case1) {
 
 GTEST_TEST(detray_coordinates, jacobian_line2D_case2) {
 
-    using jac_engine = detail::jacobian_engine<line2D<test_algebra>>;
+    using jac_engine = detail::jacobian_engine<test_algebra>;
+    using frame_type = line2D<test_algebra>;
 
     // Preparation work
     vector3 z = {1.f, 2.f, 3.f};
@@ -118,8 +120,8 @@ GTEST_TEST(detray_coordinates, jacobian_line2D_case2) {
 
     // Test Jacobian transformation
     const bound_matrix<test_algebra> J =
-        jac_engine::free_to_bound_jacobian(trf, free_params) *
-        jac_engine::bound_to_free_jacobian(trf, ln, bound_vec);
+        jac_engine::free_to_bound_jacobian<frame_type>(trf, free_params) *
+        jac_engine::bound_to_free_jacobian<frame_type>(trf, ln, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {
         for (unsigned int j = 0u; j < 6u; j++) {

--- a/tests/unit_tests/cpu/propagator/jacobian_polar.cpp
+++ b/tests/unit_tests/cpu/propagator/jacobian_polar.cpp
@@ -32,7 +32,8 @@ const scalar isclose{1e-5f};
 // This test polar2D coordinate
 GTEST_TEST(detray_propagator, jacobian_polar2D) {
 
-    using jac_engine = detail::jacobian_engine<polar2D<test_algebra>>;
+    using jac_engine = detail::jacobian_engine<test_algebra>;
+    using frame_type = polar2D<test_algebra>;
 
     // Preparation work
     const vector3 z = {0.f, 0.f, 1.f};
@@ -71,8 +72,8 @@ GTEST_TEST(detray_propagator, jacobian_polar2D) {
 
     // Test Jacobian transformation
     const bound_matrix<test_algebra> J =
-        jac_engine::free_to_bound_jacobian(trf, free_params) *
-        jac_engine::bound_to_free_jacobian(trf, rng, bound_vec);
+        jac_engine::free_to_bound_jacobian<frame_type>(trf, free_params) *
+        jac_engine::bound_to_free_jacobian<frame_type>(trf, rng, bound_vec);
 
     for (unsigned int i = 0u; i < 6u; i++) {
         for (unsigned int j = 0u; j < 6u; j++) {


### PR DESCRIPTION
Currently, the covariance transport uses the Jacobian engine which is templated on the frame type. While this makes the code easier to read and write, it requires the compiler to duplicate a lot of code for each of the frame types, and this duplicated code counts as multiple branches for the sake of GPU execution. Thus, this templating increases the amount of thread divergence.

This commit refactors the Jacobian engine into smaller parts, some of which are templated on the frame type and some of which are not. Client code and then take a more fine-grained approach to branching and improve divergence.