### PR TITLE
fix: Run the tolerance estimation from the beginning

### DIFF
--- a/core/include/detray/navigation/navigator.hpp
+++ b/core/include/detray/navigation/navigator.hpp
@@ -884,7 +884,8 @@ class navigator {
         }
         // If no trust could be restored for the current state, (local)
         // navigation might be exhausted: re-initialize volume
-        else {
+        if (navigation.trust_level() != navigation::trust_level::e_full ||
+            navigation.is_exhausted()) {
             DETRAY_VERBOSE_HOST_DEVICE(
                 "Full trust could not be restored! RESCURE MODE: Run init with "
                 "large tolerances");

--- a/core/include/detray/propagator/actors/parameter_resetter.hpp
+++ b/core/include/detray/propagator/actors/parameter_resetter.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,8 @@
 #include "detray/definitions/track_parametrization.hpp"
 #include "detray/propagator/base_actor.hpp"
 #include "detray/propagator/detail/jacobian_engine.hpp"
+#include "detray/propagator/detail/noise_estimation.hpp"
+#include "detray/propagator/propagation_config.hpp"
 #include "detray/utils/log.hpp"
 
 namespace detray {
@@ -21,6 +23,18 @@ template <concepts::algebra algebra_t>
 struct parameter_resetter : actor {
 
     struct state {
+
+        /// Default construction
+        state() = default;
+
+        /// Build from propagation configuration set by the user
+        DETRAY_HOST_DEVICE
+        explicit constexpr state(const propagation::config& cfg)
+            : accumulated_error{cfg.navigation.accumulated_error},
+              n_stddev{cfg.navigation.n_scattering_stddev},
+              estimate_scattering_noise{
+                  cfg.navigation.estimate_scattering_noise} {}
+
         /// Percentage of total track path to assume as accumulated error
         float accumulated_error{0.001f};
         /// Number of standard deviations to assume to model the scattering
@@ -58,84 +72,11 @@ struct parameter_resetter : actor {
 
         // Track pos/dir is not known precisely: adjust navigation tolerances
         if (resetter_state.estimate_scattering_noise) {
-            estimate_external_mask_tolerance(
+            detail::estimate_external_mask_tolerance(
                 bound_params, propagation,
                 static_cast<scalar_t>(resetter_state.n_stddev),
                 resetter_state.accumulated_error);
         }
-    }
-
-    private:
-    /// Estimate the mask tolerance that is needed for the navigation to include
-    /// the next surface from the current covariance
-    template <typename propagator_state_t>
-    DETRAY_HOST_DEVICE constexpr void estimate_external_mask_tolerance(
-        const bound_track_parameters<algebra_t>& bound_params,
-        propagator_state_t& propagation, const dscalar<algebra_t> n_stddev,
-        const dscalar<algebra_t> accumulated_error = 0.f) const {
-
-        using scalar_t = dscalar<algebra_t>;
-
-        auto& navigation = propagation._navigation;
-        auto& stepping = propagation._stepping;
-
-        // Set the noise to be expected by the navigator after all of the actors
-        // are done and the covariance is up to date
-
-        // Positional error on the current surface as an estimate of the error
-        // on the next surface
-        const auto& cov = bound_params.covariance();
-
-        const scalar_t var_loc0{
-            getter::element(cov, e_bound_loc0, e_bound_loc0)};
-        const scalar_t var_loc1{
-            getter::element(cov, e_bound_loc1, e_bound_loc1)};
-
-        // Rough estimation of the track displacement at the next surface
-        const scalar_t delta_phi{
-            n_stddev *
-            math::sqrt(getter::element(cov, e_bound_phi, e_bound_phi))};
-        const scalar_t delta_theta{
-            n_stddev *
-            math::sqrt(getter::element(cov, e_bound_theta, e_bound_theta))};
-
-        // Calculate the difference in cartesian coordinates, as the conversion
-        // uses less trigonometric functions than calculating the distance in
-        // spherical coordinates
-        const scalar_t phi_err{bound_params.phi() + delta_phi};
-        const scalar_t theta_err{bound_params.theta() + delta_theta};
-        const scalar_t sin_theta_err{math::sin(theta_err)};
-
-        dvector3D<algebra_t> displ{math::cos(phi_err) * sin_theta_err,
-                                   math::sin(phi_err) * sin_theta_err,
-                                   math::cos(theta_err)};
-
-        // Guess the portal envelope distance if there is no next target
-        const scalar_t path{
-            navigation.is_exhausted()
-                ? 5.f * unit<scalar_t>::mm
-                : math::fabs(std::as_const(navigation).target().path())};
-
-        displ = path * (displ - stepping().dir());
-
-        // Parametrized noise component that scales with the path length
-        // Accounts for material/interaction mismodelling
-        const scalar_t q{stepping.particle_hypothesis().charge()};
-        const scalar_t accumulated_noise{1.f * unit<scalar_t>::GeV /
-                                         stepping().p(q) * accumulated_error *
-                                         stepping.path_length()};
-
-        navigation.set_external_tol(math::sqrt(
-            n_stddev * n_stddev * (var_loc0 + var_loc1) +
-            vector::dot(displ, displ) + accumulated_noise * accumulated_noise));
-
-        // Clip to 5mm if the covariances are very large
-        constexpr auto max_tol{5.f * unit<scalar_t>::mm};
-        navigation.set_external_tol(navigation.external_tol() > max_tol
-                                        ? max_tol
-                                        : navigation.external_tol());
-
-        assert(std::isfinite(navigation.external_tol()));
     }
 };
 

--- a/core/include/detray/propagator/actors/parameter_transporter.hpp
+++ b/core/include/detray/propagator/actors/parameter_transporter.hpp
@@ -97,7 +97,7 @@ struct parameter_transporter : actor {
             return;
         }
         DETRAY_VERBOSE_HOST_DEVICE(
-            "Transort track parameters to current surface");
+            "Transport track parameters to current surface");
 
         // Geometry context for this track
         const auto& gctx = propagation._context;

--- a/core/include/detray/propagator/detail/noise_estimation.hpp
+++ b/core/include/detray/propagator/detail/noise_estimation.hpp
@@ -1,0 +1,111 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/algebra.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/math.hpp"
+#include "detray/definitions/units.hpp"
+#include "detray/tracks/bound_track_parameters.hpp"
+#include "detray/utils/log.hpp"
+
+namespace detray::detail {
+
+/// Estimate the mask tolerance that is needed for the navigation to include
+/// the next surface from the current covariance
+template <concepts::algebra algebra_t, typename propagator_state_t>
+DETRAY_HOST_DEVICE constexpr void estimate_external_mask_tolerance(
+    const bound_track_parameters<algebra_t>& bound_params,
+    propagator_state_t& propagation, const dscalar<algebra_t> n_stddev,
+    const dscalar<algebra_t> accumulated_error = 0.f) {
+
+    DETRAY_VERBOSE_HOST_DEVICE("Estimate noise due to scattering...");
+
+    using scalar_t = dscalar<algebra_t>;
+
+    auto& navigation = propagation._navigation;
+    auto& stepping = propagation._stepping;
+
+    DETRAY_VERBOSE_HOST_DEVICE(
+        "-> Is material surface: %s",
+        (navigation.encountered_sf_material() ? "yes" : "no"));
+
+    // Set the noise to be expected by the navigator after all of the actors
+    // are done and the covariance is up to date
+
+    // Positional error on the current surface as an estimate of the error
+    // on the next surface
+    const auto& cov = bound_params.covariance();
+
+    const scalar_t var_loc0{getter::element(cov, e_bound_loc0, e_bound_loc0)};
+    const scalar_t var_loc1{getter::element(cov, e_bound_loc1, e_bound_loc1)};
+
+    DETRAY_DEBUG_HOST_DEVICE("-> delta loc0: %f",
+                             n_stddev * math::sqrt(var_loc0));
+    DETRAY_DEBUG_HOST_DEVICE("-> delta loc1: %f",
+                             n_stddev * math::sqrt(var_loc1));
+
+    // Rough estimation of the track displacement at the next surface
+    const scalar_t delta_phi{
+        n_stddev * math::sqrt(getter::element(cov, e_bound_phi, e_bound_phi))};
+    const scalar_t delta_theta{
+        n_stddev *
+        math::sqrt(getter::element(cov, e_bound_theta, e_bound_theta))};
+
+    DETRAY_DEBUG_HOST_DEVICE("-> delta phi: %f", delta_phi);
+    DETRAY_DEBUG_HOST_DEVICE("-> delta theta: %f", delta_theta);
+
+    // Calculate the difference in cartesian coordinates, as the conversion
+    // uses less trigonometric functions than calculating the distance in
+    // spherical coordinates
+    const scalar_t phi_err{bound_params.phi() + delta_phi};
+    const scalar_t theta_err{bound_params.theta() + delta_theta};
+    const scalar_t sin_theta_err{math::sin(theta_err)};
+
+    dvector3D<algebra_t> displ{math::cos(phi_err) * sin_theta_err,
+                               math::sin(phi_err) * sin_theta_err,
+                               math::cos(theta_err)};
+
+    // Guess the portal envelope distance if there is no next target
+    const scalar_t path{
+        navigation.is_exhausted()
+            ? 5.f * unit<scalar_t>::mm
+            : math::fabs(std::as_const(navigation).target().path())};
+
+    displ = path * (displ - stepping().dir());
+
+    DETRAY_DEBUG_HOST_DEVICE("-> estimated displacement: %f",
+                             math::sqrt(vector::dot(displ, displ)));
+
+    // Parametrized noise component that scales with the path length
+    // Accounts for material/interaction mismodelling
+    const scalar_t q{stepping.particle_hypothesis().charge()};
+    const scalar_t accumulated_noise{1.f * unit<scalar_t>::GeV /
+                                     stepping().p(q) * accumulated_error *
+                                     stepping.path_length()};
+
+    DETRAY_DEBUG_HOST_DEVICE("-> accumulated noise: %f", accumulated_noise);
+
+    navigation.set_external_tol(math::sqrt(
+        n_stddev * n_stddev * (var_loc0 + var_loc1) +
+        vector::dot(displ, displ) + accumulated_noise * accumulated_noise));
+
+    // Clip to 5mm if the covariances are very large
+    constexpr auto max_tol{5.f * unit<scalar_t>::mm};
+    navigation.set_external_tol(navigation.external_tol() > max_tol
+                                    ? max_tol
+                                    : navigation.external_tol());
+
+    assert(std::isfinite(navigation.external_tol()));
+
+    DETRAY_DEBUG_HOST_DEVICE("=> scattering noise: %f",
+                             navigation.external_tol());
+}
+
+}  // namespace detray::detail

--- a/core/include/detray/propagator/detail/print_stepper_state.hpp
+++ b/core/include/detray/propagator/detail/print_stepper_state.hpp
@@ -76,11 +76,11 @@ DETRAY_HOST inline std::string print_state(const state_type &state,
     constexpr int cw{20};
 
     // Remove trailing newlines
-    debug_stream << std::left << std::setw(cw) << "Step size"
-                 << state.step_size() << std::endl;
-    debug_stream << std::setw(cw) << "no. RK adjustments" << n_trials
+    debug_stream << std::left << std::setw(cw)
+                 << "Step size: " << state.step_size() << std::endl;
+    debug_stream << std::setw(cw) << "no. RK adjustments: " << n_trials
                  << std::endl;
-    debug_stream << std::setw(cw) << "Step size scale factor" << step_scalor;
+    debug_stream << std::setw(cw) << "Step size scale factor: " << step_scalor;
 
     return debug_stream.str();
 }

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -16,6 +16,7 @@
 #include "detray/propagator/actor_chain.hpp"
 #include "detray/propagator/base_stepper.hpp"
 #include "detray/propagator/concepts.hpp"
+#include "detray/propagator/detail/noise_estimation.hpp"
 #include "detray/propagator/propagation_config.hpp"
 #include "detray/tracks/tracks.hpp"
 #include "detray/utils/log.hpp"
@@ -206,6 +207,14 @@ struct propagator {
 
         DETRAY_VERBOSE_HOST("Starting propagation for track:\n" << track);
 
+        // Open the navigation area according to uncertainties in initital track
+        // params
+        if (m_cfg.navigation.estimate_scattering_noise &&
+            !stepping.bound_params().is_invalid()) {
+            detail::estimate_external_mask_tolerance(stepping.bound_params(),
+                                                     propagation, 2u);
+        }
+
         // Initialize the navigation
         m_navigator.init(track, navigation, m_cfg.navigation, context);
         propagation._heartbeat = navigation.is_alive();
@@ -322,6 +331,14 @@ struct propagator {
         auto &context = propagation._context;
         const auto &track = stepping();
         assert(!track.is_invalid());
+
+        // Open the navigation area according to uncertainties in initital track
+        // params
+        if (m_cfg.navigation.estimate_scattering_noise &&
+            !stepping.bound_params().is_invalid()) {
+            detail::estimate_external_mask_tolerance(stepping.bound_params(),
+                                                     propagation, 2u);
+        }
 
         // Initialize the navigation
         m_navigator.init(track, navigation, m_cfg.navigation, context);

--- a/tests/benchmarks/cpu/propagation.cpp
+++ b/tests/benchmarks/cpu/propagation.cpp
@@ -75,6 +75,8 @@ int main(int argc, char** argv) {
     // Configure propagation
     propagation::config prop_cfg{};
     prop_cfg.navigation.search_window = {3u, 3u};
+    // No scattering in test tracks
+    prop_cfg.navigation.estimate_scattering_noise = false;
 
     std::clog << prop_cfg << std::endl;
 
@@ -113,9 +115,7 @@ int main(int argc, char** argv) {
     dtuple<> empty_state{};
 
     pointwise_material_interactor<bench_algebra>::state interactor_state{};
-    parameter_resetter<bench_algebra>::state resetter_state{};
-    // No scattering in test tracks
-    resetter_state.estimate_scattering_noise = false;
+    parameter_resetter<bench_algebra>::state resetter_state{prop_cfg};
 
     auto actor_states =
         detail::make_tuple<dtuple>(interactor_state, resetter_state);

--- a/tests/benchmarks/cuda/propagation.cpp
+++ b/tests/benchmarks/cuda/propagation.cpp
@@ -70,6 +70,8 @@ int main(int argc, char** argv) {
     // Configure propagation
     propagation::config prop_cfg{};
     prop_cfg.navigation.search_window = {3u, 3u};
+    // No scattering in test tracks
+    prop_cfg.navigation.estimate_scattering_noise = false;
 
     std::clog << prop_cfg << std::endl;
 
@@ -108,9 +110,7 @@ int main(int argc, char** argv) {
     dtuple<> empty_state{};
 
     pointwise_material_interactor<bench_algebra>::state interactor_state{};
-    parameter_resetter<bench_algebra>::state resetter_state{};
-    // No scattering in test tracks
-    resetter_state.estimate_scattering_noise = false;
+    parameter_resetter<bench_algebra>::state resetter_state{prop_cfg};
 
     auto actor_states =
         detail::make_tuple<dtuple>(interactor_state, resetter_state);

--- a/tests/include/detray/test/device/cuda/material_validation.cu
+++ b/tests/include/detray/test/device/cuda/material_validation.cu
@@ -64,8 +64,7 @@ __global__ void material_validation_kernel(
     typename pathlimit_aborter_t::state aborter_state{cfg.stepping.path_limit};
     typename pointwise_material_interactor<algebra_t>::state interactor_state{};
     typename material_tracer_t::state mat_tracer_state{mat_steps.at(trk_id)};
-    typename parameter_resetter<algebra_t>::state resetter_state{};
-    resetter_state.estimate_scattering_noise = false;
+    typename parameter_resetter<algebra_t>::state resetter_state{cfg};
 
     auto actor_states = ::detray::tie(aborter_state, interactor_state,
                                       mat_tracer_state, resetter_state);

--- a/tests/include/detray/test/device/propagator_test.hpp
+++ b/tests/include/detray/test/device/propagator_test.hpp
@@ -136,8 +136,7 @@ inline auto run_propagation_host(vecmem::memory_resource *mr,
         tracer_state.collect_only_on_surface(true);
         typename pathlimit_aborter_t::state pathlimit_state{
             cfg.stepping.path_limit};
-        parameter_resetter_t::state resetter_state{};
-        resetter_state.estimate_scattering_noise = false;
+        parameter_resetter_t::state resetter_state{cfg};
         pointwise_material_interactor<test_algebra>::state interactor_state{};
         auto actor_states = detray::tie(tracer_state, pathlimit_state,
                                         interactor_state, resetter_state);

--- a/tests/include/detray/test/utils/inspectors.hpp
+++ b/tests/include/detray/test/utils/inspectors.hpp
@@ -212,7 +212,9 @@ struct object_tracer {
             // Also log volume switches that happen without position update
             if ((vector::norm(last_pos - pos) >=
                  10.f * std::numeric_limits<scalar_t>::epsilon()) ||
-                (state.is_on_portal() && current_vol != state.volume())) {
+                (state.is_on_portal() && current_vol != state.volume()) ||
+                state.current().sf_desc.barcode() !=
+                    object_trace.back().intersection.sf_desc.barcode()) {
 
                 object_trace.push_back({pos, dir, state.current()});
                 last_pos = pos;

--- a/tests/include/detray/test/utils/perigee_stopper.hpp
+++ b/tests/include/detray/test/utils/perigee_stopper.hpp
@@ -74,6 +74,13 @@ struct perigee_stopper : actor {
             return;
         }
 
+        // At least the exit portal should be reachable
+        if (navigation.is_exhausted()) {
+            prop_state._heartbeat &=
+                navigation.abort("Pergigee stopper has no next candidate");
+            return;
+        }
+
         auto &stepping = prop_state._stepping;
         auto &track = stepping();
 

--- a/tests/include/detray/test/validation/material_validation_utils.hpp
+++ b/tests/include/detray/test/validation/material_validation_utils.hpp
@@ -256,9 +256,7 @@ inline auto record_material(
         cfg.stepping.path_limit};
     typename pointwise_material_interactor<algebra_t>::state interactor_state{};
     typename material_tracer_t::state mat_tracer_state{*host_mr};
-    typename parameter_resetter<algebra_t>::state resetter_state{};
-    // The truth track is not scattered, so the direction is known precisely
-    resetter_state.estimate_scattering_noise = false;
+    typename parameter_resetter<algebra_t>::state resetter_state{cfg};
 
     auto actor_states = detray::tie(pathlimit_aborter_state, interactor_state,
                                     mat_tracer_state, resetter_state);

--- a/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
@@ -81,6 +81,7 @@ int main(int argc, char **argv) {
     cfg_str_nav.n_tracks(cfg_ray_scan.track_generator().n_tracks());
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
+    cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_str_nav.propagation().navigation.min_mask_tolerance =
         static_cast<float>(mask_tolerance[0]);
     cfg_str_nav.propagation().navigation.max_mask_tolerance =
@@ -110,6 +111,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.name("telescope_detector_helix_navigation");
     cfg_hel_nav.n_tracks(cfg_hel_scan.track_generator().n_tracks());
     cfg_hel_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_hel_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_hel_nav.propagation().navigation.overstep_tolerance =
         -100.f * unit<float>::um;
 

--- a/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
@@ -75,6 +75,7 @@ int main(int argc, char **argv) {
     cfg_str_nav.name("toy_detector_straight_line_navigation");
     cfg_str_nav.n_tracks(cfg_ray_scan.track_generator().n_tracks());
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
     cfg_str_nav.propagation().navigation.min_mask_tolerance =
@@ -105,6 +106,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.name("toy_detector_helix_navigation");
     cfg_hel_nav.n_tracks(cfg_hel_scan.track_generator().n_tracks());
     cfg_hel_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_hel_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
 
     test::register_checks<test::helix_navigation>(

--- a/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
@@ -75,6 +75,7 @@ int main(int argc, char **argv) {
     cfg_str_nav.name("wire_chamber_straight_line_navigation");
     cfg_str_nav.n_tracks(cfg_ray_scan.track_generator().n_tracks());
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
     cfg_str_nav.propagation().navigation.min_mask_tolerance =
@@ -106,6 +107,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.name("wire_chamber_helix_navigation");
     cfg_hel_nav.n_tracks(cfg_hel_scan.track_generator().n_tracks());
     cfg_hel_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_hel_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_hel_nav.propagation().navigation.min_mask_tolerance *= 11.f;
     cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
 

--- a/tests/integration_tests/cpu/propagator/backward_propagation.cpp
+++ b/tests/integration_tests/cpu/propagator/backward_propagation.cpp
@@ -89,15 +89,15 @@ TEST_P(BackwardPropagation, backward_propagation) {
     const bound_track_parameters<test_algebra> bound_param0(
         det.surface(0u).barcode(), bound_vector, bound_cov);
 
-    // Actors
-    pointwise_material_interactor<test_algebra>::state interactor{};
-    parameter_resetter<test_algebra>::state resetter_state{};
-    resetter_state.estimate_scattering_noise = false;
-
     propagation::config prop_cfg{};
     prop_cfg.stepping.rk_error_tol = 1e-7f * unit<float>::mm;
     prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
+    prop_cfg.navigation.estimate_scattering_noise = false;
     propagator_t p{prop_cfg};
+
+    // Actors
+    pointwise_material_interactor<test_algebra>::state interactor{};
+    parameter_resetter<test_algebra>::state resetter_state{prop_cfg};
 
     // Forward state
     propagator_t::state fw_state(bound_param0, hom_bfield, det,

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -469,6 +469,7 @@ bound_getter<test_algebra>::state evaluate_bound_param(
     propagation::config cfg{};
     cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tolerance);
     cfg.navigation.path_tolerance = static_cast<float>(path_tolerance);
+    cfg.navigation.estimate_scattering_noise = false;
     cfg.stepping.rk_error_tol = static_cast<float>(rk_tolerance);
     cfg.stepping.use_eloss_gradient = true;
     cfg.stepping.use_field_gradient = use_field_gradient;
@@ -479,8 +480,7 @@ bound_getter<test_algebra>::state evaluate_bound_param(
     bound_getter<test_algebra>::state bound_getter_state{};
     bound_getter_state.track_ID = trk_count;
     bound_getter_state.m_min_path_length = detector_length * 0.75f;
-    parameter_resetter<test_algebra>::state resetter_state{};
-    resetter_state.estimate_scattering_noise = false;
+    parameter_resetter<test_algebra>::state resetter_state{cfg};
     auto actor_states = detray::tie(bound_getter_state, resetter_state);
 
     // Init propagator states for the reference track
@@ -511,6 +511,7 @@ bound_param_vector_type get_displaced_bound_vector(
     propagation::config cfg{};
     cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tolerance);
     cfg.navigation.path_tolerance = static_cast<float>(path_tolerance);
+    cfg.navigation.estimate_scattering_noise = false;
     cfg.stepping.rk_error_tol = static_cast<float>(rk_tolerance);
     cfg.stepping.do_covariance_transport = false;
 
@@ -526,8 +527,7 @@ bound_param_vector_type get_displaced_bound_vector(
     bound_getter<test_algebra>::state bound_getter_state{};
     bound_getter_state.track_ID = trk_count;
     bound_getter_state.m_min_path_length = detector_length * 0.75f;
-    parameter_resetter<test_algebra>::state resetter_state{};
-    resetter_state.estimate_scattering_noise = false;
+    parameter_resetter<test_algebra>::state resetter_state{cfg};
 
     auto actor_states = detray::tie(bound_getter_state, resetter_state);
     dstate.set_particle(ptc);

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -224,6 +224,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
     propagation::config cfg{};
     cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tol);
     cfg.navigation.search_window = {3u, 3u};
+    cfg.navigation.estimate_scattering_noise = false;
     propagator_t p{cfg};
 
     // Iterate through uniformly distributed momentum directions
@@ -337,6 +338,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
     propagation::config cfg{};
     cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tol);
     cfg.navigation.search_window = {3u, 3u};
+    cfg.navigation.estimate_scattering_noise = false;
     propagator_t p{cfg};
 
     // Iterate through uniformly distributed momentum directions
@@ -348,8 +350,7 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
         pathlimit_aborter<scalar>::state unlimted_aborter_state{};
         pathlimit_aborter<scalar>::state pathlimit_aborter_state{path_limit};
         pointwise_material_interactor<test_algebra>::state interactor_state{};
-        parameter_resetter<test_algebra>::state resetter_state{};
-        resetter_state.estimate_scattering_noise = false;
+        parameter_resetter<test_algebra>::state resetter_state{cfg};
 
         // Create actor states tuples
         auto actor_states = detray::tie(unlimted_aborter_state,
@@ -479,6 +480,7 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorToyDetector, direct_navigator) {
     cfg.navigation.overstep_tolerance =
         static_cast<float>(std::get<0>(GetParam()));
     cfg.navigation.search_window = {3u, 3u};
+    cfg.navigation.estimate_scattering_noise = false;
     propagation::config direct_cfg{};
     direct_cfg.navigation.min_mask_tolerance = 1.f * unit<float>::mm;
     direct_cfg.navigation.max_mask_tolerance = 1.f * unit<float>::mm;
@@ -491,8 +493,7 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorToyDetector, direct_navigator) {
 
         // Build actor states: the helix inspector can be shared
         pointwise_material_interactor<test_algebra>::state interactor_state{};
-        parameter_resetter<test_algebra>::state resetter_state{};
-        resetter_state.estimate_scattering_noise = false;
+        parameter_resetter<test_algebra>::state resetter_state{cfg};
         vecmem::data::vector_buffer<detray::geometry::barcode> seqs_buffer{
             100u, host_mr, vecmem::data::buffer_type::resizable};
         vecmem::data::vector_buffer<detray::geometry::barcode>
@@ -667,6 +668,7 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorWireChamber, direct_navigator) {
     cfg.navigation.overstep_tolerance =
         static_cast<float>(std::get<0>(GetParam()));
     cfg.navigation.search_window = {5u, 5u};
+    cfg.navigation.estimate_scattering_noise = false;
     propagation::config direct_cfg{};
     direct_cfg.navigation.min_mask_tolerance = 10.f * unit<float>::mm;
     direct_cfg.navigation.max_mask_tolerance = 10.f * unit<float>::mm;
@@ -679,8 +681,7 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorWireChamber, direct_navigator) {
 
         // Build actor states: the helix inspector can be shared
         pointwise_material_interactor<test_algebra>::state interactor_state{};
-        parameter_resetter<test_algebra>::state resetter_state{};
-        resetter_state.estimate_scattering_noise = false;
+        parameter_resetter<test_algebra>::state resetter_state{cfg};
         vecmem::data::vector_buffer<detray::geometry::barcode> seqs_buffer{
             100u, host_mr, vecmem::data::buffer_type::resizable};
         vecmem::data::vector_buffer<detray::geometry::barcode>

--- a/tests/integration_tests/device/cuda/propagator_cuda_kernel.cu
+++ b/tests/integration_tests/device/cuda/propagator_cuda_kernel.cu
@@ -52,9 +52,7 @@ __global__ void propagator_test_kernel(
     tracer_state.collect_only_on_surface(true);
     pathlimit_aborter_t::state aborter_state{cfg.stepping.path_limit};
     pointwise_material_interactor<test_algebra>::state interactor_state{};
-    parameter_resetter_t::state resetter_state{};
-    // No multilpe scattering simulated in this test
-    resetter_state.estimate_scattering_noise = false;
+    parameter_resetter_t::state resetter_state{cfg};
 
     // Create the actor states
     auto actor_states = ::detray::tie(tracer_state, aborter_state,

--- a/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
@@ -82,6 +82,7 @@ int main(int argc, char **argv) {
     cfg_str_nav.name("telescope_detector_straight_line_navigation_cuda");
     cfg_str_nav.n_tracks(cfg_ray_scan.track_generator().n_tracks());
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
     cfg_str_nav.propagation().navigation.min_mask_tolerance =
         static_cast<float>(mask_tolerance[0]);
@@ -112,6 +113,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.name("telescope_detector_helix_navigation_cuda");
     cfg_hel_nav.n_tracks(cfg_hel_scan.track_generator().n_tracks());
     cfg_hel_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_hel_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_hel_nav.propagation().navigation.overstep_tolerance =
         -100.f * unit<float>::um;
 

--- a/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
@@ -75,6 +75,7 @@ int main(int argc, char **argv) {
     cfg_str_nav.name("toy_detector_straight_line_navigation_cuda");
     cfg_str_nav.n_tracks(cfg_ray_scan.track_generator().n_tracks());
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
     cfg_str_nav.propagation().navigation.min_mask_tolerance =
@@ -110,6 +111,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.name("toy_detector_helix_navigation_cuda");
     cfg_hel_nav.n_tracks(cfg_hel_scan.track_generator().n_tracks());
     cfg_hel_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_hel_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
 
     test::register_checks<detray::cuda::helix_navigation>(

--- a/tests/integration_tests/device/cuda/wire_chamber_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/wire_chamber_navigation_validation.cpp
@@ -78,6 +78,7 @@ int main(int argc, char **argv) {
     cfg_str_nav.name("wire_chamber_straight_line_navigation_cuda");
     cfg_str_nav.n_tracks(cfg_ray_scan.track_generator().n_tracks());
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
     auto mask_tolerance = cfg_ray_scan.mask_tolerance();
     cfg_str_nav.propagation().navigation.min_mask_tolerance =
@@ -114,6 +115,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.name("wire_chamber_helix_navigation_cuda");
     cfg_hel_nav.n_tracks(cfg_hel_scan.track_generator().n_tracks());
     cfg_hel_nav.propagation().stepping.min_stepsize = min_stepsize;
+    cfg_hel_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_hel_nav.propagation().navigation.min_mask_tolerance *= 12.f;
     cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
 

--- a/tests/integration_tests/device/sycl/propagator_kernel.sycl
+++ b/tests/integration_tests/device/sycl/propagator_kernel.sycl
@@ -69,8 +69,7 @@ void propagator_test(
                     cfg.stepping.path_limit};
                 pointwise_material_interactor<test_algebra>::state
                     interactor_state{};
-                parameter_resetter_t::state resetter_state{};
-                resetter_state.estimate_scattering_noise = false;
+                parameter_resetter_t::state resetter_state{cfg};
 
                 // Create the actor states
                 auto actor_states =

--- a/tests/tools/python/options/propagation_options.py
+++ b/tests/tools/python/options/propagation_options.py
@@ -57,6 +57,27 @@ def propagation_options():
         default=[0, 0],
         type=int,
     )
+    parser.add_argument(
+        "--estimate_scattering_noise",
+        "-scatt",
+        help=("Open mask tol. die to scattering."),
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--n_scattering_stddev",
+        "-stddev",
+        help=("# standard deviations for scattering noise."),
+        default=2,
+        type=int,
+    )
+    parser.add_argument(
+        "--accumulated_error",
+        "-aerr",
+        help=("Positional error with path length [%]"),
+        default=0.0001,
+        type=float,
+    )
 
     # Parameter transport options
     parser.add_argument(

--- a/tests/tools/python/utils/io_utils.py
+++ b/tests/tools/python/utils/io_utils.py
@@ -153,3 +153,14 @@ def add_propagation_args(arg_list, parsed_args):
 
     if parsed_args.bfield_grad:
         arg_list.extend(["--bfield_gradient"])
+
+    if parsed_args.estimate_scattering_noise:
+        arg_list.extend(["--estimate_scattering_noise"])
+        arg_list.extend(
+            [
+                "--n_scattering_stddev",
+                str(parsed_args.n_scattering_stddev),
+                "--accumulated_error",
+                str(parsed_args.accumulated_error),
+            ]
+        )

--- a/tests/tools/src/cpu/propagation_benchmark.cpp
+++ b/tests/tools/src/cpu/propagation_benchmark.cpp
@@ -146,9 +146,7 @@ int main(int argc, char** argv) {
     dtuple<> empty_state{};
 
     pointwise_material_interactor<bench_algebra>::state interactor_state{};
-    parameter_resetter<bench_algebra>::state resetter_state{};
-    // No scattering in test tracks
-    resetter_state.estimate_scattering_noise = false;
+    parameter_resetter<bench_algebra>::state resetter_state{prop_cfg};
 
     auto actor_states =
         detail::make_tuple<dtuple>(interactor_state, resetter_state);

--- a/tests/tools/src/cpu/propagation_scaling.cpp
+++ b/tests/tools/src/cpu/propagation_scaling.cpp
@@ -174,9 +174,7 @@ int main(int argc, char** argv) {
     dtuple<> empty_state{};
 
     pointwise_material_interactor<bench_algebra>::state interactor_state{};
-    parameter_resetter<bench_algebra>::state resetter_state{};
-    // No scattering in test tracks
-    resetter_state.estimate_scattering_noise = false;
+    parameter_resetter<bench_algebra>::state resetter_state{prop_cfg};
 
     auto actor_states =
         detail::make_tuple<dtuple>(interactor_state, resetter_state);

--- a/tests/tools/src/cuda/propagation_benchmark_cuda.cpp
+++ b/tests/tools/src/cuda/propagation_benchmark_cuda.cpp
@@ -141,9 +141,7 @@ int main(int argc, char** argv) {
     dtuple<> empty_state{};
 
     pointwise_material_interactor<bench_algebra>::state interactor_state{};
-    parameter_resetter<bench_algebra>::state resetter_state{};
-    // No scattering in test tracks
-    resetter_state.estimate_scattering_noise = false;
+    parameter_resetter<bench_algebra>::state resetter_state{prop_cfg};
 
     auto actor_states =
         detail::make_tuple<dtuple>(interactor_state, resetter_state);

--- a/tests/tools/src/hip/propagation_benchmark_hip.cpp
+++ b/tests/tools/src/hip/propagation_benchmark_hip.cpp
@@ -141,9 +141,7 @@ int main(int argc, char** argv) {
     dtuple<> empty_state{};
 
     pointwise_material_interactor<bench_algebra>::state interactor_state{};
-    parameter_resetter<bench_algebra>::state resetter_state{};
-    // No scattering in test tracks
-    resetter_state.estimate_scattering_noise = false;
+    parameter_resetter<bench_algebra>::state resetter_state{prop_cfg};
 
     auto actor_states =
         detail::make_tuple<dtuple>(interactor_state, resetter_state);


### PR DESCRIPTION
A number of small fixes that appeared during traccc integration:
- estimate the noise due to scattering also for the first navigation, before the track parameter resetter runs for the first time
- reuse the magnetic field vector variable in the stepper
- add more assertions and logging to the RKN stepper
- add logging to the material interactions
- Allow to run an initialization with relaxed overstepping even after volume initialization in the navigator
- Allow the object tracer to record overlapping surfaces
- Catch the case in the perigee stopper where the exit portal is not caught and abort (needs a more permanent fix later)
- Pass the scattering noise estimation configuration through using the propagation config