### PR TITLE
feat: Configurable axes in detector display

### DIFF
--- a/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/illustrator.hpp
@@ -376,7 +376,8 @@ class illustrator {
     template <typename view_t>
     inline auto draw_detector(
         const view_t& view,
-        const typename detector_t::geometry_context& gctx = {}) const {
+        const typename detector_t::geometry_context& gctx = {},
+        const float r_length = 1100.f, const float z_length = 3100.f) const {
 
         auto p_detector = svgtools::conversion::detector(
             gctx, _detector, view, _style._detector_style, _hide_portals,
@@ -396,8 +397,8 @@ class illustrator {
                                                _style._eta_lines_style);
 
                 // Hardcoded until we find a way to scale axes automatically
-                p_eta_lines._r = 1100.f;
-                p_eta_lines._z = 3100.f;
+                p_eta_lines._r = r_length;
+                p_eta_lines._z = z_length;
 
                 det_svg.add_object(svgtools::meta::display::eta_lines(
                     "eta_lines_", p_eta_lines));

--- a/plugins/svgtools/include/detray/plugins/svgtools/meta/proto/eta_lines.hpp
+++ b/plugins/svgtools/include/detray/plugins/svgtools/meta/proto/eta_lines.hpp
@@ -21,9 +21,9 @@ struct eta_lines {
     actsvg::scalar _z{800.f};
 
     // Main eta lines
-    std::vector<actsvg::scalar> _values_main = {1.f, 2.f, 3.f, 4.f, 5.f};
+    std::vector<actsvg::scalar> _values_main = {1.f, 2.f, 3.f, 4.f};
     // Intermediate eta lines
-    std::vector<actsvg::scalar> _values_half = {0.5f, 1.5f, 2.5f, 3.5f, 4.5f};
+    std::vector<actsvg::scalar> _values_half = {0.5f, 1.5f, 2.5f, 3.5f};
 
     actsvg::style::stroke _stroke_main;
     actsvg::style::stroke _stroke_half;

--- a/tests/tools/python/impl/plot_track_params.py
+++ b/tests/tools/python/impl/plot_track_params.py
@@ -367,7 +367,7 @@ def plot_track_pos_res(
     hist_data = plot_factory.hist1D(
         x=filtered_res,
         figsize=(9, 9),
-        bins=100,
+        bins=75,
         x_axis=plotting.axis_options(
             label=r"$\mathrm{res}" + rf"\,{var}" + r"\,\mathrm{[mm]}$"
         ),

--- a/tests/tools/python/impl/plot_track_params.py
+++ b/tests/tools/python/impl/plot_track_params.py
@@ -367,7 +367,7 @@ def plot_track_pos_res(
     hist_data = plot_factory.hist1D(
         x=filtered_res,
         figsize=(9, 9),
-        bins=75,
+        bins=100,
         x_axis=plotting.axis_options(
             label=r"$\mathrm{res}" + rf"\,{var}" + r"\,\mathrm{[mm]}$"
         ),


### PR DESCRIPTION
Allow the direct configuration of the axes length and font size in the detector display. Also removes the eta=5 line, which overlaps with the z-axis