### PR TITLE
Clang (+CUDA) Fixes, main branch (2026.04.07.)

### DIFF
--- a/core/include/detray/core/detail/single_store.hpp
+++ b/core/include/detray/core/detail/single_store.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -118,13 +118,17 @@ class single_store {
     /// @returns the collections iterator at the start position
     DETRAY_HOST_DEVICE
     constexpr auto begin(const context_type &ctx = {}) const {
-        return m_container.begin() + ctx.get() * m_context_size;
+        return m_container.begin() +
+               static_cast<std::iter_difference_t<const_iterator>>(
+                   ctx.get() * m_context_size);
     }
 
     /// @returns the collections iterator sentinel
     DETRAY_HOST_DEVICE
     constexpr auto end(const context_type &ctx = {}) const {
-        return m_container.begin() + (ctx.get() + 1) * m_context_size;
+        return m_container.begin() +
+               static_cast<std::iter_difference_t<const_iterator>>(
+                   (ctx.get() + 1) * m_context_size);
     }
 
     /// @returns access to the underlying container - const

--- a/core/include/detray/utils/type_list.hpp
+++ b/core/include/detray/utils/type_list.hpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2023-2025 CERN for the benefit of the ACTS project
+ * (c) 2023-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -104,8 +104,8 @@ struct get_at {};
 
 template <std::size_t N, typename T, typename... Ts>
 struct get_at<N, list<T, Ts...>> {
-    using type =
-        std::remove_cvref_t<decltype(detray::get<N>(dtuple<T, Ts...>{}))>;
+    using type = std::remove_cvref_t<decltype(detray::get<N>(
+        std::declval<dtuple<T, Ts...>>()))>;
 };
 template <typename L, std::size_t N>
 using at = typename get_at<N, L>::type;

--- a/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
+++ b/tests/unit_tests/device/cuda/sf_finders_grid_cuda.cpp
@@ -1,6 +1,6 @@
 /** Detray library, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -234,7 +234,8 @@ TEST(grids_cuda, grid2_complete_populator) {
             // Other point with which the bin has been completed
             const scalar gbin_f{static_cast<scalar>(gbin)};
             const point3 tp{axis_r.min() + gbin_f * width_r,
-                            axis_phi.min() + gbin_f * width_phi, 0.5};
+                            axis_phi.min() + gbin_f * width_phi,
+                            static_cast<scalar>(0.5)};
 
             // Go through all points and compare
             int pt_idx{0};
@@ -312,7 +313,8 @@ TEST(grids_cuda, grid2_attach_populator) {
             // Other point with which the bin has been completed
             const scalar gbin_f{static_cast<scalar>(gbin)};
             const point3 tp{axis_r.min() + gbin_f * width_r,
-                            axis_phi.min() + gbin_f * width_phi, 0.5};
+                            axis_phi.min() + gbin_f * width_phi,
+                            static_cast<scalar>(0.5)};
 
             // Go through all points and compare
             int pt_idx{0};
@@ -422,7 +424,8 @@ TEST(grids_cuda, grid2_dynamic_attach_populator) {
             // Other point with which the bin has been completed
             const scalar gbin_f{static_cast<scalar>(gbin)};
             const point3 tp{axis_r.min() + gbin_f * width_r,
-                            axis_phi.min() + gbin_f * width_phi, 0.5};
+                            axis_phi.min() + gbin_f * width_phi,
+                            static_cast<scalar>(0.5)};
 
             // Go through all points and compare
             int pt_idx{0};


### PR DESCRIPTION
As I mentioned in #1134, I ran into an issue with my [traccc](https://github.com/acts-project/traccc) build today.

```
...
[build] /home/krasznaa/ATLAS/projects/traccc/traccc/out/build/full-native-fp64/_deps/detray-src/core/include/detray/utils/type_list.hpp(108): error: the default constructor of "detray::tuple<detray::detail::get_value_t<detray::detector<traccc::detector_traits<detray::default_metadata<traccc::default_algebra>>::metadata_type, traccc::details::device_detector_container_types>::vector_type<detray::default_metadata<traccc::default_algebra>::rectangle>>, detray::detail::get_value_t<detray::detector<traccc::detector_traits<detray::default_metadata<traccc::default_algebra>>::metadata_type, traccc::details::device_detector_container_types>::vector_type<detray::default_metadata<traccc::default_algebra>::trapezoid>>, detray::detail::get_value_t<detray::detector<traccc::detector_traits<detray::default_metadata<traccc::default_algebra>>::metadata_type, traccc::details::device_detector_container_types>::vector_type<detray::default_metadata<traccc::default_algebra>::annulus>>, detray::detail::get_value_t<detray::detector<traccc::detector_traits<detray::default_metadata<traccc::default_algebra>>::metadata_type, traccc::details::device_detector_container_types>::vector_type<detray::default_metadata<traccc::default_algebra>::cylinder>>, detray::detail::get_value_t<detray::detector<traccc::detector_traits<detray::default_metadata<traccc::default_algebra>>::metadata_type, traccc::details::device_detector_container_types>::vector_type<detray::default_metadata<traccc::default_algebra>::cylinder_portal>>, detray::detail::get_value_t<detray::detector<traccc::detector_traits<detray::default_metadata<traccc::default_algebra>>::metadata_type, traccc::details::device_detector_container_types>::vector_type<detray::default_metadata<traccc::default_algebra>::disc>>, detray::detail::get_value_t<detray::detector<traccc::detector_traits<detray::default_metadata<traccc::default_algebra>>::metadata_type, traccc::details::device_detector_container_types>::vector_type<detray::default_metadata<traccc::default_algebra>::straw_tube>>, detray::detail::get_value_t<detray::detector<traccc::detector_traits<detray::default_metadata<traccc::default_algebra>>::metadata_type, traccc::details::device_detector_container_types>::vector_type<detray::default_metadata<traccc::default_algebra>::drift_cell>>>" (aka "detray::tuple<std::add_const_t<detray::mask<detray::rectangle2D, detray::array<double>, unsigned short>>, std::add_const_t<detray::mask<detray::trapezoid2D, detray::array<double>, unsigned short>>, std::add_const_t<detray::mask<detray::annulus2D, detray::array<double>, unsigned short>>, std::add_const_t<detray::mask<detray::cylinder2D, detray::array<double>, unsigned short>>, std::add_const_t<detray::mask<detray::concentric_cylinder2D, detray::array<double>, unsigned short>>, std::add_const_t<detray::mask<detray::ring2D, detray::array<double>, unsigned short>>, std::add_const_t<detray::mask<detray::line<false>, detray::array<double>, unsigned short>>, std::add_const_t<detray::mask<detray::line<true>, detray::array<double>, unsigned short>>>") cannot be referenced -- it is a deleted function
[build]           std::remove_cvref_t<decltype(detray::get<N>(dtuple<T, Ts...>{}))>;
[build]                                                                       ^
[build]           detected during:
[build]             instantiation of class "detray::types::get_at<N, detray::types::list<T, Ts...>> [with N=0UL, T=const detray::mask<detray::rectangle2D, traccc::default_algebra, uint_least16_t>, Ts=<const detray::mask<detray::trapezoid2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::annulus2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::cylinder2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::concentric_cylinder2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::ring2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::line_circular, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::line_square, traccc::default_algebra, uint_least16_t>>]" at line 111
[build]             instantiation of type "detray::types::at<detray::types::list<const detray::mask<detray::rectangle2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::trapezoid2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::annulus2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::cylinder2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::concentric_cylinder2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::ring2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::line_circular, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::line_square, traccc::default_algebra, uint_least16_t>>, 0UL>" at line 275
[build]             instantiation of "auto detray::types::filtered_list<orig_list_t,type_selector,I,Fs...>(const detray::types::list<Fs...> &) [with orig_list_t=detray::types::list<const detray::mask<detray::rectangle2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::trapezoid2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::annulus2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::cylinder2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::concentric_cylinder2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::ring2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::line_circular, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::line_square, traccc::default_algebra, uint_least16_t>>, type_selector=detray::actor::parameter_transporter<traccc::default_algebra>::select_frame, I=0UL, Fs=<>]" at line 94 of /home/krasznaa/ATLAS/projects/traccc/traccc/out/build/full-native-fp64/_deps/detray-src/core/include/detray/utils/type_registry.hpp
[build]             instantiation of class "detray::types::mapped_registry<registry_t, type_selector_t> [with registry_t=detray::types::registry<detray::default_metadata<traccc::default_algebra>::mask_ids, const detray::mask<detray::rectangle2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::trapezoid2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::annulus2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::cylinder2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::concentric_cylinder2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::ring2D, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::line_circular, traccc::default_algebra, uint_least16_t>, const detray::mask<detray::line_square, traccc::default_algebra, uint_least16_t>>, type_selector_t=detray::actor::parameter_transporter<traccc::default_algebra>::select_frame]" at line 488 of /home/krasznaa/ATLAS/projects/traccc/traccc/out/build/full-native-fp64/_deps/detray-src/core/include/detray/propagator/actors/parameter_updater.hpp
[build]             instantiation of "detray::actor::parameter_transporter<algebra_t>::bound_matrix_type detray::actor::parameter_transporter<algebra_t>::get_full_jacobian(propagator_state_t &, const detray::actor::parameter_transporter<algebra_t>::bound_track_parameters_type &) const [with algebra_t=traccc::default_algebra, propagator_state_t=detray::propagator<detray::rk_stepper<traccc::cuda::bfield_t, traccc::default_algebra, detray::constrained_step<traccc::scalar>, detray::stepper_rk_policy<traccc::scalar>, detray::stepping::void_inspector, 1U>, detray::caching_navigator<const detray::detector<detray::default_metadata<traccc::default_algebra>, traccc::details::device_detector_container_types>, 8UL, detray::navigation::void_inspector, detray::intersection2D<detray::surface_descriptor<detray::detail::typed_index<detray::default_metadata<traccc::default_algebra>::mask_ids, detray::detail::index_range<detray::dindex, true, uint_least32_t, 268435200U, 255U>, uint_least32_t, 4026531840U, 268435455U>, detray::detail::typed_index<detray::default_metadata<traccc::default_algebra>::material_ids, detray::dindex, uint_least32_t, 4026531840U, 268435455U>, detray::dindex, uint_least16_t>, traccc::default_algebra, false>>, traccc::details::ckf_actor_chain_t>::state_base<false>]" at line 371 of /home/krasznaa/ATLAS/projects/traccc/traccc/out/build/full-native-fp64/_deps/detray-src/core/include/detray/propagator/actors/parameter_updater.hpp
...
```

Which, while being a perfectly valid error, I could so far only reproduce inside of that build. This project's own build does not break down on that piece of code for me. Even though I use the same compiler setup that I use in the failing traccc build as well. :thinking: (Even weirder is that only the CUDA build breaks down. The SYCL build, which uses Clang for both the host and the device compiler, finishes successfully. :confused:)

But I did encounter some warnings (turned errors by `-Werror`) in my Detray build. Which I also tried to fix in this PR.