### PR TITLE
ref: Set the default scalar type to float

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following cmake options are available and can also be specified explicitly f
 | DETRAY_BUILD_BENCHMARKS  | Build the detray benchmarks | OFF |
 | DETRAY_BUILD_CLI_TOOLS  | Build the detray command line tools | OFF |
 | DETRAY_BUILD_TUTORIALS  | Build the examples of detray | OFF |
-| DETRAY_CUSTOM_SCALARTYPE | Floating point precision | double |
+| DETRAY_CUSTOM_SCALARTYPE | Floating point precision | float |
 | DETRAY_EIGEN_PLUGIN | Build Eigen math plugin | OFF |
 | DETRAY_SMATRIX_PLUGIN | Build ROOT/SMatrix math plugin | OFF |
 | DETRAY_VC_AOS_PLUGIN | Build Vc based AoS math plugin | OFF |

--- a/plugins/algebra/CMakeLists.txt
+++ b/plugins/algebra/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Temporary setting for the scalar type, until it can be removed.
 set(DETRAY_CUSTOM_SCALARTYPE
-    "double"
+    "float"
     CACHE STRING
     "Scalar type to use in the Detray code"
 )


### PR DESCRIPTION
The biggest focus in conjunction with GPUs is single precision computation, so set the default scalar type to `float`