### PR TITLE
fix: some propagation bugs

### DIFF
--- a/core/include/detray/builders/volume_builder.hpp
+++ b/core/include/detray/builders/volume_builder.hpp
@@ -107,6 +107,10 @@ class volume_builder : public volume_builder_interface<detector_t> {
 
         DETRAY_VERBOSE_HOST("Build surfaces...");
 
+        assert(!m_surfaces.empty());
+        assert(!m_transforms.empty());
+        assert(!m_masks.all_empty());
+
         // Prepare volume data
         m_volume.set_index(static_cast<dindex>(det.volumes().size()));
 

--- a/core/include/detray/geometry/surface.hpp
+++ b/core/include/detray/geometry/surface.hpp
@@ -148,12 +148,7 @@ class surface {
 
     /// @returns true if the surface carries material.
     DETRAY_HOST_DEVICE
-    constexpr auto has_material() const -> bool {
-        return m_desc.material().id() !=
-                   static_cast<typename descr_t::material_link::id_type>(
-                       detector_t::materials::id::e_none) &&
-               !m_desc.material().is_invalid();
-    }
+    constexpr bool has_material() const { return m_desc.has_material(); }
 
     /// @returns the mask volume link
     DETRAY_HOST_DEVICE

--- a/core/include/detray/geometry/surface_descriptor.hpp
+++ b/core/include/detray/geometry/surface_descriptor.hpp
@@ -149,6 +149,13 @@ class surface_descriptor {
         return m_material;
     }
 
+    /// @returns true if the surface descriptor has a valid material link
+    DETRAY_HOST_DEVICE
+    constexpr auto has_material() const -> bool {
+        return (m_material.id() != material_link::id_type::e_none) &&
+               !m_material.is_invalid();
+    }
+
     /// @returns true if the surface is a senstive detector module.
     DETRAY_HOST_DEVICE
     constexpr auto is_sensitive() const -> bool {

--- a/core/include/detray/geometry/volume_descriptor.hpp
+++ b/core/include/detray/geometry/volume_descriptor.hpp
@@ -235,6 +235,13 @@ class volume_descriptor {
                       static_cast<typename material_link::index_type>(mat_idx)};
     }
 
+    /// @returns true if the volume descriptor has a valid material link
+    DETRAY_HOST_DEVICE
+    constexpr auto has_material() const -> bool {
+        return (m_mat_link.id() != material_link::id_type::e_none) &&
+               !m_mat_link.is_invalid();
+    }
+
     /// @returns link to all acceleration data structures - const access
     DETRAY_HOST_DEVICE constexpr auto accel_link() const
         -> const accel_link_type& {

--- a/core/include/detray/navigation/policies.hpp
+++ b/core/include/detray/navigation/policies.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/algebra.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/math.hpp"
+#include "detray/definitions/units.hpp"
 #include "detray/propagator/base_actor.hpp"
 
 // system includes
@@ -114,7 +115,7 @@ struct stepper_rk_policy : actor {
         auto &navigation = propagation._navigation;
 
         // In case of an overlap, have navigator re-evaluate the next candidate
-        if (math::fabs(navigation()) <= 1e-5f) {
+        if (math::fabs(navigation()) <= 1.f * unit<float>::um) {
             navigation.set_high_trust();
             return;
         }

--- a/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
+++ b/core/include/detray/propagator/actors/pointwise_material_interactor.hpp
@@ -230,7 +230,7 @@ struct pointwise_material_interactor : actor {
         const scalar_type next_qop{(q != 0.f) ? q / next_p : 1.f / next_p};
         vector.set_qop((next_p == 0.f) ? inv : next_qop);
 
-        DETRAY_DEBUG_HOST_DEVICE("-> new abs. momentum: %f", next_qop);
+        DETRAY_DEBUG_HOST_DEVICE("-> new abs. momentum: %f", next_p);
 
         DETRAY_DEBUG_HOST_DEVICE("-> Update qop: before: %f, after: %f", q / p,
                                  vector.qop());

--- a/core/include/detray/propagator/detail/noise_estimation.hpp
+++ b/core/include/detray/propagator/detail/noise_estimation.hpp
@@ -73,9 +73,10 @@ DETRAY_HOST_DEVICE constexpr void estimate_external_mask_tolerance(
                                math::cos(theta_err)};
 
     // Guess the portal envelope distance if there is no next target
+    constexpr auto max_tol{5.f * unit<scalar_t>::mm};
     const scalar_t path{
         navigation.is_exhausted()
-            ? 5.f * unit<scalar_t>::mm
+            ? max_tol
             : math::fabs(std::as_const(navigation).target().path())};
 
     displ = path * (displ - stepping().dir());
@@ -97,7 +98,6 @@ DETRAY_HOST_DEVICE constexpr void estimate_external_mask_tolerance(
         vector::dot(displ, displ) + accumulated_noise * accumulated_noise));
 
     // Clip to 5mm if the covariances are very large
-    constexpr auto max_tol{5.f * unit<scalar_t>::mm};
     navigation.set_external_tol(navigation.external_tol() > max_tol
                                     ? max_tol
                                     : navigation.external_tol());

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -211,8 +211,9 @@ struct propagator {
         // params
         if (m_cfg.navigation.estimate_scattering_noise &&
             !stepping.bound_params().is_invalid()) {
-            detail::estimate_external_mask_tolerance(stepping.bound_params(),
-                                                     propagation, 2u);
+            detail::estimate_external_mask_tolerance(
+                stepping.bound_params(), propagation,
+                static_cast<scalar_type>(m_cfg.navigation.n_scattering_stddev));
         }
 
         // Initialize the navigation
@@ -233,6 +234,8 @@ struct propagator {
         // S = propagation step
         //
         // ANSNANSNANSNANSNANSNANS...
+        scalar_type path_length{0.f};
+        unsigned int stall_counter{0u};
         for (unsigned int i = 0; i % 2 == 0 || propagation.is_alive(); ++i) {
 
             if (i % 2 == 0) {
@@ -247,6 +250,8 @@ struct propagator {
                 if (!propagation.is_alive()) {
                     continue;
                 }
+
+                path_length = stepping.path_length();
 
                 assert(!track.is_invalid());
             } else {
@@ -263,6 +268,7 @@ struct propagator {
                 // (re-)initialized
                 const bool reset_stepsize{navigation.is_on_surface() ||
                                           is_init};
+
                 // Take the step
                 propagation._heartbeat &=
                     m_stepper.step(navigation(), stepping, m_cfg.stepping,
@@ -275,6 +281,29 @@ struct propagator {
                 if (i > 0) {
                     is_init = false;
                 }
+
+                // Check if the propagation makes progress
+                if (math::fabs(stepping.path_length()) <=
+                    math::fabs(path_length + m_cfg.navigation.path_tolerance)) {
+                    if (stall_counter >= 10u) {
+                        propagation._heartbeat = false;
+                        navigation.abort("Propagation stalled");
+                        DETRAY_ERROR_HOST("Propagation stalled");
+                    } else if (stall_counter > 2u) {
+                        // Print a warning if the propagation starts stalling
+                        // (no overlap)
+                        DETRAY_WARN_HOST_DEVICE(
+                            "Propagation is stalling (counter %d)",
+                            stall_counter);
+                        DETRAY_WARN_HOST(print(propagation));
+                        DETRAY_WARN_HOST("-> Track: " << stepping());
+                    }
+                    DETRAY_DEBUG_HOST_DEVICE("Step stalled. Counter %d",
+                                             stall_counter);
+                    stall_counter++;
+                } else {
+                    stall_counter = 0u;
+                }
             }
 
             // Find next candidate
@@ -284,7 +313,7 @@ struct propagator {
             propagation._heartbeat &= navigation.is_alive();
 
             if (i % 2 == 0 && i > 0 && propagation.do_debug) {
-                DETRAY_VERBOSE_HOST(inspect(propagation));
+                DETRAY_VERBOSE_HOST(print(propagation));
             }
         }
 
@@ -309,124 +338,14 @@ struct propagator {
         return propagate(propagation, empty_state);
     }
 
-    /// Propagate method with two while loops. In the CPU, propagate and
-    /// propagate_sync() should be equivalent to each other. In the SIMT level
-    /// (e.g. GPU), the instruction of threads in the same warp is synchornized
-    /// after the internal while loop.
-    ///
-    /// @tparam state_t is the propagation state type
-    /// @tparam actor_state_t is the actor state type
-    ///
-    /// @param propagation the state of a propagation flow
-    /// @param actor_states the actor state
-    ///
-    /// @return propagation success.
-    template <typename actor_states_t>
-        requires concepts::is_state_of<actor_states_t, actor_chain_type>
-    DETRAY_HOST_DEVICE bool propagate_sync(
-        state &propagation, actor_states_t actor_state_refs) const {
-
-        auto &navigation = propagation._navigation;
-        auto &stepping = propagation._stepping;
-        auto &context = propagation._context;
-        const auto &track = stepping();
-        assert(!track.is_invalid());
-
-        // Open the navigation area according to uncertainties in initital track
-        // params
-        if (m_cfg.navigation.estimate_scattering_noise &&
-            !stepping.bound_params().is_invalid()) {
-            detail::estimate_external_mask_tolerance(stepping.bound_params(),
-                                                     propagation, 2u);
-        }
-
-        // Initialize the navigation
-        m_navigator.init(track, navigation, m_cfg.navigation, context);
-        propagation._heartbeat = navigation.is_alive();
-
-        // Run all registered actors/aborters after init
-        run_actors(actor_state_refs, propagation);
-        assert(!track.is_invalid());
-
-        // Find next candidate
-        m_navigator.update(track, navigation, m_cfg.navigation, context);
-        propagation._heartbeat &= navigation.is_alive();
-
-        bool is_init = true;
-
-        while (propagation.is_alive()) {
-
-            bool skip = true;
-
-            while (propagation.is_alive()) {
-
-                // Set access to the volume material for the stepper
-                auto vol = navigation.get_volume();
-                const material<scalar_type> *vol_mat_ptr =
-                    vol.has_material() ? vol.material_parameters(track.pos())
-                                       : nullptr;
-
-                // Break automatic step size scaling by the stepper
-                const bool reset_stepsize{navigation.is_on_surface() ||
-                                          is_init};
-                // Take the step
-                propagation._heartbeat &=
-                    m_stepper.step(navigation(), stepping, m_cfg.stepping,
-                                   reset_stepsize, vol_mat_ptr);
-
-                // Reduce navigation trust level according to stepper update
-                typename stepper_t::policy_type{}(stepping.policy_state(),
-                                                  propagation);
-
-                // Find next candidate
-                is_init = m_navigator.update(track, navigation,
-                                             m_cfg.navigation, context);
-                propagation._heartbeat &= navigation.is_alive();
-
-                // If the track is on a sensitive surface, break the loop to
-                // synchornize the threads
-                if (propagation._navigation.is_on_sensitive()) {
-                    skip = false;
-                    break;
-                } else {
-                    run_actors(actor_state_refs, propagation);
-                    assert(!track.is_invalid());
-
-                    // And check the status
-                    is_init |= m_navigator.update(
-                        track, navigation, m_cfg.navigation, context, false);
-                    propagation._heartbeat &= navigation.is_alive();
-                }
-            }
-
-            if (!skip) {
-
-                // Synchronized actor
-                run_actors(actor_state_refs, propagation);
-                assert(!track.is_invalid());
-
-                // And check the status
-                is_init |= m_navigator.update(track, navigation,
-                                              m_cfg.navigation, context, false);
-                propagation._heartbeat &= navigation.is_alive();
-            }
-
-            if (propagation.do_debug) {
-                DETRAY_VERBOSE_HOST(inspect(propagation));
-            }
-        }
-
-        // Pass on the whether the propagation was successful
-        return is_complete(propagation) || is_paused(propagation);
-    }
-
     template <typename state_t>
-    DETRAY_HOST std::string inspect(state_t &propagation) const {
+    DETRAY_HOST std::string print(state_t &propagation) const {
         const auto &navigation = propagation._navigation;
         const auto &stepping = propagation._stepping;
 
         std::stringstream debug_stream{};
-        debug_stream << std::left << std::setw(30);
+        debug_stream << std::left << std::setw(10);
+        debug_stream << "status: " << std::endl;
         switch (navigation.status()) {
             using enum navigation::status;
             case e_abort:
@@ -450,24 +369,31 @@ struct propagator {
             default:
                 break;
         }
+        debug_stream << std::endl;
 
+        debug_stream << "volume: " << std::setw(10);
         if (detail::is_invalid_value(navigation.volume())) {
-            debug_stream << "volume: " << std::setw(10) << "invalid";
+            debug_stream << "invalid";
         } else {
-            debug_stream << "volume: " << std::setw(10) << navigation.volume();
+            debug_stream << navigation.volume();
         }
+        debug_stream << std::endl;
 
-        debug_stream << "surface: " << std::setw(14);
+        debug_stream << "navigation:" << std::endl;
         if (navigation.is_on_surface()) {
-            debug_stream << navigation.barcode();
+            debug_stream << std::setw(10)
+                         << " ->on surface: " << navigation.barcode();
         } else {
-            debug_stream << "undefined";
+            debug_stream << std::setw(10) << " ->target: "
+                         << navigation.target().sf_desc.barcode();
         }
+        debug_stream << std::endl;
+        debug_stream << " ->path: " << navigation() << "mm" << std::endl;
 
-        debug_stream << "step_size: " << std::setw(10) << stepping.step_size()
-                     << std::endl;
-
-        debug_stream << std::setw(10) << detail::ray<algebra_type>(stepping());
+        debug_stream << "stepping:" << std::endl;
+        debug_stream << " -> step size: " << std::setw(10)
+                     << stepping.step_size() << "mm" << std::endl;
+        debug_stream << " ->" << detail::ray<algebra_type>(stepping());
 
         return debug_stream.str();
     }

--- a/core/include/detray/propagator/rk_stepper.ipp
+++ b/core/include/detray/propagator/rk_stepper.ipp
@@ -613,7 +613,8 @@ DETRAY_HOST_DEVICE inline bool detray::rk_stepper<
                    const material<scalar_type>* vol_mat_ptr) const {
 
     // In case of an overlap do nothing
-    if (math::fabs(dist_to_next) <= 1e-5f) {
+    if (math::fabs(dist_to_next) < 1.f * unit<float>::um) {
+        DETRAY_VERBOSE_HOST_DEVICE("Zero stepsize...");
         stepping.run_inspector(cfg, "Step skipped (Overlap): ", dist_to_next);
         return true;
     }
@@ -635,6 +636,7 @@ DETRAY_HOST_DEVICE inline bool detray::rk_stepper<
             math::max(stepping.next_step_size(), dist_to_next));
     }
 
+    DETRAY_VERBOSE_HOST_DEVICE("Distance to nex: %f mm", dist_to_next);
     DETRAY_VERBOSE_HOST_DEVICE("Take step: %f mm", stepping.step_size());
 
     // Don't allow too small stepsizes, unless the navigation needs it

--- a/tests/benchmarks/include/detray/benchmarks/cpu/propagation_benchmark.hpp
+++ b/tests/benchmarks/include/detray/benchmarks/cpu/propagation_benchmark.hpp
@@ -120,8 +120,7 @@ struct host_propagation_bm : public benchmark_base {
                     p.propagate(p_state, actor_state_refs));
             } else if constexpr (kOPT ==
                                  detray::benchmarks::propagation_opt::e_sync) {
-                ::benchmark::DoNotOptimize(
-                    p.propagate_sync(p_state, actor_state_refs));
+                /* Do nothing for now */
             }
             assert(p.is_complete(p_state));
         };

--- a/tests/benchmarks/include/detray/benchmarks/device/cuda/propagation_benchmark.cu
+++ b/tests/benchmarks/include/detray/benchmarks/device/cuda/propagation_benchmark.cu
@@ -61,7 +61,7 @@ __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
     if constexpr (kOPT == detray::benchmarks::propagation_opt::e_unsync) {
         p.propagate(p_state, actor_state_refs);
     } else if constexpr (kOPT == detray::benchmarks::propagation_opt::e_sync) {
-        p.propagate_sync(p_state, actor_state_refs);
+        /* Do nothing for now */
     }
 }
 

--- a/tests/benchmarks/include/detray/benchmarks/device/hip/propagation_benchmark.hip
+++ b/tests/benchmarks/include/detray/benchmarks/device/hip/propagation_benchmark.hip
@@ -61,7 +61,7 @@ __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
     if constexpr (kOPT == detray::benchmarks::propagation_opt::e_unsync) {
         p.propagate(p_state, actor_state_refs);
     } else if constexpr (kOPT == detray::benchmarks::propagation_opt::e_sync) {
-        p.propagate_sync(p_state, actor_state_refs);
+        /* Do nothing for now */
     }
 }
 

--- a/tests/include/detray/test/validation/navigation_validation_config.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_config.hpp
@@ -41,7 +41,7 @@ struct navigation_validation_config
     std::size_t m_n_tracks{detray::detail::invalid_value<std::size_t>()};
     /// Particle hypothesis (truth particle from simulation)
     pdg_particle<scalar_type> m_ptc_hypo{muon<scalar_type>()};
-    /// Navigaiton direction
+    /// Navigation direction
     navigation::direction m_nav_dir{navigation::direction::e_forward};
     /// Collect only the sensitive intersections for comparison
     bool m_collect_sensitives_only{false};

--- a/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -551,9 +551,8 @@ auto compare_traces(
                     DETRAY_WARN_HOST(
                         "Track "
                         << trk_no << ", inters. " << idx
-                        << ": Non-portal surfaces are swapped in trace, "
-                           "possibly due to overlaps or large mask "
-                           "tolerances.");
+                        << ": Surfaces are swapped in trace, "
+                           "possibly due to overlaps/large mask tolerances.");
                 }
                 // Have already checked the next record
                 ++i;

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -266,8 +266,6 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
         using resetter_state_t = parameter_resetter<test_algebra>::state;
         detail::get<resetter_state_t>(actor_states).estimate_scattering_noise =
             false;
-        detail::get<resetter_state_t>(actor_states_sync)
-            .estimate_scattering_noise = false;
         detail::get<resetter_state_t>(actor_states_lim)
             .estimate_scattering_noise = false;
 
@@ -275,11 +273,6 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
         ASSERT_TRUE(
             p.propagate(state, actor_chain_t::setup_actor_states(actor_states)))
             << state._navigation.inspector().to_string() << std::endl;
-
-        // Test propagate sync method
-        ASSERT_TRUE(p.propagate_sync(
-            sync_state, actor_chain_t::setup_actor_states(actor_states_sync)))
-            << sync_state._navigation.inspector().to_string() << std::endl;
 
         // Propagate with path limit
         ASSERT_FALSE(p.propagate(
@@ -290,15 +283,6 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
             << "Absolute path length: " << lim_state._stepping.abs_path_length()
             << ", path limit: " << path_limit << std::endl;
         //<< state._navigation.inspector().to_string() << std::endl;
-
-        // Compare the navigation status vector between propagate and
-        // propagate_sync function
-        const auto nav_status =
-            detray::get<helix_inspector::state>(actor_states)._nav_status;
-        const auto sync_nav_status =
-            detray::get<helix_inspector::state>(actor_states_sync)._nav_status;
-        ASSERT_TRUE(nav_status.size() > 0);
-        ASSERT_TRUE(nav_status == sync_nav_status);
     }
 }
 
@@ -713,7 +697,6 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorWireChamber, direct_navigator) {
         navigator_t::state& navigation = state._navigation;
 
         // Propagate the entire detector
-        // state.do_debug = true;
         ASSERT_TRUE(p.propagate(state, actor_states))
             << navigation.inspector().to_string();
 

--- a/tests/tools/python/impl/plot_navigation_validation.py
+++ b/tests/tools/python/impl/plot_navigation_validation.py
@@ -192,7 +192,7 @@ def plot_detector_scan_data(
     )
 
 
-""" Plot the intersection data gathered during the navigaiton validation """
+""" Plot the intersection data gathered during the navigation validation """
 
 
 def plot_navigation_intersection_data(
@@ -225,7 +225,7 @@ def plot_navigation_intersection_data(
     )
 
 
-""" Plot the track data gathered during the navigaiton validation """
+""" Plot the track data gathered during the navigation validation """
 
 
 def plot_navigation_track_data(

--- a/tests/tools/python/material_validation.py
+++ b/tests/tools/python/material_validation.py
@@ -174,7 +174,7 @@ def __main__():
     mat_plotter.X0_vs_eta(df_scan, "material_scan", det_name, plot_factory, out_format)
     mat_plotter.L0_vs_eta(df_scan, "material_scan", det_name, plot_factory, out_format)
 
-    # Navigaiton material Traces
+    # Navigation material Traces
     # CPU
     mat_plotter.X0_vs_eta_phi(
         df_cpu, "cpu_material_trace", det_name, plot_factory, out_format

--- a/tests/unit_tests/cpu/builders/homogeneous_material_builder.cpp
+++ b/tests/unit_tests/cpu/builders/homogeneous_material_builder.cpp
@@ -14,6 +14,7 @@
 #include "detray/builders/volume_builder.hpp"
 #include "detray/core/detector.hpp"
 #include "detray/definitions/indexing.hpp"
+#include "detray/geometry/shapes/rectangle2D.hpp"
 
 // Detray test include(s)
 #include "detray/test/framework/types.hpp"

--- a/tests/unit_tests/cpu/builders/homogeneous_volume_material_builder.cpp
+++ b/tests/unit_tests/cpu/builders/homogeneous_volume_material_builder.cpp
@@ -8,8 +8,10 @@
 // Detray include(s)
 #include "detray/builders/homogeneous_volume_material_builder.hpp"
 
+#include "detray/builders/surface_factory.hpp"
 #include "detray/core/detector.hpp"
 #include "detray/definitions/indexing.hpp"
+#include "detray/geometry/shapes/rectangle2D.hpp"
 #include "detray/materials/predefined_materials.hpp"
 
 // Detray test include(s)
@@ -29,12 +31,14 @@
 using namespace detray;
 
 using scalar = detray::test::scalar;
+using point3 = test::point3;
 
 /// Unittest: Test the construction of a collection of materials
 TEST(detray_builders, homogeneous_volume_material_builder) {
 
     using metadata_t = test::default_metadata;
     using detector_t = detector<metadata_t>;
+    using transform3 = typename detector_t::transform3_type;
 
     constexpr auto material_id{detector_t::materials::id::e_raw_material};
 
@@ -49,6 +53,15 @@ TEST(detray_builders, homogeneous_volume_material_builder) {
     auto mat_builder =
         homogeneous_volume_material_builder<detector_t>{std::move(vbuilder)};
 
+    // Add some surfaces
+    using rectangle_factory = surface_factory<detector_t, rectangle2D>;
+    auto sf_factory = std::make_shared<rectangle_factory>();
+    sf_factory->push_back({surface_id::e_sensitive,
+                           transform3(point3{0.f, 0.f, -1.f}), 1u,
+                           std::vector<scalar>{10.f, 8.f}});
+    mat_builder.add_surfaces(sf_factory);
+
+    // Set volume material
     mat_builder.set_material(argon_liquid<scalar>{});
 
     // Add the volume to the detector

--- a/tests/unit_tests/cpu/builders/volume_builder.cpp
+++ b/tests/unit_tests/cpu/builders/volume_builder.cpp
@@ -210,12 +210,20 @@ GTEST_TEST(detray_builders, volume_builder) {
 
     using metadata_t = test::default_metadata;
     using detector_t = detector<metadata_t>;
+    using transform3 = typename detector_t::transform3_type;
 
     detector_t d(host_mr);
 
     EXPECT_TRUE(d.volumes().size() == 0u);
 
+    using rectangle_factory = surface_factory<detector_t, rectangle2D>;
+    auto sf_factory = std::make_shared<rectangle_factory>();
+    sf_factory->push_back({surface_id::e_sensitive,
+                           transform3(point3{0.f, 0.f, -1.f}), 1u,
+                           std::vector<scalar>{10.f, 8.f}});
+
     volume_builder<detector_t> vbuilder{volume_id::e_cylinder};
+    vbuilder.add_surfaces(sf_factory);
     vbuilder.build(d);
 
     const auto& vol = d.volumes().back();


### PR DESCRIPTION
Fixes several small things:
- some renaming and reshuffling in the surface and volume (descriptor) classes
- fixes the momentum value printout in a material interactor log message
- makes the number of stddev to assume for the mask tolerance estimation configurable in the propagation init
- has the propagator supervise if the track path length is actually advancing and aborting if it does not
- remove the `propagate_sync` method, which is no longer used
- clean up the propagation debug printing
- fixes the distance criterion for an overlap in the stepper, aborters and navigation policies
- fixes an assertion in the builder unittests, which is triggered if a volume is built without containing any surfaces