### PR TITLE
Turn stepper and propagator members into refs

### DIFF
--- a/core/include/detray/definitions/detail/qualifiers.hpp
+++ b/core/include/detray/definitions/detail/qualifiers.hpp
@@ -61,3 +61,9 @@
 #else
 #define DETRAY_NO_UNIQUE_ADDRESS
 #endif
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+#define DETRAY_GRID_CONSTANT __grid_constant__
+#else
+#define DETRAY_GRID_CONSTANT
+#endif

--- a/core/include/detray/propagator/base_stepper.hpp
+++ b/core/include/detray/propagator/base_stepper.hpp
@@ -51,6 +51,7 @@ class base_stepper {
     using bound_track_parameters_type = bound_track_parameters<algebra_t>;
     using free_matrix_type = free_matrix<algebra_t>;
     using bound_matrix_type = bound_matrix<algebra_t>;
+    using magnetic_field_type = void;
 
     using inspector_type = inspector_t;
     using policy_type = policy_t;

--- a/core/include/detray/propagator/propagator.hpp
+++ b/core/include/detray/propagator/propagator.hpp
@@ -47,7 +47,7 @@ struct propagator {
     using bound_track_parameters_type =
         typename stepper_t::bound_track_parameters_type;
 
-    propagation::config m_cfg;
+    const propagation::config &m_cfg;
 
     stepper_t m_stepper;
     navigator_t m_navigator;
@@ -89,7 +89,10 @@ struct propagator {
             const free_track_parameters_type &free_params,
             const field_t &magnetic_field, const detector_type &det,
             const context_type &ctx = {})
-            requires(!states_as_reference)
+            requires(!states_as_reference &&
+                     requires { typename stepper_type::magnetic_field_type; } &&
+                     std::same_as<field_t,
+                                  typename stepper_type::magnetic_field_type>)
             : _stepping(free_params, magnetic_field),
               _navigation(det),
               _context(ctx) {}
@@ -112,7 +115,10 @@ struct propagator {
             const field_t &magnetic_field, const detector_type &det,
             typename navigator_type::state::view_type nav_view,
             const context_type &ctx = {})
-            requires(!states_as_reference)
+            requires(!states_as_reference &&
+                     requires { typename stepper_type::magnetic_field_type; } &&
+                     std::same_as<field_t,
+                                  typename stepper_type::magnetic_field_type>)
             : _stepping(free_params, magnetic_field),
               _navigation(det, nav_view),
               _context(ctx) {}
@@ -140,6 +146,9 @@ struct propagator {
                                       const field_t &magnetic_field,
                                       const detector_type &det,
                                       const context_type &ctx = {})
+            requires(requires { typename stepper_type::magnetic_field_type; } &&
+                     std::same_as<field_t,
+                                  typename stepper_type::magnetic_field_type>)
             : _stepping(param, magnetic_field, det, ctx),
               _navigation(det),
               _context(ctx) {
@@ -154,6 +163,9 @@ struct propagator {
             const field_t &magnetic_field, const detector_type &det,
             typename navigator_type::state::view_type nav_view,
             const context_type &ctx = {})
+            requires(requires { typename stepper_type::magnetic_field_type; } &&
+                     std::same_as<field_t,
+                                  typename stepper_type::magnetic_field_type>)
             : _stepping(param, magnetic_field, det, ctx),
               _navigation(det, nav_view),
               _context(ctx) {

--- a/core/include/detray/propagator/rk_stepper.hpp
+++ b/core/include/detray/propagator/rk_stepper.hpp
@@ -251,7 +251,7 @@ class rk_stepper final
         scalar_type m_next_step_size{0.f};
 
         /// Magnetic field view
-        const magnetic_field_type m_magnetic_field;
+        const magnetic_field_type& m_magnetic_field;
     };
 
     /// Take a step, using an adaptive Runge-Kutta algorithm.

--- a/tests/benchmarks/include/detray/benchmarks/cpu/propagation_benchmark.hpp
+++ b/tests/benchmarks/include/detray/benchmarks/cpu/propagation_benchmark.hpp
@@ -108,7 +108,9 @@ struct host_propagation_bm : public benchmark_base {
             typename actor_chain_t::state_ref_tuple actor_state_refs =
                 actor_chain_t::setup_actor_states(actor_states);
 
-            typename propagator_t::state p_state(track, *bfield, *det);
+            typename propagator_t::stepper_type::magnetic_field_type
+                bfield_view(*bfield);
+            typename propagator_t::state p_state(track, bfield_view, *det);
             // Particle hypothesis
             auto &ptc = p_state.stepping().particle_hypothesis();
             p_state.set_particle(update_particle_hypothesis(ptc, track));

--- a/tests/benchmarks/include/detray/benchmarks/device/cuda/propagation_benchmark.cu
+++ b/tests/benchmarks/include/detray/benchmarks/device/cuda/propagation_benchmark.cu
@@ -12,8 +12,10 @@ namespace detray::benchmarks {
 
 template <typename propagator_t, detray::benchmarks::propagation_opt kOPT>
 __global__ void __launch_bounds__(256, 4) propagator_benchmark_kernel(
-    propagation::config cfg,
+    const DETRAY_GRID_CONSTANT propagation::config cfg,
+    const DETRAY_GRID_CONSTANT
     typename propagator_t::detector_type::view_type det_view,
+    const DETRAY_GRID_CONSTANT
     typename propagator_t::stepper_type::magnetic_field_type field_view,
     const typename propagator_t::actor_chain_type::state_tuple
         *device_actor_state_ptr,

--- a/tests/include/detray/test/device/cuda/navigation_validation.cu
+++ b/tests/include/detray/test/device/cuda/navigation_validation.cu
@@ -115,8 +115,10 @@ __global__ void navigation_validation_kernel(
 
         p.propagate(propagation, actor_states);
     } else {
+        typename propagator_t::stepper_type::magnetic_field_type bfield_view(
+            field_data);
         typename propagator_t::state propagation(
-            track, field_data, det,
+            track, bfield_view, det,
             typename navigator_t::state::view_type{
                 recorded_intersections_view.ptr()[trk_id]});
         propagation.set_particle(update_particle_hypothesis(ptc_hypo, track));

--- a/tests/include/detray/test/device/propagator_test.hpp
+++ b/tests/include/detray/test/device/propagator_test.hpp
@@ -114,7 +114,7 @@ template <typename bfield_bknd_t, typename host_detector_t>
 inline auto run_propagation_host(vecmem::memory_resource *mr,
                                  const host_detector_t &det,
                                  const propagation::config &cfg,
-                                 covfie::field<bfield_bknd_t> &field,
+                                 const covfie::field<bfield_bknd_t> &field,
                                  const vecmem::vector<test_track> &tracks)
     -> vecmem::jagged_vector<detail::step_data<test_algebra>> {
 
@@ -145,7 +145,8 @@ inline auto run_propagation_host(vecmem::memory_resource *mr,
             detray::tie(tracer_state, pathlimit_state, transporter_state,
                         interactor_state, resetter_state);
 
-        typename propagator_host_t::state state(trk, field, det);
+        typename covfie::field<bfield_bknd_t>::view_t bfield_view(field);
+        typename propagator_host_t::state state(trk, bfield_view, det);
 
         state.stepping().template set_constraint<step::constraint::e_accuracy>(
             cfg.stepping.step_constraint);

--- a/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -211,8 +211,10 @@ inline auto record_propagation(
         propagation =
             std::make_unique<typename propagator_t::state>(track, det, ctx);
     } else {
+        typename propagator_t::stepper_type::magnetic_field_type bfield_view(
+            bfield);
         propagation = std::make_unique<typename propagator_t::state>(
-            track, bfield, det, ctx);
+            track, bfield_view, det, ctx);
     }
 
     // Set the initial covariances
@@ -257,8 +259,10 @@ inline auto record_propagation(
             fw_propagation = std::make_unique<typename fw_propagator_t::state>(
                 track, det, ctx);
         } else {
+            typename fw_propagator_t::stepper_type::magnetic_field_type
+                bfield_view(bfield);
             fw_propagation = std::make_unique<typename fw_propagator_t::state>(
-                track, bfield, det, ctx);
+                track, bfield_view, det, ctx);
         }
 
         // Make a deep copy of states for forward propagation, but omit the

--- a/tests/integration_tests/cpu/material/material_interaction.cpp
+++ b/tests/integration_tests/cpu/material/material_interaction.cpp
@@ -350,7 +350,9 @@ GTEST_TEST(detray_material, telescope_geometry_volume_material) {
             -100.f * unit<float>::um;
         propagator_t p{prop_cfg};
 
-        propagator_t::state state(bound_param, const_bfield, det);
+        propagator_t::stepper_type::magnetic_field_type bfield_view(
+            const_bfield);
+        propagator_t::state state(bound_param, bfield_view, det);
 
         pathlimit_aborter_t::state abrt_state{path_limit};
         auto actor_states = detray::tie(abrt_state);

--- a/tests/integration_tests/cpu/propagator/backward_propagation.cpp
+++ b/tests/integration_tests/cpu/propagator/backward_propagation.cpp
@@ -64,6 +64,7 @@ TEST_P(BackwardPropagation, backward_propagation) {
     vector3 B{0.f * unit<scalar>::T, 0.f * unit<scalar>::T,
               1.f * unit<scalar>::T};
     const bfield_t hom_bfield = create_const_field<scalar>(B);
+    const bfield_t::view_t bfield_view(hom_bfield);
 
     using navigator_t = caching_navigator<decltype(det)>;
     using rk_stepper_t = rk_stepper<bfield_t::view_t, test_algebra>;
@@ -102,7 +103,7 @@ TEST_P(BackwardPropagation, backward_propagation) {
     parameter_resetter<test_algebra>::state resetter_state{prop_cfg};
 
     // Forward state
-    propagator_t::state fw_state(bound_param0, hom_bfield, det,
+    propagator_t::state fw_state(bound_param0, bfield_view, det,
                                  prop_cfg.context);
     fw_state.set_particle(ptc);
     fw_state.debug(true);
@@ -122,7 +123,7 @@ TEST_P(BackwardPropagation, backward_propagation) {
     EXPECT_EQ(bound_param1.surface_link().index(), positions.size() - 1u);
 
     // Backward state
-    propagator_t::state bw_state(bound_param1, hom_bfield, det,
+    propagator_t::state bw_state(bound_param1, bfield_view, det,
                                  prop_cfg.context);
     bw_state.set_particle(ptc);
     bw_state.debug(true);

--- a/tests/integration_tests/cpu/propagator/guided_navigator.cpp
+++ b/tests/integration_tests/cpu/propagator/guided_navigator.cpp
@@ -87,7 +87,8 @@ GTEST_TEST(detray_navigation, guided_navigator) {
     // Propagator
     propagation::config prop_cfg{};
     propagator_t p{prop_cfg};
-    propagator_t::state guided_state(track, b_field, telescope_det);
+    propagator_t::stepper_type::magnetic_field_type bfield_view(b_field);
+    propagator_t::state guided_state(track, bfield_view, telescope_det);
 
     // Propagate
     p.propagate(guided_state, detray::tie(pathlimit));

--- a/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
+++ b/tests/integration_tests/cpu/propagator/jacobian_validation.cpp
@@ -489,7 +489,8 @@ bound_getter<test_algebra>::state evaluate_bound_param(
         detray::tie(transporter_state, bound_getter_state, resetter_state);
 
     // Init propagator states for the reference track
-    typename propagator_t::state state(initial_param, field, det);
+    typename propagator_t::stepper_type::magnetic_field_type bfield_view(field);
+    typename propagator_t::state state(initial_param, bfield_view, det);
 
     // Run the propagation for the reference track
     state.set_particle(ptc);
@@ -528,7 +529,8 @@ bound_param_vector_type get_displaced_bound_vector(
     bound_track_parameters<test_algebra> dparam = ref_param;
     dparam[target_index] += displacement;
 
-    typename propagator_t::state dstate(dparam, field, det);
+    typename propagator_t::stepper_type::magnetic_field_type bfield_view(field);
+    typename propagator_t::state dstate(dparam, bfield_view, det);
 
     // Actor states
     parameter_transporter<test_algebra>::state transporter_state{};

--- a/tests/integration_tests/cpu/propagator/propagation_caching_navigator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagation_caching_navigator.cpp
@@ -245,9 +245,11 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_const_bfield) {
         pathlimit_aborter_state.set_path_limit(path_limit);
 
         // Init propagator states
-        propagator_t::state state(track, bfield, det);
-        propagator_t::state sync_state(track, bfield, det);
-        propagator_t::state lim_state(lim_track, bfield, det);
+        typename propagator_t::stepper_type::magnetic_field_type bfield_view(
+            bfield);
+        propagator_t::state state(track, bfield_view, det);
+        propagator_t::state sync_state(track, bfield_view, det);
+        propagator_t::state lim_state(lim_track, bfield_view, det);
 
         state.debug(true);
         sync_state.debug(true);
@@ -347,8 +349,10 @@ TEST_P(PropagatorWithRkStepper, rk4_propagator_inhom_bfield) {
                         interactor_state, resetter_state);
 
         // Init propagator states
-        propagator_t::state state(track, bfield, det);
-        propagator_t::state lim_state(lim_track, bfield, det);
+        typename propagator_t::stepper_type::magnetic_field_type bfield_view(
+            bfield);
+        propagator_t::state state(track, bfield_view, det);
+        propagator_t::state lim_state(lim_track, bfield_view, det);
 
         // Set step constraints
         state.stepping().template set_constraint<step::constraint::e_accuracy>(

--- a/tests/integration_tests/cpu/propagator/propagation_direct_navigator.cpp
+++ b/tests/integration_tests/cpu/propagator/propagation_direct_navigator.cpp
@@ -89,6 +89,7 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorToyDetector, direct_navigator) {
 
     // Build mangetic field
     const bfield_t bfield = create_const_field<scalar>(std::get<1>(GetParam()));
+    const bfield_t::view_t bfield_view(bfield);
 
     // Track generator config
     generator_t::configuration trk_gen_cfg{};
@@ -137,7 +138,7 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorToyDetector, direct_navigator) {
         auto actor_states = detray::tie(transporter_state, interactor_state,
                                         sequencer_state, resetter_state);
 
-        propagator_t::state state(track, bfield, det);
+        propagator_t::state state(track, bfield_view, det);
         navigator_t::state& navigation = state.navigation();
 
         // Propagate the entire detector
@@ -153,8 +154,8 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorToyDetector, direct_navigator) {
                 detray::tie(transporter_state, interactor_state,
                             sequencer_backward_state, resetter_state);
 
-            direct_propagator_t::state direct_forward_state(track, bfield, det,
-                                                            seqs_buffer);
+            direct_propagator_t::state direct_forward_state(track, bfield_view,
+                                                            det, seqs_buffer);
 
             ASSERT_TRUE(direct_p.propagate(direct_forward_state,
                                            direct_forward_actor_states));
@@ -185,8 +186,8 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorToyDetector, direct_navigator) {
                 static_cast<float>(state.stepping().bound_params().p(q)) * tol);
 
             direct_propagator_t::state direct_backward_state(
-                direct_forward_state.stepping().bound_params(), bfield, det,
-                seqs_buffer);
+                direct_forward_state.stepping().bound_params(), bfield_view,
+                det, seqs_buffer);
             direct_backward_state.navigation().set_direction(
                 detray::navigation::direction::e_backward);
             direct_backward_state.navigation().reset();
@@ -278,6 +279,7 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorWireChamber, direct_navigator) {
 
     // Build mangetic field
     const bfield_t bfield = create_const_field<scalar>(std::get<1>(GetParam()));
+    const bfield_t::view_t bfield_view(bfield);
 
     // Truth track generation
     generator_t::configuration trk_gen_cfg{};
@@ -327,7 +329,7 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorWireChamber, direct_navigator) {
         auto actor_states = detray::tie(transporter_state, interactor_state,
                                         sequencer_state, resetter_state);
 
-        propagator_t::state state(track, bfield, det);
+        propagator_t::state state(track, bfield_view, det);
         navigator_t::state& navigation = state.navigation();
 
         // Propagate the entire detector
@@ -343,8 +345,8 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorWireChamber, direct_navigator) {
                 detray::tie(transporter_state, interactor_state,
                             sequencer_backward_state, resetter_state);
 
-            direct_propagator_t::state direct_forward_state(track, bfield, det,
-                                                            seqs_buffer);
+            direct_propagator_t::state direct_forward_state(track, bfield_view,
+                                                            det, seqs_buffer);
 
             ASSERT_TRUE(direct_p.propagate(direct_forward_state,
                                            direct_forward_actor_states));
@@ -375,8 +377,8 @@ TEST_P(PropagatorWithRkStepperDirectNavigatorWireChamber, direct_navigator) {
                 static_cast<float>(state.stepping().bound_params().p(q)) * tol);
 
             direct_propagator_t::state direct_backward_state(
-                direct_forward_state.stepping().bound_params(), bfield, det,
-                seqs_buffer);
+                direct_forward_state.stepping().bound_params(), bfield_view,
+                det, seqs_buffer);
             direct_backward_state.navigation().set_direction(
                 detray::navigation::direction::e_backward);
             direct_backward_state.navigation().reset();

--- a/tests/unit_tests/cpu/detectors/telescope_detector.cpp
+++ b/tests/unit_tests/cpu/detectors/telescope_detector.cpp
@@ -101,6 +101,8 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         b_field_t::backend_t::configuration_t{B_z[0], B_z[1], B_z[2]})};
     b_field_t b_field_x{covfie::make_parameter_pack(
         b_field_t::backend_t::configuration_t{B_x[0], B_x[1], B_x[2]})};
+    b_field_t::view_t b_field_z_view(b_field_z);
+    b_field_t::view_t b_field_x_view(b_field_x);
 
     // steppers
     rk_stepper_t rk_stepper_z;
@@ -189,11 +191,11 @@ GTEST_TEST(detray_detectors, telescope_detector) {
 
     // propagation states
     prop_state<stepping_state_t, navigation_state_t> propgation_z1(
-        test_track_z1, b_field_z, z_tel_det1);
+        test_track_z1, b_field_z_view, z_tel_det1);
     prop_state<stepping_state_t, navigation_state_t> propgation_z2(
-        test_track_z2, b_field_z, z_tel_det2);
+        test_track_z2, b_field_z_view, z_tel_det2);
     prop_state<stepping_state_t, navigation_state_t> propgation_x(
-        test_track_x, b_field_x, x_tel_det);
+        test_track_x, b_field_x_view, x_tel_det);
 
     stepping_state_t &stepping_z1 = propgation_z1._stepping;
     stepping_state_t &stepping_z2 = propgation_z2._stepping;
@@ -304,7 +306,7 @@ GTEST_TEST(detray_detectors, telescope_detector) {
         tel_navigator;
 
     prop_state<stepping_state_t, navigation_state_t> tel_propagation(
-        pilot_track, b_field_z, tel_detector);
+        pilot_track, b_field_z_view, tel_detector);
     navigation_state_t &tel_navigation = tel_propagation._navigation;
     stepping_state_t &tel_stepping = tel_propagation._stepping;
 

--- a/tests/unit_tests/cpu/propagator/rk_stepper.cpp
+++ b/tests/unit_tests/cpu/propagator/rk_stepper.cpp
@@ -58,6 +58,7 @@ GTEST_TEST(detray_propagator, rk_stepper) {
     vector3 B{1.f * unit<scalar>::T, 1.f * unit<scalar>::T,
               1.f * unit<scalar>::T};
     const bfield_t hom_bfield = create_const_field<scalar>(B);
+    const bfield_t::view_t bfield_view(hom_bfield);
 
     // RK stepper
     rk_stepper_t<bfield_t> rk_stepper;
@@ -83,8 +84,8 @@ GTEST_TEST(detray_propagator, rk_stepper) {
         detail::helix helix(track, B);
 
         // RK Stepping into forward direction
-        rk_stepper_t<bfield_t>::state rk_state{track, hom_bfield};
-        crk_stepper_t<bfield_t>::state crk_state{c_track, hom_bfield};
+        rk_stepper_t<bfield_t>::state rk_state{track, bfield_view};
+        crk_stepper_t<bfield_t>::state crk_state{c_track, bfield_view};
 
         // Set step size constraint to half the nominal step size =>
         // crk_stepper will need twice as many steps
@@ -149,6 +150,7 @@ TEST(detray_propagator, rk_stepper_inhomogeneous_bfield) {
     // Read the magnetic field map
     using bfield_t = bfield::inhom_field_t<scalar>;
     bfield_t inhom_bfield = create_inhom_field<scalar>();
+    const bfield_t::view_t bfield_view(inhom_bfield);
 
     // RK stepper
     rk_stepper_t<bfield_t> rk_stepper;
@@ -171,8 +173,8 @@ TEST(detray_propagator, rk_stepper_inhomogeneous_bfield) {
         free_track_parameters<test_algebra> c_track(track);
 
         // RK Stepping into forward direction
-        rk_stepper_t<bfield_t>::state rk_state{track, inhom_bfield};
-        crk_stepper_t<bfield_t>::state crk_state{c_track, inhom_bfield};
+        rk_stepper_t<bfield_t>::state rk_state{track, bfield_view};
+        crk_stepper_t<bfield_t>::state crk_state{c_track, bfield_view};
 
         crk_state.template set_constraint<constraint::e_user>(stepsize_constr);
         ASSERT_NEAR(crk_state.constraints().template size<>(),

--- a/tutorials/src/cpu/propagation/propagation.cpp
+++ b/tutorials/src/cpu/propagation/propagation.cpp
@@ -67,6 +67,7 @@ int main() {
     // Create the bfield
     detray::tutorial::vector3 B{0.f, 0.f, 2.f * detray::unit<scalar>::T};
     const bfield_t bfield = detray::create_const_field<scalar>(B);
+    const bfield_t::view_t bfield_view(bfield);
 
     // Build the propagator
     detray::propagation::config prop_cfg{};
@@ -93,7 +94,8 @@ int main() {
     prop_cfg.context = gctx;
     for (auto track : track_generator_t{trck_cfg}) {
 
-        propagator_t::state propagation(track, bfield, det, prop_cfg.context);
+        propagator_t::state propagation(track, bfield_view, det,
+                                        prop_cfg.context);
 
         propagation.set_particle(
             detray::update_particle_hypothesis(ptc, track));


### PR DESCRIPTION
This commit turns the propagator config and RK stepper magnetic field members into references, and turns the benchmark kernel arguments into grid constant objects to match.