### PR TITLE
feat: mapped type registry (reduce shape type-induced branching)

### DIFF
--- a/core/include/detray/builders/grid_builder.hpp
+++ b/core/include/detray/builders/grid_builder.hpp
@@ -208,7 +208,7 @@ class grid_builder : public volume_decorator<detector_t> {
         }
 
         // Add the grid to the detector and link it to its volume
-        constexpr auto gid{detector_t::accel::template get_id<grid_t>()};
+        constexpr auto gid{types::id<typename detector_t::accel, grid_t>};
         DETRAY_DEBUG_HOST("Grid indices: m_id=" << m_id << ", gid=" << gid);
 
         det._accelerators.template push_back<gid>(m_grid);

--- a/core/include/detray/builders/homogeneous_material_builder.hpp
+++ b/core/include/detray/builders/homogeneous_material_builder.hpp
@@ -103,8 +103,8 @@ class homogeneous_material_builder final : public volume_decorator<detector_t> {
                 sf.update_material(offset);
                 DETRAY_DEBUG_HOST("-> material now: " << sf.material());
             }
-            if constexpr (detector_t::materials::template is_defined<
-                              material_rod<scalar_type>>()) {
+            if constexpr (types::contains<typename detector_t::materials,
+                                          material_rod<scalar_type>>) {
                 if (sf.material().id() == material_id::e_rod) {
                     DETRAY_DEBUG_HOST(
                         "-> update material rod offset: "
@@ -120,8 +120,8 @@ class homogeneous_material_builder final : public volume_decorator<detector_t> {
                           << m_materials.template size<material_id::e_slab>()
                           << " slabs into detector materials");
 
-        if constexpr (detector_t::materials::template is_defined<
-                          material_rod<scalar_type>>()) {
+        if constexpr (types::contains<typename detector_t::materials,
+                                      material_rod<scalar_type>>) {
             DETRAY_DEBUG_HOST("-> Appending "
                               << m_materials.template size<material_id::e_rod>()
                               << " rods into detector materials");

--- a/core/include/detray/builders/homogeneous_material_factory.hpp
+++ b/core/include/detray/builders/homogeneous_material_factory.hpp
@@ -359,8 +359,8 @@ class homogeneous_material_factory final
                 mat_idx = this->insert_in_container(mat_coll, mat_slab,
                                                     m_links.at(sf_idx).second);
             }
-            if constexpr (detector_t::materials::template is_defined<
-                              material_rod<scalar_type>>()) {
+            if constexpr (types::contains<typename detector_t::materials,
+                                          material_rod<scalar_type>>) {
                 if (m_links.at(sf_idx).first == material_id::e_rod) {
                     auto &mat_coll =
                         materials.template get<material_id::e_rod>();

--- a/core/include/detray/builders/homogeneous_material_generator.hpp
+++ b/core/include/detray/builders/homogeneous_material_generator.hpp
@@ -184,8 +184,8 @@ class homogeneous_material_generator final
             bool is_line{false};
             link_t mat_link;
 
-            if constexpr (detector_t::materials::template is_defined<
-                              material_rod<scalar_t>>()) {
+            if constexpr (types::contains<typename detector_t::materials,
+                                          material_rod<scalar_t>>) {
 
                 using mask_id = typename detector_t::masks::id;
 

--- a/core/include/detray/builders/material_map_generator.hpp
+++ b/core/include/detray/builders/material_map_generator.hpp
@@ -230,8 +230,8 @@ class material_map_generator final : public factory_decorator<detector_t> {
             const auto sf_idx{m_surface_range[0] + i};
 
             // Skip line surfaces, if any are defined
-            if constexpr (detector_t::materials::template is_defined<
-                              material_rod<scalar_t>>()) {
+            if constexpr (types::contains<typename detector_t::materials,
+                                          material_rod<scalar_t>>) {
 
                 const mask_id sf_mask_id = sf.mask().id();
                 if (sf_mask_id == mask_id::e_straw_tube ||

--- a/core/include/detray/core/detail/multi_store.hpp
+++ b/core/include/detray/core/detail/multi_store.hpp
@@ -61,11 +61,7 @@ class multi_store {
 
     /// Allow matching between IDs and collection value types
     /// @{
-    using value_types = type_registry<ID, detail::get_value_t<Ts>...>;
-    template <ID id>
-    using get_type = typename value_types::template get_type<id>::type;
-    template <typename T>
-    using get_id = typename value_types::template get_index<T>;
+    using value_types = types::registry<ID, detail::get_value_t<Ts>...>;
     /// @}
 
     /// Underlying tuple container that can handle vecmem views
@@ -131,28 +127,33 @@ class multi_store {
     /// @returns the collections iterator at the start position.
     template <ID id = ID{0}>
     DETRAY_HOST_DEVICE constexpr auto begin(const context_type & /*ctx*/ = {}) {
-        return detail::get<value_types::to_index(id)>(m_tuple_container)
+        return detail::get<types::index_cast<value_types, id>>(
+                   m_tuple_container)
             .begin();
     }
 
     /// @returns the collections iterator sentinel.
     template <ID id = ID{0}>
     DETRAY_HOST_DEVICE constexpr auto end(const context_type & /*ctx*/ = {}) {
-        return detail::get<value_types::to_index(id)>(m_tuple_container).end();
+        return detail::get<types::index_cast<value_types, id>>(
+                   m_tuple_container)
+            .end();
     }
 
     /// @returns a data collection by @tparam ID - const
     template <ID id>
     DETRAY_HOST_DEVICE constexpr decltype(auto) get(
         const context_type & /*ctx*/ = {}) const noexcept {
-        return detail::get<value_types::to_index(id)>(m_tuple_container);
+        return detail::get<types::index_cast<value_types, id>>(
+            m_tuple_container);
     }
 
     /// @returns a data collection by @tparam ID - non-const
     template <ID id>
     DETRAY_HOST_DEVICE constexpr decltype(auto) get(
         const context_type & /*ctx*/ = {}) noexcept {
-        return detail::get<value_types::to_index(id)>(m_tuple_container);
+        return detail::get<types::index_cast<value_types, id>>(
+            m_tuple_container);
     }
 
     /// @returns the size of a data collection by @tparam ID
@@ -160,14 +161,15 @@ class multi_store {
     DETRAY_HOST_DEVICE constexpr auto size(
         const context_type & /*ctx*/ = {}) const noexcept -> dindex {
         return static_cast<dindex>(
-            detail::get<value_types::to_index(id)>(m_tuple_container).size());
+            detail::get<types::index_cast<value_types, id>>(m_tuple_container)
+                .size());
     }
 
     /// @returns the number of elements in all collections
     template <std::size_t current_idx = 0>
     DETRAY_HOST_DEVICE auto total_size(const context_type &ctx = {},
                                        dindex n = 0u) const noexcept -> dindex {
-        n += size<value_types::to_id(current_idx)>(ctx);
+        n += size<types::id_cast<value_types, current_idx>>(ctx);
 
         if constexpr (current_idx < sizeof...(Ts) - 1) {
             return total_size<current_idx + 1>(ctx, n);
@@ -179,7 +181,8 @@ class multi_store {
     template <ID id>
     DETRAY_HOST_DEVICE constexpr auto empty(
         const context_type & /*ctx*/ = {}) const noexcept -> bool {
-        return detail::get<value_types::to_index(id)>(m_tuple_container)
+        return detail::get<types::index_cast<value_types, id>>(
+                   m_tuple_container)
             .empty();
     }
 
@@ -187,7 +190,7 @@ class multi_store {
     template <std::size_t current_idx = 0>
     DETRAY_HOST_DEVICE constexpr bool all_empty(const context_type &ctx = {},
                                                 bool is_empty = true) const {
-        is_empty &= empty<value_types::to_id(current_idx)>(ctx);
+        is_empty &= empty<types::id_cast<value_types, current_idx>>(ctx);
 
         if constexpr (current_idx < sizeof...(Ts) - 1) {
             return all_empty<current_idx + 1>(ctx, is_empty);
@@ -198,13 +201,14 @@ class multi_store {
     /// Removes and destructs all elements in a specific collection.
     template <ID id>
     DETRAY_HOST void clear(const context_type & /*ctx*/) {
-        detail::get<value_types::to_index(id)>(m_tuple_container).clear();
+        detail::get<types::index_cast<value_types, id>>(m_tuple_container)
+            .clear();
     }
 
     /// Removes and destructs all elements in the container.
     template <std::size_t current_idx = 0>
     DETRAY_HOST void clear_all(const context_type &ctx = {}) {
-        clear<value_types::to_id(current_idx)>(ctx);
+        clear<types::id_cast<value_types, current_idx>>(ctx);
 
         if constexpr (current_idx < sizeof...(Ts) - 1) {
             clear_all<current_idx + 1>(ctx);
@@ -214,14 +218,16 @@ class multi_store {
     /// Reserve memory of size @param n for a collection given by @tparam id
     template <ID id>
     DETRAY_HOST void reserve(std::size_t n, const context_type & /*ctx*/) {
-        detail::get<value_types::to_index(id)>(m_tuple_container).reserve(n);
+        detail::get<types::index_cast<value_types, id>>(m_tuple_container)
+            .reserve(n);
     }
 
     /// Resize the underlying container to @param n for a collection given by
     /// @tparam id
     template <ID id>
     DETRAY_HOST void resize(std::size_t n, const context_type & /*ctx*/) {
-        detail::get<value_types::to_index(id)>(m_tuple_container).resize(n);
+        detail::get<types::index_cast<value_types, id>>(m_tuple_container)
+            .resize(n);
     }
 
     /// Add a new element to a collection
@@ -236,7 +242,8 @@ class multi_store {
     DETRAY_HOST constexpr auto push_back(
         const T &arg,
         const context_type & /*ctx*/ = {}) noexcept(false) -> void {
-        auto &coll = detail::get<value_types::to_index(id)>(m_tuple_container);
+        auto &coll =
+            detail::get<types::index_cast<value_types, id>>(m_tuple_container);
         return coll.push_back(arg);
     }
 
@@ -251,7 +258,8 @@ class multi_store {
     template <ID id, typename... Args>
     DETRAY_HOST constexpr decltype(auto) emplace_back(
         const context_type & /*ctx*/ = {}, Args &&...args) noexcept(false) {
-        auto &coll = detail::get<value_types::to_index(id)>(m_tuple_container);
+        auto &coll =
+            detail::get<types::index_cast<value_types, id>>(m_tuple_container);
         return coll.emplace_back(std::forward<Args>(args)...);
     }
 
@@ -291,7 +299,8 @@ class multi_store {
     template <std::size_t current_idx = 0>
     DETRAY_HOST void append(const multi_store &other,
                             const context_type &ctx = {}) noexcept(false) {
-        auto &coll = other.template get<value_types::to_id(current_idx)>();
+        auto &coll =
+            other.template get<types::id_cast<value_types, current_idx>>();
         insert(coll, ctx);
 
         if constexpr (current_idx < sizeof...(Ts) - 1) {
@@ -309,7 +318,8 @@ class multi_store {
     template <std::size_t current_idx = 0>
     DETRAY_HOST void append(multi_store &&other,
                             const context_type &ctx = {}) noexcept(false) {
-        auto &coll = other.template get<value_types::to_id(current_idx)>();
+        auto &coll =
+            other.template get<types::id_cast<value_types, current_idx>>();
         insert(std::move(coll), ctx);
 
         if constexpr (current_idx < sizeof...(Ts) - 1) {

--- a/core/include/detray/core/detail/tuple_container.hpp
+++ b/core/include/detray/core/detail/tuple_container.hpp
@@ -27,8 +27,6 @@ namespace detray::detail {
 
 /// @brief detray tuple wrapper.
 ///
-/// @tparam An enum of type IDs that needs to match the [value] types of the
-/// @c Ts pack.
 /// @tparam tuple_t is the type of the underlying tuple container
 /// @tparam Ts are the types of tuple elements. They need to define their own
 /// vecmem view type in order to be managed by the container when moving data

--- a/core/include/detray/core/detail/type_traits.hpp
+++ b/core/include/detray/core/detail/type_traits.hpp
@@ -26,7 +26,7 @@ template <typename>
 struct contains_grids;
 
 template <class ID, typename... Ts>
-struct contains_grids<type_registry<ID, Ts...>> {
+struct contains_grids<types::registry<ID, Ts...>> {
     static constexpr bool value{(concepts::grid<Ts> || ...)};
 };
 
@@ -40,7 +40,7 @@ template <typename>
 struct contains_surface_grids;
 
 template <class ID, typename... Ts>
-struct contains_surface_grids<type_registry<ID, Ts...>> {
+struct contains_surface_grids<types::registry<ID, Ts...>> {
     static constexpr bool value{(concepts::surface_grid<Ts> || ...)};
 };
 
@@ -58,7 +58,7 @@ template <typename>
 struct contains_material_slabs {};
 
 template <class ID, typename... Ts>
-struct contains_material_slabs<type_registry<ID, Ts...>> {
+struct contains_material_slabs<types::registry<ID, Ts...>> {
     static constexpr bool value{(concepts::material_slab<Ts> || ...)};
 };
 
@@ -73,7 +73,7 @@ template <typename>
 struct contains_material_rods {};
 
 template <class ID, typename... Ts>
-struct contains_material_rods<type_registry<ID, Ts...>> {
+struct contains_material_rods<types::registry<ID, Ts...>> {
     static constexpr bool value{(concepts::material_rod<Ts> || ...)};
 };
 
@@ -88,7 +88,7 @@ template <typename>
 struct contains_homogeneous_material {};
 
 template <class ID, typename... Ts>
-struct contains_homogeneous_material<type_registry<ID, Ts...>> {
+struct contains_homogeneous_material<types::registry<ID, Ts...>> {
     static constexpr bool value{(concepts::homogeneous_material<Ts> || ...)};
 };
 
@@ -103,7 +103,7 @@ template <typename>
 struct contains_material_maps {};
 
 template <class ID, typename... Ts>
-struct contains_material_maps<type_registry<ID, Ts...>> {
+struct contains_material_maps<types::registry<ID, Ts...>> {
     static constexpr bool value{(concepts::material_map<Ts> || ...)};
 };
 

--- a/core/include/detray/geometry/mask.hpp
+++ b/core/include/detray/geometry/mask.hpp
@@ -196,7 +196,7 @@ class mask {
     ///
     /// @returns an intersection status e_inside / e_outside
     template <concepts::point point_t>
-    DETRAY_HOST_DEVICE constexpr dbool<algebra_type> is_inside(
+    DETRAY_HOST_DEVICE constexpr dbool<algebra_t> is_inside(
         const point_t& loc_p,
         const scalar_type tol =
             std::numeric_limits<scalar_type>::epsilon()) const {

--- a/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
+++ b/core/include/detray/navigation/intersection/ray_cylinder_portal_intersector.hpp
@@ -13,11 +13,8 @@
 #include "detray/definitions/math.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/coordinates/concentric_cylindrical2D.hpp"
-#include "detray/geometry/coordinates/cylindrical2D.hpp"
 #include "detray/navigation/intersection/intersection.hpp"
-#include "detray/navigation/intersection/ray_cylinder_intersector.hpp"
 #include "detray/tracks/ray.hpp"
-#include "detray/utils/quadratic_equation.hpp"
 
 // System include(s)
 #include <type_traits>

--- a/core/include/detray/utils/concepts.hpp
+++ b/core/include/detray/utils/concepts.hpp
@@ -37,6 +37,10 @@ concept same_as_cvref =
 template <typename T, typename U>
 concept same_as_no_const = std::same_as<std::remove_cv_t<T>, U>;
 
+/// Type identifier concept
+template <typename T>
+concept type_id = std::is_enum_v<T>;
+
 /// Index concept to access vector/matrix elements
 template <typename T>
 concept index = std::is_integral_v<T> && !std::same_as<T, bool>;

--- a/core/include/detray/utils/consistency_checker.hpp
+++ b/core/include/detray/utils/consistency_checker.hpp
@@ -14,6 +14,7 @@
 #include "detray/materials/predefined_materials.hpp"
 #include "detray/utils/log.hpp"
 #include "detray/utils/ranges.hpp"
+#include "detray/utils/type_registry.hpp"
 
 // System include(s)
 #include <iostream>
@@ -40,18 +41,19 @@ void report_empty(const store_t &store,
                   [[maybe_unused]] const std::string &store_name,
                   std::index_sequence<I...> /*seq*/) {
 
-    ((store.template empty<store_t::value_types::to_id(I)>() ?
+    ((store.template empty<types::id_cast<typename store_t::value_types, I>>()
+          ?
 #if DETRAY_LOG_LVL < 0
-                                                             std::clog << ""
+          std::clog << ""
 #else
-                                                             // The log macro
-                                                             // does not compile
-                                                             // here...
+          // The log macro
+          // does not compile
+          // here...
           std::clog << "DETRAY WARNING (HOST): " << __FILENAME__ << ":"
                     << __LINE__ << " " << store_name
                     << " has empty collection no. " << I << std::endl
 #endif
-                                                             : std::clog << ""),
+          : std::clog << ""),
      ...);
 }
 

--- a/core/include/detray/utils/detector_statistics.hpp
+++ b/core/include/detray/utils/detector_statistics.hpp
@@ -59,8 +59,8 @@ template <std::size_t I = 0u, typename store_t>
 DETRAY_HOST_DEVICE inline std::size_t n_grids(const store_t& store,
                                               std::size_t n = 0u) {
 
-    constexpr auto coll_id{store_t::value_types::to_id(I)};
-    using value_type = typename store_t::template get_type<coll_id>;
+    constexpr auto coll_id{types::id_cast<typename store_t::value_types, I>};
+    using value_type = types::get<typename store_t::value_types, coll_id>;
 
     if constexpr (detray::concepts::grid<value_type>) {
         n += store.template size<coll_id>();

--- a/core/include/detray/utils/grid/detail/axis.hpp
+++ b/core/include/detray/utils/grid/detail/axis.hpp
@@ -207,9 +207,7 @@ template <bool ownership, typename local_frame_t, concepts::axis... axis_ts>
 class multi_axis {
 
     /// Match an axis to its label at compile time
-    using axis_reg = type_registry<axis::label, axis_ts...>;
-    template <axis::label L>
-    using label_matcher = typename axis_reg::template get_type<L>;
+    using axis_reg = types::registry<axis::label, axis_ts...>;
 
     public:
     /// Dimension of the local coordinate system that is spanned by the axes
@@ -324,20 +322,20 @@ class multi_axis {
 
     /// Build an axis object in place.
     /// @{
-    /// @tparam index the position of the axis in the parameter pack. Also
+    /// @tparam I the position of the axis in the parameter pack. Also
     ///               determines which axes data are used to build the instance.
     /// @returns an axis object, corresponding to the index.
-    template <std::size_t index>
-    DETRAY_HOST_DEVICE typename label_matcher<axis_reg::to_id(index)>::type
+    template <std::size_t I>
+    DETRAY_HOST_DEVICE types::get<axis_reg, types::id_cast<axis_reg, I>>
     get_axis() const {
-        return {m_edge_offsets[index], &bin_edges()};
+        return {m_edge_offsets[I], &bin_edges()};
     }
 
     /// @tparam L label of the axis.
     /// @returns an axis object, corresponding to the label.
     template <axis::label L>
-    DETRAY_HOST_DEVICE typename label_matcher<L>::type get_axis() const {
-        return get_axis<axis_reg::to_index(L)>();
+    DETRAY_HOST_DEVICE types::get<axis_reg, L> get_axis() const {
+        return get_axis<types::index_cast<axis_reg, L>>();
     }
 
     /// @tparam axis_t type of the axis.
@@ -476,7 +474,8 @@ class multi_axis {
     DETRAY_HOST_DEVICE void get_axis_nbins(const axis_t &ax,
                                            loc_bin_index &n_bins) const {
         // Get the index corresponding to the axis label (e.g. bin_x <=> 0)
-        constexpr auto loc_idx{axis_reg::to_index(axis_t::bounds_type::label)};
+        constexpr auto loc_idx{
+            types::index_cast<axis_reg, axis_t::bounds_type::label>};
         n_bins[loc_idx] = ax.nbins();
     }
 
@@ -493,7 +492,8 @@ class multi_axis {
     DETRAY_HOST_DEVICE void get_axis_bin(const axis_t &ax, const point_type &p,
                                          loc_bin_index &bin_indices) const {
         // Get the index corresponding to the axis label (e.g. bin_x <=> 0)
-        constexpr auto loc_idx{axis_reg::to_index(axis_t::bounds_type::label)};
+        constexpr auto loc_idx{
+            types::index_cast<axis_reg, axis_t::bounds_type::label>};
         bin_indices[loc_idx] = ax.bin(p[loc_idx]);
     }
 
@@ -515,7 +515,8 @@ class multi_axis {
         const darray<neighbor_t, 2> &nhood,
         multi_bin_range<dim> &bin_ranges) const {
         // Get the index corresponding to the axis label (e.g. bin_range_x = 0)
-        constexpr auto loc_idx{axis_reg::to_index(axis_t::bounds_type::label)};
+        constexpr auto loc_idx{
+            types::index_cast<axis_reg, axis_t::bounds_type::label>};
         bin_ranges[loc_idx] = ax.range(p[loc_idx], nhood);
     }
 

--- a/core/include/detray/utils/type_registry.hpp
+++ b/core/include/detray/utils/type_registry.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,23 +10,27 @@
 // Project include(s)
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/indexing.hpp"
+#include "detray/utils/concepts.hpp"
+#include "detray/utils/log.hpp"
 #include "detray/utils/type_list.hpp"
 
 // System include(s)
 #include <type_traits>
 #include <utility>
 
-namespace detray {
+namespace detray::types {
 
-/// @brief match types with indices and vice versa.
+/// @brief match types with indices/identifiers and vice versa.
 ///
 /// @tparam IDs enum that references the types (not used in base class)
-/// @tparam registered_types the types that can be mapped to indices
-template <class ID, typename... registered_types>
-class type_registry {
+/// @tparam registered_types the types that is mapped to the ID enum values
+template <concepts::type_id ID, typename... registered_types>
+class registry {
     public:
-    // Make the type IDs accessible
+    /// Make the type IDs accessible
     using id = ID;
+    /// Make the registered types accessible
+    using type_list = detray::types::list<registered_types...>;
 
     /// Conventions for some basic info
     enum : std::size_t {
@@ -35,117 +39,353 @@ class type_registry {
         e_unknown = sizeof...(registered_types) + 1,
     };
 
-    /// Get the index for a type. Needs to be unrolled in case of thrust tuple.
-    template <typename object_t>
-    DETRAY_HOST_DEVICE static constexpr ID get_id() {
-        return unroll_ids<std::decay_t<object_t>, registered_types...>();
-    }
-
-    /// Get the index for a type. Use template parameter deduction.
-    template <typename object_t>
-    DETRAY_HOST_DEVICE static constexpr ID get_id(const object_t& /*obj*/) {
-        return get_id<object_t>();
-    }
-
-    /// Checks whether a given types is known in the registry.
-    /// Use template parameter deduction.
-    template <typename object_t>
-    DETRAY_HOST_DEVICE static constexpr bool is_defined(
-        const object_t& /*obj*/) {
-        return (get_id<object_t>() != static_cast<ID>(e_unknown));
-    }
-
-    /// Checks whether a given types is known in the registry.
-    template <typename object_t>
-    DETRAY_HOST_DEVICE static constexpr bool is_defined() {
-        return (get_id<object_t>() != static_cast<ID>(e_unknown));
-    }
-
-    /// Checks whether a given index can be mapped to a type.
+    /// @returns whether a given index/identifier can be mapped to a type.
+    /// @{
+    /// @param type_idx the type index to be checked
     DETRAY_HOST_DEVICE static constexpr bool is_valid(
-        const std::size_t type_id) {
-        return type_id < n_types;
+        const std::size_t type_idx) {
+        return type_idx < n_types;
     }
 
-    /// Convert index to ID and do some (limited) checking.
-    ///
-    /// @tparam ref_idx matches to index arg to perform static checks
-    /// @param index argument to be converted to valid id type
-    ///
-    /// @return the matching ID type.
-    template <std::size_t ref_idx = 0>
-    DETRAY_HOST_DEVICE static constexpr ID to_id(const std::size_t index) {
-        if (ref_idx == index) {
-            // Produce a more helpful error than the usual tuple index error
-            static_assert(
-                is_valid(ref_idx),
-                "Index out of range: Please make sure that indices and type "
-                "enums match the number of types in container.");
-            return static_cast<ID>(ref_idx);
-        }
-        if constexpr (ref_idx < sizeof...(registered_types) - 1) {
-            return to_id<ref_idx + 1>(index);
-        }
-        // This produces a compiler error when used in type unrolling code
-        return static_cast<ID>(sizeof...(registered_types));
+    /// @param type_id the type identifier to be checked
+    template <typename id_t = id>
+        requires(!std::convertible_to<id_t, std::size_t>)
+    DETRAY_HOST_DEVICE static constexpr bool is_valid(const id_t type_id) {
+        return static_cast<std::size_t>(type_id) < n_types;
     }
-
-    /// Convert index to ID and do some (limited) checking.
-    ///
-    /// @tparam ref_idx matches to index arg to perform static checks
-    /// @param index argument to be converted to valid id type
-    ///
-    /// @return the matching ID type.
-    template <std::size_t ref_idx = 0>
-    DETRAY_HOST_DEVICE static constexpr std::size_t to_index(const ID id) {
-        if (to_id(ref_idx) == id) {
-            // Produce a more helpful error than the usual tuple index error
-            static_assert(
-                is_valid(ref_idx),
-                "Index out of range: Please make sure that indices and type "
-                "enums match the number of types in container.");
-            return ref_idx;
-        }
-        if constexpr (ref_idx < sizeof...(registered_types) - 1) {
-            return to_index<ref_idx + 1>(id);
-        }
-        // This produces a compiler error when used in type unrolling code
-        return sizeof...(registered_types);
-    }
-
-    /// Extract an index and check it.
-    template <typename object_t>
-    struct get_index {
-        static constexpr ID value = get_id<object_t>();
-        DETRAY_HOST_DEVICE
-        constexpr bool operator()() const noexcept { return is_valid(value); }
-    };
-
-    /// Return a type for an index. If the index cannot be mapped, there will be
-    /// a compiler error.
-    template <ID type_id>
-    struct get_type {
-        using type = types::at<types::list<registered_types...>,
-                               static_cast<int>(to_index(type_id))>;
-    };
-
-    private:
-    /// dummy type
-    struct empty_type {};
-
-    /// Gets the position of a type in a parameter pack, without using tuples.
-    template <typename object_t, typename first_t = empty_type,
-              typename... remaining_types>
-    DETRAY_HOST_DEVICE static constexpr ID unroll_ids() {
-        if constexpr (!std::is_same_v<first_t, empty_type> &&
-                      !std::is_same_v<object_t, first_t>) {
-            return unroll_ids<object_t, remaining_types...>();
-        }
-        if constexpr (std::is_same_v<object_t, first_t>) {
-            return static_cast<ID>(n_types - sizeof...(remaining_types) - 1);
-        }
-        return static_cast<ID>(e_unknown);
-    }
+    /// @}
 };
 
-}  // namespace detray
+/// @brief Select a number of types from another registry and map their IDs to a
+/// continous range of new type indices.
+///
+/// @note Contrary to the original type registry, the type ID does not match the
+/// position of the filtered type in the mapped registry anymore
+///
+/// @tparam registry_t the original type registry
+/// @tparam type_selector_t how to select the new types from teh original ones
+template <typename registry_t, class type_selector_t>
+class mapped_registry : public registry_t {
+    public:
+    /// Make the original type ids accessible
+    using id = typename registry_t::id;
+    /// Make the original types accessible
+    using orig_types = typename registry_t::type_list;
+    /// Make the filtered types accessible
+    using type_list =
+        decltype(detray::types::filtered_list<orig_types, type_selector_t>());
+
+    /// Conventions for some basic info
+    enum : std::size_t {
+        n_types = detray::types::size<type_list>,
+        e_any = detray::types::size<type_list>,
+        e_unknown = detray::types::size<type_list> + 1u,
+    };
+
+    /// @returns whether a given index/identifier can be mapped to a filtered
+    /// type.
+    /// @{
+    /// @param filtered_type_idx the filtered type index to be checked
+    DETRAY_HOST_DEVICE static constexpr bool is_valid(
+        const std::size_t filtered_type_idx) {
+        return filtered_type_idx < n_types;
+    }
+
+    /// @param orig_id the original type identifier (ID) to be checked
+    template <typename id_t = id>
+        requires(!std::convertible_to<id_t, std::size_t>)
+    DETRAY_HOST_DEVICE static constexpr bool is_valid(const id_t orig_id) {
+        if (static_cast<std::size_t>(orig_id) >= m_idx_map.size()) {
+            return false;
+        } else {
+            return mapped_index(orig_id) < n_types;
+        }
+    }
+    /// @}
+
+    /// @returns the array that maps the original type positions to the new ones
+    DETRAY_HOST_DEVICE
+    static constexpr const auto& index_map() { return m_idx_map; }
+
+    /// @returns the filtered type index corresponding to the original type
+    /// index
+    DETRAY_HOST_DEVICE
+    static constexpr std::size_t mapped_index(const std::size_t orig_idx) {
+        return m_idx_map.at(orig_idx);
+    }
+
+    /// @returns the filtered type index corresponding to the original type ID
+    DETRAY_HOST_DEVICE
+    static constexpr std::size_t mapped_index(const id orig_id) {
+        return m_idx_map.at(static_cast<std::size_t>(orig_id));
+    }
+
+    private:
+    /// How to map the original type positions to the new ones
+    static constexpr std::array<dindex, registry_t::n_types> m_idx_map =
+        detray::types::filtered_indices<orig_types, type_selector_t>(
+            detray::types::list{});
+};
+
+/// Specialization of the type list @c size trait
+/// @see detray/utils/type_list.hpp
+/// @{
+template <concepts::type_id ID, typename... Ts>
+struct get_size<registry<ID, Ts...>>
+    : std::integral_constant<std::size_t, sizeof...(Ts)> {};
+
+template <typename R, class S>
+struct get_size<mapped_registry<R, S>>
+    : std::integral_constant<std::size_t, mapped_registry<R, S>::n_types> {};
+/// @}
+
+/// Specialization of the type list @c contains trait
+/// @see detray/utils/type_list.hpp
+/// @{
+template <typename T, std::size_t I, concepts::type_id ID, typename... Ts>
+struct contains_impl<T, I, registry<ID, Ts...>>
+    : public contains_impl<T, I, typename registry<ID, Ts...>::type_list> {};
+
+template <typename T, std::size_t I, typename R, class S>
+struct contains_impl<T, I, mapped_registry<R, S>> {
+    // Figure out which type list to check
+    // (use original list if 'T' is from there, otherwise try filtered list)
+    using orig_list_t = typename mapped_registry<R, S>::orig_types;
+    using filt_list_t = typename mapped_registry<R, S>::type_list;
+    using type_list_t =
+        std::conditional_t<contains<orig_list_t, T>, orig_list_t, filt_list_t>;
+
+    using base_t = contains_impl<T, I, type_list_t>;
+
+    static constexpr bool value = base_t::value;
+    // The type is not contained in 'type_list'm the position will be invalid:
+    // Do not pass that to the range-checked array of the filtered indices
+    static constexpr std::size_t pos =
+        (!base_t::value
+             ? std::numeric_limits<std::size_t>::max()
+             // Depending on which type list the type belongs to, map the index
+             : (std::same_as<type_list_t, orig_list_t>
+                    ? mapped_registry<R, S>::mapped_index(base_t::pos)
+                    : base_t::pos));
+};
+/// @}
+
+/// Specialization of the type list @c size trait
+/// @see detray/utils/type_list.hpp
+/// @{
+template <std::size_t N, concepts::type_id ID, typename... Ts>
+struct get_at<N, registry<ID, Ts...>> {
+    static_assert(registry<ID, Ts...>::is_valid(N),
+                  "Index out of range in type registry 'at'");
+    using type =
+        typename get_at<N, typename registry<ID, Ts...>::type_list>::type;
+};
+
+template <std::size_t N, typename R, class S>
+struct get_at<N, mapped_registry<R, S>> {
+    static_assert(mapped_registry<R, S>::is_valid(N),
+                  "Index out of range in mapped type registry 'at'");
+    using type =
+        typename get_at<N, typename mapped_registry<R, S>::type_list>::type;
+};
+/// @}
+
+/// Traits for the type registry
+/// @{
+
+/// Get the ID of a type
+/// @{
+template <typename = void, typename = void>
+struct get_id {};
+
+template <typename T, concepts::type_id ID, typename... Ts>
+struct get_id<T, registry<ID, Ts...>> {
+    static constexpr ID value =
+        static_cast<ID>(position<typename registry<ID, Ts...>::type_list, T>);
+
+    static_assert(registry<ID, Ts...>::is_valid(value),
+                  "Unmatched type ID in type registry 'id'");
+};
+
+template <typename T, typename R, class S>
+struct get_id<T, mapped_registry<R, S>> {
+    using mapped_reg_t = mapped_registry<R, S>;
+    static_assert(contains<typename mapped_reg_t::orig_types, T>,
+                  "Filtered types cannot be matched to original type IDs");
+
+    using id_t = typename mapped_reg_t::id;
+    static constexpr id_t value =
+        static_cast<id_t>(position<typename mapped_reg_t::orig_types, T>);
+
+    static_assert(mapped_reg_t::is_valid(value),
+                  "Unmatched type ID in mapped type registry 'id'");
+};
+
+template <typename R, typename T>
+inline constexpr R::id id{get_id<T, R>::value};
+/// @}
+
+/// Get the type corresponding to an ID
+/// @{
+template <std::size_t I, typename = void>
+struct get_type {};
+
+template <std::size_t I, typename ID, typename... Ts>
+struct get_type<I, registry<ID, Ts...>> {
+    static_assert(registry<ID, Ts...>::is_valid(I),
+                  "Unmatched type ID in type registry 'get'");
+
+    using type = at<registry<ID, Ts...>, I>;
+};
+
+template <std::size_t I, typename R, class S>
+struct get_type<I, mapped_registry<R, S>> {
+    static_assert(
+        mapped_registry<R, S>::is_valid(mapped_registry<R, S>::mapped_index(I)),
+        "Unmatched type ID in mapped type registry 'get'");
+
+    using type =
+        at<mapped_registry<R, S>, mapped_registry<R, S>::mapped_index(I)>;
+};
+
+template <typename R, auto I>
+using get = typename get_type<static_cast<std::size_t>(I), R>::type;
+/// @}
+
+/// Get the type corresponding to an ID
+/// @{
+template <std::size_t I, typename = void>
+struct cast_impl_id {};
+
+template <std::size_t I, typename ID, typename... Ts>
+struct cast_impl_id<I, registry<ID, Ts...>> {
+    static_assert(registry<ID, Ts...>::is_valid(I),
+                  "Cannot cast to ID: Invalid index for type registry");
+
+    static constexpr ID value = static_cast<ID>(I);
+};
+
+template <std::size_t I, typename R, class S>
+struct cast_impl_id<I, mapped_registry<R, S>> {
+    static_assert(
+        mapped_registry<R, S>::is_valid(mapped_registry<R, S>::mapped_index(I)),
+        "Cannot cast to ID: Invalid index for ,apped type registry");
+
+    using ID = typename mapped_registry<R, S>::id;
+    static constexpr ID value = static_cast<ID>(I);
+};
+
+template <std::size_t I, typename = void>
+struct cast_impl_idx {};
+
+template <std::size_t I, typename ID, typename... Ts>
+struct cast_impl_idx<I, registry<ID, Ts...>> {
+    static_assert(registry<ID, Ts...>::is_valid(I),
+                  "Cannot cast to index: Invalid index for type registry");
+
+    static constexpr std::size_t value = I;
+};
+
+template <std::size_t I, typename R, class S>
+struct cast_impl_idx<I, mapped_registry<R, S>> {
+    static_assert(
+        mapped_registry<R, S>::is_valid(mapped_registry<R, S>::mapped_index(I)),
+        "Cannot cast to index: Invalid index for ,apped type registry");
+
+    static constexpr std::size_t value = mapped_registry<R, S>::mapped_index(I);
+};
+
+template <typename R, std::size_t I>
+inline constexpr R::id id_cast = cast_impl_id<I, R>::value;
+
+template <typename R, auto I>
+inline constexpr std::size_t index_cast =
+    cast_impl_idx<static_cast<std::size_t>(I), R>::value;
+/// @}
+
+/// @}
+
+/// Variadic unrolling of the tuple that calls a functor on the element that
+/// corresponds to @param idx.
+///
+/// @tparam functor_t functor that will be called on the element.
+/// @tparam Args argument types for the functor
+/// @tparam current_idx Current index into the container tuple. Is converted
+///         to an id_t and tested aginst the given id.
+/// @tparam remaining_idcs te remaining tuple indices to be tested.
+///
+/// @see https://godbolt.org/z/qd6xns7KG
+template <typename registry_t, typename functor_t, typename... Args,
+          std::size_t current_idx = 0u, std::size_t... remaining_idcs>
+DETRAY_HOST_DEVICE decltype(auto) visit_helper(
+    const std::size_t idx,
+    std::index_sequence<current_idx, remaining_idcs...> /*seq*/, Args&&... As) {
+
+    using return_t = std::invoke_result_t<
+        functor_t, const types::front<typename registry_t::type_list>&,
+        Args...>;
+
+    // Check if the current tuple index is matched to the target index
+    if (idx == current_idx) {
+        return functor_t{}(
+            types::at<typename registry_t::type_list, current_idx>{},
+            std::forward<Args>(As)...);
+    }
+
+    // Check the next index
+    if constexpr (sizeof...(remaining_idcs) >= 1u) {
+
+        using next_elem_t =
+            types::at<typename registry_t::type_list, current_idx + 1>;
+        using next_return_t =
+            std::invoke_result_t<functor_t, const next_elem_t&, Args...>;
+        static_assert(
+            std::same_as<return_t, next_return_t>,
+            "Functor return type must be the same for all elements of the "
+            "tuple.");
+
+        return visit_helper<registry_t, functor_t>(
+            idx, std::index_sequence<remaining_idcs...>{},
+            std::forward<Args>(As)...);
+    } else if constexpr (std::is_same_v<return_t, void>) {
+        return;
+    } else {
+        return return_t{};
+    }
+}
+
+/// Visits a tuple element according to its @param idx and calls
+/// @tparam functor_t with the arguments @param As on it.
+///
+/// @returns the functor result (this is necessarily always of the same
+/// type, regardless the input tuple element type).
+template <typename registry_t, typename functor_t, typename... Args>
+DETRAY_HOST_DEVICE decltype(auto) visit(const std::size_t idx, Args&&... As)
+    requires(std::invocable<functor_t,
+                            const types::front<typename registry_t::type_list>&,
+                            Args...>)
+{
+    return visit_helper<registry_t, functor_t>(
+        idx, std::make_index_sequence<registry_t::n_types>{},
+        std::forward<Args>(As)...);
+}
+
+/// Visits a tuple element according to its @param idx and calls
+/// @tparam functor_t with the arguments @param As on it.
+///
+/// @returns the functor result (this is necessarily always of the same
+/// type, regardless the input tuple element type).
+template <typename registry_t, typename functor_t, typename... Args>
+DETRAY_HOST_DEVICE decltype(auto) visit(const typename registry_t::id id,
+                                        Args&&... As)
+    requires(std::invocable<functor_t,
+                            const types::front<typename registry_t::type_list>&,
+                            Args...>)
+{
+    assert(registry_t::is_valid(static_cast<std::size_t>(id)));
+
+    return visit<registry_t, functor_t>(static_cast<std::size_t>(id),
+                                        std::forward<Args>(As)...);
+}
+
+}  // namespace detray::types

--- a/io/include/detray/io/backend/detail/grid_reader.hpp
+++ b/io/include/detray/io/backend/detail/grid_reader.hpp
@@ -419,8 +419,8 @@ class grid_reader {
 
         // The compiler will instantiate this function for all possible types of
         // grids: Only proceed, if the grid type is known by the detector
-        if constexpr (detector_t::accel::template is_defined<grid_t>() ||
-                      detector_t::materials::template is_defined<grid_t>()) {
+        if constexpr (types::contains<typename detector_t::accel, grid_t> ||
+                      types::contains<typename detector_t::materials, grid_t>) {
             // Decorate the current volume builder with the grid
             using builder_t = grid_builder_t<detector_t, grid_t, bin_filler_t,
                                              grid_factory_type<grid_t>>;

--- a/io/include/detray/io/backend/detail/type_info.hpp
+++ b/io/include/detray/io/backend/detail/type_info.hpp
@@ -34,14 +34,14 @@ constexpr io::shape_id get_id() {
 
     /// Register the mask shapes to the @c shape_id enum
     using shape_registry =
-        type_registry<io::shape_id, annulus2D, cuboid3D, cylinder2D, cylinder3D,
-                      concentric_cylinder2D, rectangle2D, ring2D, trapezoid2D,
-                      line_square, line_circular, single3D<0>, single3D<1>,
-                      single3D<2>>;
+        types::registry<io::shape_id, annulus2D, cuboid3D, cylinder2D,
+                        cylinder3D, concentric_cylinder2D, rectangle2D, ring2D,
+                        trapezoid2D, line_square, line_circular, single3D<0>,
+                        single3D<1>, single3D<2>>;
 
     // Find the correct shape IO id;
-    if constexpr (shape_registry::is_defined(shape_t{})) {
-        return shape_registry::get_id(shape_t{});
+    if constexpr (types::contains<shape_registry, shape_t>) {
+        return types::id<shape_registry, shape_t>;
     } else {
         return io::shape_id::unknown;
     }
@@ -54,13 +54,13 @@ constexpr io::material_id get_id() {
 
     /// Register the material types to the @c material_id enum
     using mat_registry =
-        type_registry<io::material_id, void, void, void, void, void, void,
-                      material_slab<scalar_t>, material_rod<scalar_t>,
-                      material<scalar_t>>;
+        types::registry<io::material_id, void, void, void, void, void, void,
+                        material_slab<scalar_t>, material_rod<scalar_t>,
+                        material<scalar_t>>;
 
     // Find the correct material IO id;
-    if constexpr (mat_registry::is_defined(material_t{})) {
-        return mat_registry::get_id(material_t{});
+    if constexpr (types::contains<mat_registry, material_t>) {
+        return types::id<mat_registry, material_t>;
     } else {
         return io::material_id::unknown;
     }
@@ -74,14 +74,14 @@ constexpr io::material_id get_id() {
     using algebra_t = typename map_frame_t::algebra_type;
 
     /// Register the material types to the @c material_id enum
-    using mat_registry = type_registry<
+    using mat_registry = types::registry<
         io::material_id, polar2D<algebra_t>, cartesian2D<algebra_t>,
         cartesian3D<algebra_t>, concentric_cylindrical2D<algebra_t>,
         cylindrical2D<algebra_t>, cylindrical3D<algebra_t>, void, void>;
 
     // Find the correct material IO id;
-    if constexpr (mat_registry::is_defined(map_frame_t{})) {
-        return mat_registry::get_id(map_frame_t{});
+    if constexpr (types::contains<mat_registry, map_frame_t>) {
+        return types::id<mat_registry, map_frame_t>;
     } else {
         return io::material_id::unknown;
     }
@@ -98,14 +98,14 @@ constexpr io::accel_id get_id() {
     /// @note the first type corresponds to a non-grid type in the enum
     /// (brute force)
     using frame_registry =
-        type_registry<io::accel_id, void, cartesian2D<algebra_t>,
-                      cartesian3D<algebra_t>, polar2D<algebra_t>,
-                      concentric_cylindrical2D<algebra_t>,
-                      cylindrical2D<algebra_t>, cylindrical3D<algebra_t>>;
+        types::registry<io::accel_id, void, cartesian2D<algebra_t>,
+                        cartesian3D<algebra_t>, polar2D<algebra_t>,
+                        concentric_cylindrical2D<algebra_t>,
+                        cylindrical2D<algebra_t>, cylindrical3D<algebra_t>>;
 
     // Find the correct grid shape IO id;
-    if constexpr (frame_registry::is_defined(frame_t{})) {
-        return frame_registry::get_id(frame_t{});
+    if constexpr (types::contains<frame_registry, frame_t>) {
+        return types::id<frame_registry, frame_t>;
     } else {
         return io::accel_id::unknown;
     }
@@ -124,9 +124,9 @@ struct mask_info {
 
 /// Check for a stereo annulus shape
 template <typename detector_t>
-    requires(detector_t::masks::template is_defined<
-             mask<annulus2D, typename detector_t::algebra_type,
-                  std::uint_least16_t>>())
+    requires(types::contains<typename detector_t::masks,
+                             mask<annulus2D, typename detector_t::algebra_type,
+                                  std::uint_least16_t>>)
 struct mask_info<io::shape_id::annulus2, detector_t> {
     using type = annulus2D;
     static constexpr
@@ -135,9 +135,9 @@ struct mask_info<io::shape_id::annulus2, detector_t> {
 
 /// Check for a 2D cylinder shape
 template <typename detector_t>
-    requires(detector_t::masks::template is_defined<
-             mask<cylinder2D, typename detector_t::algebra_type,
-                  std::uint_least16_t>>())
+    requires(types::contains<typename detector_t::masks,
+                             mask<cylinder2D, typename detector_t::algebra_type,
+                                  std::uint_least16_t>>)
 struct mask_info<io::shape_id::cylinder2, detector_t> {
     using type = cylinder2D;
     static constexpr typename detector_t::masks::id value{
@@ -146,9 +146,10 @@ struct mask_info<io::shape_id::cylinder2, detector_t> {
 
 /// Check for a 2D cylinder portal shape
 template <typename detector_t>
-    requires(detector_t::masks::template is_defined<
+    requires(types::contains<
+             typename detector_t::masks,
              mask<concentric_cylinder2D, typename detector_t::algebra_type,
-                  std::uint_least16_t>>())
+                  std::uint_least16_t>>)
 struct mask_info<io::shape_id::portal_cylinder2, detector_t> {
     using type = concentric_cylinder2D;
     static constexpr typename detector_t::masks::id value{
@@ -157,9 +158,10 @@ struct mask_info<io::shape_id::portal_cylinder2, detector_t> {
 
 /// Check for a cell wire line shape
 template <typename detector_t>
-    requires(detector_t::masks::template is_defined<
-             mask<line_square, typename detector_t::algebra_type,
-                  std::uint_least16_t>>())
+    requires(
+        types::contains<typename detector_t::masks,
+                        mask<line_square, typename detector_t::algebra_type,
+                             std::uint_least16_t>>)
 struct mask_info<io::shape_id::drift_cell, detector_t> {
     using type = line_square;
     static constexpr typename detector_t::masks::id value{
@@ -168,9 +170,10 @@ struct mask_info<io::shape_id::drift_cell, detector_t> {
 
 /// Check for a straw wire line shape
 template <typename detector_t>
-    requires(detector_t::masks::template is_defined<
-             mask<line_circular, typename detector_t::algebra_type,
-                  std::uint_least16_t>>())
+    requires(
+        types::contains<typename detector_t::masks,
+                        mask<line_circular, typename detector_t::algebra_type,
+                             std::uint_least16_t>>)
 struct mask_info<io::shape_id::straw_tube, detector_t> {
     using type = line_circular;
     static constexpr typename detector_t::masks::id value{
@@ -179,9 +182,10 @@ struct mask_info<io::shape_id::straw_tube, detector_t> {
 
 /// Check for a rectangle shape
 template <typename detector_t>
-    requires(detector_t::masks::template is_defined<
-             mask<rectangle2D, typename detector_t::algebra_type,
-                  std::uint_least16_t>>())
+    requires(
+        types::contains<typename detector_t::masks,
+                        mask<rectangle2D, typename detector_t::algebra_type,
+                             std::uint_least16_t>>)
 struct mask_info<io::shape_id::rectangle2, detector_t> {
     using type = rectangle2D;
     static constexpr typename detector_t::masks::id value{
@@ -190,9 +194,9 @@ struct mask_info<io::shape_id::rectangle2, detector_t> {
 
 /// Check for a ring/disc shape
 template <typename detector_t>
-    requires(
-        detector_t::masks::template is_defined<mask<
-            ring2D, typename detector_t::algebra_type, std::uint_least16_t>>())
+    requires(types::contains<typename detector_t::masks,
+                             mask<ring2D, typename detector_t::algebra_type,
+                                  std::uint_least16_t>>)
 struct mask_info<io::shape_id::ring2, detector_t> {
     using type = ring2D;
     static constexpr typename detector_t::masks::id value{
@@ -201,9 +205,10 @@ struct mask_info<io::shape_id::ring2, detector_t> {
 
 /// Check for a single masked value (1st value is checked)
 template <typename detector_t>
-    requires(detector_t::masks::template is_defined<
-             mask<single3D<0>, typename detector_t::algebra_type,
-                  std::uint_least16_t>>())
+    requires(
+        types::contains<typename detector_t::masks,
+                        mask<single3D<0>, typename detector_t::algebra_type,
+                             std::uint_least16_t>>)
 struct mask_info<io::shape_id::single1, detector_t> {
     using type = single3D<0>;
     static constexpr
@@ -212,9 +217,10 @@ struct mask_info<io::shape_id::single1, detector_t> {
 
 /// Check for a single masked value (2nd value is checked)
 template <typename detector_t>
-    requires(detector_t::masks::template is_defined<
-             mask<single3D<1>, typename detector_t::algebra_type,
-                  std::uint_least16_t>>())
+    requires(
+        types::contains<typename detector_t::masks,
+                        mask<single3D<1>, typename detector_t::algebra_type,
+                             std::uint_least16_t>>)
 struct mask_info<io::shape_id::single2, detector_t> {
     using type = single3D<1>;
     static constexpr
@@ -223,9 +229,10 @@ struct mask_info<io::shape_id::single2, detector_t> {
 
 /// Check for a single masked value (3rd value is checked)
 template <typename detector_t>
-    requires(detector_t::masks::template is_defined<
-             mask<single3D<2>, typename detector_t::algebra_type,
-                  std::uint_least16_t>>())
+    requires(
+        types::contains<typename detector_t::masks,
+                        mask<single3D<2>, typename detector_t::algebra_type,
+                             std::uint_least16_t>>)
 struct mask_info<io::shape_id::single3, detector_t> {
     using type = single3D<2>;
     static constexpr
@@ -234,9 +241,10 @@ struct mask_info<io::shape_id::single3, detector_t> {
 
 /// Check for a trapezoid shape
 template <typename detector_t>
-    requires(detector_t::masks::template is_defined<
-             mask<trapezoid2D, typename detector_t::algebra_type,
-                  std::uint_least16_t>>())
+    requires(
+        types::contains<typename detector_t::masks,
+                        mask<trapezoid2D, typename detector_t::algebra_type,
+                             std::uint_least16_t>>)
 struct mask_info<io::shape_id::trapezoid2, detector_t> {
     using type = trapezoid2D;
     static constexpr typename detector_t::masks::id value{
@@ -258,8 +266,9 @@ struct mat_map_info {
 
 /// Check for a 2D disc material map
 template <typename detector_t>
-    requires(detector_t::materials::template is_defined<
-             material_map<typename detector_t::algebra_type, ring2D>>())
+    requires(types::contains<
+             typename detector_t::materials,
+             material_map<typename detector_t::algebra_type, ring2D>>)
 struct mat_map_info<io::material_id::ring2_map, detector_t> {
     using type = material_map<typename detector_t::algebra_type, ring2D>;
     static constexpr typename detector_t::materials::id value{
@@ -268,8 +277,9 @@ struct mat_map_info<io::material_id::ring2_map, detector_t> {
 
 /// Check for a 2D cartesian material map
 template <typename detector_t>
-    requires(detector_t::materials::template is_defined<
-             material_map<typename detector_t::algebra_type, rectangle2D>>())
+    requires(types::contains<
+             typename detector_t::materials,
+             material_map<typename detector_t::algebra_type, rectangle2D>>)
 struct mat_map_info<io::material_id::rectangle2_map, detector_t> {
     using type = material_map<typename detector_t::algebra_type, rectangle2D>;
     static constexpr typename detector_t::materials::id value{
@@ -278,8 +288,9 @@ struct mat_map_info<io::material_id::rectangle2_map, detector_t> {
 
 /// Check for a 3D cuboid volume material map
 template <typename detector_t>
-    requires(detector_t::materials::template is_defined<
-             material_map<typename detector_t::algebra_type, cuboid3D>>())
+    requires(types::contains<
+             typename detector_t::materials,
+             material_map<typename detector_t::algebra_type, cuboid3D>>)
 struct mat_map_info<io::material_id::cuboid3_map, detector_t> {
     using type = material_map<typename detector_t::algebra_type, cuboid3D>;
     static constexpr typename detector_t::materials::id value{
@@ -288,8 +299,9 @@ struct mat_map_info<io::material_id::cuboid3_map, detector_t> {
 
 /// Check for a 2D cylindrical material map
 template <typename detector_t>
-    requires(detector_t::materials::template is_defined<
-             material_map<typename detector_t::algebra_type, cylinder2D>>())
+    requires(types::contains<
+             typename detector_t::materials,
+             material_map<typename detector_t::algebra_type, cylinder2D>>)
 struct mat_map_info<io::material_id::cylinder2_map, detector_t> {
     using type = material_map<typename detector_t::algebra_type, cylinder2D>;
     static constexpr typename detector_t::materials::id value{
@@ -298,8 +310,9 @@ struct mat_map_info<io::material_id::cylinder2_map, detector_t> {
 
 /// Check for a 2D concentric cylindrical material map
 template <typename detector_t>
-    requires(detector_t::materials::template is_defined<material_map<
-                 typename detector_t::algebra_type, concentric_cylinder2D>>())
+    requires(types::contains<typename detector_t::materials,
+                             material_map<typename detector_t::algebra_type,
+                                          concentric_cylinder2D>>)
 struct mat_map_info<io::material_id::concentric_cylinder2_map, detector_t> {
     using type =
         material_map<typename detector_t::algebra_type, concentric_cylinder2D>;
@@ -309,8 +322,9 @@ struct mat_map_info<io::material_id::concentric_cylinder2_map, detector_t> {
 
 /// Check for a 3D cylindrical volume material map
 template <typename detector_t>
-    requires(detector_t::materials::template is_defined<
-             material_map<typename detector_t::algebra_type, cylinder3D>>())
+    requires(types::contains<
+             typename detector_t::materials,
+             material_map<typename detector_t::algebra_type, cylinder3D>>)
 struct mat_map_info<io::material_id::cylinder3_map, detector_t> {
     using type = material_map<typename detector_t::algebra_type, cylinder3D>;
     static constexpr typename detector_t::materials::id value{

--- a/tests/include/detray/test/common/build_toy_detector.hpp
+++ b/tests/include/detray/test/common/build_toy_detector.hpp
@@ -519,9 +519,8 @@ inline void add_cylinder_grid(
     using scalar_t = dscalar<typename detector_t::algebra_type>;
 
     constexpr auto grid_id = detector_t::accel::id::e_cylinder2_grid;
+    using cyl_grid_t = types::get<typename detector_t::accel, grid_id>;
 
-    using cyl_grid_t =
-        typename detector_t::accelerator_container::template get_type<grid_id>;
     using grid_builder_t =
         grid_builder<detector_t, cyl_grid_t, detray::fill_by_pos>;
 
@@ -556,9 +555,8 @@ inline void add_disc_grid(
     using scalar_t = dscalar<typename detector_t::algebra_type>;
 
     constexpr auto grid_id = detector_t::accel::id::e_disc_grid;
+    using disc_grid_t = types::get<typename detector_t::accel, grid_id>;
 
-    using disc_grid_t =
-        typename detector_t::accelerator_container::template get_type<grid_id>;
     using grid_builder_t =
         grid_builder<detector_t, disc_grid_t, detray::fill_by_pos>;
 

--- a/tests/include/detray/test/common/build_wire_chamber.hpp
+++ b/tests/include/detray/test/common/build_wire_chamber.hpp
@@ -169,8 +169,7 @@ inline auto build_wire_chamber(
 
     // Prepare grid building
     constexpr auto grid_id{detector_t::accel::id::e_cylinder2_grid};
-    using cyl_grid_t =
-        typename detector_t::accelerator_container::template get_type<grid_id>;
+    using cyl_grid_t = types::get<typename detector_t::accel, grid_id>;
     using loc_bin_idx_t = typename cyl_grid_t::loc_bin_index;
     static_assert(cyl_grid_t::dim == 2);
     using grid_builder_t =

--- a/tests/include/detray/test/common/factories/barrel_generator.hpp
+++ b/tests/include/detray/test/common/factories/barrel_generator.hpp
@@ -160,8 +160,8 @@ class barrel_generator final : public surface_factory_interface<detector_t> {
         constexpr auto invalid_src_link{detail::invalid_value<std::uint64_t>()};
 
         // The type id of the surface mask shape
-        constexpr auto mask_id{detector_t::mask_container::template get_id<
-            mask<mask_shape_t, algebra_t>>::value};
+        constexpr auto mask_id{types::id<typename detector_t::masks,
+                                         mask<mask_shape_t, algebra_t>>};
 
         // The material will be added in a later step
         constexpr auto no_material{surface_t::material_id::e_none};

--- a/tests/include/detray/test/common/factories/endcap_generator.hpp
+++ b/tests/include/detray/test/common/factories/endcap_generator.hpp
@@ -191,8 +191,8 @@ class endcap_generator final : public surface_factory_interface<detector_t> {
         constexpr auto invalid_src_link{detail::invalid_value<std::uint64_t>()};
 
         // The type id of the surface mask shape
-        constexpr auto mask_id{detector_t::mask_container::template get_id<
-            mask<mask_shape_t, algebra_t>>::value};
+        constexpr auto mask_id{types::id<typename detector_t::masks,
+                                         mask<mask_shape_t, algebra_t>>};
         // The material will be added in a later step
         constexpr auto no_material{surface_t::material_id::e_none};
         // Modules link back to mother volume in navigation

--- a/tests/include/detray/test/common/factories/telescope_generator.hpp
+++ b/tests/include/detray/test/common/factories/telescope_generator.hpp
@@ -120,8 +120,8 @@ class telescope_generator final : public surface_factory_interface<detector_t> {
         constexpr auto invalid_src_link{detail::invalid_value<std::uint64_t>()};
 
         // The type id of the surface mask shape
-        constexpr auto mask_id{detector_t::mask_container::template get_id<
-            mask<mask_shape_t, algebra_t>>::value};
+        constexpr auto mask_id{types::id<typename detector_t::masks,
+                                         mask<mask_shape_t, algebra_t>>};
 
         // The material will be added in a later step
         constexpr auto no_material{surface_t::material_id::e_none};

--- a/tests/include/detray/test/common/factories/wire_layer_generator.hpp
+++ b/tests/include/detray/test/common/factories/wire_layer_generator.hpp
@@ -141,8 +141,8 @@ class wire_layer_generator final
         constexpr auto invalid_src_link{detail::invalid_value<std::uint64_t>()};
 
         // The type id of the surface mask shape (drift cell or straw tube)
-        constexpr auto mask_id{detector_t::mask_container::template get_id<
-            mask<mask_shape_t, algebra_t>>::value};
+        constexpr auto mask_id{types::id<typename detector_t::masks,
+                                         mask<mask_shape_t, algebra_t>>};
         // Modules link back to mother volume in navigation
         const auto mask_volume_link{static_cast<nav_link_t>(volume_idx)};
 

--- a/tests/integration_tests/cpu/CMakeLists.txt
+++ b/tests/integration_tests/cpu/CMakeLists.txt
@@ -29,6 +29,7 @@ macro(detray_add_cpu_test algebra)
        "propagator/covariance_transport.cpp"
        "propagator/guided_navigator.cpp"
        "propagator/propagator.cpp"
+       "utils/type_registry.cpp"
        LINK_LIBRARIES GTest::gtest GTest::gtest_main detray::core_${algebra}
                       vecmem::core detray::test_framework detray::test_common detray::test_utils
     )

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -630,8 +630,7 @@ bound_track_parameters<test_algebra> get_initial_parameter(
     const auto& departure_mask =
         det.mask_store().template get<mask_id>().at(mask_link.index());
 
-    using mask_t =
-        typename detector_t::mask_container::template get_type<mask_id>;
+    using mask_t = types::get<typename detector_t::masks, mask_id>;
     helix_intersector<typename mask_t::shape, test_algebra> hlx_is{};
     hlx_is.run_rtsafe = false;
     hlx_is.convergence_tolerance = helix_tolerance;
@@ -1001,8 +1000,7 @@ bound_param_vector_type get_displaced_bound_vector_helix(
         tracking_surface{det, departure_sf}.bound_to_free_vector({}, dvec);
     detail::helix<test_algebra> hlx(free_vec, field);
 
-    using mask_t =
-        typename detector_t::mask_container::template get_type<mask_id>;
+    using mask_t = types::get<typename detector_t::masks, mask_id>;
     helix_intersector<typename mask_t::shape, test_algebra> hlx_is{};
     hlx_is.run_rtsafe = false;
     hlx_is.convergence_tolerance = helix_tolerance;
@@ -1057,8 +1055,7 @@ void evaluate_jacobian_difference_helix(
     const auto& destination_mask =
         det.mask_store().template get<mask_id>().at(mask_link.index());
 
-    using mask_t =
-        typename detector_t::mask_container::template get_type<mask_id>;
+    using mask_t = types::get<typename detector_t::masks, mask_id>;
     helix_intersector<typename mask_t::shape, test_algebra> hlx_is{};
     hlx_is.run_rtsafe = false;
     hlx_is.convergence_tolerance = helix_tolerance;

--- a/tests/integration_tests/cpu/utils/type_registry.cpp
+++ b/tests/integration_tests/cpu/utils/type_registry.cpp
@@ -1,0 +1,185 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "detray/utils/type_registry.hpp"
+
+#include "detray/core/detector.hpp"
+#include "detray/definitions/indexing.hpp"
+#include "detray/detectors/toy_metadata.hpp"
+#include "detray/geometry/shapes.hpp"
+#include "detray/navigation/intersection/ray_intersector.hpp"
+
+// Detray test include(s)
+#include "detray/test/framework/types.hpp"
+
+// Google Test include(s).
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <iostream>
+
+namespace detray {
+
+template <bool do_debug = !intersection::contains_pos>
+struct select_ray_intersector {
+    template <typename mask_t>
+    using type = ray_intersector<typename mask_t::shape,
+                                 typename mask_t::algebra_type, do_debug>;
+};
+
+}  // namespace detray
+
+// Test type list implementation
+GTEST_TEST(detray_utils, mapped_type_registry) {
+    using namespace detray;
+
+    using metadata_t = test::toy_metadata;
+    using detector_t = detector<metadata_t>;
+    using test_algebra_t = detector_t::algebra_type;
+    using mask_types = typename detector_t::masks;
+    using mask_id = detector_t::masks::id;
+
+    using mapped_registry_t = types::mapped_registry<
+        detector_t::masks, select_ray_intersector<intersection::contains_pos>>;
+
+    types::print<detector_t::masks::type_list>();
+    std::cout << std::endl;
+
+    types::print<mapped_registry_t::type_list>();
+    std::cout << std::endl;
+
+    //
+    // Test the mapping
+    //
+    constexpr const auto& idx_array = mapped_registry_t::index_map();
+
+    static_assert(mapped_registry_t::n_types == 3u);
+    static_assert(types::size<mapped_registry_t> == 3u);
+    static_assert(idx_array.size() == 4u);
+
+    EXPECT_EQ(idx_array[0u], 0u);
+    EXPECT_EQ(idx_array[1u], 0u);
+    EXPECT_EQ(idx_array[2u], 1u);
+    EXPECT_EQ(idx_array[3u], 2u);
+
+    using rectangle_t = types::get<mask_types, mask_id::e_rectangle2>;
+    using trapezoid_t = types::get<mask_types, mask_id::e_trapezoid2>;
+    using cylinder_t = types::get<mask_types, mask_id::e_cylinder2>;
+    using disc_t = types::get<mask_types, mask_id::e_portal_ring2>;
+
+    static_assert(types::position<mapped_registry_t, rectangle_t> == 0u);
+    static_assert(types::position<mapped_registry_t, trapezoid_t> == 0u);
+    static_assert(types::position<mapped_registry_t, cylinder_t> == 1u);
+    static_assert(types::position<mapped_registry_t, disc_t> == 2u);
+
+    using cyl_intersector_t =
+        types::get<mapped_registry_t, mask_id::e_cylinder2>;
+    using rect_intersector_t =
+        types::get<mapped_registry_t, mask_id::e_rectangle2>;
+    using ring_intersector_t =
+        types::get<mapped_registry_t, mask_id::e_portal_ring2>;
+    using trpz_intersector_t =
+        types::get<mapped_registry_t, mask_id::e_trapezoid2>;
+
+    types::print<types::list<cyl_intersector_t>>();
+    std::cout << std::endl;
+    types::print<types::list<rect_intersector_t>>();
+    std::cout << std::endl;
+    types::print<types::list<ring_intersector_t>>();
+    std::cout << std::endl;
+    types::print<types::list<trpz_intersector_t>>();
+
+    static_assert(
+        std::same_as<cyl_intersector_t,
+                     ray_intersector<concentric_cylinder2D, test_algebra_t,
+                                     intersection::contains_pos>>,
+        "Retrieved incorrect type after mapping (cylinder2D)");
+
+    static_assert(std::same_as<rect_intersector_t,
+                               ray_intersector<rectangle2D, test_algebra_t,
+                                               intersection::contains_pos>>,
+                  "Retrieved incorrect type after mapping (rectangle2D)");
+
+    static_assert(std::same_as<ring_intersector_t,
+                               ray_intersector<ring2D, test_algebra_t,
+                                               intersection::contains_pos>>,
+                  "Retrieved incorrect type after mapping (ring2D)");
+
+    static_assert(std::same_as<trpz_intersector_t,
+                               ray_intersector<trapezoid2D, test_algebra_t,
+                                               intersection::contains_pos>>,
+                  "Retrieved incorrect type after mapping (trapezoid2D)");
+
+    // Check the indices of the mapped types
+    static_assert(types::position<mapped_registry_t, rect_intersector_t> == 0u);
+    static_assert(types::position<mapped_registry_t, trpz_intersector_t> == 0u);
+    static_assert(types::position<mapped_registry_t, cyl_intersector_t> == 1u);
+    static_assert(types::position<mapped_registry_t, ring_intersector_t> == 2u);
+
+    //
+    // Test the registry
+    //
+
+    // Get ID from the original types
+    static_assert(
+        types::id<mapped_registry_t, cylinder_t> == mask_id::e_cylinder2,
+        "ID for type cylinder intersector incorrect");
+    static_assert(
+        types::id<mapped_registry_t, rectangle_t> == mask_id::e_rectangle2,
+        "ID for type rectangle intersector incorrect");
+    static_assert(
+        types::id<mapped_registry_t, disc_t> == mask_id::e_portal_ring2,
+        "ID for type ring intersector incorrect");
+    static_assert(
+        types::id<mapped_registry_t, trapezoid_t> == mask_id::e_trapezoid2,
+        "ID for type trapezoid intersector incorrect");
+
+    // contains
+    static_assert(types::contains<mapped_registry_t, cyl_intersector_t>,
+                  "'contains' failed for cylinder intersector type");
+    static_assert(types::contains<mapped_registry_t, rect_intersector_t>,
+                  "'contains' failed for rectangle intersector type");
+    static_assert(types::contains<mapped_registry_t, ring_intersector_t>,
+                  "'contains' failed for ring intersector type");
+    static_assert(types::contains<mapped_registry_t, trpz_intersector_t>,
+                  "'contains' failed for trapezoid intersector type");
+
+    static_assert(!types::contains<mapped_registry_t, char>,
+                  "'contains' failed for 'char' type");
+    static_assert(!types::contains<mapped_registry_t, void>,
+                  "'contains' failed for 'void' type");
+
+    // Is valid
+    static_assert(mapped_registry_t::is_valid(mask_id::e_cylinder2),
+                  "ID for cylinder intersector invalid");
+    static_assert(mapped_registry_t::is_valid(mask_id::e_rectangle2),
+                  "ID for rectangle intersector invalid");
+    static_assert(mapped_registry_t::is_valid(mask_id::e_portal_ring2),
+                  "ID for ring intersector invalid");
+    static_assert(mapped_registry_t::is_valid(mask_id::e_trapezoid2),
+                  "ID for trapezoid intersector invalid");
+    assert(!mapped_registry_t::is_valid(5u) && "ID '5' not invalid");
+
+    // Get type
+    static_assert(
+        std::same_as<cyl_intersector_t,
+                     types::get<mapped_registry_t, mask_id::e_cylinder2>>,
+        "Got incorrect type for 'e_cylinder2'");
+    static_assert(
+        std::same_as<rect_intersector_t,
+                     types::get<mapped_registry_t, mask_id::e_rectangle2>>,
+        "Got incorrect type for 'e_rectangle2'");
+    static_assert(
+        std::same_as<ring_intersector_t,
+                     types::get<mapped_registry_t, mask_id::e_portal_ring2>>,
+        "Got incorrect type for 'e_portal_ring2'");
+    static_assert(
+        std::same_as<trpz_intersector_t,
+                     types::get<mapped_registry_t, mask_id::e_trapezoid2>>,
+        "Got incorrect type for 'e_trapezoid2'");
+}

--- a/tests/unit_tests/cpu/CMakeLists.txt
+++ b/tests/unit_tests/cpu/CMakeLists.txt
@@ -15,6 +15,7 @@ detray_add_unit_test(cpu
    "utils/ranges.cpp"
    "utils/tuple_helpers.cpp"
    "utils/type_list.cpp"
+   "utils/type_registry.cpp"
    "utils/sort.cpp"
    LINK_LIBRARIES GTest::gtest GTest::gtest_main detray::test_utils detray::core
 )

--- a/tests/unit_tests/cpu/core/containers.cpp
+++ b/tests/unit_tests/cpu/core/containers.cpp
@@ -111,9 +111,17 @@ GTEST_TEST(detray_core, tuple_container) {
 
 GTEST_TEST(detray_core, vector_multi_store) {
 
+    enum class type_ids : std::uint_least8_t {
+        e_size = 0u,
+        e_float = 1u,
+        e_double = 2u,
+    };
+
+    using enum type_ids;
+
     using container_t =
-        regular_multi_store<std::size_t, empty_context, std::tuple,
-                            vecmem::vector, std::size_t, float, double>;
+        regular_multi_store<type_ids, empty_context, std::tuple, vecmem::vector,
+                            std::size_t, float, double>;
 
     // Vecmem memory resource
     vecmem::host_memory_resource resource;
@@ -123,27 +131,27 @@ GTEST_TEST(detray_core, vector_multi_store) {
 
     // Base container function check
     EXPECT_EQ(vector_store.n_collections(), 3u);
-    EXPECT_EQ(vector_store.empty<0>(), true);
-    EXPECT_EQ(vector_store.empty<1>(), true);
-    EXPECT_EQ(vector_store.empty<2>(), true);
-    EXPECT_EQ(vector_store.size<0>(), 0u);
-    EXPECT_EQ(vector_store.size<1>(), 0u);
-    EXPECT_EQ(vector_store.size<2>(), 0u);
+    EXPECT_EQ(vector_store.empty<e_size>(), true);
+    EXPECT_EQ(vector_store.empty<e_float>(), true);
+    EXPECT_EQ(vector_store.empty<e_double>(), true);
+    EXPECT_EQ(vector_store.size<e_size>(), 0u);
+    EXPECT_EQ(vector_store.size<e_float>(), 0u);
+    EXPECT_EQ(vector_store.size<e_double>(), 0u);
 
     // Add elements to the container
-    vector_store.push_back<0>(1u);
-    vector_store.emplace_back<0>(empty_context{}, 2u);
-    vector_store.push_back<1>(3.1f);
-    vector_store.emplace_back<1>(empty_context{}, 4.5f);
-    vector_store.push_back<2>(5.5);
-    vector_store.emplace_back<2>(empty_context{}, 6.f);
+    vector_store.push_back<e_size>(1u);
+    vector_store.emplace_back<e_size>(empty_context{}, 2u);
+    vector_store.push_back<e_float>(3.1f);
+    vector_store.emplace_back<e_float>(empty_context{}, 4.5f);
+    vector_store.push_back<e_double>(5.5);
+    vector_store.emplace_back<e_double>(empty_context{}, 6.f);
 
-    EXPECT_EQ(vector_store.empty<0>(), false);
-    EXPECT_EQ(vector_store.empty<1>(), false);
-    EXPECT_EQ(vector_store.empty<2>(), false);
-    EXPECT_EQ(vector_store.size<0>(), 2u);
-    EXPECT_EQ(vector_store.size<1>(), 2u);
-    EXPECT_EQ(vector_store.size<2>(), 2u);
+    EXPECT_EQ(vector_store.empty<e_size>(), false);
+    EXPECT_EQ(vector_store.empty<e_float>(), false);
+    EXPECT_EQ(vector_store.empty<e_double>(), false);
+    EXPECT_EQ(vector_store.size<e_size>(), 2u);
+    EXPECT_EQ(vector_store.size<e_float>(), 2u);
+    EXPECT_EQ(vector_store.size<e_double>(), 2u);
 
     vecmem::vector<std::size_t> int_vec{3u, 4u, 5u};
     vector_store.insert(int_vec);
@@ -154,30 +162,30 @@ GTEST_TEST(detray_core, vector_multi_store) {
     vector_store.insert(vecmem::vector<double>{10.5, 7.6});
 
     // int collectiont
-    EXPECT_EQ(vector_store.size<0>(), 5u);
-    EXPECT_EQ(vector_store.get<0>()[0], 1u);
-    EXPECT_EQ(vector_store.get<0>()[1], 2u);
-    EXPECT_EQ(vector_store.get<0>()[2], 3u);
-    EXPECT_EQ(vector_store.get<0>()[3], 4u);
-    EXPECT_EQ(vector_store.get<0>()[4], 5u);
+    EXPECT_EQ(vector_store.size<e_size>(), 5u);
+    EXPECT_EQ(vector_store.get<e_size>()[0], 1u);
+    EXPECT_EQ(vector_store.get<e_size>()[1], 2u);
+    EXPECT_EQ(vector_store.get<e_size>()[2], 3u);
+    EXPECT_EQ(vector_store.get<e_size>()[3], 4u);
+    EXPECT_EQ(vector_store.get<e_size>()[4], 5u);
 
     // float collectiont
-    EXPECT_EQ(vector_store.size<1>(), 3u);
-    EXPECT_NEAR(vector_store.get<1>()[0], 3.1f, tol_single);
-    EXPECT_NEAR(vector_store.get<1>()[1], 4.5f, tol_single);
-    EXPECT_NEAR(vector_store.get<1>()[2], 12.1f, tol_single);
+    EXPECT_EQ(vector_store.size<e_float>(), 3u);
+    EXPECT_NEAR(vector_store.get<e_float>()[0], 3.1f, tol_single);
+    EXPECT_NEAR(vector_store.get<e_float>()[1], 4.5f, tol_single);
+    EXPECT_NEAR(vector_store.get<e_float>()[2], 12.1f, tol_single);
 
     // double collectiont
-    EXPECT_EQ(vector_store.size<2>(), 4u);
-    EXPECT_NEAR(vector_store.get<2>()[0], 5.5, tol_double);
-    EXPECT_NEAR(vector_store.get<2>()[1], 6., tol_double);
-    EXPECT_NEAR(vector_store.get<2>()[2], 10.5, tol_double);
-    EXPECT_NEAR(vector_store.get<2>()[3], 7.6, tol_double);
+    EXPECT_EQ(vector_store.size<e_double>(), 4u);
+    EXPECT_NEAR(vector_store.get<e_double>()[0], 5.5, tol_double);
+    EXPECT_NEAR(vector_store.get<e_double>()[1], 6., tol_double);
+    EXPECT_NEAR(vector_store.get<e_double>()[2], 10.5, tol_double);
+    EXPECT_NEAR(vector_store.get<e_double>()[3], 7.6, tol_double);
 
     // call functor
-    container_t::single_link l0{0u, 0u};
-    container_t::single_link l1{1u, 0u};
-    container_t::single_link l2{2u, 0u};
+    container_t::single_link l0{e_size, 0u};
+    container_t::single_link l1{e_float, 0u};
+    container_t::single_link l2{e_double, 0u};
     EXPECT_EQ(vector_store.visit<test_func>(l0), 5u);
     EXPECT_EQ(vector_store.visit<test_func>(l1), 3u);
     EXPECT_EQ(vector_store.visit<test_func>(l2), 4u);

--- a/tests/unit_tests/cpu/utils/type_list.cpp
+++ b/tests/unit_tests/cpu/utils/type_list.cpp
@@ -19,6 +19,31 @@ GTEST_TEST(detray_utils, type_list) {
     using namespace detray;
 
     using list = types::list<float, int, double>;
+    static_assert(types::contains<list, float>,
+                  "List should contain type 'float'");
+    static_assert(types::position<list, float> == 0u,
+                  "Wrong position for type 'float'");
+
+    static_assert(types::contains<list, int>, "List should contain type 'int'");
+    static_assert(types::position<list, int> == 1u,
+                  "Wrong position for type 'int'");
+
+    static_assert(types::contains<list, double>,
+                  "List should contain type 'double'");
+    static_assert(types::position<list, double> == 2u,
+                  "Wrong position for type 'double'");
+
+    static_assert(!types::contains<list, char>,
+                  "List should not contain type 'char'");
+    static_assert(
+        types::position<list, char> == std::numeric_limits<std::size_t>::max(),
+        "Wrong position for type 'char'");
+
+    static_assert(!types::contains<list, bool>,
+                  "List should not contain type 'bool'");
+    static_assert(
+        types::position<list, bool> == std::numeric_limits<std::size_t>::max(),
+        "Wrong position for type 'bool'");
 
     static_assert(std::is_same_v<types::front<list>, float>,
                   "Could not access type list front");

--- a/tests/unit_tests/cpu/utils/type_registry.cpp
+++ b/tests/unit_tests/cpu/utils/type_registry.cpp
@@ -1,0 +1,151 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Project include(s).
+#include "detray/utils/type_registry.hpp"
+
+// Google Test include(s).
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <cstdint>
+#include <type_traits>
+
+// Test IDs
+enum class test_ids : std::uint_least8_t {
+    e_int = 0u,
+    e_double = 1u,
+    e_float1 = 2u,
+    e_float2 = 3u,
+};
+
+// Test type registry implementation
+GTEST_TEST(detray_utils, type_registry) {
+    using namespace detray;
+    using enum test_ids;
+
+    constexpr auto int_idx{static_cast<std::size_t>(e_int)};
+    constexpr auto double_idx{static_cast<std::size_t>(e_double)};
+    constexpr auto float1_idx{static_cast<std::size_t>(e_float1)};
+    constexpr auto float2_idx{static_cast<std::size_t>(e_float2)};
+
+    using type_registry_t =
+        types::registry<test_ids, int, double, float, float>;
+
+    static_assert(type_registry_t::n_types == 4u,
+                  "Incorrect number of types in registry");
+    static_assert(types::size<type_registry_t> == 4u,
+                  "Incorrect number of types in registry");
+
+    // contains
+    static_assert(types::contains<type_registry_t, int>,
+                  "'contains' failed for 'int' type");
+    static_assert(types::contains<type_registry_t, double>,
+                  "'contains' failed for 'double' type");
+    static_assert(types::contains<type_registry_t, float>,
+                  "'contains' failed for 'float' type");
+
+    static_assert(!types::contains<type_registry_t, char>,
+                  "'contains' failed for 'char' type");
+    static_assert(!types::contains<type_registry_t, void>,
+                  "'contains' failed for 'void' type");
+
+    // Is valid
+    static_assert(type_registry_t::is_valid(int_idx),
+                  "Index for 'int' invalid");
+    static_assert(type_registry_t::is_valid(double_idx),
+                  "Index for 'double' invalid");
+    static_assert(type_registry_t::is_valid(float1_idx),
+                  "Index for 'float 1' invalid");
+    static_assert(type_registry_t::is_valid(float2_idx),
+                  "Index for 'float 2' invalid");
+    static_assert(!type_registry_t::is_valid(5u), "ID '5' not invalid");
+
+    static_assert(type_registry_t::is_valid(e_int), "ID for 'int' invalid");
+    static_assert(type_registry_t::is_valid(e_double),
+                  "ID for 'double' invalid");
+    static_assert(type_registry_t::is_valid(e_float1),
+                  "ID for 'float 1' invalid");
+    static_assert(type_registry_t::is_valid(e_float2),
+                  "ID for 'float 2' invalid");
+    static_assert(!type_registry_t::is_valid(5u), "ID '5' not invalid");
+
+    // Get index (position)
+    static_assert(types::position<type_registry_t, int> == int_idx,
+                  "Position for type 'int' incorrect");
+    static_assert(types::position<type_registry_t, double> == double_idx,
+                  "Position for type 'double' incorrect");
+    static_assert(types::position<type_registry_t, float> == float1_idx,
+                  "Position for type 'float' incorrect");
+
+    // Get ID
+    static_assert(types::id<type_registry_t, int> == e_int,
+                  "ID for type 'int' incorrect");
+    static_assert(types::id<type_registry_t, double> == e_double,
+                  "ID for type 'double' incorrect");
+    static_assert(types::id<type_registry_t, float> == e_float1,
+                  "ID for type 'float' incorrect");
+
+    // Get type at position
+    static_assert(std::same_as<int, types::at<type_registry_t, int_idx>>,
+                  "Got incorrect type at position 0");
+    static_assert(std::same_as<double, types::at<type_registry_t, double_idx>>,
+                  "Got incorrect type at position 1");
+    static_assert(std::same_as<float, types::at<type_registry_t, float1_idx>>,
+                  "Got incorrect type at position 2");
+    static_assert(std::same_as<float, types::at<type_registry_t, float2_idx>>,
+                  "Got incorrect type at position 3");
+
+    // Get type from ID
+    static_assert(std::same_as<int, types::get<type_registry_t, e_int>>,
+                  "Got incorrect type for 'e_int'");
+    static_assert(std::same_as<double, types::get<type_registry_t, e_double>>,
+                  "Got incorrect type for 'e_double'");
+    static_assert(std::same_as<float, types::get<type_registry_t, e_float1>>,
+                  "Got incorrect type for 'e_float1'");
+    static_assert(std::same_as<float, types::get<type_registry_t, e_float2>>,
+                  "Got incorrect type for 'e_float2'");
+}
+
+namespace detray::test {
+
+struct visitor {
+
+    double operator()(const int &, int arg1, double arg2) const {
+        return static_cast<double>(arg1) + arg2;
+    }
+
+    double operator()(const double &, int arg1, double arg2) const {
+        return static_cast<double>(arg1) * arg2;
+    }
+
+    double operator()(const float &, int arg1, double arg2) const {
+        return static_cast<double>(arg1) / arg2;
+    }
+};
+
+}  // namespace detray::test
+
+// Test the type registry visitor
+GTEST_TEST(detray_utils, visit_type_registry) {
+    using namespace detray;
+
+    using type_registry_t =
+        types::registry<test_ids, int, double, float, float>;
+
+    double result = types::visit<type_registry_t, test::visitor>(0u, 2, 3.f);
+    ASSERT_EQ(result, 5.);
+
+    result = types::visit<type_registry_t, test::visitor>(1u, 2, 3.f);
+    ASSERT_EQ(result, 6.);
+
+    result = types::visit<type_registry_t, test::visitor>(2u, 2, 3.f);
+    ASSERT_EQ(result, 2. / 3.);
+
+    result = types::visit<type_registry_t, test::visitor>(3u, 2, 3.f);
+    ASSERT_EQ(result, 2. / 3.);
+}

--- a/tests/unit_tests/device/cuda/container_cuda.cpp
+++ b/tests/unit_tests/device/cuda/container_cuda.cpp
@@ -168,6 +168,8 @@ TEST(container_cuda, tuple_container) {
 /// Test the regular multi store functionality
 TEST(container_cuda, regular_multi_store) {
 
+    using enum reg_type_ids;
+
     // Vecmem memory resources
     vecmem::host_memory_resource host_mr;
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -180,18 +182,18 @@ TEST(container_cuda, regular_multi_store) {
 
     // Base store function check
     EXPECT_EQ(mng_store.n_collections(), 3u);
-    EXPECT_EQ(mng_store.empty<0>(), true);
-    EXPECT_EQ(mng_store.empty<1>(), true);
-    EXPECT_EQ(mng_store.empty<2>(), true);
+    EXPECT_EQ(mng_store.empty<e_size>(), true);
+    EXPECT_EQ(mng_store.empty<e_float>(), true);
+    EXPECT_EQ(mng_store.empty<e_double>(), true);
 
     // Add elements to the store
     empty_context ctx{};
-    mng_store.emplace_back<0>(ctx, 1u);
-    mng_store.push_back<0>(2u, ctx);
-    mng_store.emplace_back<1>(ctx, 3.1f);
-    mng_store.push_back<1>(4.5f, ctx);
-    mng_store.emplace_back<2>(ctx, 5.5);
-    mng_store.push_back<2>(6.0, ctx);
+    mng_store.emplace_back<e_size>(ctx, 1u);
+    mng_store.push_back<e_size>(2u, ctx);
+    mng_store.emplace_back<e_float>(ctx, 3.1f);
+    mng_store.push_back<e_float>(4.5f, ctx);
+    mng_store.emplace_back<e_double>(ctx, 5.5);
+    mng_store.push_back<e_double>(6.0, ctx);
 
     vecmem::vector<std::size_t> int_vec{3u, 4u, 5u};
     mng_store.insert(int_vec);
@@ -203,20 +205,20 @@ TEST(container_cuda, regular_multi_store) {
 
     store.append(mng_store, ctx);
 
-    EXPECT_EQ(mng_store.size<0>(), 5u);
-    EXPECT_EQ(mng_store.size<1>(), 4u);
-    EXPECT_EQ(mng_store.size<2>(), 4u);
-    EXPECT_EQ(store.size<0>(), 5u);
-    EXPECT_EQ(store.size<1>(), 4u);
-    EXPECT_EQ(store.size<2>(), 4u);
+    EXPECT_EQ(mng_store.size<e_size>(), 5u);
+    EXPECT_EQ(mng_store.size<e_float>(), 4u);
+    EXPECT_EQ(mng_store.size<e_double>(), 4u);
+    EXPECT_EQ(store.size<e_size>(), 5u);
+    EXPECT_EQ(store.size<e_float>(), 4u);
+    EXPECT_EQ(store.size<e_double>(), 4u);
 
     // CPU sum check
-    double cpu_sum{std::accumulate(mng_store.get<0>().begin(),
-                                   mng_store.get<0>().end(), 0.)};
-    cpu_sum = std::accumulate(mng_store.get<1>().begin(),
-                              mng_store.get<1>().end(), cpu_sum);
-    cpu_sum = std::accumulate(mng_store.get<2>().begin(),
-                              mng_store.get<2>().end(), cpu_sum);
+    double cpu_sum{std::accumulate(mng_store.get<e_size>().begin(),
+                                   mng_store.get<e_size>().end(), 0.)};
+    cpu_sum = std::accumulate(mng_store.get<e_float>().begin(),
+                              mng_store.get<e_float>().end(), cpu_sum);
+    cpu_sum = std::accumulate(mng_store.get<e_double>().begin(),
+                              mng_store.get<e_double>().end(), cpu_sum);
     EXPECT_NEAR(cpu_sum, 69.9, tol);
 
     // CUDA sum check
@@ -248,6 +250,8 @@ TEST(container_cuda, regular_multi_store) {
 /// Tets the multi store with a hierarchical memory type ( @c test<> )
 TEST(container_cuda, multi_store) {
 
+    using enum type_ids;
+
     // Vecmem memory resources
     vecmem::host_memory_resource host_mr;
     vecmem::cuda::managed_memory_resource mng_mr;
@@ -260,32 +264,35 @@ TEST(container_cuda, multi_store) {
 
     // Base store function check
     EXPECT_EQ(mng_store.n_collections(), 2u);
-    EXPECT_EQ(mng_store.empty<0>(), true);
+    EXPECT_EQ(mng_store.empty<e_float>(), true);
 
     // Add elements to the store
     vecmem::vector<float> float_vec{12.1f, 5.6f};
     mng_store.insert(float_vec);
 
-    mng_store.get<1>().first = vecmem::vector<int>{2, 3};
-    mng_store.get<1>().second = vecmem::vector<double>{18., 42.6};
+    mng_store.get<e_test_class>().first = vecmem::vector<int>{2, 3};
+    mng_store.get<e_test_class>().second = vecmem::vector<double>{18., 42.6};
 
-    std::ranges::copy(mng_store.get<0>(), std::back_inserter(store.get<0>()));
-    store.get<1>() = mng_store.get<1>();
+    std::ranges::copy(mng_store.get<e_float>(),
+                      std::back_inserter(store.get<e_float>()));
+    store.get<e_test_class>() = mng_store.get<e_test_class>();
 
-    EXPECT_EQ(mng_store.size<0>(), 2u);
-    EXPECT_EQ(mng_store.get<1>().first.size(), 2u);
-    EXPECT_EQ(mng_store.get<1>().second.size(), 2u);
-    EXPECT_EQ(store.size<0>(), 2u);
-    EXPECT_EQ(store.get<1>().first.size(), 2u);
-    EXPECT_EQ(store.get<1>().second.size(), 2u);
+    EXPECT_EQ(mng_store.size<e_float>(), 2u);
+    EXPECT_EQ(mng_store.get<e_test_class>().first.size(), 2u);
+    EXPECT_EQ(mng_store.get<e_test_class>().second.size(), 2u);
+    EXPECT_EQ(store.size<e_float>(), 2u);
+    EXPECT_EQ(store.get<e_test_class>().first.size(), 2u);
+    EXPECT_EQ(store.get<e_test_class>().second.size(), 2u);
 
     // CPU sum check
-    double cpu_sum{std::accumulate(mng_store.get<0>().begin(),
-                                   mng_store.get<0>().end(), 0.)};
-    cpu_sum = std::accumulate(mng_store.get<1>().first.begin(),
-                              mng_store.get<1>().first.end(), cpu_sum);
-    cpu_sum = std::accumulate(mng_store.get<1>().second.begin(),
-                              mng_store.get<1>().second.end(), cpu_sum);
+    double cpu_sum{std::accumulate(mng_store.get<e_float>().begin(),
+                                   mng_store.get<e_float>().end(), 0.)};
+    cpu_sum =
+        std::accumulate(mng_store.get<e_test_class>().first.begin(),
+                        mng_store.get<e_test_class>().first.end(), cpu_sum);
+    cpu_sum =
+        std::accumulate(mng_store.get<e_test_class>().second.begin(),
+                        mng_store.get<e_test_class>().second.end(), cpu_sum);
     EXPECT_NEAR(cpu_sum, 83.3, tol);
 
     // CUDA sum check

--- a/tests/unit_tests/device/cuda/container_cuda_kernel.cu
+++ b/tests/unit_tests/device/cuda/container_cuda_kernel.cu
@@ -46,12 +46,14 @@ __global__ void test_reg_multi_store_kernel(
     reg_multi_store_t::view_type store_view,
     vecmem::data::vector_view<double> sum_data) {
 
+    using enum reg_type_ids;
+
     reg_multi_store_dev_t store(store_view);
     vecmem::device_vector<double> sum(sum_data);
 
-    const auto& vec0 = store.get<0>();
-    const auto& vec1 = store.get<1>();
-    const auto& vec2 = store.get<2>();
+    const auto& vec0 = store.get<e_size>();
+    const auto& vec1 = store.get<e_float>();
+    const auto& vec2 = store.get<e_double>();
 
     for (const auto e : vec0) {
         sum[0] += e;
@@ -68,12 +70,14 @@ __global__ void test_multi_store_kernel(
     multi_store_t::view_type store_view,
     vecmem::data::vector_view<double> sum_data) {
 
+    using enum type_ids;
+
     multi_store_dev_t store(store_view);
     vecmem::device_vector<double> sum(sum_data);
 
-    const auto& vec0 = store.get<0>();
-    const auto& vec1 = store.get<1>().first;
-    const auto& vec2 = store.get<1>().second;
+    const auto& vec0 = store.get<e_float>();
+    const auto& vec1 = store.get<e_test_class>().first;
+    const auto& vec2 = store.get<e_test_class>().second;
 
     for (const auto e : vec0) {
         sum[0] += e;

--- a/tests/unit_tests/device/cuda/container_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/container_cuda_kernel.hpp
@@ -35,12 +35,18 @@ using tuple_cont_dev_t =
 
 // Regular multi store test (uses vectors as containers in every tuple element)
 /// @{
+enum class reg_type_ids : std::uint_least8_t {
+    e_size = 0u,
+    e_float = 1u,
+    e_double = 2u,
+};
+
 using reg_multi_store_t =
-    regular_multi_store<int, empty_context, dtuple, vecmem::vector, std::size_t,
-                        float, double>;
-using reg_multi_store_dev_t =
-    regular_multi_store<int, empty_context, dtuple, vecmem::device_vector,
+    regular_multi_store<reg_type_ids, empty_context, dtuple, vecmem::vector,
                         std::size_t, float, double>;
+using reg_multi_store_dev_t =
+    regular_multi_store<reg_type_ids, empty_context, dtuple,
+                        vecmem::device_vector, std::size_t, float, double>;
 /// @}
 
 /// Multi store test
@@ -48,8 +54,14 @@ using reg_multi_store_dev_t =
 
 /// Test type that holds vecemem members and forces a hierarchical view/buffer
 /// treatment
+
+enum class type_ids : std::uint_least8_t {
+    e_float = 0u,
+    e_test_class = 1u,
+};
+
 template <template <typename...> class vector_t = dvector>
-struct test {
+struct test_class {
 
     using view_type = dmulti_view<dvector_view<int>, dvector_view<double>>;
     using const_view_type =
@@ -57,11 +69,11 @@ struct test {
     using buffer_type =
         dmulti_buffer<dvector_buffer<int>, dvector_buffer<double>>;
 
-    DETRAY_HOST explicit test(vecmem::memory_resource* mr)
+    DETRAY_HOST explicit test_class(vecmem::memory_resource* mr)
         : first(mr), second(mr) {}
 
     template <concepts::device_view view_t>
-    DETRAY_HOST_DEVICE explicit test(view_t v)
+    DETRAY_HOST_DEVICE explicit test_class(view_t v)
         : first(detail::get<0>(v.m_view)), second(detail::get<1>(v.m_view)) {}
 
     DETRAY_HOST view_type get_data() {
@@ -72,11 +84,12 @@ struct test {
     vector_t<double> second;
 };
 
-using multi_store_t = multi_store<std::size_t, empty_context, dtuple,
-                                  vecmem::vector<float>, test<vecmem::vector>>;
+using multi_store_t =
+    multi_store<type_ids, empty_context, dtuple, vecmem::vector<float>,
+                test_class<vecmem::vector>>;
 using multi_store_dev_t =
-    multi_store<std::size_t, empty_context, dtuple,
-                vecmem::device_vector<float>, test<vecmem::device_vector>>;
+    multi_store<type_ids, empty_context, dtuple, vecmem::device_vector<float>,
+                test_class<vecmem::device_vector>>;
 /// @}
 
 void test_single_store(typename single_store_t::view_type store_view,

--- a/tests/unit_tests/device/cuda/detector_cuda_kernel.hpp
+++ b/tests/unit_tests/device/cuda/detector_cuda_kernel.hpp
@@ -31,9 +31,9 @@ constexpr auto rectangle_id = mask_defs::id::e_rectangle2;
 constexpr auto disc_id = mask_defs::id::e_portal_ring2;
 constexpr auto cylinder_id = mask_defs::id::e_portal_cylinder2;
 
-using rectangle_t = typename mask_defs::template get_type<rectangle_id>::type;
-using disc_t = typename mask_defs::template get_type<disc_id>::type;
-using cylinder_t = typename mask_defs::template get_type<cylinder_id>::type;
+using rectangle_t = types::get<mask_defs, rectangle_id>;
+using disc_t = types::get<mask_defs, disc_id>;
+using cylinder_t = types::get<mask_defs, cylinder_id>;
 
 /// declaration of a test function for detector
 void detector_test(typename detector_host_t::view_type det_data,

--- a/tests/unit_tests/device/hip/detector_hip_kernel.hpp
+++ b/tests/unit_tests/device/hip/detector_hip_kernel.hpp
@@ -31,9 +31,9 @@ constexpr auto rectangle_id = mask_defs::id::e_rectangle2;
 constexpr auto disc_id = mask_defs::id::e_portal_ring2;
 constexpr auto cylinder_id = mask_defs::id::e_portal_cylinder2;
 
-using rectangle_t = typename mask_defs::template get_type<rectangle_id>::type;
-using disc_t = typename mask_defs::template get_type<disc_id>::type;
-using cylinder_t = typename mask_defs::template get_type<cylinder_id>::type;
+using rectangle_t = types::get<mask_defs, rectangle_id>;
+using disc_t = types::get<mask_defs, disc_id>;
+using cylinder_t = types::get<mask_defs, cylinder_id>;
 
 /// declaration of a test function for detector
 void detector_test(typename detector_host_t::view_type det_data,

--- a/tutorials/include/detray/tutorial/detector_metadata.hpp
+++ b/tutorials/include/detray/tutorial/detector_metadata.hpp
@@ -244,8 +244,8 @@ namespace detail {
 /// During the IO, check for a 2D square shape
 /*template <typename detector_t>
 struct mask_info<io::shape_id::square2, detector_t>
-    requires detector_t::masks::template is_defined<
-                                      detray::tutorial::square>()> {
+    requires types::contains<typename detector_t::masks,
+                                      detray::tutorial::square>> {
     using type = detray::tutorial::square::shape;
     // This mask id is defined in the metadat down below and determines the
     // position of the collection of square in the detector mask tuple (store)


### PR DESCRIPTION
Map type registries to each other (e.g. shapes to frames). This way, the number of branches compiled due to different shapes in the geometry will be reduced. Instead of calling the intersector code per shape, we can then call it per local geometry (i.e. planar vs cylindrical). Similarly for the Jacobian transport.