### PR TITLE
fix: HIP cpp file linking for AMD backend

### DIFF
--- a/tests/unit_tests/device/hip/CMakeLists.txt
+++ b/tests/unit_tests/device/hip/CMakeLists.txt
@@ -22,7 +22,7 @@ if(DETRAY_EIGEN_PLUGIN)
     list(APPEND algebras "eigen")
 endif()
 foreach(algebra ${algebras})
-    detray_add_unit_test(hip_${algebra}
+    detray_add_unit_test(hip_${CMAKE_HIP_PLATFORM}_${algebra}
        "detector_hip_kernel.hpp"
        "detector_hip.cpp"
        "detector_hip_kernel.hip"
@@ -31,9 +31,18 @@ foreach(algebra ${algebras})
        detray::algebra_${algebra} detray::test_common detray::test_utils HIP::hiprt
     )
 
+    # Make hipcc interpret .cpp files as .hip files to make linking work
+    # (only needed for the amd backend)
+    if(
+        ("${CMAKE_HIP_PLATFORM}" STREQUAL "hcc")
+        OR ("${CMAKE_HIP_PLATFORM}" STREQUAL "amd")
+    )
+        set_source_files_properties(detector_hip.cpp PROPERTIES LANGUAGE HIP)
+    endif()
+
     # Add definitions for HIP + algebra
     target_compile_definitions(
-        detray_unit_test_hip_${algebra}
+        detray_unit_test_hip_${CMAKE_HIP_PLATFORM}_${algebra}
         PRIVATE ${algebra}=${algebra}
     )
 endforeach()


### PR DESCRIPTION
Force AMD HIP compilation to interpret cpp files as hip files. Not sure if this is the way to go