### PR TITLE
fix: Material maps display and scale toy material maps

### DIFF
--- a/core/include/detray/builders/material_map_generator.hpp
+++ b/core/include/detray/builders/material_map_generator.hpp
@@ -49,9 +49,9 @@ inline std::vector<material_slab<scalar_t>> generate_cyl_mat(
         z_upper = math::max(z_upper, bounds[cylinder2D::e_upper_z]);
     }
 
-    // Make sure the cylinder bounds are centered around zero
+    // Generate material steps (quadratic with distance to origin)
     const scalar_t length{math::fabs(z_upper - z_lower)};
-    scalar_t z{-0.5f * length};
+    scalar_t z{z_lower};
     const scalar_t z_step{length / static_cast<scalar_t>(nbins - 1u)};
     for (std::size_t n = 0u; n < nbins; ++n) {
         ts.emplace_back(mat, static_cast<scalar_t>(scalor * z * z) + t);

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_material.hpp
@@ -83,8 +83,8 @@ struct material_converter {
             const auto material_map = mat_coll[index];
 
             // Create the bin associations
-            auto edges0 = material_map.template get_axis<0>().bin_edges();
-            auto edges1 = material_map.template get_axis<1>().bin_edges();
+            dindex edges0 = material_map.template get_axis<0>().nbins();
+            dindex edges1 = material_map.template get_axis<1>().nbins();
 
             // In the svg convention the phi axis has to be the second axis to
             // loop over
@@ -94,18 +94,20 @@ struct material_converter {
                 std::is_same_v<typename material_t::local_frame_type,
                                detray::concentric_cylindrical2D<algebra_t>>};
             if constexpr (is_cyl) {
-                edges0.swap(edges1);
+                dindex tmp = edges0;
+                edges0 = edges1;
+                edges1 = tmp;
             }
 
-            m_matrix.reserve(edges1.size());
+            m_matrix.reserve(edges1);
 
             // Material map is always 2-dimensional
-            for (dindex j = 0u; j < edges1.size(); ++j) {
+            for (dindex j = 0u; j < edges1; ++j) {
 
                 std::vector<actsvg::proto::material_slab> m_matrix_row;
-                m_matrix_row.reserve(edges1.size());
+                m_matrix_row.reserve(edges1);
 
-                for (dindex i = 0u; i < edges0.size(); ++i) {
+                for (dindex i = 0u; i < edges0; ++i) {
 
                     loc_bin_idx_t bin_idx{i, j};
                     if constexpr (is_cyl) {

--- a/plugins/svgtools/include/detray/plugins/svgtools/styling/styling.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/styling/styling.hpp
@@ -218,7 +218,7 @@ const styling::surface_material_style material_style{
     {colors::black, 1.f},
     1.f,
     colors::gradient::viridis_scale,
-    20u,
+    8u,
     {{colors::black, 1.f}, 0.4f}};
 
 // Surface styles

--- a/tests/include/detray/test/common/build_toy_detector.hpp
+++ b/tests/include/detray/test/common/build_toy_detector.hpp
@@ -89,13 +89,13 @@ struct toy_det_config {
         m_beampipe_map_cfg.mat_generator =
             detray::detail::generate_cyl_mat<scalar_t>;
 
-        m_disc_map_cfg.n_bins = {3u, 20u};
+        m_disc_map_cfg.n_bins = {5u, 20u};
         m_disc_map_cfg.axis_index = 0u;
         m_disc_map_cfg.mapped_material =
             mixture<scalar_t, silicon_tml<scalar_t, std::ratio<9, 10>>,
                     aluminium<scalar_t, std::ratio<1, 10>>>{};
         m_disc_map_cfg.thickness = 1.f * unit<scalar_t>::mm;
-        m_disc_map_cfg.scalor = 1e-6f;
+        m_disc_map_cfg.scalor = 1e-4f;
         m_disc_map_cfg.mat_generator =
             detray::detail::generate_disc_mat<scalar_t>;
 

--- a/tests/include/detray/test/cpu/material_validation.hpp
+++ b/tests/include/detray/test/cpu/material_validation.hpp
@@ -178,20 +178,16 @@ class material_validation_impl : public test::fixture_base<> {
                 }
             };
 
-            EXPECT_TRUE(get_rel_error(truth_mat.sX0, recorded_mat.sX0) <
-                        rel_error)
+            EXPECT_LT(get_rel_error(truth_mat.sX0, recorded_mat.sX0), rel_error)
                 << "Track " << n_tracks << " (X0 / path): Truth "
                 << truth_mat.sX0 << ", Nav. " << recorded_mat.sX0;
-            EXPECT_TRUE(get_rel_error(truth_mat.tX0, recorded_mat.tX0) <
-                        rel_error)
+            EXPECT_LT(get_rel_error(truth_mat.tX0, recorded_mat.tX0), rel_error)
                 << "Track " << n_tracks << " (X0 / thickness): Truth "
                 << truth_mat.tX0 << ", Nav. " << recorded_mat.tX0;
-            EXPECT_TRUE(get_rel_error(truth_mat.sL0, recorded_mat.sL0) <
-                        rel_error)
+            EXPECT_LT(get_rel_error(truth_mat.sL0, recorded_mat.sL0), rel_error)
                 << "Track " << n_tracks << " (L0 / path): Truth "
                 << truth_mat.sL0 << ", Nav. " << recorded_mat.sL0;
-            EXPECT_TRUE(get_rel_error(truth_mat.tL0, recorded_mat.tL0) <
-                        rel_error)
+            EXPECT_LT(get_rel_error(truth_mat.tL0, recorded_mat.tL0), rel_error)
                 << "Track " << n_tracks << " (L0 / thickness): Truth "
                 << truth_mat.tL0 << ", Nav. " << recorded_mat.tL0;
 

--- a/tests/include/detray/test/cpu/toy_detector_test.hpp
+++ b/tests/include/detray/test/cpu/toy_detector_test.hpp
@@ -71,15 +71,15 @@ test_mat_map(const mat_map_t& mat_map, const bool is_cyl) {
                         mat_slab.get_material() == beryllium_tml<scalar_t>{});
         }
     } else {
-        EXPECT_EQ(mat_map.nbins(), 60u);
-        EXPECT_EQ(mat_map.size(), 60u);
+        EXPECT_EQ(mat_map.nbins(), 100u);
+        EXPECT_EQ(mat_map.size(), 100u);
 
         auto n_bins = mat_map.axes().nbins_per_axis();
-        EXPECT_EQ(n_bins[0], 3u);
+        EXPECT_EQ(n_bins[0], 5u);
         EXPECT_EQ(n_bins[1], 20u);
 
         auto r_axis = mat_map.template get_axis<axis::label::e_r>();
-        EXPECT_EQ(r_axis.nbins(), 3u);
+        EXPECT_EQ(r_axis.nbins(), 5u);
         auto z_axis = mat_map.template get_axis<axis::label::e_phi>();
         EXPECT_EQ(z_axis.nbins(), 20u);
 

--- a/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
     mat_val_cfg.name("toy_detector_material_validaiton");
     // Reduce tolerance for single precision tests
     if constexpr (std::is_same_v<scalar, float>) {
-        mat_val_cfg.relative_error(1.e-5f);
+        mat_val_cfg.relative_error(1.e-4f);
     }
     mat_val_cfg.propagation() = cfg_str_nav.propagation();
     mat_val_cfg.propagation().stepping.min_stepsize = min_stepsize;


### PR DESCRIPTION
Fixes the bin index range for material maps in the SVG display and ensures that the material thickness in material maps that are translated in z scales with regard to the origin instead of their midpoint. This changes the material of the toy detector slightly, including more bins for the now fused disc maps, so that the test need to be adapted.