### PR TITLE
Build Updates, main branch (2026.04.07.)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,13 +33,14 @@
          "inherits": [ "default-fp32" ],
          "cacheVariables": {
             "DETRAY_BUILD_TESTING": "TRUE",
-            "DETRAY_SETUP_EIGEN": "TRUE",
-            "DETRAY_SETUP_FASTOR": "TRUE",
-            "DETRAY_SETUP_VC": "TRUE",
-            "DETRAY_SETUP_ACTSVG": "TRUE",
-            "DETRAY_SETUP_BENCHMARK": "TRUE",
-            "DETRAY_SETUP_COVFIE": "TRUE",
-            "DETRAY_SETUP_NLOHMANN": "TRUE"
+            "DETRAY_BUILD_BENCHMARKS": "TRUE",
+            "DETRAY_BUILD_UNITTESTS": "TRUE",
+            "DETRAY_BUILD_INTEGRATIONTESTS": "TRUE",
+            "DETRAY_EIGEN_PLUGIN": "TRUE",
+            "DETRAY_VC_AOS_PLUGIN": "TRUE",
+            "DETRAY_VC_SOA_PLUGIN": "TRUE",
+            "DETRAY_SVG_DISPLAY": "TRUE",
+            "DETRAY_FAIL_ON_WARNINGS": "TRUE"
          }
       },
       {
@@ -53,19 +54,13 @@
       {
          "name": "full-fp32",
          "displayName": "FP32 Developer Configuration: Full Build",
-         "inherits": [ "default-fp32" ],
+         "inherits": [ "dev-fp32" ],
          "cacheVariables": {
             "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-            "DETRAY_EIGEN_PLUGIN"   : "TRUE",
-            "DETRAY_FASTOR_PLUGIN"  : "TRUE",
-            "DETRAY_VC_AOS_PLUGIN"  : "TRUE",
-            "DETRAY_VC_SOA_PLUGIN"  : "TRUE",
-            "DETRAY_SMATRIX_PLUGIN" : "TRUE",
-            "DETRAY_BUILD_UNITTESTS": "TRUE",
-            "DETRAY_BUILD_INTEGRATIONTESTS": "TRUE",
             "DETRAY_BUILD_TUTORIALS": "TRUE",
-            "DETRAY_BUILD_BENCHMARKS": "TRUE",
-            "DETRAY_BUILD_CLI_TOOLS": "TRUE"
+            "DETRAY_BUILD_CLI_TOOLS": "TRUE",
+            "DETRAY_FASTOR_PLUGIN"  : "TRUE",
+            "DETRAY_SMATRIX_PLUGIN" : "TRUE"
          }
       },
       {
@@ -79,55 +74,47 @@
       {
          "name" : "cuda",
          "displayName" : "CUDA Developer Configuration",
-         "inherits" : [ "default-fp32" ],
+         "inherits" : [ "dev-fp32" ],
          "cacheVariables" : {
             "DETRAY_BUILD_CUDA"     : "TRUE",
-            "DETRAY_FASTOR_PLUGIN"  : "FALSE",
             "DETRAY_VC_AOS_PLUGIN"  : "FALSE",
-            "DETRAY_VC_SOA_PLUGIN"  : "FALSE",
-            "DETRAY_SMATRIX_PLUGIN" : "FALSE"
+            "DETRAY_VC_SOA_PLUGIN"  : "FALSE"
          }
       },
       {
          "name" : "sycl",
          "displayName" : "SYCL Developer Configuration",
-         "inherits" : [ "default-fp32" ],
+         "inherits" : [ "dev-fp32" ],
          "cacheVariables" : {
             "DETRAY_BUILD_SYCL"     : "TRUE",
-            "DETRAY_FASTOR_PLUGIN"  : "FALSE",
             "DETRAY_VC_AOS_PLUGIN"  : "FALSE",
-            "DETRAY_VC_SOA_PLUGIN"  : "FALSE",
-            "DETRAY_SMATRIX_PLUGIN" : "FALSE"
+            "DETRAY_VC_SOA_PLUGIN"  : "FALSE"
          }
       },
       {
          "name": "hip-fp32",
          "displayName": "HIP Developer Configuration",
-         "inherits" : [ "default-fp32" ],
+         "inherits" : [ "dev-fp32" ],
          "cacheVariables" : {
             "DETRAY_BUILD_HIP"      : "TRUE",
-            "DETRAY_FASTOR_PLUGIN"  : "FALSE",
             "DETRAY_VC_AOS_PLUGIN"  : "FALSE",
-            "DETRAY_VC_SOA_PLUGIN"  : "FALSE",
-            "DETRAY_SMATRIX_PLUGIN" : "FALSE"
+            "DETRAY_VC_SOA_PLUGIN"  : "FALSE"
          }
       },
             {
          "name": "hip-fp64",
          "displayName": "HIP Developer Configuration",
-         "inherits" : [ "default-fp64" ],
+         "inherits" : [ "dev-fp64" ],
          "cacheVariables" : {
             "DETRAY_BUILD_HIP"      : "TRUE",
-            "DETRAY_FASTOR_PLUGIN"  : "FALSE",
             "DETRAY_VC_AOS_PLUGIN"  : "FALSE",
-            "DETRAY_VC_SOA_PLUGIN"  : "FALSE",
-            "DETRAY_SMATRIX_PLUGIN" : "FALSE"
+            "DETRAY_VC_SOA_PLUGIN"  : "FALSE"
          }
       },
       {
          "name" : "smatrix",
          "displayName" : "SMatrix Developer Configuration",
-         "inherits" : [ "default-fp64" ],
+         "inherits" : [ "dev-fp64" ],
          "cacheVariables" : {
             "DETRAY_SMATRIX_PLUGIN" : "TRUE"
          }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,7 +29,7 @@
       },
       {
          "name": "dev-fp32",
-         "displayName": "FP32 Developer Configuration: Build all Dependencies",
+         "displayName": "FP32 Developer Configuration: Build main components",
          "inherits": [ "default-fp32" ],
          "cacheVariables": {
             "DETRAY_BUILD_TESTING": "TRUE",
@@ -45,7 +45,7 @@
       },
       {
          "name": "dev-fp64",
-         "displayName": "FP64 Developer Configuration: Build all Dependencies",
+         "displayName": "FP64 Developer Configuration: Build main components",
          "inherits": [ "dev-fp32" ],
          "cacheVariables": {
             "DETRAY_CUSTOM_SCALARTYPE" : "double"
@@ -72,8 +72,8 @@
          }
       },
       {
-         "name" : "cuda",
-         "displayName" : "CUDA Developer Configuration",
+         "name" : "cuda-fp32",
+         "displayName" : "CUDA FP32 Developer Configuration",
          "inherits" : [ "dev-fp32" ],
          "cacheVariables" : {
             "DETRAY_BUILD_CUDA"     : "TRUE",
@@ -82,8 +82,16 @@
          }
       },
       {
-         "name" : "sycl",
-         "displayName" : "SYCL Developer Configuration",
+         "name": "cuda-fp64",
+         "displayName": "CUDA FP64 Developer Configuration",
+         "inherits" : [ "cuda-fp32" ],
+         "cacheVariables" : {
+            "DETRAY_CUSTOM_SCALARTYPE" : "double"
+         }
+      },
+      {
+         "name" : "sycl-fp32",
+         "displayName" : "SYCL FP32 Developer Configuration",
          "inherits" : [ "dev-fp32" ],
          "cacheVariables" : {
             "DETRAY_BUILD_SYCL"     : "TRUE",
@@ -92,8 +100,16 @@
          }
       },
       {
+         "name": "sycl-fp64",
+         "displayName": "SYCL FP64 Developer Configuration",
+         "inherits" : [ "sycl-fp32" ],
+         "cacheVariables" : {
+            "DETRAY_CUSTOM_SCALARTYPE" : "double"
+         }
+      },
+      {
          "name": "hip-fp32",
-         "displayName": "HIP Developer Configuration",
+         "displayName": "HIP FP32 Developer Configuration",
          "inherits" : [ "dev-fp32" ],
          "cacheVariables" : {
             "DETRAY_BUILD_HIP"      : "TRUE",
@@ -101,28 +117,18 @@
             "DETRAY_VC_SOA_PLUGIN"  : "FALSE"
          }
       },
-            {
-         "name": "hip-fp64",
-         "displayName": "HIP Developer Configuration",
-         "inherits" : [ "dev-fp64" ],
-         "cacheVariables" : {
-            "DETRAY_BUILD_HIP"      : "TRUE",
-            "DETRAY_VC_AOS_PLUGIN"  : "FALSE",
-            "DETRAY_VC_SOA_PLUGIN"  : "FALSE"
-         }
-      },
       {
-         "name" : "smatrix",
-         "displayName" : "SMatrix Developer Configuration",
-         "inherits" : [ "dev-fp64" ],
+         "name": "hip-fp64",
+         "displayName": "HIP FP64 Developer Configuration",
+         "inherits" : [ "hip-fp32" ],
          "cacheVariables" : {
-            "DETRAY_SMATRIX_PLUGIN" : "TRUE"
+            "DETRAY_CUSTOM_SCALARTYPE" : "double"
          }
       },
       {
          "name" : "gitlab-cuda-ci",
          "displayName" : "Gitlab CUDA CI Configuration",
-         "inherits" : [ "default-fp32", "cuda" ],
+         "inherits" : [ "default-fp32", "cuda-fp32" ],
          "cacheVariables" : {
             "BUILD_TESTING" : "TRUE",
             "DETRAY_BUILD_HOST" : "FALSE",
@@ -138,7 +144,7 @@
       {
          "name" : "gitlab-sycl-ci",
          "displayName" : "Gitlab SYCL CI Configuration",
-         "inherits" : [ "default-fp32", "sycl" ],
+         "inherits" : [ "default-fp32", "sycl-fp32" ],
          "cacheVariables" : {
             "BUILD_TESTING" : "TRUE",
             "DETRAY_BUILD_HOST" : "FALSE",

--- a/cmake/detray-compiler-options-cuda.cmake
+++ b/cmake/detray-compiler-options-cuda.cmake
@@ -34,8 +34,17 @@ if(PROJECT_IS_TOP_LEVEL)
 
     # Make CUDA generate debug symbols for the device code as well in a debug
     # build.
-    detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G -src-in-ptx" )
-    detray_add_flag( CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-lineinfo -src-in-ptx" )
+    detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G" )
+    detray_add_flag( CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-lineinfo" )
+    if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "12.8")
+        message(
+            STATUS
+            "Disabling C++ source in PTX in order to work around a bug in CUDA 12.8."
+        )
+    else()
+        detray_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-src-in-ptx" )
+        detray_add_flag( CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-src-in-ptx" )
+    endif()
 
     # Fail on warnings, if asked for that behaviour.
     if(DETRAY_FAIL_ON_WARNINGS)


### PR DESCRIPTION
I found that I need to make a change in the code to keep [traccc](https://github.com/acts-project/traccc) building successfully with a Clang+CUDA compiler combination.

But before I could make the fix itself, I found that I needed to clean up the CMake configuration of the code a little.
  1. I made the configuration only apply `-src-in-ptx` when using an appropriate version of CUDA. Like we do [in traccc](https://github.com/acts-project/traccc/blob/main/cmake/traccc-compiler-options-cuda.cmake#L41-L48).
  2. I made the presets work a bit more reasonably out of the box. As currently the `cuda` preset for instance doesn't build any part of the project.

I tried to make sure that the CI builds/tests would continue doing what they are currently doing. :crossed_fingers: