### PR TITLE
Make `ranges::iota` a random-access range

### DIFF
--- a/core/include/detray/utils/concepts.hpp
+++ b/core/include/detray/utils/concepts.hpp
@@ -45,4 +45,14 @@ concept interval = requires(I i) {
     { detray::detail::get<1>(i) } -> concepts::arithmetic_cvref;
 };
 
+/// Concept that checks whether a type can be incremented with arbitrary
+/// integer values.
+template <typename T>
+concept random_access_incrementable = requires(T i, const T j, int n) {
+    { i += n } -> std::same_as<T &>;
+    { j + n } -> std::same_as<T>;
+    { n + j } -> std::same_as<T>;
+    { i -= n } -> std::same_as<T &>;
+    { j - n } -> std::same_as<T>;
+};
 }  // namespace detray::concepts

--- a/core/include/detray/utils/ranges/iota.hpp
+++ b/core/include/detray/utils/ranges/iota.hpp
@@ -11,9 +11,11 @@
 #include "detray/definitions/detail/qualifiers.hpp"
 #include "detray/definitions/indexing.hpp"
 #include "detray/utils/concepts.hpp"
+#include "detray/utils/ranges/detail/iterator_functions.hpp"
 #include "detray/utils/ranges/ranges.hpp"
 
 // System include(s)
+#include <concepts>
 #include <iterator>
 #include <type_traits>
 
