### PR TITLE
feat: Add residual plots for local positions

### DIFF
--- a/io/include/detray/io/csv/dfe.hpp
+++ b/io/include/detray/io/csv/dfe.hpp
@@ -260,7 +260,9 @@ inline void DsvWriter<Delimiter>::append(Arg0&& arg0, Args&&... args) {
     std::stringstream line;
     unsigned written_columns[] = {
         write(std::forward<Arg0>(arg0), line),
-        (line << Delimiter, write(std::forward<Args>(args), line))...,
+        (line << std::setprecision(std::numeric_limits<double>::max_digits10)
+              << Delimiter,
+         write(std::forward<Args>(args), line))...,
     };
     line << '\n';
     unsigned total_columns = 0;

--- a/io/include/detray/io/csv/intersection2D.hpp
+++ b/io/include/detray/io/csv/intersection2D.hpp
@@ -31,16 +31,16 @@ struct intersection2D {
     unsigned int n_masks = 1u;
     unsigned int material_id = 0u;
     unsigned int material_index = 0u;
-    double l0 = 0.;
-    double l1 = 0.;
+    double loc_0 = 0.;
+    double loc_1 = 0.;
     double path = 0.;
     unsigned int volume_link = 0u;
     int direction = 0;
     int status = 0;
 
     DFE_NAMEDTUPLE(intersection2D, track_id, identifier, type, transform_index,
-                   mask_id, mask_index, material_id, material_index, l0, l1,
-                   path, volume_link, direction, status);
+                   mask_id, mask_index, material_id, material_index, loc_0,
+                   loc_1, path, volume_link, direction, status);
 };
 
 /// Read intersections from csv file
