### PR TITLE
fix: propagation stall criterion in backward navigation

### DIFF
--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -282,8 +282,8 @@ struct propagator {
 
                 // Check if the propagation makes progress
                 if (math::fabs(stepping.path_length()) <=
-                    math::fabs(path_length +
-                               m_cfg.navigation.intersection.path_tolerance)) {
+                    math::fabs(path_length) +
+                        m_cfg.navigation.intersection.path_tolerance) {
                     if (stall_counter >= 10u) {
                         propagation._heartbeat = false;
                         navigation.abort("Propagation stalled");


### PR DESCRIPTION
The absolute value should only be taken of the negative path length. This fixes an endless loop in the backward Kalman fit for the ITk in traccc