@@ -30,16 +32,18 @@ namespace detray::ranges {
 /// @note Is not fit for lazy evaluation.
 template <std::incrementable incr_t>
 class iota_view : public detray::ranges::view_interface<iota_view<incr_t>> {
-
     private:
     /// @brief Nested iterator to generate a range of values on demand.
     struct iterator {
-
         using difference_type = std::ptrdiff_t;
         using value_type = incr_t;
         using pointer = incr_t *;
         using reference = incr_t;
-        using iterator_category = detray::ranges::bidirectional_iterator_tag;
+        using iterator_category =
+            std::conditional_t<concepts::random_access_incrementable<incr_t> &&
+                                   std::totally_ordered<incr_t>,
+                               detray::ranges::random_access_iterator_tag,
+                               detray::ranges::bidirectional_iterator_tag>;
 
         constexpr iterator()
             requires std::default_initializable<incr_t>
@@ -72,6 +76,54 @@ class iota_view : public detray::ranges::view_interface<iota_view<incr_t>> {
             --(*this);
             return tmp;
         }
+
+        DETRAY_HOST_DEVICE constexpr iterator &operator+=(
+            const difference_type n)
+            requires concepts::random_access_incrementable<incr_t>
+        {
+            difference_type nv = static_cast<difference_type>(m_i) + n;
+            // Check if the round trip between difference type and incrementor
+            // type is valid.
+            assert(static_cast<difference_type>(static_cast<incr_t>(nv)) == nv);
+            m_i = static_cast<incr_t>(nv);
+            return *this;
+        }
+
+        DETRAY_HOST_DEVICE friend constexpr iterator operator+(
+            const iterator &i, const difference_type n)
+            requires concepts::random_access_incrementable<incr_t>
+        {
+            return iterator(i.m_i + n);
+        }
+
+        DETRAY_HOST_DEVICE friend constexpr iterator operator+(
+            const difference_type n, const iterator &i)
+            requires concepts::random_access_incrementable<incr_t>
+        {
+            return iterator(i.m_i + n);
+        }
+
+        DETRAY_HOST_DEVICE constexpr iterator &operator-=(
+            const difference_type n)
+            requires concepts::random_access_incrementable<incr_t>
+        {
+            m_i -= n;
+            return *this;
+        }
+
+        DETRAY_HOST_DEVICE friend constexpr iterator operator-(
+            const iterator &i, const difference_type n)
+            requires concepts::random_access_incrementable<incr_t>
+        {
+            return iterator(i.m_i - n);
+        }
+
+        DETRAY_HOST_DEVICE friend constexpr difference_type operator-(
+            const iterator &i, const iterator &j)
+            requires concepts::random_access_incrementable<incr_t>
+        {
+            return i.m_i - j.m_i;
+        }
         /// @}
 
         /// @returns the current value in the sequence - copy
@@ -81,11 +133,26 @@ class iota_view : public detray::ranges::view_interface<iota_view<incr_t>> {
             return m_i;
         }
 
+        DETRAY_HOST_DEVICE
+        constexpr incr_t operator[](const difference_type n) const
+            requires concepts::random_access_incrementable<incr_t>
+        {
+            return static_cast<incr_t>(m_i + n);
+        }
+
         private:
         /// @returns true if incremetables are the same
         DETRAY_HOST_DEVICE
         friend constexpr bool operator==(const iterator &lhs,
                                          const iterator &rhs) = default;
+
+        DETRAY_HOST_DEVICE
+        friend constexpr auto operator<=>(const iterator &lhs,
+                                          const iterator &rhs)
+            requires std::totally_ordered<incr_t>
+        {
+            return lhs.m_i <=> rhs.m_i;
+        };
 
         /// Current value of sequence
         incr_t m_i{};

--- a/tests/integration_tests/cpu/utils/ranges.cpp
+++ b/tests/integration_tests/cpu/utils/ranges.cpp
@@ -26,7 +26,7 @@ GTEST_TEST(detray_utils, ranges_subrange_iota) {
     // Check iterator category
     static_assert(detray::ranges::forward_range<decltype(iota_sr)>);
     static_assert(detray::ranges::bidirectional_range<decltype(iota_sr)>);
-    static_assert(!detray::ranges::random_access_range<decltype(iota_sr)>);
+    static_assert(detray::ranges::random_access_range<decltype(iota_sr)>);
 
     std::size_t i{4u};
     for (const auto v : iota_sr) {
@@ -102,10 +102,10 @@ GTEST_TEST(detray_utils, ranges_pick_static_joined_sequence) {
     // Check iterator category
     static_assert(detray::ranges::forward_range<decltype(indices)>);
     static_assert(detray::ranges::bidirectional_range<decltype(indices)>);
-    static_assert(!detray::ranges::random_access_range<decltype(indices)>);
+    static_assert(detray::ranges::random_access_range<decltype(indices)>);
     static_assert(detray::ranges::forward_range<decltype(selected)>);
     static_assert(detray::ranges::bidirectional_range<decltype(selected)>);
-    static_assert(!detray::ranges::random_access_range<decltype(selected)>);
+    static_assert(detray::ranges::random_access_range<decltype(selected)>);
 
     // Test inherited member functions
     const auto [i, v] = selected[2];

--- a/tests/unit_tests/cpu/utils/ranges.cpp
+++ b/tests/unit_tests/cpu/utils/ranges.cpp
@@ -199,7 +199,7 @@ GTEST_TEST(detray_utils, ranges_iota_single) {
     static_assert(detray::ranges::view<decltype(seq)>);
     static_assert(detray::ranges::forward_range<decltype(seq)>);
     static_assert(detray::ranges::bidirectional_range<decltype(seq)>);
-    static_assert(!detray::ranges::random_access_range<decltype(seq)>);
+    static_assert(detray::ranges::random_access_range<decltype(seq)>);
 
     // Test prerequisits for LagacyIterator
     static_assert(
@@ -230,7 +230,7 @@ GTEST_TEST(detray_utils, ranges_iota_interval) {
     static_assert(std::is_copy_assignable_v<decltype(seq)>);
     static_assert(detray::ranges::forward_range<decltype(seq)>);
     static_assert(detray::ranges::bidirectional_range<decltype(seq)>);
-    static_assert(!detray::ranges::random_access_range<decltype(seq)>);
+    static_assert(detray::ranges::random_access_range<decltype(seq)>);
 
     // Test prerequisits for LagacyIterator
     static_assert(


### PR DESCRIPTION
This commit updates the `ranges::iota` range such that, if the chosen incrementable is also random-access incrementable, the entire range becomes a random access range.