### PR TITLE
CI Update, main branch (2025.07.28.)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # Detray library, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -47,7 +47,7 @@ test_cuda:
 build_sycl:
   tags: [docker-gpu-nvidia]
   stage: build
-  image: "ghcr.io/acts-project/ubuntu2404_oneapi:56"
+  image: "ghcr.io/acts-project/ubuntu2404_oneapi:81"
   artifacts:
     paths:
       - build
@@ -64,7 +64,7 @@ build_sycl:
 test_sycl:
   stage: test
   tags: [docker-gpu-nvidia]
-  image: "ghcr.io/acts-project/ubuntu2404_oneapi:56"
+  image: "ghcr.io/acts-project/ubuntu2404_oneapi:81"
   needs:
     - build_sycl
   variables:


### PR DESCRIPTION
Upgraded the image used by the GitLab SYCL tests to `ghcr.io/acts-project/ubuntu2404_oneapi:81`.

This is to switch to using oneAPI 2025.0, which seems to not run into the bug that #1026 seems to have found. :thinking: 