### PR TITLE
Fix: navigation comparison tool call to SVG display

### DIFF
--- a/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -1148,7 +1148,7 @@ auto compare_to_navigation(
                     detray::detector_scanner::display_error(
                         ctx, det, names, cfg.name(), ideal_traj, truth_trace,
                         cfg.svg_style(), i, n_samples, recorded_trace,
-                        cfg.verbose());
+                        {dindex_invalid, dindex_invalid}, cfg.verbose());
                 }
             }
         }


### PR DESCRIPTION
Add the indices to highlighted intersections to the call to the SVG error display in the navigation comparison tool.