### PR TITLE
Replace Vecmem device vectors by smaller type

### DIFF
--- a/core/include/detray/core/detail/container_buffers.hpp
+++ b/core/include/detray/core/detail/container_buffers.hpp
@@ -115,6 +115,18 @@ struct get_buffer<const vecmem::device_vector<T>, void> {
     using type = vecmem::data::vector_buffer<const T>;
 };
 
+/// Specialization of the buffer getter for @c vecmem::device_vector
+template <typename T>
+struct get_buffer<compact_device_vector<T>, void> {
+    using type = vecmem::data::vector_buffer<T>;
+};
+
+/// Specialization of the buffer getter for @c vecmem::device_vector - const
+template <typename T>
+struct get_buffer<const compact_device_vector<T>, void> {
+    using type = vecmem::data::vector_buffer<const T>;
+};
+
 template <class T>
 using get_buffer_t = typename get_buffer<T>::type;
 /// @}

--- a/core/include/detray/core/detail/container_views.hpp
+++ b/core/include/detray/core/detail/container_views.hpp
@@ -24,7 +24,7 @@ namespace detray {
 
 /// Container types used in device code
 using device_container_types =
-    container_types<vecmem::device_vector, vecmem::jagged_device_vector>;
+    container_types<compact_device_vector, vecmem::jagged_device_vector>;
 
 /// Specialized view for @c vecmem::vector containers
 template <typename T>
@@ -120,6 +120,18 @@ struct get_view<vecmem::device_vector<T>> : public std::true_type {
 /// Specialization of the view getter for @c vecmem::device_vector - const
 template <typename T>
 struct get_view<const vecmem::device_vector<T>> : public std::true_type {
+    using type = dvector_view<const T>;
+};
+
+/// Specialization of the view getter for @c vecmem::device_vector
+template <typename T>
+struct get_view<compact_device_vector<T>> : public std::true_type {
+    using type = dvector_view<T>;
+};
+
+/// Specialization of the view getter for @c vecmem::device_vector - const
+template <typename T>
+struct get_view<const compact_device_vector<T>> : public std::true_type {
     using type = dvector_view<const T>;
 };
 

--- a/core/include/detray/definitions/containers.hpp
+++ b/core/include/detray/definitions/containers.hpp
@@ -37,6 +37,113 @@ using dmap = std::map<key_t, value_t>;
 template <class... types>
 using dtuple = detray::tuple<types...>;
 
+template <typename value_t>
+struct compact_device_vector {
+    using value_type = value_t;
+    using size_type = unsigned int;
+    using difference_type = std::ptrdiff_t;
+    using reference = std::add_lvalue_reference_t<value_type>;
+    using const_reference =
+        std::add_lvalue_reference_t<std::add_const_t<value_type>>;
+    using pointer = std::add_pointer_t<value_type>;
+    using const_pointer = std::add_pointer_t<std::add_const_t<value_type>>;
+
+    using iterator = pointer;
+    using const_iterator = const_pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    DETRAY_HOST_DEVICE compact_device_vector(
+        const vecmem::data::vector_view<value_type>& data)
+        : m_ptr(data.ptr()), m_size(data.size()) {}
+
+    DETRAY_HOST_DEVICE
+    reference at(size_type pos) {
+        assert(pos < size());
+        return m_ptr[pos];
+    }
+    DETRAY_HOST_DEVICE
+    const_reference at(size_type pos) const {
+        assert(pos < size());
+        return m_ptr[pos];
+    }
+
+    DETRAY_HOST_DEVICE
+    reference operator[](size_type pos) { return m_ptr[pos]; }
+    DETRAY_HOST_DEVICE
+    const_reference operator[](size_type pos) const { return m_ptr[pos]; }
+
+    DETRAY_HOST_DEVICE
+    reference front() {
+        assert(size() > 0);
+        return m_ptr[0];
+    }
+    DETRAY_HOST_DEVICE
+    const_reference front() const {
+        assert(size() > 0);
+        return m_ptr[0];
+    }
+
+    DETRAY_HOST_DEVICE
+    reference back() {
+        assert(size() > 0);
+        return m_ptr[size() - 1];
+    }
+    DETRAY_HOST_DEVICE
+    const_reference back() const {
+        assert(size() > 0);
+        return m_ptr[size() - 1];
+    }
+
+    DETRAY_HOST_DEVICE
+    pointer data() { return m_ptr; }
+    DETRAY_HOST_DEVICE
+    const_pointer data() const { return m_ptr; }
+
+    DETRAY_HOST_DEVICE
+    iterator begin() { return iterator(m_ptr); }
+    DETRAY_HOST_DEVICE
+    const_iterator begin() const { return const_iterator(m_ptr); }
+    DETRAY_HOST_DEVICE
+    const_iterator cbegin() const { return begin(); }
+
+    DETRAY_HOST_DEVICE
+    iterator end() { return iterator(m_ptr + size()); }
+    DETRAY_HOST_DEVICE
+    const_iterator end() const { return const_iterator(m_ptr + size()); }
+    DETRAY_HOST_DEVICE
+    const_iterator cend() const { return end(); }
+
+    DETRAY_HOST_DEVICE
+    reverse_iterator rbegin() { return reverse_iterator(end()); }
+    DETRAY_HOST_DEVICE
+    const_reverse_iterator rbegin() const {
+        return const_reverse_iterator(end());
+    }
+    DETRAY_HOST_DEVICE
+    const_reverse_iterator crbegin() const { return rbegin(); }
+
+    DETRAY_HOST_DEVICE
+    reverse_iterator rend() { return reverse_iterator(begin()); }
+    DETRAY_HOST_DEVICE
+    const_reverse_iterator rend() const {
+        return const_reverse_iterator(begin());
+    }
+    DETRAY_HOST_DEVICE
+    const_reverse_iterator crend() const { return rend(); }
+
+    DETRAY_HOST_DEVICE
+    bool empty() const { return (size() == 0); }
+    DETRAY_HOST_DEVICE
+    size_type size() const { return m_size; }
+    DETRAY_HOST_DEVICE
+    size_type capacity() const { return m_size; }
+
+    private:
+    pointer m_ptr;
+    size_type m_size;
+};
+
 /// @brief Bundle container type definitions
 template <template <typename...> class vector_t = dvector,
           template <typename...> class jagged_vector_t = djagged_vector,


### PR DESCRIPTION
This commit replaces the Vecmem device vectors used in the detector (which are 24 bytes each) by a new, smaller, custom type that has a size of 12 bytes (or 16 with padding) which strongly shrinks the size of the detector.