### PR TITLE
Flatten propagation loop structure

### DIFF
--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -764,10 +764,14 @@ class navigator {
     ///
     /// @returns a heartbeat to indicate if the navigation is still alive
     template <typename track_t>
-    DETRAY_HOST_DEVICE inline bool update(
-        const track_t &track, state &navigation, const navigation::config &cfg,
-        const context_type &ctx = {},
-        const bool /*is_before_actor*/ = true) const {
+    DETRAY_HOST_DEVICE
+#ifdef __CUDA_ARCH__
+        __attribute__((always_inline))
+#endif
+        inline bool
+        update(const track_t &track, state &navigation,
+               const navigation::config &cfg, const context_type &ctx = {},
+               const bool /*is_before_actor*/ = true) const {
 
         assert(!track.is_invalid());
 


### PR DESCRIPTION
This commit flattens the propagation loop structure with the primary goal of reducing the number of different call sites to the navigation update method. Currently. we update the navigator in three different places and this is expensive due to divergence. This commit puts all of those calls into one place in a loop, mirroring the same functional structure that was present before.

I measure a significant performance improvement due to this in traccc, and it also greatly reduces the size of the kernels.