### PR TITLE
ref: reduce branching in Jacobian calculation

### DIFF
--- a/core/include/detray/propagator/detail/jacobian_cartesian.hpp
+++ b/core/include/detray/propagator/detail/jacobian_cartesian.hpp
@@ -44,15 +44,15 @@ struct jacobian<cartesian2D<algebra_t>> {
     /// @}
 
     DETRAY_HOST_DEVICE
-    static inline rotation_matrix reference_frame(
+    static constexpr rotation_matrix reference_frame(
         const transform3_type &trf3, const point3_type & /*pos*/,
         const vector3_type & /*dir*/) {
         return trf3.rotation();
     }
 
-    DETRAY_HOST_DEVICE static inline free_to_path_matrix_type path_derivative(
-        const transform3_type &trf3, const point3_type & /*pos*/,
-        const vector3_type &dir, const vector3_type & /*dtds*/) {
+    DETRAY_HOST_DEVICE static constexpr free_to_path_matrix_type
+    path_derivative(const transform3_type &trf3, const point3_type & /*pos*/,
+                    const vector3_type &dir, const vector3_type & /*dtds*/) {
 
         free_to_path_matrix_type derivative =
             matrix::zero<free_to_path_matrix_type>();

--- a/core/include/detray/propagator/detail/jacobian_cylindrical.hpp
+++ b/core/include/detray/propagator/detail/jacobian_cylindrical.hpp
@@ -44,9 +44,9 @@ struct jacobian<cylindrical2D<algebra_t>> {
         free_to_bound_jacobian_submatrix<algebra_type>;
 
     DETRAY_HOST_DEVICE
-    static inline rotation_matrix reference_frame(const transform3_type &trf3,
-                                                  const point3_type &pos,
-                                                  const vector3_type &dir) {
+    static constexpr rotation_matrix reference_frame(
+        const transform3_type &trf3, const point3_type &pos,
+        const vector3_type &dir) {
 
         rotation_matrix rot = matrix::zero<rotation_matrix>();
 
@@ -72,9 +72,9 @@ struct jacobian<cylindrical2D<algebra_t>> {
         return rot;
     }
 
-    DETRAY_HOST_DEVICE static inline free_to_path_matrix_type path_derivative(
-        const transform3_type &trf3, const point3_type &pos,
-        const vector3_type &dir, const vector3_type & /*dtds*/) {
+    DETRAY_HOST_DEVICE static constexpr free_to_path_matrix_type
+    path_derivative(const transform3_type &trf3, const point3_type &pos,
+                    const vector3_type &dir, const vector3_type & /*dtds*/) {
 
         free_to_path_matrix_type derivative =
             matrix::zero<free_to_path_matrix_type>();

--- a/core/include/detray/propagator/detail/jacobian_engine.hpp
+++ b/core/include/detray/propagator/detail/jacobian_engine.hpp
@@ -46,7 +46,7 @@ struct jacobian_engine {
 
     template <typename frame_t, typename mask_t>
         requires concepts::point<typename frame_t::loc_point>
-    DETRAY_HOST_DEVICE static inline bound_to_free_matrix_type
+    DETRAY_HOST_DEVICE static constexpr bound_to_free_matrix_type
     bound_to_free_jacobian(
         const transform3_type& trf3, const mask_t& mask,
         const bound_parameters_vector<algebra_type>& bound_vec) {
@@ -202,7 +202,7 @@ struct jacobian_engine {
 
     template <typename frame_t>
         requires concepts::point<typename frame_t::loc_point>
-    DETRAY_HOST_DEVICE static inline free_to_bound_matrix_type
+    DETRAY_HOST_DEVICE static constexpr free_to_bound_matrix_type
     free_to_bound_jacobian(
         const transform3_type& trf3,
         const free_track_parameters<algebra_type>& free_params) {
@@ -247,7 +247,7 @@ struct jacobian_engine {
 
     template <typename frame_t>
         requires concepts::point<typename frame_t::loc_point>
-    DETRAY_HOST_DEVICE static inline free_to_path_matrix_type
+    DETRAY_HOST_DEVICE static constexpr free_to_path_matrix_type
     free_to_path_derivative(const vector3_type& pos, const vector3_type& dir,
                             const vector3_type& dtds,
                             const transform3_type& trf3) {
@@ -256,7 +256,7 @@ struct jacobian_engine {
         return jacobian_t::path_derivative(trf3, pos, dir, dtds);
     }
 
-    DETRAY_HOST_DEVICE static inline path_to_free_matrix_type
+    DETRAY_HOST_DEVICE static constexpr path_to_free_matrix_type
     path_to_free_derivative(const vector3_type& dir, const vector3_type& dtds,
                             const scalar_type dqopds) {
 
@@ -275,10 +275,10 @@ struct jacobian_engine {
 
     template <typename frame_t>
         requires concepts::point<typename frame_t::loc_point>
-    DETRAY_HOST_DEVICE static inline free_matrix<algebra_type> path_correction(
-        const vector3_type& pos, const vector3_type& dir,
-        const vector3_type& dtds, const scalar_type dqopds,
-        const transform3_type& trf3) {
+    DETRAY_HOST_DEVICE static constexpr free_matrix<algebra_type>
+    path_correction(const vector3_type& pos, const vector3_type& dir,
+                    const vector3_type& dtds, const scalar_type dqopds,
+                    const transform3_type& trf3) {
 
         return path_to_free_derivative(dir, dtds, dqopds) *
                free_to_path_derivative<frame_t>(pos, dir, dtds, trf3);

--- a/core/include/detray/propagator/detail/jacobian_line.hpp
+++ b/core/include/detray/propagator/detail/jacobian_line.hpp
@@ -43,9 +43,9 @@ struct jacobian<line2D<algebra_t>> {
     /// @}
 
     DETRAY_HOST_DEVICE
-    static inline rotation_matrix reference_frame(const transform3_type &trf3,
-                                                  const point3_type & /*pos*/,
-                                                  const vector3_type &dir) {
+    static constexpr rotation_matrix reference_frame(
+        const transform3_type &trf3, const point3_type & /*pos*/,
+        const vector3_type &dir) {
 
         rotation_matrix rot = matrix::zero<rotation_matrix>();
 
@@ -70,9 +70,9 @@ struct jacobian<line2D<algebra_t>> {
         return rot;
     }
 
-    DETRAY_HOST_DEVICE static inline free_to_path_matrix_type path_derivative(
-        const transform3_type &trf3, const point3_type &pos,
-        const vector3_type &dir, const vector3_type &dtds) {
+    DETRAY_HOST_DEVICE static constexpr free_to_path_matrix_type
+    path_derivative(const transform3_type &trf3, const point3_type &pos,
+                    const vector3_type &dir, const vector3_type &dtds) {
 
         free_to_path_matrix_type derivative =
             matrix::zero<free_to_path_matrix_type>();

--- a/core/include/detray/propagator/detail/jacobian_polar.hpp
+++ b/core/include/detray/propagator/detail/jacobian_polar.hpp
@@ -47,15 +47,15 @@ struct jacobian<polar2D<algebra_t>> {
     /// @}
 
     DETRAY_HOST_DEVICE
-    static inline rotation_matrix reference_frame(
+    static constexpr rotation_matrix reference_frame(
         const transform3_type &trf3, const point3_type & /*pos*/,
         const vector3_type & /*dir*/) {
         return trf3.rotation();
     }
 
-    DETRAY_HOST_DEVICE static inline free_to_path_matrix_type path_derivative(
-        const transform3_type &trf3, const point3_type & /*pos*/,
-        const vector3_type &dir, const vector3_type & /*dtds*/) {
+    DETRAY_HOST_DEVICE static constexpr free_to_path_matrix_type
+    path_derivative(const transform3_type &trf3, const point3_type & /*pos*/,
+                    const vector3_type &dir, const vector3_type & /*dtds*/) {
 
         free_to_path_matrix_type derivative =
             matrix::zero<free_to_path_matrix_type>();

--- a/core/include/detray/utils/type_list.hpp
+++ b/core/include/detray/utils/type_list.hpp
@@ -17,7 +17,9 @@
 #include <string_view>
 #include <type_traits>
 
-namespace detray::types {
+namespace detray {
+
+namespace types {
 
 /// @brief type list implementation
 /// @see https://www.codingwiththomas.com/blog/getting-started-with-typelists
@@ -134,6 +136,22 @@ struct do_push_front<N, list<Ts...>> {
 template <typename L, typename N>
 using push_front = typename do_push_front<N, L>::type;
 /// @}
+
+/// Traits for the type list
+/// @{
+namespace detail {
+
+template <typename = void>
+struct is_type_list : public std::false_type {};
+
+template <typename... Ts>
+struct is_type_list<types::list<Ts...>> : public std::true_type {};
+
+template <typename L>
+inline constexpr bool is_type_list_v{is_type_list<L>::value};
+
+}  // namespace detail
+///@}
 
 /// Print the type list
 /// @{
@@ -311,4 +329,16 @@ DETRAY_HOST_DEVICE consteval auto filtered_indices(
     }
 }
 
-}  // namespace detray::types
+}  // namespace types
+
+/// Type list concepts
+/// @{
+namespace concepts {
+
+template <typename L>
+concept type_list = types::detail::is_type_list_v<L>;
+
+}
+///@}
+
+}  // namespace detray

--- a/tests/integration_tests/cpu/utils/type_registry.cpp
+++ b/tests/integration_tests/cpu/utils/type_registry.cpp
@@ -56,7 +56,7 @@ GTEST_TEST(detray_utils, mapped_type_registry) {
     //
     // Test the mapping
     //
-    constexpr const auto& idx_array = mapped_registry_t::index_map();
+    constexpr auto idx_array = mapped_registry_t::index_map();
 
     static_assert(mapped_registry_t::n_types == 3u);
     static_assert(types::size<mapped_registry_t> == 3u);


### PR DESCRIPTION
Use the mapped type registry to branch only on the local frame type instead of the mask shape type. Like this, rectangle and trapezoid shapes will take the same code branch to calculate the Jacobian transport.