### PR TITLE
fix: don't override material in homogeneous material factory

### DIFF
--- a/core/include/detray/builders/homogeneous_material_factory.hpp
+++ b/core/include/detray/builders/homogeneous_material_factory.hpp
@@ -283,6 +283,12 @@ class homogeneous_material_factory final
 
         // Add the material to the surfaces that the data links against
         for (auto [i, sf] : detray::views::pick(surfaces, m_indices)) {
+            if (sf.material().id() < detector_t::materials::id::e_none) {
+                // This surface already has a material link, skip it in this
+                // factory
+                continue;
+            }
+
             std::size_t sf_idx{i - sf_offset};
             const material<scalar_type> &mat = m_materials.at(sf_idx);
             scalar_type t = m_thickness.at(sf_idx);


### PR DESCRIPTION
Previously, the homogeneous material writer would unconditionally overwrite material in surfaces which already have e.g. material grids. This is now checked and the surface is skipped.