### PR TITLE
fix: index range size

### DIFF
--- a/core/include/detray/core/detail/indexing.hpp
+++ b/core/include/detray/core/detail/indexing.hpp
@@ -49,8 +49,9 @@ inline constexpr bool sized_index_range{true};
 /// @tparam value_t underlying bit encoded value type
 /// @tparam lower_mask how many bist to use for the lower index
 template <typename index_t, bool contains_size = !sized_index_range,
-          typename value_t = std::uint_least32_t,
-          value_t lower_mask = 0xffff0000, value_t upper_mask = ~lower_mask>
+          typename value_t = std::uint_least64_t,
+          value_t lower_mask = 0xffffffff00000000,
+          value_t upper_mask = ~lower_mask>
 requires std::convertible_to<index_t, value_t> struct index_range {
     using index_type = index_t;
     using encoder = detail::bit_encoder<value_t>;
@@ -320,10 +321,6 @@ struct multi_index {
     /// Print operator
     DETRAY_HOST
     friend std::ostream& operator<<(std::ostream& os, const multi_index& mi) {
-        if (mi.is_invalid()) {
-            return (os << "undefined");
-        }
-
         os << "[";
         bool writeSeparator = false;
         for (auto i = 0u; i < N; ++i) {

--- a/core/include/detray/utils/bit_encoder.hpp
+++ b/core/include/detray/utils/bit_encoder.hpp
@@ -53,6 +53,14 @@ class bit_encoder {
         static constexpr void set_bits(value_t& v, const value_t id) noexcept {
         // Use integral constant to enforce compile time evaluation of shift
         v = (v & ~mask) | ((id << extract_shift(mask)) & mask);
+
+        // Make sure, the value 'id' can be safely encoded with the bits
+        // specified by 'mask' (unless it is an invalid value which has all bits
+        // set to 1)
+        assert(((id == ~static_cast<value_t>(0)) ||
+                (id == static_cast<value_t>(~static_cast<unsigned int>(0))) ||
+                (get_bits<mask>(v) == id)) &&
+               "Not enough bits in mask to encode value");
     }
 
     private:

--- a/tests/include/detray/test/cpu/toy_detector_test.hpp
+++ b/tests/include/detray/test/cpu/toy_detector_test.hpp
@@ -133,7 +133,7 @@ inline bool toy_detector_test(
 
     // Link to outer world (leaving detector)
     constexpr auto leaving_world{detail::invalid_value<nav_link_t>()};
-    constexpr auto inv_link{detail::invalid_value<dindex>()};
+    constexpr auto inv_link{dindex_invalid};
     const bool has_grids =
         (accel.template size<accel_ids::e_cylinder2_grid>() != 0u) ||
         (accel.template size<accel_ids::e_disc_grid>() != 0u);
@@ -272,7 +272,8 @@ inline bool toy_detector_test(
             ++sf_itr;
             ++trf_index;
             mask_link.shift(1u);
-            if (sf_itr->material().id() != material_ids::e_none) {
+            if (sf_itr->material().id() != material_ids::e_none &&
+                !material_index.is_invalid()) {
                 ++material_index;
             }
         }

--- a/tests/unit_tests/cpu/core/indexing.cpp
+++ b/tests/unit_tests/cpu/core/indexing.cpp
@@ -33,7 +33,7 @@ GTEST_TEST(detray_core, index_range) {
 
     using index_t = detail::index_range<unsigned int>;
     constexpr auto inv_idx{
-        static_cast<unsigned int>(std::numeric_limits<std::uint16_t>::max())};
+        static_cast<unsigned int>(std::numeric_limits<std::uint32_t>::max())};
 
     static_assert(concepts::interval<index_t>);
 
@@ -119,7 +119,7 @@ GTEST_TEST(detray_core, sized_index_range) {
     using index_t =
         detail::index_range<unsigned int, detail::sized_index_range>;
     constexpr auto inv_idx{
-        static_cast<unsigned int>(std::numeric_limits<std::uint16_t>::max())};
+        static_cast<unsigned int>(std::numeric_limits<std::uint32_t>::max())};
 
     static_assert(concepts::interval<index_t>);
 

--- a/tests/unit_tests/cpu/core/indexing.cpp
+++ b/tests/unit_tests/cpu/core/indexing.cpp
@@ -22,7 +22,7 @@ using namespace detray;
 namespace {
 
 /// Define mask types
-enum class mask_ids : unsigned int {
+enum class mask_ids : std::uint8_t {
     e_unmasked = 0u,
 };
 
@@ -32,8 +32,7 @@ enum class mask_ids : unsigned int {
 GTEST_TEST(detray_core, index_range) {
 
     using index_t = detail::index_range<unsigned int>;
-    constexpr auto inv_idx{
-        static_cast<unsigned int>(std::numeric_limits<std::uint32_t>::max())};
+    constexpr auto inv_idx{std::numeric_limits<std::uint32_t>::max()};
 
     static_assert(concepts::interval<index_t>);
 
@@ -118,8 +117,7 @@ GTEST_TEST(detray_core, sized_index_range) {
     // Index range that contains lower index and number of elements
     using index_t =
         detail::index_range<unsigned int, detail::sized_index_range>;
-    constexpr auto inv_idx{
-        static_cast<unsigned int>(std::numeric_limits<std::uint32_t>::max())};
+    constexpr auto inv_idx{std::numeric_limits<std::uint32_t>::max()};
 
     static_assert(concepts::interval<index_t>);
 
@@ -264,7 +262,7 @@ GTEST_TEST(detray_core, typed_index) {
     EXPECT_TRUE(ti.is_invalid());
     ti.set_id(mask_ids::e_unmasked);
     EXPECT_FALSE(ti.is_invalid());
-    ti.set_index((1u << 30) - 1u);
+    ti.set_index((1u << 28) - 1u);
     EXPECT_TRUE(ti.is_invalid());
     ti.set_index(21u);
     EXPECT_FALSE(ti.is_invalid());


### PR DESCRIPTION
Increase the bits for the index range back to 64, because otherwise overflows can happen in the material maps, where the grid collections might have to index a couple of 100 000 bins. Also added an assertion that will catch this in the future.