@@ -91,8 +91,8 @@ inline auto read_intersection2D(const std::string &file_name) {
         inters.sf_desc = {inters_data.transform_index, mask_link, material_link,
                           dindex_invalid, surface_id::e_unknown};
         inters.sf_desc.set_barcode(geometry::barcode{inters_data.identifier});
-        inters.local = {static_cast<scalar_t>(inters_data.l0),
-                        static_cast<scalar_t>(inters_data.l1), 0.f};
+        inters.local = {static_cast<scalar_t>(inters_data.loc_0),
+                        static_cast<scalar_t>(inters_data.loc_1), 0.f};
         inters.path = static_cast<scalar_t>(inters_data.path);
         inters.volume_link = static_cast<nav_link_t>(inters_data.volume_link);
         inters.direction = static_cast<bool>(inters_data.direction);
@@ -165,8 +165,8 @@ inline void write_intersection2D(
             inters_data.material_id =
                 static_cast<unsigned int>(inters.sf_desc.material().id());
             inters_data.material_index = inters.sf_desc.material().index();
-            inters_data.l0 = inters.local[0];
-            inters_data.l1 = inters.local[1];
+            inters_data.loc_0 = inters.local[0];
+            inters_data.loc_1 = inters.local[1];
             inters_data.path = inters.path;
             inters_data.volume_link = inters.volume_link;
             inters_data.direction = static_cast<int>(inters.direction);

--- a/tests/include/detray/test/cpu/detector_scan.hpp
+++ b/tests/include/detray/test/cpu/detector_scan.hpp
@@ -98,8 +98,8 @@ class detector_scan : public test::fixture_base<> {
                 m_cfg.name());
 
         const std::string det_name{m_det.name(m_names)};
-        const std::string prefix{k_use_rays ? det_name + "_ray_"
-                                            : det_name + "_helix_"};
+        const std::string prefix{k_use_rays ? det_name + "_ray"
+                                            : det_name + "_helix"};
         std::ios_base::openmode io_mode = std::ios::trunc | std::ios::out;
         detray::io::file_handle debug_file{prefix + "_detector_scan.txt",
                                            io_mode};
@@ -202,6 +202,7 @@ class detector_scan : public test::fixture_base<> {
             const auto pT_range = m_cfg.track_generator().mom_range();
             // Remove floating point imprecisions
             momentum_str =
+                "_" +
                 std::to_string(
                     std::floor(10. * static_cast<double>(pT_range[0])) / 10.) +
                 "_" +
@@ -210,10 +211,10 @@ class detector_scan : public test::fixture_base<> {
                 "_GeV";
         }
 
-        std::string track_param_file_name{m_cfg.track_param_file() + "_" +
+        std::string track_param_file_name{m_cfg.track_param_file() +
                                           momentum_str + ".csv"};
 
-        std::string intersection_file_name{m_cfg.intersection_file() + "_" +
+        std::string intersection_file_name{m_cfg.intersection_file() +
                                            momentum_str + ".csv"};
 
         const bool data_files_exist{io::file_exists(intersection_file_name) &&

--- a/tests/include/detray/test/cpu/navigation_validation.hpp
+++ b/tests/include/detray/test/cpu/navigation_validation.hpp
@@ -18,6 +18,7 @@
 #include "detray/test/framework/fixture_base.hpp"
 #include "detray/test/framework/whiteboard.hpp"
 #include "detray/test/validation/detector_scan_utils.hpp"
+#include "detray/test/validation/detector_scanner.hpp"
 #include "detray/test/validation/material_validation_utils.hpp"
 #include "detray/test/validation/navigation_validation_config.hpp"
 #include "detray/test/validation/navigation_validation_utils.hpp"
@@ -286,6 +287,7 @@ class navigation_validation : public test::fixture_base<> {
         std::string momentum_str{""};
         if constexpr (!k_use_rays) {
             momentum_str =
+                "_" +
                 std::to_string(std::floor(10. * static_cast<double>(min_pT)) /
                                10.) +
                 "_" +
@@ -296,15 +298,19 @@ class navigation_validation : public test::fixture_base<> {
 
         const auto data_path{
             std::filesystem::path{m_cfg.track_param_file()}.parent_path()};
-        const auto truth_trk_path{data_path / (prefix + "truth_track_params_" +
-                                               momentum_str + ".csv")};
-        const auto trk_path{data_path / (prefix + "navigation_track_params_" +
-                                         momentum_str + ".csv")};
-        const auto mat_path{data_path / (prefix + "accumulated_material_" +
-                                         momentum_str + ".csv")};
-        const auto missed_path{
-            data_path /
-            (prefix + "missed_intersections_dists_" + momentum_str + ".csv")};
+
+        // Create an output file path
+        auto make_path = [&data_path, &prefix,
+                          &momentum_str](const std::string &name) {
+            return data_path / (prefix + name + momentum_str + ".csv");
+        };
+
+        const auto truth_trk_path{make_path("truth_track_params")};
+        const auto trk_path{make_path("navigation_track_params")};
+        const auto truth_intr_path{make_path("truth_intersections")};
+        const auto intr_path{make_path("navigation_intersections")};
+        const auto mat_path{make_path("accumulated_material")};
+        const auto missed_path{make_path("missed_intersections_dists")};
 
         // Write the distance of the missed intersection local position
         // to the surface boundaries to file for plotting
@@ -312,6 +318,10 @@ class navigation_validation : public test::fixture_base<> {
             m_det, m_names, missed_path.string(), missed_intersections);
         detector_scanner::write_tracks(truth_trk_path.string(), truth_traces);
         navigation_validator::write_tracks(trk_path.string(), recorded_traces);
+        detector_scanner::write_intersections(truth_intr_path.string(),
+                                              truth_traces);
+        detector_scanner::write_intersections(intr_path.string(),
+                                              recorded_traces);
         material_validator::write_material(mat_path.string(), mat_records);
 
         std::cout
@@ -321,6 +331,10 @@ class navigation_validation : public test::fixture_base<> {
                   << std::endl;
         std::cout << "INFO: Wrote recorded track states in: " << trk_path
                   << std::endl;
+        std::cout << "INFO: Wrote recorded truth intersections in: "
+                  << truth_intr_path << std::endl;
+        std::cout << "INFO: Wrote recorded track intersections in: "
+                  << intr_path << std::endl;
         std::cout << "INFO: Wrote accumulated material in: " << mat_path
                   << std::endl;
     }

--- a/tests/include/detray/test/validation/detector_scanner.hpp
+++ b/tests/include/detray/test/validation/detector_scanner.hpp
@@ -204,11 +204,36 @@ inline auto write_intersections(
     // Split data
     for (const auto &trace : intersection_traces) {
 
-        intersections.push_back({});
-        intersections.back().reserve(trace.size());
+        auto &intrs = intersections.emplace_back();
+        intrs.reserve(trace.size());
 
         for (const auto &record : trace) {
-            intersections.back().push_back(record.intersection);
+            intrs.push_back(record.intersection);
+        }
+    }
+
+    // Write to file
+    io::csv::write_intersection2D(intersection_file_name, intersections);
+}
+
+/// Write the @param intersection_traces to file
+template <typename record_t>
+inline auto write_intersections(
+    const std::string &intersection_file_name,
+    const dvector<dvector<record_t>> &intersection_traces) {
+
+    using intersection_t = typename record_t::intersection_type;
+
+    std::vector<std::vector<intersection_t>> intersections{};
+
+    // Split data
+    for (const auto &trace : intersection_traces) {
+
+        auto &intrs = intersections.emplace_back();
+        intrs.reserve(trace.size());
+
+        for (const auto &record : trace) {
+            intrs.push_back(record.intersection);
         }
     }
 

--- a/tests/tools/include/detray/options/detector_io_options.hpp
+++ b/tests/tools/include/detray/options/detector_io_options.hpp
@@ -71,7 +71,8 @@ void add_options<detray::io::detector_writer_config>(
         "Output directory for detector files")("compactify_json",
                                                "not implemented")(
         "write_material", "toggle material output")("write_grids",
-                                                    "toggle grid output");
+                                                    "toggle grid output")(
+        "replace_files", "whether to replace existing files");
 }
 
 /// Configure the detray detector writer
@@ -86,6 +87,7 @@ void configure_options<detray::io::detector_writer_config>(
     cfg.compactify_json(vm.count("compactify_json"));
     cfg.write_material(vm.count("write_material"));
     cfg.write_grids(vm.count("write_grids"));
+    cfg.replace_files(vm.count("replace_files"));
 }
 
 }  // namespace detray::options

--- a/tests/tools/python/impl/__init__.py
+++ b/tests/tools/python/impl/__init__.py
@@ -7,8 +7,11 @@ from .plot_benchmark_results import (
 )
 from .plot_navigation_validation import (
     read_scan_data,
-    read_navigation_data,
-    plot_navigation_data,
+    read_navigation_intersection_data,
+    read_navigation_track_data,
+    plot_detector_scan_data,
+    plot_navigation_intersection_data,
+    plot_navigation_track_data,
 )
 from .plot_material_scan import (
     read_material_data,
@@ -17,11 +20,12 @@ from .plot_material_scan import (
     X0_vs_eta,
     L0_vs_eta,
 )
-from .plot_ray_scan import (
-    read_ray_scan_data,
+from .plot_detector_scan import (
+    read_detector_scan_data,
+    read_intersection_data,
     plot_intersection_points_xy,
     plot_intersection_points_rz,
-    plot_detector_scan_data,
+    plot_intersection_pos_res,
 )
 from .plot_track_params import (
     read_track_data,

--- a/tests/tools/python/impl/plot_track_params.py
+++ b/tests/tools/python/impl/plot_track_params.py
@@ -79,7 +79,7 @@ def plot_track_params(opts, detector, track_type, plot_factory, out_format, df):
 
     __create_plot(
         x=p,
-        bins=100,
+        bins=1 if np.std(p) < 1e-10 else 100,
         x_axis=x_axis_opts,
         y_axis=y_axis_opts._replace(log_scale=10),
         suffix="p_dist",
@@ -89,7 +89,12 @@ def plot_track_params(opts, detector, track_type, plot_factory, out_format, df):
     pT = np.sqrt(np.square(df["px"]) + np.square(df["py"]))
     x_axis_opts = plotting.axis_options(label=r"$p_{T}\,\mathrm{[GeV]}$")
 
-    __create_plot(x=pT, bins=100, x_axis=x_axis_opts, suffix="pT_dist")
+    __create_plot(
+        x=pT,
+        bins=1 if np.std(pT) < 1e-10 else 100,
+        x_axis=x_axis_opts,
+        suffix="pT_dist",
+    )
 
     # Plot the x-origin
     x_axis_opts = plotting.axis_options(label=r"$x\,\mathrm{[mm]}$")
@@ -329,6 +334,7 @@ def plot_track_pos_res(
 
     tracks = "rays" if scan_type == "ray" else "helices"
 
+    assert len(df1[var]) == len(df2[var])
     res = df1[var] - df2[var]
 
     # Remove outliers
@@ -357,7 +363,7 @@ def plot_track_pos_res(
         vert_anchor=1.28,
     )
 
-    # Plot the xy coordinates of the filtered intersections points
+    # Plot the residuals as a histogram and fit a gaussian to it
     hist_data = plot_factory.hist1D(
         x=filtered_res,
         figsize=(9, 9),
@@ -379,5 +385,5 @@ def plot_track_pos_res(
     l2 = label2.replace(" ", "_").replace("(", "").replace(")", "")
 
     plot_factory.write_plot(
-        hist_data, f"{detector_name}_{scan_type}_res_{var}_{l1}_{l2}", out_format
+        hist_data, f"{detector_name}_{scan_type}_track_res_{var}_{l1}_{l2}", out_format
     )

--- a/tests/tools/python/navigation_validation.py
+++ b/tests/tools/python/navigation_validation.py
@@ -5,9 +5,17 @@
 # Mozilla Public License Version 2.0
 
 # detray imports
-from impl import read_scan_data, read_navigation_data, plot_navigation_data
+from impl import (
+    read_scan_data,
+    read_navigation_intersection_data,
+    read_navigation_track_data,
+)
+from impl import (
+    plot_detector_scan_data,
+    plot_navigation_intersection_data,
+    plot_navigation_track_data,
+)
 from impl import plot_track_params
-from impl import plot_detector_scan_data, plot_track_pos_dist, plot_track_pos_res
 from options import (
     common_options,
     detector_io_options,
@@ -181,12 +189,74 @@ def __main__():
         logging, datadir, det_name, p_min, p_max
     )
 
+    # Plot detector scan data
     plot_detector_scan_data(
         args, det_name, plot_factory, "ray", ray_scan_df, out_format
     )
     plot_detector_scan_data(
         args, det_name, plot_factory, "helix", helix_scan_df, out_format
     )
+
+    # Read the recorded intersection data
+    (
+        ray_nav_intr_df,
+        ray_nav_intr_truth_df,
+        ray_nav_intr_cuda_df,
+        helix_nav_intr_df,
+        helix_nav_intr_truth_df,
+        helix_nav_intr_cuda_df,
+    ) = read_navigation_intersection_data(
+        logging, datadir, det_name, p_min, p_max, args.cuda
+    )
+
+    # Plot intersection data
+    label_cpu = "navigation (CPU)"
+    label_cuda = "navigation (CUDA)"
+
+    plot_navigation_intersection_data(
+        args,
+        det_name,
+        plot_factory,
+        "ray",
+        ray_nav_intr_truth_df,
+        ray_nav_intr_df,
+        label_cpu,
+        out_format,
+    )
+
+    plot_navigation_intersection_data(
+        args,
+        det_name,
+        plot_factory,
+        "helix",
+        helix_nav_intr_truth_df,
+        helix_nav_intr_df,
+        label_cpu,
+        out_format,
+    )
+
+    if args.cuda:
+        plot_navigation_intersection_data(
+            args,
+            det_name,
+            plot_factory,
+            "ray",
+            ray_nav_intr_truth_df,
+            ray_nav_intr_cuda_df,
+            label_cuda,
+            out_format,
+        )
+
+        plot_navigation_intersection_data(
+            args,
+            det_name,
+            plot_factory,
+            "helix",
+            helix_nav_intr_truth_df,
+            helix_nav_intr_cuda_df,
+            label_cuda,
+            out_format,
+        )
 
     # Plot distributions of track parameter values
     # Only take initial track parameters from generator
@@ -199,7 +269,7 @@ def __main__():
         args, det_name, "ray", plot_factory, out_format, ray_intial_trk_df
     )
 
-    # Read the recorded data
+    # Read the recorded track data
     (
         ray_nav_df,
         ray_truth_df,
@@ -207,13 +277,10 @@ def __main__():
         helix_nav_df,
         helix_truth_df,
         helix_nav_cuda_df,
-    ) = read_navigation_data(logging, datadir, det_name, p_min, p_max, args.cuda)
+    ) = read_navigation_track_data(logging, datadir, det_name, p_min, p_max, args.cuda)
 
-    # Plot
-    label_cpu = "navigation (CPU)"
-    label_cuda = "navigation (CUDA)"
-
-    plot_navigation_data(
+    # Plot track data
+    plot_navigation_track_data(
         args,
         det_name,
         plot_factory,
@@ -225,7 +292,7 @@ def __main__():
         out_format,
     )
 
-    plot_navigation_data(
+    plot_navigation_track_data(
         args,
         det_name,
         plot_factory,
@@ -239,7 +306,7 @@ def __main__():
 
     if args.cuda:
         # Truth vs. Device
-        plot_navigation_data(
+        plot_navigation_track_data(
             args,
             det_name,
             plot_factory,
@@ -251,7 +318,7 @@ def __main__():
             out_format,
         )
 
-        plot_navigation_data(
+        plot_navigation_track_data(
             args,
             det_name,
             plot_factory,
@@ -264,7 +331,7 @@ def __main__():
         )
 
         # Host vs. Device
-        plot_navigation_data(
+        plot_navigation_track_data(
             args,
             det_name,
             plot_factory,
@@ -276,7 +343,7 @@ def __main__():
             out_format,
         )
 
-        plot_navigation_data(
+        plot_navigation_track_data(
             args,
             det_name,
             plot_factory,


### PR DESCRIPTION
Plot the residuals of the local positions of the intersections found by the detector scan and the navigator to make sure, they are smaller than the intrinsic resolution of a pixel detector. Also fixes a precision issue in dfe libs that prevented the output of enough digits to calculate the residual.