### PR TITLE
feat: Update to actsvg version to 0.4.57

### DIFF
--- a/extern/actsvg/CMakeLists.txt
+++ b/extern/actsvg/CMakeLists.txt
@@ -22,7 +22,7 @@ set(DETRAY_ACTSVG_GIT_REPOSITORY
     CACHE STRING
     "Git repository to take actsvg from"
 )
-set(DETRAY_ACTSVG_GIT_TAG "v0.4.45" CACHE STRING "Version of actsvg to build")
+set(DETRAY_ACTSVG_GIT_TAG "v0.4.57" CACHE STRING "Version of actsvg to build")
 mark_as_advanced(DETRAY_ACTSVG_GIT_REPOSITORY DETRAY_ACTSVG_GIT_TAG)
 
 # Mark the import as a system library on modern CMake versions

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/surface_grid.hpp
@@ -50,11 +50,10 @@ struct bin_association_getter {
             using scalar_t = typename transform3_t::scalar_type;
             using point2_t = typename transform3_t::point2;
 
-            // The sheet display only works for 2-dimensional grids
+            // The actsvg display only works for 2-dimensional grids
             if constexpr (accel_t::dim != 2u) {
-                std::cout
-                    << "WARNIGN: Only 2D grids can be displayed as actvg sheets"
-                    << std::endl;
+                std::cout << "WARNIGN: Only 2D grids can be displayed in actvg"
+                          << std::endl;
                 return {};
             }
 

--- a/plugins/svgtools/include/detray/plugins/svgtools/conversion/volume.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/conversion/volume.hpp
@@ -58,7 +58,7 @@ auto volume(const typename detector_t::geometry_context& context,
     actsvg::proto::volume<point3_container_t> p_volume;
     p_volume._index = d_volume.index();
 
-    // Prepare surfaces to be displayed in module/grid sheets
+    // Prepare surfaces to be displayed in grids
     std::vector<actsvg::proto::surface<point3_container_t>> p_sensitves;
 
     // Convert grid, if present
@@ -98,7 +98,7 @@ auto volume(const typename detector_t::geometry_context& context,
                 p_surface._aux_info["module_info"] = {sf_info};
                 p_surface._aux_info["grid_info"] = {sf_info};
 
-                // Put the sensitive surfaces in the module/grid sheets
+                // Put the sensitive surfaces in the grids
                 if (sf.is_sensitive()) {
                     p_sensitves.push_back(p_surface);
                 }

--- a/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
@@ -322,12 +322,6 @@ class illustrator {
         std::string id = p_volume._name + "_" + svg_id(view);
         auto vol_svg = svgtools::utils::group(id);
 
-        [[maybe_unused]] auto display_mode =
-            _hide_grids ? actsvg::display::e_module_info
-                        : actsvg::display::e_grid_info;
-
-        actsvg::svg::object sheet;
-
         // zr and xy - views of volume including the portals
         if constexpr (!std::is_same_v<view_t, actsvg::views::z_phi>) {
 
@@ -338,25 +332,9 @@ class illustrator {
                     actsvg::display::grid(id + "_grid", p_volume._surface_grid);
                 vol_svg.add_object(grid_svg);
             }
-
-            // Display the surfaces connected to the grid: in zphi-view for
-            // barrel, and xy-view for endcaps
-        } else if (gr_type == conversion::detail::grid_type::e_barrel) {
-            p_volume._name = det_name() + "_" + p_volume._name;
-            sheet = actsvg::display::barrel_sheet(
-                p_volume._name + "_sheet_zphi", p_volume, {800, 800},
-                display_mode);
-        }
-        if constexpr (std::is_same_v<view_t, actsvg::views::x_y>) {
-            if (gr_type == conversion::detail::grid_type::e_endcap) {
-                p_volume._name = det_name() + "_" + p_volume._name;
-                sheet = actsvg::display::endcap_sheet(
-                    p_volume._name + "_sheet_xy", p_volume, {800, 800},
-                    display_mode);
-            }
         }
 
-        return std::tuple{vol_svg, sheet};
+        return vol_svg;
     }
 
     /// @brief Converts multiple detray volumes of the detector to an svg.
@@ -375,21 +353,18 @@ class illustrator {
         // Overlay the volume svgs
         auto vol_group =
             svgtools::utils::group(det_name() + "_volumes_" + svg_id(view));
-        // The surface[grid] sheets per volume
-        std::vector<actsvg::svg::object> sheets;
 
         for (const auto index : indices) {
 
-            auto [vol_svg, sheet] = draw_volume(index, view, gctx);
+            auto vol_svg = draw_volume(index, view, gctx);
 
             // The general volume display
             if constexpr (!std::is_same_v<view_t, actsvg::views::z_phi>) {
                 vol_group.add_object(vol_svg);
             }
-            sheets.push_back(std::move(sheet));
         }
 
-        return std::tuple(vol_group, sheets);
+        return vol_group;
     }
 
     /// @brief Converts a detray detector to an svg.

--- a/tests/include/detray/test/validation/svg_display.hpp
+++ b/tests/include/detray/test/validation/svg_display.hpp
@@ -194,7 +194,7 @@ inline void svg_display(
         draw_intersection_and_traj_svg(gctx, il, truth_trace, traj, traj_name,
                                        recorded_trace, xy, highlight_idx);
 
-    const auto [vol_xy_svg, _] = il.draw_volumes(volumes, xy, gctx);
+    const auto vol_xy_svg = il.draw_volumes(volumes, xy, gctx);
     detray::svgtools::write_svg(
         path / (outfile + "_" + vol_xy_svg._id + "_" + traj_name),
         {xy_axis, vol_xy_svg, svg_traj});

--- a/tests/tools/src/cpu/detector_display.cpp
+++ b/tests/tools/src/cpu/detector_display.cpp
@@ -139,21 +139,15 @@ int main(int argc, char** argv) {
 
     // Display the volumes
     if (!volumes.empty()) {
-        const auto [vol_xy_svg, xy_sheets] = il.draw_volumes(volumes, xy, gctx);
+        const auto vol_xy_svg = il.draw_volumes(volumes, xy, gctx);
         detray::svgtools::write_svg(path / vol_xy_svg._id,
                                     {xy_axis, vol_xy_svg});
-        for (const auto& sheet : xy_sheets) {
-            detray::svgtools::write_svg(path / sheet._id, sheet);
-        }
 
-        const auto [vol_zr_svg, _sh] = il.draw_volumes(volumes, zr, gctx);
+        const auto vol_zr_svg = il.draw_volumes(volumes, zr, gctx);
         detray::svgtools::write_svg(path / vol_zr_svg._id,
                                     {zr_axis, vol_zr_svg});
 
-        const auto [_vol, zphi_sheets] = il.draw_volumes(volumes, zphi, gctx);
-        for (const auto& sheet : zphi_sheets) {
-            detray::svgtools::write_svg(path / sheet._id, sheet);
-        }
+        const auto _vol = il.draw_volumes(volumes, zphi, gctx);
     }
 
     // Display the surfaces

--- a/tests/unit_tests/svgtools/grids.cpp
+++ b/tests/unit_tests/svgtools/grids.cpp
@@ -48,11 +48,10 @@ GTEST_TEST(svgtools, grids) {
     for (const detray::dindex i : indices) {
         // Draw volume i.
         il.hide_grids(false);
-        const auto [volume_svg, sheet] = il.draw_volume(i, view);
+        const auto volume_svg = il.draw_volume(i, view);
 
         // Write volume i and its grid
         detray::svgtools::write_svg("test_svgtools_volume_" + volume_svg._id,
                                     volume_svg);
-        detray::svgtools::write_svg("test_svgtools_grid_" + sheet._id, sheet);
     }
 }

--- a/tests/unit_tests/svgtools/groups.cpp
+++ b/tests/unit_tests/svgtools/groups.cpp
@@ -65,11 +65,11 @@ GTEST_TEST(svgtools, groups) {
     // Visualisation of a group of volumes.
     const std::array volume_group_indices{3u, 5u};
 
-    const auto [vol_group_xy, sh1] = il.draw_volumes(volume_group_indices, xy);
+    const auto vol_group_xy = il.draw_volumes(volume_group_indices, xy);
     detray::svgtools::write_svg("test_svgtools_volume_group_xy",
                                 {axes, vol_group_xy});
 
-    const auto [vol_group_zr, sh2] = il.draw_volumes(volume_group_indices, zr);
+    const auto vol_group_zr = il.draw_volumes(volume_group_indices, zr);
     detray::svgtools::write_svg("test_svgtools_volume_group_zr",
                                 {axes, vol_group_zr});
 

--- a/tests/unit_tests/svgtools/trajectories.cpp
+++ b/tests/unit_tests/svgtools/trajectories.cpp
@@ -62,7 +62,7 @@ GTEST_TEST(svgtools, trajectories) {
     const detray::svgtools::illustrator il{det, names};
 
     // Show the relevant volumes in the detector.
-    const auto [svg_volumes, _] =
+    const auto svg_volumes =
         il.draw_volumes(std::vector{7u, 9u, 11u, 13u}, view);
 
     // Creating a ray.

--- a/tests/unit_tests/svgtools/volumes.cpp
+++ b/tests/unit_tests/svgtools/volumes.cpp
@@ -62,9 +62,7 @@ GTEST_TEST(svgtools, volumes) {
     for (detray::dindex i : indices) {
         std::string name = "test_svgtools_volume" + std::to_string(i);
         // Visualization of volume i:
-        const auto [vol_svg_xy, xy_sheets] = il.draw_volume(i, xy);
-        detray::svgtools::write_svg(name + "_xy", {axes, vol_svg_xy});
-        const auto [vol_svg_zr, _] = il.draw_volume(i, zr);
-        detray::svgtools::write_svg(name + "_zr", {axes, vol_svg_zr});
+        const auto vol_svg_xy = il.draw_volume(i, xy);
+        const auto vol_svg_zr = il.draw_volume(i, zr);
     }
 }

--- a/tests/unit_tests/svgtools/web.cpp
+++ b/tests/unit_tests/svgtools/web.cpp
@@ -72,7 +72,7 @@ GTEST_TEST(svgtools, web) {
 
     // Draw the volumes and include them in the svg vector.
     for (detray::dindex i : indices) {
-        const auto [svg, _] = il.draw_volume(i, view);
+        const auto svg = il.draw_volume(i, view);
         svgs.push_back(svg);
     }
 


### PR DESCRIPTION
Update to actsvg version to 0.4.57, which fixes several issues in the material maps display. Removes the capability to display the surface grids sheets, as this was removed from actsvg.