### PR TITLE
Optimize several linear algebra operations

### DIFF
--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -191,6 +191,12 @@ class base_stepper {
 
         /// @returns the current transport Jacbian.
         DETRAY_HOST_DEVICE
+        inline free_matrix_type &transport_jacobian() {
+            return m_jac_transport;
+        }
+
+        /// @returns the current transport Jacbian.
+        DETRAY_HOST_DEVICE
         inline const free_matrix_type &transport_jacobian() const {
             return m_jac_transport;
         }

--- a/core/include/detray/propagator/line_stepper.hpp
+++ b/core/include/detray/propagator/line_stepper.hpp
@@ -71,7 +71,8 @@ class line_stepper final
             /// NOTE: Let's skip the element for d(time)/d(qoverp) for the
             /// moment..
 
-            this->set_transport_jacobian(D * this->transport_jacobian());
+            algebra::generic::math::set_inplace_product_left(
+                this->transport_jacobian(), D);
         }
 
         DETRAY_HOST_DEVICE

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -331,7 +331,8 @@ DETRAY_HOST_DEVICE inline void detray::rk_stepper<
     getter::set_block(D, dFdqop, 0u, 7u);
     getter::set_block(D, dGdqop, 4u, 7u);
 
-    this->set_transport_jacobian(D * this->transport_jacobian());
+    algebra::generic::math::set_inplace_product_left(this->transport_jacobian(),
+                                                     D);
 }
 
 template <typename magnetic_field_t, detray::concepts::algebra algebra_t,


### PR DESCRIPTION
This commit (which inherits largely from #901) implements a series of optimizations to the ways linear algebra operations are performed in the steppers and parameter transporters. These optimizations largely leverage the in-place operations provided by algebra plugins.