### PR TITLE
Make RK stepper flags known at compile time

### DIFF
--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -16,6 +16,10 @@
 #include "detray/tracks/tracks.hpp"
 
 namespace detray {
+enum class rk_stepper_flags : std::uint32_t {
+    e_allow_covariance_transport = 1,
+    e_allow_field_gradient = 2,
+};
 
 /// Runge-Kutta-Nystrom 4th order stepper implementation
 ///
@@ -25,7 +29,12 @@ namespace detray {
 template <typename magnetic_field_t, concepts::algebra algebra_t,
           typename constraint_t = unconstrained_step<dscalar<algebra_t>>,
           typename policy_t = stepper_rk_policy<dscalar<algebra_t>>,
-          typename inspector_t = stepping::void_inspector>
+          typename inspector_t = stepping::void_inspector,
+          std::uint32_t flags_v =
+              (static_cast<std::uint32_t>(
+                   rk_stepper_flags::e_allow_covariance_transport) |
+               static_cast<std::uint32_t>(
+                   rk_stepper_flags::e_allow_field_gradient))>
 class rk_stepper final
     : public base_stepper<algebra_t, constraint_t, policy_t, inspector_t> {
 

--- a/tests/benchmarks/cuda/propagation.cpp
+++ b/tests/benchmarks/cuda/propagation.cpp
@@ -122,7 +122,7 @@ int main(int argc, char** argv) {
         detray::benchmarks::cuda_propagation_bm,
         detray::benchmarks::cuda_propagator_type<
             detray::benchmarks::toy_metadata, field_bknd_t,
-            detray::benchmarks::default_chain>>(
+            detray::benchmarks::default_chain, true>>(
         "TOY_DETECTOR_W_COV_TRANSPORT", bench_cfg, prop_cfg, toy_det, bfield,
         &actor_states, track_samples, n_tracks, &dev_mr);
 
@@ -131,7 +131,7 @@ int main(int argc, char** argv) {
         detray::benchmarks::cuda_propagation_bm,
         detray::benchmarks::cuda_propagator_type<
             detray::benchmarks::toy_metadata, field_bknd_t,
-            detray::benchmarks::empty_chain>>(
+            detray::benchmarks::empty_chain, false>>(
         "TOY_DETECTOR", bench_cfg, prop_cfg, toy_det, bfield, &empty_state,
         track_samples, n_tracks, &dev_mr);
 
@@ -140,7 +140,7 @@ int main(int argc, char** argv) {
         detray::benchmarks::cuda_propagation_bm,
         detray::benchmarks::cuda_propagator_type<
             detray::benchmarks::default_metadata, field_bknd_t,
-            detray::benchmarks::default_chain>>(
+            detray::benchmarks::default_chain, true>>(
         "WIRE_CHAMBER_W_COV_TRANSPORT", bench_cfg, prop_cfg, wire_chamber,
         bfield, &actor_states, track_samples, n_tracks, &dev_mr);
 
@@ -149,7 +149,7 @@ int main(int argc, char** argv) {
         detray::benchmarks::cuda_propagation_bm,
         detray::benchmarks::cuda_propagator_type<
             detray::benchmarks::default_metadata, field_bknd_t,
-            detray::benchmarks::empty_chain>>(
+            detray::benchmarks::empty_chain, false>>(
         "WIRE_CHAMBER", bench_cfg, prop_cfg, wire_chamber, bfield, &empty_state,
         track_samples, n_tracks, &dev_mr);
 

--- a/tests/benchmarks/include/detray/benchmarks/device/cuda/propagation_benchmark.cu
+++ b/tests/benchmarks/include/detray/benchmarks/device/cuda/propagation_benchmark.cu
@@ -116,37 +116,46 @@ void run_propagation_kernel(
 }
 
 /// Macro declaring the template instantiations for the different detector types
-#define DECLARE_PROPAGATION_BENCHMARK(METADATA, CHAIN, FIELD, OPT)             \
-                                                                               \
-    template void                                                              \
-    run_propagation_kernel<cuda_propagator_type<METADATA, FIELD, CHAIN>, OPT>( \
-        const propagation::config &, detector<METADATA>::view_type,            \
-        covfie::field_view<FIELD>,                                             \
-        cuda_propagator_type<METADATA, FIELD,                                  \
-                             CHAIN>::actor_chain_type::state_tuple *,          \
-        vecmem::data::vector_view<                                             \
-            free_track_parameters<detector<METADATA>::algebra_type>>,          \
-        const int);                                                            \
-                                                                               \
-    template cuda_propagator_type<METADATA, FIELD,                             \
-                                  CHAIN>::actor_chain_type::state_tuple *      \
-    setup_actor_states<cuda_propagator_type<METADATA, FIELD, CHAIN>>(          \
-        cuda_propagator_type<METADATA, FIELD,                                  \
-                             CHAIN>::actor_chain_type::state_tuple *);         \
-                                                                               \
-    template void                                                              \
-    release_actor_states<cuda_propagator_type<METADATA, FIELD, CHAIN>>(        \
-        cuda_propagator_type<METADATA, FIELD,                                  \
-                             CHAIN>::actor_chain_type::state_tuple *);
+#define DECLARE_PROPAGATION_BENCHMARK(METADATA, CHAIN, FIELD, OPT, COV_TRANS) \
+                                                                              \
+    template void run_propagation_kernel<                                     \
+        cuda_propagator_type<METADATA, FIELD, CHAIN, COV_TRANS>, OPT>(        \
+        const propagation::config &, detector<METADATA>::view_type,           \
+        covfie::field_view<FIELD>,                                            \
+        cuda_propagator_type<METADATA, FIELD, CHAIN,                          \
+                             COV_TRANS>::actor_chain_type::state_tuple *,     \
+        vecmem::data::vector_view<                                            \
+            free_track_parameters<detector<METADATA>::algebra_type>>,         \
+        const int);                                                           \
+                                                                              \
+    template cuda_propagator_type<METADATA, FIELD, CHAIN,                     \
+                                  COV_TRANS>::actor_chain_type::state_tuple * \
+    setup_actor_states<                                                       \
+        cuda_propagator_type<METADATA, FIELD, CHAIN, COV_TRANS>>(             \
+        cuda_propagator_type<METADATA, FIELD, CHAIN,                          \
+                             COV_TRANS>::actor_chain_type::state_tuple *);    \
+                                                                              \
+    template void release_actor_states<                                       \
+        cuda_propagator_type<METADATA, FIELD, CHAIN, COV_TRANS>>(             \
+        cuda_propagator_type<METADATA, FIELD, CHAIN,                          \
+                             COV_TRANS>::actor_chain_type::state_tuple *);
 
 DECLARE_PROPAGATION_BENCHMARK(benchmarks::default_metadata, empty_chain,
-                              const_field_t, propagation_opt::e_unsync)
+                              const_field_t, propagation_opt::e_unsync, true)
 DECLARE_PROPAGATION_BENCHMARK(benchmarks::default_metadata, default_chain,
-                              const_field_t, propagation_opt::e_unsync)
+                              const_field_t, propagation_opt::e_unsync, true)
+DECLARE_PROPAGATION_BENCHMARK(benchmarks::default_metadata, empty_chain,
+                              const_field_t, propagation_opt::e_unsync, false)
+DECLARE_PROPAGATION_BENCHMARK(benchmarks::default_metadata, default_chain,
+                              const_field_t, propagation_opt::e_unsync, false)
 
 DECLARE_PROPAGATION_BENCHMARK(benchmarks::toy_metadata, empty_chain,
-                              const_field_t, propagation_opt::e_unsync)
+                              const_field_t, propagation_opt::e_unsync, true)
 DECLARE_PROPAGATION_BENCHMARK(benchmarks::toy_metadata, default_chain,
-                              const_field_t, propagation_opt::e_unsync)
+                              const_field_t, propagation_opt::e_unsync, true)
+DECLARE_PROPAGATION_BENCHMARK(benchmarks::toy_metadata, empty_chain,
+                              const_field_t, propagation_opt::e_unsync, false)
+DECLARE_PROPAGATION_BENCHMARK(benchmarks::toy_metadata, default_chain,
+                              const_field_t, propagation_opt::e_unsync, false)
 
 }  // namespace detray::benchmarks

--- a/tests/benchmarks/include/detray/benchmarks/device/cuda/propagation_benchmark.hpp
+++ b/tests/benchmarks/include/detray/benchmarks/device/cuda/propagation_benchmark.hpp
@@ -54,12 +54,22 @@ using default_chain = actor_chain<parameter_transporter<algebra_t>,
 using const_field_t = bfield::const_bknd_t<benchmarks::scalar>;
 
 template <typename metadata_t, typename bfield_t,
-          template <typename> class actor_chain_t>
-using cuda_propagator_type =
-    propagator<rk_stepper<covfie::field_view<bfield_t>,
-                          typename detector<metadata_t>::algebra_type>,
-               navigator<detector<metadata_t>>,
-               actor_chain_t<typename detector<metadata_t>::algebra_type>>;
+          template <typename> class actor_chain_t,
+          bool allow_cov_transport = true>
+using cuda_propagator_type = propagator<
+    rk_stepper<
+        covfie::field_view<bfield_t>,
+        typename detector<metadata_t>::algebra_type,
+        unconstrained_step<
+            dscalar<typename detector<metadata_t>::algebra_type>>,
+        stepper_rk_policy<dscalar<typename detector<metadata_t>::algebra_type>>,
+        stepping::void_inspector,
+        (allow_cov_transport
+             ? static_cast<std::uint32_t>(
+                   rk_stepper_flags::e_allow_covariance_transport)
+             : 0u)>,
+    navigator<detector<metadata_t>>,
+    actor_chain_t<typename detector<metadata_t>::algebra_type>>;
 
 /// Launch the propagation kernelfor benchmarking
 ///


### PR DESCRIPTION
This commit makes some of the flags for the RK stepper, specifically the flag for covariance transport and field gradient usage, known at compile time such that the compiler can more aggressively optimize code that doesn't need this functionality.