### PR TITLE
fix: a number of propagation issues

### DIFF
--- a/core/include/detray/navigation/caching_navigator.hpp
+++ b/core/include/detray/navigation/caching_navigator.hpp
@@ -249,6 +249,8 @@ class caching_navigator
                 navigation.status(navigation::status::e_unknown);
                 // This will run into the fair trust case below.
                 navigation.set_fair_trust();
+
+                DETRAY_VERBOSE_HOST("High trust broken:\n" << navigation);
             } else {
                 // Update navigation flow on the new candidate information
                 navigation::update_status(navigation, cfg);

--- a/core/include/detray/navigation/navigation_config.hpp
+++ b/core/include/detray/navigation/navigation_config.hpp
@@ -31,7 +31,7 @@ struct config {
     /// Percentage of total track path to assume as accumulated error
     float accumulated_error{0.001f};
     /// Number of standard deviations to assume to model the scattering noise
-    int n_scattering_stddev{2};
+    int n_scattering_stddev{3};
     /// Add adaptive mask tolerance to navigation
     bool estimate_scattering_noise{true};
 

--- a/core/include/detray/navigation/navigation_state.hpp
+++ b/core/include/detray/navigation/navigation_state.hpp
@@ -605,6 +605,16 @@ class base_state : public detray::ranges::view_interface<
     }
 
     private:
+    /// @returns a string stream that prints the navigation state details
+    DETRAY_HOST
+    friend std::ostream &operator<<(std::ostream &os, const derived_t &s) {
+
+        os << detray::navigation::print_state(s)
+           << detray::navigation::print_candidates(
+                  s, {}, point3_t{0.f, 0.f, 0.f}, vector3_t{0.f, 0.f, 0.f});
+        return os;
+    }
+
     /// Our cache of candidates (intersections with any kind of surface)
     candidate_cache_t m_candidates;
 

--- a/core/include/detray/navigation/navigator_base.hpp
+++ b/core/include/detray/navigation/navigator_base.hpp
@@ -91,8 +91,9 @@ class navigator_base {
 
         // Update was completely successful (most likely case)
         if (navigation.trust_level() == navigation::trust_level::e_full) {
-            DETRAY_VERBOSE_HOST_DEVICE("Update complete: dist to next %fmm",
-                                       navigation());
+            DETRAY_VERBOSE_HOST_DEVICE(
+                "Full trust, nothing left to do: dist to next %f mm",
+                navigation());
             return false;
         }
 
@@ -123,7 +124,7 @@ class navigator_base {
                                      "Re-init: ");
         }
 
-        DETRAY_VERBOSE_HOST_DEVICE("Update complete: dist to next %fmm",
+        DETRAY_VERBOSE_HOST_DEVICE("Update complete: dist to next %f mm",
                                    navigation());
 
         return is_init;

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -137,6 +137,7 @@ class base_stepper {
         /// Set the current step size
         DETRAY_HOST_DEVICE
         inline void set_step_size(const scalar_type step) {
+            assert(math::fabs(step) > 1e-4f * unit<scalar_type>::mm);
             m_step_size = step;
         }
 

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -319,7 +319,7 @@ struct propagator {
         // Pass on the whether the propagation was successful
         DETRAY_VERBOSE_HOST("Finished propagation for track:\n" << track);
         if (finished(propagation)) {
-            DETRAY_VERBOSE_HOST_DEVICE("Status: COMPLETE");
+            DETRAY_VERBOSE_HOST_DEVICE("Status: SUCCESS");
         } else if (is_paused(propagation)) {
             DETRAY_VERBOSE_HOST_DEVICE("Status: PAUSED");
         } else {

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -96,6 +96,7 @@ class rk_stepper final
         /// Set the next step size
         DETRAY_HOST_DEVICE
         inline void set_next_step_size(const scalar_type step) {
+            assert(math::fabs(step) >= 1e-4f * unit<scalar_type>::mm);
             m_next_step_size = step;
         }
 


### PR DESCRIPTION
Mainly improve the log output and
- fix setting the navigation trust level, when in rescue mode
- add print operator to navigator state for convenience
- fix setting the next step size in the stepper, so that it never gets to zero (mostly an issue if an overlap is encountered)