### PR TITLE
Fix: data dir option for cuda material validation

### DIFF
--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -369,7 +369,7 @@ inline bool check_consistency(const detector_t &det, const bool verbose = false,
         }
     }
 
-    std::cout << "INFO: Detector check: OK" << std::endl;
+    std::cout << "INFO: Consistency check: OK" << std::endl;
 
     return true;
 }

--- a/tests/include/detray/test/common/event_generator/uniform_track_generator_config.hpp
+++ b/tests/include/detray/test/common/event_generator/uniform_track_generator_config.hpp
@@ -231,7 +231,7 @@ struct uniform_track_generator_config {
         const auto& phi_range = cfg.phi_range();
 
         // General
-        out << "\nUnform track generator\n"
+        out << "\nUniform track generator\n"
             << "----------------------------\n"
             << "  Random seed           : " << cfg.seed() << "\n"
             << "  No. tracks            : " << cfg.n_tracks() << "\n"

--- a/tests/tools/src/cpu/detector_display.cpp
+++ b/tests/tools/src/cpu/detector_display.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv) {
     auto style = detray::svgtools::styling::tableau_colorblind::style;
 
     // Specific options for this test
-    po::options_description desc("\ndetray detector validation options");
+    po::options_description desc("\ndetray detector display options");
 
     std::vector<dindex> volumes;
     std::vector<dindex> surfaces;


### PR DESCRIPTION
Fix the `datadir` option also for the CUDA material validation to make the material validation python script work. Also fixes a few typos