### PR TITLE
fix: CUDA integration test linking and make cmake more verbose

### DIFF
--- a/plugins/algebra/CMakeLists.txt
+++ b/plugins/algebra/CMakeLists.txt
@@ -11,6 +11,8 @@ set(DETRAY_CUSTOM_SCALARTYPE
     "Scalar type to use in the Detray code"
 )
 
+message(STATUS "Using detray scalar type: ${DETRAY_CUSTOM_SCALARTYPE}")
+
 # Add all subdirectories.
 add_subdirectory(array)
 if(DETRAY_EIGEN_PLUGIN)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,7 +114,10 @@ endif()
 if(DETRAY_BUILD_TESTING)
     # Build host and device specific test code
     add_subdirectory(include/detray/test/cpu)
-    add_subdirectory(include/detray/test/device)
+
+    if(DETRAY_BUILD_CUDA OR DETRAY_BUILD_HIP OR DETRAY_BUILD_SYCL)
+        add_subdirectory(include/detray/test/device)
+    endif()
 
     # Build the unittests
     if(DETRAY_BUILD_UNITTESTS)

--- a/tests/benchmarks/include/detray/benchmarks/cpu/CMakeLists.txt
+++ b/tests/benchmarks/include/detray/benchmarks/cpu/CMakeLists.txt
@@ -4,6 +4,8 @@
 #
 # Mozilla Public License Version 2.0
 
+message(STATUS "Building 'detray::benchmark_cpu' component")
+
 # Set the CPU build flags.
 include(detray-compiler-options-cpp)
 

--- a/tests/benchmarks/include/detray/benchmarks/device/cuda/CMakeLists.txt
+++ b/tests/benchmarks/include/detray/benchmarks/device/cuda/CMakeLists.txt
@@ -23,6 +23,8 @@ endif()
 
 # Set up a benchamrk library for CUDA
 foreach(algebra ${algebra_plugins})
+    message(STATUS "Building 'detray::benchmark_cuda_${algebra}' component")
+
     add_library(
         detray_benchmark_cuda_${algebra}
         STATIC

--- a/tests/include/detray/test/cpu/CMakeLists.txt
+++ b/tests/include/detray/test/cpu/CMakeLists.txt
@@ -4,6 +4,8 @@
 #
 # Mozilla Public License Version 2.0
 
+message(STATUS "Building 'detray::test_cpu' component")
+
 # Set the CPU build flags.
 include(detray-compiler-options-cpp)
 

--- a/tests/include/detray/test/device/CMakeLists.txt
+++ b/tests/include/detray/test/device/CMakeLists.txt
@@ -4,6 +4,8 @@
 #
 # Mozilla Public License Version 2.0
 
+message(STATUS "Building 'detray::test_device' component")
+
 # Set up a device test library
 add_library(detray_test_device INTERFACE "propagator_test.hpp")
 add_library(detray::test_device ALIAS detray_test_device)

--- a/tests/include/detray/test/device/cuda/CMakeLists.txt
+++ b/tests/include/detray/test/device/cuda/CMakeLists.txt
@@ -4,6 +4,8 @@
 #
 # Mozilla Public License Version 2.0
 
+message(STATUS "Building 'detray::test_cuda' component")
+
 # C++17 support for CUDA requires CMake 3.18.
 cmake_minimum_required(VERSION 3.18)
 

--- a/tests/integration_tests/device/cuda/CMakeLists.txt
+++ b/tests/integration_tests/device/cuda/CMakeLists.txt
@@ -29,8 +29,8 @@ foreach(algebra ${algebras})
        "propagator_cuda_kernel.hpp"
        "propagator_cuda.cpp"
        "propagator_cuda_kernel.cu"
-       LINK_LIBRARIES GTest::gtest_main vecmem::cuda covfie::cuda
-                       detray::core detray::algebra_${algebra} detray::test_cuda
+       LINK_LIBRARIES GTest::gtest_main CUDA::cudart vecmem::cuda covfie::cuda
+                       detray::core detray::algebra_${algebra} detray::test_device
                        detray::test_common
     )
 

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -4,6 +4,8 @@
 #
 # Mozilla Public License Version 2.0
 
+message(STATUS "Building 'detray::tools' component")
+
 include(CMakeFindDependencyMacro)
 
 find_dependency(Boost COMPONENTS program_options)

--- a/tests/tools/src/cuda/CMakeLists.txt
+++ b/tests/tools/src/cuda/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 #Mozilla Public License Version 2.0
 
-message(STATUS "Building detray device command line tools")
+message(STATUS "Building detray CUDA command line tools")
 
 # Enable CUDA as a language.
 enable_language(CUDA)


### PR DESCRIPTION
Link the cuda propagation integration test against the `test_device` component and add more status messages