### PR TITLE
fix: Switch on all benchmark build variations in the CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -88,7 +88,6 @@ jobs:
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
         cmake --preset full-fp32 \
           -DCMAKE_CXX_STANDARD=${{ matrix.PLATFORM.CXX_STANDARD }} \
-          -DDETRAY_BUILD_BENCHMARKS=OFF \
           -DDETRAY_FAIL_ON_WARNINGS=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} \
           -DDETRAY_CUSTOM_SCALARTYPE=${{ matrix.SCALAR_TYPE }} \


### PR DESCRIPTION
Some benchmark builds are currently disabled in the CI and only the build used for the continuous benchmark is tested. This PR switches all benchmark builds on and fixes resulting errors