### PR TITLE
feat: add HIP backends to python benchmark script and fix a few warnings

### DIFF
--- a/core/include/detray/definitions/detail/hip_definitions.hpp
+++ b/core/include/detray/definitions/detail/hip_definitions.hpp
@@ -1,13 +1,13 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
-#if defined(__HIPCC__) || defined(__NVCC__)
+#if defined(__HIP__) || defined(__NVCC__)
 
 #include <assert.h>
 #include <hip/hip_runtime.h>
@@ -16,10 +16,9 @@
 #include <stdlib.h>
 
 /// Number of threads per Warp
-#define WARP_SIZE 32
+#define WARP_SIZE warpSize
 
 /// Helper macro used for checking  , type return values.
-
 #define DETRAY_HIP_ERROR_CHECK(ans) \
     { hipAssert((ans), __FILE__, __LINE__); }
 inline void hipAssert(hipError_t code, const char *file, int line,

--- a/tests/benchmarks/include/detray/benchmarks/device/hip/propagation_benchmark.hip
+++ b/tests/benchmarks/include/detray/benchmarks/device/hip/propagation_benchmark.hip
@@ -35,7 +35,7 @@ __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
         tracks_view);
 
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
-    if (gid >= tracks.size()) {
+    if (gid >= static_cast<int>(tracks.size())) {
         return;
     }
 
@@ -73,7 +73,7 @@ typename propagator_t::actor_chain_type::state_tuple *setup_actor_states(
     using actor_state_t = typename propagator_t::actor_chain_type::state_tuple;
     actor_state_t *device_actor_state_ptr{nullptr};
 
-    hipError_t success =
+    [[maybe_unused]] hipError_t success =
         hipMalloc((void **)&device_actor_state_ptr, sizeof(actor_state_t));
     assert(success == hipSuccess);
 

--- a/tests/tools/python/propagation_benchmarks.py
+++ b/tests/tools/python/propagation_benchmarks.py
@@ -31,7 +31,7 @@ import subprocess
 import sys
 
 # Known hardware backend types
-bknd_types = ["cpu", "cuda", "sycl"]
+bknd_types = ["cpu", "cuda", "hip_amd", "hip_nvidia", "sycl"]
 
 # Patterns to be removed from processor names for simplicity
 bknd_patterns = [
@@ -119,6 +119,10 @@ def __generate_benchmark_dict(
     benchmarks = {"CPU": {}}
     if args.cuda:
         benchmarks["CUDA"] = {}
+    if args.hip_amd:
+        benchmarks["HIP_AMD"] = {}
+    if args.hip_nvidia:
+        benchmarks["HIP_NVIDIA"] = {}
     if args.sycl:
         # benchmarks["SYCL"] = {}
         logging.error(f"SYCL propagation {bench_type} is not implemented")
@@ -158,7 +162,7 @@ def __generate_benchmark_dict(
 
         # Try to find the processor name
         bknd_name = "Unknown"
-        if bknd == "CUDA" or bknd == "SYCL":
+        if bknd == "CUDA" or bknd == "HIP_NVIDIA" or bknd == "SYCL":
             # Try to get the GPU name
             try:
                 gpu_str = str(
@@ -180,6 +184,12 @@ def __generate_benchmark_dict(
             except Exception as e:
                 # Name remains 'Unknown'
                 print(e)
+
+            bknd_name = f"{bknd.removesuffix('_NVIDIA')} {bknd_name}"
+
+        elif bknd == "HIP_AMD":
+            bknd_name = "AMD card"
+            bknd_name = f"{bknd.removesuffix('_AMD')} {bknd_name}"
         else:
             bknd_name = __compactify_bknd_name(platform.processor())
 
@@ -287,6 +297,18 @@ def __main__():
     parser.add_argument(
         "--cuda",
         help=("Run the CUDA propagation benchmarks."),
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--hip_amd",
+        help=("Run the HIP AMD propagation benchmarks."),
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--hip_nvidia",
+        help=("Run the HIP NVIDIA propagation benchmarks."),
         action="store_true",
         default=False,
     )


### PR DESCRIPTION
Add the HIP AMD and NVIDIA benchmark options to the python benchmark script. Also fixes a few compiler warnings for the benchmarks and adjusts the warp size, which is not always 32 on AMD devices