### PR TITLE
ref: intersection config

### DIFF
--- a/core/include/detray/navigation/detail/print_state.hpp
+++ b/core/include/detray/navigation/detail/print_state.hpp
@@ -121,8 +121,9 @@ DETRAY_HOST inline std::string print_candidates(const state_type &state,
     constexpr int cw{20};
 
     debug_stream << std::left << std::setw(cw) << "Overstep tol.:"
-                 << cfg.overstep_tolerance / detray::unit<scalar_t>::um << " um"
-                 << std::endl;
+                 << cfg.intersection.overstep_tolerance /
+                        detray::unit<scalar_t>::um
+                 << " um" << std::endl;
 
     debug_stream << std::setw(cw) << "Track:"
                  << "pos: [r = " << vector::perp(track_pos)

--- a/core/include/detray/navigation/direct_navigator.hpp
+++ b/core/include/detray/navigation/direct_navigator.hpp
@@ -17,8 +17,8 @@
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/barcode.hpp"
 #include "detray/navigation/intersection/intersection.hpp"
+#include "detray/navigation/intersection/intersection_kernel.hpp"
 #include "detray/navigation/intersection/ray_intersector.hpp"
-#include "detray/navigation/intersection_kernel.hpp"
 #include "detray/navigation/navigation_config.hpp"
 #include "detray/navigation/navigation_state.hpp"
 #include "detray/navigation/navigator.hpp"
@@ -196,7 +196,7 @@ class direct_navigator {
         }
 
         assert(!navigation.get_target_barcode().is_invalid());
-        update_intersection(track, navigation, cfg, ctx);
+        update_intersection(track, navigation, cfg.intersection, ctx);
 
         if (is_before_actor_run) {
             if (navigation.has_reached_candidate(navigation.target(), cfg)) {
@@ -209,7 +209,8 @@ class direct_navigator {
                                                         cfg));
 
                 if (!navigation.no_next_external()) {
-                    update_intersection(track, navigation, cfg, ctx);
+                    update_intersection(track, navigation, cfg.intersection,
+                                        ctx);
                 }
 
                 DETRAY_VERBOSE_HOST_DEVICE("Update complete: On surface");
@@ -234,7 +235,8 @@ class direct_navigator {
     private:
     template <typename track_t>
     DETRAY_HOST_DEVICE inline void update_intersection(
-        const track_t &track, state &navigation, const navigation::config &cfg,
+        const track_t &track, state &navigation,
+        const intersection::config &intr_cfg,
         const context_type &ctx = {}) const {
 
         if (navigation.target().sf_desc.barcode().is_invalid()) {
@@ -250,11 +252,8 @@ class direct_navigator {
                     track.pos(),
                     static_cast<scalar_type>(navigation.direction()) *
                         track.dir()),
-                navigation.target(), det.transform_store(), ctx,
-                cfg.template mask_tolerance<scalar_type>(),
-                static_cast<scalar_type>(cfg.mask_tolerance_scalor),
-                scalar_type{0.f},
-                static_cast<scalar_type>(cfg.overstep_tolerance));
+                navigation.target(), det.transform_store(), ctx, intr_cfg,
+                scalar_type{0.f});
 
         // If an intersection is not found, proceed the track with safe step
         // size

--- a/core/include/detray/navigation/intersection/intersection_config.hpp
+++ b/core/include/detray/navigation/intersection/intersection_config.hpp
@@ -1,0 +1,52 @@
+/** Detray library, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Project include(s)
+#include "detray/definitions/detail/qualifiers.hpp"
+#include "detray/definitions/units.hpp"
+
+// System include(s)
+#include <ostream>
+
+namespace detray::intersection {
+
+/// Intersector configuration
+struct config {
+    /// Tolerance on the mask 'is_inside' check:
+    /// @{
+    /// Minimal tolerance: ~ position uncertainty on surface
+    float min_mask_tolerance{1e-5f * unit<float>::mm};
+    /// Maximal tolerance: loose tolerance when still far away from surface
+    float max_mask_tolerance{3.f * unit<float>::mm};
+    /// Scale factor on the path used for the mask tolerance calculation
+    float mask_tolerance_scalor{5e-2f};
+    /// @}
+    /// Maximal absolute path distance for a track to be considered 'on surface'
+    float path_tolerance{1.f * unit<float>::um};
+    /// How far behind the track position to look for candidates
+    float overstep_tolerance{-1000.f * unit<float>::um};
+
+    /// Print the intersector configuration
+    DETRAY_HOST
+    friend std::ostream& operator<<(std::ostream& out, const config& cfg) {
+        out << "  Min. mask tolerance   : "
+            << cfg.min_mask_tolerance / detray::unit<float>::mm << " [mm]\n"
+            << "  Max. mask tolerance   : "
+            << cfg.max_mask_tolerance / detray::unit<float>::mm << " [mm]\n"
+            << "  Mask tolerance scalor : " << cfg.mask_tolerance_scalor << "\n"
+            << "  Path tolerance        : "
+            << cfg.path_tolerance / detray::unit<float>::um << " [um]\n"
+            << "  Overstep tolerance    : "
+            << cfg.overstep_tolerance / detray::unit<float>::um << " [um]\n";
+
+        return out;
+    }
+};
+
+}  // namespace detray::intersection

--- a/core/include/detray/navigation/intersector.hpp
+++ b/core/include/detray/navigation/intersector.hpp
@@ -8,11 +8,10 @@
 #pragma once
 
 // Project include(s)
-#include <iostream>
-
 #include "detray/definitions/algebra.hpp"
 #include "detray/geometry/concepts.hpp"
 #include "detray/navigation/intersection/helix_intersector.hpp"
+#include "detray/navigation/intersection/intersection_config.hpp"
 #include "detray/navigation/intersection/ray_intersector.hpp"
 
 namespace detray {
@@ -58,7 +57,7 @@ struct intersector {
     /// @param mask_tolerance is the tolerance for mask edges
     /// @param overstep_tol negative cutoff for the path
     ///
-    /// @return the intersection
+    /// @return the intersection result
     /// @{
     template <typename S = shape_t>
         requires(!concepts::cylindrical_shape<S, algebra_type>)
@@ -84,20 +83,18 @@ struct intersector {
         requires(!concepts::cylindrical_shape<S, algebra_type>)
     DETRAY_HOST_DEVICE constexpr result_type point_of_intersection(
         const detail::helix<algebra_t> &h, const transform3_type &trf,
-        const scalar_type overstep_tol = 0.f) const {
+        const scalar_type /*overstep_tol*/ = 0.f) const {
 
-        return helix_intersector_type{}.point_of_intersection(h, trf,
-                                                              overstep_tol);
+        return helix_intersector_type{}.point_of_intersection(h, trf);
     }
 
     template <typename mask_t, typename S = shape_t>
         requires concepts::cylindrical_shape<S, algebra_type>
     DETRAY_HOST_DEVICE constexpr result_type point_of_intersection(
         const detail::helix<algebra_t> &h, const transform3_type &trf,
-        const mask_t &mask, const scalar_type overstep_tol = 0.f) const {
+        const mask_t &mask, const scalar_type /*overstep_tol*/ = 0.f) const {
 
-        return helix_intersector_type{}.point_of_intersection(h, trf, mask,
-                                                              overstep_tol);
+        return helix_intersector_type{}.point_of_intersection(h, trf, mask);
     }
     /// @}
 
@@ -106,15 +103,11 @@ struct intersector {
     DETRAY_HOST_DEVICE inline decltype(auto) operator()(
         const detail::ray<algebra_t> &ray, const surface_descr_t &sf,
         const mask_t &mask, const transform3_type &trf,
-        const darray<scalar_type, 2u> mask_tolerance =
-            {0.f, 1.f * unit<scalar_type>::mm},
-        const scalar_type mask_tol_scalor = 0.f,
-        const scalar_type external_mask_tol = 0.f,
-        const scalar_type overstep_tol = 0.f) const {
+        const intersection::config &cfg = {},
+        const scalar_type external_mask_tol = 0.f) const {
 
-        return ray_intersector_type{}(ray, sf, mask, trf, mask_tolerance,
-                                      mask_tol_scalor, external_mask_tol,
-                                      overstep_tol);
+        return ray_intersector_type{}(ray, sf, mask, trf, cfg,
+                                      external_mask_tol);
     }
 
     /// @returns the intersection(s) between a surface and the helix @param h
@@ -122,12 +115,9 @@ struct intersector {
     DETRAY_HOST_DEVICE inline decltype(auto) operator()(
         const detail::helix<algebra_t> &h, const surface_descr_t &sf,
         const mask_t &mask, const transform3_type &trf,
-        const darray<scalar_type, 2u> mask_tolerance =
-            {0.f, 1.f * unit<scalar_type>::mm},
-        const scalar_type = 0.f, const scalar_type = 0.f,
-        const scalar_type = 0.f) const {
+        const intersection::config &cfg = {}, const scalar_type = 0.f) const {
 
-        return helix_intersector_type{}(h, sf, mask, trf, mask_tolerance);
+        return helix_intersector_type{}(h, sf, mask, trf, cfg);
     }
 
     private:

--- a/core/include/detray/navigation/navigation_config.hpp
+++ b/core/include/detray/navigation/navigation_config.hpp
@@ -11,6 +11,7 @@
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/definitions/units.hpp"
+#include "detray/navigation/intersection/intersection_config.hpp"
 
 // System include(s)
 #include <ostream>
@@ -20,18 +21,7 @@ namespace detray::navigation {
 /// Navigation configuration
 struct config {
     /// Tolerance on the mask 'is_inside' check:
-    /// @{
-    /// Minimal tolerance: ~ position uncertainty on surface
-    float min_mask_tolerance{1e-5f * unit<float>::mm};
-    /// Maximal tolerance: loose tolerance when still far away from surface
-    float max_mask_tolerance{3.f * unit<float>::mm};
-    /// Scale factor on the path used for the mask tolerance calculation
-    float mask_tolerance_scalor{5e-2f};
-    /// @}
-    /// Maximal absolute path distance for a track to be considered 'on surface'
-    float path_tolerance{1.f * unit<float>::um};
-    /// How far behind the track position to look for candidates
-    float overstep_tolerance{-1000.f * unit<float>::um};
+    intersection::config intersection{};
     /// Search window size for grid based acceleration structures
     /// (0, 0): only look at current bin
     darray<dindex, 2> search_window = {0u, 0u};
@@ -45,24 +35,10 @@ struct config {
     /// Add adaptive mask tolerance to navigation
     bool estimate_scattering_noise{true};
 
-    /// @returns the mask tolerances
-    template <concepts::scalar scalar_t>
-    DETRAY_HOST_DEVICE constexpr darray<scalar_t, 2u> mask_tolerance() const {
-        return {min_mask_tolerance, max_mask_tolerance};
-    }
-
     /// Print the navigation configuration
     DETRAY_HOST
     friend std::ostream& operator<<(std::ostream& out, const config& cfg) {
-        out << "  Min. mask tolerance   : "
-            << cfg.min_mask_tolerance / detray::unit<float>::mm << " [mm]\n"
-            << "  Max. mask tolerance   : "
-            << cfg.max_mask_tolerance / detray::unit<float>::mm << " [mm]\n"
-            << "  Mask tolerance scalor : " << cfg.mask_tolerance_scalor << "\n"
-            << "  Path tolerance        : "
-            << cfg.path_tolerance / detray::unit<float>::um << " [um]\n"
-            << "  Overstep tolerance    : "
-            << cfg.overstep_tolerance / detray::unit<float>::um << " [um]\n"
+        out << cfg.intersection
             << "  Search window         : " << cfg.search_window[0] << " x "
             << cfg.search_window[1] << "\n";
 

--- a/core/include/detray/navigation/navigation_state.hpp
+++ b/core/include/detray/navigation/navigation_state.hpp
@@ -537,7 +537,7 @@ class base_state : public detray::ranges::view_interface<
     /// @returns true if a candidate lies on a surface - const
     DETRAY_HOST_DEVICE constexpr bool has_reached_candidate(
         const candidate_t &candidate, const navigation::config &cfg) const {
-        return (math::fabs(candidate.path()) < cfg.path_tolerance);
+        return (math::fabs(candidate.path()) < cfg.intersection.path_tolerance);
     }
 
     /// Clear the state

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -284,7 +284,8 @@ struct propagator {
 
                 // Check if the propagation makes progress
                 if (math::fabs(stepping.path_length()) <=
-                    math::fabs(path_length + m_cfg.navigation.path_tolerance)) {
+                    math::fabs(path_length +
+                               m_cfg.navigation.intersection.path_tolerance)) {
                     if (stall_counter >= 10u) {
                         propagation._heartbeat = false;
                         navigation.abort("Propagation stalled");

--- a/tests/benchmarks/cpu/intersect_all.cpp
+++ b/tests/benchmarks/cpu/intersect_all.cpp
@@ -9,8 +9,9 @@
 #include "detray/core/detector.hpp"
 #include "detray/definitions/units.hpp"
 #include "detray/geometry/surface.hpp"
+#include "detray/navigation/intersection/intersection_config.hpp"
+#include "detray/navigation/intersection/intersection_kernel.hpp"
 #include "detray/navigation/intersection/ray_intersector.hpp"
-#include "detray/navigation/intersection_kernel.hpp"
 #include "detray/tracks/ray.hpp"
 #include "detray/tracks/tracks.hpp"
 #include "detray/utils/log.hpp"
@@ -75,6 +76,11 @@ void BM_INTERSECT_ALL(benchmark::State &state) {
         .phi_steps(phi_steps)
         .origin(origin);
 
+    // Intersector configuration
+    intersection::config intr_cfg{.min_mask_tolerance = 1.f * unit<float>::um,
+                                  .max_mask_tolerance = 1.f * unit<float>::mm};
+    constexpr const scalar_t external_mask_tol{0.f};
+
     for (auto _ : state) {
 
         for (const auto track : trk_generator) {
@@ -85,10 +91,7 @@ void BM_INTERSECT_ALL(benchmark::State &state) {
                 sf.template visit_mask<
                     intersection_initialize<ray_intersector>>(
                     intersections, detail::ray(track), sf_desc, transforms,
-                    geo_context,
-                    std::array<scalar_t, 2>{1.f * unit<scalar_t>::um,
-                                            1.f * unit<scalar_t>::mm},
-                    scalar_t{0.f});
+                    geo_context, intr_cfg, external_mask_tol);
 
                 ++n_surfaces;
             }

--- a/tests/benchmarks/cpu/intersectors.cpp
+++ b/tests/benchmarks/cpu/intersectors.cpp
@@ -129,7 +129,7 @@ void BM_INTERSECT_PLANES_AOS(benchmark::State& state) {
     using mask_t = mask<rectangle2D, algebra_s, std::uint_least16_t>;
 
     auto dists = get_dists<algebra_s>(n_surfaces);
-    auto [plane_descs, tranforms] = test::planes_along_direction<algebra_s>(
+    auto [plane_descs, transforms] = test::planes_along_direction<algebra_s>(
         dists, dvector3D<algebra_s>{1.f, 1.f, 1.f});
 
     constexpr mask_t rect{0u, 100.f, 200.f};
@@ -153,7 +153,7 @@ void BM_INTERSECT_PLANES_AOS(benchmark::State& state) {
         for (const auto& ray : rays) {
 
             for (std::size_t i = 0u; i < plane_descs.size(); ++i) {
-                auto is = pi(ray, plane_descs[i], masks[i], tranforms[i]);
+                auto is = pi(ray, plane_descs[i], masks[i], transforms[i]);
 
 #ifdef DETRAY_BENCHMARK_PRINTOUTS
                 if (is.is_inside()) {
@@ -187,7 +187,7 @@ void BM_INTERSECT_PLANES_SOA(benchmark::State& state) {
     using vector3_t = dvector3D<algebra_v>;
 
     auto dists = get_dists<algebra_v>(n_surfaces);
-    auto [plane_descs, tranforms] = test::planes_along_direction<algebra_v>(
+    auto [plane_descs, transforms] = test::planes_along_direction<algebra_v>(
         dists, vector3_t{1.f, 1.f, 1.f});
 
     std::vector<mask_t> masks{};
@@ -214,7 +214,7 @@ void BM_INTERSECT_PLANES_SOA(benchmark::State& state) {
         for (const auto& ray : rays) {
 
             for (std::size_t i = 0u; i < plane_descs.size(); ++i) {
-                auto is = pi(ray, plane_descs[i], masks[i], tranforms[i]);
+                auto is = pi(ray, plane_descs[i], masks[i], transforms[i]);
 
                 benchmark::DoNotOptimize(is);
 

--- a/tests/include/detray/test/framework/fixture_base.hpp
+++ b/tests/include/detray/test/framework/fixture_base.hpp
@@ -13,7 +13,7 @@
 #include "detray/propagator/propagator.hpp"
 
 // Detray test include(s)
-#include "detray/test/common/test_configuration.hpp"
+#include "detray/test/framework/test_configuration.hpp"
 #include "detray/test/framework/types.hpp"
 
 // GTest include(s)
@@ -48,7 +48,8 @@ class fixture_base : public scope {
           inf{cfg.inf},
           epsilon{cfg.epsilon},
           path_limit{cfg.propagation().stepping.path_limit},
-          overstep_tolerance{cfg.propagation().navigation.overstep_tolerance},
+          overstep_tolerance{
+              cfg.propagation().navigation.intersection.overstep_tolerance},
           step_constraint{cfg.propagation().stepping.step_constraint} {}
 
     /// @returns the benchmark name

--- a/tests/include/detray/test/framework/test_configuration.hpp
+++ b/tests/include/detray/test/framework/test_configuration.hpp
@@ -49,18 +49,16 @@ struct configuration {
     const propagation::config& propagation() const { return m_prop_cfg; }
     /// @}
 
+    private:
     /// Print configuration
-    std::ostream& operator<<(std::ostream& os) {
-        os << " -> test tolerance:  \t " << tol() << std::endl;
-        os << " -> trk path limit:  \t " << propagation().stepping.path_limit
-           << std::endl;
-        os << " -> overstepping tol:\t "
-           << propagation().navigation.overstep_tolerance << std::endl;
-        os << " -> step constraint:  \t "
-           << propagation().stepping.step_constraint << std::endl;
-        os << std::endl;
+    friend std::ostream& operator<<(std::ostream& out,
+                                    const configuration& cfg) {
+        out << "Test Configuration\n"
+            << "----------------------------\n"
+            << "  test tolerance        : " << cfg.tol() << "\n\n";
+        out << cfg.propagation();
 
-        return os;
+        return out;
     }
 };
 

--- a/tests/include/detray/test/validation/detector_scan_config.hpp
+++ b/tests/include/detray/test/validation/detector_scan_config.hpp
@@ -11,7 +11,7 @@
 #include "detray/plugins/svgtools/styling/styling.hpp"
 
 // Detray test include(s)
-#include "detray/test/common/test_configuration.hpp"
+#include "detray/test/framework/test_configuration.hpp"
 
 // System include(s)
 #include <limits>
@@ -36,9 +36,7 @@ struct detector_scan_config
     std::string m_intersection_file{"truth_intersections"};
     std::string m_track_param_file{"truth_trk_parameters"};
     /// Mask tolerance for the intersectors
-    darray<scalar_type, 2> m_mask_tol{
-        std::numeric_limits<scalar_type>::epsilon(),
-        std::numeric_limits<scalar_type>::epsilon()};
+    scalar_type m_mask_tol{std::numeric_limits<scalar_type>::epsilon()};
     /// B-field vector for helix
     vector3_type m_B{0.f * unit<scalar_type>::T, 0.f * unit<scalar_type>::T,
                      2.f * unit<scalar_type>::T};
@@ -59,7 +57,7 @@ struct detector_scan_config
     const std::string &name() const { return m_name; }
     const std::string &intersection_file() const { return m_intersection_file; }
     const std::string &track_param_file() const { return m_track_param_file; }
-    darray<scalar_type, 2> mask_tolerance() const { return m_mask_tol; }
+    scalar_type mask_tolerance() const { return m_mask_tol; }
     const vector3_type &B_vector() { return m_B; }
     bool write_intersections() const { return m_write_inters; }
     trk_gen_config_t &track_generator() { return m_trk_gen_cfg; }
@@ -83,7 +81,7 @@ struct detector_scan_config
         m_track_param_file = f;
         return *this;
     }
-    detector_scan_config &mask_tolerance(const darray<scalar_type, 2> tol) {
+    detector_scan_config &mask_tolerance(const scalar_type tol) {
         m_mask_tol = tol;
         return *this;
     }

--- a/tests/include/detray/test/validation/material_validation_config.hpp
+++ b/tests/include/detray/test/validation/material_validation_config.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 // Detray test include(s)
-#include "detray/test/common/test_configuration.hpp"
+#include "detray/test/framework/test_configuration.hpp"
 
 // Vecmem include(s)
 #include <vecmem/memory/memory_resource.hpp>

--- a/tests/include/detray/test/validation/navigation_validation_config.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_config.hpp
@@ -14,7 +14,7 @@
 #include "detray/plugins/svgtools/styling/styling.hpp"
 
 // Detray test include(s)
-#include "detray/test/common/test_configuration.hpp"
+#include "detray/test/framework/test_configuration.hpp"
 
 // System include(s)
 #include <limits>

--- a/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/telescope_detector_navigation.cpp
@@ -80,12 +80,11 @@ int main(int argc, char **argv) {
     cfg_str_nav.name("telescope_detector_straight_line_navigation");
     cfg_str_nav.n_tracks(cfg_ray_scan.track_generator().n_tracks());
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
-    auto mask_tolerance = cfg_ray_scan.mask_tolerance();
     cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
-    cfg_str_nav.propagation().navigation.min_mask_tolerance =
-        static_cast<float>(mask_tolerance[0]);
-    cfg_str_nav.propagation().navigation.max_mask_tolerance =
-        static_cast<float>(mask_tolerance[1]);
+    cfg_str_nav.propagation().navigation.intersection.min_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
+    cfg_str_nav.propagation().navigation.intersection.max_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
 
     test::register_checks<test::straight_line_navigation>(
         tel_det, tel_names, cfg_str_nav, ctx, white_board);
@@ -94,8 +93,7 @@ int main(int argc, char **argv) {
     test::helix_scan<tel_detector_t>::config cfg_hel_scan{};
     cfg_hel_scan.name("telescope_detector_helix_scan");
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar>(),
-                                 detray::detail::invalid_value<scalar>()});
+    cfg_hel_scan.mask_tolerance(detray::detail::invalid_value<scalar>());
     cfg_hel_scan.track_generator().n_tracks(10000u);
     cfg_hel_scan.overlaps_tol(min_stepsize);
     cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar>::GeV);
@@ -112,7 +110,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.n_tracks(cfg_hel_scan.track_generator().n_tracks());
     cfg_hel_nav.propagation().stepping.min_stepsize = min_stepsize;
     cfg_hel_nav.propagation().navigation.estimate_scattering_noise = false;
-    cfg_hel_nav.propagation().navigation.overstep_tolerance =
+    cfg_hel_nav.propagation().navigation.intersection.overstep_tolerance =
         -100.f * unit<float>::um;
 
     test::register_checks<test::helix_navigation>(

--- a/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/toy_detector_navigation.cpp
@@ -77,11 +77,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
     cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
-    auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance =
-        static_cast<float>(mask_tolerance[0]);
-    cfg_str_nav.propagation().navigation.max_mask_tolerance =
-        static_cast<float>(mask_tolerance[1]);
+    cfg_str_nav.propagation().navigation.intersection.min_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
+    cfg_str_nav.propagation().navigation.intersection.max_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
 
     test::register_checks<test::straight_line_navigation>(
         toy_det, toy_names, cfg_str_nav, ctx, white_board);
@@ -90,8 +89,7 @@ int main(int argc, char **argv) {
     test::helix_scan<toy_detector_t>::config cfg_hel_scan{};
     cfg_hel_scan.name("toy_detector_helix_scan");
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar>(),
-                                 detray::detail::invalid_value<scalar>()});
+    cfg_hel_scan.mask_tolerance(detray::detail::invalid_value<scalar>());
     cfg_hel_scan.track_generator().n_tracks(10000u);
     cfg_hel_scan.overlaps_tol(min_stepsize);
     cfg_hel_scan.track_generator().randomize_charge(true);

--- a/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
+++ b/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
@@ -77,11 +77,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
     cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
-    auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance =
-        static_cast<float>(mask_tolerance[0]);
-    cfg_str_nav.propagation().navigation.max_mask_tolerance =
-        static_cast<float>(mask_tolerance[1]);
+    cfg_str_nav.propagation().navigation.intersection.min_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
+    cfg_str_nav.propagation().navigation.intersection.max_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
 
     test::register_checks<test::straight_line_navigation>(
         det, names, cfg_str_nav, ctx, white_board);
@@ -90,8 +89,7 @@ int main(int argc, char **argv) {
     test::helix_scan<wire_chamber_t>::config cfg_hel_scan{};
     cfg_hel_scan.name("wire_chamber_helix_scan");
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar>(),
-                                 detray::detail::invalid_value<scalar>()});
+    cfg_hel_scan.mask_tolerance(detray::detail::invalid_value<scalar>());
     cfg_hel_scan.track_generator().n_tracks(10000u);
     cfg_hel_scan.track_generator().randomize_charge(true);
     cfg_hel_scan.track_generator().eta_range(-1.f, 1.f);
@@ -108,7 +106,8 @@ int main(int argc, char **argv) {
     cfg_hel_nav.n_tracks(cfg_hel_scan.track_generator().n_tracks());
     cfg_hel_nav.propagation().stepping.min_stepsize = min_stepsize;
     cfg_hel_nav.propagation().navigation.estimate_scattering_noise = false;
-    cfg_hel_nav.propagation().navigation.min_mask_tolerance *= 11.f;
+    cfg_hel_nav.propagation().navigation.intersection.min_mask_tolerance *=
+        11.f;
     cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
 
     test::register_checks<test::helix_navigation>(det, names, cfg_hel_nav, ctx,

--- a/tests/integration_tests/cpu/material/material_interaction.cpp
+++ b/tests/integration_tests/cpu/material/material_interaction.cpp
@@ -82,7 +82,8 @@ GTEST_TEST(detray_material, telescope_geometry_energy_loss) {
 
     // Propagator is built from the stepper and navigator
     propagation::config prop_cfg{};
-    prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
+    prop_cfg.navigation.intersection.overstep_tolerance =
+        -100.f * unit<float>::um;
     propagator_t p{prop_cfg};
 
     constexpr scalar iniP{10.f * unit<scalar>::GeV};
@@ -204,7 +205,8 @@ GTEST_TEST(detray_material, telescope_geometry_scattering_angle) {
 
     // Propagator is built from the stepper and navigator
     propagation::config prop_cfg{};
-    prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
+    prop_cfg.navigation.intersection.overstep_tolerance =
+        -100.f * unit<float>::um;
     propagator_t p{prop_cfg};
 
     constexpr scalar q{-1.f};
@@ -340,7 +342,8 @@ GTEST_TEST(detray_material, telescope_geometry_volume_material) {
 
         // Propagator is built from the stepper and navigator
         propagation::config prop_cfg{};
-        prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
+        prop_cfg.navigation.intersection.overstep_tolerance =
+            -100.f * unit<float>::um;
         propagator_t p{prop_cfg};
 
         propagator_t::state state(bound_param, const_bfield, det);

--- a/tests/integration_tests/cpu/propagator/backward_propagation.cpp
+++ b/tests/integration_tests/cpu/propagator/backward_propagation.cpp
@@ -91,7 +91,8 @@ TEST_P(BackwardPropagation, backward_propagation) {
 
     propagation::config prop_cfg{};
     prop_cfg.stepping.rk_error_tol = 1e-7f * unit<float>::mm;
-    prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
+    prop_cfg.navigation.intersection.overstep_tolerance =
+        -100.f * unit<float>::um;
     prop_cfg.navigation.estimate_scattering_noise = false;
     propagator_t p{prop_cfg};
 

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -469,8 +469,10 @@ bound_getter<test_algebra>::state evaluate_bound_param(
 
     // Propagator is built from the stepper and navigator
     propagation::config cfg{};
-    cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tolerance);
-    cfg.navigation.path_tolerance = static_cast<float>(path_tolerance);
+    cfg.navigation.intersection.overstep_tolerance =
+        static_cast<float>(overstep_tolerance);
+    cfg.navigation.intersection.path_tolerance =
+        static_cast<float>(path_tolerance);
     cfg.navigation.estimate_scattering_noise = false;
     cfg.stepping.rk_error_tol = static_cast<float>(rk_tolerance);
     cfg.stepping.use_eloss_gradient = true;
@@ -511,8 +513,10 @@ bound_param_vector_type get_displaced_bound_vector(
     const unsigned int target_index, const scalar displacement) {
 
     propagation::config cfg{};
-    cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tolerance);
-    cfg.navigation.path_tolerance = static_cast<float>(path_tolerance);
+    cfg.navigation.intersection.overstep_tolerance =
+        static_cast<float>(overstep_tolerance);
+    cfg.navigation.intersection.path_tolerance =
+        static_cast<float>(path_tolerance);
     cfg.navigation.estimate_scattering_noise = false;
     cfg.stepping.rk_error_tol = static_cast<float>(rk_tolerance);
     cfg.stepping.do_covariance_transport = false;

--- a/tests/integration_tests/cpu/propagator/propagator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagator.cpp
@@ -222,7 +222,8 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
 
     // Propagator is built from the stepper and navigator
     propagation::config cfg{};
-    cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tol);
+    cfg.navigation.intersection.overstep_tolerance =
+        static_cast<float>(overstep_tol);
     cfg.navigation.search_window = {3u, 3u};
     cfg.navigation.estimate_scattering_noise = false;
     propagator_t p{cfg};
@@ -320,7 +321,8 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
 
     // Propagator is built from the stepper and navigator
     propagation::config cfg{};
-    cfg.navigation.overstep_tolerance = static_cast<float>(overstep_tol);
+    cfg.navigation.intersection.overstep_tolerance =
+        static_cast<float>(overstep_tol);
     cfg.navigation.search_window = {3u, 3u};
     cfg.navigation.estimate_scattering_noise = false;
     propagator_t p{cfg};
@@ -461,14 +463,17 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorToyDetector, direct_navigator) {
 
     // Propagation configuration
     propagation::config cfg{};
-    cfg.navigation.overstep_tolerance =
+    cfg.navigation.intersection.overstep_tolerance =
         static_cast<float>(std::get<0>(GetParam()));
     cfg.navigation.search_window = {3u, 3u};
     cfg.navigation.estimate_scattering_noise = false;
     propagation::config direct_cfg{};
-    direct_cfg.navigation.min_mask_tolerance = 1.f * unit<float>::mm;
-    direct_cfg.navigation.max_mask_tolerance = 1.f * unit<float>::mm;
-    direct_cfg.navigation.overstep_tolerance = -30.f * unit<float>::mm;
+    direct_cfg.navigation.intersection.min_mask_tolerance =
+        1.f * unit<float>::mm;
+    direct_cfg.navigation.intersection.max_mask_tolerance =
+        1.f * unit<float>::mm;
+    direct_cfg.navigation.intersection.overstep_tolerance =
+        -30.f * unit<float>::mm;
     propagator_t p{cfg};
     direct_propagator_t direct_p{direct_cfg};
 
@@ -649,14 +654,17 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorWireChamber, direct_navigator) {
 
     // Propagation configuration
     propagation::config cfg{};
-    cfg.navigation.overstep_tolerance =
+    cfg.navigation.intersection.overstep_tolerance =
         static_cast<float>(std::get<0>(GetParam()));
     cfg.navigation.search_window = {5u, 5u};
     cfg.navigation.estimate_scattering_noise = false;
     propagation::config direct_cfg{};
-    direct_cfg.navigation.min_mask_tolerance = 10.f * unit<float>::mm;
-    direct_cfg.navigation.max_mask_tolerance = 10.f * unit<float>::mm;
-    direct_cfg.navigation.overstep_tolerance = -30.f * unit<float>::mm;
+    direct_cfg.navigation.intersection.min_mask_tolerance =
+        10.f * unit<float>::mm;
+    direct_cfg.navigation.intersection.max_mask_tolerance =
+        10.f * unit<float>::mm;
+    direct_cfg.navigation.intersection.overstep_tolerance =
+        -30.f * unit<float>::mm;
     propagator_t p{cfg};
     direct_propagator_t direct_p{direct_cfg};
 

--- a/tests/integration_tests/device/cuda/propagator_cuda.cpp
+++ b/tests/integration_tests/device/cuda/propagator_cuda.cpp
@@ -37,7 +37,8 @@ TEST_P(CudaPropConstBFieldMng, propagator) {
     cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
     // Configuration for non-z-aligned B-fields
-    cfg.propagation.navigation.overstep_tolerance = std::get<0>(GetParam());
+    cfg.propagation.navigation.intersection.overstep_tolerance =
+        std::get<0>(GetParam());
     cfg.propagation.stepping.step_constraint = std::get<1>(GetParam());
 
     // Get the magnetic field
@@ -71,7 +72,8 @@ TEST_P(CudaPropConstBFieldCpy, propagator) {
     cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
     // Configuration for non-z-aligned B-fields
-    cfg.propagation.navigation.overstep_tolerance = std::get<0>(GetParam());
+    cfg.propagation.navigation.intersection.overstep_tolerance =
+        std::get<0>(GetParam());
     cfg.propagation.stepping.step_constraint = std::get<1>(GetParam());
 
     // Get the magnetic field

--- a/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/telescope_navigation_validation.cpp
@@ -83,11 +83,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.n_tracks(cfg_ray_scan.track_generator().n_tracks());
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
     cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
-    auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance =
-        static_cast<float>(mask_tolerance[0]);
-    cfg_str_nav.propagation().navigation.max_mask_tolerance =
-        static_cast<float>(mask_tolerance[1]);
+    cfg_str_nav.propagation().navigation.intersection.min_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
+    cfg_str_nav.propagation().navigation.intersection.max_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
 
     test::register_checks<detray::cuda::straight_line_navigation>(
         tel_det, tel_names, cfg_str_nav, ctx, white_board);
@@ -96,8 +95,7 @@ int main(int argc, char **argv) {
     test::helix_scan<tel_detector_t>::config cfg_hel_scan{};
     cfg_hel_scan.name("telescope_detector_helix_scan_for_cuda");
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar>(),
-                                 detray::detail::invalid_value<scalar>()});
+    cfg_hel_scan.mask_tolerance(detray::detail::invalid_value<scalar>());
     cfg_hel_scan.track_generator().n_tracks(10000u);
     cfg_hel_scan.overlaps_tol(min_stepsize);
     cfg_hel_scan.track_generator().p_tot(10.f * unit<scalar>::GeV);
@@ -114,7 +112,7 @@ int main(int argc, char **argv) {
     cfg_hel_nav.n_tracks(cfg_hel_scan.track_generator().n_tracks());
     cfg_hel_nav.propagation().stepping.min_stepsize = min_stepsize;
     cfg_hel_nav.propagation().navigation.estimate_scattering_noise = false;
-    cfg_hel_nav.propagation().navigation.overstep_tolerance =
+    cfg_hel_nav.propagation().navigation.intersection.overstep_tolerance =
         -100.f * unit<float>::um;
 
     test::register_checks<detray::cuda::helix_navigation>(

--- a/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/toy_detector_navigation_validation.cpp
@@ -77,11 +77,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
     cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
-    auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance =
-        static_cast<float>(mask_tolerance[0]);
-    cfg_str_nav.propagation().navigation.max_mask_tolerance =
-        static_cast<float>(mask_tolerance[1]);
+    cfg_str_nav.propagation().navigation.intersection.min_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
+    cfg_str_nav.propagation().navigation.intersection.max_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
 
     test::register_checks<detray::cuda::straight_line_navigation>(
         toy_det, toy_names, cfg_str_nav, ctx, white_board);
@@ -90,8 +89,7 @@ int main(int argc, char **argv) {
     test::helix_scan<toy_detector_t>::config cfg_hel_scan{};
     cfg_hel_scan.name("toy_detector_helix_scan_for_cuda");
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar>(),
-                                 detray::detail::invalid_value<scalar>()});
+    cfg_hel_scan.mask_tolerance(detray::detail::invalid_value<scalar>());
     // Run only 1000 track in double precision in the CI (time limit)
     if constexpr (std::same_as<scalar, double>) {
         cfg_hel_scan.track_generator().n_tracks(1000u);

--- a/tests/integration_tests/device/cuda/wire_chamber_navigation_validation.cpp
+++ b/tests/integration_tests/device/cuda/wire_chamber_navigation_validation.cpp
@@ -80,11 +80,10 @@ int main(int argc, char **argv) {
     cfg_str_nav.propagation().stepping.min_stepsize = min_stepsize;
     cfg_str_nav.propagation().navigation.estimate_scattering_noise = false;
     cfg_str_nav.propagation().navigation.search_window = {3u, 3u};
-    auto mask_tolerance = cfg_ray_scan.mask_tolerance();
-    cfg_str_nav.propagation().navigation.min_mask_tolerance =
-        static_cast<float>(mask_tolerance[0]);
-    cfg_str_nav.propagation().navigation.max_mask_tolerance =
-        static_cast<float>(mask_tolerance[1]);
+    cfg_str_nav.propagation().navigation.intersection.min_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
+    cfg_str_nav.propagation().navigation.intersection.max_mask_tolerance =
+        static_cast<float>(cfg_ray_scan.mask_tolerance());
 
     test::register_checks<detray::cuda::straight_line_navigation>(
         det, names, cfg_str_nav, ctx, white_board);
@@ -93,8 +92,7 @@ int main(int argc, char **argv) {
     test::helix_scan<wire_chamber_t>::config cfg_hel_scan{};
     cfg_hel_scan.name("wire_chamber_helix_scan_for_cuda");
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    cfg_hel_scan.mask_tolerance({detray::detail::invalid_value<scalar>(),
-                                 detray::detail::invalid_value<scalar>()});
+    cfg_hel_scan.mask_tolerance(detray::detail::invalid_value<scalar>());
     // Run only 1000 track in double precision in the CI (time limit)
     if constexpr (std::same_as<scalar, double>) {
         cfg_hel_scan.track_generator().n_tracks(1000u);
@@ -116,7 +114,8 @@ int main(int argc, char **argv) {
     cfg_hel_nav.n_tracks(cfg_hel_scan.track_generator().n_tracks());
     cfg_hel_nav.propagation().stepping.min_stepsize = min_stepsize;
     cfg_hel_nav.propagation().navigation.estimate_scattering_noise = false;
-    cfg_hel_nav.propagation().navigation.min_mask_tolerance *= 12.f;
+    cfg_hel_nav.propagation().navigation.intersection.min_mask_tolerance *=
+        12.f;
     cfg_hel_nav.propagation().navigation.search_window = {3u, 3u};
 
     test::register_checks<detray::cuda::helix_navigation>(

--- a/tests/integration_tests/device/sycl/propagator.sycl
+++ b/tests/integration_tests/device/sycl/propagator.sycl
@@ -55,7 +55,8 @@ TEST_P(SyclPropConstBFieldMng, propagator) {
     cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
     // Configuration for non-z-aligned B-fields
-    cfg.propagation.navigation.overstep_tolerance = std::get<0>(GetParam());
+    cfg.propagation.navigation.intersection.overstep_tolerance =
+        std::get<0>(GetParam());
     cfg.propagation.stepping.step_constraint = std::get<1>(GetParam());
 
     // Set the magnetic field
@@ -97,7 +98,8 @@ TEST_P(SyclPropConstBFieldCpy, propagator) {
     cfg.track_generator.eta_range(-3.f, 3.f);
     cfg.propagation.navigation.search_window = {3u, 3u};
     // Configuration for non-z-aligned B-fields
-    cfg.propagation.navigation.overstep_tolerance = std::get<0>(GetParam());
+    cfg.propagation.navigation.intersection.overstep_tolerance =
+        std::get<0>(GetParam());
     cfg.propagation.stepping.step_constraint = std::get<1>(GetParam());
 
     // Set the magnetic field

--- a/tests/tools/include/detray/options/propagation_options.hpp
+++ b/tests/tools/include/detray/options/propagation_options.hpp
@@ -33,23 +33,23 @@ void add_options<detray::navigation::config>(
         "Search window size for the grid")(
         "min_mask_tolerance",
         boost::program_options::value<float>()->default_value(
-            cfg.min_mask_tolerance / unit<float>::mm),
+            cfg.intersection.min_mask_tolerance / unit<float>::mm),
         "Minimum mask tolerance [mm]")(
         "max_mask_tolerance",
         boost::program_options::value<float>()->default_value(
-            cfg.max_mask_tolerance / unit<float>::mm),
+            cfg.intersection.max_mask_tolerance / unit<float>::mm),
         "Maximum mask tolerance [mm]")(
         "mask_tolerance_scalor",
         boost::program_options::value<float>()->default_value(
-            cfg.mask_tolerance_scalor),
+            cfg.intersection.mask_tolerance_scalor),
         "Mask tolerance scale factor")(
         "overstep_tolerance",
         boost::program_options::value<float>()->default_value(
-            cfg.overstep_tolerance / unit<float>::um),
+            cfg.intersection.overstep_tolerance / unit<float>::um),
         "Overstepping tolerance [um] NOTE: Must be negative!")(
         "path_tolerance",
         boost::program_options::value<float>()->default_value(
-            cfg.path_tolerance / unit<float>::um),
+            cfg.intersection.path_tolerance / unit<float>::um),
         "Tol. to decide when a track is on surface [um]")(
         "estimate_scattering_noise",
         "Open the navigation surface tolerance according to an estimation of "
@@ -125,31 +125,31 @@ void configure_options<detray::navigation::config>(
         const float mask_tol{vm["min_mask_tolerance"].as<float>()};
         assert(mask_tol >= 0.f);
 
-        cfg.min_mask_tolerance = mask_tol * unit<float>::mm;
+        cfg.intersection.min_mask_tolerance = mask_tol * unit<float>::mm;
     }
     if (!vm["max_mask_tolerance"].defaulted()) {
         const float mask_tol{vm["max_mask_tolerance"].as<float>()};
         assert(mask_tol >= 0.f);
 
-        cfg.max_mask_tolerance = mask_tol * unit<float>::mm;
+        cfg.intersection.max_mask_tolerance = mask_tol * unit<float>::mm;
     }
     if (!vm["mask_tolerance_scalor"].defaulted()) {
         const float mask_tol_scalor{vm["mask_tolerance_scalor"].as<float>()};
         assert(mask_tol_scalor >= 0.f);
 
-        cfg.mask_tolerance_scalor = mask_tol_scalor;
+        cfg.intersection.mask_tolerance_scalor = mask_tol_scalor;
     }
     if (!vm["overstep_tolerance"].defaulted()) {
         const float overstep_tol{vm["overstep_tolerance"].as<float>()};
         assert(overstep_tol <= 0.f);
 
-        cfg.overstep_tolerance = overstep_tol * unit<float>::um;
+        cfg.intersection.overstep_tolerance = overstep_tol * unit<float>::um;
     }
     if (!vm["path_tolerance"].defaulted()) {
         const float path_tol{vm["path_tolerance"].as<float>()};
         assert(path_tol >= 0.f);
 
-        cfg.path_tolerance = path_tol * unit<float>::um;
+        cfg.intersection.path_tolerance = path_tol * unit<float>::um;
     }
     cfg.estimate_scattering_noise = false;
     if (vm.count("estimate_scattering_noise")) {

--- a/tests/tools/src/cpu/navigation_validation.cpp
+++ b/tests/tools/src/cpu/navigation_validation.cpp
@@ -113,8 +113,7 @@ int main(int argc, char** argv) {
 
     hel_scan_cfg.name(det_name + "_helix_scan");
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    hel_scan_cfg.mask_tolerance({detray::detail::invalid_value<scalar>(),
-                                 detray::detail::invalid_value<scalar>()});
+    hel_scan_cfg.mask_tolerance(detray::detail::invalid_value<scalar>());
     hel_scan_cfg.intersection_file(file_prefix + "_helix_scan_intersections");
     hel_scan_cfg.track_param_file(file_prefix + "_helix_scan_track_parameters");
 
@@ -131,11 +130,10 @@ int main(int argc, char** argv) {
     // Number of tracks to check
     str_nav_cfg.n_tracks(ray_scan_cfg.track_generator().n_tracks());
     // Ensure that the same mask tolerance is used
-    auto mask_tolerance = ray_scan_cfg.mask_tolerance();
-    str_nav_cfg.propagation().navigation.min_mask_tolerance =
-        static_cast<float>(mask_tolerance[0]);
-    str_nav_cfg.propagation().navigation.max_mask_tolerance =
-        static_cast<float>(mask_tolerance[1]);
+    str_nav_cfg.propagation().navigation.intersection.min_mask_tolerance =
+        static_cast<float>(ray_scan_cfg.mask_tolerance());
+    str_nav_cfg.propagation().navigation.intersection.max_mask_tolerance =
+        static_cast<float>(ray_scan_cfg.mask_tolerance());
     str_nav_cfg.intersection_file(ray_scan_cfg.intersection_file());
     str_nav_cfg.track_param_file(ray_scan_cfg.track_param_file());
 

--- a/tests/tools/src/cuda/navigation_validation_cuda.cpp
+++ b/tests/tools/src/cuda/navigation_validation_cuda.cpp
@@ -103,8 +103,7 @@ int main(int argc, char** argv) {
 
     hel_scan_cfg.name(det_name + "_helix_scan_for_cuda");
     // Let the Newton algorithm dynamically choose tol. based on approx. error
-    hel_scan_cfg.mask_tolerance({detray::detail::invalid_value<scalar>(),
-                                 detray::detail::invalid_value<scalar>()});
+    hel_scan_cfg.mask_tolerance(detray::detail::invalid_value<scalar>());
     hel_scan_cfg.intersection_file(file_prefix + "_helix_scan_intersections");
     hel_scan_cfg.track_param_file(file_prefix + "_helix_scan_track_parameters");
 
@@ -117,11 +116,10 @@ int main(int argc, char** argv) {
     // Number of tracks to check
     str_nav_cfg.n_tracks(ray_scan_cfg.track_generator().n_tracks());
     // Ensure that the same mask tolerance is used
-    auto mask_tolerance = ray_scan_cfg.mask_tolerance();
-    str_nav_cfg.propagation().navigation.min_mask_tolerance =
-        static_cast<float>(mask_tolerance[0]);
-    str_nav_cfg.propagation().navigation.max_mask_tolerance =
-        static_cast<float>(mask_tolerance[1]);
+    str_nav_cfg.propagation().navigation.intersection.min_mask_tolerance =
+        static_cast<float>(ray_scan_cfg.mask_tolerance());
+    str_nav_cfg.propagation().navigation.intersection.max_mask_tolerance =
+        static_cast<float>(ray_scan_cfg.mask_tolerance());
     str_nav_cfg.intersection_file(ray_scan_cfg.intersection_file());
     str_nav_cfg.track_param_file(ray_scan_cfg.track_param_file());
 

--- a/tests/unit_tests/cpu/navigation/navigator.cpp
+++ b/tests/unit_tests/cpu/navigation/navigator.cpp
@@ -376,8 +376,7 @@ GTEST_TEST(detray_navigation, navigator_wire_chamber) {
     stepper_t stepper;
     navigator_t nav;
     navigation::config nav_cfg{};
-    nav_cfg.mask_tolerance_scalor = 1e-2f;
-    nav_cfg.path_tolerance = 1.f * unit<float>::um;
+    nav_cfg.intersection.mask_tolerance_scalor = 1e-2f;
     nav_cfg.search_window = {3u, 3u};
 
     stepping::config step_cfg{};

--- a/tests/unit_tests/cpu/propagator/covariance_transport.cpp
+++ b/tests/unit_tests/cpu/propagator/covariance_transport.cpp
@@ -100,7 +100,8 @@ GTEST_TEST(detray_propagator, covariance_transport) {
         det.surface(0u).barcode(), bound_vector, bound_cov);
 
     propagation::config prop_cfg{};
-    prop_cfg.navigation.overstep_tolerance = -100.f * unit<float>::um;
+    prop_cfg.navigation.intersection.overstep_tolerance =
+        -100.f * unit<float>::um;
     propagator_t p{prop_cfg};
     propagator_t::state propagation(bound_param0, det, prop_cfg.context);
 


### PR DESCRIPTION
Move the mask tolerances into dedicated config in order to clean up interfaces. Also moves intersection kernel file into the intersection folder